### PR TITLE
Repositories as a first-class subsystem: always-current monitor, safe worktree and branch cleanup, fleet API, recommendations, and agent hand-off

### DIFF
--- a/docs/INSPECTION-repositories-full.md
+++ b/docs/INSPECTION-repositories-full.md
@@ -1,0 +1,115 @@
+# Inspection: repositories-full
+
+## BLOCKER — Provisional repository rows still expose destructive actions
+
+**File:** `src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs:61-70`, `src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs:86-94`, `src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs:176-190`, `src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs:228-240`
+
+**What is wrong:** A warm-start row is dimmed but remains clickable. Opening it immediately attaches the cached path to the detail view and its Changes panel, where stage, commit, and permanent discard actions are enabled from a fresh status read. Branch deletion is also reachable. There is no provisional check in the row click, `OpenDetail`, `RepositoryDetailView.Attach`, or `ChangesDiffView`.
+
+**How verified:** `RepoRow_PointerPressed` invokes `RepoOpenRequested` for every non-empty path without checking `row.Verifying`; `OpenDetail` unconditionally attaches that path; `ShowTab("Changes")` is the default; and `DiscardButton_Click` calls `GitWriteService.DiscardAsync`. The only provisional action guard in the diff is inside `WorktreesView`, so the repeated claim that provisional entries are “never acted on” is false. A cached path that has been repurposed for another repository can therefore receive destructive actions before the monitor verifies its identity.
+
+## BLOCKER — The C2 upstream test can still produce a false “origin gone” verdict
+
+**File:** `src/CcDirector.Core/Git/WorktreeInventoryService.cs:108-116`, `src/CcDirector.Core/Git/GitBranchService.cs:103-112`
+
+**What is wrong:** Both implementations treat any non-empty `branch.<name>.merge` as proof that the same-named branch once existed on `origin`, then ignore the configured merge ref and query `ls-remote origin <local-name>`. A valid local branch can track a differently named upstream ref, or a ref on a remote other than `origin`. In those cases the same-named origin branch is absent even though the configured upstream has not gone, and `originGone` becomes true.
+
+**How verified:** Both hunks reduce the config result to `hadUpstream` and then run `ls-remote --heads origin entry.Branch/name`. Neither reads `branch.<name>.remote`, and neither uses the value of `branch.<name>.merge`. `BranchSafetyEvaluator` accepts `originGone` as a sufficient signal even when `containedInMain` is false, and the worktree evaluator receives the same false-positive signal. Delete-time/reap-time recomputation repeats the identical flawed test, so live re-verification does not close this data-loss path.
+
+## MAJOR — Branch deletion has a force-delete time-of-check/time-of-use gap
+
+**File:** `src/CcDirector.Core/Git/GitBranchService.cs:151-165`
+
+**What is wrong:** `DeleteIfSafeAsync` derives safety through multiple subprocesses, returns to managed code, and later executes `git branch -D`. A concurrent process can advance or retarget the branch after the verdict but before the force-delete command. `-D` does not re-check whether the branch’s current tip is merged.
+
+**How verified:** The method awaits `ListAsync`, tests the returned `SafeToDelete` boolean, and then launches a separate unconditional force-delete command. No object ID from the inspected tip is carried into the destructive operation. The batch path does call `DeleteIfSafeAsync` per branch, but every call retains this gap.
+
+## MAJOR — The reaper can be invoked with a linked-worktree path
+
+**File:** `src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs:190-214`, `src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs:294-318`, `src/CcDirector.Core/Git/RepositoryMonitor.cs:212-239`
+
+**What is wrong:** Both refresh and reap fall back from `_repoEntryPath` to the session’s `_repoPath`, which the class explicitly says may be a linked worktree. `RecomputeOneAsync` accepts a `.git` file as sufficient repository identity and stores the result under the supplied path, so refreshing while the owning entry is unresolved can make the worktree path the monitor entry. The same fallback is also reachable if the owning entry disappears while the reap confirmation overlay is open.
+
+**How verified:** `RefreshAsync` selects `_repoEntryPath ?? _repoPath`; `RunReapAsync` repeats that expression and passes it directly to `_reaper.ReapAsync`; and `RecomputeOneAsync` treats either a `.git` directory or `.git` file as a repo without canonicalizing to the primary checkout. The regression test for sessions inside worktrees checks only the rendered count and never captures the actual reaper argument.
+
+## MAJOR — Watcher recomputes discard live-session occupancy
+
+**File:** `src/CcDirector.Core/Git/RepositoryWatcher.cs:165-174`, `src/CcDirector.Core/Git/RepositoryMonitor.cs:212-239`, `src/CcDirector.Core/Git/RepositoryStatusService.cs:84-114`
+
+**What is wrong:** Watcher-triggered recomputation always calls `RecomputeOneAsync(repoPath)` without live sessions. That new status replaces the monitor’s prior status, including `InUseBySession` worktree classifications computed during a UI refresh/full scan. An actively used worktree can consequently be published, recommended, and pushed as safe-to-reap until another session-aware scan happens.
+
+**How verified:** `RepositoryWatcher` has no live-session provider and omits the optional `sessions` argument. `RecomputeOneAsync` passes that null value into `_compute` and overwrites `_byPath[key]`. `RepositoryStatusService` derives the worktree counts and full worktree records from the resulting inventory. The watcher tests inject a lightweight compute delegate that ignores sessions, so they cannot detect this state regression.
+
+## MAJOR — Full scans and watcher recomputes can concurrently overwrite the same repository
+
+**File:** `src/CcDirector.Core/Git/RepositoryMonitor.cs:167-178`, `src/CcDirector.Core/Git/RepositoryMonitor.cs:212-251`, `src/CcDirector.Core/Git/RepositoryWatcher.cs:165-174`
+
+**What is wrong:** `RecomputeOneAsync` is not coordinated with `IsScanning`, the full-scan cancellation source, or any per-repository single-flight guard. Existing watchers remain active during later full rescans, so both paths can run the expensive git computation for one repository concurrently and publish in completion order. An older or session-less result can overwrite a newer result.
+
+**How verified:** The full-scan and single-recompute paths each call `_compute` outside `_gate` and later assign `_byPath[key]` under only a short dictionary lock. The added recompute path never checks scan state or participates in scan cancellation. The tests trigger watcher changes only after the initial scan has completed and contain no in-flight rescan case.
+
+## MAJOR — Worktree size measurement is an unbounded, non-cancellable scan bottleneck
+
+**File:** `src/CcDirector.Core/Git/RepositoryStatusService.cs:84-91`, `src/CcDirector.Core/Git/RepositoryStatusService.cs:126-164`
+
+**What is wrong:** Every cache miss performs a synchronous recursive walk of every file in a worktree, with no file-count limit, byte budget, time budget, or cancellation check. Initial discovery of the stated hundreds of large worktrees can keep the monitor in “verifying” for a prolonged period, and concurrent watcher/full-scan computations can duplicate those walks.
+
+**How verified:** `MeasureWorktreeBytes` directly enumerates `Directory.EnumerateFiles(... RecurseSubdirectories = true)` and calls `FileInfo.Length` for every result. It takes no cancellation token and is invoked serially inside the worktree projection before a `RepositoryStatus` is returned. No size-measurement test exercises a large tree, cancellation, or scan latency.
+
+## MINOR — The process-wide size cache grows forever
+
+**File:** `src/CcDirector.Core/Git/RepositoryStatusService.cs:126-163`
+
+**What is wrong:** The static `ConcurrentDictionary` retains one normalized path entry for every worktree ever measured. Reaped, moved, and deleted worktrees are never evicted, so a long-running Director accumulates stale keys and measurements indefinitely.
+
+**How verified:** The only operations shown are `TryGetValue` and assignment. No removal, capacity bound, expiration, or reconciliation with the current inventory exists. Reparse points are skipped by the enumeration options, but that does not address cache lifetime.
+
+## MAJOR — An old SignalR connection can retake repository-store ownership
+
+**File:** `src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs:37-52`
+
+**What is wrong:** A push from any connection ID different from the currently stored one always wins. After a new connection replaces an old connection, a late push from the still-draining old connection is “new” relative to the current entry and is accepted, switching ownership back. The two connections can then alternate accepted stale snapshots.
+
+**How verified:** Sequence rejection is applied only when `sameConnection` is true; every different connection overwrites `ConnectionId`, `LastSequence`, and the repositories. The test covers `conn1 -> conn2` but not `conn1 -> conn2 -> conn1`, and the store does not consult the stream registry’s current connection ownership.
+
+## MAJOR — Provisional status is erased from the fleet worktree surface
+
+**File:** `src/CcDirector.ControlApi/RepositoryDtoMapper.cs:58-78`, `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:786-811`, `src/CcDirector.Gateway.Contracts/RepositoryDtos.cs:66-83`, `tools/cc-devthrottle/src/repo_ops.py:86-122`
+
+**What is wrong:** A provisional repository snapshot is accepted and its worktrees are flattened without either filtering them or carrying a provisional bit. The CLI then prints `safe-to-reap` and includes the bytes in “reclaimable” totals exactly as if the verdict were live. Consumers of `/worktrees` cannot distinguish cached safety testimony from verified state.
+
+**How verified:** `RepoStatusDto` has `Provisional`, but `FleetWorktreeDto` does not. Both flattening implementations copy each worktree regardless of `r.Provisional`. The CLI reads only `state` and `sizeBytes`. History explicitly filters provisional rows, demonstrating that the pushed stream can contain them, while the fleet worktree path has no equivalent guard.
+
+## MAJOR — The new Discard action permanently destroys tracked work with one click
+
+**File:** `src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml:70-76`, `src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs:228-250`
+
+**What is wrong:** Selecting an unstaged tracked file exposes “Discard changes,” and clicking it immediately invokes the destructive write service. There is no confirmation, displayed loss summary, approval step, or recovery information.
+
+**How verified:** `DiscardButton_Click` directly delegates to `_write.DiscardAsync` through `WriteActionAsync`; the only preconditions are a non-null repository and selection. The test suite checks rendered diff rows but contains no discard-action test.
+
+## MINOR — Rail navigation hides repository detail without detaching it
+
+**File:** `src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs:96-125`, `src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs:100-125`
+
+**What is wrong:** Clicking Local repositories, Root folders, or Recommendations while detail is open merely sets `DetailPage.IsVisible = false`. The detail remains subscribed to `RepositoryMonitor.Upserted`; if the Worktrees tab was opened, its three monitor subscriptions also remain active. Hidden controls continue receiving and dispatching updates until the back button or a later attach happens.
+
+**How verified:** Only `CloseDetail` calls `DetailPage.Detach`. `ShowPage`, used by all rail buttons, does not. `RepositoryDetailView.Attach` subscribes to `Upserted`, and `WorktreesView.Attach` subscribes to `Upserted`, `Removed`, and `ProgressChanged`.
+
+## MAJOR — Repository history conflates distinct repositories and Directors
+
+**File:** `src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs:8-21`, `src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs:61-93`, `src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs:145`
+
+**What is wrong:** The persistence key is tenant/date/machine/repository **name** only. It omits Director ID, repository path, provider, and remote URL. Two distinct repositories with the same leaf name on one machine, or two Directors reporting the same machine/name, overwrite each other, corrupting weekly totals and dirty callouts.
+
+**How verified:** `RepoDailySnapshot` does not store Director ID or path even though the incoming DTO contains both, and `Key` concatenates only `Tenant`, `Date`, `MachineName`, and `Name`. The tenant partition itself is sourced from the bound hub connection and filtered on reads, but the tests use unique names and do not exercise an identity collision.
+
+## NOTE — The principal safety and compatibility claims are not exercised by the added tests
+
+**File:** `src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs:12-19`, `src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs:126-152`, `src/CcDirector.Core.Tests/GitBranchServiceTests.cs:55-201`, `src/CcDirector.Core.Tests/RepositoryWatcherTests.cs:20-164`, `src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs:1-93`, `src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs:1-108`
+
+**What is wrong:** The comments claim more coverage than the tests provide. The unexercised top claims are: provisional entries cannot be acted on; reaping from a session in a linked worktree passes the owning primary repository path; the branch service rejects a never-pushed or differently named upstream under C2; real repository recomputation cannot feed watcher signals back into itself; watcher activity during a full scan is serialized safely; monitor events and detach paths are UI-thread/lifetime safe; size walks are bounded, cancellable, reparse-safe, and cache-stable; tenant isolation holds through the actual hub plus all three HTTP endpoints rather than only direct store calls; a shared repo/session sequence remains acceptable to `PushedSessionStore`; and CLI rendering tolerates missing or malformed fields.
+
+**How verified:** The one-brain tests assert counts only and contain no provisional or reap invocation despite their class comment. The detail render tests end at `Assert.NotNull`. The C2 regression exists only for `WorktreeInventoryService`. Watcher tests replace the real git computation with a trivial delegate and run after scanning. Gateway tests call stores directly, with no bound connection/request endpoint tests. No test in the diff interleaves repository and session pushes, measures a real large worktree, exercises navigation detach, or calls either destructive UI action.
+
+Verdict: BLOCK — multiple live-reverification, provisional-state, watcher-consistency, and persistence defects can misclassify or destroy repository work.

--- a/docs/MISSION-repositories-full-2026-07-23.md
+++ b/docs/MISSION-repositories-full-2026-07-23.md
@@ -1,7 +1,11 @@
 # Mission: Repositories, handled like they matter (2026-07-23)
 
-Status: ACTIVE. Branch `mission/repositories-full`, worktree `D:\ReposFred\devthrottle-repos-mission`.
-Conduct: `.claude/skills/mission/SKILL.md`. Running state: `docs/MISSION-repositories-full-STATE.md`.
+Status: COMPLETE (2026-07-24). The owner approved the QA report and the branch was landed on
+origin/main as one squash-merged pull request; the mission worktree was removed afterwards.
+The full record - eight inspection rounds, every finding, ruling, and fix - is in
+`docs/MISSION-repositories-full-INSPECTION-1.md` through `-6.md` and the running state in
+`docs/MISSION-repositories-full-STATE.md`, all in the past tense now.
+Conduct followed: `.claude/skills/mission/SKILL.md`.
 
 ## The why
 The owner ended up with roughly 300 dangling worktrees eating 100 gigabytes because nothing watched,

--- a/docs/MISSION-repositories-full-2026-07-23.md
+++ b/docs/MISSION-repositories-full-2026-07-23.md
@@ -1,0 +1,51 @@
+# Mission: Repositories, handled like they matter (2026-07-23)
+
+Status: ACTIVE. Branch `mission/repositories-full`, worktree `D:\ReposFred\devthrottle-repos-mission`.
+Conduct: `.claude/skills/mission/SKILL.md`. Running state: `docs/MISSION-repositories-full-STATE.md`.
+
+## The why
+The owner ended up with roughly 300 dangling worktrees eating 100 gigabytes because nothing watched,
+nothing warned, and cleanup required git fluency he should never need. When this mission is done,
+repositories are a first-class DevThrottle subsystem: the Director always knows every repo, worktree,
+branch, change, and who is working where; the Gateway centralizes it so any agent can ask in one call;
+the system remembers over time and recommends cleanup in plain language; and agents do the dirty work.
+A user who has never heard the word "worktree" stays clean without learning it.
+
+## The specification
+GitHub issue thefrederiksen/devthrottle_internal#510 (the full plan with per-phase work items and
+tests), building on #507 (the shipped engine v1). Mockups (v4):
+https://claude.ai/code/artifact/5a61b4d6-1cd8-4c9d-a6e4-d03b37c78362
+
+## Rulings already made
+- All phases (A, C, B, D, E from #510) build on this ONE mission branch; the final merge to
+  origin/main happens only after the owner approves the QA report. (Stated by the owner.)
+- Order on the branch: A -> B -> C -> D -> E (C's research runs early; C lands after the
+  Director-side model is final so the pushed DTO is stable). (Architect ruling.)
+- Phase E's scheduled cleanup agent stays OUT (marked optional in #510). (Architect ruling,
+  announced to the owner.)
+- Disk size: per-worktree sizes are required (they drive "reclaim N GB"); whole-repo sizes may be
+  reduced or cached if measurement is too slow. (Architect ruling, announced.)
+- The Recommendations panel lives in the Repositories home as a rail page, not on the Home screen.
+  (Architect ruling, announced.)
+- Destructive actions remain Director-local in this mission (the local reaper with its fail-closed
+  verdict + live re-verify). Fleet-remote reap routing is OUT of scope; the Gateway API is
+  read-only. (Architect ruling - matches the #510 trust rule.)
+
+## The work, in landing order
+1. A-model: worktree list + per-worktree sizes + dirty-since + provisional (verifying) flag on the model.
+2. A-unify: the per-session Source Control tab reads the monitor (one brain).
+3. A-watcher: FileSystemWatcher, debounced, recompute one repo per change.
+4. A/B-detail: repository drill-down screen (tabs) in the Repositories home, reap in the home,
+   verifying visual state, plain-language explainers.
+5. B: diff viewer; branches with safe-delete verdict; pull requests; history.
+6. C: Director push of the repository model to the Gateway; GET /repositories + /worktrees;
+   cc-devthrottle repo list / worktree list; local relay fallback.
+7. D: Gateway persistence (repo_snapshots, worktree_events + EF migration), recommendation rules
+   (folded server-side/service-side), Recommendations page, weekly report section.
+8. E: "Hand to an agent" dialog + brief templates + spawn wiring.
+9. QA: full suites, slot-5 build from this branch, real-machine QA harness, independent Codex
+   inspection, QA report for the owner.
+
+## Out of scope
+Scheduled cleanup agent; fleet-remote reap routing; Cockpit web surfaces for repositories; account
+catalogs (browse not-yet-cloned repos); GitButler-style branch virtualization.

--- a/docs/MISSION-repositories-full-INSPECTION-1.md
+++ b/docs/MISSION-repositories-full-INSPECTION-1.md
@@ -274,6 +274,7 @@ cache eviction (F7, F8), stale-connection rejection (F9), and the history key co
       F4/F5/F6 127d8875, F3 11c43c71, F7 e80a7b3c, F8 3b395c8e, F9 31ab7f86, F10 587e55d3,
       F13 7b272aab, F11 f35c21bc, F12 7dee9aa7; F14 via the tests above)
 - [x] All three suites green (Core 3423 passed / 0 failed / 8 skipped; Avalonia 289 passed /
-      0 failed; Gateway full-suite result recorded in the Manager's report)
+      0 failed; Gateway 3672 passed / 0 failed / 17 skipped, the skips being the usual gated
+      live-Postgres proofs)
 - [ ] Second inspection pass over the fix diff
 - [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-1.md
+++ b/docs/MISSION-repositories-full-INSPECTION-1.md
@@ -1,0 +1,279 @@
+# Inspection round 1 - findings and Architect rulings
+
+Mission: repositories-full (devthrottle_internal#510). Branch: mission/repositories-full.
+Inspector: independent Codex review of the full mission diff (5950 lines), verdict BLOCK.
+This file records each finding and the Architect's ruling on how it is to be fixed. The
+Manager verifies each finding against the code first; a finding that turns out not to be
+real is documented here as rejected, with the evidence, instead of being "fixed".
+
+Conduct: every fix lands WITH its regression test in the same commit (a fix and its guard
+are one unit). Plain-English commit messages, no abbreviations, no attribution of any kind,
+ASCII only. No fallback programming: fail loudly, never silently degrade.
+
+Fix round outcome summary (Manager, 2026-07-24): all fourteen findings verified against the
+code; thirteen confirmed and fixed with regression tests, one commit per finding (F4/F5/F6
+land together as one coherent monitor reshape). One half of F1's ruling (the recommendation
+engine skipping provisional entries) was found already implemented and tested on the branch;
+the evidence is recorded under F1. F14 is satisfied by the tests the fixes added.
+
+## F1 (BLOCKER) Provisional repository rows still expose destructive actions
+
+Finding: warm-start (provisional) rows are dimmed but clickable; opening one attaches its
+cached path to the detail screen where stage, commit, discard and branch deletion are all
+reachable. Only the Worktrees panel guards provisional state.
+
+Ruling: a provisional entry must never open the detail screen. The row click is ignored
+while the entry is verifying (the row already carries the "verifying" chip that explains
+why). Additionally the recommendation engine must skip provisional entries entirely - a
+recommendation is an acting surface. Test: a provisional entry's row click does not open
+detail; recommendations over a provisional entry list are empty.
+
+Outcome: FIXED in commit 3b7bc63e. Verified: the row click and RepositoriesView.OpenDetail
+ignored Provisional. Fix: a still-verifying row never opens the detail screen (guarded at the
+row click AND at OpenDetail, so every route in is covered). Note: the second half of the
+ruling - the recommendation engine skipping provisional entries - was ALREADY implemented on
+the branch before this fix round (RecommendationEngine.Evaluate filters on !r.Provisional,
+guarded by the existing test ProvisionalEntries_NeverGenerateRecommendations); no change was
+needed there. Tests: ShouldOpenRow_ProvisionalRow_IsNotOpenable_VerifiedRowIs and
+OpenDetail_ProvisionalEntry_IsRefused_VerifiedEntryOpens.
+
+## F2 (BLOCKER) C2 can produce a false "origin gone" verdict
+
+Finding: both WorktreeInventoryService and GitBranchService treat any branch.<name>.merge
+value as proof an upstream existed, then test existence of origin/<local-name> - ignoring
+the configured remote and the configured upstream ref name. A branch tracking a different
+remote, or an upstream with a different name, can be falsely ruled origin-gone and safe.
+
+Ruling: C2 means "the CONFIGURED upstream ref no longer exists on the CONFIGURED remote".
+Read branch.<name>.remote and branch.<name>.merge; query that remote for that ref. If
+either config value is missing the branch is not eligible for C2 (unchanged). Fix both
+implementations. Regression tests: (a) upstream ref name differs from the local name and
+still exists on the remote - NOT safe; (b) configured upstream genuinely deleted - safe;
+(c) the existing never-pushed and squash-merge tests stay green.
+
+Outcome: FIXED in commit 6706845d. Verified: both implementations read branch.<name>.merge
+only as an existence gate, then queried ls-remote origin <local-name>. Fix: a shared
+ConfiguredUpstreamProbe reads branch.<name>.remote plus branch.<name>.merge and queries the
+configured remote for the configured ref; either value missing means C2 does not apply. Both
+new tests were proven to FAIL against the old code before the fix landed. Tests:
+Branch_TrackingDifferentlyNamedUpstream_ThatStillExists_IsNotSafe,
+Branch_WhoseConfiguredUpstreamWasDeleted_IsSafe,
+WorktreeBranch_TrackingASecondRemote_WhoseRefStillExists_IsNotSafe; the existing
+never-pushed and squash-merge tests stay green.
+
+## F3 (MAJOR) Branch force-delete has a time-of-check to time-of-use gap
+
+Finding: the verdict is computed, then "git branch -D" runs as a separate process; a
+concurrent commit can move the branch tip in between, and the force delete destroys it.
+
+Ruling: delete atomically against the verified tip: "git update-ref -d refs/heads/<name>
+<verified-sha>". Git refuses the delete if the ref no longer points at that sha - the
+race window closes. On success remove the branch.<name> config section as cleanup. On
+refusal, report "branch moved since it was verified - not deleted" and leave it. Test:
+delete with a stale expected sha is refused and the branch survives.
+
+Outcome: FIXED in commit 11c43c71. Verified: verdict and "git branch -D" were separate
+subprocess calls with nothing binding the verified tip to the delete. Fix: BranchInfo carries
+TipCommit; deletion runs "git update-ref -d refs/heads/<name> <verified-sha>", which git
+refuses when the ref moved; on success the branch.<name> config section is removed. Tests:
+Delete_WithAStaleVerifiedTip_IsRefused_AndTheBranchSurvives,
+Delete_SafeBranch_RemovesTheBranchConfigSection.
+
+## F4 (MAJOR) The reaper and the monitor can receive a linked-worktree path
+
+Finding: WorktreesView falls back from the resolved entry path to the raw session path,
+which may be a linked worktree; RecomputeOneAsync accepts a path whose .git is a FILE -
+which is exactly what a linked worktree has - and would store it as a repository entry.
+
+Ruling: canonicalize to the primary repository before acting or storing. Resolve
+"git rev-parse --git-common-dir" from the target path and derive the primary checkout;
+the reaper and RecomputeOneAsync both operate on the primary path only. A linked-worktree
+path passed to RecomputeOneAsync must result in the PRIMARY entry being recomputed, never
+a new entry keyed at the worktree path. Tests for both.
+
+Outcome: FIXED in commit 127d8875 (together with F5 and F6 - one monitor reshape). Verified:
+RunReapAsync fell back to the raw session path and RecomputeOneAsync accepted a .git-file
+path as an entry. Fix: RecomputeOneAsync canonicalizes a linked-worktree path to its primary
+checkout via git rev-parse --git-common-dir (failing loudly when it cannot); the reaper only
+ever runs against the resolved repository entry - the fallback to the session path is gone.
+Tests: RecomputeOne_LinkedWorktreePath_RecomputesThePrimaryEntry (real git),
+Reap_FromASessionSittingInAWorktree_TargetsThePrimaryRepositoryPath,
+Reap_WhenTheOwningEntryIsUnresolved_DoesNothing.
+
+## F5 (MAJOR) Every background compute is session-blind
+
+Finding: the app's background rescan (App.axaml.cs) and every watcher recompute pass no
+live sessions, so the in-use-by-session state is only ever present after a manual panel
+refresh; a watcher recompute actively ERASES it, and the erased result is pushed to the
+Gateway and can mark an occupied worktree safe to reap.
+
+Ruling: the monitor owns a LiveSessionsProvider (an async function returning the current
+live sessions). RescanAsync and RecomputeOneAsync call it on every compute; the per-call
+sessions parameter is removed so there is exactly one source. MainWindow wires the
+provider at startup (same source the panels use today). Test: a watcher-style recompute
+preserves the in-use classification supplied by the provider.
+
+Outcome: FIXED in commit 127d8875. Verified: the watcher and the background rescan passed no
+sessions, and each recompute overwrote the session-aware classification. Fix: the monitor
+owns LiveSessionsProvider and consults it on every compute; the per-call sessions parameters
+on RescanAsync and RecomputeOneAsync are removed; MainWindow wires the provider at startup
+(the same source the panels use). Test:
+RecomputeOne_ConsultsTheLiveSessionsProvider_PreservingInUse.
+
+## F6 (MAJOR) Full scans and single recomputes can overwrite each other
+
+Finding: RecomputeOneAsync is uncoordinated with a running scan; concurrent computes for
+the same repository publish in completion order, so an older result can land last.
+
+Ruling: single-flight per repository, and recomputes requested during a full scan are
+deferred until the scan completes (then run). The invariant under test: a recompute
+racing a scan can never leave the model holding the older of the two results.
+
+Outcome: FIXED in commit 127d8875. Verified: RecomputeOneAsync was uncoordinated with a
+running scan and with concurrent recomputes. Fix: computes are single-flight per repository
+(a per-repository semaphore serializes compute plus publish), and a recompute requested while
+a scan runs is deferred and drained after the scan completes. Both tests were proven to fail
+against a mutated monitor with the lock and the deferral disabled. Tests:
+RecomputeOne_DuringAScan_IsDeferred_AndRunsAfterTheScan,
+RecomputeOne_RacingRecomputes_NeverLeaveTheOlderResultLast.
+
+## F7 (MAJOR) Worktree size measurement is unbounded and non-cancellable
+
+Finding: MeasureWorktreeBytes walks every file with no cancellation; first discovery of
+many large worktrees can stall the scan pipeline with no way to supersede it.
+
+Ruling: thread the compute's CancellationToken into the measurement and honor it during
+enumeration. No file caps or byte budgets - a silently truncated size is a lie; cancel
+cleanly or measure fully.
+
+Outcome: FIXED in commit e80a7b3c. Verified: MeasureWorktreeBytes walked every file with no
+cancellation path. Fix: the compute's CancellationToken is threaded into the measurement and
+checked per file; cancellation propagates (GetStatusAsync no longer folds it into a failure
+status) and a partial measurement is never cached or returned. No caps or budgets, per the
+ruling. Tests: Measure_Cancelled_Throws_AndStoresNoPartialResult,
+Measure_Uncancelled_ReturnsTheFullSize_AndCachesIt.
+
+## F8 (MINOR) The size cache grows forever
+
+Finding: entries for reaped, moved or deleted worktrees are never evicted from the
+process-wide size cache.
+
+Ruling: after each completed scan, evict cache entries whose path was not among the
+worktrees seen by that scan.
+
+Outcome: FIXED in commit 3b395c8e. Verified: the static size cache had lookup and insert
+only. Fix: after each completed scan the monitor evicts cache entries whose path was not
+among the worktrees that scan saw. Test:
+CompletedScan_EvictsCachedSizes_ForWorktreesNoLongerPresent.
+
+## F9 (MAJOR) An old SignalR connection can retake ownership of the pushed store
+
+Finding: sequence rejection only applies to the SAME connection; a late push from a
+superseded connection is accepted because its id differs. Two live connections can
+alternate, each overwriting the other with staler data.
+
+Ruling: only the director's CURRENT connection may push. The Gateway already tracks the
+live connection per director for command routing; the hub checks the pushing connection
+against it and drops pushes from any other. Test: connection 1 pushes, connection 2 takes
+over, a late push from connection 1 is rejected.
+
+Outcome: FIXED in commit 31ab7f86. Verified: sequence rejection applied only to the same
+connection id, so a superseded connection's push was accepted as "new". Fix: the repository
+store now follows the session store's ownership discipline - the hub registers the current
+connection at Hello and unregisters it on disconnect, and ApplySnapshot drops any push that
+is not from the current connection. Tests: LatePush_FromASupersededConnection_IsRejected
+(conn1 -> conn2 -> late conn1), Push_WithoutARegisteredConnection_IsRejected,
+Unregister_OnlyClearsTheCurrentConnection.
+
+## F10 (MAJOR) Provisional status is erased from the fleet worktrees endpoint
+
+Finding: flattening drops the provisional flag; cached (unverified) worktrees are served
+as "safe-to-reap" facts, and the CLI counts their bytes as reclaimable.
+
+Ruling: fail closed in the fold (the Gateway owns the verdict; clients stay dumb). For a
+provisional repository: the flattened worktree state string is "verifying" (never
+"safe-to-reap"), FleetWorktreeDto carries Provisional, and the repository DTO's safe
+count folds to zero until verification completes. The CLI needs no new logic - it already
+keys off the folded state string. Tests at the mapper.
+
+Outcome: FIXED in commit 587e55d3. Verified: both flatten paths dropped the provisional flag
+and served cached worktrees as safe-to-reap. Fix: one shared fold (FleetWorktreeFold in the
+contracts assembly) used by BOTH the Gateway /worktrees endpoint and the Director's local
+relay serves a provisional repository's worktrees as "verifying" (never "safe-to-reap") and
+FleetWorktreeDto carries Provisional; the Director-side mapper folds the repository DTO's
+safe count to zero while provisional. The CLI keys off the folded state string and needed no
+change. Tests at the mapper:
+Map_ProvisionalRepository_FoldsSafeCountToZero_AndWorktreesToVerifying,
+Flatten_ProvisionalRepository_ServesVerifying_EvenWhenThePushedStateSaysSafe, plus the two
+verified-path counterparts.
+
+## F11 (MAJOR) Discard permanently destroys tracked work with one click
+
+Finding: "Discard changes" invokes the destructive write immediately - no confirmation,
+no statement of what is lost.
+
+Ruling: a plain-words confirmation before any discard: "This permanently deletes your
+changes in N files. There is no undo." with the file names visible, buttons "Delete
+changes" and "Keep changes". (This matches the owner's standing instruction that
+destructive actions get a recency display and a plain-English warning, not lawyer speak.)
+
+Outcome: FIXED in commit f35c21bc. Verified: DiscardButton_Click invoked the destructive
+write directly. Fix: discard first shows "This permanently deletes your changes in N files.
+There is no undo." with the file names visible and buttons "Delete changes" and "Keep
+changes"; only the explicit Delete runs the write, and the pending set is consumed so a
+stray second confirm is inert. Tests: DiscardWarning_StatesTheLossInPlainWords,
+Discard_ShowsTheConfirmation_AndKeepChangesRunsNoWrite,
+Discard_DeleteChanges_RunsTheWrite_ForExactlyTheNamedFiles.
+
+## F12 (MINOR) Rail navigation hides the detail screen without detaching it
+
+Finding: navigating via the left rail hides the detail page but leaves its monitor
+subscriptions live.
+
+Ruling: leaving the detail page through ANY path detaches its subscriptions.
+
+Outcome: FIXED in commit 7dee9aa7. Verified: only CloseDetail detached; ShowPage (the rail
+buttons) only hid the page. Fix: ShowPage detaches the detail page, so leaving it through
+ANY path releases its monitor subscriptions. Test:
+RailNavigation_AwayFromDetail_DetachesTheDetailPage.
+
+## F13 (MAJOR) Repository history conflates repositories that share a leaf name
+
+Finding: the history key is tenant|date|machine|name - two repositories with the same
+folder name on one machine overwrite each other's daily snapshots.
+
+Ruling: the key includes the repository PATH (tenant|date|machine|path, lowercased);
+the name stays for display. Records without a path are ignored on load (the file format
+is days old and unreleased - no migration). Test: same-name different-path repositories
+do not collide.
+
+Outcome: FIXED in commit 7b272aab. Verified: the key was tenant|date|machine|name. Fix: the
+key is tenant|date|machine|path (lowercased); the name stays for display; rows without a
+path are ignored on load and on observe (no migration - the format is days old and
+unreleased). Tests: SameLeafName_DifferentPaths_DoNotOverwriteEachOther,
+Load_IgnoresLegacyRowsWithoutAPath, PathlessPushedRow_IsIgnored_NotKeyed.
+
+## F14 (NOTE) Untested claims
+
+The inspector's list of untested claims is accepted. Each fix above lands with its
+regression test; the specific gaps called out (provisional action blocking, reaper path
+canonicalization, C2 upstream shapes, stale-connection rejection, history key collision)
+are exactly the tests the fixes must add.
+
+Outcome: SATISFIED by the tests added across F1-F13 (each fix landed with its regression
+test in the same commit). The specific gaps the inspector called out are covered:
+provisional action blocking (F1, F10), the reaper path from a linked-worktree session (F4),
+C2 upstream shapes (F2), watcher-style recomputes with the live-session provider (F5),
+watcher activity during a full scan (F6), navigation detach (F12), cancelled size walks and
+cache eviction (F7, F8), stale-connection rejection (F9), and the history key collision
+(F13).
+
+## Status
+
+- [x] Fixes implemented and committed per finding, with tests (F2 6706845d, F1 3b7bc63e,
+      F4/F5/F6 127d8875, F3 11c43c71, F7 e80a7b3c, F8 3b395c8e, F9 31ab7f86, F10 587e55d3,
+      F13 7b272aab, F11 f35c21bc, F12 7dee9aa7; F14 via the tests above)
+- [x] All three suites green (Core 3423 passed / 0 failed / 8 skipped; Avalonia 289 passed /
+      0 failed; Gateway full-suite result recorded in the Manager's report)
+- [ ] Second inspection pass over the fix diff
+- [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-2.md
+++ b/docs/MISSION-repositories-full-INSPECTION-2.md
@@ -1,0 +1,260 @@
+# Inspection round 2 - findings and Architect rulings
+
+Mission: repositories-full. Branch: mission/repositories-full (round-1 fixes through 53f4f97a).
+Inspector: the same independent reviewer, judging the round-1 fix diff. Verdict: BLOCK.
+Closed cleanly: F4, F8, F9, F10 (worktrees side), F11, F12. The rest carry residual gaps,
+one fix regressed, and three new findings arrived. Rulings below are binding; the Manager
+verifies each against the code first and records the outcome under each item.
+
+Conduct: unchanged from round 1 - fix and regression test are one commit, plain English,
+no attribution, ASCII only, no fallback programming.
+
+## R2-1 (from F3) REGRESSION: update-ref delete bypasses checked-out-branch protection
+
+Finding: "git update-ref -d refs/heads/x <sha>" binds the tip but does not reproduce
+"git branch -D"'s refusal to delete a branch that is checked out. A checkout into a linked
+worktree between verification and deletion leaves that worktree with a broken symbolic HEAD.
+Also: the branch config section can be removed AFTER another process recreated the branch.
+
+Ruling: keep the tip-bound atomic delete, add a compensating post-check. Immediately after
+a successful update-ref delete, list the worktrees; if any worktree HEAD symbolically
+referenced the deleted branch, RESTORE the ref at the verified sha (we hold the exact sha,
+so restoration is lossless) and report "branch is checked out in a worktree - restored, not
+deleted". Remove the config section only after confirming the ref is absent at that moment;
+the residual millisecond window there is accepted and documented (worst case: a just-
+recreated branch loses its tracking config - annoying, never destructive to commits).
+Test: delete a branch that a linked worktree has checked out; the branch must survive (or
+be restored) and the worktree HEAD must remain valid.
+
+Outcome: FIXED in commit e572d940. Verified: DeleteAtVerifiedTipAsync ran update-ref -d and
+then removed the config section unconditionally, with no post-delete worktree check (the git
+premise was probed first: after the delete, worktree list --porcelain still names the branch
+for the broken worktree, and recreating the ref at the held sha restores it losslessly). Fix:
+after a successful delete the worktrees are listed (the primary checkout included); any HEAD
+still referencing the branch triggers a lossless restore at the verified sha and the refusal
+"branch is checked out in a worktree - restored, not deleted"; a failed worktree listing also
+restores (fail closed); the config section is removed only after confirming the ref is absent
+at that moment, with the residual window documented in the method remarks. Test:
+Delete_BranchCheckedOutInAWorktreeAfterVerification_IsRestored_AndTheWorktreeHeadStaysValid -
+run against the unfixed code first and seen failing (the delete succeeded).
+
+## R2-2 (NEW, MAJOR) A cancelled scan can publish after a newer scan removed the repository
+
+Finding: RescanAsync awaits the compute, then publishes without re-checking cancellation;
+a superseded scan can republish a repository the newer scan just removed.
+
+Ruling: publishes are guarded by compute-start ordering (see R2-5) AND a cancelled scan
+never publishes: after the compute returns, re-check the token (and that this scan is still
+the owner) under the gate before writing to the model. Test: a scan cancelled after compute
+but before publish leaves the newer scan's model untouched.
+
+Outcome: FIXED in commit f7391c1d (on top of the R2-5 publish path, fc88f6e8). Verified:
+RescanAsync published after the compute with no token re-check - the next loop iteration's
+check was too late. Fix: the token AND scan ownership (the scan's cancellation source is
+still the monitor's current one) are re-checked under the gate at the publish itself and at
+the reconcile. Tests: Rescan_CancelledAfterComputeButBeforePublish_NeverPublishes (seen
+failing before the fix - the stamps alone cannot catch it because no newer compute ruled the
+key) and Rescan_Superseded_CannotRepublishARepositoryTheNewerScanRemoved (the inspector's
+scenario; already held via the R2-5 removal stamp, kept as the named guard).
+
+## R2-3 (NEW, MAJOR) /repositories is fail-open for old-Director provisional safe counts
+
+Finding: the zero-safe-count fold runs on the fixed Director's outgoing mapper only. A
+pre-fix Director pushes Provisional=true with WorktreesSafeToReap greater than zero, and
+the Gateway serves that through GET /repositories unchanged (only /worktrees got the
+serve-time fold).
+
+Ruling: the Gateway owns the verdict at SERVE time for both endpoints. GET /repositories
+applies the same fold before serving: a provisional repository's safe count serves as
+zero and its nested worktree states serve as "verifying". One shared fold, two call sites,
+covered by a test that feeds the old-Director shape (Provisional=true, stale safe count).
+
+Outcome: FIXED in commit 9c24bad8. Verified: GET /repositories served the pushed rows
+verbatim - only /worktrees had a serve-time fold. Fix: the contracts assembly carries the one
+repository-level fold (FleetWorktreeFold.FoldRepositoryForServe - provisional serves zero
+safe count and "verifying" worktrees, as a copy, never mutating the cached instance); the two
+call sites are the GET /repositories serve path and the Director's outgoing mapper, which now
+builds the raw DTO and applies the same shared fold instead of its inline copy. Tests:
+FoldRepositoryForServe_OldDirectorProvisionalShape_ServesZeroSafeCount_AndVerifyingWorktrees
+(feeds the exact old-Director shape: Provisional=true, safe count 2, states "safe-to-reap")
+and FoldRepositoryForServe_VerifiedRepository_PassesThroughUnchanged.
+
+## R2-4 (NEW, MAJOR) A repeated Hello on the same connection resets sequence protection
+
+Finding: RegisterConnection sets LastSequence = -1 unconditionally, so a second Hello on
+the SAME connection lets an older sequence replay.
+
+Ruling: reset the baseline only when the connection id actually changes; a repeat Hello
+from the current connection keeps the existing baseline. Test: push sequence 100, repeat
+Hello on the same connection, push sequence 50 - rejected.
+
+Outcome: FIXED in commit a7372d80. Verified: RegisterConnection set LastSequence = -1
+unconditionally. Fix: the baseline resets only when ownership changes to a different
+connection; a repeated Hello from the current connection is a logged no-op. Test:
+RepeatedHello_OnTheSameConnection_KeepsTheSequenceBaseline (the ruling's exact sequence:
+push 100, repeat Hello, push 50 rejected) - run against the unfixed code first and seen
+failing (sequence 50 was accepted).
+
+## R2-5 (from F6) Scan-boundary races are narrowed, not linearized
+
+Finding: the IsScanning check and the semaphore acquisition are not atomic, so an older
+compute can still publish over a newer one across the scan boundary in both directions;
+deferred recomputes discard the caller's token and swallow failures.
+
+Ruling: enforce "newest compute wins" at the PUBLISH, not the lock: every compute takes a
+monotonically increasing start stamp; the model records the stamp per key; a publish whose
+stamp is older than the recorded one is dropped. The per-repository semaphore stays (it
+is an efficiency device, not the correctness device). Deferred recomputes keep their own
+tokens; a deferred request whose token is cancelled is skipped; a deferred failure is
+logged as an ERROR, never silently absorbed into a success path. Tests: the two boundary
+orderings the inspector described both end with the newer result in the model.
+
+Outcome: FIXED in commit fc88f6e8. Verified: the IsScanning check and the semaphore
+acquisition were not atomic; the drain used the scan caller's token and caught every
+exception into an ordinary log line. Fix: every compute takes a monotonically increasing
+start stamp; both publish sites go through one guarded method (PublishIfNewestLocked) that
+drops a publish whose stamp is older than the key's recorded one; a removal (scan reconcile
+or a gone-path recompute) counts as a publish of "absent" and is stamped, so an older
+in-flight compute can never resurrect a removed repository. Deferred requests keep their
+requester's own token (skipped when cancelled, cancellation logged as such at drain), and a
+deferred failure is logged as an ERROR. Tests (both run against the unfixed code first and
+seen failing): RecomputeOne_StartedBeforeAScanThatRemovedTheRepository_CannotResurrectIt
+(boundary ordering 1 - the late publish resurrected the removed repository) and
+RecomputeOne_DeferredThenCancelledByItsRequester_IsSkippedAtDrain (deferral semantics - the
+drain ran the cancelled request under the scan's token).
+
+## R2-6 (from F1) The detail-screen guard fails open on an unknown entry
+
+Finding: OpenDetail refuses a KNOWN provisional entry but proceeds when FindForPath
+returns null - an unknown path reaches the destructive detail surface.
+
+Ruling: fail closed. OpenDetail requires a positively known, verified entry
+(non-null AND Provisional=false); anything else is refused. Test: unknown path is refused.
+
+Outcome: FIXED in commit 0e7c0768. Verified: OpenDetail refused only a known provisional
+entry and proceeded on null. Fix: only a positively known, verified entry (present in the
+model AND not provisional) opens the detail screen; null and provisional are both refused
+with the reason logged. Test: OpenDetail_UnknownPath_IsRefused_FailClosed - run against the
+unfixed code first and seen failing (the detail page opened for an unknown path).
+
+## R2-7 (from F2) Multi-valued merge configuration defeats the upstream probe
+
+Finding: git permits multiple branch.<name>.merge values; --get returns one, and the probe
+can rule "upstream gone" while another configured merge ref survives.
+
+Ruling: fail closed on ambiguity. Read with --get-all; more than one merge value means the
+branch is NOT eligible for the origin-gone signal (C2 simply does not apply, same as a
+missing value). Test: a branch with two merge values is never ruled safe via C2.
+
+Outcome: FIXED in commit 66c071c8. Verified: the probe used --get, which silently returns
+the LAST of multiple merge values (probed against real git first). Fix: the probe reads with
+--get-all and more than one merge value makes the branch ineligible for the origin-gone
+signal, exactly as if no upstream were configured; both callers (branch safety and the
+worktree inventory) share the probe. Test:
+Branch_WithTwoConfiguredMergeValues_IsNeverRuledSafeViaUpstreamGone (two merge refs, the one
+--get would select deleted, the other surviving) - run against the unfixed code first and
+seen failing with the exact false verdict ("Origin branch deleted after merge").
+
+## R2-8 (from F5) The live-sessions source is fail-open until wired
+
+Finding: LiveSessionsProvider is a nullable property; a scan or watcher recompute that
+runs before MainWindow assigns it silently publishes session-blind classifications.
+
+Ruling: scanning without a session source is a programming error and fails loudly:
+RescanAsync and RecomputeOneAsync throw InvalidOperationException when no provider is
+wired. The app wires the provider BEFORE it triggers the first background rescan (reorder
+startup). Tests construct monitors with an explicit stub provider. Test: an unwired
+monitor's scan throws.
+
+Outcome: FIXED in commit 0be45623. Verified: the provider was nullable with a fail-open read
+(provider is null -> compute with null sessions), and App.InitializeServices started the
+first rescan BEFORE MainWindow (which wires the provider in its constructor) existed. Fix:
+RescanAsync and RecomputeOneAsync throw InvalidOperationException while unwired, the
+mid-compute fetch throws instead of returning null, and the first rescan moved out of
+InitializeServices into ShowMainWindow immediately after the MainWindow constructor - the
+wire-before-scan ordering is structural. All monitor-constructing tests across the Core and
+Avalonia suites now wire an explicit stub provider. Test:
+Monitor_WithoutALiveSessionsProvider_RefusesToScanOrRecompute.
+
+## R2-9 (from F13) History key still conflates Directors; path normalization is thin
+
+Finding: the key omits DirectorId (two Directors on one machine name and path overwrite
+each other), and raw lowercasing plus untrimmed separators conflate or split paths.
+
+Ruling: the key includes DirectorId (tenant|date|machine|director|path); paths are
+trimmed of trailing separators before keying; lowercasing stays (a case-only collision on
+a case-sensitive filesystem merges two history rows - accepted and documented, never
+destructive). Test: same machine and path, two Director ids - two rows.
+
+Outcome: FIXED in commit bb27d762. Verified: the key was tenant|date|machine|path with raw
+untrimmed paths. Fix: the key is tenant|date|machine|director|path with trailing separators
+trimmed before lowercasing; rows without a Director id are ignored on load and on observe
+(the same no-migration rule as F13's pathless rows); the lowercase acceptance is documented
+at the key. Tests (all three run against the unfixed code first and seen failing):
+SameMachineAndPath_TwoDirectors_KeepSeparateRows, TrailingSeparator_DoesNotSplitTheRow,
+Load_IgnoresLegacyRowsWithoutADirectorId.
+
+## R2-10 (from F7) Residual: cancellation cannot interrupt a single blocked filesystem call
+
+Ruling: REJECTED as a further code change, with rationale recorded here: cancellation is
+now honored per enumerated file; the residual exposure is one blocked filesystem call
+inside Directory.EnumerateFiles, which no token can interrupt without imposing a timeout,
+and a timeout that silently truncates a size is the exact lie the no-fallback rule forbids.
+The compute runs on a background thread; a blocked walk delays freshness, never the UI.
+Documented as a known limitation in the measurement's remarks.
+
+Outcome: REJECTED per the ruling - no code change. The documented-limitation remark was
+added to MeasureWorktreeBytes in commit ba0d48b3.
+
+## R2-11 (MINOR) Per-repository semaphores are never reclaimed
+
+Ruling: evict semaphore entries alongside the size-cache eviction after a completed scan:
+remove entries whose key is no longer in the model and whose semaphore is currently
+un-held. The brief cross-over where a re-created key briefly holds two semaphores is
+accepted and documented (single-flight degrades to double-flight for one compute; the
+publish-stamp rule from R2-5 still guarantees the newest result wins).
+
+Outcome: FIXED in commit 98e73336. Verified: _repoLocks had lookup and insert only. Fix:
+after each completed scan, alongside the size-cache eviction, lock entries whose key left
+the model and whose semaphore is un-held are removed (a held semaphore has a compute in
+flight and is kept; evicted semaphores are not disposed because a stale reference may still
+be awaited); the crossover is documented in the code. The R2-5 publish-stamp map gets the
+same eviction so it cannot become the next process-lifetime leak (a removal stamp survives
+exactly one more completed scan - long enough to drop any late publish from a compute that
+started before the removal). Tests:
+CompletedScan_EvictsSemaphores_ForRepositoriesNoLongerPresent and
+CompletedScan_KeepsTheSemaphore_WhileAComputeStillHoldsIt.
+
+## R2-12 (from F14) Test gaps
+
+Ruling: every ruling above lands with its named regression test (that covers the
+inspector's items for the fixes themselves, including the old-Director /repositories
+compatibility shape). Of the remaining wish-list: a real-git watcher-during-scan test is
+IN scope (it exercises R2-5 end to end). The hub-level reconnect integration test, the
+mixed repository/session shared-sequence test, and the malformed-field CLI tests are
+recorded as honest gaps for the QA report rather than blockers - each guards a surface
+already covered by a unit-level test of the same rule.
+
+Outcome: SATISFIED. Every ruling above landed with its named regression test in the same
+commit (including the old-Director /repositories compatibility shape under R2-3). The
+in-scope real-git watcher-during-scan test landed in commit c256484e:
+Watcher_FiringDuringAScan_IsDeferred_AndTheNewestStateLandsAfterTheScan - a real
+FileSystemWatcher over a real .git directory fires on a real commit made while a scan is
+mid-flight; the recompute is proven deferred while IsScanning is true, and after the scan
+publishes its pre-commit result the drained recompute lands the post-commit head (ruling
+R2-5 end to end). HONEST GAPS for the QA report, per the ruling: the hub-level
+reconnect/disconnect integration test over real Hello/OnDisconnectedAsync ordering, the
+mixed repository/session shared-sequence test, and the malformed or missing-field
+command-line tests.
+
+## Status
+
+- [x] Fixes implemented and committed per ruling, with tests (R2-1 e572d940, R2-2 f7391c1d,
+      R2-3 9c24bad8, R2-4 a7372d80, R2-5 fc88f6e8, R2-6 0e7c0768, R2-7 66c071c8,
+      R2-8 0be45623, R2-9 bb27d762, R2-10 ba0d48b3 remark only, R2-11 98e73336,
+      R2-12 c256484e)
+- [x] Core + Avalonia + Gateway suites green (Core 3433 passed / 0 failed / 8 skipped;
+      Avalonia 290 passed / 0 failed; Gateway 3678 passed / 0 failed / 17 skipped, the skips
+      being the usual gated live-Postgres proofs)
+- [ ] Third inspection pass
+- [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-3.md
+++ b/docs/MISSION-repositories-full-INSPECTION-3.md
@@ -1,0 +1,170 @@
+# Inspection round 3 - findings and Architect rulings
+
+Mission: repositories-full. Branch: mission/repositories-full (round-2 fixes through c9b429a2,
+plus e3b9d01a - see R3-3). Inspector: the same independent reviewer, judging the round-2 fix
+diff. Verdict: BLOCK.
+
+CLOSED this round: R2-2 (cancelled-scan publish), R2-3 (/repositories serve fold), R2-4
+(repeated Hello), R2-6 (unknown-path fail closed), R2-7 (multi-valued merge), R2-9 (history
+identity), R2-10 (accepted limitation), R2-11 (semaphore eviction). Remaining: the branch-
+delete compensation, the monitor's stamp/lifecycle correctness, and test gaps. Rulings below
+are binding; the Manager verifies each first and records the outcome under each item.
+
+Conduct: unchanged - fix and regression test are one commit, plain English, no attribution,
+ASCII only, no fallback programming.
+
+## R3-1 (MAJOR) The branch restore can overwrite a concurrently recreated branch
+
+Finding: the compensation restore runs "git update-ref refs/heads/x <verifiedSha>" with no
+expected old value. If another process recreated the branch at a new commit between the
+delete and the restore, the restore silently rewinds that new branch to the old commit.
+
+Ruling: the restore is CREATE-ONLY: "git update-ref refs/heads/<name> <verifiedSha>
+<40 zeros>" - git refuses when the ref already exists. If the ref exists again, the
+concurrently recreated branch stands (the worktree HEAD is valid again by that very fact)
+and the outcome reports plainly that the branch was deleted and a new branch of the same
+name has since appeared. Test: recreate the branch at a different commit between delete
+and restore; the recreated tip must survive untouched.
+
+Outcome: FIXED in 44f6895d. Probed against real git 2.49 first: create-only on an absent
+ref succeeds; on an existing ref it exits 128 ("reference already exists") and leaves the
+tip untouched. Restore now passes the forty-zero expected old value; a refused create with
+the ref present reports the branch deleted and a same-named branch since appeared; with
+the ref absent it stays the loud restore-failure path. GitCommandRunner unsealed (virtual
+RunAsync) as the test seam. Test watched failing first: the recreated tip came back
+rewound to the verified sha.
+
+## R3-2 (MAJOR) Cancellation can bypass the post-delete compensation
+
+Finding: everything after the successful ref delete still runs on the caller's token;
+cancellation in that window skips the worktree check and the restore, leaving a checked-out
+worktree with a broken HEAD.
+
+Ruling: compensation is a non-cancellable phase. From the moment the delete succeeds, the
+worktree listing, the restore decision, and the config-section cleanup run with
+CancellationToken.None, structured so that every exit path (including exceptions from the
+listing itself, which already restore per the round-2 ruling) completes compensation before
+the method returns or throws. Test: cancel the token immediately after the delete succeeds;
+the branch must end either cleanly deleted (no worktree held it) or restored - never
+deleted-with-broken-worktree.
+
+Outcome: FIXED in 146fc55e. Every command after the successful delete (worktree listing,
+create-only restore, recreated-ref probe, ref-absence check, config cleanup) runs on
+CancellationToken.None; the caller's token governs only the delete. Two tests watched
+failing first (both threw OperationCanceledException out of the post-delete worktree
+listing): cancel-with-worktree now ends restored with a healthy worktree HEAD;
+cancel-without-worktree ends cleanly deleted with the branch config section removed.
+
+## R3-3 (MAJOR) Production startup faulted the first scan unwired - ALREADY FIXED, VERIFY
+
+Finding (inspector, and independently the live slot-5 Director): the provider was wired in
+MainWindow_Loaded, which fires after layout, while ShowMainWindow starts the first rescan
+synchronously - the scan lost the race, threw the refuse-to-scan error, and the failure
+died in the unobserved-task finalizer; the model stayed provisional forever.
+
+Status: the Architect already fixed this in commit e3b9d01a after the live Director exposed
+it (wiring moved into the MainWindow constructor, which ShowMainWindow runs to completion
+before triggering the scan; the fire-and-forget task now has an OnlyOnFaulted continuation
+that logs an ERROR immediately). Live proof recorded: before the fix, slot 5 served all 30
+repositories as "verifying" indefinitely with the exception in the log; after it, the live
+harness passes 8 of 8 with verified states. The Manager's job here: VERIFY e3b9d01a fully
+covers the finding (constructor ordering, observed task) and record the outcome; no code
+change unless verification fails. An application-level unit test would require constructing
+the full MainWindow in a headless harness; the live-Director proof stands in its place and
+is recorded as such (honest gap in the QA report).
+
+Outcome: VERIFIED against the working tree at e3b9d01a and after. Evidence: (1) the
+provider is wired in the MainWindow CONSTRUCTOR (MainWindow.axaml.cs, before
+BuildNativeMenu) - App.ShowMainWindow runs "new MainWindow()" to completion before it
+calls StartRepositoryRescan, so the ordering is structural; (2) StartRepositoryRescan
+observes the task with a ContinueWith(OnlyOnFaulted) that logs an ERROR immediately;
+(3) InitializeServices deliberately starts no scan (LoadCache only) and the watcher set
+installs only on ScanCompleted, which cannot fire before a scan; (4) no other scan or
+recompute trigger exists before window construction (the only other RecomputeOneAsync
+caller is the user-driven Worktrees view, post-UI). No code change needed.
+
+## R3-4 (MAJOR) Removal tombstones do not survive the computes they protect
+
+Finding: (a) the gone-path recompute stamps absence only when the model already holds the
+key - a first-time compute in flight can later publish a repository that a newer check saw
+vanish; (b) EvictStaleComputeState drops a removal stamp after one further scan even while
+the key's semaphore is held, which is proof a compute is still in flight.
+
+Ruling: absence is ALWAYS stamped, whether or not a model row exists; and eviction never
+removes stamp state for a key whose semaphore is currently held. Tests: the first-time-
+compute-races-gone case, and the compute-held-across-two-scans case, both ending with the
+repository absent.
+
+Outcome: FIXED in 4810f469. The gone path stamps absence unconditionally (row or no row),
+and the eviction sweep skips any stamp whose key's semaphore is currently held. Both
+interleaving tests watched failing first - each ended with the removed repository
+resurrected in the model before the fix, absent after.
+
+## R3-5 (MAJOR) Scan removals are ordered by reconciliation time, not observation time
+
+Finding: reconciliation takes a fresh stamp when it publishes absence, so an old scan's
+delayed reconciliation can outrank - and remove - a repository that a newer compute
+legitimately created and published after that scan enumerated.
+
+Ruling: a scan's removals publish with the SCAN'S OWN START stamp, captured when the scan
+began. Any compute that started after the scan therefore outranks the scan's removals and
+survives. (A repository that is genuinely gone will be removed by its own later gone-path
+recompute or the next scan.) Test: newer add during an older scan's tail survives the older
+scan's reconciliation.
+
+Outcome: FIXED in 6f68fde7. The scan captures its start stamp under the gate at the
+cancellation-source swap; reconciliation publishes every removal with that stamp and skips
+any key whose recorded publish stamp is newer (that publish came from a compute that began
+after the scan). Test watched failing first: a repository created and published while the
+older scan was still enumerating was removed by its reconciliation before the fix, and
+survives untouched after, while the scan's own results and genuine removals still land.
+
+## R3-6 (MAJOR) Scan lifecycle state is not owned by the active scan
+
+Finding: a superseded scan's finally clears IsScanning while its replacement is still
+scanning (letting watcher recomputes bypass deferral), and an externally cancelled scan
+returns without draining deferred requests, stranding them until some later scan completes.
+
+Ruling: lifecycle state belongs to the CURRENT scan only: IsScanning is cleared (and
+progress reset) only by the scan whose cancellation source is still the monitor's current
+one, checked under the gate. Deferred requests are drained on every scan exit path unless
+a newer scan has taken ownership - in which case that newer scan is responsible for the
+drain, and its completion path must provably reach them. Tests: superseded-scan-does-not-
+clear-IsScanning, and cancelled-scan-with-no-successor drains its deferred requests.
+
+Outcome: FIXED in 4b0da3c5. The scan's exit checks ownership under the gate against the
+monitor's current cancellation source; only the owning scan clears IsScanning, raises
+progress, and drains the deferred requests - in the finally, so every owning exit path
+(completed, cancelled, faulted) reaches the drain, and a superseded scan touches nothing.
+A non-completed scan still never raises ScanCompleted. Both tests watched failing first:
+the superseded scan cleared IsScanning for its live replacement (a watcher recompute then
+bypassed deferral), and the cancelled scan stranded its deferred recompute. The
+superseded-scan test also proves the NEWER scan's completion path reaches the requests
+deferred during the superseded interval.
+
+## R3-7 Test gaps from round 3
+
+Ruling: every ruling above lands with its regression test watched failing first. In
+addition: the old-Director /repositories compatibility test must exercise the ACTUAL
+endpoint (request in, folded JSON out), not the fold helper alone. Accepted as recorded
+gaps (QA report, not blockers): the application-level wiring test (live proof instead,
+R3-3), the hub-plus-HTTP tenant-isolation integration matrix, hub-level reconnect
+ordering, mixed shared-sequence, malformed-field CLI tests.
+
+Outcome: FIXED in e8c84af3. RepositoriesEndpointServeFoldTests hosts the production
+GatewayEndpoints.Map over HTTP with a real PushedRepositoryStore (registered connection,
+applied snapshot) and asserts on GET /repositories' served JSON: the pre-fix-Director
+shape folds to a zero safe count and "verifying" worktrees; a verified repository serves
+as pushed. Teeth proven by temporarily removing the endpoint's fold call - the
+old-Director assertion went red (stale safe count of two served) and green again with the
+fold restored. Every R3-1 through R3-6 test above was watched failing first. The listed
+accepted gaps stay recorded for the QA report, not fixed.
+
+## Status
+
+- [x] Fixes implemented and committed per ruling, with tests: R3-1 44f6895d, R3-2 146fc55e,
+      R3-3 VERIFIED (no change), R3-4 4810f469, R3-5 6f68fde7, R3-6 4b0da3c5, R3-7 e8c84af3
+- [x] Core + Avalonia + Gateway suites green: Core 3441 passed / 8 skipped / 0 failed,
+      Avalonia 290 passed / 0 failed, Gateway 3680 passed / 17 skipped / 0 failed
+- [ ] Fourth inspection pass
+- [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-4.md
+++ b/docs/MISSION-repositories-full-INSPECTION-4.md
@@ -1,0 +1,177 @@
+# Inspection round 4 - findings and Architect rulings
+
+Mission: repositories-full. Branch: mission/repositories-full (round-3 fixes through efdf9baf).
+Inspector: the same independent reviewer, judging the round-3 fix diff. Verdict: BLOCK.
+
+CLOSED this round: R3-1 (create-only restore), R3-3 (startup wiring), R3-4 (tombstone basics),
+and the endpoint-level compatibility test. Remaining: the delete's cancellation boundary and
+exception safety, and four precise monitor interleavings. Rulings below are binding; the
+Manager verifies each first and records the outcome under each item.
+
+Conduct: unchanged - fix and regression test are one commit, plain English, no attribution,
+ASCII only, no fallback programming.
+
+## R4-1 (MAJOR) The destructive act and its compensation must be one non-cancellable unit
+
+Finding: the caller's token is passed into the delete command's own process wait, so
+cancellation can land after git mutated the ref but before the successful result returns -
+and compensation then never runs. Separately, the post-delete commands are sequential
+awaits with no surrounding recovery structure: any exception inside compensation escapes
+and skips the restore and the config-absence check.
+
+Ruling: the caller's cancellation applies BEFORE the destructive act only. The token is
+checked immediately before the delete is issued; the delete command itself and everything
+after it run on CancellationToken.None. The whole post-delete phase is wrapped so that ANY
+exception inside compensation still attempts the create-only restore before the exception
+propagates (restore-on-the-way-out; the restore itself already cannot overwrite a
+recreated branch). Tests: cancellation raced into the delete's process wait never skips
+compensation; a worktree-listing exception still restores the ref.
+
+Outcome: FIXED in d0998b5e. Verified first: the caller's token was passed into the delete
+command and the runner's process wait, and no recovery structure wrapped the compensation.
+The token is now checked immediately before the delete; the delete command and every
+compensation command run on CancellationToken.None; the whole post-delete phase is wrapped
+so any exception inside compensation attempts the create-only restore on the way out, with
+the ORIGINAL exception always propagating (the restore attempt is logged, never allowed to
+replace it). Both tests watched failing first: cancellation raced into the delete's process
+wait escaped as OperationCanceledException with no compensation (new seam
+CancelDuringProcessWaitGitRunner runs the child's mutation to completion, then cancels,
+then surfaces the wait's cancellation - the window the plain InterleavingGitRunner cannot
+reach), and a thrown worktree listing left the ref deleted with a broken worktree HEAD.
+
+## R4-2 (MINOR) A failed ref probe is treated as confirmed absence during config cleanup
+
+Finding: any unsuccessful rev-parse - not only the missing-ref exit - is read as "the ref
+is absent", allowing cleanup of a live branch's tracking configuration on a transient
+failure.
+
+Ruling: discriminate the exit. "git rev-parse --verify --quiet" exits 1 for a missing ref;
+only that exact outcome permits the config cleanup. Any other failure skips cleanup (the
+stale section is inert; a wrong cleanup is not). Test: a probe failing with a non-missing
+exit leaves the config section alone.
+
+Outcome: FIXED in 69fae0a2. Verified first: any unsuccessful probe fell through to the
+cleanup. Only exit 1 now permits it; any other failure logs the probe's exit and leaves the
+section alone. Test watched failing first: a probe returning exit 128 (new seam
+CannedResultGitRunner) had the live branch's config section removed. The existing exit-1
+test still proves cleanup runs on the genuine missing-ref outcome - the other failure
+direction stays guarded.
+
+## R4-3 (MAJOR) Scan absence does not tombstone an unpublished in-flight compute
+
+Finding: compute-start stamps live in a local variable until publication, and
+reconciliation only visits model rows - a rowless compute older than the scan is invisible
+and can publish stale state after reconciliation.
+
+Ruling: in-flight computes are registered: every compute records its start stamp in a
+pending map (under the gate) when it begins and clears it when it publishes or abandons.
+Scan reconciliation writes its absence tombstone for every key the scan did not see that
+has EITHER a model row OR a pending compute. The older pending compute's publish is then
+outranked by the tombstone and dropped. Test: the inspector's exact interleaving - rowless
+compute starts, scan observes the path absent, compute publishes after reconciliation -
+ends with the repository absent.
+
+Outcome: FIXED in 5dcb2374. Verified first: stamps lived in a local variable until
+publication and reconciliation visited only model rows. Every compute (scan and single
+recompute) now registers its start stamp in a pending map in the same gated region that
+hands the stamp out, cleared on publish or abandon in the finally; reconciliation
+tombstones every unseen key with a row OR a pending compute; the stamp-eviction sweep also
+keeps any stamp whose key has a registered pending compute (direct in-flight proof across
+the documented single-flight semaphore crossover). Test watched failing first: the
+inspector's exact interleaving ended with the vanished repository resurrected.
+
+## R4-4 (MAJOR) Scan lifecycle: ownership is a stale snapshot and enumeration is unguarded
+
+Finding: (a) the owner check, the IsScanning clear, and the drain are not one atomic
+region - a replacement scan can take ownership between them, and because the new scan only
+sets IsScanning after enumeration, the old drain can run recomputes concurrently with the
+new scan; (b) ScanCompleted is raised later with no ownership re-check; (c) _enumerate
+runs before the try/finally, so an enumeration fault while superseded strands IsScanning
+and the deferred queue forever.
+
+Ruling: three structural changes. (1) A scan takes ownership, sets IsScanning=true, and
+captures its start stamp in ONE gated region at the very start, BEFORE enumeration; from
+that point everything runs inside try/finally, so an enumeration fault cleans up. (2) The
+finally's owner check, IsScanning clear, and completion decision happen under one gate
+acquisition; ScanCompleted and the completion log are raised only when that same gated
+decision said owner. (3) Drained deferred recomputes go through the normal deferral check
+themselves - if a newer scan has meanwhile started (IsScanning is true again), they
+re-defer to that scan instead of running concurrently with it. Tests: the old-drain-during-
+new-enumeration case ends with the recompute deferred, not concurrent; an enumeration
+fault in a superseded scan leaves IsScanning false and the deferred queue drained by
+SOMETHING (the thrower or the successor - prove which).
+
+Outcome: FIXED in 1a1d7325. Verified first: enumeration ran before the try/finally, the
+scanning flag was set only after enumeration, the exit's owner check and the drain were
+separate gate acquisitions, and ScanCompleted fired with no ownership recheck. All three
+structural changes landed: one gated region takes ownership + IsScanning + start stamp
+before enumeration with everything after it in try/finally; the exit's owner check, flag
+clear, and completion decision are one gate acquisition, with the completion log and
+ScanCompleted raised only per that decision; drained deferred recomputes go back through
+the deferral check and re-defer to a newer scan. A superseded scan also no longer clobbers
+its replacement's progress counters. Both tests watched failing first: the drained deferred
+recompute ran concurrently inside the replacement's enumeration, and the enumeration fault
+stranded IsScanning true with the deferred request never run. The fault test proves WHICH
+scan drains: the faulting successor, which owned the monitor at its exit. The round-3
+scan-start-stamp test reached its window through a recompute during enumeration - that
+route now correctly defers, so the test was reworked to the still-reachable window (a
+recompute parked on the single-flight semaphore before the scan started, stamped after);
+its assertions are unchanged.
+
+## R4-5 (MAJOR) Gone-path absence is stamped after its filesystem observation
+
+Finding: the gone path observes the filesystem first and takes its stamp later, inside the
+gate - a newer add can start, publish, and then be removed by the older observation, which
+received the higher stamp. Same observation-time principle as the scan fix, unapplied here.
+
+Ruling: the gone path takes its stamp BEFORE touching the filesystem. Under the gate it
+applies the removal only if no newer publish stamp exists for the key; a newer publish
+means the absence observation is stale, and the gone path yields (the newer state stands;
+if the repository is truly gone a later observation will remove it). Test: gone
+observation racing a newer add leaves the newly added repository in the model.
+
+Outcome: FIXED in 3e366acd. Verified first: the filesystem was observed before the gate
+and the stamp taken inside it afterward. The gone path now takes its observation stamp
+before touching the filesystem and, under the gate, applies the removal only when no newer
+publish stamp exists - otherwise it logs and yields. The filesystem observation moved
+behind a new injectable isRepository seam (constructor parameter, default unchanged) so the
+test can hold the observation open at its exact point in time. Test watched failing first
+against the seam-only intermediate stage with the ordering unfixed: the gone observation
+racing a newer add removed the newly added repository from the model.
+
+## R4-6 Test gaps for the above
+
+Ruling: each ruling lands with its regression test watched failing first, using seams that
+can actually reach the windows (the inspector noted the existing InterleavingGitRunner
+cannot cancel between the child's mutation and the wait's return - build the seam that
+can). Anything from the round-4 list not covered by these rulings stays recorded as an
+accepted gap in the QA report, not silently dropped.
+
+Outcome: DONE across d0998b5e, 69fae0a2, 5dcb2374, 1a1d7325, 3e366acd - every ruling's
+test was watched failing first (R4-5 against the seam-only intermediate stage, since its
+seam and fix live in the same file). The four surviving failure modes from the round-4
+review's test-gap list are each now covered: the cancellation window inside the delete's
+process wait (CancelDuringProcessWaitGitRunner), a thrown compensation command
+(ThrowingGitRunner), the ownership-snapshot/drain race (the drain-re-defers test reaches
+the replacement mid-enumeration), and the rowless older compute kept alive through
+reconciliation.
+
+Accepted gaps, recorded for the QA report and not silently dropped:
+- The residual millisecond window between the exit-1 absence probe and the config-section
+  removal (a just-recreated branch can lose its tracking config - annoying, never
+  destructive to commits). Accepted and documented in code since round 2; the inspector
+  noted R4-2 as distinct from this window, and the ruling left it standing.
+- Carried from round 3 (unchanged): the application-level startup-wiring test (live
+  Director proof stands in its place), the hub-plus-HTTP tenant-isolation integration
+  matrix, hub-level reconnect ordering, mixed shared-sequence, and malformed-field CLI
+  tests.
+
+## Status
+
+- [x] Fixes implemented and committed per ruling, with tests: R4-1 d0998b5e, R4-2 69fae0a2,
+      R4-3 5dcb2374, R4-4 1a1d7325, R4-5 3e366acd, R4-6 covered across those five plus the
+      accepted gaps recorded above
+- [x] Core + Avalonia + Gateway suites green: Core 3448 passed / 8 skipped / 0 failed,
+      Avalonia 290 passed / 0 failed, Gateway 3680 passed / 17 skipped / 0 failed
+- [ ] Fifth inspection pass
+- [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-5.md
+++ b/docs/MISSION-repositories-full-INSPECTION-5.md
@@ -1,0 +1,74 @@
+# Inspection round 5 - findings, rulings, and outcomes
+
+Mission: repositories-full. Branch: mission/repositories-full (round-4 fixes through ef85357f).
+Inspector: the same independent reviewer, judging the round-4 fix diff. Verdict: BLOCK.
+
+CLOSED this round: R4-2 (exact missing-ref cleanup), R4-3 (pending-compute registration),
+R4-4 (scan lifecycle - including confirmation that the reworked round-3 test was NOT
+weakened), R4-5 (gone-path observation stamping, with the injected repository predicate
+confirmed to preserve the prior semantics exactly). Remaining: three findings, all in the
+round-4 fix code itself. The fixes for these were made directly by the Architect (as with
+the startup-wiring fix in commit e3b9d01a) because each was a surgical change of a few
+lines; both carry regression tests watched failing first, and the round-6 inspection judges
+them like any other fix.
+
+## R5-1 (MAJOR) An exception from the destructive delete command bypasses restoration
+
+Finding: the delete await preceded the compensation try block. A process-layer or injected-
+runner exception thrown AFTER the child git process already deleted the ref escaped without
+any restore attempt.
+
+Ruling: the delete command itself moves inside the recovery boundary. The create-only
+restore is safe in both directions - if the delete never happened, the ref still exists and
+git refuses the create - so restore-on-the-way-out covers "threw before mutation" and
+"threw after mutation" without knowing which occurred. The pre-delete cancellation check
+stays OUTSIDE the boundary (a pre-delete cancellation mutated nothing and needs no restore
+attempt), and a REFUSED delete (git said the ref moved) keeps its existing return path.
+
+Outcome: FIXED in commit 804eb3ee. Regression test watched failing first
+(Delete_DeleteCommandThrowsAfterItsMutation_RestoresTheRefBeforeTheExceptionPropagates,
+with the new MutateThenThrowGitRunner seam that runs the mutation to completion and then
+throws): before the fix the branch stayed deleted with the worktree broken; after it, the
+ref is restored and the original exception still propagates.
+
+## R5-2 (MAJOR) Diagnostic logging can defeat restore-on-the-way-out
+
+Finding: FileLog.Write can throw during a concurrent logger shutdown (its queue refuses
+adds once stopped). The log line before the restore attempt could skip restoration; the log
+line before the rethrow could replace the original exception.
+
+Ruling: logging inside the destructive-recovery path - and only there - is best-effort by
+design: a SafeLog helper swallows logging failures, because in this one path the restore
+outranks the log. Everywhere else a logging failure still surfaces normally.
+
+Outcome: FIXED in commit 804eb3ee (same commit - same recovery path). Structural change
+with no direct unit test: forcing the global logger to throw mid-test would destabilize
+the parallel suite. Recorded as an accepted gap; the helper is three lines and the round-6
+inspection reviews it directly.
+
+## R5-3 (MINOR) A throwing progress subscriber skips the deferred-recompute drain
+
+Finding: the owning scan's exit raised ProgressChanged and then drained; a subscriber
+exception between the two stranded the deferred requests after IsScanning was already
+cleared.
+
+Ruling: the drain sits in a finally - it runs whatever the subscriber does, and the
+subscriber's exception still propagates loudly.
+
+Outcome: FIXED in commit e4fc3870. Regression test watched failing first
+(Rescan_ProgressSubscriberThrowsAtExit_StillDrainsTheDeferredRecomputes): before the fix
+the deferred recompute was stranded (one compute instead of two); after it, the drain runs
+and the exception escapes.
+
+## Suites after the round-5 fixes
+
+Core 3450 passed / 0 failed / 8 skipped (includes the two new regression tests).
+Avalonia 290 passed / 0 failed. Gateway rerun in progress at the time of writing; the
+round-5 fixes touch no Gateway code.
+
+## Status
+
+- [x] Fixes implemented and committed per ruling, with tests
+- [x] Core + Avalonia suites green (Gateway rerun for the record in progress)
+- [ ] Sixth inspection pass (in progress)
+- [ ] QA report to the owner

--- a/docs/MISSION-repositories-full-INSPECTION-6.md
+++ b/docs/MISSION-repositories-full-INSPECTION-6.md
@@ -1,0 +1,69 @@
+# Inspection rounds 6, 7, and 8 - findings, rulings, outcomes, and the PASS
+
+Mission: repositories-full. Branch: mission/repositories-full.
+Inspector: the same independent reviewer, one round per fix diff. These three rounds
+judged the tail of the loop - each one a diff of a few files - and ended in the mission's
+first PASS verdict. Fixes in these rounds were made directly by the Architect (surgical
+changes of a few lines each); every one carries a regression test watched failing first,
+except where the record below says a trigger is untestable and why.
+
+## Round 6 (BLOCK) - judging the round-5 fixes (804eb3ee, e4fc3870)
+
+All three round-5 fixes CLOSED. Two new findings:
+
+R6-1 (MAJOR): pulling the delete inside the recovery try also pulled the REFUSED-delete
+return in with it - a throwing log line on the refusal path would reroute into the restore
+attempt, and when the branch was already entirely gone, that restore would RECREATE a
+branch another process had legitimately deleted.
+Ruling: the refusal is reported OUTSIDE every recovery boundary. Two separate boundaries
+(delete command; compensation) with the refusal between them; the restore factored into
+one never-throwing helper used by both.
+Outcome: FIXED in 35f83481. The regression trigger (a log line throwing during logger
+shutdown) is untestable without destabilizing the global logger for the parallel suite;
+the restructure makes the reroute impossible by construction, and the new test
+Delete_RefusedBecauseTheBranchIsAlreadyGone_NeverRecreatesIt pins the reachable
+invariant.
+
+R6-2 (MINOR): with the drain awaited inside a finally, a drain failure silently replaced
+an in-flight progress-subscriber exception.
+Ruling: capture the subscriber exception, rethrow it with its type intact after the
+drain; when both throw, both surface together in one aggregate.
+Outcome: FIXED in 1fa7bb1e. The existing round-5 test still proves the subscriber
+exception propagates with its exact type.
+
+## Round 7 (BLOCK) - judging the round-6 fixes (35f83481, 1fa7bb1e)
+
+Both round-6 fixes CLOSED. One new finding:
+
+R7-1 (MAJOR): Exception.Message is virtual; the restore helper's diagnostic evaluated it
+BEFORE the restore attempt, so an exception with a throwing Message getter - surfaced by
+the process layer after the delete mutated the ref - skipped the restore entirely and
+replaced itself with the getter's exception.
+Ruling: the restore attempt comes first; every diagnostic is after the fact; message
+extraction goes through a guarded helper (falls back to the exception type name).
+Outcome: FIXED in 2a0f6188. Test watched failing first
+(Delete_ExceptionWithAThrowingMessageGetter_StillRestoresAndPropagatesTheOriginalType,
+with a ThrowingMessageException seam): before the fix the branch stayed deleted and the
+wrong exception type surfaced; after it the branch is restored and the original type
+propagates.
+
+## Round 8 - judging the round-7 fix (2a0f6188)
+
+R7-1 CLOSED: argument construction before the restore touches only existing strings and
+constants; both later message accesses are guarded; neither toxic getter can replace the
+original exception.
+
+One MINOR: the refused and failed restore log arms no longer named the initiating
+exception. Fixed as prescribed (SafeMessage(cause) appended after the restore attempt in
+both arms) - the change is entirely inside the after-the-fact logging, so no further
+inspection round was called for it.
+
+VERDICT: PASS - nothing above MINOR remains.
+
+## Where that leaves the loop
+
+Eight rounds total: 14 findings in round 1, narrowing every round, PASS in round 8.
+Every fix landed with a regression test watched failing first except the two recorded
+untestable triggers (logger-shutdown throw; both documented in the code). The accepted
+limitations and test gaps are recorded in rounds 2 through 5 and restated in the QA
+report.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -4,37 +4,46 @@ Branch: mission/repositories-full · Worktree: D:\ReposFred\devthrottle-repos-mi
 Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-23.md
 
 ## Done (committed on the branch)
-- (nothing yet)
+1. Phase A: model (worktree list+sizes+dirty-since+provisional), monitor enrich/recompute-one/
+   find-for-path, RepositoryWatcher (git-signal scoped, debounced), one-brain unify (session tab
+   reads monitor), verifying visual state. Commit "phase A".
+2. Phase B services + C2 DATA-LOSS FIX (origin-gone requires upstream; regression test): DiffParser,
+   GitDiffService, GitBranchService+BranchSafetyEvaluator, PullRequestService (gh/az parsers),
+   GitHistoryService. Commit "phase B services".
+3. Phase B UI + E: RepositoryDetailView (tabs: Changes diff viewer / Worktrees reuse / Branches /
+   Pull requests / History), ChangesDiffView, list click-through, HandToAgentDialog +
+   AgentBriefTemplates (hard rules + no-attribution), MainWindow spawn+stage-brief wiring.
+   Commit "phase B UI + phase E hand-off".
 
-## In progress
-- Step 1 (A-model): worktree list + sizes + dirty-since + provisional on the model.
+## In progress (built, tests running, NOT yet committed)
+4. Phase C: Gateway.Contracts RepoStatusDto/WorktreeDto/FleetWorktreeDto; RepositoryDtoMapper
+   (ControlApi, folds state strings); GatewayStreamClient repoSnapshot + PushRepoSnapshot (own
+   try/catch, old-Gateway safe); ControlApiHost monitor ctor param + WireRepositoryPush (3s
+   debounce) + SnapshotRepositories; GatewayClient ListFleetRepositories/WorktreesAsync;
+   ControlEndpoints /fleet/repositories + /fleet/worktrees (relay + standalone monitor fallback);
+   Gateway PushedRepositoryStore + DirectorHub.PushRepoSnapshot + GET /repositories + /worktrees
+   (tenant-scoped via ResolveReadTenant, streamStaleResolved); GatewayHost singletons + Map arg;
+   CLI repo_ops.py + cli.py repo/worktree list.
+   Gateway store tests written (PushedRepositoryStoreTests) - background run pending.
+5. Phase D (partial): RecommendationEngine (Core, pure, 6 tests green) + Recommendations rail page
+   in RepositoriesView (badge, cards, Show me -> detail, Hand to an agent).
+
+## Also built (with C, awaiting the same test runs)
+- App passes RepositoryMonitor into ControlApiHost (verified in source).
+- D persistence v1 FILE-BACKED (Architect deviation from #510's "real tables", documented in the
+  store remarks): Gateway RepoHistoryStore (JSONL at CcStorage.Root()/repo-history.jsonl), fed from
+  accepted PushRepoSnapshot only, provisional rows excluded; WeeklyTrends (per-week peaks) +
+  DirtyOverThreshold; GET /reports/repositories-weekly (tenant-scoped). Postgres = follow-up that
+  changes persistence, not shape. Tests written (RepoHistoryStoreTests).
+
+## Not built (honest gaps for the QA report)
+- Postgres persistence for the history (file-backed v1 instead - see above).
+- Worktree dwell-time events (appeared/reaped/reclaimed-bytes event log) - trends are snapshot-based.
+- Fleet-remote reap routing (out of scope per brief ruling; Gateway API is read-only).
+- Phase E scheduled cleanup agent (out of scope per brief ruling).
+- Weekly report HTML section (the endpoint serves JSON; the report renderer integration is follow-up).
 
 ## Next
-- Step 2 (A-unify), then per the brief's landing order.
-
-## Notes for a fresh seat
-- Owner approval required before ANY merge to origin/main. Commit/push to the branch freely.
-
-## C research (received, condensed - trust but verify line numbers)
-- Session push: GatewayStreamClient (ControlApi) dials Gateway SignalR hub /director-stream,
-  MessagePack. Sends: Hello, then InvokeAsync("PushSnapshot", seq, SessionDto[]) / "PushDelta" /
-  "RemoveSession"; one Interlocked _sequence shared by all sends. Snapshot func injected by
-  ControlApiHost.BuildStreamClient (~line 736); event wiring in WireDoorbellPush (~825); periodic
-  re-push timer already exists (reuse for repos).
-- Gateway receive: DirectorHub (Gateway/Streaming/DirectorHub.cs) methods Hello/PushSnapshot/
-  PushDelta/RemoveSession -> PushedSessionStore keyed Tenant -> directorId; tenant resolved from the
-  authenticated device key, NEVER the payload. Clone as PushedRepositoryStore + new hub methods
-  PushRepoSnapshot/RemoveRepo (never change existing signatures; old Gateway returns HubException
-  on unknown method - harmless, sends are try/caught).
-- GET /sessions shape to clone: GatewayEndpoints.Map (~753): ResolveReadTenant (403 unbound on
-  hosted), registry.ListDirectors(tenant) + ?machine= filter, pushedSessions.TryGetFresh per
-  Director, FleetRosterCache grace. Add GET /repositories + /worktrees the same way.
-- Local relay: ControlEndpoints /fleet/sessions (~376): gw.ListFleetSessionsAsync else standalone
-  fallback. Add /fleet/repositories + /fleet/worktrees; fallback reads RepositoryMonitor.Snapshot()
-  - pass the monitor into ControlApiHost ctor (App.axaml.cs ~521) and into ControlEndpoints.Map.
-- DTO casing: HTTP = camelCase web defaults; Python director.field() reads both. Stream = MessagePack
-  (member-based). RepositoryStatus lives in Core; mirror a contract DTO in Gateway.Contracts for the
-  push (SessionDto precedent).
-- Python CLI: tools/cc-devthrottle/src/cli.py typer app; session_app pattern (~42/76/486);
-  session_ops.list_sessions uses director.get_json("fleet/sessions"), rich Table box.ASCII, bare
-  print for --json. Add repo_ops/worktree_ops + repo_app/worktree_app identically.
+- Verify App passes monitor to ControlApiHost; run Gateway tests; commit C+D; full three suites;
+  slot-5 build + real-machine QA harness (repo list/worktree list CLI against live Director);
+  Codex inspection; QA report artifact; notify owner.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -70,12 +70,16 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
   stamp/lifecycle interleavings. Rulings: docs/MISSION-repositories-full-INSPECTION-3.md.
   All fixed/verified by Manager round 3, pushed through efdf9baf; suites green (Core 3441 /
   Avalonia 290 / Gateway 3680, 0 failed). Slot 5 rebuilt at efdf9baf; live harness 8/8.
-- Round 4 (BLOCK): create-only restore, startup wiring, tombstone basics CLOSED. Remaining:
-  the delete's cancellation boundary (token inside the delete's process wait can skip
-  compensation) + compensation not exception-safe; four monitor interleavings (rowless
-  in-flight computes invisible to reconciliation; stale ownership snapshot at drain;
-  enumeration outside try/finally; gone-path stamps at publication not observation time).
-  Rulings: docs/MISSION-repositories-full-INSPECTION-4.md. Manager round 4 seated.
+- Round 4 (BLOCK): create-only restore, startup wiring, tombstone basics CLOSED. Remaining
+  fixed by Manager round 4 through ef85357f (suites: Core 3448 / Avalonia 290 / Gateway 3680,
+  0 failed). Rulings + outcomes: docs/MISSION-repositories-full-INSPECTION-4.md.
+- Round 5 (BLOCK): four of five areas CLOSED. Three findings in the round-4 fix code (delete
+  command outside the recovery boundary; recovery-path logging able to defeat the restore;
+  throwing progress subscriber skips the drain) - fixed directly by the Architect in
+  804eb3ee + e4fc3870, tests watched failing first, Core 3450 / Avalonia 290 green.
+  Record: docs/MISSION-repositories-full-INSPECTION-5.md. Round-6 inspection in progress;
+  final Gateway suite rerun in progress; slot 5 live at ef85357f with harness 8/8 (needs one
+  final rebuild at the tip once round 6 passes).
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -58,7 +58,17 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
 - Round 2 (BLOCK): fixes re-inspected; 6 closed clean, 1 REGRESSION (update-ref delete bypasses
   checked-out protection), 3 new majors (cancelled-scan late publish; /repositories serve-time
   fold missing for old Directors; repeated Hello resets sequence), rest partial. Rulings:
-  docs/MISSION-repositories-full-INSPECTION-2.md. Manager round 2 seated and fixing.
+  docs/MISSION-repositories-full-INSPECTION-2.md. All fixed by Manager round 2, pushed through
+  c9b429a2; suites green (Core 3433 / Avalonia 290 / Gateway 3678, 0 failed).
+- LIVE CATCH between rounds: first live run of the round-2 build exposed the R2-8 wiring as
+  non-structural (provider wired in MainWindow_Loaded; ShowMainWindow's scan fires first,
+  throws, dies unobserved; model provisional forever). Architect fixed in e3b9d01a
+  (constructor wiring + observed task); slot 5 rebuilt; live harness 8/8 with verified states.
+  The round-3 inspection found the SAME defect independently - two mechanisms converged.
+- Round 3 (BLOCK): 8 of the round-2 items CLOSED. Remaining: branch-restore compensation
+  unsafe (create-only restore needed; cancellation can bypass compensation) and five monitor
+  stamp/lifecycle interleavings (tombstones, reconcile-time stamps, scan ownership, stranded
+  deferrals). Rulings: docs/MISSION-repositories-full-INSPECTION-3.md. Manager round 3 seated.
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -86,9 +86,15 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
   Avalonia 290 / Gateway 3680, 0 failed (7,422 passing). Slot 5 live at the tip, harness
   8 of 8. Inspection verdict: PASS (round 8). QA report published:
   https://claude.ai/code/artifact/89592685-99f5-459a-86b0-999bf536651d
-- WAITING ON THE OWNER: approval to merge. On approval, slice the branch into pull requests
-  in build order (model+monitor, git services, screens, Gateway push+endpoints,
-  history+recommendations, hand-off) and drive each to merged on origin/main.
+- APPROVED (2026-07-24): the owner approved the merge ("Approved, merge it all into origin
+  main"). Landing decision (Architect): ONE squash-merged pull request, not slices - every
+  intermediate state of the branch is known-defective (that is what the eight inspection
+  rounds proved and fixed), so only the PASS-verdict tip may exist on main; a squash lands
+  exactly that, and the whole diff was already line-level reviewed across the eight rounds
+  recorded in the INSPECTION documents. origin/main had moved 11 commits; merged in
+  (conflicts in MainWindow.axaml.cs and DirectorHub.cs, both additive, both kept both
+  sides), full solution rebuilt, all three suites rerun on the merged tree before the pull
+  request was opened. MISSION COMPLETE once the pull request is merged.
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -73,13 +73,17 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
 - Round 4 (BLOCK): create-only restore, startup wiring, tombstone basics CLOSED. Remaining
   fixed by Manager round 4 through ef85357f (suites: Core 3448 / Avalonia 290 / Gateway 3680,
   0 failed). Rulings + outcomes: docs/MISSION-repositories-full-INSPECTION-4.md.
-- Round 5 (BLOCK): four of five areas CLOSED. Three findings in the round-4 fix code (delete
-  command outside the recovery boundary; recovery-path logging able to defeat the restore;
-  throwing progress subscriber skips the drain) - fixed directly by the Architect in
-  804eb3ee + e4fc3870, tests watched failing first, Core 3450 / Avalonia 290 green.
-  Record: docs/MISSION-repositories-full-INSPECTION-5.md. Round-6 inspection in progress;
-  final Gateway suite rerun in progress; slot 5 live at ef85357f with harness 8/8 (needs one
-  final rebuild at the tip once round 6 passes).
+- Round 5 (BLOCK): four of five areas CLOSED; three findings fixed by the Architect in
+  804eb3ee + e4fc3870. Record: docs/MISSION-repositories-full-INSPECTION-5.md.
+- Rounds 6-8: round 6 BLOCK (refusal-path reroute R6-1 fixed 35f83481; drain exception
+  ordering R6-2 fixed 1fa7bb1e); round 7 BLOCK (throwing Message getter R7-1 fixed
+  2a0f6188); round 8 **PASS** - nothing above MINOR; the one MINOR (log the initiating
+  exception in the refused/failed restore arms) fixed as prescribed. Record:
+  docs/MISSION-repositories-full-INSPECTION-6.md. Core 3451 green post-round-6; branch
+  service class green post-round-7/8 changes; clean full Gateway rerun in progress (the
+  first attempt hung under machine contention and was killed - own test process).
+- Remaining: Gateway rerun green -> final slot-5 rebuild at tip + live harness -> QA report
+  artifact -> owner approval -> slice and land on origin/main.
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -1,0 +1,18 @@
+# Mission state - repositories-full
+
+Branch: mission/repositories-full · Worktree: D:\ReposFred\devthrottle-repos-mission
+Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-23.md
+
+## Done (committed on the branch)
+- (nothing yet)
+
+## In progress
+- Step 1 (A-model): worktree list + sizes + dirty-since + provisional on the model.
+
+## Next
+- Step 2 (A-unify), then per the brief's landing order.
+
+## Notes for a fresh seat
+- Phase C research (Gateway push path + CLI structure) was delegated; findings land in this file
+  under "C research" when received.
+- Owner approval required before ANY merge to origin/main. Commit/push to the branch freely.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -82,8 +82,13 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
   docs/MISSION-repositories-full-INSPECTION-6.md. Core 3451 green post-round-6; branch
   service class green post-round-7/8 changes; clean full Gateway rerun in progress (the
   first attempt hung under machine contention and was killed - own test process).
-- Remaining: Gateway rerun green -> final slot-5 rebuild at tip + live harness -> QA report
-  artifact -> owner approval -> slice and land on origin/main.
+- FINAL STATE (2026-07-24): all three suites green at the tip a89617f3 - Core 3452 /
+  Avalonia 290 / Gateway 3680, 0 failed (7,422 passing). Slot 5 live at the tip, harness
+  8 of 8. Inspection verdict: PASS (round 8). QA report published:
+  https://claude.ai/code/artifact/89592685-99f5-459a-86b0-999bf536651d
+- WAITING ON THE OWNER: approval to merge. On approval, slice the branch into pull requests
+  in build order (model+monitor, git services, screens, Gateway push+endpoints,
+  history+recommendations, hand-off) and drive each to merged on origin/main.
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -67,8 +67,15 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
   The round-3 inspection found the SAME defect independently - two mechanisms converged.
 - Round 3 (BLOCK): 8 of the round-2 items CLOSED. Remaining: branch-restore compensation
   unsafe (create-only restore needed; cancellation can bypass compensation) and five monitor
-  stamp/lifecycle interleavings (tombstones, reconcile-time stamps, scan ownership, stranded
-  deferrals). Rulings: docs/MISSION-repositories-full-INSPECTION-3.md. Manager round 3 seated.
+  stamp/lifecycle interleavings. Rulings: docs/MISSION-repositories-full-INSPECTION-3.md.
+  All fixed/verified by Manager round 3, pushed through efdf9baf; suites green (Core 3441 /
+  Avalonia 290 / Gateway 3680, 0 failed). Slot 5 rebuilt at efdf9baf; live harness 8/8.
+- Round 4 (BLOCK): create-only restore, startup wiring, tombstone basics CLOSED. Remaining:
+  the delete's cancellation boundary (token inside the delete's process wait can skip
+  compensation) + compensation not exception-safe; four monitor interleavings (rowless
+  in-flight computes invisible to reconciliation; stale ownership snapshot at drain;
+  enumeration outside try/finally; gone-path stamps at publication not observation time).
+  Rulings: docs/MISSION-repositories-full-INSPECTION-4.md. Manager round 4 seated.
 
 ## Next
 - Manager round 2 finishes R2-1..R2-12 and pushes.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -51,8 +51,17 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
 - Phase E scheduled cleanup agent (out of scope per brief ruling).
 - Weekly report HTML section (the endpoint serves JSON; the report renderer integration is follow-up).
 
+## Inspection loop
+- Round 1 (BLOCK): 14 findings; all fixed by Manager round 1, pushed through 53f4f97a; three
+  suites green (Core 3423 / Avalonia 289 / Gateway 3672, 0 failed). Slot 5 rebuilt on the fixed
+  branch; live harness 8/8 PASS (port 7880).
+- Round 2 (BLOCK): fixes re-inspected; 6 closed clean, 1 REGRESSION (update-ref delete bypasses
+  checked-out protection), 3 new majors (cancelled-scan late publish; /repositories serve-time
+  fold missing for old Directors; repeated Hello resets sequence), rest partial. Rulings:
+  docs/MISSION-repositories-full-INSPECTION-2.md. Manager round 2 seated and fixing.
+
 ## Next
-- Manager finishes inspection-round-1 fixes (F1-F14) and pushes.
-- Architect: final three-suite pass on the fixed branch; rebuild slot 5 and smoke the changed UI
-  (discard confirmation, provisional click block); second Codex inspection over the fix diff;
-  QA report artifact; notify owner; WAIT for approval before anything lands on origin/main.
+- Manager round 2 finishes R2-1..R2-12 and pushes.
+- Architect: three-suite verification; slot-5 rebuild + live harness re-run; THIRD inspection
+  pass over the round-2 diff; QA report artifact; notify owner; WAIT for approval before
+  anything lands on origin/main.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -15,7 +15,7 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
    AgentBriefTemplates (hard rules + no-attribution), MainWindow spawn+stage-brief wiring.
    Commit "phase B UI + phase E hand-off".
 
-## In progress (built, tests running, NOT yet committed)
+## Done (continued)
 4. Phase C: Gateway.Contracts RepoStatusDto/WorktreeDto/FleetWorktreeDto; RepositoryDtoMapper
    (ControlApi, folds state strings); GatewayStreamClient repoSnapshot + PushRepoSnapshot (own
    try/catch, old-Gateway safe); ControlApiHost monitor ctor param + WireRepositoryPush (3s
@@ -23,10 +23,18 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
    ControlEndpoints /fleet/repositories + /fleet/worktrees (relay + standalone monitor fallback);
    Gateway PushedRepositoryStore + DirectorHub.PushRepoSnapshot + GET /repositories + /worktrees
    (tenant-scoped via ResolveReadTenant, streamStaleResolved); GatewayHost singletons + Map arg;
-   CLI repo_ops.py + cli.py repo/worktree list.
-   Gateway store tests written (PushedRepositoryStoreTests) - background run pending.
+   CLI repo_ops.py + cli.py repo/worktree list. All committed through db9f65d9.
 5. Phase D (partial): RecommendationEngine (Core, pure, 6 tests green) + Recommendations rail page
    in RepositoriesView (badge, cards, Show me -> detail, Hand to an agent).
+6. Live QA loop against slot-5 Director (PID 78204, port 7880): all 8 harness checks PASS
+   (scratchpad qa-mission-live.txt). Three live defects found and fixed during that loop:
+   /fleet 502 on old Gateway (404 -> local fallback), SPA-fallback route-absent detection
+   (200 text/html), CLI stringified-value bug (typed _raw/_int reads).
+7. Full Gateway suite green: 3662 passed, 0 failed, 17 skipped.
+8. INSPECTION ROUND 1 (Codex, independent): verdict BLOCK - 2 blockers, 8 majors, 2 minors,
+   1 untested-claims note. Findings + Architect rulings: docs/MISSION-repositories-full-
+   INSPECTION-1.md. A Manager is fixing all findings per ruling, one commit per finding,
+   tests included, on this branch.
 
 ## Also built (with C, awaiting the same test runs)
 - App passes RepositoryMonitor into ControlApiHost (verified in source).
@@ -44,6 +52,7 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
 - Weekly report HTML section (the endpoint serves JSON; the report renderer integration is follow-up).
 
 ## Next
-- Verify App passes monitor to ControlApiHost; run Gateway tests; commit C+D; full three suites;
-  slot-5 build + real-machine QA harness (repo list/worktree list CLI against live Director);
-  Codex inspection; QA report artifact; notify owner.
+- Manager finishes inspection-round-1 fixes (F1-F14) and pushes.
+- Architect: final three-suite pass on the fixed branch; rebuild slot 5 and smoke the changed UI
+  (discard confirmation, provisional click block); second Codex inspection over the fix diff;
+  QA report artifact; notify owner; WAIT for approval before anything lands on origin/main.

--- a/docs/MISSION-repositories-full-STATE.md
+++ b/docs/MISSION-repositories-full-STATE.md
@@ -13,6 +13,28 @@ Spec: devthrottle_internal#510 · Brief: docs/MISSION-repositories-full-2026-07-
 - Step 2 (A-unify), then per the brief's landing order.
 
 ## Notes for a fresh seat
-- Phase C research (Gateway push path + CLI structure) was delegated; findings land in this file
-  under "C research" when received.
 - Owner approval required before ANY merge to origin/main. Commit/push to the branch freely.
+
+## C research (received, condensed - trust but verify line numbers)
+- Session push: GatewayStreamClient (ControlApi) dials Gateway SignalR hub /director-stream,
+  MessagePack. Sends: Hello, then InvokeAsync("PushSnapshot", seq, SessionDto[]) / "PushDelta" /
+  "RemoveSession"; one Interlocked _sequence shared by all sends. Snapshot func injected by
+  ControlApiHost.BuildStreamClient (~line 736); event wiring in WireDoorbellPush (~825); periodic
+  re-push timer already exists (reuse for repos).
+- Gateway receive: DirectorHub (Gateway/Streaming/DirectorHub.cs) methods Hello/PushSnapshot/
+  PushDelta/RemoveSession -> PushedSessionStore keyed Tenant -> directorId; tenant resolved from the
+  authenticated device key, NEVER the payload. Clone as PushedRepositoryStore + new hub methods
+  PushRepoSnapshot/RemoveRepo (never change existing signatures; old Gateway returns HubException
+  on unknown method - harmless, sends are try/caught).
+- GET /sessions shape to clone: GatewayEndpoints.Map (~753): ResolveReadTenant (403 unbound on
+  hosted), registry.ListDirectors(tenant) + ?machine= filter, pushedSessions.TryGetFresh per
+  Director, FleetRosterCache grace. Add GET /repositories + /worktrees the same way.
+- Local relay: ControlEndpoints /fleet/sessions (~376): gw.ListFleetSessionsAsync else standalone
+  fallback. Add /fleet/repositories + /fleet/worktrees; fallback reads RepositoryMonitor.Snapshot()
+  - pass the monitor into ControlApiHost ctor (App.axaml.cs ~521) and into ControlEndpoints.Map.
+- DTO casing: HTTP = camelCase web defaults; Python director.field() reads both. Stream = MessagePack
+  (member-based). RepositoryStatus lives in Core; mirror a contract DTO in Gateway.Contracts for the
+  push (SessionDto precedent).
+- Python CLI: tools/cc-devthrottle/src/cli.py typer app; session_app pattern (~42/76/486);
+  session_ops.list_sessions uses director.get_json("fleet/sessions"), rich Table box.ASCII, bare
+  print for --json. Add repo_ops/worktree_ops + repo_app/worktree_app identically.

--- a/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The one-brain rule (issue #510 phase A): the per-session Source Control Worktrees tab and the
+/// Repositories home render the SAME monitor model. These tests drive the per-session WorktreesView
+/// from a monitor and assert it shows the monitor's worktrees - including when the session sits in
+/// a WORKTREE of the repo rather than the repo itself - and that provisional entries cannot be acted on.
+/// </summary>
+public class OneBrainRegressionTests
+{
+    private static WorktreeInfo Wt(string branch, WorktreeSafety safety, WorktreeSafetyReason reason) => new()
+    {
+        Path = $"/repo/wt-{branch}",
+        Branch = branch,
+        Safety = safety,
+        Reason = reason,
+        Explanation = "x",
+        IsClean = true,
+    };
+
+    private static RepositoryMonitor MonitorWithRepo(string repoPath, params WorktreeInfo[] worktrees)
+        => new(
+            enumerate: _ => new[] { repoPath },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+            {
+                Path = p,
+                Name = "repo",
+                IsClean = true,
+                Worktrees = worktrees,
+                WorktreesSafeToReap = System.Linq.Enumerable.Count(worktrees, w => w.Safety == WorktreeSafety.SafeToReap),
+                WorktreeCount = worktrees.Length,
+                Success = true,
+            }));
+
+    [AvaloniaFact]
+    public async Task SessionTab_RendersTheMonitorsWorktrees_ForTheRepoPath()
+    {
+        var monitor = MonitorWithRepo("/repo",
+            Wt("done", WorktreeSafety.SafeToReap, WorktreeSafetyReason.OriginBranchGone),
+            Wt("busy", WorktreeSafety.NeedsAttention, WorktreeSafetyReason.NotProvenMerged));
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new WorktreesView();
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+        window.Show();
+        view.Attach(monitor, "/repo");
+        Dispatcher.UIThread.RunJobs();
+
+        // Same numbers the Repositories home computes from the same entry.
+        Assert.Equal(1, view.OrphanedCount);
+    }
+
+    [AvaloniaFact]
+    public async Task SessionTab_FindsTheRepo_WhenTheSessionSitsInAWorktree()
+    {
+        var wt = Wt("feature", WorktreeSafety.SafeToReap, WorktreeSafetyReason.ContainedInMain);
+        var monitor = MonitorWithRepo("/repo", wt);
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new WorktreesView();
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+        window.Show();
+        view.Attach(monitor, wt.Path); // the session lives IN the worktree
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, view.OrphanedCount); // resolved to the owning repository's entry
+    }
+
+    [AvaloniaFact]
+    public async Task SessionTab_UpdatesLive_WhenTheMonitorRecomputes()
+    {
+        // A real folder with a .git marker so RecomputeOneAsync takes the recompute path, not the
+        // it-is-gone removal path.
+        var repoDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-onebrain-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(System.IO.Path.Combine(repoDir, ".git"));
+        try
+        {
+            var worktrees = new List<WorktreeInfo> { Wt("done", WorktreeSafety.SafeToReap, WorktreeSafetyReason.OriginBranchGone) };
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { repoDir },
+                compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+                {
+                    Path = p, Name = "repo", IsClean = true,
+                    Worktrees = worktrees.ToArray(),
+                    WorktreesSafeToReap = System.Linq.Enumerable.Count(worktrees, w => w.Safety == WorktreeSafety.SafeToReap),
+                    WorktreeCount = worktrees.Count,
+                    Success = true,
+                }));
+            await monitor.RescanAsync(new[] { "/roots" });
+
+            var view = new WorktreesView();
+            var window = new Window { Content = view, Width = 800, Height = 600 };
+            window.Show();
+            view.Attach(monitor, repoDir);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(1, view.OrphanedCount);
+
+            // The worktree gets reaped elsewhere; the monitor recomputes; the tab follows - no rescan here.
+            worktrees.Clear();
+            await monitor.RecomputeOneAsync(repoDir);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, view.OrphanedCount);
+        }
+        finally
+        {
+            try { System.IO.Directory.Delete(repoDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
@@ -28,6 +28,10 @@ public class OneBrainRegressionTests
         IsClean = true,
     };
 
+    /// <summary>An explicit empty-session source: the monitor refuses to scan unwired (R2-8).</summary>
+    internal static Func<System.Threading.CancellationToken, Task<IReadOnlyList<LiveSessionRef>>> NoSessions
+        => _ => Task.FromResult<IReadOnlyList<LiveSessionRef>>(Array.Empty<LiveSessionRef>());
+
     private static RepositoryMonitor MonitorWithRepo(string repoPath, params WorktreeInfo[] worktrees)
         => new(
             enumerate: _ => new[] { repoPath },
@@ -40,7 +44,7 @@ public class OneBrainRegressionTests
                 WorktreesSafeToReap = System.Linq.Enumerable.Count(worktrees, w => w.Safety == WorktreeSafety.SafeToReap),
                 WorktreeCount = worktrees.Length,
                 Success = true,
-            }));
+            })) { LiveSessionsProvider = NoSessions };
 
     [AvaloniaFact]
     public async Task SessionTab_RendersTheMonitorsWorktrees_ForTheRepoPath()
@@ -151,7 +155,7 @@ public class OneBrainRegressionTests
                     WorktreesSafeToReap = System.Linq.Enumerable.Count(worktrees, w => w.Safety == WorktreeSafety.SafeToReap),
                     WorktreeCount = worktrees.Count,
                     Success = true,
-                }));
+                })) { LiveSessionsProvider = NoSessions };
             await monitor.RescanAsync(new[] { "/roots" });
 
             var view = new WorktreesView();

--- a/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
+++ b/src/CcDirector.Avalonia.Tests/OneBrainRegressionTests.cs
@@ -76,6 +76,62 @@ public class OneBrainRegressionTests
         Assert.Equal(1, view.OrphanedCount); // resolved to the owning repository's entry
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F4): the reaper must target the repository ENTRY path,
+    // never the session's own folder (which can be a linked worktree of that repository).
+    // ---------------------------------------------------------------------------------------
+    [AvaloniaFact]
+    public async Task Reap_FromASessionSittingInAWorktree_TargetsThePrimaryRepositoryPath()
+    {
+        var wt = Wt("feature", WorktreeSafety.SafeToReap, WorktreeSafetyReason.ContainedInMain);
+        var monitor = MonitorWithRepo("/repo", wt);
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new WorktreesView();
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+        window.Show();
+        view.Attach(monitor, wt.Path); // the session lives IN the worktree
+        Dispatcher.UIThread.RunJobs();
+
+        string? reapedPath = null;
+        view.ReapServiceOverride = (path, _) =>
+        {
+            reapedPath = path;
+            return Task.FromResult(new ReapResult { Success = true });
+        };
+        await view.RunReapAsync();
+
+        Assert.Equal("/repo", reapedPath); // the entry path - NOT the worktree the session sits in
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F4): while the owning entry is unresolved there is nothing
+    // safe to reap - the old fallback to the raw session path could hand the reaper a linked
+    // worktree.
+    // ---------------------------------------------------------------------------------------
+    [AvaloniaFact]
+    public async Task Reap_WhenTheOwningEntryIsUnresolved_DoesNothing()
+    {
+        var monitor = MonitorWithRepo("/repo");
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new WorktreesView();
+        var window = new Window { Content = view, Width = 800, Height = 600 };
+        window.Show();
+        view.Attach(monitor, "/somewhere/unrelated"); // no entry resolves for this path
+        Dispatcher.UIThread.RunJobs();
+
+        string? reapedPath = null;
+        view.ReapServiceOverride = (path, _) =>
+        {
+            reapedPath = path;
+            return Task.FromResult(new ReapResult { Success = true });
+        };
+        await view.RunReapAsync();
+
+        Assert.Null(reapedPath); // the reaper was never invoked
+    }
+
     [AvaloniaFact]
     public async Task SessionTab_UpdatesLive_WhenTheMonitorRecomputes()
     {

--- a/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
@@ -13,6 +13,44 @@ namespace CcDirector.Avalonia.Tests;
 
 public class RepositoriesViewRenderTests
 {
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F1): a provisional (warm-start, still verifying) entry
+    // must never open the detail screen - detail exposes stage, commit, discard, and branch
+    // delete against a cached path that has not been re-verified. A verified entry opens fine.
+    // ---------------------------------------------------------------------------------------
+    [AvaloniaFact]
+    public async Task OpenDetail_ProvisionalEntry_IsRefused_VerifiedEntryOpens()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), "ccd-provcache-" + Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(cachePath, System.Text.Json.JsonSerializer.Serialize(new[]
+        {
+            new RepositoryStatus { Path = "/repo/cached", Name = "cached", Success = true },
+        }));
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/repo/cached" },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "cached", Success = true }),
+            cachePath: cachePath);
+        monitor.LoadCache(); // entry is now provisional - no scan has re-verified it
+
+        var store = new RootDirectoryStore(
+            Path.Combine(Path.GetTempPath(), "ccd-provroots-" + Guid.NewGuid().ToString("N") + ".json"));
+        var view = new RepositoriesView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach(monitor, store, () => { });
+        Dispatcher.UIThread.RunJobs();
+
+        view.OpenDetail("/repo/cached");
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(view.DetailPage.IsVisible); // refused while verifying
+
+        // After the scan re-verifies the entry, the same open succeeds.
+        await monitor.RescanAsync(new[] { "/roots" });
+        view.OpenDetail("/repo/cached");
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(view.DetailPage.IsVisible);
+    }
+
     [AvaloniaFact]
     public void RepositoriesView_LoadsAndAttachesToMonitorAndRoots()
     {

--- a/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
@@ -52,6 +52,35 @@ public class RepositoriesViewRenderTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-6): the detail-screen guard fails CLOSED. An
+    // UNKNOWN path (FindForPath returns null - a stale recommendation, a queued navigation
+    // after the monitor removed the entry) must be refused exactly like a provisional one:
+    // only a positively known, verified entry may reach the destructive detail surface.
+    // ---------------------------------------------------------------------------------------
+    [AvaloniaFact]
+    public async Task OpenDetail_UnknownPath_IsRefused_FailClosed()
+    {
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/repo/known" },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "known", Success = true }));
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var store = new RootDirectoryStore(
+            Path.Combine(Path.GetTempPath(), "ccd-unknownroots-" + Guid.NewGuid().ToString("N") + ".json"));
+        var view = new RepositoriesView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach(monitor, store, () => { });
+        Dispatcher.UIThread.RunJobs();
+
+        view.OpenDetail("/repo/not-in-the-model"); // the monitor knows nothing about this path
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(view.DetailPage.IsVisible); // refused - unknown is not verified
+        Assert.False(view.DetailPage.IsAttached);
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection finding F12): leaving the detail page through ANY path - the rail
     // buttons included - releases its monitor subscriptions, not just the back button.
     // ---------------------------------------------------------------------------------------

--- a/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
@@ -29,7 +29,7 @@ public class RepositoriesViewRenderTests
         var monitor = new RepositoryMonitor(
             enumerate: _ => new[] { "/repo/cached" },
             compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "cached", Success = true }),
-            cachePath: cachePath);
+            cachePath: cachePath) { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
         monitor.LoadCache(); // entry is now provisional - no scan has re-verified it
 
         var store = new RootDirectoryStore(
@@ -62,7 +62,8 @@ public class RepositoriesViewRenderTests
     {
         var monitor = new RepositoryMonitor(
             enumerate: _ => new[] { "/repo/known" },
-            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "known", Success = true }));
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "known", Success = true }))
+        { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
         await monitor.RescanAsync(new[] { "/roots" });
 
         var store = new RootDirectoryStore(
@@ -89,7 +90,8 @@ public class RepositoriesViewRenderTests
     {
         var monitor = new RepositoryMonitor(
             enumerate: _ => new[] { "/repo" },
-            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "repo", IsClean = true, Success = true }));
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "repo", IsClean = true, Success = true }))
+        { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
         await monitor.RescanAsync(new[] { "/roots" });
 
         var store = new RootDirectoryStore(
@@ -117,7 +119,8 @@ public class RepositoriesViewRenderTests
     {
         var monitor = new RepositoryMonitor(
             enumerate: _ => Array.Empty<string>(),
-            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = p, Success = true }));
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = p, Success = true }))
+        { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
         var store = new RootDirectoryStore(
             Path.Combine(Path.GetTempPath(), "ccd-reposview-" + Guid.NewGuid().ToString("N") + ".json"));
 

--- a/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoriesViewRenderTests.cs
@@ -51,6 +51,38 @@ public class RepositoriesViewRenderTests
         Assert.True(view.DetailPage.IsVisible);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F12): leaving the detail page through ANY path - the rail
+    // buttons included - releases its monitor subscriptions, not just the back button.
+    // ---------------------------------------------------------------------------------------
+    [AvaloniaFact]
+    public async Task RailNavigation_AwayFromDetail_DetachesTheDetailPage()
+    {
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/repo" },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = "repo", IsClean = true, Success = true }));
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var store = new RootDirectoryStore(
+            Path.Combine(Path.GetTempPath(), "ccd-railroots-" + Guid.NewGuid().ToString("N") + ".json"));
+        var view = new RepositoriesView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach(monitor, store, () => { });
+        Dispatcher.UIThread.RunJobs();
+
+        view.OpenDetail("/repo");
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(view.DetailPage.IsVisible);
+        Assert.True(view.DetailPage.IsAttached);
+
+        view.ShowPage("repos"); // what the rail's Repositories button invokes
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(view.DetailPage.IsVisible);
+        Assert.False(view.DetailPage.IsAttached); // hidden AND detached - no live subscriptions remain
+    }
+
     [AvaloniaFact]
     public void RepositoriesView_LoadsAndAttachesToMonitorAndRoots()
     {

--- a/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
@@ -196,7 +196,7 @@ public class RepositoryDetailRenderTests
             {
                 Path = p, Name = "widget", Branch = "main", IsClean = true,
                 RemoteUrl = "https://github.com/acme/widget.git", Success = true,
-            }));
+            })) { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
         await monitor.RescanAsync(new[] { "/roots" });
 
         var view = new RepositoryDetailView();

--- a/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+public class RepositoryDetailPureTests
+{
+    [Fact]
+    public void HeaderStats_ComposesTheStoryLine()
+    {
+        var s = new RepositoryStatus
+        {
+            Branch = "main",
+            IsClean = false,
+            UncommittedCount = 13,
+            DirtySinceUtc = DateTime.UtcNow.AddDays(-3),
+            AheadCount = 0,
+            BehindCount = 142,
+            WorktreeCount = 6,
+            WorktreeBytes = 5_400_000_000,
+            Success = true,
+        };
+        var line = RepositoryDetailView.HeaderStats(s);
+        Assert.Contains("branch main", line);
+        Assert.Contains("13 uncommitted for 3 day(s)", line);
+        Assert.Contains("behind 142", line);
+        Assert.Contains("6 worktree(s), 5.0 GB", line);
+    }
+
+    [Theory]
+    [InlineData(0, "0 KB")]
+    [InlineData(512, "1 KB")]
+    [InlineData(1_500_000, "1 MB")]
+    [InlineData(1_200_000_000, "1.1 GB")]
+    public void FormatBytes_HumanReadable(long bytes, string expected)
+        => Assert.Equal(expected, RepositoryDetailView.FormatBytes(bytes));
+
+    [Fact]
+    public void ToBranchRow_SafeBranch_Deletable_CurrentIsNot()
+    {
+        var safe = RepositoryDetailView.ToBranchRow(new BranchInfo
+        {
+            Name = "done", SafeToDelete = true, Explanation = "Pull request merged.",
+        });
+        Assert.True(safe.CanDelete);
+        Assert.Equal("safe to delete", safe.Chip);
+
+        var current = RepositoryDetailView.ToBranchRow(new BranchInfo
+        {
+            Name = "main", IsCurrent = true, SafeToDelete = false, Explanation = "The branch you are on - switch away before deleting.",
+        });
+        Assert.False(current.CanDelete);
+        Assert.Equal("current", current.Chip);
+        Assert.True(current.IsCurrent);
+    }
+
+    [Fact]
+    public void ToPullRequestRow_MapsChecksAndReview()
+    {
+        var row = RepositoryDetailView.ToPullRequestRow(new PullRequestInfo
+        {
+            Number = 42, Title = "The fix", Author = "soren", Branch = "fix/it",
+            Checks = ChecksState.Failing, ReviewState = "changes requested",
+            Url = "https://example/pr/42", CreatedUtc = new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc),
+        });
+        Assert.Equal("X", row.ChecksGlyph);
+        Assert.Contains("#42", row.Meta);
+        Assert.Contains("fix/it", row.Meta);
+        Assert.Equal("changes requested", row.Chip);
+        Assert.True(row.HasChip);
+    }
+
+    [Fact]
+    public void BuildRows_DiffRendering_MapsKindsAndBinary()
+    {
+        var rows = ChangesDiffView.BuildRows(new[]
+        {
+            new FileDiff
+            {
+                NewPath = "a.cs",
+                Hunks = new[]
+                {
+                    new DiffHunk
+                    {
+                        Header = "@@ -1,2 +1,2 @@",
+                        Lines = new[]
+                        {
+                            new DiffLine { Kind = DiffLineKind.Context, Text = "keep", OldNumber = 1, NewNumber = 1 },
+                            new DiffLine { Kind = DiffLineKind.Removed, Text = "old", OldNumber = 2 },
+                            new DiffLine { Kind = DiffLineKind.Added, Text = "new", NewNumber = 2 },
+                        },
+                    },
+                },
+            },
+            new FileDiff { NewPath = "logo.png", IsBinary = true },
+        });
+
+        Assert.Equal(5, rows.Count); // hunk header + 3 lines + binary notice - and nothing invented
+        Assert.Equal("@@ -1,2 +1,2 @@", rows[0].Text);
+        Assert.Equal("keep", rows[1].Text);
+        Assert.Equal("2", rows[2].OldNo);
+        Assert.Equal("", rows[2].NewNo);
+        Assert.Equal("", rows[3].OldNo);
+        Assert.Equal("2", rows[3].NewNo);
+        Assert.Contains("binary", rows[4].Text);
+    }
+}
+
+public class RepositoryDetailRenderTests
+{
+    [AvaloniaFact]
+    public async Task DetailView_AttachesAndRendersHeader_FromMonitor()
+    {
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/repo" },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+            {
+                Path = p, Name = "widget", Branch = "main", IsClean = true,
+                RemoteUrl = "https://github.com/acme/widget.git", Success = true,
+            }));
+        await monitor.RescanAsync(new[] { "/roots" });
+
+        var view = new RepositoryDetailView();
+        var window = new Window { Content = view, Width = 900, Height = 620 };
+        window.Show();
+        view.Attach(monitor, "/repo");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(view);
+    }
+
+    [AvaloniaFact]
+    public void HandToAgentDialog_Constructs_AndBuildsABrief()
+    {
+        var repo = new RepositoryStatus
+        {
+            Path = "/repo", Name = "widget", Branch = "main",
+            IsClean = false, UncommittedCount = 7, Success = true,
+        };
+        var dialog = new global::CcDirector.Avalonia.HandToAgentDialog(repo);
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(dialog);
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryDetailViewTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -109,6 +110,78 @@ public class RepositoryDetailPureTests
         Assert.Equal("", rows[3].OldNo);
         Assert.Equal("2", rows[3].NewNo);
         Assert.Contains("binary", rows[4].Text);
+    }
+}
+
+/// <summary>
+/// REGRESSION (inspection finding F11): discard never destroys tracked work on one click - a
+/// plain-words confirmation stating exactly what is lost stands between the button and the write.
+/// </summary>
+public class DiscardConfirmationTests
+{
+    [Fact]
+    public void DiscardWarning_StatesTheLossInPlainWords()
+    {
+        Assert.Equal("This permanently deletes your changes in 1 file. There is no undo.",
+            ChangesDiffView.DiscardWarning(1));
+        Assert.Equal("This permanently deletes your changes in 3 files. There is no undo.",
+            ChangesDiffView.DiscardWarning(3));
+    }
+
+    [AvaloniaFact]
+    public void Discard_ShowsTheConfirmation_AndKeepChangesRunsNoWrite()
+    {
+        var view = new ChangesDiffView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach("/repo");
+
+        bool discardRan = false;
+        view.DiscardServiceOverride = (_, _) =>
+        {
+            discardRan = true;
+            return Task.FromResult(new GitWriteResult { Success = true });
+        };
+
+        Assert.False(view.DiscardConfirmOverlay.IsVisible);
+        view.ShowDiscardConfirmation(new[] { "src/App.cs" });
+
+        Assert.True(view.DiscardConfirmOverlay.IsVisible);
+        Assert.Contains("permanently deletes", view.DiscardConfirmTitle.Text);
+        Assert.Contains("no undo", view.DiscardConfirmTitle.Text);
+        Assert.Contains("src/App.cs", view.DiscardConfirmFiles.Text); // the loss is named
+        Assert.False(discardRan); // showing the confirmation wrote NOTHING
+
+        view.KeepChanges();
+        Assert.False(view.DiscardConfirmOverlay.IsVisible);
+        Assert.False(discardRan); // keeping the changes wrote nothing either
+    }
+
+    [AvaloniaFact]
+    public async Task Discard_DeleteChanges_RunsTheWrite_ForExactlyTheNamedFiles()
+    {
+        var view = new ChangesDiffView();
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        view.Attach("/repo");
+
+        IReadOnlyList<string>? discarded = null;
+        view.DiscardServiceOverride = (_, files) =>
+        {
+            discarded = files;
+            return Task.FromResult(new GitWriteResult { Success = true });
+        };
+
+        view.ShowDiscardConfirmation(new[] { "src/App.cs" });
+        await view.DeleteChangesAsync();
+
+        Assert.Equal(new[] { "src/App.cs" }, discarded);
+        Assert.False(view.DiscardConfirmOverlay.IsVisible);
+
+        // A second confirm without a fresh confirmation is inert - the pending set was consumed.
+        discarded = null;
+        await view.DeleteChangesAsync();
+        Assert.Null(discarded);
     }
 }
 

--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewRenderTests.cs
@@ -21,7 +21,7 @@ public class RepositoryListViewRenderTests
                 Branch = "main",
                 IsClean = true,
                 Success = true,
-            }));
+            })) { LiveSessionsProvider = OneBrainRegressionTests.NoSessions };
 
     [AvaloniaFact]
     public void RepositoryListView_LoadsAndLaysOut()

--- a/src/CcDirector.Avalonia.Tests/RepositoryListViewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/RepositoryListViewTests.cs
@@ -104,6 +104,22 @@ public class RepositoryListViewTests
         Assert.Equal("2 worktrees · 1 safe · 1 in use", row.Worktrees);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F1): a provisional (still verifying) row must never open
+    // the detail screen - the detail screen exposes stage, commit, discard, and branch delete.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void ShouldOpenRow_ProvisionalRow_IsNotOpenable_VerifiedRowIs()
+    {
+        var provisional = new RepoRowItem { Path = "/repo/cached", Verifying = true };
+        var verified = new RepoRowItem { Path = "/repo/live", Verifying = false };
+        var pathless = new RepoRowItem { Path = "", Verifying = false };
+
+        Assert.False(RepositoryListView.ShouldOpenRow(provisional));
+        Assert.True(RepositoryListView.ShouldOpenRow(verified));
+        Assert.False(RepositoryListView.ShouldOpenRow(pathless));
+    }
+
     [Fact]
     public void BuildSummary_CountsReposDirtyAndReapable()
     {

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -150,6 +150,12 @@ public partial class App : Application
         mainWindow.Show();
         FileLog.Write("[CcDirector] Main window shown");
 
+        // The FIRST repository rescan starts HERE, not in InitializeServices (ruling R2-8): the
+        // MainWindow constructor above wired RepositoryMonitor.LiveSessionsProvider, and the
+        // monitor refuses to scan without it. Triggering the scan after the constructor makes
+        // the wire-before-scan ordering structural, not incidental.
+        StartRepositoryRescan();
+
         StartUpdateService(mainWindow);
     }
 
@@ -198,7 +204,9 @@ public partial class App : Application
             }
         };
 
-        StartRepositoryRescan();
+        // NOTE: the first repository rescan is deliberately NOT started here. The monitor requires
+        // its live-session source, which the MainWindow constructor wires - ShowMainWindow starts
+        // the scan right after that wiring (ruling R2-8).
 
         SessionStateStore = new SessionStateStore();
 

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -38,6 +38,8 @@ public partial class App : Application
     public RepositoryMonitor RepositoryMonitor { get; } = new(
         cachePath: System.IO.Path.Combine(
             CcDirector.Core.Storage.CcStorage.ToolConfig("director"), "repo-worktree-cache.json"));
+
+    private RepositoryWatcher? _repositoryWatcher;
     public SessionStateStore SessionStateStore { get; private set; } = null!;
 
     /// <summary>
@@ -176,6 +178,26 @@ public partial class App : Application
         // Warm start: show the last run's repositories instantly from the cache, then scan in the
         // background to re-verify and reconcile (issue #507, phase 2).
         RepositoryMonitor.LoadCache();
+
+        // After each completed scan, watch the roots and every known repository's git signals so a
+        // change recomputes only the affected repo - react to change instead of re-scanning (#510 A).
+        _repositoryWatcher = new RepositoryWatcher(RepositoryMonitor);
+        RepositoryMonitor.ScanCompleted += () =>
+        {
+            try
+            {
+                var watchRoots = RootDirectoryStore.Roots
+                    .Select(r => r.Path)
+                    .Where(p => !string.IsNullOrWhiteSpace(p))
+                    .ToList();
+                _repositoryWatcher.SyncWatches(watchRoots, RepositoryMonitor.Snapshot().Select(s => s.Path));
+            }
+            catch (Exception ex)
+            {
+                CcDirector.Core.Utilities.FileLog.Write($"[App] watcher sync failed: {ex.Message}");
+            }
+        };
+
         StartRepositoryRescan();
 
         SessionStateStore = new SessionStateStore();

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -540,7 +540,10 @@ public partial class App : Application
                 return Task.CompletedTask;
             };
 
-            ControlApiHost = new ControlApiHost(SessionManager, version, requestShutdown, repositoryRegistry: RepositoryRegistry);
+            ControlApiHost = new ControlApiHost(SessionManager, version, requestShutdown, repositoryRegistry: RepositoryRegistry,
+                // Repositories mission (#510 phase C): the monitor feeds the Gateway push and the
+                // /fleet/repositories - /fleet/worktrees standalone fallback.
+                repositoryMonitor: RepositoryMonitor);
 
             _ = Task.Run(async () =>
             {

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -169,7 +169,13 @@ public partial class App : Application
             .Select(r => r.Path)
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .ToList();
-        _ = System.Threading.Tasks.Task.Run(() => RepositoryMonitor.RescanAsync(roots));
+        // The task is observed, never orphaned: a scan that throws (for example the monitor's
+        // refuse-to-scan-unwired guard) must land in the log as an ERROR immediately, not
+        // surface minutes later as an unobserved-task finalizer message.
+        _ = System.Threading.Tasks.Task.Run(() => RepositoryMonitor.RescanAsync(roots))
+            .ContinueWith(
+                t => FileLog.Write($"[App] ERROR repository rescan FAILED: {t.Exception?.GetBaseException().Message}"),
+                System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted);
     }
 
     private void InitializeServices(SplashScreen splash)

--- a/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml
+++ b/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml
@@ -32,6 +32,7 @@
         </DataTemplate>
     </UserControl.DataTemplates>
 
+    <Panel>
     <Grid ColumnDefinitions="240,1,*">
         <!-- File list -->
         <Grid Grid.Column="0" RowDefinitions="*,Auto" Background="#252526">
@@ -84,4 +85,24 @@
             </ScrollViewer>
         </Grid>
     </Grid>
+
+    <!-- Discard confirmation: a destructive action states plainly what is lost before it acts. -->
+    <Border x:Name="DiscardConfirmOverlay" IsVisible="False" Background="#C0000000">
+        <Border Background="#252526" BorderBrush="#5A2A2A" BorderThickness="1" CornerRadius="6"
+                MaxWidth="560" Padding="18" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <StackPanel Spacing="10">
+                <TextBlock x:Name="DiscardConfirmTitle" Foreground="#F0A6A6" FontSize="13"
+                           FontWeight="SemiBold" TextWrapping="Wrap" />
+                <TextBlock x:Name="DiscardConfirmFiles" Foreground="#CCCCCC" FontSize="11.5"
+                           FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap" />
+                <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+                    <Button x:Name="KeepChangesButton" Content="Keep changes" Background="#3C3C3C"
+                            Foreground="#CCCCCC" FontSize="11.5" Padding="12,5" Click="KeepChangesButton_Click" />
+                    <Button x:Name="DeleteChangesButton" Content="Delete changes" Background="#7A2E2E"
+                            Foreground="White" FontSize="11.5" Padding="12,5" Click="DeleteChangesButton_Click" />
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Border>
+    </Panel>
 </UserControl>

--- a/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml
+++ b/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml
@@ -1,0 +1,87 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.ChangesDiffView"
+             Background="#1E1E1E">
+
+    <UserControl.DataTemplates>
+        <!-- One changed file in the left list -->
+        <DataTemplate DataType="controls:DiffFileItem">
+            <Border Background="Transparent" Padding="8,4" PointerPressed="FileRow_PointerPressed">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Left" Text="{Binding StatusChar}" Foreground="{Binding StatusBrush}"
+                               FontFamily="Cascadia Mono, Consolas" FontSize="11" FontWeight="Bold" Width="14" />
+                    <TextBlock Text="{Binding Display}" Foreground="{Binding NameBrush}" FontSize="11"
+                               FontFamily="Cascadia Mono, Consolas" TextTrimming="CharacterEllipsis" />
+                </DockPanel>
+            </Border>
+        </DataTemplate>
+
+        <!-- One rendered diff row -->
+        <DataTemplate DataType="controls:DiffRowItem">
+            <Border Background="{Binding RowBg}">
+                <Grid ColumnDefinitions="42,42,*">
+                    <TextBlock Grid.Column="0" Text="{Binding OldNo}" Foreground="#5A5A5A" FontSize="11"
+                               FontFamily="Cascadia Mono, Consolas" TextAlignment="Right" Padding="0,0,8,0" />
+                    <TextBlock Grid.Column="1" Text="{Binding NewNo}" Foreground="#5A5A5A" FontSize="11"
+                               FontFamily="Cascadia Mono, Consolas" TextAlignment="Right" Padding="0,0,8,0" />
+                    <TextBlock Grid.Column="2" Text="{Binding Text}" Foreground="{Binding TextBrush}" FontSize="11.5"
+                               FontFamily="Cascadia Mono, Consolas" TextWrapping="NoWrap" />
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <Grid ColumnDefinitions="240,1,*">
+        <!-- File list -->
+        <Grid Grid.Column="0" RowDefinitions="*,Auto" Background="#252526">
+            <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="4,6">
+                    <TextBlock x:Name="StagedHeader" Text="STAGED" Foreground="#6B6B6B" FontSize="9.5"
+                               FontWeight="SemiBold" Margin="8,2,8,4" />
+                    <ItemsControl x:Name="StagedFiles" />
+                    <TextBlock x:Name="UnstagedHeader" Text="CHANGES" Foreground="#6B6B6B" FontSize="9.5"
+                               FontWeight="SemiBold" Margin="8,10,8,4" />
+                    <ItemsControl x:Name="UnstagedFiles" />
+                    <TextBlock x:Name="NoChangesText" Text="No uncommitted changes." Foreground="#555555"
+                               FontSize="11" Margin="8,10,8,4" IsVisible="False" />
+                </StackPanel>
+            </ScrollViewer>
+            <!-- Commit box -->
+            <Border Grid.Row="1" BorderBrush="#3C3C3C" BorderThickness="0,1,0,0" Padding="8">
+                <StackPanel Spacing="6">
+                    <TextBox x:Name="CommitMessage" Watermark="Commit message" FontSize="11.5"
+                             AcceptsReturn="True" MaxHeight="64" Background="#1E1E1E" />
+                    <Button x:Name="CommitButton" Content="Commit staged" Background="#0E639C" Foreground="White"
+                            FontSize="11.5" Padding="10,5" HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center" Click="CommitButton_Click" />
+                </StackPanel>
+            </Border>
+        </Grid>
+
+        <Border Grid.Column="1" Background="#3C3C3C" />
+
+        <!-- Diff pane -->
+        <Grid Grid.Column="2" RowDefinitions="Auto,*">
+            <Border Grid.Row="0" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="0,0,0,1" Padding="10,6">
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                        <Button x:Name="StageButton" Content="Stage" Background="#3C3C3C" Foreground="#CCCCCC"
+                                FontSize="11" Padding="10,3" Click="StageButton_Click" IsVisible="False" />
+                        <Button x:Name="UnstageButton" Content="Unstage" Background="#3C3C3C" Foreground="#CCCCCC"
+                                FontSize="11" Padding="10,3" Click="UnstageButton_Click" IsVisible="False" />
+                        <Button x:Name="DiscardButton" Content="Discard changes" Background="#5A2A2A" Foreground="#F0A6A6"
+                                FontSize="11" Padding="10,3" Click="DiscardButton_Click" IsVisible="False" />
+                    </StackPanel>
+                    <TextBlock x:Name="DiffFileName" Text="Select a file to see its changes"
+                               Foreground="#8A8A8A" FontSize="11.5" FontFamily="Cascadia Mono, Consolas"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                </DockPanel>
+            </Border>
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                          Background="#161616">
+                <ItemsControl x:Name="DiffRows" Margin="0,4" />
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs
@@ -78,6 +78,8 @@ public partial class ChangesDiffView : UserControl
     {
         _repoPath = null;
         _selected = null;
+        _pendingDiscard = null;
+        DiscardConfirmOverlay.IsVisible = false;
         StagedFiles.ItemsSource = null;
         UnstagedFiles.ItemsSource = null;
         DiffRows.ItemsSource = null;
@@ -234,8 +236,72 @@ public partial class ChangesDiffView : UserControl
     private async void UnstageButton_Click(object? sender, RoutedEventArgs e) => await WriteActionAsync(
         item => _write.UnstageAsync(_repoPath!, new[] { item.Path }));
 
-    private async void DiscardButton_Click(object? sender, RoutedEventArgs e) => await WriteActionAsync(
-        item => _write.DiscardAsync(_repoPath!, new[] { item.Path }));
+    // ----- discard, behind a plain-words confirmation (inspection finding F11) -----
+
+    private IReadOnlyList<string>? _pendingDiscard;
+
+    /// <summary>
+    /// Test seam: when set, replaces the real discard write. Lets a headless test observe whether
+    /// (and for which files) the destructive write ran, without touching a repository.
+    /// </summary>
+    internal Func<string, IReadOnlyList<string>, Task<GitWriteResult>>? DiscardServiceOverride { get; set; }
+
+    /// <summary>
+    /// Discard never acts directly: it first shows what would be permanently deleted and waits for
+    /// an explicit "Delete changes". One click must never destroy tracked work.
+    /// </summary>
+    private void DiscardButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_repoPath is null || _selected is null)
+            return;
+        ShowDiscardConfirmation(new[] { _selected.Path });
+    }
+
+    internal void ShowDiscardConfirmation(IReadOnlyList<string> files)
+    {
+        _pendingDiscard = files;
+        DiscardConfirmTitle.Text = DiscardWarning(files.Count);
+        DiscardConfirmFiles.Text = string.Join(Environment.NewLine, files);
+        DiscardConfirmOverlay.IsVisible = true;
+    }
+
+    /// <summary>The plain-English statement of loss shown before any discard. Pure and unit-tested.</summary>
+    internal static string DiscardWarning(int fileCount)
+        => $"This permanently deletes your changes in {fileCount} file{(fileCount == 1 ? "" : "s")}. There is no undo.";
+
+    private void KeepChangesButton_Click(object? sender, RoutedEventArgs e) => KeepChanges();
+
+    internal void KeepChanges()
+    {
+        _pendingDiscard = null;
+        DiscardConfirmOverlay.IsVisible = false;
+    }
+
+    private async void DeleteChangesButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await DeleteChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ChangesDiffView] DeleteChangesButton_Click FAILED: {ex.Message}");
+        }
+    }
+
+    internal async Task DeleteChangesAsync()
+    {
+        var files = _pendingDiscard;
+        KeepChanges(); // clear the pending state and hide the overlay either way
+        if (files is null || files.Count == 0 || _repoPath is null)
+            return;
+        var result = DiscardServiceOverride is { } discard
+            ? await discard(_repoPath, files)
+            : await _write.DiscardAsync(_repoPath, files);
+        if (!result.Success)
+            FileLog.Write($"[ChangesDiffView] discard failed: {result.Error}");
+        await RefreshAsync();
+    }
 
     private async Task WriteActionAsync(Func<DiffFileItem, Task<GitWriteResult>> action)
     {

--- a/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/ChangesDiffView.axaml.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>A changed file in the left list of the diff viewer.</summary>
+public sealed class DiffFileItem
+{
+    public string Path { get; init; } = "";
+    public string Display { get; init; } = "";
+    public string StatusChar { get; init; } = "";
+    public bool IsStaged { get; init; }
+    public bool IsUntracked { get; init; }
+    public bool Selected { get; set; }
+    public ISolidColorBrush StatusBrush { get; init; } = Brushes.Gray;
+    public ISolidColorBrush NameBrush => Selected ? Brushes.White : Dim;
+    private static readonly ISolidColorBrush Dim = new SolidColorBrush(Color.Parse("#AAAAAA"));
+}
+
+/// <summary>One rendered row of the diff pane (a hunk header or a code line).</summary>
+public sealed class DiffRowItem
+{
+    public string Text { get; init; } = "";
+    public string OldNo { get; init; } = "";
+    public string NewNo { get; init; } = "";
+    public IBrush RowBg { get; init; } = Brushes.Transparent;
+    public IBrush TextBrush { get; init; } = Brushes.Gray;
+}
+
+/// <summary>
+/// The diff viewer: changed files on the left (staged/unstaged), the selected file's diff on the
+/// right, with stage/unstage/discard and a commit box. Reads via GitDiffService/GitStatusProvider;
+/// writes via the existing GitWriteService.
+/// </summary>
+public partial class ChangesDiffView : UserControl
+{
+    private static readonly IBrush AddBg = new SolidColorBrush(Color.Parse("#12301C"));
+    private static readonly IBrush DelBg = new SolidColorBrush(Color.Parse("#33191B"));
+    private static readonly IBrush HunkBg = new SolidColorBrush(Color.Parse("#1A2330"));
+    private static readonly IBrush AddFg = new SolidColorBrush(Color.Parse("#89D9A2"));
+    private static readonly IBrush DelFg = new SolidColorBrush(Color.Parse("#E39A9A"));
+    private static readonly IBrush CtxFg = new SolidColorBrush(Color.Parse("#B8B8B8"));
+    private static readonly IBrush HunkFg = new SolidColorBrush(Color.Parse("#6A9FD8"));
+    private static readonly ISolidColorBrush Amber = new SolidColorBrush(Color.Parse("#F59E0B"));
+    private static readonly ISolidColorBrush Green = new SolidColorBrush(Color.Parse("#22C55E"));
+    private static readonly ISolidColorBrush Red = new SolidColorBrush(Color.Parse("#EF4444"));
+
+    private readonly GitStatusProvider _status = new();
+    private readonly GitDiffService _diff = new();
+    private readonly GitWriteService _write = new();
+    private string? _repoPath;
+    private DiffFileItem? _selected;
+    private List<DiffFileItem> _staged = new();
+    private List<DiffFileItem> _unstaged = new();
+
+    public ChangesDiffView()
+    {
+        InitializeComponent();
+    }
+
+    public void Attach(string repoPath)
+    {
+        FileLog.Write($"[ChangesDiffView] Attach: {repoPath}");
+        _repoPath = repoPath;
+        _selected = null;
+        _ = RefreshAsync();
+    }
+
+    public void Detach()
+    {
+        _repoPath = null;
+        _selected = null;
+        StagedFiles.ItemsSource = null;
+        UnstagedFiles.ItemsSource = null;
+        DiffRows.ItemsSource = null;
+        DiffFileName.Text = "Select a file to see its changes";
+    }
+
+    private async Task RefreshAsync()
+    {
+        var repo = _repoPath;
+        if (repo is null)
+            return;
+        try
+        {
+            GitStatusProvider.InvalidateCache(repo);
+            var status = await _status.GetStatusAsync(repo);
+            if (_repoPath != repo)
+                return;
+
+            _staged = status.StagedChanges.Select(f => ToItem(f, staged: true)).ToList();
+            _unstaged = status.UnstagedChanges.Select(f => ToItem(f, staged: false)).ToList();
+
+            StagedFiles.ItemsSource = _staged;
+            UnstagedFiles.ItemsSource = _unstaged;
+            StagedHeader.IsVisible = _staged.Count > 0;
+            UnstagedHeader.IsVisible = _unstaged.Count > 0;
+            NoChangesText.IsVisible = _staged.Count == 0 && _unstaged.Count == 0;
+
+            // Keep the selection if the file still exists; otherwise clear the pane.
+            var keep = _selected is null
+                ? null
+                : _staged.Concat(_unstaged).FirstOrDefault(f => f.Path == _selected.Path && f.IsStaged == _selected.IsStaged);
+            if (keep != null)
+                await SelectAsync(keep);
+            else
+            {
+                _selected = null;
+                DiffRows.ItemsSource = null;
+                DiffFileName.Text = "Select a file to see its changes";
+                StageButton.IsVisible = UnstageButton.IsVisible = DiscardButton.IsVisible = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ChangesDiffView] RefreshAsync FAILED: {ex.Message}");
+        }
+    }
+
+    private DiffFileItem ToItem(GitFileEntry f, bool staged) => new()
+    {
+        Path = f.FilePath,
+        Display = f.FilePath,
+        StatusChar = f.StatusChar,
+        IsStaged = staged,
+        IsUntracked = f.Status == GitFileStatus.Untracked,
+        StatusBrush = f.Status switch
+        {
+            GitFileStatus.Added or GitFileStatus.Untracked => Green,
+            GitFileStatus.Deleted => Red,
+            _ => Amber,
+        },
+    };
+
+    private async void FileRow_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        try
+        {
+            if ((sender as Border)?.DataContext is DiffFileItem item)
+                await SelectAsync(item);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ChangesDiffView] FileRow_PointerPressed FAILED: {ex.Message}");
+        }
+    }
+
+    private async Task SelectAsync(DiffFileItem item)
+    {
+        var repo = _repoPath;
+        if (repo is null)
+            return;
+        foreach (var f in _staged.Concat(_unstaged)) f.Selected = false;
+        item.Selected = true;
+        _selected = item;
+
+        DiffFileName.Text = item.Path;
+        StageButton.IsVisible = !item.IsStaged;
+        UnstageButton.IsVisible = item.IsStaged;
+        DiscardButton.IsVisible = !item.IsStaged && !item.IsUntracked;
+
+        IReadOnlyList<FileDiff> diffs;
+        if (item.IsUntracked)
+        {
+            var one = await _diff.UntrackedAsync(repo, item.Path);
+            diffs = one is null ? Array.Empty<FileDiff>() : new[] { one };
+        }
+        else
+        {
+            diffs = item.IsStaged
+                ? await _diff.StagedAsync(repo, item.Path)
+                : await _diff.UnstagedAsync(repo, item.Path);
+        }
+
+        DiffRows.ItemsSource = BuildRows(diffs);
+        // Repaint selection highlight (items are plain objects, not observable).
+        StagedFiles.ItemsSource = null; StagedFiles.ItemsSource = _staged;
+        UnstagedFiles.ItemsSource = null; UnstagedFiles.ItemsSource = _unstaged;
+    }
+
+    /// <summary>Pure: parsed file diffs to rendered rows (unit-tested).</summary>
+    internal static IReadOnlyList<DiffRowItem> BuildRows(IReadOnlyList<FileDiff> diffs)
+    {
+        var rows = new List<DiffRowItem>();
+        foreach (var file in diffs)
+        {
+            if (file.IsBinary)
+            {
+                rows.Add(new DiffRowItem { Text = "(binary file - no text diff)", TextBrush = CtxFg, RowBg = HunkBg });
+                continue;
+            }
+            foreach (var hunk in file.Hunks)
+            {
+                rows.Add(new DiffRowItem { Text = hunk.Header, TextBrush = HunkFg, RowBg = HunkBg });
+                foreach (var line in hunk.Lines)
+                {
+                    rows.Add(new DiffRowItem
+                    {
+                        Text = line.Text,
+                        OldNo = line.OldNumber?.ToString() ?? "",
+                        NewNo = line.NewNumber?.ToString() ?? "",
+                        RowBg = line.Kind switch
+                        {
+                            DiffLineKind.Added => AddBg,
+                            DiffLineKind.Removed => DelBg,
+                            _ => Brushes.Transparent,
+                        },
+                        TextBrush = line.Kind switch
+                        {
+                            DiffLineKind.Added => AddFg,
+                            DiffLineKind.Removed => DelFg,
+                            _ => CtxFg,
+                        },
+                    });
+                }
+            }
+        }
+        if (rows.Count == 0)
+            rows.Add(new DiffRowItem { Text = "(no differences)", TextBrush = CtxFg });
+        return rows;
+    }
+
+    private async void StageButton_Click(object? sender, RoutedEventArgs e) => await WriteActionAsync(
+        item => _write.StageAsync(_repoPath!, new[] { item.Path }));
+
+    private async void UnstageButton_Click(object? sender, RoutedEventArgs e) => await WriteActionAsync(
+        item => _write.UnstageAsync(_repoPath!, new[] { item.Path }));
+
+    private async void DiscardButton_Click(object? sender, RoutedEventArgs e) => await WriteActionAsync(
+        item => _write.DiscardAsync(_repoPath!, new[] { item.Path }));
+
+    private async Task WriteActionAsync(Func<DiffFileItem, Task<GitWriteResult>> action)
+    {
+        try
+        {
+            if (_repoPath is null || _selected is null)
+                return;
+            var result = await action(_selected);
+            if (!result.Success)
+                FileLog.Write($"[ChangesDiffView] write action failed: {result.Error}");
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ChangesDiffView] write action FAILED: {ex.Message}");
+        }
+    }
+
+    private async void CommitButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var repo = _repoPath;
+            var message = CommitMessage.Text;
+            if (repo is null || string.IsNullOrWhiteSpace(message))
+                return;
+            var result = await _write.CommitAsync(repo, message.Trim());
+            if (result.Success)
+                CommitMessage.Text = "";
+            else
+                FileLog.Write($"[ChangesDiffView] commit failed: {result.Error}");
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ChangesDiffView] CommitButton_Click FAILED: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
@@ -42,6 +42,7 @@
 
         <Panel Grid.Column="2">
             <controls:RepositoryListView x:Name="ReposPage" IsVisible="True" />
+            <controls:RepositoryDetailView x:Name="DetailPage" IsVisible="False" />
 
             <ScrollViewer x:Name="RootsPage" IsVisible="False" VerticalScrollBarVisibility="Auto">
                 <StackPanel Margin="16" Spacing="12">

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
@@ -32,6 +32,15 @@
                 <Button x:Name="ReposRailButton" Classes="railItem active" Click="ReposRailButton_Click">
                     <TextBlock Text="Local repositories" VerticalAlignment="Center" />
                 </Button>
+                <Button x:Name="RecoRailButton" Classes="railItem" Click="RecoRailButton_Click">
+                    <DockPanel LastChildFill="False">
+                        <TextBlock Text="Recommendations" VerticalAlignment="Center" />
+                        <Border DockPanel.Dock="Right" x:Name="RecoBadge" Background="#F59E0B" CornerRadius="8"
+                                Padding="6,1" Margin="8,0,0,0" VerticalAlignment="Center" IsVisible="False">
+                            <TextBlock x:Name="RecoBadgeText" Text="0" Foreground="#1E1E1E" FontSize="9" FontWeight="SemiBold" />
+                        </Border>
+                    </DockPanel>
+                </Button>
                 <Button x:Name="RootsRailButton" Classes="railItem" Click="RootsRailButton_Click">
                     <TextBlock Text="Root folders" VerticalAlignment="Center" />
                 </Button>
@@ -43,6 +52,40 @@
         <Panel Grid.Column="2">
             <controls:RepositoryListView x:Name="ReposPage" IsVisible="True" />
             <controls:RepositoryDetailView x:Name="DetailPage" IsVisible="False" />
+
+            <ScrollViewer x:Name="RecoPage" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="14" Spacing="8">
+                    <TextBlock Text="Recommendations" Foreground="#CCCCCC" FontSize="14" FontWeight="SemiBold" />
+                    <TextBlock Text="What the background scan suggests, in plain language. Nothing here happens without you."
+                               Foreground="#888888" FontSize="11" TextWrapping="Wrap" MaxWidth="560" />
+                    <TextBlock x:Name="RecoEmptyText" Text="Nothing to recommend - your repositories look tidy."
+                               Foreground="#22C55E" FontSize="12" IsVisible="False" Margin="0,6,0,0" />
+                    <ItemsControl x:Name="RecoList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="controls:RecommendationRowItem">
+                                <Border Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="6"
+                                        Padding="12,10" Margin="0,0,0,8">
+                                    <Grid ColumnDefinitions="4,12,*">
+                                        <Border Grid.Column="0" Background="{Binding StripeBrush}" CornerRadius="2" />
+                                        <StackPanel Grid.Column="2" Spacing="3">
+                                            <TextBlock Text="{Binding Title}" Foreground="#CCCCCC" FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                            <TextBlock Text="{Binding Body}" Foreground="#AAAAAA" FontSize="11" TextWrapping="Wrap" />
+                                            <TextBlock Text="{Binding Why}" Foreground="#6B6B6B" FontSize="10" FontStyle="Italic" TextWrapping="Wrap" />
+                                            <StackPanel Orientation="Horizontal" Spacing="7" Margin="0,6,0,0">
+                                                <Button Content="Show me" Background="#3C3C3C" Foreground="#CCCCCC"
+                                                        FontSize="11" Padding="10,3" Click="RecoShow_Click" />
+                                                <Button Content="Hand to an agent" Background="#0E639C" Foreground="White"
+                                                        FontSize="11" Padding="10,3" IsVisible="{Binding HasRepo}"
+                                                        Click="RecoHandOff_Click" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
 
             <ScrollViewer x:Name="RootsPage" IsVisible="False" VerticalScrollBarVisibility="Auto">
                 <StackPanel Margin="16" Spacing="12">

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -92,17 +92,20 @@ public partial class RepositoriesView : UserControl
     }
 
     /// <summary>
-    /// Drill into one repository's detail screen. A provisional (still verifying) entry never
-    /// opens it, whatever the route in - the detail screen is an acting surface (stage, commit,
-    /// discard, branch delete) and cached, unverified data must not receive actions.
+    /// Drill into one repository's detail screen. The guard fails CLOSED (ruling R2-6): only a
+    /// positively known, VERIFIED entry opens it - a provisional (still verifying) entry is
+    /// refused, and so is an UNKNOWN path (a stale recommendation or a queued navigation after
+    /// the monitor removed the entry). The detail screen is an acting surface (stage, commit,
+    /// discard, branch delete) and anything short of verified data must not receive actions.
     /// </summary>
     internal void OpenDetail(string repoPath)
     {
         if (_monitor is null)
             return;
-        if (_monitor.FindForPath(repoPath) is { Provisional: true })
+        var entry = _monitor.FindForPath(repoPath);
+        if (entry is null || entry.Provisional)
         {
-            FileLog.Write($"[RepositoriesView] detail refused - entry still verifying: {repoPath}");
+            FileLog.Write($"[RepositoriesView] detail refused - {(entry is null ? "unknown path" : "entry still verifying")}: {repoPath}");
             return;
         }
         ReposPage.IsVisible = false;

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -25,8 +25,19 @@ public partial class RepositoriesView : UserControl
     private static readonly FontFamily Mono = new("Cascadia Mono, Consolas");
 
     private bool _attached;
+    private RepositoryMonitor? _monitor;
     private RootDirectoryStore? _store;
     private Action? _onRefresh;
+
+    /// <summary>The owner chose a hand-off on a repo; the host spawns a session with the brief staged.</summary>
+    public event Action<string, string>? HandToAgentRequested;
+
+    /// <summary>Live sessions provider, forwarded to the detail's worktrees panel.</summary>
+    public Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider
+    {
+        get => DetailPage.LiveSessionsProvider;
+        set => DetailPage.LiveSessionsProvider = value;
+    }
 
     public RepositoriesView()
     {
@@ -39,16 +50,38 @@ public partial class RepositoriesView : UserControl
     /// </summary>
     public void Attach(RepositoryMonitor monitor, RootDirectoryStore store, Action onRefreshRequested)
     {
+        _monitor = monitor;
         _store = store;
         _onRefresh = onRefreshRequested;
         if (!_attached)
         {
             FileLog.Write("[RepositoriesView] Attach");
             ReposPage.RefreshRequested += onRefreshRequested;
+            ReposPage.RepoOpenRequested += OpenDetail;
+            DetailPage.BackRequested += CloseDetail;
+            DetailPage.HandToAgentRequested += (path, brief) => HandToAgentRequested?.Invoke(path, brief);
             ReposPage.Attach(monitor);
             _attached = true;
         }
         RenderRoots();
+    }
+
+    /// <summary>Drill into one repository's detail screen.</summary>
+    private void OpenDetail(string repoPath)
+    {
+        if (_monitor is null)
+            return;
+        ReposPage.IsVisible = false;
+        RootsPage.IsVisible = false;
+        DetailPage.IsVisible = true;
+        DetailPage.Attach(_monitor, repoPath);
+    }
+
+    private void CloseDetail()
+    {
+        DetailPage.Detach();
+        DetailPage.IsVisible = false;
+        ShowRoots(false);
     }
 
     private void ReposRailButton_Click(object? sender, RoutedEventArgs e) => ShowRoots(false);
@@ -56,6 +89,7 @@ public partial class RepositoriesView : UserControl
 
     private void ShowRoots(bool roots)
     {
+        DetailPage.IsVisible = false;
         ReposPage.IsVisible = !roots;
         RootsPage.IsVisible = roots;
         SetActive(ReposRailButton, !roots);

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -9,6 +9,31 @@ using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia.Controls;
 
+/// <summary>One recommendation card - display data only; the engine folded the strings.</summary>
+public sealed class RecommendationRowItem
+{
+    public string Title { get; init; } = "";
+    public string Body { get; init; } = "";
+    public string Why { get; init; } = "";
+    public string? RepoPath { get; init; }
+    public bool HasRepo => RepoPath is { Length: > 0 };
+    public IBrush StripeBrush { get; init; } = Brushes.Gray;
+
+    public static RecommendationRowItem From(Recommendation r) => new()
+    {
+        Title = r.Title,
+        Body = r.Body,
+        Why = r.Why,
+        RepoPath = r.RepoPath,
+        StripeBrush = r.Severity switch
+        {
+            1 => new SolidColorBrush(Color.Parse("#22C55E")),
+            2 => new SolidColorBrush(Color.Parse("#F59E0B")),
+            _ => new SolidColorBrush(Color.Parse("#3B82F6")),
+        },
+    };
+}
+
 /// <summary>
 /// The Repositories home: a left sub-rail hosting the live local-repository list and the root-folder
 /// registration, shown as a pinned, non-modal view inside the main window (issue #507, phase 4).
@@ -84,16 +109,68 @@ public partial class RepositoriesView : UserControl
         ShowRoots(false);
     }
 
-    private void ReposRailButton_Click(object? sender, RoutedEventArgs e) => ShowRoots(false);
-    private void RootsRailButton_Click(object? sender, RoutedEventArgs e) => ShowRoots(true);
+    private void ReposRailButton_Click(object? sender, RoutedEventArgs e) => ShowPage("repos");
+    private void RootsRailButton_Click(object? sender, RoutedEventArgs e) => ShowPage("roots");
+    private void RecoRailButton_Click(object? sender, RoutedEventArgs e) => ShowPage("reco");
 
-    private void ShowRoots(bool roots)
+    private void ShowRoots(bool roots) => ShowPage(roots ? "roots" : "repos");
+
+    private void ShowPage(string page)
     {
         DetailPage.IsVisible = false;
-        ReposPage.IsVisible = !roots;
-        RootsPage.IsVisible = roots;
-        SetActive(ReposRailButton, !roots);
-        SetActive(RootsRailButton, roots);
+        ReposPage.IsVisible = page == "repos";
+        RootsPage.IsVisible = page == "roots";
+        RecoPage.IsVisible = page == "reco";
+        SetActive(ReposRailButton, page == "repos");
+        SetActive(RootsRailButton, page == "roots");
+        SetActive(RecoRailButton, page == "reco");
+        if (page == "reco")
+            RenderRecommendations();
+    }
+
+    // ----- recommendations (folded by the engine; this only renders) -----
+
+    /// <summary>Recompute + render the recommendation cards and the rail badge.</summary>
+    public void RenderRecommendations()
+    {
+        if (_monitor is null)
+            return;
+        var recs = RecommendationEngine.Evaluate(_monitor.Snapshot());
+        RecoList.ItemsSource = recs.Select(RecommendationRowItem.From).ToList();
+        RecoEmptyText.IsVisible = recs.Count == 0;
+        RecoBadgeText.Text = recs.Count.ToString();
+        RecoBadge.IsVisible = recs.Count > 0;
+    }
+
+    private void RecoShow_Click(object? sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.DataContext is not RecommendationRowItem row)
+            return;
+        if (row.RepoPath is { Length: > 0 } path)
+            OpenDetail(path);
+        else
+            ShowPage("repos"); // the fleet-wide reap summary: the list shows where the safe worktrees are
+    }
+
+    private async void RecoHandOff_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (_monitor is null || (sender as Button)?.DataContext is not RecommendationRowItem row || row.RepoPath is null)
+                return;
+            var repo = _monitor.FindForPath(row.RepoPath);
+            var window = TopLevel.GetTopLevel(this) as Window;
+            if (repo is null || window is null)
+                return;
+            var dialog = new global::CcDirector.Avalonia.HandToAgentDialog(repo);
+            var brief = await dialog.ShowDialog<string?>(window);
+            if (!string.IsNullOrWhiteSpace(brief))
+                HandToAgentRequested?.Invoke(row.RepoPath, brief);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoriesView] RecoHandOff_Click FAILED: {ex.Message}");
+        }
     }
 
     private static void SetActive(Button button, bool active)

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -124,8 +124,11 @@ public partial class RepositoriesView : UserControl
 
     private void ShowRoots(bool roots) => ShowPage(roots ? "roots" : "repos");
 
-    private void ShowPage(string page)
+    internal void ShowPage(string page)
     {
+        // Leaving the detail page through ANY path - rail buttons included - releases its monitor
+        // subscriptions; hiding it while subscribed would keep it rendering forever (finding F12).
+        DetailPage.Detach();
         DetailPage.IsVisible = false;
         ReposPage.IsVisible = page == "repos";
         RootsPage.IsVisible = page == "roots";

--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml.cs
@@ -91,11 +91,20 @@ public partial class RepositoriesView : UserControl
         RenderRoots();
     }
 
-    /// <summary>Drill into one repository's detail screen.</summary>
-    private void OpenDetail(string repoPath)
+    /// <summary>
+    /// Drill into one repository's detail screen. A provisional (still verifying) entry never
+    /// opens it, whatever the route in - the detail screen is an acting surface (stage, commit,
+    /// discard, branch delete) and cached, unverified data must not receive actions.
+    /// </summary>
+    internal void OpenDetail(string repoPath)
     {
         if (_monitor is null)
             return;
+        if (_monitor.FindForPath(repoPath) is { Provisional: true })
+        {
+            FileLog.Write($"[RepositoriesView] detail refused - entry still verifying: {repoPath}");
+            return;
+        }
         ReposPage.IsVisible = false;
         RootsPage.IsVisible = false;
         DetailPage.IsVisible = true;

--- a/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml
@@ -1,0 +1,149 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:CcDirector.Avalonia.Controls"
+             x:Class="CcDirector.Avalonia.Controls.RepositoryDetailView"
+             Background="#1E1E1E">
+
+    <UserControl.DataTemplates>
+        <!-- Branch row -->
+        <DataTemplate DataType="controls:BranchRowItem">
+            <Border Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="4"
+                    Padding="11,8" Margin="0,0,0,6">
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                        <Border CornerRadius="6" Padding="7,2" Background="{Binding ChipBg}" BorderBrush="{Binding ChipBr}" BorderThickness="1">
+                            <TextBlock Text="{Binding Chip}" Foreground="{Binding ChipFg}" FontSize="10" FontFamily="Cascadia Mono, Consolas" />
+                        </Border>
+                        <Button Content="Delete" Background="#5A2A2A" Foreground="#F0A6A6" FontSize="11" Padding="10,3"
+                                IsVisible="{Binding CanDelete}" Click="DeleteBranch_Click" />
+                    </StackPanel>
+                    <StackPanel Spacing="2">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="{Binding Name}" Foreground="#CCCCCC" FontSize="12.5" FontWeight="SemiBold"
+                                       FontFamily="Cascadia Mono, Consolas" />
+                            <Border Background="#0E639C" CornerRadius="4" Padding="6,0" VerticalAlignment="Center"
+                                    IsVisible="{Binding IsCurrent}">
+                                <TextBlock Text="current" Foreground="White" FontSize="9" />
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="{Binding Meta}" Foreground="#8A8A8A" FontSize="10.5" FontFamily="Cascadia Mono, Consolas" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+        </DataTemplate>
+
+        <!-- Pull request row -->
+        <DataTemplate DataType="controls:PullRequestRowItem">
+            <Border Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="4"
+                    Padding="11,8" Margin="0,0,0,6">
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                        <Border CornerRadius="6" Padding="7,2" Background="{Binding ChipBg}" BorderBrush="{Binding ChipBr}" BorderThickness="1"
+                                IsVisible="{Binding HasChip}">
+                            <TextBlock Text="{Binding Chip}" Foreground="{Binding ChipFg}" FontSize="10" FontFamily="Cascadia Mono, Consolas" />
+                        </Border>
+                        <Button Content="Open" Background="#3C3C3C" Foreground="#CCCCCC" FontSize="11" Padding="10,3"
+                                Click="OpenPullRequest_Click" />
+                    </StackPanel>
+                    <StackPanel Spacing="2">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock Text="{Binding ChecksGlyph}" Foreground="{Binding ChecksBrush}" FontSize="12" FontWeight="Bold" />
+                            <TextBlock Text="{Binding Title}" Foreground="#CCCCCC" FontSize="12.5" FontWeight="SemiBold"
+                                       TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+                        <TextBlock Text="{Binding Meta}" Foreground="#8A8A8A" FontSize="10.5" FontFamily="Cascadia Mono, Consolas" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+        </DataTemplate>
+
+        <!-- Commit row -->
+        <DataTemplate DataType="controls:CommitRowItem">
+            <Border Padding="10,5" Background="Transparent">
+                <DockPanel>
+                    <TextBlock DockPanel.Dock="Left" Text="{Binding Hash}" Foreground="#4A9EFF" FontSize="11"
+                               FontFamily="Cascadia Mono, Consolas" Width="70" />
+                    <TextBlock DockPanel.Dock="Right" Text="{Binding When}" Foreground="#6B6B6B" FontSize="10.5"
+                               FontFamily="Cascadia Mono, Consolas" Margin="10,0,0,0" />
+                    <TextBlock Text="{Binding Subject}" Foreground="#CCCCCC" FontSize="11.5" TextTrimming="CharacterEllipsis" />
+                </DockPanel>
+            </Border>
+        </DataTemplate>
+    </UserControl.DataTemplates>
+
+    <Grid RowDefinitions="Auto,Auto,*">
+        <!-- Header -->
+        <Border Grid.Row="0" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="0,0,0,1" Padding="14,10">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                    <Button x:Name="OpenVsCodeButton" Content="Open in VS Code" Background="#3C3C3C" Foreground="#CCCCCC"
+                            FontSize="11" Padding="10,4" Click="OpenVsCodeButton_Click" />
+                    <Button x:Name="HandToAgentButton" Content="Hand to an agent" Background="#0E639C" Foreground="White"
+                            FontSize="11" FontWeight="SemiBold" Padding="10,4" Click="HandToAgentButton_Click" />
+                </StackPanel>
+                <StackPanel Spacing="2">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button x:Name="BackButton" Content="&#8592;" Background="Transparent" Foreground="#8A8A8A"
+                                FontSize="14" Padding="4,0" BorderThickness="0" Click="BackButton_Click"
+                                ToolTip.Tip="Back to all repositories" />
+                        <TextBlock x:Name="RepoName" Text="" Foreground="#CCCCCC" FontSize="16" FontWeight="SemiBold" />
+                    </StackPanel>
+                    <TextBlock x:Name="RepoUrl" Text="" Foreground="#4A9EFF" FontSize="10.5" FontFamily="Cascadia Mono, Consolas" />
+                    <TextBlock x:Name="RepoStats" Text="" Foreground="#8A8A8A" FontSize="10.5" FontFamily="Cascadia Mono, Consolas" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- Tab strip -->
+        <Border Grid.Row="1" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="0,0,0,1" Padding="8,0">
+            <StackPanel Orientation="Horizontal" Spacing="2">
+                <Button x:Name="TabChanges" Content="Changes" Classes="detailTab" Click="TabChanges_Click" />
+                <Button x:Name="TabWorktrees" Content="Worktrees" Classes="detailTab" Click="TabWorktrees_Click" />
+                <Button x:Name="TabBranches" Content="Branches" Classes="detailTab" Click="TabBranches_Click" />
+                <Button x:Name="TabPullRequests" Content="Pull requests" Classes="detailTab" Click="TabPullRequests_Click" />
+                <Button x:Name="TabHistory" Content="History" Classes="detailTab" Click="TabHistory_Click" />
+            </StackPanel>
+        </Border>
+
+        <!-- Panels -->
+        <Panel Grid.Row="2">
+            <controls:ChangesDiffView x:Name="ChangesPanel" IsVisible="True" />
+            <controls:WorktreesView x:Name="WorktreesPanel" IsVisible="False" />
+            <ScrollViewer x:Name="BranchesPanel" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="12" Spacing="8">
+                    <TextBlock x:Name="BranchesStatus" Text="Loading branches..." Foreground="#888888" FontSize="12" FontStyle="Italic" />
+                    <ItemsControl x:Name="BranchesList" />
+                    <Button x:Name="DeleteSafeBranchesButton" Content="Delete safe branches" Background="#8B2E2E" Foreground="White"
+                            FontSize="11.5" Padding="12,5" IsVisible="False" Click="DeleteSafeBranchesButton_Click" />
+                </StackPanel>
+            </ScrollViewer>
+            <ScrollViewer x:Name="PullRequestsPanel" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="12" Spacing="8">
+                    <TextBlock x:Name="PullRequestsStatus" Text="Loading pull requests..." Foreground="#888888" FontSize="12" FontStyle="Italic" />
+                    <ItemsControl x:Name="PullRequestsList" />
+                </StackPanel>
+            </ScrollViewer>
+            <ScrollViewer x:Name="HistoryPanel" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="12,8">
+                    <TextBlock x:Name="HistoryStatus" Text="Loading history..." Foreground="#888888" FontSize="12" FontStyle="Italic" />
+                    <ItemsControl x:Name="HistoryList" />
+                </StackPanel>
+            </ScrollViewer>
+        </Panel>
+    </Grid>
+
+    <UserControl.Styles>
+        <Style Selector="Button.detailTab">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="#8A8A8A" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Padding" Value="12,7" />
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+        <Style Selector="Button.detailTab.active">
+            <Setter Property="Foreground" Value="#FFFFFF" />
+            <Setter Property="BorderBrush" Value="#007ACC" />
+            <Setter Property="BorderThickness" Value="0,0,0,2" />
+        </Style>
+    </UserControl.Styles>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+public sealed class BranchRowItem
+{
+    public string Name { get; init; } = "";
+    public bool IsCurrent { get; init; }
+    public string Meta { get; init; } = "";
+    public string Chip { get; init; } = "";
+    public bool CanDelete { get; init; }
+    public IBrush ChipFg { get; init; } = Brushes.Gray;
+    public IBrush ChipBg { get; init; } = Brushes.Transparent;
+    public IBrush ChipBr { get; init; } = Brushes.Gray;
+}
+
+public sealed class PullRequestRowItem
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = "";
+    public string Meta { get; init; } = "";
+    public string Chip { get; init; } = "";
+    public bool HasChip => Chip.Length > 0;
+    public string ChecksGlyph { get; init; } = "";
+    public string Url { get; init; } = "";
+    public IBrush ChecksBrush { get; init; } = Brushes.Gray;
+    public IBrush ChipFg { get; init; } = Brushes.Gray;
+    public IBrush ChipBg { get; init; } = Brushes.Transparent;
+    public IBrush ChipBr { get; init; } = Brushes.Gray;
+}
+
+public sealed class CommitRowItem
+{
+    public string Hash { get; init; } = "";
+    public string Subject { get; init; } = "";
+    public string When { get; init; } = "";
+}
+
+/// <summary>
+/// One repository, everything about it: Changes (diff viewer), Worktrees (the shared triaged view
+/// with the reaper), Branches (safe-delete verdicts), Pull requests, and History. Renders the
+/// monitor's model for the header; tab content loads lazily on first open.
+/// </summary>
+public partial class RepositoryDetailView : UserControl
+{
+    private static readonly IBrush GreenFg = new SolidColorBrush(Color.Parse("#22C55E"));
+    private static readonly IBrush GreenBg = new SolidColorBrush(Color.Parse("#1B3A2A"));
+    private static readonly IBrush GreenBr = new SolidColorBrush(Color.Parse("#1E5138"));
+    private static readonly IBrush AmberFg = new SolidColorBrush(Color.Parse("#F59E0B"));
+    private static readonly IBrush AmberBg = new SolidColorBrush(Color.Parse("#3A2A1B"));
+    private static readonly IBrush AmberBr = new SolidColorBrush(Color.Parse("#5A4326"));
+    private static readonly IBrush RedFg = new SolidColorBrush(Color.Parse("#F0A6A6"));
+    private static readonly IBrush RedBg = new SolidColorBrush(Color.Parse("#3A1B1B"));
+    private static readonly IBrush RedBr = new SolidColorBrush(Color.Parse("#5A2830"));
+    private static readonly IBrush MutedFg = new SolidColorBrush(Color.Parse("#8A8A8A"));
+    private static readonly IBrush MutedBg = new SolidColorBrush(Color.Parse("#2D2D30"));
+    private static readonly IBrush MutedBr = new SolidColorBrush(Color.Parse("#3C3C3C"));
+
+    private readonly GitBranchService _branches = new();
+    private readonly PullRequestService _pullRequests = new();
+    private readonly GitHistoryService _history = new();
+
+    private RepositoryMonitor? _monitor;
+    private string? _repoPath;
+    private RepositoryStatus? _current;
+    private readonly HashSet<string> _loadedTabs = new();
+
+    /// <summary>Back to the repository list.</summary>
+    public event Action? BackRequested;
+
+    /// <summary>The owner chose a hand-off; the host spawns a session in the repo with this brief staged.</summary>
+    public event Action<string, string>? HandToAgentRequested; // (repoPath, brief)
+
+    /// <summary>Live sessions provider, forwarded to the worktrees panel (in-use + reap guard).</summary>
+    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider
+    {
+        get => WorktreesPanel.LiveSessionsProvider;
+        set => WorktreesPanel.LiveSessionsProvider = value;
+    }
+
+    public RepositoryDetailView()
+    {
+        InitializeComponent();
+    }
+
+    public void Attach(RepositoryMonitor monitor, string repoPath)
+    {
+        FileLog.Write($"[RepositoryDetailView] Attach: {repoPath}");
+        Detach();
+        _monitor = monitor;
+        _repoPath = repoPath;
+        _loadedTabs.Clear();
+        monitor.Upserted += OnUpserted;
+        RenderHeader();
+        ShowTab("Changes");
+    }
+
+    public void Detach()
+    {
+        if (_monitor is { } m)
+        {
+            m.Upserted -= OnUpserted;
+            _monitor = null;
+        }
+        ChangesPanel.Detach();
+        WorktreesPanel.Detach();
+        _repoPath = null;
+        _current = null;
+    }
+
+    private void OnUpserted(RepositoryStatus s)
+    {
+        if (_repoPath != null && string.Equals(
+                WorktreeReaperService.NormalizePath(s.Path),
+                WorktreeReaperService.NormalizePath(_repoPath), StringComparison.OrdinalIgnoreCase))
+            Dispatcher.UIThread.Post(RenderHeader);
+    }
+
+    private void RenderHeader()
+    {
+        if (_monitor is null || _repoPath is null)
+            return;
+        _current = _monitor.FindForPath(_repoPath);
+        if (_current is null)
+            return;
+        RepoName.Text = _current.Name;
+        RepoUrl.Text = _current.RemoteUrl ?? "(no remote)";
+        RepoStats.Text = HeaderStats(_current);
+    }
+
+    /// <summary>Pure header line (unit-tested).</summary>
+    internal static string HeaderStats(RepositoryStatus s)
+    {
+        var parts = new List<string> { $"branch {s.Branch}" };
+        parts.Add(s.IsClean ? "clean" : $"{s.UncommittedCount} uncommitted{DirtyDays(s)}");
+        if (s.AheadCount > 0 || s.BehindCount > 0) parts.Add($"ahead {s.AheadCount} / behind {s.BehindCount}");
+        if (s.BehindMainCount > 0) parts.Add($"behind main {s.BehindMainCount}");
+        if (s.WorktreeCount > 0) parts.Add($"{s.WorktreeCount} worktree(s), {FormatBytes(s.WorktreeBytes)}");
+        return string.Join(" · ", parts);
+    }
+
+    private static string DirtyDays(RepositoryStatus s)
+        => s.DirtySinceUtc is { } since
+            ? $" for {(int)Math.Max(0, (DateTime.UtcNow - since).TotalDays)} day(s)"
+            : "";
+
+    internal static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:0.0} GB",
+        >= 1_048_576 => $"{bytes / 1_048_576.0:0} MB",
+        > 0 => $"{bytes / 1024.0:0} KB",
+        _ => "0 KB",
+    };
+
+    // ----- tabs -----
+
+    private void TabChanges_Click(object? s, RoutedEventArgs e) => ShowTab("Changes");
+    private void TabWorktrees_Click(object? s, RoutedEventArgs e) => ShowTab("Worktrees");
+    private void TabBranches_Click(object? s, RoutedEventArgs e) => ShowTab("Branches");
+    private void TabPullRequests_Click(object? s, RoutedEventArgs e) => ShowTab("PullRequests");
+    private void TabHistory_Click(object? s, RoutedEventArgs e) => ShowTab("History");
+
+    private void ShowTab(string tab)
+    {
+        ChangesPanel.IsVisible = tab == "Changes";
+        WorktreesPanel.IsVisible = tab == "Worktrees";
+        BranchesPanel.IsVisible = tab == "Branches";
+        PullRequestsPanel.IsVisible = tab == "PullRequests";
+        HistoryPanel.IsVisible = tab == "History";
+
+        SetActive(TabChanges, tab == "Changes");
+        SetActive(TabWorktrees, tab == "Worktrees");
+        SetActive(TabBranches, tab == "Branches");
+        SetActive(TabPullRequests, tab == "PullRequests");
+        SetActive(TabHistory, tab == "History");
+
+        if (_repoPath is null || !_loadedTabs.Add(tab))
+            return;
+        switch (tab)
+        {
+            case "Changes": ChangesPanel.Attach(_repoPath); break;
+            case "Worktrees": if (_monitor != null) WorktreesPanel.Attach(_monitor, _repoPath); break;
+            case "Branches": _ = LoadBranchesAsync(); break;
+            case "PullRequests": _ = LoadPullRequestsAsync(); break;
+            case "History": _ = LoadHistoryAsync(); break;
+        }
+    }
+
+    private static void SetActive(Button b, bool active)
+    {
+        if (active) b.Classes.Add("active");
+        else b.Classes.Remove("active");
+    }
+
+    // ----- branches -----
+
+    private async Task LoadBranchesAsync()
+    {
+        var repo = _repoPath;
+        if (repo is null) return;
+        BranchesStatus.Text = "Loading branches...";
+        BranchesStatus.IsVisible = true;
+        try
+        {
+            var branches = await Task.Run(() => _branches.ListAsync(repo));
+            if (_repoPath != repo) return;
+            var rows = branches.Select(ToBranchRow).ToList();
+            BranchesList.ItemsSource = rows;
+            BranchesStatus.IsVisible = false;
+            int safe = branches.Count(b => b.SafeToDelete);
+            DeleteSafeBranchesButton.Content = $"Delete {safe} safe branch{(safe == 1 ? "" : "es")}";
+            DeleteSafeBranchesButton.IsVisible = safe > 0;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] LoadBranchesAsync FAILED: {ex.Message}");
+            BranchesStatus.Text = $"Could not list branches: {ex.Message}";
+        }
+    }
+
+    internal static BranchRowItem ToBranchRow(BranchInfo b)
+    {
+        var meta = new List<string>();
+        if (b.AheadOfMain > 0) meta.Add($"ahead {b.AheadOfMain}");
+        if (b.BehindMain > 0) meta.Add($"behind {b.BehindMain}");
+        if (b.LastCommitUtc is { } when) meta.Add($"last commit {when:yyyy-MM-dd}");
+        meta.Add(b.Explanation);
+        return new BranchRowItem
+        {
+            Name = b.Name,
+            IsCurrent = b.IsCurrent,
+            Meta = string.Join(" · ", meta),
+            Chip = b.SafeToDelete ? "safe to delete" : (b.CheckedOutInWorktree ? "in a worktree" : (b.IsCurrent ? "current" : "has work")),
+            CanDelete = b.SafeToDelete,
+            ChipFg = b.SafeToDelete ? GreenFg : (b.IsCurrent || b.CheckedOutInWorktree ? MutedFg : AmberFg),
+            ChipBg = b.SafeToDelete ? GreenBg : (b.IsCurrent || b.CheckedOutInWorktree ? MutedBg : AmberBg),
+            ChipBr = b.SafeToDelete ? GreenBr : (b.IsCurrent || b.CheckedOutInWorktree ? MutedBr : AmberBr),
+        };
+    }
+
+    private async void DeleteBranch_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (_repoPath is null || (sender as Button)?.DataContext is not BranchRowItem row)
+                return;
+            var (deleted, message) = await _branches.DeleteIfSafeAsync(_repoPath, row.Name);
+            FileLog.Write($"[RepositoryDetailView] delete branch {row.Name}: {(deleted ? "deleted" : "refused")} - {message}");
+            _loadedTabs.Remove("Branches");
+            ShowTab("Branches");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] DeleteBranch_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private async void DeleteSafeBranchesButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var repo = _repoPath;
+            if (repo is null) return;
+            var branches = await Task.Run(() => _branches.ListAsync(repo));
+            foreach (var b in branches.Where(x => x.SafeToDelete))
+            {
+                var (deleted, message) = await _branches.DeleteIfSafeAsync(repo, b.Name);
+                FileLog.Write($"[RepositoryDetailView] batch delete {b.Name}: {(deleted ? "ok" : "refused")} - {message}");
+            }
+            _loadedTabs.Remove("Branches");
+            ShowTab("Branches");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] DeleteSafeBranchesButton_Click FAILED: {ex.Message}");
+        }
+    }
+
+    // ----- pull requests -----
+
+    private async Task LoadPullRequestsAsync()
+    {
+        var repo = _repoPath;
+        if (repo is null || _current is null) return;
+        PullRequestsStatus.Text = "Loading pull requests...";
+        PullRequestsStatus.IsVisible = true;
+        try
+        {
+            var result = await Task.Run(() => _pullRequests.ListOpenAsync(repo, _current.Provider));
+            if (_repoPath != repo) return;
+            if (!result.Success)
+            {
+                PullRequestsStatus.Text = result.Error ?? "Could not list pull requests.";
+                return;
+            }
+            PullRequestsList.ItemsSource = result.Items.Select(ToPullRequestRow).ToList();
+            PullRequestsStatus.Text = "No open pull requests.";
+            PullRequestsStatus.IsVisible = result.Items.Count == 0;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] LoadPullRequestsAsync FAILED: {ex.Message}");
+            PullRequestsStatus.Text = $"Could not list pull requests: {ex.Message}";
+        }
+    }
+
+    internal static PullRequestRowItem ToPullRequestRow(PullRequestInfo pr)
+    {
+        var meta = new List<string> { $"#{pr.Number}", pr.Author, pr.Branch };
+        if (pr.IsDraft) meta.Add("draft");
+        if (pr.CreatedUtc is { } created) meta.Add($"opened {created:yyyy-MM-dd}");
+        var (glyph, brush) = pr.Checks switch
+        {
+            ChecksState.Passing => ("OK", GreenFg),
+            ChecksState.Running => ("...", AmberFg),
+            ChecksState.Failing => ("X", RedFg),
+            _ => ("-", MutedFg),
+        };
+        var chip = pr.ReviewState;
+        return new PullRequestRowItem
+        {
+            Number = pr.Number,
+            Title = pr.Title,
+            Meta = string.Join(" · ", meta.Where(m => m.Length > 0)),
+            Chip = chip,
+            ChecksGlyph = glyph,
+            ChecksBrush = brush,
+            Url = pr.Url,
+            ChipFg = chip == "approved" ? GreenFg : chip == "changes requested" ? RedFg : AmberFg,
+            ChipBg = chip == "approved" ? GreenBg : chip == "changes requested" ? RedBg : AmberBg,
+            ChipBr = chip == "approved" ? GreenBr : chip == "changes requested" ? RedBr : AmberBr,
+        };
+    }
+
+    private void OpenPullRequest_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if ((sender as Button)?.DataContext is PullRequestRowItem row && row.Url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(row.Url) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] OpenPullRequest_Click FAILED: {ex.Message}");
+        }
+    }
+
+    // ----- history -----
+
+    private async Task LoadHistoryAsync()
+    {
+        var repo = _repoPath;
+        if (repo is null) return;
+        try
+        {
+            var commits = await Task.Run(() => _history.RecentAsync(repo));
+            if (_repoPath != repo) return;
+            HistoryList.ItemsSource = commits.Select(c => new CommitRowItem
+            {
+                Hash = c.ShortHash,
+                Subject = c.Subject,
+                When = c.WhenUtc is { } w ? w.ToLocalTime().ToString("yyyy-MM-dd HH:mm") : "",
+            }).ToList();
+            HistoryStatus.IsVisible = commits.Count == 0;
+            HistoryStatus.Text = "No commits.";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] LoadHistoryAsync FAILED: {ex.Message}");
+            HistoryStatus.Text = $"Could not read history: {ex.Message}";
+        }
+    }
+
+    // ----- header actions -----
+
+    private void BackButton_Click(object? sender, RoutedEventArgs e) => BackRequested?.Invoke();
+
+    private void OpenVsCodeButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (_repoPath is null) return;
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("code", $"\"{_repoPath}\"") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] OpenVsCodeButton_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private async void HandToAgentButton_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (_repoPath is null || _current is null)
+                return;
+            var window = TopLevel.GetTopLevel(this) as Window;
+            if (window is null)
+                return;
+            var dialog = new global::CcDirector.Avalonia.HandToAgentDialog(_current);
+            var brief = await dialog.ShowDialog<string?>(window);
+            if (!string.IsNullOrWhiteSpace(brief))
+                HandToAgentRequested?.Invoke(_repoPath, brief);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryDetailView] HandToAgentButton_Click FAILED: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryDetailView.axaml.cs
@@ -118,6 +118,9 @@ public partial class RepositoryDetailView : UserControl
         _current = null;
     }
 
+    /// <summary>Test probe: true while the view holds live monitor subscriptions.</summary>
+    internal bool IsAttached => _monitor != null;
+
     private void OnUpserted(RepositoryStatus s)
     {
         if (_repoPath != null && string.Equals(

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
@@ -12,7 +12,9 @@
                     CornerRadius="4"
                     Padding="12,9"
                     Margin="0,0,0,7"
-                    Opacity="{Binding RowOpacity}">
+                    Opacity="{Binding RowOpacity}"
+                    Cursor="Hand"
+                    PointerPressed="RepoRow_PointerPressed">
                 <Grid ColumnDefinitions="*,Auto,Auto,Auto">
                     <!-- Identity -->
                     <StackPanel Grid.Column="0" Spacing="3" VerticalAlignment="Center">

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml
@@ -11,7 +11,8 @@
                     BorderThickness="1"
                     CornerRadius="4"
                     Padding="12,9"
-                    Margin="0,0,0,7">
+                    Margin="0,0,0,7"
+                    Opacity="{Binding RowOpacity}">
                 <Grid ColumnDefinitions="*,Auto,Auto,Auto">
                     <!-- Identity -->
                     <StackPanel Grid.Column="0" Spacing="3" VerticalAlignment="Center">
@@ -20,6 +21,11 @@
                             <Border Background="Transparent" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="4"
                                     Padding="6,1" VerticalAlignment="Center" IsVisible="{Binding HasProvider}">
                                 <TextBlock Text="{Binding Provider}" Foreground="#8A8A8A" FontSize="9.5" />
+                            </Border>
+                            <Border Background="#3A2A1B" BorderBrush="#5A4326" BorderThickness="1" CornerRadius="4"
+                                    Padding="6,1" VerticalAlignment="Center" IsVisible="{Binding Verifying}"
+                                    ToolTip.Tip="Shown from the last run; the background scan is re-checking it">
+                                <TextBlock Text="verifying..." Foreground="#C9A24A" FontSize="9.5" />
                             </Border>
                         </StackPanel>
                         <TextBlock Text="{Binding SubPath}" Foreground="#666666" FontSize="10.5"

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
@@ -58,6 +58,18 @@ public partial class RepositoryListView : UserControl
     /// <summary>Raised when the user clicks Refresh; the host triggers the monitor to rescan.</summary>
     public event Action? RefreshRequested;
 
+    /// <summary>Raised when a repository row is clicked - the host opens its detail screen.</summary>
+    public event Action<string>? RepoOpenRequested;
+
+    private void RepoRow_PointerPressed(object? sender, global::Avalonia.Input.PointerPressedEventArgs e)
+    {
+        if ((sender as Control)?.DataContext is RepoRowItem row && row.Path.Length > 0)
+        {
+            FileLog.Write($"[RepositoryListView] open repo: {row.Path}");
+            RepoOpenRequested?.Invoke(row.Path);
+        }
+    }
+
     public RepositoryListView()
     {
         InitializeComponent();

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
@@ -21,6 +21,10 @@ public sealed class RepoRowItem
     public string Sync { get; init; } = "";
     public string Worktrees { get; init; } = "";
 
+    /// <summary>True for warm-start cache entries not yet re-verified - rendered dimmed.</summary>
+    public bool Verifying { get; init; }
+    public double RowOpacity => Verifying ? 0.55 : 1.0;
+
     public ISolidColorBrush WhereFg { get; init; } = Brushes.Gray;
     public ISolidColorBrush WhereBg { get; init; } = Brushes.Transparent;
     public ISolidColorBrush WhereBr { get; init; } = Brushes.Gray;
@@ -140,6 +144,7 @@ public partial class RepositoryListView : UserControl
             Where = WhereText(s),
             Sync = SyncText(s),
             Worktrees = WorktreeText(s),
+            Verifying = s.Provisional,
             WhereFg = dirty ? Amber : Green,
             WhereBg = dirty ? AmberBg : GreenBg,
             WhereBr = dirty ? AmberBr : GreenBr,

--- a/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/RepositoryListView.axaml.cs
@@ -63,12 +63,23 @@ public partial class RepositoryListView : UserControl
 
     private void RepoRow_PointerPressed(object? sender, global::Avalonia.Input.PointerPressedEventArgs e)
     {
-        if ((sender as Control)?.DataContext is RepoRowItem row && row.Path.Length > 0)
+        if ((sender as Control)?.DataContext is not RepoRowItem row)
+            return;
+        if (!ShouldOpenRow(row))
         {
-            FileLog.Write($"[RepositoryListView] open repo: {row.Path}");
-            RepoOpenRequested?.Invoke(row.Path);
+            FileLog.Write($"[RepositoryListView] row click ignored - entry still verifying: {row.Path}");
+            return;
         }
+        FileLog.Write($"[RepositoryListView] open repo: {row.Path}");
+        RepoOpenRequested?.Invoke(row.Path);
     }
+
+    /// <summary>
+    /// A provisional (still verifying) entry never opens the detail screen - the detail screen is
+    /// an acting surface (stage, commit, discard, branch delete) and cached, unverified data must
+    /// not receive actions. The row's "verifying" chip already explains the wait.
+    /// </summary>
+    internal static bool ShouldOpenRow(RepoRowItem row) => row.Path.Length > 0 && !row.Verifying;
 
     public RepositoryListView()
     {

--- a/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SourceControlView.axaml.cs
@@ -42,13 +42,17 @@ public partial class SourceControlView : UserControl
         WorktreesPage.OrphanedCountChanged += OnWorktreesOrphanedCountChanged;
     }
 
-    /// <summary>Point both pages at the repository. The rail resets to the default Changes page.</summary>
-    public void Attach(string repoPath)
+    /// <summary>
+    /// Point both pages at the repository. The rail resets to the default Changes page. The
+    /// Worktrees page renders the background monitor's model (one brain); the Changes page keeps
+    /// its own fast file-status poll (uncommitted files change second to second).
+    /// </summary>
+    public void Attach(RepositoryMonitor monitor, string repoPath)
     {
         FileLog.Write($"[SourceControlView] Attach: {repoPath}");
         ShowPage(worktrees: false);
         ChangesPage.Attach(repoPath);
-        WorktreesPage.Attach(repoPath);
+        WorktreesPage.Attach(monitor, repoPath);
     }
 
     /// <summary>Tear down both pages when the session context goes away.</summary>

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -187,8 +187,9 @@ public partial class WorktreesView : UserControl
     }
 
     /// <summary>
-    /// Ask the background monitor to recompute this one repository (with fresh live-session data),
-    /// then render its updated model. The view itself never scans.
+    /// Ask the background monitor to recompute this one repository, then render its updated model.
+    /// The monitor owns the live-session source and canonicalizes a worktree path to its primary
+    /// checkout itself. The view itself never scans.
     /// </summary>
     private async Task RefreshAsync()
     {
@@ -203,8 +204,7 @@ public partial class WorktreesView : UserControl
 
         try
         {
-            var liveSessions = await FetchLiveSessionsAsync();
-            await Task.Run(() => _monitor.RecomputeOneAsync(entryPath!, liveSessions));
+            await Task.Run(() => _monitor.RecomputeOneAsync(entryPath!));
         }
         catch (Exception ex)
         {
@@ -292,11 +292,18 @@ public partial class WorktreesView : UserControl
         await RunReapAsync();
     }
 
-    private async Task RunReapAsync()
+    /// <summary>
+    /// Test seam: when set, replaces the real reaper call. Lets a headless test observe exactly
+    /// which repository path the reap targets without deleting anything.
+    /// </summary>
+    internal Func<string, IReadOnlySet<string>, Task<ReapResult>>? ReapServiceOverride { get; set; }
+
+    internal async Task RunReapAsync()
     {
-        // The reaper runs against the repository entry, not the session's own folder (which may
-        // itself be a worktree of that repository).
-        var repoPath = _repoEntryPath ?? _repoPath;
+        // The reaper runs against the repository entry ONLY - never the session's own folder,
+        // which may itself be a linked worktree of that repository. Until the monitor has resolved
+        // the owning entry there is nothing safe to reap.
+        var repoPath = _repoEntryPath;
         if (string.IsNullOrWhiteSpace(repoPath) || _isReaping || _provisional)
             return;
 
@@ -313,10 +320,12 @@ public partial class WorktreesView : UserControl
             // still protected (belt-and-suspenders on top of the detector's classification).
             var liveSessions = await FetchLiveSessionsAsync();
             var protectedPaths = ToProtectedSet(liveSessions);
-            var result = await Task.Run(() => _reaper.ReapAsync(repoPath!, protectedPaths));
+            var result = ReapServiceOverride is { } reap
+                ? await reap(repoPath!, protectedPaths)
+                : await Task.Run(() => _reaper.ReapAsync(repoPath!, protectedPaths));
 
-            if ((_repoEntryPath ?? _repoPath) != repoPath)
-                return;
+            if (_repoEntryPath != repoPath)
+                return; // the view moved to another repository while the reaper ran
 
             // Re-scan first so the counts, badge, and listing reflect what actually happened,
             // then lay the result banner on top of the refreshed view.

--- a/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/WorktreesView.axaml.cs
@@ -42,11 +42,12 @@ public partial class WorktreesView : UserControl
     private static readonly ISolidColorBrush AttentionBrush = new SolidColorBrush(Color.Parse("#F59E0B"));
     private static readonly ISolidColorBrush InUseBrush = new SolidColorBrush(Color.Parse("#3B82F6"));
 
-    private readonly WorktreeInventoryService _service = new();
     private readonly WorktreeReaperService _reaper = new();
-    private string? _repoPath;
+    private RepositoryMonitor? _monitor;
+    private string? _repoPath;          // the session's working directory (may be a worktree path)
+    private string? _repoEntryPath;     // the owning repository's path in the monitor model
+    private bool _provisional;          // entry came from the warm-start cache - display only, never act
     private WorktreeInventory? _lastInventory;
-    private bool _isLoading;
     private bool _isReaping;
 
     /// <summary>Raised (on the UI thread) whenever the safe-to-reap count changes, so the host can badge the tab.</summary>
@@ -67,19 +68,40 @@ public partial class WorktreesView : UserControl
         InitializeComponent();
     }
 
-    /// <summary>Point the view at a repository and kick off a scan. Immediate "Loading..." feedback.</summary>
-    public void Attach(string repoPath)
+    /// <summary>
+    /// Point the view at a repository (or a worktree of one) and render the background monitor's
+    /// model for it - the one-brain rule: this tab never scans, it displays what the service knows,
+    /// updating live as the monitor streams.
+    /// </summary>
+    public void Attach(RepositoryMonitor monitor, string repoPath)
     {
         FileLog.Write($"[WorktreesView] Attach: {repoPath}");
+        Detach();
+        _monitor = monitor;
         _repoPath = repoPath;
-        _ = RefreshAsync();
+        monitor.Upserted += OnMonitorChanged;
+        monitor.Removed += OnMonitorChanged;
+        monitor.ProgressChanged += OnMonitorProgress;
+        RenderFromMonitor();
     }
+
+    private void OnMonitorChanged(RepositoryStatus _) => Dispatcher.UIThread.Post(RenderFromMonitor);
+    private void OnMonitorProgress() => Dispatcher.UIThread.Post(RenderFromMonitor);
 
     /// <summary>Clear the view when the session context goes away.</summary>
     public void Detach()
     {
         FileLog.Write("[WorktreesView] Detach");
+        if (_monitor is { } m)
+        {
+            m.Upserted -= OnMonitorChanged;
+            m.Removed -= OnMonitorChanged;
+            m.ProgressChanged -= OnMonitorProgress;
+            _monitor = null;
+        }
         _repoPath = null;
+        _repoEntryPath = null;
+        _provisional = false;
         _lastInventory = null;
         SafeList.ItemsSource = null;
         NeedsList.ItemsSource = null;
@@ -103,6 +125,49 @@ public partial class WorktreesView : UserControl
         _ = RefreshAsync();
     }
 
+    /// <summary>
+    /// Render this repository's slice of the monitor model. Provisional (warm-start) entries render
+    /// dimmed and cannot be reaped until a live scan confirms them.
+    /// </summary>
+    private void RenderFromMonitor()
+    {
+        if (_monitor is null || _repoPath is null)
+            return;
+
+        var entry = _monitor.FindForPath(_repoPath);
+        if (entry is null)
+        {
+            _repoEntryPath = null;
+            StatusText.Text = _monitor.IsScanning
+                ? $"Scanning repositories... {_monitor.ScanDone} of {_monitor.ScanTotal}"
+                : "This folder is not under a registered root directory. Add its root under Repositories.";
+            StatusText.IsVisible = true;
+            ContentScroller.IsVisible = false;
+            SetOrphanedCount(0);
+            return;
+        }
+
+        _repoEntryPath = entry.Path;
+        _provisional = entry.Provisional;
+
+        var inventory = new WorktreeInventory
+        {
+            RepositoryPath = entry.Path,
+            Worktrees = entry.Worktrees,
+            Success = true,
+        };
+        _lastInventory = inventory;
+        Render(inventory);
+
+        // Warm-start trust rule: show it, dim it, never act on it.
+        ContentScroller.Opacity = entry.Provisional ? 0.55 : 1.0;
+        if (entry.Provisional)
+        {
+            ReapButton.IsVisible = false;
+            ShowBanner("Showing the last run while verifying... actions unlock when the scan confirms this repository.");
+        }
+    }
+
     private async void CopyReportButton_Click(object? sender, RoutedEventArgs e)
     {
         try
@@ -122,45 +187,34 @@ public partial class WorktreesView : UserControl
     }
 
     /// <summary>
-    /// Scan the repository off the UI thread, then render the result. Shows a clear message on
-    /// failure rather than silently degrading.
+    /// Ask the background monitor to recompute this one repository (with fresh live-session data),
+    /// then render its updated model. The view itself never scans.
     /// </summary>
     private async Task RefreshAsync()
     {
-        var repoPath = _repoPath;
-        if (string.IsNullOrWhiteSpace(repoPath) || _isLoading)
+        if (_monitor is null)
+            return;
+        var entryPath = _repoEntryPath ?? _repoPath;
+        if (string.IsNullOrWhiteSpace(entryPath))
             return;
 
-        _isLoading = true;
-        StatusText.Text = "Loading worktrees...";
+        StatusText.Text = "Refreshing...";
         StatusText.IsVisible = true;
-        ContentScroller.IsVisible = false;
 
         try
         {
-            // Ask the host which sessions are live on this machine (best-effort) so a git-safe
-            // worktree with a session in it is shown as "in use" rather than "safe to reap".
             var liveSessions = await FetchLiveSessionsAsync();
-            var inventory = await Task.Run(() => _service.GetInventoryAsync(repoPath, true, liveSessions));
-
-            // Ignore stale results if the view was re-pointed while we were scanning.
-            if (_repoPath != repoPath)
-                return;
-
-            _lastInventory = inventory;
-            Render(inventory);
+            await Task.Run(() => _monitor.RecomputeOneAsync(entryPath!, liveSessions));
         }
         catch (Exception ex)
         {
             FileLog.Write($"[WorktreesView] RefreshAsync FAILED: {ex.Message}");
-            StatusText.Text = $"Could not read worktrees: {ex.Message}";
+            StatusText.Text = $"Could not refresh: {ex.Message}";
             StatusText.IsVisible = true;
-            ContentScroller.IsVisible = false;
+            return;
         }
-        finally
-        {
-            _isLoading = false;
-        }
+
+        RenderFromMonitor();
     }
 
     private void Render(WorktreeInventory inventory)
@@ -212,6 +266,9 @@ public partial class WorktreesView : UserControl
     /// <summary>Show the confirmation overlay listing exactly what will be removed.</summary>
     private void ReapButton_Click(object? sender, RoutedEventArgs e)
     {
+        // Warm-start trust rule: never act on a provisional (cached, unverified) entry.
+        if (_provisional)
+            return;
         // Worktrees a live session is running in are already classified out of the safe set, so
         // the safe list is exactly what the button removes.
         if (_lastInventory is not { Success: true } inventory || inventory.SafeToReapCount == 0)
@@ -237,8 +294,10 @@ public partial class WorktreesView : UserControl
 
     private async Task RunReapAsync()
     {
-        var repoPath = _repoPath;
-        if (string.IsNullOrWhiteSpace(repoPath) || _isReaping)
+        // The reaper runs against the repository entry, not the session's own folder (which may
+        // itself be a worktree of that repository).
+        var repoPath = _repoEntryPath ?? _repoPath;
+        if (string.IsNullOrWhiteSpace(repoPath) || _isReaping || _provisional)
             return;
 
         _isReaping = true;
@@ -254,9 +313,9 @@ public partial class WorktreesView : UserControl
             // still protected (belt-and-suspenders on top of the detector's classification).
             var liveSessions = await FetchLiveSessionsAsync();
             var protectedPaths = ToProtectedSet(liveSessions);
-            var result = await Task.Run(() => _reaper.ReapAsync(repoPath, protectedPaths));
+            var result = await Task.Run(() => _reaper.ReapAsync(repoPath!, protectedPaths));
 
-            if (_repoPath != repoPath)
+            if ((_repoEntryPath ?? _repoPath) != repoPath)
                 return;
 
             // Re-scan first so the counts, badge, and listing reflect what actually happened,

--- a/src/CcDirector.Avalonia/HandToAgentDialog.axaml
+++ b/src/CcDirector.Avalonia/HandToAgentDialog.axaml
@@ -1,0 +1,56 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.HandToAgentDialog"
+        Title="Hand to an agent"
+        Width="560" Height="560"
+        MinWidth="480" MinHeight="460"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        Background="#252526">
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="16">
+        <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,10">
+            <TextBlock x:Name="HeaderText" Text="Hand this repository to an agent" Foreground="#CCCCCC"
+                       FontSize="15" FontWeight="SemiBold" />
+            <TextBlock x:Name="SubText" Text="" Foreground="#8A8A8A" FontSize="11.5" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Spacing="6" Margin="0,0,0,10">
+            <RadioButton x:Name="OptProtect" GroupName="kind" IsChecked="True" Foreground="#CCCCCC" FontSize="12"
+                         Checked="Option_Changed">
+                <StackPanel Spacing="1">
+                    <TextBlock Text="Sort and protect the changes" FontWeight="SemiBold" />
+                    <TextBlock Text="Commit in sensible pieces, push a branch, open a pull request for your review."
+                               Foreground="#8A8A8A" FontSize="10.5" TextWrapping="Wrap" />
+                </StackPanel>
+            </RadioButton>
+            <RadioButton x:Name="OptCleanup" GroupName="kind" Foreground="#CCCCCC" FontSize="12" Checked="Option_Changed">
+                <StackPanel Spacing="1">
+                    <TextBlock Text="Clean up - keep only what matters" FontWeight="SemiBold" />
+                    <TextBlock Text="Classify the files and show you a discard list BEFORE touching anything."
+                               Foreground="#8A8A8A" FontSize="10.5" TextWrapping="Wrap" />
+                </StackPanel>
+            </RadioButton>
+            <RadioButton x:Name="OptExplain" GroupName="kind" Foreground="#CCCCCC" FontSize="12" Checked="Option_Changed">
+                <StackPanel Spacing="1">
+                    <TextBlock Text="Just explain what's here" FontWeight="SemiBold" />
+                    <TextBlock Text="A written summary. No changes of any kind." Foreground="#8A8A8A" FontSize="10.5" />
+                </StackPanel>
+            </RadioButton>
+        </StackPanel>
+
+        <Border Grid.Row="2" Background="#161616" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="6" Padding="10">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <TextBlock x:Name="BriefPreview" Text="" Foreground="#9A9A9A" FontSize="10.5"
+                           FontFamily="Cascadia Mono, Consolas" TextWrapping="Wrap" />
+            </ScrollViewer>
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+            <Button Content="Cancel" Background="#3C3C3C" Foreground="#CCCCCC" Padding="14,6" FontSize="12"
+                    Click="CancelButton_Click" />
+            <Button Content="Start agent session" Background="#0E639C" Foreground="White" Padding="14,6" FontSize="12"
+                    FontWeight="SemiBold" Click="StartButton_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/CcDirector.Avalonia/HandToAgentDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/HandToAgentDialog.axaml.cs
@@ -1,0 +1,60 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// The hand-off dialog: the owner chooses an outcome in plain language, sees EXACTLY the brief the
+/// agent will receive, and confirms. Returns the brief text (dialog result), or null on cancel. The
+/// host then spawns a session in the repository with the brief staged in the prompt box - the owner
+/// reads and sends it; the agent never starts unseen.
+/// </summary>
+public partial class HandToAgentDialog : Window
+{
+    private readonly RepositoryStatus? _repo;
+
+    public HandToAgentDialog()
+    {
+        InitializeComponent();
+    }
+
+    public HandToAgentDialog(RepositoryStatus repo) : this()
+    {
+        _repo = repo;
+        HeaderText.Text = $"Hand {repo.Name} to an agent";
+        SubText.Text = repo.IsClean
+            ? "The tree is clean - an agent can still explain or tidy branches and worktrees."
+            : $"{repo.UncommittedCount} uncommitted file(s). Choose what the agent should do:";
+        UpdatePreview();
+    }
+
+    private AgentHandOffKind SelectedKind =>
+        OptCleanup.IsChecked == true ? AgentHandOffKind.CleanUp
+        : OptExplain.IsChecked == true ? AgentHandOffKind.ExplainOnly
+        : AgentHandOffKind.ProtectChanges;
+
+    private void Option_Changed(object? sender, RoutedEventArgs e) => UpdatePreview();
+
+    private void UpdatePreview()
+    {
+        if (_repo is null || BriefPreview is null)
+            return;
+        BriefPreview.Text = AgentBriefTemplates.Build(SelectedKind, _repo);
+    }
+
+    private void CancelButton_Click(object? sender, RoutedEventArgs e) => Close(null);
+
+    private void StartButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_repo is null)
+        {
+            Close(null);
+            return;
+        }
+        FileLog.Write($"[HandToAgentDialog] hand-off chosen: {SelectedKind} for {_repo.Path}");
+        Close(AgentBriefTemplates.Build(SelectedKind, _repo));
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -168,6 +168,15 @@ public partial class MainWindow : Window
         AlphaMode.Changed += OnAlphaModeChanged;
         Closed += (_, _) => AlphaMode.Changed -= OnAlphaModeChanged;
 
+        // The monitor's live-session source is wired HERE, in the constructor, NOT in
+        // MainWindow_Loaded: App.ShowMainWindow starts the first repository rescan
+        // synchronously right after constructing this window, and the monitor refuses to
+        // scan unwired (ruling R2-8). Loaded fires asynchronously after layout, so wiring
+        // there loses the race and the first scan throws - which is exactly what happened
+        // on the first live run of the fixed build.
+        if (global::Avalonia.Application.Current is App appForMonitor)
+            appForMonitor.RepositoryMonitor.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
+
         BuildNativeMenu();
     }
 
@@ -249,12 +258,10 @@ public partial class MainWindow : Window
         SourceControlView.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
 
         // Keep the pinned Repositories badge (safe-to-reap worktree count) in sync with the scan.
+        // (The monitor's LiveSessionsProvider itself is wired in the CONSTRUCTOR - it must be
+        // in place before App.ShowMainWindow triggers the first rescan; see the ctor comment.)
         if (global::Avalonia.Application.Current is App appForRepo)
         {
-            // The monitor owns the live-session source: every compute (full scan or watcher
-            // recompute) consults it, so background recomputes can never erase the
-            // in-use-by-session classification.
-            appForRepo.RepositoryMonitor.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
             appForRepo.RepositoryMonitor.Upserted += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
             appForRepo.RepositoryMonitor.Removed += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
             appForRepo.RepositoryMonitor.ProgressChanged += () => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -251,6 +251,10 @@ public partial class MainWindow : Window
         // Keep the pinned Repositories badge (safe-to-reap worktree count) in sync with the scan.
         if (global::Avalonia.Application.Current is App appForRepo)
         {
+            // The monitor owns the live-session source: every compute (full scan or watcher
+            // recompute) consults it, so background recomputes can never erase the
+            // in-use-by-session classification.
+            appForRepo.RepositoryMonitor.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
             appForRepo.RepositoryMonitor.Upserted += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
             appForRepo.RepositoryMonitor.Removed += _ => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);
             appForRepo.RepositoryMonitor.ProgressChanged += () => Dispatcher.UIThread.Post(UpdateRepositoriesBadge);

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1832,8 +1832,10 @@ public partial class MainWindow : Window
         TerminalHost.Attach(vm.Session);
         UpdateScrollBar();
 
-        // Attach source control (hide tab if no .git)
-        SourceControlView.Attach(vm.Session.RepoPath);
+        // Attach source control (hide tab if no .git). The Worktrees page renders the background
+        // repository monitor's model - the same brain as the Repositories home.
+        if (global::Avalonia.Application.Current is App scApp)
+            SourceControlView.Attach(scApp.RepositoryMonitor, vm.Session.RepoPath);
         UpdateSourceControlTabVisibility(vm.Session.RepoPath);
 
         // Show prompt bar

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -257,6 +257,10 @@ public partial class MainWindow : Window
             UpdateRepositoriesBadge();
         }
 
+        // Repository detail: live sessions for the worktrees panel, and the hand-to-an-agent flow.
+        RepositoriesView.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
+        RepositoriesView.HandToAgentRequested += OnRepositoryHandToAgent;
+
         // Wire prompt input text changes for slash command autocomplete
         PromptInput.TextChanged += PromptInput_TextChanged;
         PromptInput.LostFocus += (_, _) => SlashCommandPopup.IsOpen = false;
@@ -4090,6 +4094,25 @@ public partial class MainWindow : Window
     {
         BtnRepositories.Background = new global::Avalonia.Media.SolidColorBrush(
             global::Avalonia.Media.Color.Parse(active ? "#094771" : "#2A2A2A"));
+    }
+
+    /// <summary>
+    /// The hand-off: spawn a session in the repository and stage the brief in its prompt box, so
+    /// the owner reads exactly what the agent will be told and presses send themselves.
+    /// </summary>
+    private void OnRepositoryHandToAgent(string repoPath, string brief)
+    {
+        FileLog.Write($"[MainWindow] hand to agent: {repoPath}");
+        RepositoriesOverlay.IsVisible = false;
+        SetRepositoriesActive(false);
+        var vm = CreateSession(repoPath);
+        if (vm is null)
+            return;
+        vm.Session.PendingPromptText = brief;
+        if (_activeSession == vm)
+            PromptInput.Text = brief; // already selected - stage it into the visible prompt box now
+        SaveSessionToHistory(vm);
+        SwitchLeftTab("Terminal");
     }
 
     /// <summary>Show the safe-to-reap worktree count on the pinned Repositories entry.</summary>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -214,8 +214,9 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// If true, bearer-token or cookie auth is required for all routes except /healthz/login/logout.
     /// If false (default), the Director is completely open. The Tailscale tailnet is the trust boundary.
     /// </param>
-    public ControlApiHost(SessionManager sessionManager, string version, Func<Task> requestShutdownAsync, bool useEphemeralPort = false, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, string? directorId = null, string? instancesDirectory = null)
+    public ControlApiHost(SessionManager sessionManager, string version, Func<Task> requestShutdownAsync, bool useEphemeralPort = false, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, string? directorId = null, string? instancesDirectory = null, Core.Git.RepositoryMonitor? repositoryMonitor = null)
     {
+        _repositoryMonitor = repositoryMonitor;
         _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _version = version ?? "0.0.0";
         _requestShutdownAsync = requestShutdownAsync ?? throw new ArgumentNullException(nameof(requestShutdownAsync));
@@ -492,7 +493,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         // change is picked up without a restart. Standalone/no-Gateway resolves to null (line omitted).
         var signedInUserProvider = new Core.Account.SignedInUserProvider(Core.Configuration.GatewayConfig.Load);
 
-        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore, ct => signedInUserProvider.ResolveAsync(ct));
+        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore, ct => signedInUserProvider.ResolveAsync(ct), _repositoryMonitor);
 
         // Gateway Cleanup mission: the Director floor's tunnel-bounce. An operator/launcher can force
         // this Director to re-establish its OUTBOUND tunnel without a full restart. Loopback floor route.
@@ -617,6 +618,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         _streamClient = BuildStreamClient(gatewayConfig);
         _streamClient?.Start();
         WireDoorbellPush();
+        WireRepositoryPush();
 
         IsListening = true;
         StartupError = null;
@@ -755,7 +757,10 @@ public sealed class ControlApiHost : IAsyncDisposable
             sessionManager: _sessionManager,
             // Gateway Cleanup mission (tunnel-only): the tunnel drives the desktop connectivity light directly -
             // connected = green (a live stream IS the proven two-way link), reconnecting = yellow.
-            monitor: GatewayMonitor);
+            monitor: GatewayMonitor,
+            // Repositories mission (#510 phase C): the repository/worktree snapshot rides the same
+            // tunnel; null when this host was built without a monitor (tests, older callers).
+            repoSnapshot: _repositoryMonitor is null ? null : SnapshotRepositories);
     }
 
     /// <summary>
@@ -792,6 +797,34 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// </summary>
     private List<SessionDto> SnapshotFullSessions()
         => _sessionManager.ListSessions().Select(s => ControlEndpoints.Map(s, DirectorId)).ToList();
+
+    private readonly Core.Git.RepositoryMonitor? _repositoryMonitor;
+    private Timer? _repoPushDebounce;
+
+    /// <summary>The repository snapshot for the stream and the local relay (#510 phase C).</summary>
+    private List<RepoStatusDto> SnapshotRepositories()
+        => (_repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
+            .Select(s => RepositoryDtoMapper.Map(s, DirectorId, Environment.MachineName))
+            .ToList();
+
+    /// <summary>
+    /// Push the repository snapshot on model changes, debounced: a scan streaming thirty upserts
+    /// coalesces into one push a few seconds after it settles (plus the periodic reseed).
+    /// </summary>
+    private void WireRepositoryPush()
+    {
+        if (_repositoryMonitor is null)
+            return;
+        void Schedule()
+        {
+            _repoPushDebounce?.Dispose();
+            _repoPushDebounce = new Timer(_ => _streamClient?.NotifyRepoSnapshot(), null,
+                TimeSpan.FromSeconds(3), Timeout.InfiniteTimeSpan);
+        }
+        _repositoryMonitor.Upserted += _ => Schedule();
+        _repositoryMonitor.Removed += _ => Schedule();
+        _repositoryMonitor.ScanCompleted += Schedule;
+    }
 
     /// <summary>Per-session mechanical-state snapshot for the heartbeat body (issue #186).</summary>
     private List<SessionStateSnapshot> SnapshotSessionStates()

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -401,6 +401,11 @@ internal static class ControlEndpoints
         // GET /fleet/repositories + /fleet/worktrees - the repository/worktree directory (#510 phase C).
         // With a Gateway, relay its fleet-wide aggregation; standalone, serve this Director's own
         // monitor model. Read-only: reaping always runs on the owning Director with a live re-verify.
+        List<RepoStatusDto> LocalRepoDtos() =>
+            (repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
+                .Select(s => RepositoryDtoMapper.Map(s, directorId, Environment.MachineName))
+                .ToList();
+
         app.MapGet("/fleet/repositories", async (CancellationToken ct) =>
         {
             var gw = gatewayClientProvider?.Invoke();
@@ -408,7 +413,12 @@ internal static class ControlEndpoints
             {
                 try
                 {
-                    return Results.Json(await gw.ListFleetRepositoriesAsync(ct));
+                    var fleet = await gw.ListFleetRepositoriesAsync(ct);
+                    // null = the Gateway is older and has no /repositories yet - serve this
+                    // Director's own model (version tolerance, not outage-hiding: a DOWN Gateway
+                    // still fails loud below).
+                    if (fleet != null)
+                        return Results.Json(fleet);
                 }
                 catch (Exception ex)
                 {
@@ -417,10 +427,7 @@ internal static class ControlEndpoints
                         statusCode: StatusCodes.Status502BadGateway);
                 }
             }
-            var local = (repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
-                .Select(s => RepositoryDtoMapper.Map(s, directorId, Environment.MachineName))
-                .ToList();
-            return Results.Json(local);
+            return Results.Json(LocalRepoDtos());
         });
 
         app.MapGet("/fleet/worktrees", async (CancellationToken ct) =>
@@ -430,7 +437,9 @@ internal static class ControlEndpoints
             {
                 try
                 {
-                    return Results.Json(await gw.ListFleetWorktreesAsync(ct));
+                    var fleet = await gw.ListFleetWorktreesAsync(ct);
+                    if (fleet != null)
+                        return Results.Json(fleet);
                 }
                 catch (Exception ex)
                 {
@@ -439,9 +448,7 @@ internal static class ControlEndpoints
                         statusCode: StatusCodes.Status502BadGateway);
                 }
             }
-            var repos = (repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
-                .Select(s => RepositoryDtoMapper.Map(s, directorId, Environment.MachineName));
-            return Results.Json(RepositoryDtoMapper.Flatten(repos));
+            return Results.Json(RepositoryDtoMapper.Flatten(LocalRepoDtos()));
         });
 
         // POST /fleet/send - deliver one message. A local target is delivered directly (works with

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -30,7 +30,7 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal static class ControlEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null, MissionStore? missionStore = null, Func<CancellationToken, Task<SignedInUser?>>? signedInUserResolver = null)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null, MissionStore? missionStore = null, Func<CancellationToken, Task<SignedInUser?>>? signedInUserResolver = null, Core.Git.RepositoryMonitor? repositoryMonitor = null)
     {
         // ===== Healthz =====
         app.MapGet("/healthz", () => Results.Json(new HealthDto
@@ -396,6 +396,52 @@ internal static class ControlEndpoints
                 .Select(s => MapWithIdentity(s, turnSummaryCache))
                 .ToList();
             return Results.Json(local);
+        });
+
+        // GET /fleet/repositories + /fleet/worktrees - the repository/worktree directory (#510 phase C).
+        // With a Gateway, relay its fleet-wide aggregation; standalone, serve this Director's own
+        // monitor model. Read-only: reaping always runs on the owning Director with a live re-verify.
+        app.MapGet("/fleet/repositories", async (CancellationToken ct) =>
+        {
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    return Results.Json(await gw.ListFleetRepositoriesAsync(ct));
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/repositories relay FAILED: {ex.Message}");
+                    return Results.Json(new { error = $"Cannot reach the Gateway: {ex.Message}" },
+                        statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+            var local = (repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
+                .Select(s => RepositoryDtoMapper.Map(s, directorId, Environment.MachineName))
+                .ToList();
+            return Results.Json(local);
+        });
+
+        app.MapGet("/fleet/worktrees", async (CancellationToken ct) =>
+        {
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    return Results.Json(await gw.ListFleetWorktreesAsync(ct));
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/worktrees relay FAILED: {ex.Message}");
+                    return Results.Json(new { error = $"Cannot reach the Gateway: {ex.Message}" },
+                        statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+            var repos = (repositoryMonitor?.Snapshot() ?? (IReadOnlyList<Core.Git.RepositoryStatus>)Array.Empty<Core.Git.RepositoryStatus>())
+                .Select(s => RepositoryDtoMapper.Map(s, directorId, Environment.MachineName));
+            return Results.Json(RepositoryDtoMapper.Flatten(repos));
         });
 
         // POST /fleet/send - deliver one message. A local target is delivered directly (works with

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -228,6 +228,36 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         return list;
     }
 
+    /// <summary>The fleet's repositories (GET /repositories). Throws when the Gateway is disabled or the call fails.</summary>
+    public async Task<List<RepoStatusDto>> ListFleetRepositoriesAsync(CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot list fleet repositories.");
+        FileLog.Write("[GatewayClient] ListFleetRepositoriesAsync: GET /repositories");
+        using var resp = await _http.GetAsync("repositories", ct);
+        if (!resp.IsSuccessStatusCode)
+            throw await RelayFailureAsync(resp, "GET /repositories", ct);
+        var list = await resp.Content.ReadFromJsonAsync<List<RepoStatusDto>>(ct);
+        if (list is null)
+            throw new InvalidOperationException("Gateway GET /repositories returned an unparsable body.");
+        return list;
+    }
+
+    /// <summary>The fleet's worktrees, flattened (GET /worktrees). Throws when the Gateway is disabled or the call fails.</summary>
+    public async Task<List<FleetWorktreeDto>> ListFleetWorktreesAsync(CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot list fleet worktrees.");
+        FileLog.Write("[GatewayClient] ListFleetWorktreesAsync: GET /worktrees");
+        using var resp = await _http.GetAsync("worktrees", ct);
+        if (!resp.IsSuccessStatusCode)
+            throw await RelayFailureAsync(resp, "GET /worktrees", ct);
+        var list = await resp.Content.ReadFromJsonAsync<List<FleetWorktreeDto>>(ct);
+        if (list is null)
+            throw new InvalidOperationException("Gateway GET /worktrees returned an unparsable body.");
+        return list;
+    }
+
     /// <summary>
     /// Relay a single message to a session anywhere in the fleet via the Gateway's
     /// POST /sessions/{sid}/prompt. Fire-and-forget (WaitForIdle=false). Throws when the

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -228,6 +228,18 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         return list;
     }
 
+
+    /// <summary>
+    /// True when the Gateway does not actually serve this route: an explicit 404, or the Cockpit
+    /// single-page-app fallback answering an unknown GET with 200 text/html. Either way the route
+    /// is absent on that Gateway version and the caller serves its own local model. A JSON error
+    /// or a 5xx is a REAL failure and is never mistaken for absence.
+    /// </summary>
+    private static bool RouteAbsent(HttpResponseMessage resp)
+        => resp.StatusCode == HttpStatusCode.NotFound
+           || (resp.IsSuccessStatusCode
+               && !string.Equals(resp.Content.Headers.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase));
+
     /// <summary>
     /// The fleet's repositories (GET /repositories). Returns NULL when the Gateway answers 404 -
     /// an older Gateway that does not know the route yet (version tolerance, the same posture as
@@ -240,9 +252,9 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             throw new InvalidOperationException("Gateway is not configured; cannot list fleet repositories.");
         FileLog.Write("[GatewayClient] ListFleetRepositoriesAsync: GET /repositories");
         using var resp = await _http.GetAsync("repositories", ct);
-        if (resp.StatusCode == HttpStatusCode.NotFound)
+        if (RouteAbsent(resp))
         {
-            FileLog.Write("[GatewayClient] GET /repositories: 404 (older Gateway) - caller serves local");
+            FileLog.Write("[GatewayClient] GET /repositories: route absent on this Gateway (404 or non-JSON fallback) - caller serves local");
             return null;
         }
         if (!resp.IsSuccessStatusCode)
@@ -263,9 +275,9 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             throw new InvalidOperationException("Gateway is not configured; cannot list fleet worktrees.");
         FileLog.Write("[GatewayClient] ListFleetWorktreesAsync: GET /worktrees");
         using var resp = await _http.GetAsync("worktrees", ct);
-        if (resp.StatusCode == HttpStatusCode.NotFound)
+        if (RouteAbsent(resp))
         {
-            FileLog.Write("[GatewayClient] GET /worktrees: 404 (older Gateway) - caller serves local");
+            FileLog.Write("[GatewayClient] GET /worktrees: route absent on this Gateway (404 or non-JSON fallback) - caller serves local");
             return null;
         }
         if (!resp.IsSuccessStatusCode)

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -228,13 +228,23 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         return list;
     }
 
-    /// <summary>The fleet's repositories (GET /repositories). Throws when the Gateway is disabled or the call fails.</summary>
-    public async Task<List<RepoStatusDto>> ListFleetRepositoriesAsync(CancellationToken ct = default)
+    /// <summary>
+    /// The fleet's repositories (GET /repositories). Returns NULL when the Gateway answers 404 -
+    /// an older Gateway that does not know the route yet (version tolerance, the same posture as
+    /// the stream push skipping on an old hub); the caller then serves its own local model.
+    /// Throws when the Gateway is disabled or genuinely fails.
+    /// </summary>
+    public async Task<List<RepoStatusDto>?> ListFleetRepositoriesAsync(CancellationToken ct = default)
     {
         if (!_config.IsEnabled)
             throw new InvalidOperationException("Gateway is not configured; cannot list fleet repositories.");
         FileLog.Write("[GatewayClient] ListFleetRepositoriesAsync: GET /repositories");
         using var resp = await _http.GetAsync("repositories", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+        {
+            FileLog.Write("[GatewayClient] GET /repositories: 404 (older Gateway) - caller serves local");
+            return null;
+        }
         if (!resp.IsSuccessStatusCode)
             throw await RelayFailureAsync(resp, "GET /repositories", ct);
         var list = await resp.Content.ReadFromJsonAsync<List<RepoStatusDto>>(ct);
@@ -243,13 +253,21 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         return list;
     }
 
-    /// <summary>The fleet's worktrees, flattened (GET /worktrees). Throws when the Gateway is disabled or the call fails.</summary>
-    public async Task<List<FleetWorktreeDto>> ListFleetWorktreesAsync(CancellationToken ct = default)
+    /// <summary>
+    /// The fleet's worktrees, flattened (GET /worktrees). NULL on 404 (older Gateway - caller
+    /// serves its own local model); throws when the Gateway is disabled or genuinely fails.
+    /// </summary>
+    public async Task<List<FleetWorktreeDto>?> ListFleetWorktreesAsync(CancellationToken ct = default)
     {
         if (!_config.IsEnabled)
             throw new InvalidOperationException("Gateway is not configured; cannot list fleet worktrees.");
         FileLog.Write("[GatewayClient] ListFleetWorktreesAsync: GET /worktrees");
         using var resp = await _http.GetAsync("worktrees", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+        {
+            FileLog.Write("[GatewayClient] GET /worktrees: 404 (older Gateway) - caller serves local");
+            return null;
+        }
         if (!resp.IsSuccessStatusCode)
             throw await RelayFailureAsync(resp, "GET /worktrees", ct);
         var list = await resp.Content.ReadFromJsonAsync<List<FleetWorktreeDto>>(ct);

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -30,6 +30,13 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     private readonly string _directorId;
     private readonly string _version;
     private readonly Func<List<SessionDto>> _snapshot;
+
+    /// <summary>
+    /// The repository/worktree snapshot provider (issue devthrottle_internal#510, phase C). Null in
+    /// older callers and tests: repo pushes are then simply skipped. Pushed as full snapshots only -
+    /// repositories change slowly, so there is no delta path.
+    /// </summary>
+    private readonly Func<List<RepoStatusDto>>? _repoSnapshot;
     private readonly Func<DirectorCommand, Task<DirectorCommandResult>>? _commandDispatcher;
     private readonly TimeSpan _rePushInterval;
 
@@ -80,8 +87,10 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         Func<DirectorCommand, Task<DirectorCommandResult>>? commandDispatcher = null,
         TimeSpan? rePushInterval = null,
         SessionManager? sessionManager = null,
-        GatewayConnectionMonitor? monitor = null)
+        GatewayConnectionMonitor? monitor = null,
+        Func<List<RepoStatusDto>>? repoSnapshot = null)
     {
+        _repoSnapshot = repoSnapshot;
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _directorId = string.IsNullOrWhiteSpace(directorId) ? throw new ArgumentException("directorId is required", nameof(directorId)) : directorId;
         _version = version ?? "";
@@ -303,6 +312,36 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         {
             FileLog.Write($"[GatewayStreamClient] reseed failed (auto-reconnect will retry): {ex.Message}");
         }
+
+        // The repository snapshot rides the same reseed cadence, in its OWN try/catch: an old Gateway
+        // without the PushRepoSnapshot hub method throws a HubException here, and that must never take
+        // the session reseed down with it (best-effort, no capability negotiation - see phase C notes).
+        if (_repoSnapshot != null && conn.State == HubConnectionState.Connected)
+        {
+            try
+            {
+                var repoSeq = Interlocked.Increment(ref _sequence);
+                await conn.InvokeAsync("PushRepoSnapshot", repoSeq, _repoSnapshot().ToArray());
+                FileLog.Write($"[GatewayStreamClient] reseeded repository snapshot seq={repoSeq}");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[GatewayStreamClient] repository reseed skipped (older Gateway?): {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Push the current full repository snapshot. Fire-and-forget; callers debounce. A drop is
+    /// reconciled by the next reseed/re-push tick.
+    /// </summary>
+    public void NotifyRepoSnapshot()
+    {
+        if (_repoSnapshot is null) return;
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        var seq = Interlocked.Increment(ref _sequence);
+        _ = SendAsync(() => conn.InvokeAsync("PushRepoSnapshot", seq, _repoSnapshot().ToArray()), "PushRepoSnapshot");
     }
 
     /// <summary>Push one changed session. Fire-and-forget; a drop is reconciled by the next snapshot.</summary>

--- a/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
+++ b/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
@@ -1,0 +1,80 @@
+using CcDirector.Core.Git;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Maps the Director's live repository model to the wire DTOs pushed to the Gateway and served by
+/// the local relay. The fold happens HERE, once: worktree safety becomes a finished state string
+/// every client renders verbatim.
+/// </summary>
+public static class RepositoryDtoMapper
+{
+    public static RepoStatusDto Map(RepositoryStatus s, string directorId, string machineName) => new()
+    {
+        DirectorId = directorId,
+        MachineName = machineName,
+        Path = s.Path,
+        Name = s.Name,
+        RemoteUrl = s.RemoteUrl,
+        Provider = s.Provider.ToString(),
+        Org = s.Org,
+        Branch = s.Branch,
+        IsClean = s.IsClean,
+        UncommittedCount = s.UncommittedCount,
+        DirtySinceUtc = s.DirtySinceUtc,
+        AheadCount = s.AheadCount,
+        BehindCount = s.BehindCount,
+        BehindMainCount = s.BehindMainCount,
+        WorktreeCount = s.WorktreeCount,
+        WorktreesSafeToReap = s.WorktreesSafeToReap,
+        WorktreesInUse = s.WorktreesInUse,
+        WorktreesNeedAttention = s.WorktreesNeedAttention,
+        WorktreeBytes = s.WorktreeBytes,
+        Provisional = s.Provisional,
+        Worktrees = s.Worktrees.Select(Map).ToList(),
+    };
+
+    public static WorktreeDto Map(WorktreeInfo w) => new()
+    {
+        Path = w.Path,
+        Branch = w.Branch,
+        State = StateString(w.Safety),
+        Reason = w.Explanation,
+        SessionLabels = w.OpenSessions.ToList(),
+        SizeBytes = w.SizeBytes,
+        LastActivityUtc = w.LastActivityUtc,
+        AheadOfMain = w.AheadOfMain,
+        BehindMain = w.BehindMain,
+        DirtyFileCount = w.DirtyFileCount,
+        IsDetachedHead = w.IsDetachedHead,
+    };
+
+    /// <summary>The folded state string. Every surface renders this; nothing re-derives it.</summary>
+    public static string StateString(WorktreeSafety safety) => safety switch
+    {
+        WorktreeSafety.SafeToReap => "safe-to-reap",
+        WorktreeSafety.InUseBySession => "in-use",
+        _ => "needs-attention",
+    };
+
+    /// <summary>Flattens repository DTOs into fleet worktree rows (GET /worktrees).</summary>
+    public static List<FleetWorktreeDto> Flatten(IEnumerable<RepoStatusDto> repositories, double dataAgeSeconds = 0)
+        => repositories
+            .SelectMany(r => r.Worktrees.Select(w => new FleetWorktreeDto
+            {
+                RepoName = r.Name,
+                RepoPath = r.Path,
+                MachineName = r.MachineName,
+                DirectorId = r.DirectorId,
+                Path = w.Path,
+                Branch = w.Branch,
+                State = w.State,
+                Reason = w.Reason,
+                SessionLabels = w.SessionLabels,
+                SizeBytes = w.SizeBytes,
+                LastActivityUtc = w.LastActivityUtc,
+                DataAgeSeconds = dataAgeSeconds,
+            }))
+            .ToList();
+}

--- a/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
+++ b/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
@@ -27,20 +27,22 @@ public static class RepositoryDtoMapper
         BehindCount = s.BehindCount,
         BehindMainCount = s.BehindMainCount,
         WorktreeCount = s.WorktreeCount,
-        WorktreesSafeToReap = s.WorktreesSafeToReap,
+        // Fail closed for a provisional (still-verifying) entry: cached data never advertises a
+        // safe count, and its worktrees fold to "verifying" - never "safe-to-reap".
+        WorktreesSafeToReap = s.Provisional ? 0 : s.WorktreesSafeToReap,
         WorktreesInUse = s.WorktreesInUse,
         WorktreesNeedAttention = s.WorktreesNeedAttention,
         WorktreeBytes = s.WorktreeBytes,
         Provisional = s.Provisional,
-        Worktrees = s.Worktrees.Select(Map).ToList(),
+        Worktrees = s.Worktrees.Select(w => Map(w, s.Provisional)).ToList(),
     };
 
-    public static WorktreeDto Map(WorktreeInfo w) => new()
+    public static WorktreeDto Map(WorktreeInfo w, bool provisional = false) => new()
     {
         Path = w.Path,
         Branch = w.Branch,
-        State = StateString(w.Safety),
-        Reason = w.Explanation,
+        State = provisional ? FleetWorktreeFold.VerifyingState : StateString(w.Safety),
+        Reason = provisional ? "Still verifying this repository - cached data is never acted on." : w.Explanation,
         SessionLabels = w.OpenSessions.ToList(),
         SizeBytes = w.SizeBytes,
         LastActivityUtc = w.LastActivityUtc,
@@ -58,23 +60,10 @@ public static class RepositoryDtoMapper
         _ => "needs-attention",
     };
 
-    /// <summary>Flattens repository DTOs into fleet worktree rows (GET /worktrees).</summary>
+    /// <summary>
+    /// Flattens repository DTOs into fleet worktree rows (GET /worktrees). Delegates to the one
+    /// shared fold in the contracts assembly, which fails closed for provisional repositories.
+    /// </summary>
     public static List<FleetWorktreeDto> Flatten(IEnumerable<RepoStatusDto> repositories, double dataAgeSeconds = 0)
-        => repositories
-            .SelectMany(r => r.Worktrees.Select(w => new FleetWorktreeDto
-            {
-                RepoName = r.Name,
-                RepoPath = r.Path,
-                MachineName = r.MachineName,
-                DirectorId = r.DirectorId,
-                Path = w.Path,
-                Branch = w.Branch,
-                State = w.State,
-                Reason = w.Reason,
-                SessionLabels = w.SessionLabels,
-                SizeBytes = w.SizeBytes,
-                LastActivityUtc = w.LastActivityUtc,
-                DataAgeSeconds = dataAgeSeconds,
-            }))
-            .ToList();
+        => FleetWorktreeFold.Flatten(repositories, dataAgeSeconds);
 }

--- a/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
+++ b/src/CcDirector.ControlApi/RepositoryDtoMapper.cs
@@ -10,39 +10,44 @@ namespace CcDirector.ControlApi;
 /// </summary>
 public static class RepositoryDtoMapper
 {
-    public static RepoStatusDto Map(RepositoryStatus s, string directorId, string machineName) => new()
-    {
-        DirectorId = directorId,
-        MachineName = machineName,
-        Path = s.Path,
-        Name = s.Name,
-        RemoteUrl = s.RemoteUrl,
-        Provider = s.Provider.ToString(),
-        Org = s.Org,
-        Branch = s.Branch,
-        IsClean = s.IsClean,
-        UncommittedCount = s.UncommittedCount,
-        DirtySinceUtc = s.DirtySinceUtc,
-        AheadCount = s.AheadCount,
-        BehindCount = s.BehindCount,
-        BehindMainCount = s.BehindMainCount,
-        WorktreeCount = s.WorktreeCount,
-        // Fail closed for a provisional (still-verifying) entry: cached data never advertises a
-        // safe count, and its worktrees fold to "verifying" - never "safe-to-reap".
-        WorktreesSafeToReap = s.Provisional ? 0 : s.WorktreesSafeToReap,
-        WorktreesInUse = s.WorktreesInUse,
-        WorktreesNeedAttention = s.WorktreesNeedAttention,
-        WorktreeBytes = s.WorktreeBytes,
-        Provisional = s.Provisional,
-        Worktrees = s.Worktrees.Select(w => Map(w, s.Provisional)).ToList(),
-    };
+    /// <summary>
+    /// Builds the raw DTO and then applies the ONE shared repository-level fold
+    /// (<see cref="FleetWorktreeFold.FoldRepositoryForServe"/>, ruling R2-3): a provisional
+    /// entry's safe count folds to zero and its worktrees to "verifying". The Gateway applies
+    /// the same fold at serve time, so a pre-fix Director's pushed shape cannot bypass it.
+    /// </summary>
+    public static RepoStatusDto Map(RepositoryStatus s, string directorId, string machineName)
+        => FleetWorktreeFold.FoldRepositoryForServe(new RepoStatusDto
+        {
+            DirectorId = directorId,
+            MachineName = machineName,
+            Path = s.Path,
+            Name = s.Name,
+            RemoteUrl = s.RemoteUrl,
+            Provider = s.Provider.ToString(),
+            Org = s.Org,
+            Branch = s.Branch,
+            IsClean = s.IsClean,
+            UncommittedCount = s.UncommittedCount,
+            DirtySinceUtc = s.DirtySinceUtc,
+            AheadCount = s.AheadCount,
+            BehindCount = s.BehindCount,
+            BehindMainCount = s.BehindMainCount,
+            WorktreeCount = s.WorktreeCount,
+            WorktreesSafeToReap = s.WorktreesSafeToReap,
+            WorktreesInUse = s.WorktreesInUse,
+            WorktreesNeedAttention = s.WorktreesNeedAttention,
+            WorktreeBytes = s.WorktreeBytes,
+            Provisional = s.Provisional,
+            Worktrees = s.Worktrees.Select(Map).ToList(),
+        });
 
-    public static WorktreeDto Map(WorktreeInfo w, bool provisional = false) => new()
+    public static WorktreeDto Map(WorktreeInfo w) => new()
     {
         Path = w.Path,
         Branch = w.Branch,
-        State = provisional ? FleetWorktreeFold.VerifyingState : StateString(w.Safety),
-        Reason = provisional ? "Still verifying this repository - cached data is never acted on." : w.Explanation,
+        State = StateString(w.Safety),
+        Reason = w.Explanation,
         SessionLabels = w.OpenSessions.ToList(),
         SizeBytes = w.SizeBytes,
         LastActivityUtc = w.LastActivityUtc,

--- a/src/CcDirector.Core.Tests/AgentBriefTemplatesTests.cs
+++ b/src/CcDirector.Core.Tests/AgentBriefTemplatesTests.cs
@@ -1,0 +1,69 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class AgentBriefTemplatesTests
+{
+    private static RepositoryStatus Repo(int uncommitted = 5, int behindMain = 0, DateTime? dirtySince = null) => new()
+    {
+        Path = @"D:\Repos\widget",
+        Name = "widget",
+        Branch = "main",
+        IsClean = uncommitted == 0,
+        UncommittedCount = uncommitted,
+        AheadCount = 1,
+        BehindCount = 2,
+        BehindMainCount = behindMain,
+        DirtySinceUtc = dirtySince,
+        Success = true,
+    };
+
+    [Theory]
+    [InlineData(AgentHandOffKind.ProtectChanges, "open a pull request")]
+    [InlineData(AgentHandOffKind.CleanUp, "WAIT for approval")]
+    [InlineData(AgentHandOffKind.ExplainOnly, "NO changes")]
+    public void Build_EachKind_CarriesItsTask_AndTheHardRules(AgentHandOffKind kind, string marker)
+    {
+        var brief = AgentBriefTemplates.Build(kind, Repo());
+
+        Assert.Contains(@"D:\Repos\widget", brief);
+        Assert.Contains(marker, brief);
+        Assert.Contains("NEVER force-push", brief);
+        Assert.Contains("Do not add any attribution", brief);
+    }
+
+    [Fact]
+    public void Build_LandOrDiscard_NamesTheWorktree()
+    {
+        var wt = new WorktreeInfo { Path = @"D:\Repos\widget-wt", Branch = "stranded", AheadOfMain = 3, BehindMain = 10 };
+        var brief = AgentBriefTemplates.Build(AgentHandOffKind.LandOrDiscardWorktree, Repo(), wt);
+        Assert.Contains(@"D:\Repos\widget-wt", brief);
+        Assert.Contains("stranded", brief);
+        Assert.Contains("ahead 3", brief);
+    }
+
+    [Fact]
+    public void Build_NeverContainsAssistantAttribution()
+    {
+        // The standing law: nothing the agent produces carries assistant attribution - and the brief
+        // itself must not either. Checked across every kind.
+        foreach (AgentHandOffKind kind in Enum.GetValues<AgentHandOffKind>())
+        {
+            var brief = AgentBriefTemplates.Build(kind, Repo(), new WorktreeInfo { Path = "x", Branch = "b" });
+            Assert.DoesNotContain("Claude", brief);
+            Assert.DoesNotContain("Anthropic", brief);
+            // The PROHIBITION may name the trailer ("no Co-authored-by trailer"); an actual trailer
+            // always carries the colon - that exact shape must never appear.
+            Assert.DoesNotContain("Co-Authored-By:", brief, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Generated with [", brief);
+        }
+    }
+
+    [Fact]
+    public void Build_DirtySince_RendersTheSittingDays()
+    {
+        var brief = AgentBriefTemplates.Build(AgentHandOffKind.ProtectChanges, Repo(dirtySince: DateTime.UtcNow.AddDays(-12)));
+        Assert.Contains("12 day(s)", brief);
+    }
+}

--- a/src/CcDirector.Core.Tests/DiffParserTests.cs
+++ b/src/CcDirector.Core.Tests/DiffParserTests.cs
@@ -1,0 +1,156 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class DiffParserTests
+{
+    private const string Simple = """
+diff --git a/src/App.cs b/src/App.cs
+index 1111111..2222222 100644
+--- a/src/App.cs
++++ b/src/App.cs
+@@ -10,4 +10,5 @@ class App
+ line ten
+-old line eleven
++new line eleven
++inserted twelve
+ line thirteen
+""";
+
+    [Fact]
+    public void Parse_SingleFile_HunkLinesAndNumbers()
+    {
+        var files = DiffParser.Parse(Simple);
+
+        var f = Assert.Single(files);
+        Assert.Equal("src/App.cs", f.OldPath);
+        Assert.Equal("src/App.cs", f.NewPath);
+        Assert.False(f.IsBinary);
+        Assert.False(f.IsRename);
+        Assert.Equal(2, f.Added);
+        Assert.Equal(1, f.Removed);
+
+        var h = Assert.Single(f.Hunks);
+        Assert.StartsWith("@@ -10,4 +10,5 @@", h.Header);
+        Assert.Equal(5, h.Lines.Count);
+
+        Assert.Equal(DiffLineKind.Context, h.Lines[0].Kind);
+        Assert.Equal(10, h.Lines[0].OldNumber);
+        Assert.Equal(10, h.Lines[0].NewNumber);
+
+        Assert.Equal(DiffLineKind.Removed, h.Lines[1].Kind);
+        Assert.Equal(11, h.Lines[1].OldNumber);
+        Assert.Null(h.Lines[1].NewNumber);
+
+        Assert.Equal(DiffLineKind.Added, h.Lines[2].Kind);
+        Assert.Null(h.Lines[2].OldNumber);
+        Assert.Equal(11, h.Lines[2].NewNumber);
+
+        Assert.Equal(DiffLineKind.Added, h.Lines[3].Kind);
+        Assert.Equal(12, h.Lines[3].NewNumber);
+
+        Assert.Equal(DiffLineKind.Context, h.Lines[4].Kind);
+        Assert.Equal(12, h.Lines[4].OldNumber);
+        Assert.Equal(13, h.Lines[4].NewNumber);
+    }
+
+    [Fact]
+    public void Parse_TwoFiles_SplitsCorrectly()
+    {
+        var two = Simple + "\n" + """
+diff --git a/b.txt b/b.txt
+--- a/b.txt
++++ b/b.txt
+@@ -1 +1 @@
+-x
++y
+""";
+        var files = DiffParser.Parse(two);
+        Assert.Equal(2, files.Count);
+        Assert.Equal("b.txt", files[1].NewPath);
+        Assert.Equal(1, files[1].Added);
+        Assert.Equal(1, files[1].Removed);
+    }
+
+    [Fact]
+    public void Parse_Rename_IsFlagged()
+    {
+        var rename = """
+diff --git a/old-name.cs b/new-name.cs
+similarity index 97%
+rename from old-name.cs
+rename to new-name.cs
+""";
+        var f = Assert.Single(DiffParser.Parse(rename));
+        Assert.True(f.IsRename);
+        Assert.Equal("old-name.cs", f.OldPath);
+        Assert.Equal("new-name.cs", f.NewPath);
+    }
+
+    [Fact]
+    public void Parse_Binary_IsFlagged()
+    {
+        var binary = """
+diff --git a/logo.png b/logo.png
+index 1111111..2222222 100644
+Binary files a/logo.png and b/logo.png differ
+""";
+        var f = Assert.Single(DiffParser.Parse(binary));
+        Assert.True(f.IsBinary);
+        Assert.Empty(f.Hunks);
+    }
+
+    [Fact]
+    public void Parse_NewFile_DevNullOldPath()
+    {
+        var added = """
+diff --git a/fresh.txt b/fresh.txt
+new file mode 100644
+--- /dev/null
++++ b/fresh.txt
+@@ -0,0 +1,2 @@
++hello
++world
+""";
+        var f = Assert.Single(DiffParser.Parse(added));
+        Assert.Equal("", f.OldPath);
+        Assert.Equal("fresh.txt", f.NewPath);
+        Assert.Equal(2, f.Added);
+    }
+
+    [Fact]
+    public void Parse_NoNewlineMarker_IsSkippedNotRendered()
+    {
+        var diff = """
+diff --git a/a.txt b/a.txt
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-x
++y
+\ No newline at end of file
+""";
+        var f = Assert.Single(DiffParser.Parse(diff));
+        var h = Assert.Single(f.Hunks);
+        Assert.Equal(2, h.Lines.Count); // the backslash metadata line is not content
+    }
+
+    [Fact]
+    public void Parse_EmptyOrNull_ReturnsNoFiles()
+    {
+        Assert.Empty(DiffParser.Parse(""));
+        Assert.Empty(DiffParser.Parse(null));
+    }
+
+    [Theory]
+    [InlineData("@@ -10,4 +12,5 @@", 10, 12)]
+    [InlineData("@@ -1 +1 @@", 1, 1)]
+    [InlineData("@@ garbage @@", 1, 1)] // malformed header renders from line 1 rather than crashing
+    public void ParseHunkHeader_ExtractsStarts(string header, int oldStart, int newStart)
+    {
+        var (o, n) = DiffParser.ParseHunkHeader(header);
+        Assert.Equal(oldStart, o);
+        Assert.Equal(newStart, n);
+    }
+}

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -277,6 +277,40 @@ public sealed class GitBranchServiceTests : IDisposable
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-7): git permits MULTIPLE branch.<name>.merge
+    // values (an octopus pull), and "git config --get" silently returns only the last one - so
+    // the probe could rule "upstream gone" while ANOTHER configured merge ref still exists on
+    // the remote. A multi-valued merge configuration is ambiguous and must fail closed: the
+    // branch is simply not eligible for the origin-gone signal, same as a missing value.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Branch_WithTwoConfiguredMergeValues_IsNeverRuledSafeViaUpstreamGone()
+    {
+        RunGit(_repo, "checkout", "-b", "octopus");
+        WriteFile("o.txt", "o\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "unmerged work with two configured merge refs");
+        RunGit(_repo, "push", "origin", "octopus:refs/heads/first-upstream");
+        RunGit(_repo, "push", "origin", "octopus:refs/heads/second-upstream");
+        RunGit(_repo, "config", "branch.octopus.remote", "origin");
+        RunGit(_repo, "config", "branch.octopus.merge", "refs/heads/first-upstream");
+        RunGit(_repo, "config", "--add", "branch.octopus.merge", "refs/heads/second-upstream");
+        RunGit(_repo, "checkout", "main");
+
+        // The value "--get" would select (the LAST one) is deleted on the remote; the OTHER
+        // configured merge ref survives. Before the fix this was ruled origin-gone and safe.
+        RunGit(_repo, "push", "origin", "--delete", "second-upstream");
+
+        var branches = await new GitBranchService().ListAsync(_repo);
+        var branch = Assert.Single(branches, b => b.Name == "octopus");
+        Assert.False(branch.SafeToDelete, branch.Explanation);
+
+        var (deleted, _) = await new GitBranchService().DeleteIfSafeAsync(_repo, "octopus");
+        Assert.False(deleted);
+        Assert.Contains("octopus", (await new GitBranchService().ListAsync(_repo)).Select(b => b.Name));
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-1): "git update-ref -d" binds the tip but does
     // not reproduce "git branch -D"'s refusal to delete a branch that is checked out. When a
     // checkout into a linked worktree lands between verification and deletion, the delete must

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -276,6 +276,39 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.True(branch.SafeToDelete, branch.Explanation);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-1): "git update-ref -d" binds the tip but does
+    // not reproduce "git branch -D"'s refusal to delete a branch that is checked out. When a
+    // checkout into a linked worktree lands between verification and deletion, the delete must
+    // be compensated: the ref is restored at the verified sha (lossless - we hold the exact
+    // commit) and the worktree's HEAD stays valid.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_BranchCheckedOutInAWorktreeAfterVerification_IsRestored_AndTheWorktreeHeadStaysValid()
+    {
+        RunGit(_repo, "branch", "raced");
+        var verifiedTip = RunGit(_repo, "rev-parse", "raced").Trim();
+
+        // The race: AFTER the verdict was computed, another process checks the branch out into
+        // a linked worktree - the tip is unchanged, so the tip-bound delete alone would succeed
+        // and leave this worktree with a broken symbolic HEAD.
+        var wt = Path.Combine(_root, "wt-raced");
+        RunGit(_repo, "worktree", "add", wt, "raced");
+
+        var svc = new GitBranchService();
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "raced", verifiedTip, "test");
+
+        Assert.False(deleted);
+        Assert.Contains("checked out in a worktree", message);
+
+        // The branch survived (or was restored) at exactly the verified commit.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/raced").Trim());
+
+        // The worktree's HEAD is intact and usable.
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
     private void WriteFile(string rel, string content)
         => File.WriteAllText(Path.Combine(_repo, rel), content);
 

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>The pure safe-delete verdict matrix - the same fail-closed shape as worktrees.</summary>
+public class BranchSafetyEvaluatorTests
+{
+    [Fact]
+    public void Current_NeverSafe_EvenWhenMerged()
+    {
+        var (safe, _) = BranchSafetyEvaluator.Evaluate(
+            isCurrent: true, checkedOutInWorktree: false, inspectionSucceeded: true,
+            pullRequestMerged: true, originBranchGone: true, containedInMain: true);
+        Assert.False(safe);
+    }
+
+    [Fact]
+    public void CheckedOutInWorktree_NeverSafe_EvenWhenMerged()
+    {
+        var (safe, why) = BranchSafetyEvaluator.Evaluate(
+            isCurrent: false, checkedOutInWorktree: true, inspectionSucceeded: true,
+            pullRequestMerged: true, originBranchGone: true, containedInMain: true);
+        Assert.False(safe);
+        Assert.Contains("worktree", why);
+    }
+
+    [Fact]
+    public void InspectionFailed_NeverSafe()
+    {
+        var (safe, _) = BranchSafetyEvaluator.Evaluate(false, false, inspectionSucceeded: false, true, true, true);
+        Assert.False(safe);
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]  // pull request merged
+    [InlineData(false, true, false)]  // origin branch gone
+    [InlineData(false, false, true)]  // contained in main
+    public void AnySingleMergeSignal_IsSufficient(bool pr, bool gone, bool contained)
+    {
+        var (safe, _) = BranchSafetyEvaluator.Evaluate(false, false, true, pr, gone, contained);
+        Assert.True(safe);
+    }
+
+    [Fact]
+    public void NoSignal_NotSafe_FailClosed()
+    {
+        var (safe, why) = BranchSafetyEvaluator.Evaluate(false, false, true, false, false, false);
+        Assert.False(safe);
+        Assert.Contains("not proven", why);
+    }
+}
+
+/// <summary>Real-git integration: listing verdicts and the delete-time re-verify.</summary>
+public sealed class GitBranchServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _origin;
+    private readonly string _repo;
+
+    public GitBranchServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-branch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _origin = Path.Combine(_root, "origin.git");
+        _repo = Path.Combine(_root, "repo");
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", _origin);
+        RunGit(_root, "-c", "init.defaultBranch=main", "clone", _origin, _repo);
+        RunGit(_repo, "config", "user.email", "test@cc-director.local");
+        RunGit(_repo, "config", "user.name", "CC Director Test");
+        RunGit(_repo, "config", "commit.gpgsign", "false");
+        WriteFile("README.md", "init\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "initial");
+        RunGit(_repo, "branch", "-M", "main");
+        RunGit(_repo, "push", "-u", "origin", "main");
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    [Fact]
+    public async Task List_MergedBranch_SafeToDelete_UnmergedBranch_NotSafe()
+    {
+        // merged: commit on branch, push, fast-forward main, keep origin branch (contained-in-main path)
+        RunGit(_repo, "checkout", "-b", "merged");
+        WriteFile("m.txt", "m\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "merged work");
+        RunGit(_repo, "push", "-u", "origin", "merged");
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "merge", "--ff-only", "merged");
+        RunGit(_repo, "push", "origin", "main");
+
+        // unmerged: a commit main does not have
+        RunGit(_repo, "checkout", "-b", "unmerged");
+        WriteFile("u.txt", "u\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "unmerged work");
+        RunGit(_repo, "checkout", "main");
+
+        var branches = await new GitBranchService().ListAsync(_repo);
+
+        var merged = Assert.Single(branches, b => b.Name == "merged");
+        Assert.True(merged.SafeToDelete);
+
+        var unmerged = Assert.Single(branches, b => b.Name == "unmerged");
+        Assert.False(unmerged.SafeToDelete);
+        Assert.Equal(1, unmerged.AheadOfMain);
+
+        var main = Assert.Single(branches, b => b.Name == "main");
+        Assert.True(main.IsCurrent);
+        Assert.False(main.SafeToDelete);
+    }
+
+    [Fact]
+    public async Task Delete_RefusesCurrent_AndBranchHeldByAWorktree()
+    {
+        // held: checked out in a linked worktree
+        RunGit(_repo, "branch", "held");
+        RunGit(_repo, "worktree", "add", Path.Combine(_root, "wt-held"), "held");
+
+        var svc = new GitBranchService();
+
+        var (deletedCurrent, whyCurrent) = await svc.DeleteIfSafeAsync(_repo, "main");
+        Assert.False(deletedCurrent);
+        Assert.Contains("branch you are on", whyCurrent);
+
+        var (deletedHeld, whyHeld) = await svc.DeleteIfSafeAsync(_repo, "held");
+        Assert.False(deletedHeld);
+        Assert.Contains("worktree", whyHeld);
+
+        // Both still exist.
+        var names = (await svc.ListAsync(_repo)).Select(b => b.Name).ToList();
+        Assert.Contains("main", names);
+        Assert.Contains("held", names);
+    }
+
+    [Fact]
+    public async Task Delete_SafeBranch_Deletes_AndUnmergedIsRefused()
+    {
+        RunGit(_repo, "checkout", "-b", "done");
+        WriteFile("d.txt", "d\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "done work");
+        RunGit(_repo, "push", "-u", "origin", "done");
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "merge", "--ff-only", "done");
+        RunGit(_repo, "push", "origin", "main");
+
+        RunGit(_repo, "checkout", "-b", "keep");
+        WriteFile("k.txt", "k\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "keep work");
+        RunGit(_repo, "checkout", "main");
+
+        var svc = new GitBranchService();
+
+        var (deleted, msg) = await svc.DeleteIfSafeAsync(_repo, "done");
+        Assert.True(deleted, msg);
+
+        var (refused, why) = await svc.DeleteIfSafeAsync(_repo, "keep");
+        Assert.False(refused);
+        Assert.Contains("not proven", why);
+
+        var names = (await svc.ListAsync(_repo)).Select(b => b.Name).ToList();
+        Assert.DoesNotContain("done", names);
+        Assert.Contains("keep", names);
+    }
+
+    private void WriteFile(string rel, string content)
+        => File.WriteAllText(Path.Combine(_repo, rel), content);
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {stderr}");
+        return stdout;
+    }
+}

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -519,6 +519,64 @@ public sealed class GitBranchServiceTests : IDisposable
         RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-2): only the exact missing-ref outcome of
+    // "rev-parse --verify --quiet" (exit 1) permits the config cleanup. Any OTHER failure - a
+    // transient or repository-level error - proves nothing about the ref's absence, and
+    // cleaning up on it could strip a live branch's tracking configuration. The stale section
+    // is inert; a wrong cleanup is not.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_RefProbeFailsWithANonMissingExit_LeavesTheConfigSectionAlone()
+    {
+        RunGit(_repo, "checkout", "-b", "probe-fail");
+        WriteFile("p.txt", "p\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "probe fail work");
+        RunGit(_repo, "push", "-u", "origin", "probe-fail"); // -u writes branch.probe-fail.remote and .merge
+        RunGit(_repo, "checkout", "main");
+        var verifiedTip = RunGit(_repo, "rev-parse", "probe-fail").Trim();
+
+        // The post-delete ref probe fails with a NON-missing exit (a transient failure).
+        var git = new CannedResultGitRunner(
+            args => args.Length >= 1 && args[0] == "rev-parse" && args.Contains("refs/heads/probe-fail"),
+            new GitCommandResult { Success = false, ExitCode = 128, Error = "fatal: injected transient failure" });
+
+        var svc = new GitBranchService(git);
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "probe-fail", verifiedTip, "test");
+
+        // The delete itself stands - but absence was NOT proven, so the config section stays.
+        Assert.True(deleted, message);
+        Assert.Equal("origin", RunGit(_repo, "config", "--get", "branch.probe-fail.remote").Trim());
+        Assert.Equal("refs/heads/probe-fail", RunGit(_repo, "config", "--get", "branch.probe-fail.merge").Trim());
+    }
+
+    /// <summary>
+    /// A git runner that replaces the first command matching <c>match</c> with a canned
+    /// result - the deterministic stand-in for a transient git failure with a specific exit
+    /// code. Every other command runs for real.
+    /// </summary>
+    private sealed class CannedResultGitRunner : GitCommandRunner
+    {
+        private readonly Func<string[], bool> _match;
+        private readonly GitCommandResult _canned;
+        private int _fired;
+
+        public CannedResultGitRunner(Func<string[], bool> match, GitCommandResult canned)
+        {
+            _match = match;
+            _canned = canned;
+        }
+
+        public override async Task<GitCommandResult> RunAsync(
+            string workingDirectory, string[] args, CancellationToken ct = default)
+        {
+            if (_match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
+                return _canned;
+            return await base.RunAsync(workingDirectory, args, ct);
+        }
+    }
+
     /// <summary>
     /// A git runner that fires an interleaved action right after the first command matching
     /// <c>match</c> succeeds - the deterministic stand-in for "another process acted between

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -176,6 +176,59 @@ public sealed class GitBranchServiceTests : IDisposable
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F3): deletion binds to the verified tip. When the branch
+    // moves between the verdict and the delete (a concurrent commit), git refuses and the
+    // branch - including the new commit - survives.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_WithAStaleVerifiedTip_IsRefused_AndTheBranchSurvives()
+    {
+        RunGit(_repo, "checkout", "-b", "moving");
+        WriteFile("m1.txt", "one\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "first commit");
+        var verifiedTip = RunGit(_repo, "rev-parse", "moving").Trim();
+
+        // The concurrent commit: the branch tip moves AFTER the verdict was computed.
+        WriteFile("m2.txt", "two\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "commit that arrived after verification");
+        RunGit(_repo, "checkout", "main");
+
+        var svc = new GitBranchService();
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "moving", verifiedTip, "test");
+
+        Assert.False(deleted);
+        Assert.Contains("moved since it was verified", message);
+        var branches = await svc.ListAsync(_repo);
+        var survivor = Assert.Single(branches, b => b.Name == "moving");
+        Assert.NotEqual(verifiedTip, survivor.TipCommit); // the newer commit is intact
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The success path of the atomic delete also cleans up the branch's config section.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_SafeBranch_RemovesTheBranchConfigSection()
+    {
+        RunGit(_repo, "checkout", "-b", "tidy");
+        WriteFile("t.txt", "t\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "tidy work");
+        RunGit(_repo, "push", "-u", "origin", "tidy"); // -u writes branch.tidy.remote and .merge
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "merge", "--ff-only", "tidy");
+        RunGit(_repo, "push", "origin", "main");
+
+        var svc = new GitBranchService();
+        var (deleted, msg) = await svc.DeleteIfSafeAsync(_repo, "tidy");
+        Assert.True(deleted, msg);
+
+        Assert.DoesNotContain("tidy", (await svc.ListAsync(_repo)).Select(b => b.Name));
+        Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "config", "--get", "branch.tidy.merge"));
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection finding F2): C2 must test the CONFIGURED upstream, not
     // origin/<local-name>. A branch tracking a differently named upstream ref that still
     // exists must NOT be ruled origin-gone (before the fix it was, and was deletable).

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -452,6 +452,73 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "config", "--get", "branch.cancel-clean.merge"));
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-1): cancellation raced into the DELETE'S OWN
+    // process wait never skips compensation. The real hazard lives inside GitCommandRunner:
+    // WaitForExitAsync(token) can throw OperationCanceledException AFTER the child git process
+    // already deleted the ref - the successful result is then concealed and no compensation
+    // runs, leaving a checked-out worktree with a broken symbolic HEAD. The delete command must
+    // run on CancellationToken.None; the caller's token applies before the destructive act only.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_CancellationRacedIntoTheDeletesProcessWait_NeverSkipsCompensation()
+    {
+        RunGit(_repo, "branch", "wait-race");
+        var verifiedTip = RunGit(_repo, "rev-parse", "wait-race").Trim();
+
+        // Checked out into a worktree AFTER verification - compensation must restore.
+        var wt = Path.Combine(_root, "wt-wait-race");
+        RunGit(_repo, "worktree", "add", wt, "wait-race");
+
+        using var cts = new CancellationTokenSource();
+        var git = new CancelDuringProcessWaitGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            () => cts.Cancel());
+
+        var svc = new GitBranchService(git);
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "wait-race", verifiedTip, "test", cts.Token);
+
+        Assert.False(deleted);
+        Assert.Contains("worktree", message);
+
+        // The mutation was never concealed: compensation ran, the branch is back at the
+        // verified commit, and the worktree's HEAD is intact and usable.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/wait-race").Trim());
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-1): ANY exception inside compensation still
+    // attempts the create-only restore before the exception propagates. A thrown worktree
+    // listing is the severe case - the code can neither prove the delete safe nor leave the
+    // ref missing, so the ref must be back when the exception reaches the caller.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_WorktreeListingThrows_StillRestoresTheRefBeforeTheExceptionPropagates()
+    {
+        RunGit(_repo, "branch", "throw-race");
+        var verifiedTip = RunGit(_repo, "rev-parse", "throw-race").Trim();
+
+        // Checked out into a worktree AFTER verification - losing the ref breaks this worktree.
+        var wt = Path.Combine(_root, "wt-throw-race");
+        RunGit(_repo, "worktree", "add", wt, "throw-race");
+
+        var git = new ThrowingGitRunner(
+            args => args.Length >= 1 && args[0] == "worktree",
+            () => new InvalidOperationException("injected worktree listing failure"));
+
+        var svc = new GitBranchService(git);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.DeleteAtVerifiedTipAsync(_repo, "throw-race", verifiedTip, "test"));
+
+        // The exception escaped LOUDLY - but the ref was restored on the way out, so the
+        // worktree's HEAD is intact and usable.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/throw-race").Trim());
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
     /// <summary>
     /// A git runner that fires an interleaved action right after the first command matching
     /// <c>match</c> succeeds - the deterministic stand-in for "another process acted between
@@ -476,6 +543,71 @@ public sealed class GitBranchServiceTests : IDisposable
             if (result.Success && _match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
                 await _interleaved();
             return result;
+        }
+    }
+
+    /// <summary>
+    /// A git runner that reproduces the exact cancellation window inside the production
+    /// runner's process wait (ruling R4-6): for the first command matching <c>match</c>, the
+    /// child git process runs TO COMPLETION first (the mutation happens), the interleaved
+    /// cancellation then fires, and the wait's cancellation is surfaced exactly where
+    /// <c>WaitForExitAsync(token)</c> would surface it - AFTER the mutation, BEFORE the
+    /// successful result is returned. The plain InterleavingGitRunner cannot reach this
+    /// window because it only acts after RunAsync already returned its result.
+    /// </summary>
+    private sealed class CancelDuringProcessWaitGitRunner : GitCommandRunner
+    {
+        private readonly Func<string[], bool> _match;
+        private readonly Action _cancel;
+        private int _fired;
+
+        public CancelDuringProcessWaitGitRunner(Func<string[], bool> match, Action cancel)
+        {
+            _match = match;
+            _cancel = cancel;
+        }
+
+        public override async Task<GitCommandResult> RunAsync(
+            string workingDirectory, string[] args, CancellationToken ct = default)
+        {
+            if (_match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
+            {
+                // The child's mutation completes regardless of the caller's token.
+                var result = await base.RunAsync(workingDirectory, args, CancellationToken.None);
+                _cancel();
+                // WaitForExitAsync(token) throws here when the caller's token was passed in -
+                // concealing the completed mutation. A token of CancellationToken.None sails
+                // through, which is exactly what ruling R4-1 requires of the delete command.
+                ct.ThrowIfCancellationRequested();
+                return result;
+            }
+            return await base.RunAsync(workingDirectory, args, ct);
+        }
+    }
+
+    /// <summary>
+    /// A git runner that throws from the first command matching <c>match</c> - the
+    /// deterministic stand-in for a runtime failure (a process-start failure and the like)
+    /// inside a compensation command.
+    /// </summary>
+    private sealed class ThrowingGitRunner : GitCommandRunner
+    {
+        private readonly Func<string[], bool> _match;
+        private readonly Func<Exception> _exception;
+        private int _fired;
+
+        public ThrowingGitRunner(Func<string[], bool> match, Func<Exception> exception)
+        {
+            _match = match;
+            _exception = exception;
+        }
+
+        public override async Task<GitCommandResult> RunAsync(
+            string workingDirectory, string[] args, CancellationToken ct = default)
+        {
+            if (_match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
+                throw _exception();
+            return await base.RunAsync(workingDirectory, args, ct);
         }
     }
 

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -551,6 +551,70 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.Equal("refs/heads/probe-fail", RunGit(_repo, "config", "--get", "branch.probe-fail.merge").Trim());
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 5): an exception from the DELETE COMMAND ITSELF, thrown
+    // AFTER the child git process already deleted the ref, must not bypass restoration. The
+    // delete await sits inside the recovery boundary: the create-only restore is safe in both
+    // directions (if the delete never happened, the ref still exists and git refuses the
+    // create), so the restore-on-the-way-out covers "threw before mutation" and "threw after
+    // mutation" without knowing which occurred. The original exception still propagates.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_DeleteCommandThrowsAfterItsMutation_RestoresTheRefBeforeTheExceptionPropagates()
+    {
+        RunGit(_repo, "branch", "mutate-throw");
+        var verifiedTip = RunGit(_repo, "rev-parse", "mutate-throw").Trim();
+
+        // Checked out into a worktree AFTER verification - losing the ref breaks this worktree.
+        var wt = Path.Combine(_root, "wt-mutate-throw");
+        RunGit(_repo, "worktree", "add", wt, "mutate-throw");
+
+        // The delete runs TO COMPLETION (the ref is really gone), then the process layer throws.
+        var git = new MutateThenThrowGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            () => new IOException("injected process-layer failure after the mutation"));
+
+        var svc = new GitBranchService(git);
+        await Assert.ThrowsAsync<IOException>(
+            () => svc.DeleteAtVerifiedTipAsync(_repo, "mutate-throw", verifiedTip, "test"));
+
+        // The exception escaped LOUDLY - but the ref was restored on the way out, so the
+        // worktree's HEAD is intact and usable.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/mutate-throw").Trim());
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
+    /// <summary>
+    /// A git runner that runs the first command matching <c>match</c> TO COMPLETION - the
+    /// mutation really happens - and then throws, exactly where a process-layer failure after
+    /// the child exited would surface. The plain ThrowingGitRunner throws INSTEAD of running
+    /// the command, which is the other direction of the same hazard.
+    /// </summary>
+    private sealed class MutateThenThrowGitRunner : GitCommandRunner
+    {
+        private readonly Func<string[], bool> _match;
+        private readonly Func<Exception> _exception;
+        private int _fired;
+
+        public MutateThenThrowGitRunner(Func<string[], bool> match, Func<Exception> exception)
+        {
+            _match = match;
+            _exception = exception;
+        }
+
+        public override async Task<GitCommandResult> RunAsync(
+            string workingDirectory, string[] args, CancellationToken ct = default)
+        {
+            if (_match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
+            {
+                await base.RunAsync(workingDirectory, args, CancellationToken.None);
+                throw _exception();
+            }
+            return await base.RunAsync(workingDirectory, args, ct);
+        }
+    }
+
     /// <summary>
     /// A git runner that replaces the first command matching <c>match</c> with a canned
     /// result - the deterministic stand-in for a transient git failure with a specific exit

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -387,6 +387,71 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.Contains("same name has since appeared", message);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-2): everything after the successful ref delete
+    // is a NON-CANCELLABLE compensation phase. Cancellation landing right after the delete
+    // must not skip the worktree check and the restore - that left a checked-out worktree
+    // with a broken symbolic HEAD. The branch must end restored here (a worktree holds it).
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_CancelledRightAfterTheDeleteSucceeds_StillRestoresTheWorktreeHeldBranch()
+    {
+        RunGit(_repo, "branch", "cancel-race");
+        var verifiedTip = RunGit(_repo, "rev-parse", "cancel-race").Trim();
+
+        // Checked out into a worktree AFTER verification - compensation must restore.
+        var wt = Path.Combine(_root, "wt-cancel");
+        RunGit(_repo, "worktree", "add", wt, "cancel-race");
+
+        // The caller's token is cancelled the instant the delete succeeds.
+        using var cts = new CancellationTokenSource();
+        var git = new InterleavingGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            () => { cts.Cancel(); return Task.CompletedTask; });
+
+        var svc = new GitBranchService(git);
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "cancel-race", verifiedTip, "test", cts.Token);
+
+        Assert.False(deleted);
+        Assert.Contains("worktree", message);
+
+        // Never deleted-with-broken-worktree: the branch is back at the verified commit and
+        // the worktree's HEAD is intact and usable.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/cancel-race").Trim());
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The other legal end state under ruling R3-2: no worktree holds the branch, so a
+    // cancellation right after the delete still lets compensation run to completion and the
+    // branch ends CLEANLY deleted (worktree listing, ref check, and config cleanup all ran).
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_CancelledRightAfterTheDeleteSucceeds_NoWorktree_EndsCleanlyDeleted()
+    {
+        RunGit(_repo, "checkout", "-b", "cancel-clean");
+        WriteFile("cc.txt", "cc\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "cancel clean work");
+        RunGit(_repo, "push", "-u", "origin", "cancel-clean"); // -u writes branch config to clean up
+        RunGit(_repo, "checkout", "main");
+        var verifiedTip = RunGit(_repo, "rev-parse", "cancel-clean").Trim();
+
+        using var cts = new CancellationTokenSource();
+        var git = new InterleavingGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            () => { cts.Cancel(); return Task.CompletedTask; });
+
+        var svc = new GitBranchService(git);
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "cancel-clean", verifiedTip, "test", cts.Token);
+
+        Assert.True(deleted, message);
+        Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "rev-parse", "--verify", "refs/heads/cancel-clean"));
+        // The compensation phase finished: the branch's config section was cleaned up too.
+        Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "config", "--get", "branch.cancel-clean.merge"));
+    }
+
     /// <summary>
     /// A git runner that fires an interleaved action right after the first command matching
     /// <c>match</c> succeeds - the deterministic stand-in for "another process acted between

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -608,6 +608,42 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "rev-parse", "--verify", "refs/heads/already-gone"));
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 7): the restore helper must be immune to an exception whose
+    // Message property ITSELF throws (Message is virtual). Building the diagnostic string
+    // before the restore attempt evaluated cause.Message, so such an exception skipped the
+    // restore and replaced itself with the Message getter's exception. The restore now comes
+    // first and message extraction is guarded, so the branch is restored and the ORIGINAL
+    // exception type still propagates.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_ExceptionWithAThrowingMessageGetter_StillRestoresAndPropagatesTheOriginalType()
+    {
+        RunGit(_repo, "branch", "toxic-message");
+        var verifiedTip = RunGit(_repo, "rev-parse", "toxic-message").Trim();
+
+        var wt = Path.Combine(_root, "wt-toxic-message");
+        RunGit(_repo, "worktree", "add", wt, "toxic-message");
+
+        var git = new MutateThenThrowGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            () => new ThrowingMessageException());
+
+        var svc = new GitBranchService(git);
+        await Assert.ThrowsAsync<ThrowingMessageException>(
+            () => svc.DeleteAtVerifiedTipAsync(_repo, "toxic-message", verifiedTip, "test"));
+
+        // The restore ran despite the toxic Message getter, and the worktree is healthy.
+        Assert.Equal(verifiedTip, RunGit(_repo, "rev-parse", "refs/heads/toxic-message").Trim());
+        Assert.Equal(verifiedTip, RunGit(wt, "rev-parse", "HEAD").Trim());
+        RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
+    }
+
+    private sealed class ThrowingMessageException : Exception
+    {
+        public override string Message => throw new InvalidOperationException("toxic Message getter");
+    }
+
     /// <summary>
     /// A git runner that runs the first command matching <c>match</c> TO COMPLETION - the
     /// mutation really happens - and then throws, exactly where a process-layer failure after

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -585,6 +585,29 @@ public sealed class GitBranchServiceTests : IDisposable
         RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 6): a REFUSED delete must never end in a restore attempt.
+    // A refusal means git verified the ref did not match and mutated nothing; when the branch
+    // is already entirely gone (another process deleted it), a restore attempt on the refusal
+    // path would RECREATE the deleted branch. The refusal is reported outside every recovery
+    // boundary, so no exception can reroute it into a restore.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_RefusedBecauseTheBranchIsAlreadyGone_NeverRecreatesIt()
+    {
+        RunGit(_repo, "branch", "already-gone");
+        var verifiedTip = RunGit(_repo, "rev-parse", "already-gone").Trim();
+        RunGit(_repo, "branch", "-D", "already-gone"); // another process fully deleted it
+
+        var svc = new GitBranchService();
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "already-gone", verifiedTip, "test");
+
+        Assert.False(deleted);
+        Assert.Contains("moved since it was verified", message);
+        // The branch stays GONE - the refusal path performed no recovery mutation.
+        Assert.Throws<InvalidOperationException>(() => RunGit(_repo, "rev-parse", "--verify", "refs/heads/already-gone"));
+    }
+
     /// <summary>
     /// A git runner that runs the first command matching <c>match</c> TO COMPLETION - the
     /// mutation really happens - and then throws, exactly where a process-layer failure after

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -343,6 +343,77 @@ public sealed class GitBranchServiceTests : IDisposable
         RunGit(wt, "status", "--short"); // throws on a broken HEAD - a healthy worktree does not
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-1): the compensation restore is CREATE-ONLY.
+    // When another process recreates the branch at a NEW commit between the delete and the
+    // restore, the restore must refuse (git's expected-old-value of forty zeros) and the
+    // recreated tip must survive untouched - the old restore silently rewound it.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Delete_BranchRecreatedBetweenDeleteAndRestore_TheRecreatedTipSurvivesUntouched()
+    {
+        RunGit(_repo, "branch", "raced");
+        var verifiedTip = RunGit(_repo, "rev-parse", "raced").Trim();
+
+        // The commit the concurrent recreation will point at - different from the verified tip.
+        WriteFile("r.txt", "r\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "the recreated branch's commit");
+        var recreatedTip = RunGit(_repo, "rev-parse", "main").Trim();
+        Assert.NotEqual(verifiedTip, recreatedTip);
+
+        // Checked out into a worktree AFTER verification, so compensation decides on a restore.
+        var wt = Path.Combine(_root, "wt-recreate");
+        RunGit(_repo, "worktree", "add", wt, "raced");
+
+        // The interleaved "other process": right after our delete succeeds, it recreates the
+        // branch at the newer commit.
+        var git = new InterleavingGitRunner(
+            args => args.Length >= 2 && args[0] == "update-ref" && args[1] == "-d",
+            async () =>
+            {
+                var recreate = await new GitCommandRunner().RunAsync(
+                    _repo, new[] { "update-ref", "refs/heads/raced", recreatedTip });
+                Assert.True(recreate.Success, recreate.Error);
+            });
+
+        var svc = new GitBranchService(git);
+        var (deleted, message) = await svc.DeleteAtVerifiedTipAsync(_repo, "raced", verifiedTip, "test");
+
+        // The concurrently recreated branch stands, at ITS tip - never rewound to the verified
+        // sha - and the outcome says plainly what happened.
+        Assert.Equal(recreatedTip, RunGit(_repo, "rev-parse", "refs/heads/raced").Trim());
+        Assert.True(deleted, message);
+        Assert.Contains("same name has since appeared", message);
+    }
+
+    /// <summary>
+    /// A git runner that fires an interleaved action right after the first command matching
+    /// <c>match</c> succeeds - the deterministic stand-in for "another process acted between
+    /// two of our git commands".
+    /// </summary>
+    private sealed class InterleavingGitRunner : GitCommandRunner
+    {
+        private readonly Func<string[], bool> _match;
+        private readonly Func<Task> _interleaved;
+        private int _fired;
+
+        public InterleavingGitRunner(Func<string[], bool> match, Func<Task> interleaved)
+        {
+            _match = match;
+            _interleaved = interleaved;
+        }
+
+        public override async Task<GitCommandResult> RunAsync(
+            string workingDirectory, string[] args, CancellationToken ct = default)
+        {
+            var result = await base.RunAsync(workingDirectory, args, ct);
+            if (result.Success && _match(args) && Interlocked.Exchange(ref _fired, 1) == 0)
+                await _interleaved();
+            return result;
+        }
+    }
+
     private void WriteFile(string rel, string content)
         => File.WriteAllText(Path.Combine(_repo, rel), content);
 

--- a/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GitBranchServiceTests.cs
@@ -175,6 +175,54 @@ public sealed class GitBranchServiceTests : IDisposable
         Assert.Contains("keep", names);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F2): C2 must test the CONFIGURED upstream, not
+    // origin/<local-name>. A branch tracking a differently named upstream ref that still
+    // exists must NOT be ruled origin-gone (before the fix it was, and was deletable).
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Branch_TrackingDifferentlyNamedUpstream_ThatStillExists_IsNotSafe()
+    {
+        RunGit(_repo, "checkout", "-b", "local-name");
+        WriteFile("x.txt", "x\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "unmerged work tracked under a different upstream name");
+        RunGit(_repo, "push", "origin", "local-name:refs/heads/remote-name");
+        RunGit(_repo, "config", "branch.local-name.remote", "origin");
+        RunGit(_repo, "config", "branch.local-name.merge", "refs/heads/remote-name");
+        RunGit(_repo, "checkout", "main");
+
+        var branches = await new GitBranchService().ListAsync(_repo);
+        var branch = Assert.Single(branches, b => b.Name == "local-name");
+        Assert.False(branch.SafeToDelete, branch.Explanation);
+
+        var (deleted, _) = await new GitBranchService().DeleteIfSafeAsync(_repo, "local-name");
+        Assert.False(deleted);
+        Assert.Contains("local-name", (await new GitBranchService().ListAsync(_repo)).Select(b => b.Name));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The counterpart: when the CONFIGURED upstream (a differently named ref) genuinely was
+    // deleted on the remote, the branch IS safe via the upstream-gone signal.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Branch_WhoseConfiguredUpstreamWasDeleted_IsSafe()
+    {
+        RunGit(_repo, "checkout", "-b", "was-merged");
+        WriteFile("y.txt", "y\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "work later squash merged and its upstream deleted");
+        RunGit(_repo, "push", "origin", "was-merged:refs/heads/upstream-name");
+        RunGit(_repo, "config", "branch.was-merged.remote", "origin");
+        RunGit(_repo, "config", "branch.was-merged.merge", "refs/heads/upstream-name");
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "push", "origin", "--delete", "upstream-name");
+
+        var branches = await new GitBranchService().ListAsync(_repo);
+        var branch = Assert.Single(branches, b => b.Name == "was-merged");
+        Assert.True(branch.SafeToDelete, branch.Explanation);
+    }
+
     private void WriteFile(string rel, string content)
         => File.WriteAllText(Path.Combine(_repo, rel), content);
 

--- a/src/CcDirector.Core.Tests/PullRequestServiceTests.cs
+++ b/src/CcDirector.Core.Tests/PullRequestServiceTests.cs
@@ -1,0 +1,145 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>Golden tests: real-shaped gh/az JSON fixtures parsed to display rows.</summary>
+public class PullRequestServiceTests
+{
+    private const string GitHubFixture = """
+[
+  {
+    "number": 2081,
+    "title": "Repositories v1 polish",
+    "author": { "login": "thefrederiksen" },
+    "headRefName": "feat/repository-warmstart-cache",
+    "isDraft": false,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "url": "https://github.com/thefrederiksen/devthrottle/pull/2081",
+    "createdAt": "2026-07-23T18:00:00Z",
+    "statusCheckRollup": [
+      { "status": "COMPLETED", "conclusion": "SUCCESS" },
+      { "status": "COMPLETED", "conclusion": "SUCCESS" }
+    ]
+  },
+  {
+    "number": 2065,
+    "title": "Bump dependencies (weekly)",
+    "author": { "login": "dependabot" },
+    "headRefName": "deps/weekly",
+    "isDraft": false,
+    "reviewDecision": "CHANGES_REQUESTED",
+    "url": "https://github.com/thefrederiksen/devthrottle/pull/2065",
+    "createdAt": "2026-07-17T09:00:00Z",
+    "statusCheckRollup": [
+      { "status": "COMPLETED", "conclusion": "SUCCESS" },
+      { "status": "COMPLETED", "conclusion": "FAILURE" },
+      { "status": "IN_PROGRESS", "conclusion": "" }
+    ]
+  },
+  {
+    "number": 2072,
+    "title": "Tenant-scoped worker seam",
+    "author": { "login": "fleet" },
+    "headRefName": "mtr/g8-worker-seam",
+    "isDraft": true,
+    "reviewDecision": "",
+    "url": "https://github.com/thefrederiksen/devthrottle/pull/2072",
+    "createdAt": "2026-07-22T14:30:00Z",
+    "statusCheckRollup": [
+      { "status": "IN_PROGRESS", "conclusion": "" }
+    ]
+  },
+  {
+    "number": 2001,
+    "title": "No checks configured",
+    "author": { "login": "thefrederiksen" },
+    "headRefName": "docs/tidy",
+    "isDraft": false,
+    "reviewDecision": "APPROVED",
+    "url": "https://github.com/thefrederiksen/devthrottle/pull/2001",
+    "createdAt": "2026-07-20T08:00:00Z",
+    "statusCheckRollup": []
+  }
+]
+""";
+
+    [Fact]
+    public void ParseGitHub_MapsRowsChecksAndReviews()
+    {
+        var items = PullRequestService.ParseGitHub(GitHubFixture);
+        Assert.Equal(4, items.Count);
+
+        var passing = items[0];
+        Assert.Equal(2081, passing.Number);
+        Assert.Equal("thefrederiksen", passing.Author);
+        Assert.Equal("feat/repository-warmstart-cache", passing.Branch);
+        Assert.Equal(ChecksState.Passing, passing.Checks);
+        Assert.Equal("review required", passing.ReviewState);
+        Assert.False(passing.IsDraft);
+        Assert.NotNull(passing.CreatedUtc);
+
+        var failing = items[1];
+        Assert.Equal(ChecksState.Failing, failing.Checks); // a failure outranks the one still running
+        Assert.Equal("changes requested", failing.ReviewState);
+
+        var draft = items[2];
+        Assert.True(draft.IsDraft);
+        Assert.Equal(ChecksState.Running, draft.Checks);
+        Assert.Equal("", draft.ReviewState);
+
+        var noChecks = items[3];
+        Assert.Equal(ChecksState.None, noChecks.Checks);
+        Assert.Equal("approved", noChecks.ReviewState);
+    }
+
+    private const string AzureFixture = """
+[
+  {
+    "pullRequestId": 4102,
+    "title": "ERP knowledge base builder",
+    "createdBy": { "displayName": "Soren Frederiksen" },
+    "sourceRefName": "refs/heads/feature/erp-knowledge-base-builder",
+    "isDraft": false,
+    "url": "https://dev.azure.com/mindzie/_apis/git/pullRequests/4102"
+  }
+]
+""";
+
+    [Fact]
+    public void ParseAzure_MapsRows_BranchWithoutRefsPrefix()
+    {
+        var items = PullRequestService.ParseAzure(AzureFixture);
+        var pr = Assert.Single(items);
+        Assert.Equal(4102, pr.Number);
+        Assert.Equal("Soren Frederiksen", pr.Author);
+        Assert.Equal("feature/erp-knowledge-base-builder", pr.Branch);
+        Assert.Equal(ChecksState.None, pr.Checks); // listing parity in v1
+    }
+
+    [Theory]
+    [InlineData("APPROVED", "approved")]
+    [InlineData("CHANGES_REQUESTED", "changes requested")]
+    [InlineData("REVIEW_REQUIRED", "review required")]
+    [InlineData("", "")]
+    [InlineData("SOMETHING_NEW", "")]
+    public void MapReviewDecision_FinishedStrings(string decision, string expected)
+        => Assert.Equal(expected, PullRequestService.MapReviewDecision(decision));
+}
+
+public class GitHistoryServiceTests
+{
+    [Fact]
+    public void Parse_TabSeparatedLog_MapsRows_SubjectMayContainTabsSafely()
+    {
+        var output = "abc1234\tSoren\t1753293600\tfix: the thing\n"
+                   + "def5678\tAgent\t1753207200\tfeat: subject\twith a tab\n";
+        var items = GitHistoryService.Parse(output);
+        Assert.Equal(2, items.Count);
+        Assert.Equal("abc1234", items[0].ShortHash);
+        Assert.Equal("Soren", items[0].Author);
+        Assert.NotNull(items[0].WhenUtc);
+        Assert.Equal("fix: the thing", items[0].Subject);
+        Assert.Equal("feat: subject\twith a tab", items[1].Subject); // split limited to 4 parts
+    }
+}

--- a/src/CcDirector.Core.Tests/RecommendationEngineTests.cs
+++ b/src/CcDirector.Core.Tests/RecommendationEngineTests.cs
@@ -1,0 +1,126 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class RecommendationEngineTests
+{
+    private static readonly DateTime Now = new(2026, 07, 23, 12, 0, 0, DateTimeKind.Utc);
+
+    private static RepositoryStatus Repo(
+        string name,
+        int safeWorktrees = 0,
+        long safeBytes = 0,
+        int uncommitted = 0,
+        int dirtyDaysAgo = 0,
+        int behindMain = 0,
+        bool provisional = false)
+    {
+        var worktrees = new List<WorktreeInfo>();
+        for (int i = 0; i < safeWorktrees; i++)
+            worktrees.Add(new WorktreeInfo
+            {
+                Path = $"/r/{name}-wt{i}",
+                Branch = $"b{i}",
+                Safety = WorktreeSafety.SafeToReap,
+                SizeBytes = safeBytes / Math.Max(1, safeWorktrees),
+            });
+        return new RepositoryStatus
+        {
+            Path = $"/r/{name}",
+            Name = name,
+            Branch = "main",
+            IsClean = uncommitted == 0,
+            UncommittedCount = uncommitted,
+            DirtySinceUtc = uncommitted > 0 ? Now.AddDays(-dirtyDaysAgo) : null,
+            BehindMainCount = behindMain,
+            WorktreesSafeToReap = safeWorktrees,
+            WorktreeCount = safeWorktrees,
+            Worktrees = worktrees,
+            Provisional = provisional,
+            Success = true,
+        };
+    }
+
+    [Fact]
+    public void ReapSafe_SummarizesAcrossRepos_WithReclaimBytes()
+    {
+        var recs = RecommendationEngine.Evaluate(new[]
+        {
+            Repo("a", safeWorktrees: 2, safeBytes: 2_147_483_648),
+            Repo("b", safeWorktrees: 1, safeBytes: 1_073_741_824),
+        }, Now);
+
+        var reap = Assert.Single(recs, r => r.Kind == RecommendationKind.ReapSafeWorktrees);
+        Assert.Equal(1, reap.Severity);
+        Assert.Contains("3 worktrees are finished", reap.Title);
+        Assert.Contains("3.0 GB", reap.Title);
+        Assert.Equal(3_221_225_472, reap.ReclaimBytes);
+        Assert.Contains("never counted", reap.Why);
+    }
+
+    [Fact]
+    public void DirtyRepo_PastThreshold_GetsAProtectRecommendation_UnderThresholdDoesNot()
+    {
+        var recs = RecommendationEngine.Evaluate(new[]
+        {
+            Repo("old-mess", uncommitted: 434, dirtyDaysAgo: 12),
+            Repo("fresh-work", uncommitted: 5, dirtyDaysAgo: 2),
+        }, Now);
+
+        var protect = Assert.Single(recs, r => r.Kind == RecommendationKind.ProtectDirtyRepo);
+        Assert.Contains("old-mess", protect.Title);
+        Assert.Contains("434 uncommitted files sitting for 12 days", protect.Title);
+        Assert.Equal("/r/old-mess", protect.RepoPath);
+        Assert.DoesNotContain(recs, r => r.Title.Contains("fresh-work"));
+    }
+
+    [Fact]
+    public void BehindMain_PastThreshold_GetsADriftRecommendation()
+    {
+        var recs = RecommendationEngine.Evaluate(new[]
+        {
+            Repo("drifting", behindMain: 70),
+            Repo("close", behindMain: 10),
+        }, Now);
+
+        var drift = Assert.Single(recs, r => r.Kind == RecommendationKind.FarBehindMain);
+        Assert.Contains("drifting", drift.Title);
+        Assert.Contains("70 commits behind main", drift.Title);
+        Assert.DoesNotContain(recs, r => r.Title.Contains("close"));
+    }
+
+    [Fact]
+    public void ProvisionalEntries_NeverGenerateRecommendations()
+    {
+        // The warm-start trust rule extends to coaching: unverified data recommends nothing.
+        var recs = RecommendationEngine.Evaluate(new[]
+        {
+            Repo("cached", safeWorktrees: 5, uncommitted: 100, dirtyDaysAgo: 30, behindMain: 99, provisional: true),
+        }, Now);
+
+        Assert.Empty(recs);
+    }
+
+    [Fact]
+    public void CleanFleet_NoRecommendations()
+    {
+        Assert.Empty(RecommendationEngine.Evaluate(new[] { Repo("tidy") }, Now));
+    }
+
+    [Fact]
+    public void Ordering_IsSeverity_ReapFirst()
+    {
+        var recs = RecommendationEngine.Evaluate(new[]
+        {
+            Repo("drifting", behindMain: 50),
+            Repo("dirty", uncommitted: 9, dirtyDaysAgo: 10),
+            Repo("reapable", safeWorktrees: 1, safeBytes: 1024),
+        }, Now);
+
+        Assert.Equal(3, recs.Count);
+        Assert.Equal(RecommendationKind.ReapSafeWorktrees, recs[0].Kind);
+        Assert.Equal(RecommendationKind.ProtectDirtyRepo, recs[1].Kind);
+        Assert.Equal(RecommendationKind.FarBehindMain, recs[2].Kind);
+    }
+}

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -643,6 +643,109 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-4a): absence is ALWAYS stamped, whether or not
+    // a model row exists. A FIRST-TIME compute in flight (the model has no row yet) must not
+    // publish a repository that a newer gone-path check already saw vanish - before the fix the
+    // gone path wrote a tombstone only when the model held the key, so the vanished repository
+    // was resurrected by the older compute's late publish.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_FirstTimeComputeInFlight_CannotPublishARepositoryANewerCheckSawVanish()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-firstgone-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var computeEntered = new TaskCompletionSource();
+            var releaseCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => Array.Empty<string>(),
+                compute: async (p, _, _) =>
+                {
+                    computeEntered.TrySetResult();
+                    await releaseCompute.Task; // the FIRST-TIME compute is slow
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            // The model is EMPTY - this is the repository's first-ever compute, and it blocks.
+            var firstCompute = monitor.RecomputeOneAsync(dir);
+            await computeEntered.Task;
+
+            // The repository vanishes, and a NEWER check observes it gone (no model row exists).
+            Directory.Delete(System.IO.Path.Combine(dir, ".git"), recursive: true);
+            await monitor.RecomputeOneAsync(dir);
+
+            // The older first-time compute finally publishes - it must be dropped.
+            releaseCompute.SetResult();
+            await firstCompute;
+
+            Assert.Empty(monitor.Snapshot()); // the vanished repository was never resurrected
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-4b): eviction never drops stamp state for a key
+    // whose semaphore is currently held - a held semaphore is proof a compute is still in
+    // flight. Before the fix the removal stamp was evicted after one further completed scan,
+    // and the still-running compute could then publish and resurrect the removed repository.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_HeldAcrossTwoCompletedScans_CannotResurrectTheRemovedRepository()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-twoscan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var paths = new List<string> { dir };
+            var recomputeEntered = new TaskCompletionSource();
+            var releaseRecompute = new TaskCompletionSource();
+            bool blockNextCompute = false;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => paths.ToList(),
+                compute: async (p, _, _) =>
+                {
+                    if (blockNextCompute)
+                    {
+                        blockNextCompute = false;
+                        recomputeEntered.SetResult();
+                        await releaseRecompute.Task; // the OLD compute stays in flight
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            await monitor.RescanAsync(new[] { "/r" }); // the model holds the repository
+            Assert.Single(monitor.Snapshot());
+
+            // The old recompute starts and blocks inside its compute, holding the semaphore.
+            blockNextCompute = true;
+            var oldRecompute = monitor.RecomputeOneAsync(dir);
+            await recomputeEntered.Task;
+
+            // Scan one removes the repository (and stamps the removal). Scan two completes with
+            // the key absent and not removed by THAT scan - the eviction sweep must still keep
+            // the removal stamp, because the key's semaphore is held.
+            paths.Clear();
+            await monitor.RescanAsync(new[] { "/r" });
+            Assert.Empty(monitor.Snapshot());
+            await monitor.RescanAsync(new[] { "/r" });
+
+            // The old compute finally publishes - it must still be dropped.
+            releaseRecompute.SetResult();
+            await oldRecompute;
+
+            Assert.Empty(monitor.Snapshot()); // absent stays absent, two scans later too
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -915,6 +915,55 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-3): scan absence tombstones an UNPUBLISHED
+    // in-flight compute. A rowless compute that started before the scan, stayed in flight
+    // while the scan observed the path absent, and publishes only after reconciliation used to
+    // be invisible - its stamp lived in a local variable until publication and reconciliation
+    // visited only model rows, so the late publish resurrected a repository the scan had just
+    // proven absent. In-flight computes are now registered in a pending map, and
+    // reconciliation tombstones every unseen key that has a row OR a pending compute.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_ObservingAPathAbsent_TombstonesARowlessInFlightCompute()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-rowless-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var computeEntered = new TaskCompletionSource();
+            var releaseCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => Array.Empty<string>(), // the scan observes the path ABSENT
+                compute: async (p, _, _) =>
+                {
+                    computeEntered.TrySetResult();
+                    await releaseCompute.Task; // the rowless FIRST-TIME compute stays in flight
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            // The model is EMPTY: this is the repository's first-ever compute - no row exists
+            // and nothing has been published for its key. It blocks mid-compute.
+            var firstCompute = monitor.RecomputeOneAsync(dir);
+            await computeEntered.Task;
+
+            // A full scan runs TO COMPLETION - enumeration, reconciliation, eviction - while
+            // the rowless compute is still in flight.
+            await monitor.RescanAsync(new[] { "/r" });
+
+            // The older compute finally publishes - the scan's absence tombstone must outrank
+            // and drop it.
+            releaseCompute.SetResult();
+            await firstCompute;
+
+            Assert.Empty(monitor.Snapshot()); // the repository the scan proved absent stays absent
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -1137,6 +1137,51 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-5): the gone path takes its stamp BEFORE
+    // touching the filesystem. It used to observe the filesystem first and stamp inside the
+    // gate afterward - a newer add could start, publish, and then be removed by the OLDER
+    // absence observation, which received the HIGHER stamp. Stamps order by observation time:
+    // when a newer publish stamp exists for the key, the stale absence observation yields (the
+    // newer state stands; a repository truly gone is removed by a later observation).
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_GoneObservationRacingANewerAdd_LeavesTheNewlyAddedRepositoryInTheModel()
+    {
+        var observationEntered = new TaskCompletionSource();
+        var releaseObservation = new TaskCompletionSource();
+        int observations = 0;
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => Array.Empty<string>(),
+            compute: (p, _, _) => Task.FromResult(Status(p)),
+            isRepository: p =>
+            {
+                if (Interlocked.Increment(ref observations) == 1)
+                {
+                    // The FIRST call is the gone check: it has LOOKED at the filesystem and
+                    // seen the repository absent, but has not yet applied its removal.
+                    observationEntered.SetResult();
+                    releaseObservation.Task.Wait();
+                    return false;
+                }
+                return true; // the newer add observes the repository present
+            }) { LiveSessionsProvider = NoSessions };
+
+        // The gone observation begins and holds mid-observation.
+        var goneCheck = Task.Run(() => monitor.RecomputeOneAsync("/r/x"));
+        await observationEntered.Task;
+
+        // A NEWER add starts and publishes while the older absence observation is in flight.
+        await monitor.RecomputeOneAsync("/r/x");
+        Assert.Single(monitor.Snapshot());
+
+        // The older absence observation finally applies - it must yield to the newer publish.
+        releaseObservation.SetResult();
+        await goneCheck;
+
+        Assert.Single(monitor.Snapshot()); // the newly added repository stands
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -568,6 +568,81 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-11): per-repository semaphores are evicted
+    // alongside the size-cache eviction after a completed scan - an entry whose key left the
+    // model and whose semaphore is un-held is removed, so the process-lifetime lock map cannot
+    // grow forever with removed, moved, and transient repositories.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task CompletedScan_EvictsSemaphores_ForRepositoriesNoLongerPresent()
+    {
+        var paths = new List<string> { "/r/a", "/r/b" };
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => paths.ToList(),
+            compute: (p, _, _) => Task.FromResult(Status(p)))
+        { LiveSessionsProvider = NoSessions };
+
+        await monitor.RescanAsync(new[] { "/r" });
+        Assert.True(monitor.RepoLockExistsFor("/r/a"));
+        Assert.True(monitor.RepoLockExistsFor("/r/b"));
+
+        paths.Remove("/r/b");
+        await monitor.RescanAsync(new[] { "/r" });
+
+        Assert.True(monitor.RepoLockExistsFor("/r/a"));  // still in the model - kept
+        Assert.False(monitor.RepoLockExistsFor("/r/b")); // departed and un-held - evicted
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The eviction's safety property (ruling R2-11): a semaphore HELD by an in-flight compute
+    // is never evicted, even when its repository just left the model.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task CompletedScan_KeepsTheSemaphore_WhileAComputeStillHoldsIt()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-heldlock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var paths = new List<string> { dir };
+            var recomputeEntered = new TaskCompletionSource();
+            var releaseRecompute = new TaskCompletionSource();
+            bool blockNextCompute = false;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => paths.ToList(),
+                compute: async (p, _, _) =>
+                {
+                    if (blockNextCompute)
+                    {
+                        blockNextCompute = false;
+                        recomputeEntered.SetResult();
+                        await releaseRecompute.Task;
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            await monitor.RescanAsync(new[] { "/r" });
+
+            // A recompute holds the semaphore while a scan removes the repository.
+            blockNextCompute = true;
+            var oldRecompute = monitor.RecomputeOneAsync(dir);
+            await recomputeEntered.Task;
+
+            paths.Clear();
+            await monitor.RescanAsync(new[] { "/r" });
+
+            Assert.True(monitor.RepoLockExistsFor(dir)); // held - kept despite the removal
+
+            releaseRecompute.SetResult();
+            await oldRecompute;
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -16,10 +16,15 @@ public class RepositoryMonitorTests
         Success = true,
     };
 
+    /// <summary>An explicit empty-session source: the monitor refuses to scan unwired (R2-8).</summary>
+    private static Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>> NoSessions
+        => _ => Task.FromResult<IReadOnlyList<LiveSessionRef>>(Array.Empty<LiveSessionRef>());
+
     private static RepositoryMonitor MonitorOver(IReadOnlyList<string> paths, Action? perCompute = null)
         => new(
             enumerate: _ => paths,
-            compute: (p, _, _) => { perCompute?.Invoke(); return Task.FromResult(Status(p)); });
+            compute: (p, _, _) => { perCompute?.Invoke(); return Task.FromResult(Status(p)); })
+        { LiveSessionsProvider = NoSessions };
 
     [Fact]
     public async Task Rescan_StreamsEachRepository_AndBuildsModel()
@@ -60,7 +65,8 @@ public class RepositoryMonitorTests
         var paths = new List<string>(first);
         var monitor = new RepositoryMonitor(
             enumerate: _ => paths.ToList(),
-            compute: (p, _, _) => Task.FromResult(Status(p)));
+            compute: (p, _, _) => Task.FromResult(Status(p)))
+        { LiveSessionsProvider = NoSessions };
 
         await monitor.RescanAsync(new[] { "/r" });
         Assert.Equal(3, monitor.Snapshot().Count);
@@ -87,7 +93,7 @@ public class RepositoryMonitorTests
             var m1 = new RepositoryMonitor(
                 enumerate: _ => new[] { "/r/a", "/r/b", "/r/c" },
                 compute: (p, _, _) => Task.FromResult(Status(p)),
-                cachePath: cachePath);
+                cachePath: cachePath) { LiveSessionsProvider = NoSessions };
             await m1.RescanAsync(new[] { "/r" });
             Assert.True(File.Exists(cachePath));
 
@@ -95,7 +101,7 @@ public class RepositoryMonitorTests
             var m2 = new RepositoryMonitor(
                 enumerate: _ => new[] { "/r/a", "/r/b" }, // "c" is gone now
                 compute: (p, _, _) => Task.FromResult(Status(p)),
-                cachePath: cachePath);
+                cachePath: cachePath) { LiveSessionsProvider = NoSessions };
             m2.LoadCache();
             Assert.Equal(3, m2.Snapshot().Count); // instant content, no scan yet
 
@@ -156,10 +162,10 @@ public class RepositoryMonitorTests
         var cachePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-prov-" + Guid.NewGuid().ToString("N") + ".json");
         try
         {
-            var m1 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath);
+            var m1 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath) { LiveSessionsProvider = NoSessions };
             await m1.RescanAsync(new[] { "/r" });
 
-            var m2 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath);
+            var m2 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath) { LiveSessionsProvider = NoSessions };
             m2.LoadCache();
             Assert.True(Assert.Single(m2.Snapshot()).Provisional); // cached = verifying, never acted on
 
@@ -179,7 +185,8 @@ public class RepositoryMonitorTests
         Directory.CreateDirectory(dir); // exists, but has no .git
         try
         {
-            var monitor = new RepositoryMonitor(_ => new[] { dir }, (p, _, _) => Task.FromResult(Status(p)));
+            var monitor = new RepositoryMonitor(_ => new[] { dir }, (p, _, _) => Task.FromResult(Status(p)))
+            { LiveSessionsProvider = NoSessions };
             await monitor.RescanAsync(new[] { "/r" });
             Assert.Single(monitor.Snapshot());
 
@@ -227,7 +234,7 @@ public class RepositoryMonitorTests
                 {
                     lock (computedPaths) computedPaths.Add(p);
                     return Task.FromResult(Status(p));
-                });
+                }) { LiveSessionsProvider = NoSessions };
             await monitor.RescanAsync(new[] { root });
 
             await monitor.RecomputeOneAsync(wt); // the watcher hands over a linked-worktree path
@@ -308,7 +315,7 @@ public class RepositoryMonitorTests
                         await releaseScanCompute.Task;
                     }
                     return Status(p) with { UncommittedCount = call, IsClean = false };
-                });
+                }) { LiveSessionsProvider = NoSessions };
 
             var scanTask = monitor.RescanAsync(new[] { "/r" });
             await scanComputeEntered.Task; // the scan is mid-compute and holds the model
@@ -355,7 +362,7 @@ public class RepositoryMonitorTests
                         await releaseFirstCompute.Task; // the OLD compute is slow
                     }
                     return Status(p) with { UncommittedCount = call, IsClean = false };
-                });
+                }) { LiveSessionsProvider = NoSessions };
 
             var oldRecompute = monitor.RecomputeOneAsync(dir);
             await firstComputeEntered.Task;
@@ -403,7 +410,7 @@ public class RepositoryMonitorTests
                         await releaseRecompute.Task; // the OLD recompute is slow
                     }
                     return Status(p);
-                });
+                }) { LiveSessionsProvider = NoSessions };
 
             await monitor.RescanAsync(new[] { "/r" }); // the model holds the repository
             Assert.Single(monitor.Snapshot());
@@ -450,7 +457,7 @@ public class RepositoryMonitorTests
                 computeEntered.SetResult();
                 await releaseCompute.Task; // hold the compute so cancellation lands first
                 return Status(p);
-            });
+            }) { LiveSessionsProvider = NoSessions };
 
         using var cts = new CancellationTokenSource();
         var scanTask = monitor.RescanAsync(new[] { "/r" }, cts.Token);
@@ -488,7 +495,7 @@ public class RepositoryMonitorTests
                     await releaseOldCompute.Task;
                 }
                 return Status(p);
-            });
+            }) { LiveSessionsProvider = NoSessions };
 
         await monitor.RescanAsync(new[] { "/r" }); // the model holds /r/x
         Assert.Single(monitor.Snapshot());
@@ -537,7 +544,7 @@ public class RepositoryMonitorTests
                         await releaseScanCompute.Task;
                     }
                     return Status(p);
-                });
+                }) { LiveSessionsProvider = NoSessions };
 
             var scanTask = monitor.RescanAsync(new[] { "/r" });
             await scanComputeEntered.Task; // the scan is mid-compute
@@ -558,6 +565,24 @@ public class RepositoryMonitorTests
         {
             Directory.Delete(dir, recursive: true);
         }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
+    // programming error and fails LOUDLY. An unwired monitor used to silently publish
+    // session-blind safety classifications - an occupied worktree could be marked safe to reap.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Monitor_WithoutALiveSessionsProvider_RefusesToScanOrRecompute()
+    {
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/r/a" },
+            compute: (p, _, _) => Task.FromResult(Status(p)));
+        // No LiveSessionsProvider wired.
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => monitor.RescanAsync(new[] { "/r" }));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => monitor.RecomputeOneAsync("/r/a"));
+        Assert.Empty(monitor.Snapshot()); // nothing was published session-blind
     }
 
     private static string RunGit(string workingDir, params string[] args)
@@ -594,7 +619,7 @@ public class RepositoryMonitorTests
                 IsClean = !dirty,
                 UncommittedCount = dirty ? 5 : 0,
                 Success = true,
-            }));
+            })) { LiveSessionsProvider = NoSessions };
 
         await monitor.RescanAsync(new[] { "/r" });
         Assert.True(monitor.Snapshot()[0].IsClean);

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -110,6 +110,92 @@ public class RepositoryMonitorTests
         }
     }
 
+    // ----- enrichment: provisional + dirty-since (the model-level rules) -----
+
+    [Fact]
+    public void Enrich_FreshScan_ClearsProvisional()
+    {
+        var fresh = Status("/r/a") with { Provisional = true };
+        Assert.False(RepositoryMonitor.Enrich(fresh, null).Provisional);
+    }
+
+    [Fact]
+    public void Enrich_TreeJustTurnedDirty_StampsDirtySinceNow()
+    {
+        var fresh = Status("/r/a") with { IsClean = false, UncommittedCount = 2 };
+        var prevClean = Status("/r/a");
+
+        var enriched = RepositoryMonitor.Enrich(fresh, prevClean);
+
+        Assert.NotNull(enriched.DirtySinceUtc);
+        Assert.True((DateTime.UtcNow - enriched.DirtySinceUtc!.Value).TotalMinutes < 1);
+    }
+
+    [Fact]
+    public void Enrich_StillDirty_CarriesDirtySinceForward()
+    {
+        var origin = new DateTime(2026, 07, 01, 12, 0, 0, DateTimeKind.Utc);
+        var fresh = Status("/r/a") with { IsClean = false, UncommittedCount = 5 };
+        var prevDirty = Status("/r/a") with { IsClean = false, UncommittedCount = 2, DirtySinceUtc = origin };
+
+        Assert.Equal(origin, RepositoryMonitor.Enrich(fresh, prevDirty).DirtySinceUtc);
+    }
+
+    [Fact]
+    public void Enrich_BackToClean_ClearsDirtySince()
+    {
+        var fresh = Status("/r/a"); // clean
+        var prevDirty = Status("/r/a") with { IsClean = false, DirtySinceUtc = DateTime.UtcNow.AddDays(-3) };
+
+        Assert.Null(RepositoryMonitor.Enrich(fresh, prevDirty).DirtySinceUtc);
+    }
+
+    [Fact]
+    public async Task LoadCache_MarksEntriesProvisional_AndScanClearsIt()
+    {
+        var cachePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-prov-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var m1 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath);
+            await m1.RescanAsync(new[] { "/r" });
+
+            var m2 = new RepositoryMonitor(_ => new[] { "/r/a" }, (p, _, _) => Task.FromResult(Status(p)), cachePath);
+            m2.LoadCache();
+            Assert.True(Assert.Single(m2.Snapshot()).Provisional); // cached = verifying, never acted on
+
+            await m2.RescanAsync(new[] { "/r" });
+            Assert.False(Assert.Single(m2.Snapshot()).Provisional); // live scan confirmed it
+        }
+        finally
+        {
+            if (File.Exists(cachePath)) File.Delete(cachePath);
+        }
+    }
+
+    [Fact]
+    public async Task RecomputeOne_NonRepoFolder_RemovesTheEntry()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-notrepo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir); // exists, but has no .git
+        try
+        {
+            var monitor = new RepositoryMonitor(_ => new[] { dir }, (p, _, _) => Task.FromResult(Status(p)));
+            await monitor.RescanAsync(new[] { "/r" });
+            Assert.Single(monitor.Snapshot());
+
+            var removed = new List<string>();
+            monitor.Removed += s => removed.Add(s.Path);
+            await monitor.RecomputeOneAsync(dir);
+
+            Assert.Empty(monitor.Snapshot());
+            Assert.Single(removed);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Rescan_Upsert_UpdatesExistingEntryInPlace()
     {

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -748,9 +748,16 @@ public class RepositoryMonitorTests
     // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 3, ruling R3-5): a scan's removals publish with the SCAN'S
     // OWN START stamp, not a fresh stamp taken at reconciliation time. A repository legitimately
-    // created and published by a compute that started AFTER the scan began must survive that
+    // published by a compute whose start stamp is NEWER than the scan's must survive that
     // scan's reconciliation - before the fix the delayed reconciliation took a newer stamp and
     // removed it.
+    //
+    // Reworked for round 4 (ruling R4-4): a scan is now visibly scanning from the same gated
+    // region that takes ownership, BEFORE enumeration - so the original route to this window (a
+    // recompute during a slow enumeration) correctly DEFERS instead of publishing. The window
+    // that remains reachable: a recompute that passed the deferral check before the scan
+    // started, parked on the repository's single-flight semaphore behind an in-flight compute,
+    // and handed its start stamp only after the scan had begun.
     // ---------------------------------------------------------------------------------------
     [Fact]
     public async Task Rescan_RepositoryPublishedByAComputeThatStartedAfterTheScanBegan_SurvivesItsReconciliation()
@@ -759,38 +766,53 @@ public class RepositoryMonitorTests
         Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
         try
         {
-            bool blockNextEnumerate = false;
-            var enumerateEntered = new TaskCompletionSource();
-            using var releaseEnumerate = new ManualResetEventSlim(false);
+            var firstDirComputeEntered = new TaskCompletionSource();
+            var releaseFirstDirCompute = new TaskCompletionSource();
+            var scanComputeEntered = new TaskCompletionSource();
+            var releaseScanCompute = new TaskCompletionSource();
+            int dirComputes = 0;
             var monitor = new RepositoryMonitor(
-                enumerate: _ =>
+                enumerate: _ => new[] { "/r/a" }, // the enumeration never sees the new repository
+                compute: async (p, _, _) =>
                 {
-                    if (blockNextEnumerate)
+                    if (p == "/r/a")
                     {
-                        blockNextEnumerate = false;
-                        enumerateEntered.SetResult();
-                        releaseEnumerate.Wait(); // the scan already began; its enumeration is slow
+                        scanComputeEntered.TrySetResult();
+                        await releaseScanCompute.Task;
                     }
-                    return new[] { "/r/a" }; // the enumeration never saw the new repository
-                },
-                compute: (p, _, _) => Task.FromResult(Status(p)))
-            { LiveSessionsProvider = NoSessions };
+                    else if (Interlocked.Increment(ref dirComputes) == 1)
+                    {
+                        firstDirComputeEntered.TrySetResult();
+                        await releaseFirstDirCompute.Task;
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
 
-            blockNextEnumerate = true;
-            var scanTask = Task.Run(() => monitor.RescanAsync(new[] { "/r" }));
-            await enumerateEntered.Task;
+            // Compute A holds the repository's semaphore, mid-compute.
+            var computeA = monitor.RecomputeOneAsync(dir);
+            await firstDirComputeEntered.Task;
 
-            // The repository is created NOW, and a compute that started AFTER the scan began
-            // publishes it (the scan is not marked running yet, so nothing defers this).
-            await monitor.RecomputeOneAsync(dir);
+            // Compute B passes the deferral check (no scan is running yet) and parks on the
+            // semaphore behind A. Its start stamp has NOT been handed out yet.
+            var computeB = monitor.RecomputeOneAsync(dir);
+
+            // The scan begins - it takes its start stamp now and blocks in its own compute.
+            var scanTask = monitor.RescanAsync(new[] { "/r" });
+            await scanComputeEntered.Task;
+
+            // A finishes; B then acquires the semaphore, is handed a stamp NEWER than the
+            // scan's, and publishes the repository the enumeration never saw.
+            releaseFirstDirCompute.SetResult();
+            await computeA;
+            await computeB;
             Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
 
             var removed = new List<string>();
             monitor.Removed += s => removed.Add(s.Path);
-            releaseEnumerate.Set();
+            releaseScanCompute.SetResult();
             await scanTask;
 
-            // The newer add outranks the older scan's removals and survives untouched.
+            // The newer publish outranks the older scan's removals and survives untouched.
             Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
             Assert.DoesNotContain(dir, removed);
             Assert.Contains(monitor.Snapshot(), s => s.Path == "/r/a"); // the scan's own result stands
@@ -907,6 +929,157 @@ public class RepositoryMonitorTests
             Assert.False(monitor.IsScanning);
             Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
             Assert.False(scanCompletedRaised); // a cancelled scan still never reports completion
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-4): the old scan's drain must not run
+    // recomputes concurrently with a replacement scan. Ownership was a stale snapshot: the old
+    // scan checked ownership and cleared IsScanning under the gate, released it, and only THEN
+    // drained - a replacement scan could take ownership in that interval, and because it set
+    // IsScanning only after enumeration, the old drain saw the monitor as idle and ran the
+    // deferred recompute inside the new scan. A scan now sets IsScanning in the same gated
+    // region that takes ownership, BEFORE enumeration, and drained deferred recomputes go back
+    // through the normal deferral check - re-deferring to the newer scan.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_DeferredRecomputeDrainedWhileAReplacementIsEnumerating_ReDefersToTheReplacement()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-draindefer-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var scanOneComputeEntered = new TaskCompletionSource();
+            var releaseScanOneCompute = new TaskCompletionSource();
+            var scanTwoEnumerateEntered = new TaskCompletionSource();
+            using var releaseScanTwoEnumerate = new ManualResetEventSlim(false);
+            int enumerateCalls = 0;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ =>
+                {
+                    if (Interlocked.Increment(ref enumerateCalls) == 2)
+                    {
+                        // The REPLACEMENT scan owns the monitor and is still enumerating.
+                        scanTwoEnumerateEntered.SetResult();
+                        releaseScanTwoEnumerate.Wait();
+                    }
+                    return new[] { "/r/a" };
+                },
+                compute: async (p, _, _) =>
+                {
+                    if (p == "/r/a" && !scanOneComputeEntered.Task.IsCompleted)
+                    {
+                        scanOneComputeEntered.TrySetResult();
+                        await releaseScanOneCompute.Task;
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            Task? scanTwo = null;
+            bool scanTwoStarted = false;
+            monitor.ProgressChanged += () =>
+            {
+                // Scan one's OWNING exit raises progress after clearing the scanning flag and
+                // BEFORE draining. Start the replacement scan exactly there and hold it inside
+                // its enumeration - scan one's drain then runs while the replacement owns the
+                // monitor mid-enumeration, which is the inspector's interleaving.
+                if (!monitor.IsScanning && !scanTwoStarted)
+                {
+                    scanTwoStarted = true;
+                    scanTwo = Task.Run(() => monitor.RescanAsync(new[] { "/r" }));
+                    scanTwoEnumerateEntered.Task.Wait();
+                }
+            };
+
+            var scanOne = monitor.RescanAsync(new[] { "/r" });
+            await scanOneComputeEntered.Task;
+
+            // A watcher recompute arrives during scan one and is deferred.
+            await monitor.RecomputeOneAsync(dir);
+            Assert.DoesNotContain(monitor.Snapshot(), s => s.Path == dir);
+
+            // Scan one completes; its exit starts the replacement (handler above), then drains.
+            releaseScanOneCompute.SetResult();
+            await scanOne;
+
+            // The drained recompute must have RE-DEFERRED to the replacement scan - never run
+            // concurrently with it.
+            Assert.DoesNotContain(monitor.Snapshot(), s => s.Path == dir);
+            Assert.True(monitor.IsScanning); // the replacement is still scanning
+
+            releaseScanTwoEnumerate.Set();
+            await scanTwo!;
+
+            // The replacement's completion path reached the re-deferred request.
+            Assert.False(monitor.IsScanning);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 4, ruling R4-4): an enumeration fault cannot strand the
+    // lifecycle state. Enumeration ran BEFORE the scan's try/finally - when a replacement scan
+    // took ownership and then its enumeration threw, the replaced scan refused cleanup (not
+    // the owner) and the replacement never reached any cleanup path: IsScanning and the
+    // deferred queue were stranded forever. Enumeration now runs inside the try/finally, so
+    // the THROWER - which owns the monitor - releases the lifecycle state and drains the
+    // deferred queue on its way out (proving WHICH scan drains: the faulting successor).
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_EnumerationFaultInAScanThatSupersededAnother_ReleasesLifecycleStateAndDrains()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-enumfault-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var scanOneComputeEntered = new TaskCompletionSource();
+            var releaseScanOneCompute = new TaskCompletionSource();
+            int enumerateCalls = 0;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ =>
+                {
+                    if (Interlocked.Increment(ref enumerateCalls) == 2)
+                        throw new InvalidOperationException("injected enumeration fault");
+                    return new[] { "/r/a" };
+                },
+                compute: async (p, _, _) =>
+                {
+                    if (!scanOneComputeEntered.Task.IsCompleted)
+                    {
+                        scanOneComputeEntered.TrySetResult();
+                        await releaseScanOneCompute.Task;
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            var scanOne = monitor.RescanAsync(new[] { "/r" });
+            await scanOneComputeEntered.Task; // scan one is mid-compute and visibly scanning
+
+            // A watcher recompute arrives and is deferred on the running scan.
+            await monitor.RecomputeOneAsync(dir);
+
+            // The replacement scan takes ownership, then its enumeration throws. The fault
+            // propagates LOUDLY to the caller.
+            await Assert.ThrowsAsync<InvalidOperationException>(() => monitor.RescanAsync(new[] { "/r" }));
+
+            // The thrower owned the monitor at its exit, so IT released the lifecycle state
+            // and drained the deferred queue.
+            Assert.False(monitor.IsScanning);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
+
+            // The superseded scan exits quietly without re-clearing its replacement's state.
+            releaseScanOneCompute.SetResult();
+            await scanOne;
+            Assert.False(monitor.IsScanning);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
         }
         finally
         {

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -432,6 +432,85 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-2): a CANCELLED scan never publishes.
+    // Cancellation can land in the narrow interval after a compute returns and before its
+    // publish; re-checking only at the next loop iteration is too late. The token is
+    // re-checked under the gate at the publish itself, so the cancelled scan's result never
+    // reaches the model.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_CancelledAfterComputeButBeforePublish_NeverPublishes()
+    {
+        var computeEntered = new TaskCompletionSource();
+        var releaseCompute = new TaskCompletionSource();
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { "/r/x" },
+            compute: async (p, _, _) =>
+            {
+                computeEntered.SetResult();
+                await releaseCompute.Task; // hold the compute so cancellation lands first
+                return Status(p);
+            });
+
+        using var cts = new CancellationTokenSource();
+        var scanTask = monitor.RescanAsync(new[] { "/r" }, cts.Token);
+        await computeEntered.Task;
+
+        // The cancellation arrives while the compute is in flight; the compute itself does not
+        // observe the token and returns a result anyway - the publish must still be suppressed.
+        cts.Cancel();
+        releaseCompute.SetResult();
+        await scanTask; // a cancelled scan returns quietly - the newer owner has the model
+
+        Assert.Empty(monitor.Snapshot()); // the cancelled scan published nothing
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-2): a SUPERSEDED scan whose compute returns
+    // after the newer scan removed the repository must not republish it - even though the
+    // superseded scan is no longer the owner of the model.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_Superseded_CannotRepublishARepositoryTheNewerScanRemoved()
+    {
+        var paths = new List<string> { "/r/x" };
+        var oldComputeEntered = new TaskCompletionSource();
+        var releaseOldCompute = new TaskCompletionSource();
+        bool blockNextCompute = false;
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => paths.ToList(),
+            compute: async (p, _, _) =>
+            {
+                if (blockNextCompute)
+                {
+                    blockNextCompute = false;
+                    oldComputeEntered.SetResult();
+                    await releaseOldCompute.Task;
+                }
+                return Status(p);
+            });
+
+        await monitor.RescanAsync(new[] { "/r" }); // the model holds /r/x
+        Assert.Single(monitor.Snapshot());
+
+        // The OLD scan blocks mid-compute for /r/x.
+        blockNextCompute = true;
+        var oldScan = monitor.RescanAsync(new[] { "/r" });
+        await oldComputeEntered.Task;
+
+        // The NEW scan supersedes it; its roots no longer contain /r/x, so it removes it.
+        paths.Clear();
+        await monitor.RescanAsync(new[] { "/r" });
+        Assert.Empty(monitor.Snapshot());
+
+        // The old scan's compute returns after cancellation - its publish must be suppressed.
+        releaseOldCompute.SetResult();
+        await oldScan;
+
+        Assert.Empty(monitor.Snapshot()); // not resurrected
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-5, boundary ordering 2 / deferral semantics):
     // a recompute deferred during a scan keeps its ORIGINAL requester's token. When that
     // requester cancels before the scan completes, the drain SKIPS the request instead of

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -196,6 +196,206 @@ public class RepositoryMonitorTests
         }
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F4): a linked-worktree path (whose .git is a FILE) handed
+    // to RecomputeOneAsync must recompute the PRIMARY repository entry - never store the
+    // worktree path as a repository entry of its own. Uses real git so the canonicalization
+    // (rev-parse --git-common-dir) is the production one.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_LinkedWorktreePath_RecomputesThePrimaryEntry()
+    {
+        var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-canon-" + Guid.NewGuid().ToString("N"));
+        var primary = System.IO.Path.Combine(root, "primary");
+        var wt = System.IO.Path.Combine(root, "wt-linked");
+        Directory.CreateDirectory(primary);
+        try
+        {
+            RunGit(primary, "-c", "init.defaultBranch=main", "init");
+            RunGit(primary, "config", "user.email", "test@cc-director.local");
+            RunGit(primary, "config", "user.name", "CC Director Test");
+            RunGit(primary, "config", "commit.gpgsign", "false");
+            File.WriteAllText(System.IO.Path.Combine(primary, "README.md"), "init\n");
+            RunGit(primary, "add", "-A");
+            RunGit(primary, "commit", "-m", "initial");
+            RunGit(primary, "worktree", "add", wt);
+
+            var computedPaths = new List<string>();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { primary },
+                compute: (p, _, _) =>
+                {
+                    lock (computedPaths) computedPaths.Add(p);
+                    return Task.FromResult(Status(p));
+                });
+            await monitor.RescanAsync(new[] { root });
+
+            await monitor.RecomputeOneAsync(wt); // the watcher hands over a linked-worktree path
+
+            lock (computedPaths)
+                Assert.All(computedPaths, p => Assert.Equal(
+                    System.IO.Path.GetFullPath(primary), System.IO.Path.GetFullPath(p)));
+            var entry = Assert.Single(monitor.Snapshot());
+            Assert.Equal(System.IO.Path.GetFullPath(primary), System.IO.Path.GetFullPath(entry.Path));
+        }
+        finally
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                try { Directory.Delete(root, recursive: true); break; }
+                catch { Thread.Sleep(100); }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F5): every compute consults the monitor's own live-session
+    // provider, so a watcher-style recompute (which used to pass no sessions) can no longer
+    // erase the in-use-by-session classification.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_ConsultsTheLiveSessionsProvider_PreservingInUse()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-sess-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { dir },
+                compute: (p, sessions, _) => Task.FromResult(Status(p) with
+                {
+                    WorktreesInUse = sessions?.Count ?? 0,
+                }));
+            monitor.LiveSessionsProvider = _ => Task.FromResult<IReadOnlyList<LiveSessionRef>>(
+                new[] { new LiveSessionRef { RepoPath = dir, Label = "Busy (#7)" } });
+
+            await monitor.RescanAsync(new[] { "/r" });
+            Assert.Equal(1, Assert.Single(monitor.Snapshot()).WorktreesInUse);
+
+            // The watcher's path: no sessions argument exists any more - the provider is the source.
+            await monitor.RecomputeOneAsync(dir);
+            Assert.Equal(1, Assert.Single(monitor.Snapshot()).WorktreesInUse);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F6): a recompute requested while a full scan runs is
+    // deferred until the scan completes, then runs - so the model ends holding the NEWEST
+    // result, never the older of the two.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_DuringAScan_IsDeferred_AndRunsAfterTheScan()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-defer-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            int computeCalls = 0;
+            var scanComputeEntered = new TaskCompletionSource();
+            var releaseScanCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { dir },
+                compute: async (p, _, _) =>
+                {
+                    int call = Interlocked.Increment(ref computeCalls);
+                    if (call == 1)
+                    {
+                        scanComputeEntered.SetResult();
+                        await releaseScanCompute.Task;
+                    }
+                    return Status(p) with { UncommittedCount = call, IsClean = false };
+                });
+
+            var scanTask = monitor.RescanAsync(new[] { "/r" });
+            await scanComputeEntered.Task; // the scan is mid-compute and holds the model
+
+            // The watcher fires now: the recompute must defer, not race the scan.
+            await monitor.RecomputeOneAsync(dir);
+            Assert.Equal(1, Volatile.Read(ref computeCalls)); // deferred - no second compute yet
+
+            releaseScanCompute.SetResult();
+            await scanTask;
+
+            Assert.Equal(2, Volatile.Read(ref computeCalls)); // the deferred recompute ran after the scan
+            Assert.Equal(2, Assert.Single(monitor.Snapshot()).UncommittedCount); // newest result wins
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F6): two recomputes for the same repository are single-
+    // flight - the slower, OLDER compute can never publish after (and thereby overwrite) the
+    // newer one.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_RacingRecomputes_NeverLeaveTheOlderResultLast()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-race-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            int computeCalls = 0;
+            var firstComputeEntered = new TaskCompletionSource();
+            var releaseFirstCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { dir },
+                compute: async (p, _, _) =>
+                {
+                    int call = Interlocked.Increment(ref computeCalls);
+                    if (call == 1)
+                    {
+                        firstComputeEntered.SetResult();
+                        await releaseFirstCompute.Task; // the OLD compute is slow
+                    }
+                    return Status(p) with { UncommittedCount = call, IsClean = false };
+                });
+
+            var oldRecompute = monitor.RecomputeOneAsync(dir);
+            await firstComputeEntered.Task;
+            var newRecompute = monitor.RecomputeOneAsync(dir); // must WAIT for the old one
+
+            releaseFirstCompute.SetResult();
+            await Task.WhenAll(oldRecompute, newRecompute);
+
+            // Single-flight means the second compute ran after the first published, so the model
+            // holds the newest result. Before the fix the fast second call published first and the
+            // slow OLD result landed last.
+            Assert.Equal(2, Assert.Single(monitor.Snapshot()).UncommittedCount);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = System.Diagnostics.Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {stderr}");
+        return stdout;
+    }
+
     [Fact]
     public async Task Rescan_Upsert_UpdatesExistingEntryInPlace()
     {

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -375,6 +375,112 @@ public class RepositoryMonitorTests
         }
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-5, boundary ordering 1): a single-repository
+    // recompute that started BEFORE a newer scan can only publish AFTER that scan removed the
+    // repository from the model. Newest compute wins at the publish: the older recompute's
+    // late publish is dropped - it must not resurrect the removed repository.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_StartedBeforeAScanThatRemovedTheRepository_CannotResurrectIt()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-stale-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var paths = new List<string> { dir };
+            var recomputeEntered = new TaskCompletionSource();
+            var releaseRecompute = new TaskCompletionSource();
+            bool blockNextCompute = false;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => paths.ToList(),
+                compute: async (p, _, _) =>
+                {
+                    if (blockNextCompute)
+                    {
+                        blockNextCompute = false;
+                        recomputeEntered.SetResult();
+                        await releaseRecompute.Task; // the OLD recompute is slow
+                    }
+                    return Status(p);
+                });
+
+            await monitor.RescanAsync(new[] { "/r" }); // the model holds the repository
+            Assert.Single(monitor.Snapshot());
+
+            // The old recompute starts (it passed the IsScanning check - no scan is running yet)
+            // and blocks inside its compute.
+            blockNextCompute = true;
+            var oldRecompute = monitor.RecomputeOneAsync(dir);
+            await recomputeEntered.Task;
+
+            // A NEWER scan runs with roots that no longer contain the repository and removes it.
+            paths.Clear();
+            await monitor.RescanAsync(new[] { "/r" });
+            Assert.Empty(monitor.Snapshot());
+
+            // The old recompute finally returns and tries to publish - it must be dropped.
+            releaseRecompute.SetResult();
+            await oldRecompute;
+
+            Assert.Empty(monitor.Snapshot()); // not resurrected - the newer removal stands
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-5, boundary ordering 2 / deferral semantics):
+    // a recompute deferred during a scan keeps its ORIGINAL requester's token. When that
+    // requester cancels before the scan completes, the drain SKIPS the request instead of
+    // running it under the scan's token.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task RecomputeOne_DeferredThenCancelledByItsRequester_IsSkippedAtDrain()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-defertok-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            int computeCalls = 0;
+            var scanComputeEntered = new TaskCompletionSource();
+            var releaseScanCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { dir },
+                compute: async (p, _, _) =>
+                {
+                    int call = Interlocked.Increment(ref computeCalls);
+                    if (call == 1)
+                    {
+                        scanComputeEntered.SetResult();
+                        await releaseScanCompute.Task;
+                    }
+                    return Status(p);
+                });
+
+            var scanTask = monitor.RescanAsync(new[] { "/r" });
+            await scanComputeEntered.Task; // the scan is mid-compute
+
+            // The watcher defers a recompute, then its requester gives up before the scan ends.
+            using var requester = new CancellationTokenSource();
+            await monitor.RecomputeOneAsync(dir, requester.Token); // deferred - returns at once
+            requester.Cancel();
+
+            releaseScanCompute.SetResult();
+            await scanTask;
+
+            // The drain must SKIP the cancelled request - only the scan's one compute ran.
+            Assert.Equal(1, Volatile.Read(ref computeCalls));
+            Assert.Single(monitor.Snapshot()); // the scan's result stands untouched
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     private static string RunGit(string workingDir, params string[] args)
     {
         var psi = new System.Diagnostics.ProcessStartInfo

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -337,6 +337,64 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 5): a THROWING ProgressChanged subscriber must not skip the
+    // deferred-recompute drain. The exit invoke fires after IsScanning is already cleared, so
+    // a skipped drain would strand the deferred requests until some later scan happened to
+    // complete. The drain sits in a finally; the subscriber's exception still propagates.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_ProgressSubscriberThrowsAtExit_StillDrainsTheDeferredRecomputes()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-progthrow-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            int computeCalls = 0;
+            var scanComputeEntered = new TaskCompletionSource();
+            var releaseScanCompute = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { dir },
+                compute: async (p, _, _) =>
+                {
+                    int call = Interlocked.Increment(ref computeCalls);
+                    if (call == 1)
+                    {
+                        scanComputeEntered.SetResult();
+                        await releaseScanCompute.Task;
+                    }
+                    return Status(p) with { UncommittedCount = call, IsClean = false };
+                }) { LiveSessionsProvider = NoSessions };
+
+            // Throws ONLY on the exit invoke - the one raised after IsScanning was cleared.
+            // Mid-scan progress invokes pass through so the scan itself proceeds normally.
+            monitor.ProgressChanged += () =>
+            {
+                if (!monitor.IsScanning)
+                    throw new InvalidOperationException("injected progress subscriber failure");
+            };
+
+            var scanTask = monitor.RescanAsync(new[] { "/r" });
+            await scanComputeEntered.Task;
+
+            // A watcher recompute arrives during the scan and is deferred.
+            await monitor.RecomputeOneAsync(dir);
+            Assert.Equal(1, Volatile.Read(ref computeCalls));
+
+            releaseScanCompute.SetResult();
+            // The subscriber's exception escapes the scan LOUDLY...
+            await Assert.ThrowsAsync<InvalidOperationException>(() => scanTask);
+
+            // ...but the deferred recompute was drained anyway, not stranded.
+            Assert.Equal(2, Volatile.Read(ref computeCalls));
+            Assert.Equal(2, Assert.Single(monitor.Snapshot()).UncommittedCount);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection finding F6): two recomputes for the same repository are single-
     // flight - the slower, OLDER compute can never publish after (and thereby overwrite) the
     // newer one.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -802,6 +802,119 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-6a): scan lifecycle state belongs to the
+    // CURRENT scan only. A superseded scan's exit must not clear IsScanning while its
+    // replacement is still scanning - before the fix it did, and watcher recomputes then
+    // bypassed deferral mid-scan. The deferred request the superseded interval parks must
+    // then be drained by the NEWER scan's completion path.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_Superseded_DoesNotClearIsScanningForItsReplacement_WhichDrainsTheDeferred()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-lifecycle-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var paths = new List<string> { "/r/old" };
+            var oldEntered = new TaskCompletionSource();
+            var releaseOld = new TaskCompletionSource();
+            var newEntered = new TaskCompletionSource();
+            var releaseNew = new TaskCompletionSource();
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => paths.ToList(),
+                compute: async (p, _, _) =>
+                {
+                    if (p == "/r/old") { oldEntered.TrySetResult(); await releaseOld.Task; }
+                    if (p == "/r/new") { newEntered.TrySetResult(); await releaseNew.Task; }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            var oldScan = monitor.RescanAsync(new[] { "/r" });
+            await oldEntered.Task; // the old scan is mid-compute
+
+            paths[0] = "/r/new";
+            var newScan = monitor.RescanAsync(new[] { "/r" }); // supersedes the old scan
+            await newEntered.Task; // the new scan is mid-compute and owns the monitor
+
+            // The old scan exits (its publish is suppressed as superseded). It must NOT mark
+            // the monitor idle - the replacement scan is still running.
+            releaseOld.SetResult();
+            await oldScan;
+            Assert.True(monitor.IsScanning);
+
+            // Because the monitor still reads as scanning, a watcher recompute defers instead
+            // of racing the live scan.
+            await monitor.RecomputeOneAsync(dir);
+            Assert.DoesNotContain(monitor.Snapshot(), s => s.Path == dir); // parked, not run
+
+            // The NEWER scan's completion path must provably reach the deferred request.
+            releaseNew.SetResult();
+            await newScan;
+            Assert.False(monitor.IsScanning);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir); // drained by the new scan
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-6b): an externally cancelled scan with NO
+    // successor drains its deferred requests on the way out - before the fix it returned from
+    // the catch without draining, stranding them until some later scan happened to complete.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_CancelledExternallyWithNoSuccessor_DrainsItsDeferredRecomputes()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-canceldrain-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            var computeEntered = new TaskCompletionSource();
+            var releaseCompute = new TaskCompletionSource();
+            bool blockNextCompute = true;
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { "/r/x" },
+                compute: async (p, _, _) =>
+                {
+                    if (blockNextCompute)
+                    {
+                        blockNextCompute = false;
+                        computeEntered.SetResult();
+                        await releaseCompute.Task;
+                    }
+                    return Status(p);
+                }) { LiveSessionsProvider = NoSessions };
+
+            bool scanCompletedRaised = false;
+            monitor.ScanCompleted += () => scanCompletedRaised = true;
+
+            using var cts = new CancellationTokenSource();
+            var scanTask = monitor.RescanAsync(new[] { "/r" }, cts.Token);
+            await computeEntered.Task; // the scan is mid-compute
+
+            // A watcher recompute arrives and is deferred; its own requester never gives up.
+            await monitor.RecomputeOneAsync(dir);
+
+            // The scan is cancelled externally - no successor scan exists.
+            cts.Cancel();
+            releaseCompute.SetResult();
+            await scanTask;
+
+            // The cancelled scan cleared its own lifecycle state and drained the deferred
+            // request on its way out - the request is not stranded.
+            Assert.False(monitor.IsScanning);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
+            Assert.False(scanCompletedRaised); // a cancelled scan still never reports completion
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -746,6 +746,62 @@ public class RepositoryMonitorTests
     }
 
     // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 3, ruling R3-5): a scan's removals publish with the SCAN'S
+    // OWN START stamp, not a fresh stamp taken at reconciliation time. A repository legitimately
+    // created and published by a compute that started AFTER the scan began must survive that
+    // scan's reconciliation - before the fix the delayed reconciliation took a newer stamp and
+    // removed it.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Rescan_RepositoryPublishedByAComputeThatStartedAfterTheScanBegan_SurvivesItsReconciliation()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ccd-newadd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(System.IO.Path.Combine(dir, ".git"));
+        try
+        {
+            bool blockNextEnumerate = false;
+            var enumerateEntered = new TaskCompletionSource();
+            using var releaseEnumerate = new ManualResetEventSlim(false);
+            var monitor = new RepositoryMonitor(
+                enumerate: _ =>
+                {
+                    if (blockNextEnumerate)
+                    {
+                        blockNextEnumerate = false;
+                        enumerateEntered.SetResult();
+                        releaseEnumerate.Wait(); // the scan already began; its enumeration is slow
+                    }
+                    return new[] { "/r/a" }; // the enumeration never saw the new repository
+                },
+                compute: (p, _, _) => Task.FromResult(Status(p)))
+            { LiveSessionsProvider = NoSessions };
+
+            blockNextEnumerate = true;
+            var scanTask = Task.Run(() => monitor.RescanAsync(new[] { "/r" }));
+            await enumerateEntered.Task;
+
+            // The repository is created NOW, and a compute that started AFTER the scan began
+            // publishes it (the scan is not marked running yet, so nothing defers this).
+            await monitor.RecomputeOneAsync(dir);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
+
+            var removed = new List<string>();
+            monitor.Removed += s => removed.Add(s.Path);
+            releaseEnumerate.Set();
+            await scanTask;
+
+            // The newer add outranks the older scan's removals and survives untouched.
+            Assert.Contains(monitor.Snapshot(), s => s.Path == dir);
+            Assert.DoesNotContain(dir, removed);
+            Assert.Contains(monitor.Snapshot(), s => s.Path == "/r/a"); // the scan's own result stands
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
     // REGRESSION (inspection round 2, ruling R2-8): scanning without a live-session source is a
     // programming error and fails LOUDLY. An unwired monitor used to silently publish
     // session-blind safety classifications - an occupied worktree could be marked safe to reap.

--- a/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
@@ -71,6 +71,47 @@ public sealed class WorktreeSizeMeasurementTests : IDisposable
         // Second call with the same stamp hits the cache, cancellation not consulted before it.
         Assert.Equal(50, RepositoryStatusService.MeasureWorktreeBytes(w, CancellationToken.None));
     }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F8): a completed scan evicts cached sizes for worktrees
+    // the scan did not see, so reaped, moved, and deleted worktrees do not grow the
+    // process-wide cache forever.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task CompletedScan_EvictsCachedSizes_ForWorktreesNoLongerPresent()
+    {
+        var goneDir = Path.Combine(Path.GetTempPath(), "ccd-size-gone-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(goneDir);
+        File.WriteAllText(Path.Combine(goneDir, "g.txt"), "gone");
+        try
+        {
+            var stamp = new DateTime(2026, 07, 23, 12, 0, 0, DateTimeKind.Utc);
+            RepositoryStatusService.MeasureWorktreeBytes(new WorktreeInfo { Path = _dir, Branch = "b", LastActivityUtc = stamp }, CancellationToken.None);
+            RepositoryStatusService.MeasureWorktreeBytes(new WorktreeInfo { Path = goneDir, Branch = "g", LastActivityUtc = stamp }, CancellationToken.None);
+            Assert.True(RepositoryStatusService.SizeCacheContains(_dir));
+            Assert.True(RepositoryStatusService.SizeCacheContains(goneDir));
+
+            // A scan whose model only contains the surviving worktree.
+            var monitor = new RepositoryMonitor(
+                enumerate: _ => new[] { "/r/a" },
+                compute: (p, _, _) => Task.FromResult(new RepositoryStatus
+                {
+                    Path = p,
+                    Name = "a",
+                    IsClean = true,
+                    Success = true,
+                    Worktrees = new[] { new WorktreeInfo { Path = _dir, Branch = "b" } },
+                }));
+            await monitor.RescanAsync(new[] { "/r" });
+
+            Assert.True(RepositoryStatusService.SizeCacheContains(_dir));    // still present - kept
+            Assert.False(RepositoryStatusService.SizeCacheContains(goneDir)); // unseen - evicted
+        }
+        finally
+        {
+            try { Directory.Delete(goneDir, recursive: true); } catch { }
+        }
+    }
 }
 
 /// <summary>

--- a/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
@@ -101,7 +101,10 @@ public sealed class WorktreeSizeMeasurementTests : IDisposable
                     IsClean = true,
                     Success = true,
                     Worktrees = new[] { new WorktreeInfo { Path = _dir, Branch = "b" } },
-                }));
+                }))
+            {
+                LiveSessionsProvider = _ => Task.FromResult<IReadOnlyList<LiveSessionRef>>(Array.Empty<LiveSessionRef>()),
+            };
             await monitor.RescanAsync(new[] { "/r" });
 
             Assert.True(RepositoryStatusService.SizeCacheContains(_dir));    // still present - kept

--- a/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryStatusServiceTests.cs
@@ -24,6 +24,56 @@ public class RepositoryStatusClassifyTests
 }
 
 /// <summary>
+/// REGRESSION (inspection finding F7): the size walk honors cancellation during enumeration and
+/// never stores a partial (lying) measurement. No file caps or byte budgets exist - the walk
+/// either finishes or is cancelled cleanly.
+/// </summary>
+public sealed class WorktreeSizeMeasurementTests : IDisposable
+{
+    private readonly string _dir;
+
+    public WorktreeSizeMeasurementTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "ccd-size-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        for (int i = 0; i < 5; i++)
+            File.WriteAllText(Path.Combine(_dir, $"f{i}.txt"), new string('x', 10));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Measure_Cancelled_Throws_AndStoresNoPartialResult()
+    {
+        var stamp = new DateTime(2026, 07, 23, 10, 0, 0, DateTimeKind.Utc);
+        var w = new WorktreeInfo { Path = _dir, Branch = "b", LastActivityUtc = stamp };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        Assert.Throws<OperationCanceledException>(
+            () => RepositoryStatusService.MeasureWorktreeBytes(w, cts.Token));
+
+        // A partial measurement must not have been cached: the uncancelled walk returns the
+        // FULL size (a cached partial with the same activity stamp would short-circuit here).
+        Assert.Equal(50, RepositoryStatusService.MeasureWorktreeBytes(w, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Measure_Uncancelled_ReturnsTheFullSize_AndCachesIt()
+    {
+        var stamp = new DateTime(2026, 07, 23, 11, 0, 0, DateTimeKind.Utc);
+        var w = new WorktreeInfo { Path = _dir, Branch = "b", LastActivityUtc = stamp };
+
+        Assert.Equal(50, RepositoryStatusService.MeasureWorktreeBytes(w, CancellationToken.None));
+        // Second call with the same stamp hits the cache, cancellation not consulted before it.
+        Assert.Equal(50, RepositoryStatusService.MeasureWorktreeBytes(w, CancellationToken.None));
+    }
+}
+
+/// <summary>
 /// Integration tests over real repositories: a repo's status folds in its remote provider, its
 /// uncommitted count, and its worktree summary.
 /// </summary>

--- a/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
@@ -135,6 +135,75 @@ public sealed class RepositoryWatcherIntegrationTests : IDisposable
         Assert.InRange(Volatile.Read(ref recomputes), 1, 2);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-12; exercises ruling R2-5 end to end): a REAL
+    // RepositoryWatcher fires on a REAL git commit while a full scan is mid-flight. The
+    // watcher's recompute is deferred (the scan holds the model), runs after the scan
+    // completes, and the model ends holding the post-commit state - the newest compute wins
+    // through the real watcher -> deferral -> drain -> guarded publish pipeline.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public async Task Watcher_FiringDuringAScan_IsDeferred_AndTheNewestStateLandsAfterTheScan()
+    {
+        var repo = MakeRepo("delta");
+        var initialHead = RunGit(repo, "rev-parse", "HEAD").Trim();
+
+        bool holdNextCompute = false;
+        var scanComputeEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseScanCompute = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { repo },
+            compute: async (p, _, _) =>
+            {
+                // The commit sha is read at compute START - it proves WHEN this compute saw the
+                // repository, which is what "newest compute wins" is about.
+                var head = RunGit(p, "rev-parse", "HEAD").Trim();
+                if (Volatile.Read(ref holdNextCompute))
+                {
+                    Volatile.Write(ref holdNextCompute, false);
+                    scanComputeEntered.TrySetResult();
+                    await releaseScanCompute.Task;
+                }
+                return new RepositoryStatus { Path = p, Name = Path.GetFileName(p), Branch = head, IsClean = true, Success = true };
+            }) { LiveSessionsProvider = NoSessions };
+
+        await monitor.RescanAsync(new[] { _root }); // initial scan - the model knows the repo
+
+        using var watcher = new RepositoryWatcher(monitor);
+        var watcherProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        watcher.Recomputed += _ => watcherProcessed.TrySetResult();
+        watcher.SyncWatches(new[] { _root }, new[] { repo });
+
+        try
+        {
+            // A full scan starts and blocks mid-compute; its compute captured the OLD head.
+            Volatile.Write(ref holdNextCompute, true);
+            var scanTask = monitor.RescanAsync(new[] { _root });
+            await scanComputeEntered.Task;
+
+            // The REAL commit lands while the scan runs; the REAL watcher fires; the recompute
+            // must be deferred (it returns without computing - the scan holds the model).
+            File.WriteAllText(Path.Combine(repo, "change.txt"), "x\n");
+            RunGit(repo, "add", "-A");
+            RunGit(repo, "commit", "-m", "change during the scan");
+            var newHead = RunGit(repo, "rev-parse", "HEAD").Trim();
+            Assert.NotEqual(initialHead, newHead);
+
+            await WaitUntilAsync(() => watcherProcessed.Task.IsCompleted, TimeSpan.FromSeconds(15));
+            Assert.True(monitor.IsScanning); // the watcher was handled WHILE the scan was running
+
+            releaseScanCompute.TrySetResult();
+            await scanTask; // the scan publishes its OLD-head result, then drains the deferral
+
+            var entry = Assert.Single(monitor.Snapshot());
+            Assert.Equal(newHead, entry.Branch); // the deferred recompute landed the newest state
+        }
+        finally
+        {
+            releaseScanCompute.TrySetResult(); // never leave the compute (and Dispose) hanging
+        }
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var sw = Stopwatch.StartNew();

--- a/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class RepositoryWatcherSignalTests
+{
+    [Theory]
+    [InlineData("HEAD", true)]
+    [InlineData("packed-refs", true)]
+    [InlineData(@"refs\heads\main", true)]
+    [InlineData("refs/heads/feature/x", true)]
+    [InlineData(@"logs\HEAD", true)]
+    [InlineData(@"worktrees\wt1\HEAD", true)]
+    [InlineData("index", false)]                    // our own status scans touch this - echo risk
+    [InlineData(@"objects\ab\cdef0123", false)]     // object writes are covered by the reflog
+    [InlineData(@"logs\refs\heads\main", false)]
+    [InlineData("FETCH_HEAD", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSignal_FiltersToGitStateSignals(string? relative, bool expected)
+        => Assert.Equal(expected, RepositoryWatcher.IsSignal(relative));
+}
+
+/// <summary>
+/// Real-filesystem watcher tests: a change under one repository recomputes only that repository,
+/// and a burst of changes collapses into one recompute.
+/// </summary>
+public sealed class RepositoryWatcherIntegrationTests : IDisposable
+{
+    private readonly string _root;
+
+    public RepositoryWatcherIntegrationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-watch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    private string MakeRepo(string name)
+    {
+        var repo = Path.Combine(_root, name);
+        Directory.CreateDirectory(repo);
+        RunGit(repo, "-c", "init.defaultBranch=main", "init");
+        RunGit(repo, "config", "user.email", "test@cc-director.local");
+        RunGit(repo, "config", "user.name", "CC Director Test");
+        RunGit(repo, "config", "commit.gpgsign", "false");
+        File.WriteAllText(Path.Combine(repo, "README.md"), "init\n");
+        RunGit(repo, "add", "-A");
+        RunGit(repo, "commit", "-m", "initial");
+        return repo;
+    }
+
+    [Fact]
+    public async Task Commit_InOneRepo_RecomputesOnlyThatRepo()
+    {
+        var a = MakeRepo("alpha");
+        var b = MakeRepo("beta");
+
+        // A lightweight compute so the test observes the recompute plumbing, not git speed.
+        var computed = new List<string>();
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { a, b },
+            compute: (p, _, _) =>
+            {
+                lock (computed) computed.Add(Path.GetFileName(p));
+                return Task.FromResult(new RepositoryStatus { Path = p, Name = Path.GetFileName(p), IsClean = true, Success = true });
+            });
+        await monitor.RescanAsync(new[] { _root });
+        lock (computed) computed.Clear(); // ignore the initial scan
+
+        using var watcher = new RepositoryWatcher(monitor);
+        var recomputes = new List<string>();
+        watcher.Recomputed += p => { lock (recomputes) recomputes.Add(Path.GetFileName(p)); };
+        watcher.SyncWatches(new[] { _root }, new[] { a, b });
+
+        // A commit in alpha updates HEAD/refs/logs under alpha/.git only.
+        File.WriteAllText(Path.Combine(a, "change.txt"), "x\n");
+        RunGit(a, "add", "-A");
+        RunGit(a, "commit", "-m", "change");
+
+        await WaitUntilAsync(() => { lock (recomputes) return recomputes.Count >= 1; }, TimeSpan.FromSeconds(15));
+
+        lock (recomputes)
+        {
+            Assert.Contains("alpha", recomputes);
+            Assert.DoesNotContain("beta", recomputes);
+        }
+        lock (computed)
+        {
+            Assert.Contains("alpha", computed);
+            Assert.DoesNotContain("beta", computed);
+        }
+    }
+
+    [Fact]
+    public async Task BurstOfRefWrites_CollapsesIntoOneRecompute()
+    {
+        var a = MakeRepo("gamma");
+        var monitor = new RepositoryMonitor(
+            enumerate: _ => new[] { a },
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = Path.GetFileName(p), IsClean = true, Success = true }));
+        await monitor.RescanAsync(new[] { _root });
+
+        using var watcher = new RepositoryWatcher(monitor);
+        int recomputes = 0;
+        watcher.Recomputed += _ => Interlocked.Increment(ref recomputes);
+        watcher.SyncWatches(new[] { _root }, new[] { a });
+
+        // Ten rapid ref writes - the debounce must collapse them to one recompute.
+        var refsDir = Path.Combine(a, ".git", "refs", "heads");
+        for (int i = 0; i < 10; i++)
+        {
+            File.WriteAllText(Path.Combine(refsDir, $"burst-{i}"), "0123456789012345678901234567890123456789\n");
+            await Task.Delay(50);
+        }
+
+        await WaitUntilAsync(() => Volatile.Read(ref recomputes) >= 1, TimeSpan.FromSeconds(15));
+        // Allow one extra debounce window to elapse, then assert no pile-up followed.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Assert.InRange(Volatile.Read(ref recomputes), 1, 2);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+        Assert.Fail($"condition not met within {timeout.TotalSeconds:0}s");
+    }
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in args) psi.ArgumentList.Add(arg);
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {stderr}");
+        return stdout;
+    }
+}

--- a/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryWatcherTests.cs
@@ -46,6 +46,10 @@ public sealed class RepositoryWatcherIntegrationTests : IDisposable
         }
     }
 
+    /// <summary>An explicit empty-session source: the monitor refuses to scan unwired (R2-8).</summary>
+    private static Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>> NoSessions
+        => _ => Task.FromResult<IReadOnlyList<LiveSessionRef>>(Array.Empty<LiveSessionRef>());
+
     private string MakeRepo(string name)
     {
         var repo = Path.Combine(_root, name);
@@ -74,7 +78,7 @@ public sealed class RepositoryWatcherIntegrationTests : IDisposable
             {
                 lock (computed) computed.Add(Path.GetFileName(p));
                 return Task.FromResult(new RepositoryStatus { Path = p, Name = Path.GetFileName(p), IsClean = true, Success = true });
-            });
+            }) { LiveSessionsProvider = NoSessions };
         await monitor.RescanAsync(new[] { _root });
         lock (computed) computed.Clear(); // ignore the initial scan
 
@@ -108,7 +112,8 @@ public sealed class RepositoryWatcherIntegrationTests : IDisposable
         var a = MakeRepo("gamma");
         var monitor = new RepositoryMonitor(
             enumerate: _ => new[] { a },
-            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = Path.GetFileName(p), IsClean = true, Success = true }));
+            compute: (p, _, _) => Task.FromResult(new RepositoryStatus { Path = p, Name = Path.GetFileName(p), IsClean = true, Success = true }))
+        { LiveSessionsProvider = NoSessions };
         await monitor.RescanAsync(new[] { _root });
 
         using var watcher = new RepositoryWatcher(monitor);

--- a/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
@@ -337,6 +337,35 @@ public sealed class WorktreeInventoryIntegrationTests : IDisposable
         Assert.DoesNotContain(inventory.SafeToReap, x => x.Branch == "neverpushed");
     }
 
+    // -------------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F2): C2 must test the CONFIGURED upstream on the CONFIGURED
+    // remote. A worktree branch that tracks a SECOND remote (its ref alive there) has no branch
+    // on origin at all - before the fix that absence read as "deleted after merge" and the
+    // worktree, holding unmerged work, was marked safe to reap.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task WorktreeBranch_TrackingASecondRemote_WhoseRefStillExists_IsNotSafe()
+    {
+        var secondOrigin = Path.Combine(_root, "second.git");
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", secondOrigin);
+        RunGit(_primary, "remote", "add", "second", secondOrigin);
+
+        var wt = Path.Combine(_root, "wt-second-remote");
+        RunGit(_primary, "worktree", "add", "-b", "elsewhere", wt, "main");
+        WriteFile(wt, "e.txt", "unmerged work pushed only to the second remote\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "work on the second remote only");
+        RunGit(wt, "push", "-u", "second", "elsewhere");
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var w = Assert.Single(inventory.Worktrees, x => x.Branch == "elsewhere");
+        Assert.Equal(WorktreeSafety.NeedsAttention, w.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, w.Reason);
+        Assert.DoesNotContain(inventory.SafeToReap, x => x.Branch == "elsewhere");
+    }
+
     // ----- helpers -----
 
     private void ConfigureIdentity(string repo)

--- a/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
+++ b/src/CcDirector.Core.Tests/WorktreeInventoryIntegrationTests.cs
@@ -313,6 +313,30 @@ public sealed class WorktreeInventoryIntegrationTests : IDisposable
         Assert.Empty(free.OpenSessions);
     }
 
+    // -------------------------------------------------------------------------------------------
+    // REGRESSION (found by the branch-service tests during the repositories mission): a branch that
+    // was NEVER pushed has no origin branch, and that absence must NOT read as "deleted after merge".
+    // Before the fix, C2 marked exactly this case SAFE TO REAP - unpushed work, one click from gone.
+    // -------------------------------------------------------------------------------------------
+    [Fact]
+    public async Task NeverPushedBranch_WithUnmergedCommit_IsStranded_NotSafe()
+    {
+        var wt = Path.Combine(_root, "wt-neverpushed");
+        RunGit(_primary, "worktree", "add", "-b", "neverpushed", wt, "main");
+        WriteFile(wt, "n.txt", "unpushed work\n");
+        RunGit(wt, "add", "-A");
+        RunGit(wt, "commit", "-m", "work that exists nowhere else");
+        // Deliberately NO push: no origin branch, no upstream config.
+
+        var inventory = await new WorktreeInventoryService().GetInventoryAsync(_primary);
+
+        Assert.True(inventory.Success, inventory.Error);
+        var w = Assert.Single(inventory.Worktrees, x => x.Branch == "neverpushed");
+        Assert.Equal(WorktreeSafety.NeedsAttention, w.Safety);
+        Assert.Equal(WorktreeSafetyReason.NotProvenMerged, w.Reason);
+        Assert.DoesNotContain(inventory.SafeToReap, x => x.Branch == "neverpushed");
+    }
+
     // ----- helpers -----
 
     private void ConfigureIdentity(string repo)

--- a/src/CcDirector.Core/Git/AgentBriefTemplates.cs
+++ b/src/CcDirector.Core/Git/AgentBriefTemplates.cs
@@ -1,0 +1,87 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>The outcome the owner chose when handing a repository to an agent.</summary>
+public enum AgentHandOffKind
+{
+    /// <summary>Sort the uncommitted changes, commit in sensible pieces, push a branch, open a pull request.</summary>
+    ProtectChanges,
+
+    /// <summary>Identify junk vs real work; propose a discard list for approval before touching anything.</summary>
+    CleanUp,
+
+    /// <summary>Explain what is sitting in this repository. No changes at all.</summary>
+    ExplainOnly,
+
+    /// <summary>A stranded worktree: land the work or propose discarding it, with proof either way.</summary>
+    LandOrDiscardWorktree,
+}
+
+/// <summary>
+/// Builds the briefs a spawned agent session receives when the owner hands a repository (or a
+/// stranded worktree) over. Pure string templates - golden-tested, including the standing law that
+/// no AI attribution ever appears in anything the agent produces. The brief is staged into the new
+/// session's prompt box for the owner to read and send - the agent never starts unseen.
+/// </summary>
+public static class AgentBriefTemplates
+{
+    /// <summary>The hard rules every hand-off carries, verbatim.</summary>
+    public const string HardRules = """
+        Hard rules for this task:
+        - NEVER force-push, rebase shared branches, or delete branches with unmerged commits.
+        - NEVER discard files without first showing the list and getting explicit approval in this session.
+        - Open a pull request rather than merging to main yourself.
+        - Write all commits and pull requests as the repository owner. Do not add any attribution,
+          Co-authored-by trailer, robot emoji, or generated-with line naming any AI assistant or vendor.
+        - If anything is genuinely ambiguous, stop and ask in this session rather than guessing.
+        """;
+
+    public static string Build(AgentHandOffKind kind, RepositoryStatus repo, WorktreeInfo? worktree = null)
+    {
+        var header = $"""
+            You are working in the repository at {repo.Path} (branch {repo.Branch}).
+            State right now: {repo.UncommittedCount} uncommitted file(s){DirtyAge(repo)}, ahead {repo.AheadCount} / behind {repo.BehindCount} of origin{BehindMain(repo)}.
+            """;
+
+        var task = kind switch
+        {
+            AgentHandOffKind.ProtectChanges => """
+                TASK - protect the uncommitted changes:
+                1. Run git status and review every uncommitted file.
+                2. Group the changes into coherent pieces and commit each with a clear message.
+                3. Push a branch and open a pull request for the owner's review. Nothing merges without them.
+                4. Reply with a summary: what was committed, what looked like junk (do NOT delete it), and the pull request link.
+                """,
+            AgentHandOffKind.CleanUp => """
+                TASK - clean up, keeping only what matters:
+                1. Classify every uncommitted/untracked file: real work, generated output, or junk.
+                2. Present the full discard candidate list here and WAIT for approval.
+                3. Only after approval: discard the approved list, and commit anything that is real work.
+                """,
+            AgentHandOffKind.ExplainOnly => """
+                TASK - explain only, change nothing:
+                1. Investigate what the uncommitted files are and how they likely got here.
+                2. Write a plain-English summary: what is real work, what is generated, what can go.
+                3. Make NO changes of any kind - not even staging.
+                """,
+            AgentHandOffKind.LandOrDiscardWorktree => $"""
+                TASK - decide a stranded worktree:
+                The worktree at {worktree?.Path} (branch {worktree?.Branch}) has work that never reached origin/main
+                (ahead {worktree?.AheadOfMain}, behind {worktree?.BehindMain}).
+                1. Review the commits and any uncommitted files in that worktree.
+                2. Recommend: land it (rebase onto origin/main, push, open a pull request) or discard it - with reasons.
+                3. If landing: do it, and link the pull request. If discarding: list exactly what would be lost and WAIT for approval.
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        return $"{header}\n\n{task}\n\n{HardRules}";
+    }
+
+    private static string DirtyAge(RepositoryStatus repo)
+        => repo.DirtySinceUtc is { } since && !repo.IsClean
+            ? $" (sitting since {since:yyyy-MM-dd}, {(int)Math.Max(0, (DateTime.UtcNow - since).TotalDays)} day(s))"
+            : "";
+
+    private static string BehindMain(RepositoryStatus repo)
+        => repo.BehindMainCount > 0 ? $", {repo.BehindMainCount} behind main" : "";
+}

--- a/src/CcDirector.Core/Git/ConfiguredUpstreamProbe.cs
+++ b/src/CcDirector.Core/Git/ConfiguredUpstreamProbe.cs
@@ -25,12 +25,27 @@ public static class ConfiguredUpstreamProbe
     public static async Task<UpstreamVerdict> ProbeAsync(GitCommandRunner git, string repoPath, string branch, CancellationToken ct)
     {
         var remote = await git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{branch}.remote" }, ct);
-        var merge = await git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{branch}.merge" }, ct);
+        // --get-all, not --get: git permits MULTIPLE merge values (an octopus pull), and --get
+        // silently returns only the last one - which could be gone while another configured
+        // merge ref survives, a false "upstream gone" on a destructive path (ruling R2-7).
+        var merge = await git.RunAsync(repoPath, new[] { "config", "--get-all", $"branch.{branch}.merge" }, ct);
         var remoteName = remote.Success ? remote.Output.Trim() : "";
-        var mergeRef = merge.Success ? merge.Output.Trim() : "";
+        var mergeRefs = merge.Success
+            ? merge.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : Array.Empty<string>();
 
-        if (remoteName.Length == 0 || mergeRef.Length == 0)
+        if (remoteName.Length == 0 || mergeRefs.Length == 0)
             return new UpstreamVerdict(HasConfiguredUpstream: false, UpstreamGone: false, InspectionSucceeded: true);
+
+        if (mergeRefs.Length > 1)
+        {
+            // Ambiguous configuration fails closed: the branch is simply NOT eligible for the
+            // origin-gone signal, exactly as if no upstream were configured.
+            FileLog.Write($"[ConfiguredUpstreamProbe] branch {branch} has {mergeRefs.Length} configured merge values - C2 does not apply");
+            return new UpstreamVerdict(HasConfiguredUpstream: false, UpstreamGone: false, InspectionSucceeded: true);
+        }
+
+        var mergeRef = mergeRefs[0];
 
         // The merge ref is a full ref name (refs/heads/...), so the ls-remote pattern is exact.
         var lsRemote = await git.RunAsync(repoPath, new[] { "ls-remote", remoteName, mergeRef }, ct);

--- a/src/CcDirector.Core/Git/ConfiguredUpstreamProbe.cs
+++ b/src/CcDirector.Core/Git/ConfiguredUpstreamProbe.cs
@@ -1,0 +1,48 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Answers the C2 question - "was this branch's upstream deleted on its remote?" - against
+/// the branch's CONFIGURED upstream: <c>branch.&lt;name&gt;.remote</c> plus
+/// <c>branch.&lt;name&gt;.merge</c>. Querying origin for the LOCAL branch name is wrong twice
+/// over: the upstream ref can carry a different name than the local branch, and the remote can
+/// be one other than origin. Either mismatch makes a live upstream look deleted, which would
+/// rule real unmerged work "merged and safe to delete". If either config value is missing the
+/// branch has no configured upstream and C2 does not apply at all.
+/// </summary>
+public static class ConfiguredUpstreamProbe
+{
+    /// <summary>
+    /// <paramref name="HasConfiguredUpstream"/>: both branch.&lt;name&gt;.remote and
+    /// branch.&lt;name&gt;.merge are set. <paramref name="UpstreamGone"/>: the configured ref no
+    /// longer exists on the configured remote (only meaningful when a configured upstream exists).
+    /// <paramref name="InspectionSucceeded"/>: false when the remote could not be queried - the
+    /// caller must fail closed.
+    /// </summary>
+    public readonly record struct UpstreamVerdict(bool HasConfiguredUpstream, bool UpstreamGone, bool InspectionSucceeded);
+
+    public static async Task<UpstreamVerdict> ProbeAsync(GitCommandRunner git, string repoPath, string branch, CancellationToken ct)
+    {
+        var remote = await git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{branch}.remote" }, ct);
+        var merge = await git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{branch}.merge" }, ct);
+        var remoteName = remote.Success ? remote.Output.Trim() : "";
+        var mergeRef = merge.Success ? merge.Output.Trim() : "";
+
+        if (remoteName.Length == 0 || mergeRef.Length == 0)
+            return new UpstreamVerdict(HasConfiguredUpstream: false, UpstreamGone: false, InspectionSucceeded: true);
+
+        // The merge ref is a full ref name (refs/heads/...), so the ls-remote pattern is exact.
+        var lsRemote = await git.RunAsync(repoPath, new[] { "ls-remote", remoteName, mergeRef }, ct);
+        if (!lsRemote.Success)
+        {
+            FileLog.Write($"[ConfiguredUpstreamProbe] ls-remote {remoteName} {mergeRef} FAILED for branch {branch}: {lsRemote.Error}");
+            return new UpstreamVerdict(HasConfiguredUpstream: true, UpstreamGone: false, InspectionSucceeded: false);
+        }
+
+        return new UpstreamVerdict(
+            HasConfiguredUpstream: true,
+            UpstreamGone: string.IsNullOrWhiteSpace(lsRemote.Output),
+            InspectionSucceeded: true);
+    }
+}

--- a/src/CcDirector.Core/Git/DiffParser.cs
+++ b/src/CcDirector.Core/Git/DiffParser.cs
@@ -1,0 +1,174 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>One line of a parsed diff hunk.</summary>
+public sealed record DiffLine
+{
+    public DiffLineKind Kind { get; init; }
+    public string Text { get; init; } = "";
+
+    /// <summary>1-based line number in the OLD file, or null for an added line.</summary>
+    public int? OldNumber { get; init; }
+
+    /// <summary>1-based line number in the NEW file, or null for a deleted line.</summary>
+    public int? NewNumber { get; init; }
+}
+
+public enum DiffLineKind { Context, Added, Removed }
+
+/// <summary>A contiguous hunk of a file diff, with its header.</summary>
+public sealed record DiffHunk
+{
+    public string Header { get; init; } = "";
+    public IReadOnlyList<DiffLine> Lines { get; init; } = Array.Empty<DiffLine>();
+}
+
+/// <summary>The parsed diff of one file.</summary>
+public sealed record FileDiff
+{
+    public string OldPath { get; init; } = "";
+    public string NewPath { get; init; } = "";
+    public bool IsBinary { get; init; }
+    public bool IsRename => OldPath.Length > 0 && NewPath.Length > 0
+                            && !string.Equals(OldPath, NewPath, StringComparison.Ordinal);
+    public IReadOnlyList<DiffHunk> Hunks { get; init; } = Array.Empty<DiffHunk>();
+    public int Added { get; init; }
+    public int Removed { get; init; }
+}
+
+/// <summary>
+/// Parses unified diff output (<c>git diff</c>) into file/hunk/line records the diff viewer renders.
+/// Pure string logic - no git, fully unit-testable. Parsing IS an assertion about the format: any
+/// line that does not fit the unified-diff shape inside a hunk ends that hunk rather than being
+/// silently mis-rendered.
+/// </summary>
+public static class DiffParser
+{
+    public static IReadOnlyList<FileDiff> Parse(string? diffText)
+    {
+        var files = new List<FileDiff>();
+        if (string.IsNullOrEmpty(diffText))
+            return files;
+
+        var lines = diffText.Replace("\r\n", "\n").Split('\n');
+        int i = 0;
+        while (i < lines.Length)
+        {
+            if (!lines[i].StartsWith("diff --git ", StringComparison.Ordinal))
+            {
+                i++;
+                continue;
+            }
+
+            string oldPath = "", newPath = "";
+            bool binary = false;
+            var hunks = new List<DiffHunk>();
+            int added = 0, removed = 0;
+            i++;
+
+            // File header lines until the first hunk or the next file.
+            while (i < lines.Length
+                   && !lines[i].StartsWith("@@", StringComparison.Ordinal)
+                   && !lines[i].StartsWith("diff --git ", StringComparison.Ordinal))
+            {
+                var l = lines[i];
+                if (l.StartsWith("--- ", StringComparison.Ordinal))
+                    oldPath = StripPathPrefix(l[4..]);
+                else if (l.StartsWith("+++ ", StringComparison.Ordinal))
+                    newPath = StripPathPrefix(l[4..]);
+                else if (l.StartsWith("rename from ", StringComparison.Ordinal))
+                    oldPath = l["rename from ".Length..].Trim();
+                else if (l.StartsWith("rename to ", StringComparison.Ordinal))
+                    newPath = l["rename to ".Length..].Trim();
+                else if (l.StartsWith("Binary files ", StringComparison.Ordinal) || l.StartsWith("GIT binary patch", StringComparison.Ordinal))
+                    binary = true;
+                i++;
+            }
+
+            // Hunks.
+            while (i < lines.Length && lines[i].StartsWith("@@", StringComparison.Ordinal))
+            {
+                var header = lines[i];
+                var (oldStart, newStart) = ParseHunkHeader(header);
+                int oldNo = oldStart, newNo = newStart;
+                var hunkLines = new List<DiffLine>();
+                i++;
+
+                while (i < lines.Length)
+                {
+                    var l = lines[i];
+                    if (l.StartsWith("+", StringComparison.Ordinal))
+                    {
+                        hunkLines.Add(new DiffLine { Kind = DiffLineKind.Added, Text = l.Length > 1 ? l[1..] : "", NewNumber = newNo++ });
+                        added++;
+                    }
+                    else if (l.StartsWith("-", StringComparison.Ordinal))
+                    {
+                        hunkLines.Add(new DiffLine { Kind = DiffLineKind.Removed, Text = l.Length > 1 ? l[1..] : "", OldNumber = oldNo++ });
+                        removed++;
+                    }
+                    else if (l.StartsWith(" ", StringComparison.Ordinal) || l.Length == 0)
+                    {
+                        hunkLines.Add(new DiffLine { Kind = DiffLineKind.Context, Text = l.Length > 1 ? l[1..] : "", OldNumber = oldNo++, NewNumber = newNo++ });
+                    }
+                    else if (l.StartsWith("\\", StringComparison.Ordinal))
+                    {
+                        i++; // "\ No newline at end of file" - metadata, not content
+                        continue;
+                    }
+                    else
+                    {
+                        break; // next hunk, next file, or something that is not diff content
+                    }
+                    i++;
+                }
+
+                hunks.Add(new DiffHunk { Header = header, Lines = hunkLines });
+            }
+
+            files.Add(new FileDiff
+            {
+                OldPath = oldPath,
+                NewPath = newPath,
+                IsBinary = binary,
+                Hunks = hunks,
+                Added = added,
+                Removed = removed,
+            });
+        }
+
+        return files;
+    }
+
+    /// <summary>Strips the a/ b/ prefixes and maps /dev/null to empty.</summary>
+    private static string StripPathPrefix(string path)
+    {
+        var p = path.Trim();
+        if (p == "/dev/null")
+            return "";
+        if (p.StartsWith("a/", StringComparison.Ordinal) || p.StartsWith("b/", StringComparison.Ordinal))
+            return p[2..];
+        return p;
+    }
+
+    /// <summary>Parses "@@ -oldStart[,n] +newStart[,n] @@ ..." into the two start line numbers.</summary>
+    internal static (int OldStart, int NewStart) ParseHunkHeader(string header)
+    {
+        int oldStart = 1, newStart = 1;
+        try
+        {
+            var parts = header.Split(' ');
+            foreach (var part in parts)
+            {
+                if (part.StartsWith("-", StringComparison.Ordinal))
+                    oldStart = int.Parse(part[1..].Split(',')[0]);
+                else if (part.StartsWith("+", StringComparison.Ordinal))
+                    newStart = int.Parse(part[1..].Split(',')[0]);
+            }
+        }
+        catch
+        {
+            // A malformed header renders from line 1 rather than crashing the viewer.
+        }
+        return (oldStart, newStart);
+    }
+}

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -190,11 +190,15 @@ public sealed class GitBranchService
     /// process recreated in the window stands untouched, and the outcome reports that a branch of
     /// the same name has since appeared.
     ///
-    /// Everything after the successful delete is a NON-CANCELLABLE compensation phase (ruling
-    /// R3-2): the caller's token governs only the delete itself; the worktree listing, the
-    /// restore decision, and the config cleanup run on <see cref="CancellationToken.None"/>, so
-    /// every exit path completes compensation and cancellation can never leave a deleted branch
-    /// with a broken checked-out worktree.
+    /// The destructive act and its compensation are ONE non-cancellable unit (rulings R3-2 and
+    /// R4-1): the caller's cancellation applies BEFORE the delete only - the token is checked
+    /// immediately before the delete is issued, and the delete command itself plus everything
+    /// after it run on <see cref="CancellationToken.None"/>. A cancellable process wait could
+    /// throw AFTER the child git process already deleted the ref, concealing the completed
+    /// mutation and skipping compensation. The whole post-delete phase is additionally wrapped
+    /// so that ANY exception inside compensation still attempts the create-only restore on the
+    /// way out before the exception propagates - no exit path can leave the ref missing without
+    /// having proven the delete safe.
     ///
     /// On a confirmed delete the branch's config section is cleaned up, as <c>git branch -D</c>
     /// would have done - but only after confirming the ref is still absent at that moment, so a
@@ -206,7 +210,13 @@ public sealed class GitBranchService
     internal async Task<(bool Deleted, string Message)> DeleteAtVerifiedTipAsync(
         string repoPath, string branch, string verifiedSha, string explanation, CancellationToken ct = default)
     {
-        var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, ct);
+        // The caller's cancellation applies BEFORE the destructive act only (ruling R4-1): it
+        // is honored here and never again. The delete command itself runs on
+        // CancellationToken.None - a cancellable process wait can throw AFTER the child git
+        // process already deleted the ref, which would conceal the completed mutation and skip
+        // every compensation step below.
+        ct.ThrowIfCancellationRequested();
+        var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, CancellationToken.None);
         if (!del.Success)
         {
             FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
@@ -218,7 +228,42 @@ public sealed class GitBranchService
         // decision, and the config-section cleanup all use CancellationToken.None. Honoring the
         // caller's token after the destructive step could skip the worktree check and the
         // restore, leaving a checked-out worktree with a broken symbolic HEAD.
+        try
+        {
+            return await CompensateAfterDeleteAsync(repoPath, branch, verifiedSha, explanation);
+        }
+        catch (Exception ex)
+        {
+            // ANY exception inside compensation still attempts the create-only restore on the
+            // way out (ruling R4-1): after the delete succeeded, an escaping exception means
+            // the delete was never proven safe, so the ref must not stay missing. Create-only
+            // means a concurrently recreated branch is never overwritten. The ORIGINAL
+            // exception always propagates - the restore attempt is logged, never allowed to
+            // replace it.
+            FileLog.Write($"[GitBranchService] compensation for {branch} threw - attempting the create-only restore before the exception propagates: {ex.Message}");
+            try
+            {
+                var restoreOnTheWayOut = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
+                if (!restoreOnTheWayOut.Success)
+                    FileLog.Write($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restoreOnTheWayOut.Error.Trim()}");
+            }
+            catch (Exception restoreEx)
+            {
+                FileLog.Write($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
+            }
+            throw;
+        }
+    }
 
+    /// <summary>
+    /// The post-delete compensation phase (rulings R2-1, R3-1, R3-2, R4-1): worktree check,
+    /// create-only restore decision, and config cleanup. Runs entirely on
+    /// <see cref="CancellationToken.None"/>; the caller wraps it so any exception thrown here
+    /// still attempts the create-only restore before propagating.
+    /// </summary>
+    private async Task<(bool Deleted, string Message)> CompensateAfterDeleteAsync(
+        string repoPath, string branch, string verifiedSha, string explanation)
+    {
         // The compensating post-check (ruling R2-1). Includes the FIRST entry too: the primary
         // checkout is just as broken by losing its checked-out branch as a linked worktree is.
         var wtList = await _git.RunAsync(repoPath, new[] { "worktree", "list", "--porcelain" }, CancellationToken.None);

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -174,8 +174,21 @@ public sealed class GitBranchService
     /// <summary>
     /// The atomic delete: <c>git update-ref -d refs/heads/&lt;name&gt; &lt;verified-sha&gt;</c>.
     /// Git refuses when the ref no longer points at the verified commit, which closes the
-    /// time-of-check to time-of-use window a plain force delete leaves open. On success the
-    /// branch's config section is cleaned up, as <c>git branch -D</c> would have done.
+    /// time-of-check to time-of-use window a plain force delete leaves open.
+    ///
+    /// update-ref binds the TIP but - unlike <c>git branch -D</c> - it does NOT refuse to delete
+    /// a branch that is checked out. A checkout into a worktree can land between verification and
+    /// deletion, which would leave that worktree with a broken symbolic HEAD. Compensating
+    /// post-check: immediately after a successful delete the worktrees are listed; if any worktree
+    /// HEAD still references the deleted branch, the ref is RESTORED at the verified sha (we hold
+    /// the exact commit, so restoration is lossless) and the delete is reported as refused.
+    ///
+    /// On a confirmed delete the branch's config section is cleaned up, as <c>git branch -D</c>
+    /// would have done - but only after confirming the ref is still absent at that moment, so a
+    /// branch another process just recreated does not lose ITS configuration. The residual
+    /// millisecond window between that check and the removal is accepted and documented: worst
+    /// case a just-recreated branch loses its tracking config - annoying, never destructive to
+    /// commits.
     /// </summary>
     internal async Task<(bool Deleted, string Message)> DeleteAtVerifiedTipAsync(
         string repoPath, string branch, string verifiedSha, string explanation, CancellationToken ct = default)
@@ -185,6 +198,46 @@ public sealed class GitBranchService
         {
             FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
             return (false, $"branch moved since it was verified - not deleted");
+        }
+
+        // The compensating post-check (ruling R2-1). Includes the FIRST entry too: the primary
+        // checkout is just as broken by losing its checked-out branch as a linked worktree is.
+        var wtList = await _git.RunAsync(repoPath, new[] { "worktree", "list", "--porcelain" }, ct);
+        bool mustRestore;
+        string refusal;
+        if (!wtList.Success)
+        {
+            // Cannot PROVE no worktree holds the branch - fail closed and put the ref back.
+            FileLog.Write($"[GitBranchService] worktree list failed after deleting {branch} - restoring: {wtList.Error.Trim()}");
+            mustRestore = true;
+            refusal = "could not verify the worktrees after deletion - the branch was restored, not deleted";
+        }
+        else
+        {
+            mustRestore = WorktreeListParser.Parse(wtList.Output).Any(e => e.Branch == branch);
+            refusal = "branch is checked out in a worktree - restored, not deleted";
+        }
+        if (mustRestore)
+        {
+            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha }, ct);
+            if (!restore.Success)
+            {
+                // Restoration failing is a real error and must be loud: the commit still exists,
+                // and the exact command to recreate the ref is part of the message.
+                FileLog.Write($"[GitBranchService] RESTORE FAILED for {branch} at {verifiedSha}: {restore.Error.Trim()}");
+                return (false, $"branch is checked out in a worktree and restoring it failed - run: git update-ref refs/heads/{branch} {verifiedSha}");
+            }
+            FileLog.Write($"[GitBranchService] {branch} is checked out in a worktree - restored at {verifiedSha}, not deleted");
+            return (false, refusal);
+        }
+
+        // Config cleanup only when the ref is confirmed absent RIGHT NOW - another process may
+        // have recreated the branch after our delete, and the new branch's config is not ours.
+        var refCheck = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, ct);
+        if (refCheck.Success)
+        {
+            FileLog.Write($"[GitBranchService] {branch} was recreated after deletion - leaving the new branch's config in place");
+            return (true, $"deleted {branch} ({explanation})");
         }
 
         // git branch -D removes the branch's config section; update-ref does not, so clean it up.

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -104,14 +104,13 @@ public sealed class GitBranchService
 
             if (mainRef != null)
             {
-                // "Origin gone" only proves a merge when the branch WAS on origin (had an upstream) -
-                // a never-pushed branch's absence from origin proves nothing (same rule as worktrees).
-                var upstream = await _git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{name}.merge" }, ct);
-                bool hadUpstream = upstream.Success && !string.IsNullOrWhiteSpace(upstream.Output);
-
-                var lsRemote = await _git.RunAsync(repoPath, new[] { "ls-remote", "--heads", "origin", name }, ct);
-                inspectionOk &= lsRemote.Success;
-                originGone = hadUpstream && lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
+                // "Upstream gone" only proves a merge when the branch HAD a configured upstream -
+                // a never-pushed branch's absence from the remote proves nothing (same rule as
+                // worktrees). The probe asks the configured remote for the configured ref name,
+                // both of which can differ from origin/<local-name>.
+                var upstream = await ConfiguredUpstreamProbe.ProbeAsync(_git, repoPath, name, ct);
+                inspectionOk &= upstream.InspectionSucceeded;
+                originGone = upstream.HasConfiguredUpstream && upstream.UpstreamGone;
 
                 var cherry = await _git.RunAsync(repoPath, new[] { "cherry", mainRef, name }, ct);
                 inspectionOk &= cherry.Success;

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -1,0 +1,195 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>One local branch with its sync state and the fail-closed safe-delete verdict.</summary>
+public sealed record BranchInfo
+{
+    public string Name { get; init; } = "";
+    public bool IsCurrent { get; init; }
+
+    /// <summary>True when the branch is checked out in some linked worktree (never deletable).</summary>
+    public bool CheckedOutInWorktree { get; init; }
+
+    public int AheadOfMain { get; init; }
+    public int BehindMain { get; init; }
+    public bool OriginBranchExists { get; init; }
+    public DateTime? LastCommitUtc { get; init; }
+
+    public bool SafeToDelete { get; init; }
+    public string Explanation { get; init; } = "";
+}
+
+/// <summary>
+/// The pure safe-delete decision for a local branch - the same fail-closed shape as the worktree
+/// verdict: deletable ONLY when provably merged (origin branch gone after prune, or contained in
+/// origin/main, or its pull request merged) and never the current branch, never one checked out in
+/// a worktree. No signal = not deletable.
+/// </summary>
+public static class BranchSafetyEvaluator
+{
+    public static (bool Safe, string Explanation) Evaluate(
+        bool isCurrent,
+        bool checkedOutInWorktree,
+        bool inspectionSucceeded,
+        bool pullRequestMerged,
+        bool originBranchGone,
+        bool containedInMain)
+    {
+        if (isCurrent)
+            return (false, "The branch you are on - switch away before deleting.");
+        if (checkedOutInWorktree)
+            return (false, "Checked out in a worktree - remove the worktree first.");
+        if (!inspectionSucceeded)
+            return (false, "Could not inspect this branch - treated as unsafe.");
+        if (pullRequestMerged)
+            return (true, "Pull request merged.");
+        if (originBranchGone)
+            return (true, "Origin branch deleted after merge.");
+        if (containedInMain)
+            return (true, "All commits already contained in origin/main.");
+        return (false, "Has commits not proven to be in origin/main.");
+    }
+}
+
+/// <summary>
+/// Lists local branches with sync state and the safe-delete verdict, and deletes branches that
+/// verdict allows - re-verifying at the moment of deletion (state can change between render and
+/// click). Reuses the same git signals as the worktree detector.
+/// </summary>
+public sealed class GitBranchService
+{
+    private readonly GitCommandRunner _git;
+    private readonly IMergedPullRequestProbe _pullRequestProbe;
+
+    public GitBranchService(GitCommandRunner? git = null, IMergedPullRequestProbe? pullRequestProbe = null)
+    {
+        _git = git ?? new GitCommandRunner();
+        _pullRequestProbe = pullRequestProbe ?? new NullMergedPullRequestProbe();
+    }
+
+    public async Task<IReadOnlyList<BranchInfo>> ListAsync(string repoPath, CancellationToken ct = default)
+    {
+        FileLog.Write($"[GitBranchService] ListAsync: {repoPath}");
+        var results = new List<BranchInfo>();
+
+        var mainRef = await ResolveMainRefAsync(repoPath, ct);
+
+        // Branch list with current marker, upstream, and last commit date in one call.
+        var list = await _git.RunAsync(repoPath, new[]
+        {
+            "for-each-ref", "refs/heads",
+            "--format=%(HEAD)%09%(refname:short)%09%(committerdate:unix)"
+        }, ct);
+        if (!list.Success)
+            return results;
+
+        // Branches held by linked worktrees (never deletable from under them).
+        var worktreeBranches = await BranchesCheckedOutInWorktreesAsync(repoPath, ct);
+
+        foreach (var raw in list.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = raw.Split('\t');
+            if (parts.Length < 3)
+                continue;
+            bool isCurrent = parts[0].Trim() == "*";
+            var name = parts[1].Trim();
+            DateTime? lastCommit = long.TryParse(parts[2].Trim(), out var unix)
+                ? DateTimeOffset.FromUnixTimeSeconds(unix).UtcDateTime
+                : null;
+
+            bool inspectionOk = mainRef != null;
+            bool originGone = false, containedInMain = false, prMerged = false;
+            int ahead = 0, behind = 0;
+
+            if (mainRef != null)
+            {
+                // "Origin gone" only proves a merge when the branch WAS on origin (had an upstream) -
+                // a never-pushed branch's absence from origin proves nothing (same rule as worktrees).
+                var upstream = await _git.RunAsync(repoPath, new[] { "config", "--get", $"branch.{name}.merge" }, ct);
+                bool hadUpstream = upstream.Success && !string.IsNullOrWhiteSpace(upstream.Output);
+
+                var lsRemote = await _git.RunAsync(repoPath, new[] { "ls-remote", "--heads", "origin", name }, ct);
+                inspectionOk &= lsRemote.Success;
+                originGone = hadUpstream && lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
+
+                var cherry = await _git.RunAsync(repoPath, new[] { "cherry", mainRef, name }, ct);
+                inspectionOk &= cherry.Success;
+                containedInMain = cherry.Success && !cherry.Output
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Any(l => l.TrimStart().StartsWith('+'));
+
+                var counts = await _git.RunAsync(repoPath, new[] { "rev-list", "--left-right", "--count", $"{mainRef}...{name}" }, ct);
+                var nums = counts.Output.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                if (nums.Length >= 2 && int.TryParse(nums[0], out var l) && int.TryParse(nums[1], out var r))
+                    (behind, ahead) = (l, r);
+
+                prMerged = await _pullRequestProbe.IsBranchMergedAsync(repoPath, name, ct);
+            }
+
+            bool inWorktree = worktreeBranches.Contains(name);
+            var (safe, why) = BranchSafetyEvaluator.Evaluate(isCurrent, inWorktree, inspectionOk, prMerged, originGone, containedInMain);
+
+            results.Add(new BranchInfo
+            {
+                Name = name,
+                IsCurrent = isCurrent,
+                CheckedOutInWorktree = inWorktree,
+                AheadOfMain = ahead,
+                BehindMain = behind,
+                OriginBranchExists = !originGone && mainRef != null,
+                LastCommitUtc = lastCommit,
+                SafeToDelete = safe,
+                Explanation = why,
+            });
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Deletes a branch AFTER re-verifying its safe-delete verdict right now. Fail closed: any
+    /// verdict other than safe refuses, with the reason.
+    /// </summary>
+    public async Task<(bool Deleted, string Message)> DeleteIfSafeAsync(string repoPath, string branch, CancellationToken ct = default)
+    {
+        FileLog.Write($"[GitBranchService] DeleteIfSafeAsync: {branch} in {repoPath}");
+        var current = (await ListAsync(repoPath, ct)).FirstOrDefault(b => b.Name == branch);
+        if (current is null)
+            return (false, $"branch not found: {branch}");
+        if (!current.SafeToDelete)
+            return (false, current.Explanation);
+
+        var del = await _git.RunAsync(repoPath, new[] { "branch", "-D", branch }, ct);
+        return del.Success
+            ? (true, $"deleted {branch} ({current.Explanation})")
+            : (false, del.Error);
+    }
+
+    private async Task<HashSet<string>> BranchesCheckedOutInWorktreesAsync(string repoPath, CancellationToken ct)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        var list = await _git.RunAsync(repoPath, new[] { "worktree", "list", "--porcelain" }, ct);
+        if (!list.Success)
+            return set;
+        bool first = true; // the first entry is the primary checkout - its branch is "current", not worktree-held
+        foreach (var entry in WorktreeListParser.Parse(list.Output))
+        {
+            if (first) { first = false; continue; }
+            if (entry.Branch != null)
+                set.Add(entry.Branch);
+        }
+        return set;
+    }
+
+    private async Task<string?> ResolveMainRefAsync(string repoPath, CancellationToken ct)
+    {
+        var main = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/main" }, ct);
+        if (main.Success && !string.IsNullOrWhiteSpace(main.Output))
+            return "origin/main";
+        var master = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/master" }, ct);
+        if (master.Success && !string.IsNullOrWhiteSpace(master.Output))
+            return "origin/master";
+        return null;
+    }
+}

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -317,6 +317,16 @@ public sealed class GitBranchService
             return (true, $"deleted {branch} ({explanation})");
         }
 
+        // "rev-parse --verify --quiet" exits 1 for a missing ref - ONLY that exact outcome
+        // proves absence (ruling R4-2). Any other failure - a transient error, a repository
+        // problem - proves nothing, and cleaning up on it could strip a live branch's tracking
+        // configuration. The stale section is inert; a wrong cleanup is not, so skip.
+        if (refCheck.ExitCode != 1)
+        {
+            FileLog.Write($"[GitBranchService] ref probe for {branch} failed with exit {refCheck.ExitCode} (not the missing-ref outcome) - leaving the config section alone: {refCheck.Error.Trim()}");
+            return (true, $"deleted {branch} ({explanation})");
+        }
+
         // git branch -D removes the branch's config section; update-ref does not, so clean it up.
         // A branch without any config has no section - that outcome is expected, not an error.
         var cleanup = await _git.RunAsync(repoPath, new[] { "config", "--remove-section", $"branch.{branch}" }, CancellationToken.None);

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -217,48 +217,72 @@ public sealed class GitBranchService
         // every compensation step below.
         ct.ThrowIfCancellationRequested();
 
-        // The DELETE COMMAND ITSELF sits inside the recovery boundary (round-5 finding): the
+        // The DELETE COMMAND ITSELF sits inside a recovery boundary (round-5 finding): the
         // process layer or an injected runner can throw AFTER the child git process already
         // deleted the ref, which would otherwise bypass every compensation step. The
         // create-only restore is safe in both directions - if the delete never happened the
         // ref still exists and git refuses the create - so the restore-on-the-way-out covers
         // "threw before mutation" and "threw after mutation" without knowing which occurred.
+        //
+        // The REFUSED-delete path sits OUTSIDE every recovery boundary (round-6 finding): a
+        // refusal means git verified the ref did NOT match the verified sha and mutated
+        // nothing - a restore attempt there could RECREATE a branch some other process had
+        // legitimately deleted in full. The refusal is reported between the two boundaries,
+        // where no exception - not even a throwing log line - can reroute it into a restore.
+        //
         // Everything from the delete onward is a NON-CANCELLABLE phase (rulings R3-2, R4-1):
         // the worktree listing, the restore decision, and the config cleanup all run on
         // CancellationToken.None, because honoring the caller's token after the destructive
         // step could skip the worktree check and the restore.
+        GitCommandResult del;
         try
         {
-            var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, CancellationToken.None);
-            if (!del.Success)
-            {
-                FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
-                return (false, $"branch moved since it was verified - not deleted");
-            }
+            del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            await RestoreOnTheWayOutAsync(repoPath, branch, verifiedSha, ex);
+            throw;
+        }
 
+        if (!del.Success)
+        {
+            FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
+            return (false, $"branch moved since it was verified - not deleted");
+        }
+
+        try
+        {
             return await CompensateAfterDeleteAsync(repoPath, branch, verifiedSha, explanation);
         }
         catch (Exception ex)
         {
-            // ANY escaping exception still attempts the create-only restore on the way out
-            // (ruling R4-1): the delete was never proven safe, so the ref must not stay
-            // missing. Create-only means a concurrently recreated branch is never
-            // overwritten. The ORIGINAL exception always propagates. Logging in this path is
-            // SafeLog on purpose (round-5 finding): FileLog.Write can throw during a
-            // concurrent logger shutdown, and a log line must never be the reason the
-            // restore is skipped or the original exception is replaced.
-            SafeLog($"[GitBranchService] delete or compensation for {branch} threw - attempting the create-only restore before the exception propagates: {ex.Message}");
-            try
-            {
-                var restoreOnTheWayOut = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
-                if (!restoreOnTheWayOut.Success)
-                    SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restoreOnTheWayOut.Error.Trim()}");
-            }
-            catch (Exception restoreEx)
-            {
-                SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
-            }
+            await RestoreOnTheWayOutAsync(repoPath, branch, verifiedSha, ex);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// The restore attempted when the delete or its compensation ESCAPES with an exception
+    /// (ruling R4-1): the delete was never proven safe, so the ref must not stay missing.
+    /// Create-only, so a concurrently recreated branch is never overwritten - and harmless
+    /// when the delete never actually happened, because the still-existing ref refuses the
+    /// create. Never throws: the caller rethrows the ORIGINAL exception right after this,
+    /// and nothing here - not the restore, not a log line - may replace it (round-5
+    /// finding: logging in this path is SafeLog on purpose).
+    /// </summary>
+    private async Task RestoreOnTheWayOutAsync(string repoPath, string branch, string verifiedSha, Exception cause)
+    {
+        SafeLog($"[GitBranchService] delete or compensation for {branch} threw - attempting the create-only restore before the exception propagates: {cause.Message}");
+        try
+        {
+            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
+            if (!restore.Success)
+                SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restore.Error.Trim()}");
+        }
+        catch (Exception restoreEx)
+        {
+            SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
         }
     }
 

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -62,6 +62,10 @@ public static class BranchSafetyEvaluator
 /// </summary>
 public sealed class GitBranchService
 {
+    /// <summary>git's "expected old value" meaning "the ref must not exist" - makes a restore
+    /// create-only, so a concurrently recreated branch is never overwritten (ruling R3-1).</summary>
+    private const string ZeroSha = "0000000000000000000000000000000000000000";
+
     private readonly GitCommandRunner _git;
     private readonly IMergedPullRequestProbe _pullRequestProbe;
 
@@ -181,7 +185,10 @@ public sealed class GitBranchService
     /// deletion, which would leave that worktree with a broken symbolic HEAD. Compensating
     /// post-check: immediately after a successful delete the worktrees are listed; if any worktree
     /// HEAD still references the deleted branch, the ref is RESTORED at the verified sha (we hold
-    /// the exact commit, so restoration is lossless) and the delete is reported as refused.
+    /// the exact commit, so restoration is lossless) and the delete is reported as refused. The
+    /// restore is CREATE-ONLY (ruling R3-1, expected old value of forty zeros): a branch another
+    /// process recreated in the window stands untouched, and the outcome reports that a branch of
+    /// the same name has since appeared.
     ///
     /// On a confirmed delete the branch's config section is cleaned up, as <c>git branch -D</c>
     /// would have done - but only after confirming the ref is still absent at that moment, so a
@@ -219,9 +226,22 @@ public sealed class GitBranchService
         }
         if (mustRestore)
         {
-            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha }, ct);
+            // CREATE-ONLY restore (ruling R3-1): the expected-old-value of forty zeros makes git
+            // refuse when the ref exists again. Another process can recreate the branch at a NEW
+            // commit between our delete and this restore - an unconditional restore would silently
+            // rewind that new branch to the verified sha and discard its tip.
+            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, ct);
             if (!restore.Success)
             {
+                // Two distinct outcomes hide behind a refused create: either the ref exists again
+                // (the concurrent recreation - the new branch stands, and the worktree HEAD is
+                // valid again by that very fact), or the restore genuinely failed (loud error).
+                var recreated = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, ct);
+                if (recreated.Success)
+                {
+                    FileLog.Write($"[GitBranchService] {branch} was recreated by another process after deletion - the new branch stands, not restored");
+                    return (true, $"deleted {branch} ({explanation}) - a branch of the same name has since appeared and was left untouched");
+                }
                 // Restoration failing is a real error and must be loud: the commit still exists,
                 // and the exact command to recreate the ref is part of the message.
                 FileLog.Write($"[GitBranchService] RESTORE FAILED for {branch} at {verifiedSha}: {restore.Error.Trim()}");

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -273,17 +273,29 @@ public sealed class GitBranchService
     /// </summary>
     private async Task RestoreOnTheWayOutAsync(string repoPath, string branch, string verifiedSha, Exception cause)
     {
-        SafeLog($"[GitBranchService] delete or compensation for {branch} threw - attempting the create-only restore before the exception propagates: {cause.Message}");
+        // The restore attempt comes FIRST (round-7 finding): no diagnostic may precede it,
+        // because even building the log string evaluates the cause's Message property - which
+        // is VIRTUAL and can itself throw - before SafeLog could suppress anything. All
+        // logging here is best-effort and after the fact, with message extraction guarded.
         try
         {
             var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
-            if (!restore.Success)
-                SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restore.Error.Trim()}");
+            SafeLog(restore.Success
+                ? $"[GitBranchService] restore-on-the-way-out: {branch} restored at {verifiedSha} after: {SafeMessage(cause)}"
+                : $"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restore.Error.Trim()}");
         }
         catch (Exception restoreEx)
         {
-            SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
+            SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {SafeMessage(restoreEx)}");
         }
+    }
+
+    /// <summary>Message extraction that cannot throw: Exception.Message is virtual, and an
+    /// override that throws must not be able to derail the recovery path it is describing.</summary>
+    private static string SafeMessage(Exception ex)
+    {
+        try { return ex.Message; }
+        catch { return ex.GetType().Name; }
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -11,6 +11,9 @@ public sealed record BranchInfo
     /// <summary>True when the branch is checked out in some linked worktree (never deletable).</summary>
     public bool CheckedOutInWorktree { get; init; }
 
+    /// <summary>The commit the branch pointed at when the verdict was computed - deletion binds to it.</summary>
+    public string TipCommit { get; init; } = "";
+
     public int AheadOfMain { get; init; }
     public int BehindMain { get; init; }
     public bool OriginBranchExists { get; init; }
@@ -79,7 +82,7 @@ public sealed class GitBranchService
         var list = await _git.RunAsync(repoPath, new[]
         {
             "for-each-ref", "refs/heads",
-            "--format=%(HEAD)%09%(refname:short)%09%(committerdate:unix)"
+            "--format=%(HEAD)%09%(refname:short)%09%(committerdate:unix)%09%(objectname)"
         }, ct);
         if (!list.Success)
             return results;
@@ -90,13 +93,14 @@ public sealed class GitBranchService
         foreach (var raw in list.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
             var parts = raw.Split('\t');
-            if (parts.Length < 3)
+            if (parts.Length < 4)
                 continue;
             bool isCurrent = parts[0].Trim() == "*";
             var name = parts[1].Trim();
             DateTime? lastCommit = long.TryParse(parts[2].Trim(), out var unix)
                 ? DateTimeOffset.FromUnixTimeSeconds(unix).UtcDateTime
                 : null;
+            var tip = parts[3].Trim();
 
             bool inspectionOk = mainRef != null;
             bool originGone = false, containedInMain = false, prMerged = false;
@@ -134,6 +138,7 @@ public sealed class GitBranchService
                 Name = name,
                 IsCurrent = isCurrent,
                 CheckedOutInWorktree = inWorktree,
+                TipCommit = tip,
                 AheadOfMain = ahead,
                 BehindMain = behind,
                 OriginBranchExists = !originGone && mainRef != null,
@@ -148,7 +153,9 @@ public sealed class GitBranchService
 
     /// <summary>
     /// Deletes a branch AFTER re-verifying its safe-delete verdict right now. Fail closed: any
-    /// verdict other than safe refuses, with the reason.
+    /// verdict other than safe refuses, with the reason. The deletion binds to the verified tip:
+    /// if a concurrent commit moves the branch between the verdict and the delete, git refuses
+    /// and the branch survives.
     /// </summary>
     public async Task<(bool Deleted, string Message)> DeleteIfSafeAsync(string repoPath, string branch, CancellationToken ct = default)
     {
@@ -158,11 +165,35 @@ public sealed class GitBranchService
             return (false, $"branch not found: {branch}");
         if (!current.SafeToDelete)
             return (false, current.Explanation);
+        if (string.IsNullOrWhiteSpace(current.TipCommit))
+            return (false, $"could not read the verified tip of {branch} - not deleted");
 
-        var del = await _git.RunAsync(repoPath, new[] { "branch", "-D", branch }, ct);
-        return del.Success
-            ? (true, $"deleted {branch} ({current.Explanation})")
-            : (false, del.Error);
+        return await DeleteAtVerifiedTipAsync(repoPath, branch, current.TipCommit, current.Explanation, ct);
+    }
+
+    /// <summary>
+    /// The atomic delete: <c>git update-ref -d refs/heads/&lt;name&gt; &lt;verified-sha&gt;</c>.
+    /// Git refuses when the ref no longer points at the verified commit, which closes the
+    /// time-of-check to time-of-use window a plain force delete leaves open. On success the
+    /// branch's config section is cleaned up, as <c>git branch -D</c> would have done.
+    /// </summary>
+    internal async Task<(bool Deleted, string Message)> DeleteAtVerifiedTipAsync(
+        string repoPath, string branch, string verifiedSha, string explanation, CancellationToken ct = default)
+    {
+        var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, ct);
+        if (!del.Success)
+        {
+            FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
+            return (false, $"branch moved since it was verified - not deleted");
+        }
+
+        // git branch -D removes the branch's config section; update-ref does not, so clean it up.
+        // A branch without any config has no section - that outcome is expected, not an error.
+        var cleanup = await _git.RunAsync(repoPath, new[] { "config", "--remove-section", $"branch.{branch}" }, ct);
+        if (!cleanup.Success && !cleanup.Error.Contains("no such section", StringComparison.OrdinalIgnoreCase))
+            FileLog.Write($"[GitBranchService] config cleanup for {branch} reported: {cleanup.Error.Trim()}");
+
+        return (true, $"deleted {branch} ({explanation})");
     }
 
     private async Task<HashSet<string>> BranchesCheckedOutInWorktreesAsync(string repoPath, CancellationToken ct)

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -216,43 +216,62 @@ public sealed class GitBranchService
         // process already deleted the ref, which would conceal the completed mutation and skip
         // every compensation step below.
         ct.ThrowIfCancellationRequested();
-        var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, CancellationToken.None);
-        if (!del.Success)
-        {
-            FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
-            return (false, $"branch moved since it was verified - not deleted");
-        }
 
-        // From here on the delete has already happened, so everything below is COMPENSATION and
-        // runs as a NON-CANCELLABLE phase (ruling R3-2): the worktree listing, the restore
-        // decision, and the config-section cleanup all use CancellationToken.None. Honoring the
-        // caller's token after the destructive step could skip the worktree check and the
-        // restore, leaving a checked-out worktree with a broken symbolic HEAD.
+        // The DELETE COMMAND ITSELF sits inside the recovery boundary (round-5 finding): the
+        // process layer or an injected runner can throw AFTER the child git process already
+        // deleted the ref, which would otherwise bypass every compensation step. The
+        // create-only restore is safe in both directions - if the delete never happened the
+        // ref still exists and git refuses the create - so the restore-on-the-way-out covers
+        // "threw before mutation" and "threw after mutation" without knowing which occurred.
+        // Everything from the delete onward is a NON-CANCELLABLE phase (rulings R3-2, R4-1):
+        // the worktree listing, the restore decision, and the config cleanup all run on
+        // CancellationToken.None, because honoring the caller's token after the destructive
+        // step could skip the worktree check and the restore.
         try
         {
+            var del = await _git.RunAsync(repoPath, new[] { "update-ref", "-d", $"refs/heads/{branch}", verifiedSha }, CancellationToken.None);
+            if (!del.Success)
+            {
+                FileLog.Write($"[GitBranchService] delete refused for {branch}: ref no longer at {verifiedSha}: {del.Error.Trim()}");
+                return (false, $"branch moved since it was verified - not deleted");
+            }
+
             return await CompensateAfterDeleteAsync(repoPath, branch, verifiedSha, explanation);
         }
         catch (Exception ex)
         {
-            // ANY exception inside compensation still attempts the create-only restore on the
-            // way out (ruling R4-1): after the delete succeeded, an escaping exception means
-            // the delete was never proven safe, so the ref must not stay missing. Create-only
-            // means a concurrently recreated branch is never overwritten. The ORIGINAL
-            // exception always propagates - the restore attempt is logged, never allowed to
-            // replace it.
-            FileLog.Write($"[GitBranchService] compensation for {branch} threw - attempting the create-only restore before the exception propagates: {ex.Message}");
+            // ANY escaping exception still attempts the create-only restore on the way out
+            // (ruling R4-1): the delete was never proven safe, so the ref must not stay
+            // missing. Create-only means a concurrently recreated branch is never
+            // overwritten. The ORIGINAL exception always propagates. Logging in this path is
+            // SafeLog on purpose (round-5 finding): FileLog.Write can throw during a
+            // concurrent logger shutdown, and a log line must never be the reason the
+            // restore is skipped or the original exception is replaced.
+            SafeLog($"[GitBranchService] delete or compensation for {branch} threw - attempting the create-only restore before the exception propagates: {ex.Message}");
             try
             {
                 var restoreOnTheWayOut = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
                 if (!restoreOnTheWayOut.Success)
-                    FileLog.Write($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restoreOnTheWayOut.Error.Trim()}");
+                    SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restoreOnTheWayOut.Error.Trim()}");
             }
             catch (Exception restoreEx)
             {
-                FileLog.Write($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
+                SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {restoreEx.Message}");
             }
             throw;
         }
+    }
+
+    /// <summary>
+    /// Logging inside the destructive-recovery path must never be the reason recovery fails:
+    /// FileLog.Write can throw during a concurrent logger shutdown, which would skip the
+    /// restore or replace the original exception with a logging failure. Best-effort by
+    /// design HERE AND ONLY HERE - everywhere else a logging failure surfaces normally.
+    /// </summary>
+    private static void SafeLog(string message)
+    {
+        try { FileLog.Write(message); }
+        catch { }
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -282,11 +282,11 @@ public sealed class GitBranchService
             var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
             SafeLog(restore.Success
                 ? $"[GitBranchService] restore-on-the-way-out: {branch} restored at {verifiedSha} after: {SafeMessage(cause)}"
-                : $"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restore.Error.Trim()}");
+                : $"[GitBranchService] restore-on-the-way-out for {branch} was refused (the ref may already exist again): {restore.Error.Trim()} - initiating failure: {SafeMessage(cause)}");
         }
         catch (Exception restoreEx)
         {
-            SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {SafeMessage(restoreEx)}");
+            SafeLog($"[GitBranchService] restore-on-the-way-out for {branch} itself failed - recreate the ref with: git update-ref refs/heads/{branch} {verifiedSha}: {SafeMessage(restoreEx)} - initiating failure: {SafeMessage(cause)}");
         }
     }
 

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -190,6 +190,12 @@ public sealed class GitBranchService
     /// process recreated in the window stands untouched, and the outcome reports that a branch of
     /// the same name has since appeared.
     ///
+    /// Everything after the successful delete is a NON-CANCELLABLE compensation phase (ruling
+    /// R3-2): the caller's token governs only the delete itself; the worktree listing, the
+    /// restore decision, and the config cleanup run on <see cref="CancellationToken.None"/>, so
+    /// every exit path completes compensation and cancellation can never leave a deleted branch
+    /// with a broken checked-out worktree.
+    ///
     /// On a confirmed delete the branch's config section is cleaned up, as <c>git branch -D</c>
     /// would have done - but only after confirming the ref is still absent at that moment, so a
     /// branch another process just recreated does not lose ITS configuration. The residual
@@ -207,9 +213,15 @@ public sealed class GitBranchService
             return (false, $"branch moved since it was verified - not deleted");
         }
 
+        // From here on the delete has already happened, so everything below is COMPENSATION and
+        // runs as a NON-CANCELLABLE phase (ruling R3-2): the worktree listing, the restore
+        // decision, and the config-section cleanup all use CancellationToken.None. Honoring the
+        // caller's token after the destructive step could skip the worktree check and the
+        // restore, leaving a checked-out worktree with a broken symbolic HEAD.
+
         // The compensating post-check (ruling R2-1). Includes the FIRST entry too: the primary
         // checkout is just as broken by losing its checked-out branch as a linked worktree is.
-        var wtList = await _git.RunAsync(repoPath, new[] { "worktree", "list", "--porcelain" }, ct);
+        var wtList = await _git.RunAsync(repoPath, new[] { "worktree", "list", "--porcelain" }, CancellationToken.None);
         bool mustRestore;
         string refusal;
         if (!wtList.Success)
@@ -230,13 +242,13 @@ public sealed class GitBranchService
             // refuse when the ref exists again. Another process can recreate the branch at a NEW
             // commit between our delete and this restore - an unconditional restore would silently
             // rewind that new branch to the verified sha and discard its tip.
-            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, ct);
+            var restore = await _git.RunAsync(repoPath, new[] { "update-ref", $"refs/heads/{branch}", verifiedSha, ZeroSha }, CancellationToken.None);
             if (!restore.Success)
             {
                 // Two distinct outcomes hide behind a refused create: either the ref exists again
                 // (the concurrent recreation - the new branch stands, and the worktree HEAD is
                 // valid again by that very fact), or the restore genuinely failed (loud error).
-                var recreated = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, ct);
+                var recreated = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, CancellationToken.None);
                 if (recreated.Success)
                 {
                     FileLog.Write($"[GitBranchService] {branch} was recreated by another process after deletion - the new branch stands, not restored");
@@ -253,7 +265,7 @@ public sealed class GitBranchService
 
         // Config cleanup only when the ref is confirmed absent RIGHT NOW - another process may
         // have recreated the branch after our delete, and the new branch's config is not ours.
-        var refCheck = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, ct);
+        var refCheck = await _git.RunAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", $"refs/heads/{branch}" }, CancellationToken.None);
         if (refCheck.Success)
         {
             FileLog.Write($"[GitBranchService] {branch} was recreated after deletion - leaving the new branch's config in place");
@@ -262,7 +274,7 @@ public sealed class GitBranchService
 
         // git branch -D removes the branch's config section; update-ref does not, so clean it up.
         // A branch without any config has no section - that outcome is expected, not an error.
-        var cleanup = await _git.RunAsync(repoPath, new[] { "config", "--remove-section", $"branch.{branch}" }, ct);
+        var cleanup = await _git.RunAsync(repoPath, new[] { "config", "--remove-section", $"branch.{branch}" }, CancellationToken.None);
         if (!cleanup.Success && !cleanup.Error.Contains("no such section", StringComparison.OrdinalIgnoreCase))
             FileLog.Write($"[GitBranchService] config cleanup for {branch} reported: {cleanup.Error.Trim()}");
 

--- a/src/CcDirector.Core/Git/GitCommandRunner.cs
+++ b/src/CcDirector.Core/Git/GitCommandRunner.cs
@@ -22,13 +22,17 @@ public sealed class GitCommandResult
 /// Shared by the worktree inventory and reaper services so every git call is logged
 /// and its exit code is available. Uses <see cref="ProcessStartInfo.ArgumentList"/> so
 /// arguments are passed without shell quoting hazards.
+///
+/// <see cref="RunAsync"/> is virtual so tests can interleave a concurrent process action at an
+/// exact point between two git commands (the compensation races in <see cref="GitBranchService"/>
+/// are only reachable that way) - production code always uses this class directly.
 /// </summary>
-public sealed class GitCommandRunner
+public class GitCommandRunner
 {
     /// <summary>
     /// Runs <c>git &lt;args&gt;</c> in <paramref name="workingDirectory"/> and returns its result.
     /// </summary>
-    public async Task<GitCommandResult> RunAsync(string workingDirectory, string[] args, CancellationToken ct = default)
+    public virtual async Task<GitCommandResult> RunAsync(string workingDirectory, string[] args, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(workingDirectory) || !Directory.Exists(workingDirectory))
             return new GitCommandResult { Success = false, ExitCode = -1, Error = $"working directory not found: {workingDirectory}" };

--- a/src/CcDirector.Core/Git/GitDiffService.cs
+++ b/src/CcDirector.Core/Git/GitDiffService.cs
@@ -1,0 +1,100 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Reads diffs for the diff viewer: unstaged (working tree vs index) and staged (index vs HEAD),
+/// whole-repo or one file. Read-only; the write actions stay on <see cref="GitWriteService"/>.
+/// </summary>
+public sealed class GitDiffService
+{
+    private readonly GitCommandRunner _git;
+
+    public GitDiffService(GitCommandRunner? git = null)
+    {
+        _git = git ?? new GitCommandRunner();
+    }
+
+    /// <summary>Unstaged changes (working tree vs index), parsed. Optionally one file.</summary>
+    public async Task<IReadOnlyList<FileDiff>> UnstagedAsync(string repoPath, string? file = null, CancellationToken ct = default)
+        => await RunAndParseAsync(repoPath, BuildArgs(cached: false, file), ct);
+
+    /// <summary>Staged changes (index vs HEAD), parsed. Optionally one file.</summary>
+    public async Task<IReadOnlyList<FileDiff>> StagedAsync(string repoPath, string? file = null, CancellationToken ct = default)
+        => await RunAndParseAsync(repoPath, BuildArgs(cached: true, file), ct);
+
+    /// <summary>
+    /// The diff of one UNTRACKED file rendered as an all-added diff, so a brand-new file is
+    /// reviewable like any other change (git diff shows nothing for untracked paths).
+    /// </summary>
+    public async Task<FileDiff?> UntrackedAsync(string repoPath, string file, CancellationToken ct = default)
+    {
+        try
+        {
+            var full = Path.Combine(repoPath, file);
+            if (!File.Exists(full))
+                return null;
+            var info = new FileInfo(full);
+            if (info.Length > 2_000_000)
+                return new FileDiff { NewPath = file, IsBinary = true }; // too big to render as text
+
+            var lines = await File.ReadAllLinesAsync(full, ct);
+            if (LooksBinary(full))
+                return new FileDiff { NewPath = file, IsBinary = true };
+
+            var diffLines = lines.Select((text, i) => new DiffLine
+            {
+                Kind = DiffLineKind.Added,
+                Text = text,
+                NewNumber = i + 1,
+            }).ToList();
+
+            return new FileDiff
+            {
+                NewPath = file,
+                Hunks = new[] { new DiffHunk { Header = $"@@ -0,0 +1,{lines.Length} @@ (new file)", Lines = diffLines } },
+                Added = lines.Length,
+            };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GitDiffService] UntrackedAsync failed for {file}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string[] BuildArgs(bool cached, string? file)
+    {
+        var args = new List<string> { "diff", "--no-color" };
+        if (cached)
+            args.Add("--cached");
+        if (!string.IsNullOrWhiteSpace(file))
+        {
+            args.Add("--");
+            args.Add(file);
+        }
+        return args.ToArray();
+    }
+
+    private async Task<IReadOnlyList<FileDiff>> RunAndParseAsync(string repoPath, string[] args, CancellationToken ct)
+    {
+        var result = await _git.RunAsync(repoPath, args, ct);
+        if (!result.Success)
+        {
+            FileLog.Write($"[GitDiffService] git {string.Join(' ', args)} failed: {result.Error}");
+            return Array.Empty<FileDiff>();
+        }
+        return DiffParser.Parse(result.Output);
+    }
+
+    private static bool LooksBinary(string path)
+    {
+        using var stream = File.OpenRead(path);
+        Span<byte> probe = stackalloc byte[8000];
+        int read = stream.Read(probe);
+        for (int i = 0; i < read; i++)
+            if (probe[i] == 0)
+                return true;
+        return false;
+    }
+}

--- a/src/CcDirector.Core/Git/GitHistoryService.cs
+++ b/src/CcDirector.Core/Git/GitHistoryService.cs
@@ -1,0 +1,59 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>One commit row for the History tab.</summary>
+public sealed record CommitInfo
+{
+    public string ShortHash { get; init; } = "";
+    public string Author { get; init; } = "";
+    public DateTime? WhenUtc { get; init; }
+    public string Subject { get; init; } = "";
+}
+
+/// <summary>Reads the recent commit log for the History tab. Read-only, v1: no graph, no paging.</summary>
+public sealed class GitHistoryService
+{
+    private readonly GitCommandRunner _git;
+
+    public GitHistoryService(GitCommandRunner? git = null)
+    {
+        _git = git ?? new GitCommandRunner();
+    }
+
+    public async Task<IReadOnlyList<CommitInfo>> RecentAsync(string repoPath, int count = 30, CancellationToken ct = default)
+    {
+        var result = await _git.RunAsync(repoPath, new[]
+        {
+            "log", "-n", count.ToString(), "--format=%h%x09%an%x09%ct%x09%s"
+        }, ct);
+        if (!result.Success)
+        {
+            FileLog.Write($"[GitHistoryService] git log failed: {result.Error}");
+            return Array.Empty<CommitInfo>();
+        }
+        return Parse(result.Output);
+    }
+
+    /// <summary>Pure parser for the tab-separated log format (unit-tested).</summary>
+    internal static IReadOnlyList<CommitInfo> Parse(string output)
+    {
+        var items = new List<CommitInfo>();
+        foreach (var raw in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = raw.Split('\t', 4);
+            if (parts.Length < 4)
+                continue;
+            items.Add(new CommitInfo
+            {
+                ShortHash = parts[0].Trim(),
+                Author = parts[1].Trim(),
+                WhenUtc = long.TryParse(parts[2].Trim(), out var unix)
+                    ? DateTimeOffset.FromUnixTimeSeconds(unix).UtcDateTime
+                    : null,
+                Subject = parts[3].Trim(),
+            });
+        }
+        return items;
+    }
+}

--- a/src/CcDirector.Core/Git/PullRequestService.cs
+++ b/src/CcDirector.Core/Git/PullRequestService.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+public enum ChecksState { None, Passing, Running, Failing }
+
+/// <summary>One open pull request, provider-neutral, display-ready.</summary>
+public sealed record PullRequestInfo
+{
+    public int Number { get; init; }
+    public string Title { get; init; } = "";
+    public string Author { get; init; } = "";
+    public string Branch { get; init; } = "";
+    public bool IsDraft { get; init; }
+
+    /// <summary>Finished string: "approved", "changes requested", "review required", or "".</summary>
+    public string ReviewState { get; init; } = "";
+
+    public ChecksState Checks { get; init; }
+    public string Url { get; init; } = "";
+    public DateTime? CreatedUtc { get; init; }
+}
+
+/// <summary>The result of listing pull requests: rows, or a plain-English reason there are none.</summary>
+public sealed record PullRequestListResult
+{
+    public IReadOnlyList<PullRequestInfo> Items { get; init; } = Array.Empty<PullRequestInfo>();
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Lists open pull requests for a repository via the CLIs the machine is already signed into -
+/// gh for GitHub, az for Azure DevOps (the per-repo/per-org auth model: the repo's remote URL
+/// decides the provider; Credential Manager and the CLI logins hold the keys). Read-only.
+/// </summary>
+public sealed class PullRequestService
+{
+    /// <summary>Lists open pull requests, dispatching on the repository's provider.</summary>
+    public async Task<PullRequestListResult> ListOpenAsync(string repoPath, RepoProvider provider, CancellationToken ct = default)
+    {
+        FileLog.Write($"[PullRequestService] ListOpenAsync: {repoPath} ({provider})");
+        try
+        {
+            return provider switch
+            {
+                RepoProvider.GitHub => await ListGitHubAsync(repoPath, ct),
+                RepoProvider.AzureDevOps => await ListAzureAsync(repoPath, ct),
+                _ => new PullRequestListResult { Success = false, Error = "This repository's remote is not GitHub or Azure DevOps." },
+            };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[PullRequestService] ListOpenAsync FAILED: {ex.Message}");
+            return new PullRequestListResult { Success = false, Error = ex.Message };
+        }
+    }
+
+    private async Task<PullRequestListResult> ListGitHubAsync(string repoPath, CancellationToken ct)
+    {
+        var (exit, output, error) = await RunCliAsync("gh", new[]
+        {
+            "pr", "list", "--state", "open", "--limit", "30",
+            "--json", "number,title,author,headRefName,isDraft,reviewDecision,statusCheckRollup,url,createdAt"
+        }, repoPath, ct);
+        if (exit != 0)
+            return new PullRequestListResult { Success = false, Error = $"gh pr list failed: {FirstLine(error)} (is gh signed in? run: gh auth login)" };
+        return new PullRequestListResult { Items = ParseGitHub(output), Success = true };
+    }
+
+    private async Task<PullRequestListResult> ListAzureAsync(string repoPath, CancellationToken ct)
+    {
+        // --detect resolves org/project/repository from the git remote in the working directory.
+        var (exit, output, error) = await RunCliAsync("az", new[]
+        {
+            "repos", "pr", "list", "--status", "active", "--detect", "true", "--output", "json"
+        }, repoPath, ct);
+        if (exit != 0)
+            return new PullRequestListResult { Success = false, Error = $"az repos pr list failed: {FirstLine(error)} (is az signed in to this organization? run: az login)" };
+        return new PullRequestListResult { Items = ParseAzure(output), Success = true };
+    }
+
+    // ----- pure parsers (golden-tested from fixture JSON) -----
+
+    internal static IReadOnlyList<PullRequestInfo> ParseGitHub(string json)
+    {
+        var items = new List<PullRequestInfo>();
+        using var doc = JsonDocument.Parse(json);
+        foreach (var e in doc.RootElement.EnumerateArray())
+        {
+            items.Add(new PullRequestInfo
+            {
+                Number = e.TryGetProperty("number", out var n) ? n.GetInt32() : 0,
+                Title = Str(e, "title"),
+                Author = e.TryGetProperty("author", out var a) ? Str(a, "login") : "",
+                Branch = Str(e, "headRefName"),
+                IsDraft = e.TryGetProperty("isDraft", out var d) && d.ValueKind == JsonValueKind.True,
+                ReviewState = MapReviewDecision(Str(e, "reviewDecision")),
+                Checks = SummarizeGitHubChecks(e),
+                Url = Str(e, "url"),
+                CreatedUtc = e.TryGetProperty("createdAt", out var c) && c.TryGetDateTime(out var dt) ? dt.ToUniversalTime() : null,
+            });
+        }
+        return items;
+    }
+
+    internal static IReadOnlyList<PullRequestInfo> ParseAzure(string json)
+    {
+        var items = new List<PullRequestInfo>();
+        using var doc = JsonDocument.Parse(json);
+        foreach (var e in doc.RootElement.EnumerateArray())
+        {
+            var source = Str(e, "sourceRefName");
+            items.Add(new PullRequestInfo
+            {
+                Number = e.TryGetProperty("pullRequestId", out var n) ? n.GetInt32() : 0,
+                Title = Str(e, "title"),
+                Author = e.TryGetProperty("createdBy", out var a) ? Str(a, "displayName") : "",
+                Branch = source.StartsWith("refs/heads/", StringComparison.Ordinal) ? source["refs/heads/".Length..] : source,
+                IsDraft = e.TryGetProperty("isDraft", out var d) && d.ValueKind == JsonValueKind.True,
+                ReviewState = "", // Azure listing parity: review votes need a second call - out of v1
+                Checks = ChecksState.None,
+                Url = Str(e, "url"),
+            });
+        }
+        return items;
+    }
+
+    internal static string MapReviewDecision(string decision) => decision switch
+    {
+        "APPROVED" => "approved",
+        "CHANGES_REQUESTED" => "changes requested",
+        "REVIEW_REQUIRED" => "review required",
+        _ => "",
+    };
+
+    internal static ChecksState SummarizeGitHubChecks(JsonElement pr)
+    {
+        if (!pr.TryGetProperty("statusCheckRollup", out var rollup) || rollup.ValueKind != JsonValueKind.Array)
+            return ChecksState.None;
+
+        bool any = false, running = false, failing = false;
+        foreach (var check in rollup.EnumerateArray())
+        {
+            any = true;
+            var status = Str(check, "status");     // check runs: QUEUED / IN_PROGRESS / COMPLETED
+            var conclusion = Str(check, "conclusion"); // SUCCESS / FAILURE / ...
+            var state = Str(check, "state");       // status contexts: SUCCESS / FAILURE / PENDING
+            if (status is "QUEUED" or "IN_PROGRESS" || state == "PENDING")
+                running = true;
+            if (conclusion is "FAILURE" or "TIMED_OUT" or "CANCELLED" || state is "FAILURE" or "ERROR")
+                failing = true;
+        }
+        if (!any) return ChecksState.None;
+        if (failing) return ChecksState.Failing;   // a failure outranks anything still running
+        if (running) return ChecksState.Running;
+        return ChecksState.Passing;
+    }
+
+    private static string Str(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
+
+    private static string FirstLine(string s)
+        => s.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? "unknown error";
+
+    private static async Task<(int Exit, string Output, string Error)> RunCliAsync(string exe, string[] args, string workingDir, CancellationToken ct)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = exe,
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        try
+        {
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc is null)
+                return (-1, "", $"{exe} could not start");
+            var stdout = await proc.StandardOutput.ReadToEndAsync(ct);
+            var stderr = await proc.StandardError.ReadToEndAsync(ct);
+            await proc.WaitForExitAsync(ct);
+            return (proc.ExitCode, stdout, stderr);
+        }
+        catch (Exception ex)
+        {
+            return (-1, "", ex.Message); // exe missing entirely
+        }
+    }
+}

--- a/src/CcDirector.Core/Git/RecommendationEngine.cs
+++ b/src/CcDirector.Core/Git/RecommendationEngine.cs
@@ -1,0 +1,114 @@
+namespace CcDirector.Core.Git;
+
+public enum RecommendationKind
+{
+    /// <summary>Finished worktrees can be removed; disk comes back.</summary>
+    ReapSafeWorktrees,
+
+    /// <summary>Uncommitted work has been sitting unprotected too long.</summary>
+    ProtectDirtyRepo,
+
+    /// <summary>A branch has drifted far behind main; merging gets harder by the day.</summary>
+    FarBehindMain,
+}
+
+/// <summary>
+/// One recommendation, fully folded: finished title, body, and why-line in plain language. The UI
+/// renders these verbatim and never re-derives them (the dumb-client rule). Severity orders the
+/// list: 1 = free win, 2 = protect work, 3 = drift.
+/// </summary>
+public sealed record Recommendation
+{
+    public RecommendationKind Kind { get; init; }
+    public int Severity { get; init; }
+    public string Title { get; init; } = "";
+    public string Body { get; init; } = "";
+    public string Why { get; init; } = "";
+
+    /// <summary>The repository this recommendation is about; null for the fleet-wide reap summary.</summary>
+    public string? RepoPath { get; init; }
+
+    public long ReclaimBytes { get; init; }
+}
+
+/// <summary>
+/// Turns the repository model into plain-language recommendations - the coaching half of the
+/// repositories vision: the product tells the user what is drifting BEFORE it becomes 300 dangling
+/// worktrees, and offers the one-click or one-agent way out. Pure and threshold-driven; unit-tested
+/// as a table. Provisional (unverified warm-start) entries never generate recommendations.
+/// </summary>
+public static class RecommendationEngine
+{
+    /// <summary>Uncommitted work older than this is "sitting too long".</summary>
+    public static readonly TimeSpan DirtyThreshold = TimeSpan.FromDays(7);
+
+    /// <summary>A branch this far behind main is drifting expensively.</summary>
+    public const int BehindMainThreshold = 30;
+
+    public static IReadOnlyList<Recommendation> Evaluate(IReadOnlyList<RepositoryStatus> repositories, DateTime? nowUtc = null)
+    {
+        var now = nowUtc ?? DateTime.UtcNow;
+        var results = new List<Recommendation>();
+        var verified = repositories.Where(r => r.Success && !r.Provisional).ToList();
+
+        // 1) The free win: finished worktrees across all repos.
+        int safeCount = verified.Sum(r => r.WorktreesSafeToReap);
+        if (safeCount > 0)
+        {
+            long reclaim = verified
+                .SelectMany(r => r.Worktrees)
+                .Where(w => w.Safety == WorktreeSafety.SafeToReap)
+                .Sum(w => w.SizeBytes ?? 0);
+            results.Add(new Recommendation
+            {
+                Kind = RecommendationKind.ReapSafeWorktrees,
+                Severity = 1,
+                Title = $"Reclaim {FormatBytes(reclaim)} - {safeCount} worktree{(safeCount == 1 ? " is" : "s are")} finished and safe to remove",
+                Body = "Their work is already on origin/main and nothing is using them. Removing them deletes only leftover copies.",
+                Why = "why: merged and clean, verified by the background scan; worktrees a session is using are never counted",
+                ReclaimBytes = reclaim,
+            });
+        }
+
+        // 2) Protect work: repos dirty past the threshold.
+        foreach (var r in verified.Where(r => !r.IsClean && r.DirtySinceUtc is { } since && now - since >= DirtyThreshold)
+                     .OrderByDescending(r => r.UncommittedCount))
+        {
+            int days = (int)(now - r.DirtySinceUtc!.Value).TotalDays;
+            results.Add(new Recommendation
+            {
+                Kind = RecommendationKind.ProtectDirtyRepo,
+                Severity = 2,
+                Title = $"{r.Name} has {r.UncommittedCount} uncommitted file{(r.UncommittedCount == 1 ? "" : "s")} sitting for {days} days",
+                Body = "Uncommitted work is unprotected - a disk failure or a careless cleanup loses it. An agent can sort, commit, and push it for your review.",
+                Why = $"why: uncommitted since {r.DirtySinceUtc:yyyy-MM-dd} (threshold {DirtyThreshold.TotalDays:0} days)",
+                RepoPath = r.Path,
+            });
+        }
+
+        // 3) Drift: branches far behind main.
+        foreach (var r in verified.Where(r => r.BehindMainCount >= BehindMainThreshold)
+                     .OrderByDescending(r => r.BehindMainCount))
+        {
+            results.Add(new Recommendation
+            {
+                Kind = RecommendationKind.FarBehindMain,
+                Severity = 3,
+                Title = $"{r.Name}'s branch {r.Branch} is {r.BehindMainCount} commits behind main",
+                Body = "The longer it drifts, the harder the merge. Best next step: rebase or fold the work back while it is still cheap.",
+                Why = $"why: behind-main threshold ({BehindMainThreshold}) exceeded",
+                RepoPath = r.Path,
+            });
+        }
+
+        return results.OrderBy(x => x.Severity).ToList();
+    }
+
+    internal static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:0.0} GB",
+        >= 1_048_576 => $"{bytes / 1_048_576.0:0} MB",
+        > 0 => $"{bytes / 1024.0:0} KB",
+        _ => "0 KB",
+    };
+}

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -193,11 +193,18 @@ public sealed class RepositoryMonitor
     {
         RequireLiveSessionsProvider(nameof(RescanAsync));
         CancellationTokenSource cts;
+        long scanStartStamp;
         lock (_gate)
         {
             _cts?.Cancel();
             _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
             cts = _cts;
+            // The scan's removals publish with the SCAN'S OWN START stamp (ruling R3-5),
+            // captured here when the scan begins - never a fresh stamp at reconciliation time.
+            // A compute that starts after this moment carries a newer stamp, so its publish
+            // outranks this scan's removals: a repository created and published mid-scan
+            // survives the scan's reconciliation instead of being removed by it.
+            scanStartStamp = NextComputeStampLocked();
         }
         var ct = cts.Token;
 
@@ -253,14 +260,20 @@ public sealed class RepositoryMonitor
                 // may remove entries - a superseded scan's roots are not the truth any more.
                 if (ct.IsCancellationRequested || !ReferenceEquals(_cts, cts))
                     throw new OperationCanceledException(ct);
-                removed = _byPath.Where(kv => !seen.Contains(kv.Key)).Select(kv => kv.Value).ToList();
-                foreach (var r in removed)
+                removed = new List<RepositoryStatus>();
+                foreach (var kv in _byPath.Where(kv => !seen.Contains(kv.Key)).ToList())
                 {
-                    var removedKey = WorktreeReaperService.NormalizePath(r.Path);
-                    _byPath.Remove(removedKey);
-                    // A removal is a publish of "absent" (ruling R2-5): stamp it, so an older
-                    // compute still in flight cannot publish late and resurrect the repository.
-                    _publishStamps[removedKey] = NextComputeStampLocked();
+                    // A removal is a publish of "absent" (ruling R2-5) stamped with the scan's
+                    // START stamp (ruling R3-5). A key whose recorded publish is NEWER than the
+                    // scan start was legitimately published by a compute that began after this
+                    // scan enumerated - that publish outranks the removal, so the entry stays.
+                    // (A repository genuinely gone is removed by its own gone-path recompute or
+                    // by the next scan.)
+                    if (_publishStamps.TryGetValue(kv.Key, out var newest) && newest > scanStartStamp)
+                        continue;
+                    _byPath.Remove(kv.Key);
+                    _publishStamps[kv.Key] = scanStartStamp;
+                    removed.Add(kv.Value);
                 }
             }
             foreach (var r in removed)

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -206,6 +206,10 @@ public sealed class RepositoryMonitor
         RequireLiveSessionsProvider(nameof(RescanAsync));
         CancellationTokenSource cts;
         long scanStartStamp;
+        // Ownership, the scanning flag, and the scan's start stamp are taken in ONE gated
+        // region BEFORE enumeration (ruling R4-4): from the moment this scan owns the monitor
+        // it is visibly scanning, so a recompute arriving during enumeration - or drained by a
+        // predecessor's exit - defers to this scan instead of racing it.
         lock (_gate)
         {
             _cts?.Cancel();
@@ -217,19 +221,33 @@ public sealed class RepositoryMonitor
             // outranks this scan's removals: a repository created and published mid-scan
             // survives the scan's reconciliation instead of being removed by it.
             scanStartStamp = NextComputeStampLocked();
+            IsScanning = true;
+            ScanTotal = 0;
+            ScanDone = 0;
         }
         var ct = cts.Token;
 
-        var paths = _enumerate(roots);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        lock (_gate) { IsScanning = true; ScanTotal = paths.Count; ScanDone = 0; }
-        ProgressChanged?.Invoke();
-        FileLog.Write($"[RepositoryMonitor] rescan started: {paths.Count} repositories");
-
+        // Everything from here runs inside try/finally (ruling R4-4): an enumeration fault in
+        // a scan that owns the monitor must still release the lifecycle state and drain the
+        // deferred queue on its way out - before this, the fault left IsScanning and the
+        // deferred requests stranded forever.
         bool completed = false;
         try
         {
+            ProgressChanged?.Invoke();
+            var paths = _enumerate(roots);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            lock (_gate)
+            {
+                // A superseded scan must not clobber its replacement's progress counters.
+                if (ct.IsCancellationRequested || !ReferenceEquals(_cts, cts))
+                    throw new OperationCanceledException(ct);
+                ScanTotal = paths.Count;
+            }
+            ProgressChanged?.Invoke();
+            FileLog.Write($"[RepositoryMonitor] rescan started: {paths.Count} repositories");
+
             foreach (var path in paths)
             {
                 ct.ThrowIfCancellationRequested();
@@ -338,13 +356,16 @@ public sealed class RepositoryMonitor
             // Scan lifecycle state belongs to the CURRENT scan only (ruling R3-6): ownership is
             // checked under the gate against the monitor's current cancellation source. A
             // superseded scan exits without touching IsScanning or progress - its replacement is
-            // still scanning and owns both.
-            bool owner;
+            // still scanning and owns both. The owner check, the IsScanning clear, and the
+            // completion decision are ONE gate acquisition (ruling R4-4): ScanCompleted and the
+            // completion log are raised only when that same gated decision said owner.
+            bool owner, raiseCompleted;
             lock (_gate)
             {
                 owner = ReferenceEquals(_cts, cts);
                 if (owner)
                     IsScanning = false;
+                raiseCompleted = owner && completed;
             }
             if (owner)
             {
@@ -354,15 +375,17 @@ public sealed class RepositoryMonitor
                 // no successor never strands them. Each deferred request kept its ORIGINAL
                 // requester's token (ruling R2-5). When a newer scan superseded this one, that
                 // newer scan owns the drain: every one of ITS exit paths runs this same block.
+                // Each drained request goes back through RecomputeOneAsync's own deferral check
+                // (ruling R4-4): when a newer scan has meanwhile started, it re-defers to that
+                // scan instead of running concurrently with it.
                 await DrainDeferredRecomputesAsync();
             }
+            if (raiseCompleted)
+            {
+                FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
+                ScanCompleted?.Invoke();
+            }
         }
-
-        if (!completed)
-            return; // superseded or cancelled - never reports completion
-
-        FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
-        ScanCompleted?.Invoke();
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -372,7 +372,6 @@ public sealed class RepositoryMonitor
             }
             if (owner)
             {
-                ProgressChanged?.Invoke();
                 // Deferred requests are drained on EVERY exit path of the OWNING scan (ruling
                 // R3-6) - completed, externally cancelled, or faulted - so a cancelled scan with
                 // no successor never strands them. Each deferred request kept its ORIGINAL
@@ -380,8 +379,18 @@ public sealed class RepositoryMonitor
                 // newer scan owns the drain: every one of ITS exit paths runs this same block.
                 // Each drained request goes back through RecomputeOneAsync's own deferral check
                 // (ruling R4-4): when a newer scan has meanwhile started, it re-defers to that
-                // scan instead of running concurrently with it.
-                await DrainDeferredRecomputesAsync();
+                // scan instead of running concurrently with it. The drain sits in a finally
+                // (round-5 finding): a THROWING ProgressChanged subscriber must not skip it -
+                // IsScanning is already cleared at this point, so a skipped drain would strand
+                // the deferred requests until some later scan happened to complete.
+                try
+                {
+                    ProgressChanged?.Invoke();
+                }
+                finally
+                {
+                    await DrainDeferredRecomputesAsync();
+                }
             }
             if (raiseCompleted)
             {

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -53,6 +53,18 @@ public sealed class RepositoryMonitor
     private long _computeStampCounter;
     private readonly Dictionary<string, long> _publishStamps = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// In-flight compute registrations (ruling R4-3): key -> the start stamps of every compute
+    /// currently in flight for it. A compute's start stamp otherwise lives in a local variable
+    /// until publication, which made a ROWLESS in-flight compute invisible to scan
+    /// reconciliation - the scan observed the path absent, tombstoned nothing (no row), and the
+    /// older compute's later publish resurrected the repository. Every compute registers its
+    /// start stamp here in the same gated region that hands the stamp out, and clears it when
+    /// it publishes or abandons; reconciliation tombstones every unseen key that has a row OR a
+    /// pending compute.
+    /// </summary>
+    private readonly Dictionary<string, List<long>> _pendingComputes = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>True while a scan is in progress.</summary>
     public bool IsScanning { get; private set; }
 
@@ -221,12 +233,21 @@ public sealed class RepositoryMonitor
             foreach (var path in paths)
             {
                 ct.ThrowIfCancellationRequested();
-                var repoLock = GetRepoLock(WorktreeReaperService.NormalizePath(path));
+                var pendingKey = WorktreeReaperService.NormalizePath(path);
+                var repoLock = GetRepoLock(pendingKey);
                 await repoLock.WaitAsync(ct);
                 RepositoryStatus? published;
+                long computeStamp;
+                lock (_gate)
+                {
+                    // The stamp is handed out and the compute REGISTERED as in flight in one
+                    // gated region (ruling R4-3), so a concurrent scan's reconciliation can
+                    // see this compute even before it has published a row.
+                    computeStamp = NextComputeStampLocked();
+                    RegisterPendingComputeLocked(pendingKey, computeStamp);
+                }
                 try
                 {
-                    var computeStamp = NextComputeStamp();
                     var sessions = await FetchLiveSessionsAsync(ct);
                     var status = await _compute(path, sessions, ct);
                     var key = WorktreeReaperService.NormalizePath(status.Path);
@@ -246,6 +267,8 @@ public sealed class RepositoryMonitor
                 }
                 finally
                 {
+                    lock (_gate)
+                        ClearPendingComputeLocked(pendingKey, computeStamp);
                     repoLock.Release();
                 }
                 if (published != null)
@@ -262,7 +285,14 @@ public sealed class RepositoryMonitor
                 if (ct.IsCancellationRequested || !ReferenceEquals(_cts, cts))
                     throw new OperationCanceledException(ct);
                 removed = new List<RepositoryStatus>();
-                foreach (var kv in _byPath.Where(kv => !seen.Contains(kv.Key)).ToList())
+                // Every unseen key with a model row OR a pending in-flight compute gets the
+                // scan's absence tombstone (ruling R4-3): a rowless compute older than the
+                // scan would otherwise be invisible here and publish stale state afterward.
+                var unseenKeys = _byPath.Keys.Where(k => !seen.Contains(k))
+                    .Concat(_pendingComputes.Keys.Where(k => !seen.Contains(k)))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                foreach (var key in unseenKeys)
                 {
                     // A removal is a publish of "absent" (ruling R2-5) stamped with the scan's
                     // START stamp (ruling R3-5). A key whose recorded publish is NEWER than the
@@ -270,11 +300,14 @@ public sealed class RepositoryMonitor
                     // scan enumerated - that publish outranks the removal, so the entry stays.
                     // (A repository genuinely gone is removed by its own gone-path recompute or
                     // by the next scan.)
-                    if (_publishStamps.TryGetValue(kv.Key, out var newest) && newest > scanStartStamp)
+                    if (_publishStamps.TryGetValue(key, out var newest) && newest > scanStartStamp)
                         continue;
-                    _byPath.Remove(kv.Key);
-                    _publishStamps[kv.Key] = scanStartStamp;
-                    removed.Add(kv.Value);
+                    _publishStamps[key] = scanStartStamp;
+                    if (_byPath.TryGetValue(key, out var row))
+                    {
+                        _byPath.Remove(key);
+                        removed.Add(row);
+                    }
                 }
             }
             foreach (var r in removed)
@@ -400,9 +433,17 @@ public sealed class RepositoryMonitor
         var repoLock = GetRepoLock(targetKey);
         await repoLock.WaitAsync(ct);
         RepositoryStatus? published;
+        long computeStamp;
+        lock (_gate)
+        {
+            // Stamp hand-out and in-flight registration are one gated region (ruling R4-3):
+            // a scan that observes this path absent while the compute is still rowless can
+            // tombstone it at reconciliation instead of being resurrected by its late publish.
+            computeStamp = NextComputeStampLocked();
+            RegisterPendingComputeLocked(targetKey, computeStamp);
+        }
         try
         {
-            var computeStamp = NextComputeStamp();
             var sessions = await FetchLiveSessionsAsync(ct);
             var status = await _compute(targetPath, sessions, ct);
             lock (_gate)
@@ -410,6 +451,8 @@ public sealed class RepositoryMonitor
         }
         finally
         {
+            lock (_gate)
+                ClearPendingComputeLocked(targetKey, computeStamp);
             repoLock.Release();
         }
         if (published == null)
@@ -468,6 +511,13 @@ public sealed class RepositoryMonitor
             {
                 if (_byPath.ContainsKey(key) || removedThisScan.Contains(key))
                     continue;
+                // A registered pending compute is DIRECT proof a compute is in flight for this
+                // key (ruling R4-3) - its tombstone must outlive that compute even when the
+                // compute holds a stale reference to an already-evicted semaphore (the
+                // documented single-flight crossover), which the held-semaphore check below
+                // cannot see.
+                if (_pendingComputes.ContainsKey(key))
+                    continue;
                 // A held semaphore is proof a compute is still in flight for this key (ruling
                 // R3-4b): its stamp - a removal tombstone in particular - must survive until
                 // that compute has published and been dropped, however many scans complete in
@@ -489,15 +539,28 @@ public sealed class RepositoryMonitor
             return _repoLocks.ContainsKey(WorktreeReaperService.NormalizePath(path));
     }
 
-    /// <summary>The next compute-start stamp. Callers must NOT hold <see cref="_gate"/>.</summary>
-    private long NextComputeStamp()
-    {
-        lock (_gate)
-            return NextComputeStampLocked();
-    }
-
     /// <summary>The next compute-start stamp. Callers MUST hold <see cref="_gate"/>.</summary>
     private long NextComputeStampLocked() => ++_computeStampCounter;
+
+    /// <summary>Registers a compute as in flight for its key (ruling R4-3). Callers MUST hold
+    /// <see cref="_gate"/> and MUST have taken the stamp in the same gated region.</summary>
+    private void RegisterPendingComputeLocked(string key, long stamp)
+    {
+        if (!_pendingComputes.TryGetValue(key, out var stamps))
+            _pendingComputes[key] = stamps = new List<long>();
+        stamps.Add(stamp);
+    }
+
+    /// <summary>Clears a compute's in-flight registration on publish or abandon (ruling R4-3).
+    /// Callers MUST hold <see cref="_gate"/>.</summary>
+    private void ClearPendingComputeLocked(string key, long stamp)
+    {
+        if (!_pendingComputes.TryGetValue(key, out var stamps))
+            return;
+        stamps.Remove(stamp);
+        if (stamps.Count == 0)
+            _pendingComputes.Remove(key);
+    }
 
     /// <summary>
     /// THE one guarded publish path (ruling R2-5) - every write of a computed status into the

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -29,6 +29,7 @@ public sealed class RepositoryMonitor
     private readonly Func<IEnumerable<string>, IReadOnlyList<string>> _enumerate;
     private readonly Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>> _compute;
     private readonly Func<string, CancellationToken, Task<string?>> _resolvePrimary;
+    private readonly Func<string, bool> _isRepository;
 
     private readonly object _gate = new();
     private readonly Dictionary<string, RepositoryStatus> _byPath = new(StringComparer.OrdinalIgnoreCase);
@@ -109,12 +110,14 @@ public sealed class RepositoryMonitor
         Func<IEnumerable<string>, IReadOnlyList<string>>? enumerate = null,
         Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>>? compute = null,
         string? cachePath = null,
-        Func<string, CancellationToken, Task<string?>>? resolvePrimary = null)
+        Func<string, CancellationToken, Task<string?>>? resolvePrimary = null,
+        Func<string, bool>? isRepository = null)
     {
         _enumerate = enumerate ?? DefaultEnumerate;
         _compute = compute ?? DefaultCompute;
         _cachePath = cachePath;
         _resolvePrimary = resolvePrimary ?? DefaultResolvePrimary;
+        _isRepository = isRepository ?? DefaultIsRepository;
     }
 
     /// <summary>
@@ -411,24 +414,46 @@ public sealed class RepositoryMonitor
             }
         }
 
+        // The observation stamp is taken BEFORE touching the filesystem (ruling R4-5): stamps
+        // order by OBSERVATION time, and an absence observed before a newer add published must
+        // lose to that add. Stamping after the observation handed the OLDER observation the
+        // NEWER stamp, letting it remove the legitimately added repository.
+        long observationStamp;
+        lock (_gate)
+            observationStamp = NextComputeStampLocked();
+
         // "Gone" means the folder disappeared OR it is no longer a git repository (a root watcher
-        // fires for ANY subdirectory; a non-repo folder must never become a model entry).
-        bool gitIsFile = File.Exists(Path.Combine(repoPath, ".git"));
-        bool isRepo = Directory.Exists(repoPath)
-                      && (Directory.Exists(Path.Combine(repoPath, ".git")) || gitIsFile);
+        // fires for ANY subdirectory; a non-repo folder must never become a model entry). The
+        // observation goes through the injectable seam so tests can hold it open at its exact
+        // point in time (ruling R4-5).
+        bool isRepo = _isRepository(repoPath);
         if (!isRepo)
         {
             var key = WorktreeReaperService.NormalizePath(repoPath);
             RepositoryStatus? gone = null;
+            bool applied = false;
             lock (_gate)
             {
-                if (_byPath.TryGetValue(key, out gone))
-                    _byPath.Remove(key);
-                // Absence is ALWAYS stamped (ruling R3-4a) - whether or not a model row exists.
-                // A FIRST-TIME compute can be in flight for this key with no row published yet;
-                // without a tombstone its later publish would create the very repository this
-                // newer check just saw vanish. A removal is a publish of "absent" (ruling R2-5).
-                _publishStamps[key] = NextComputeStampLocked();
+                // Apply the removal only when no NEWER publish exists for the key (ruling
+                // R4-5): a newer publish means this absence observation is stale - the newer
+                // state stands, and a repository truly gone is removed by a later observation.
+                if (!(_publishStamps.TryGetValue(key, out var newest) && newest > observationStamp))
+                {
+                    applied = true;
+                    if (_byPath.TryGetValue(key, out gone))
+                        _byPath.Remove(key);
+                    // Absence is ALWAYS stamped (ruling R3-4a) - whether or not a model row
+                    // exists. A FIRST-TIME compute can be in flight for this key with no row
+                    // published yet; without a tombstone its later publish would create the
+                    // very repository this newer check just saw vanish. A removal is a publish
+                    // of "absent" (ruling R2-5).
+                    _publishStamps[key] = observationStamp;
+                }
+            }
+            if (!applied)
+            {
+                FileLog.Write($"[RepositoryMonitor] recompute: absence observation for {repoPath} is stale - a newer publish stands, yielding");
+                return;
             }
             if (gone != null)
             {
@@ -441,6 +466,7 @@ public sealed class RepositoryMonitor
 
         // A .git FILE marks a linked worktree - canonicalize to the primary checkout and recompute
         // THAT entry. Failing to resolve is a real error, not a reason to guess.
+        bool gitIsFile = File.Exists(Path.Combine(repoPath, ".git"));
         var targetPath = repoPath;
         if (gitIsFile)
         {
@@ -691,6 +717,12 @@ public sealed class RepositoryMonitor
 
     private static async Task<RepositoryStatus> DefaultCompute(string path, IReadOnlyList<LiveSessionRef>? sessions, CancellationToken ct)
         => await new RepositoryStatusService().GetStatusAsync(path, sessions, fetchPrune: false, ct);
+
+    /// <summary>A path is a repository when it exists and holds a .git directory (a primary
+    /// checkout) or a .git file (a linked worktree).</summary>
+    private static bool DefaultIsRepository(string path)
+        => Directory.Exists(path)
+           && (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")));
 
     /// <summary>
     /// The primary checkout owning a linked worktree: git names the shared .git directory via

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -16,9 +16,11 @@ namespace CcDirector.Core.Git;
 /// Consistency rules (issue devthrottle_internal#510, inspection round 1):
 /// - The monitor owns the live-session source (<see cref="LiveSessionsProvider"/>) and consults it
 ///   on EVERY compute, so no compute path can erase the in-use-by-session classification.
-/// - Computes are single-flight per repository, and a single-repository recompute requested while a
-///   full scan runs is deferred until the scan completes - so an older result can never overwrite a
-///   newer one.
+/// - Newest compute wins, enforced AT THE PUBLISH (inspection round 2, ruling R2-5): every compute
+///   takes a monotonically increasing start stamp, and a publish whose stamp is older than the one
+///   the model already recorded for that key - including a removal - is dropped. The per-repository
+///   semaphore (single-flight) and the defer-during-scan rule remain as efficiency devices; the
+///   stamp rule is the correctness device. Deferred recomputes keep their requester's own token.
 /// - A linked-worktree path is canonicalized to its PRIMARY checkout before computing, so a
 ///   worktree path never becomes its own model entry.
 /// </summary>
@@ -31,9 +33,25 @@ public sealed class RepositoryMonitor
     private readonly object _gate = new();
     private readonly Dictionary<string, RepositoryStatus> _byPath = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SemaphoreSlim> _repoLocks = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, string> _deferredRecomputes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, DeferredRecompute> _deferredRecomputes = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _cts;
     private readonly string? _cachePath;
+
+    /// <summary>A single-repository recompute parked while a full scan runs - it keeps the
+    /// ORIGINAL requester's token, so a request whose requester gave up is skipped at drain.</summary>
+    private readonly record struct DeferredRecompute(string Path, CancellationToken Token);
+
+    /// <summary>
+    /// Monotonically increasing compute-start stamps (ruling R2-5): every compute - scan or
+    /// single recompute - takes a stamp when it STARTS, and the model records per key the stamp
+    /// of the newest accepted publish (a removal counts as a publish of "absent"). A publish
+    /// whose stamp is older than the recorded one is dropped, so an older compute can never
+    /// overwrite - or resurrect - a newer result, whatever order the publishes arrive in. The
+    /// per-repository semaphore remains an efficiency device (it avoids duplicate concurrent
+    /// walks); THIS rule is the correctness device.
+    /// </summary>
+    private long _computeStampCounter;
+    private readonly Dictionary<string, long> _publishStamps = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>True while a scan is in progress.</summary>
     public bool IsScanning { get; private set; }
@@ -184,17 +202,17 @@ public sealed class RepositoryMonitor
                 ct.ThrowIfCancellationRequested();
                 var repoLock = GetRepoLock(WorktreeReaperService.NormalizePath(path));
                 await repoLock.WaitAsync(ct);
-                RepositoryStatus enriched;
+                RepositoryStatus? published;
                 try
                 {
+                    var computeStamp = NextComputeStamp();
                     var sessions = await FetchLiveSessionsAsync(ct);
                     var status = await _compute(path, sessions, ct);
                     var key = WorktreeReaperService.NormalizePath(status.Path);
                     seen.Add(key);
                     lock (_gate)
                     {
-                        enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
-                        _byPath[key] = enriched;
+                        published = PublishIfNewestLocked(key, status, computeStamp);
                         ScanDone++;
                     }
                 }
@@ -202,7 +220,8 @@ public sealed class RepositoryMonitor
                 {
                     repoLock.Release();
                 }
-                Upserted?.Invoke(enriched);
+                if (published != null)
+                    Upserted?.Invoke(published);
                 ProgressChanged?.Invoke();
             }
 
@@ -212,7 +231,13 @@ public sealed class RepositoryMonitor
             {
                 removed = _byPath.Where(kv => !seen.Contains(kv.Key)).Select(kv => kv.Value).ToList();
                 foreach (var r in removed)
-                    _byPath.Remove(WorktreeReaperService.NormalizePath(r.Path));
+                {
+                    var removedKey = WorktreeReaperService.NormalizePath(r.Path);
+                    _byPath.Remove(removedKey);
+                    // A removal is a publish of "absent" (ruling R2-5): stamp it, so an older
+                    // compute still in flight cannot publish late and resurrect the repository.
+                    _publishStamps[removedKey] = NextComputeStampLocked();
+                }
             }
             foreach (var r in removed)
                 Removed?.Invoke(r);
@@ -238,7 +263,8 @@ public sealed class RepositoryMonitor
         FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
 
         // Run the single-repository recomputes that arrived while this scan held the model.
-        await DrainDeferredRecomputesAsync(externalCt);
+        // Each deferred request kept its ORIGINAL requester's token (ruling R2-5).
+        await DrainDeferredRecomputesAsync();
 
         ScanCompleted?.Invoke();
     }
@@ -256,7 +282,10 @@ public sealed class RepositoryMonitor
         {
             if (IsScanning)
             {
-                _deferredRecomputes[WorktreeReaperService.NormalizePath(repoPath)] = repoPath;
+                // The deferred request keeps ITS OWN token (ruling R2-5): if the requester gives
+                // up before the scan completes, the drain skips this request instead of running
+                // it under someone else's token.
+                _deferredRecomputes[WorktreeReaperService.NormalizePath(repoPath)] = new DeferredRecompute(repoPath, ct);
                 FileLog.Write($"[RepositoryMonitor] recompute deferred until the running scan completes: {repoPath}");
                 return;
             }
@@ -274,7 +303,12 @@ public sealed class RepositoryMonitor
             lock (_gate)
             {
                 if (_byPath.TryGetValue(key, out gone))
+                {
                     _byPath.Remove(key);
+                    // A removal is a publish of "absent" (ruling R2-5): stamp it so an older
+                    // compute still in flight cannot publish late and resurrect the entry.
+                    _publishStamps[key] = NextComputeStampLocked();
+                }
             }
             if (gone != null)
             {
@@ -301,27 +335,31 @@ public sealed class RepositoryMonitor
         var targetKey = WorktreeReaperService.NormalizePath(targetPath);
         var repoLock = GetRepoLock(targetKey);
         await repoLock.WaitAsync(ct);
-        RepositoryStatus enriched;
+        RepositoryStatus? published;
         try
         {
+            var computeStamp = NextComputeStamp();
             var sessions = await FetchLiveSessionsAsync(ct);
             var status = await _compute(targetPath, sessions, ct);
             lock (_gate)
-            {
-                enriched = Enrich(status, _byPath.TryGetValue(targetKey, out var prev) ? prev : null);
-                _byPath[targetKey] = enriched;
-            }
+                published = PublishIfNewestLocked(targetKey, status, computeStamp);
         }
         finally
         {
             repoLock.Release();
         }
-        FileLog.Write($"[RepositoryMonitor] recomputed one: {enriched.Name}");
-        Upserted?.Invoke(enriched);
+        if (published == null)
+            return; // a newer compute (or a newer removal) already ruled this key - dropped
+        FileLog.Write($"[RepositoryMonitor] recomputed one: {published.Name}");
+        Upserted?.Invoke(published);
         SaveCache();
     }
 
-    /// <summary>One compute at a time per repository - publishes can never land out of order.</summary>
+    /// <summary>
+    /// One compute at a time per repository. An EFFICIENCY device only (it avoids duplicate
+    /// concurrent walks of the same working tree) - publish ordering is guaranteed by the
+    /// compute-start stamps in <see cref="PublishIfNewestLocked"/>, not by this lock.
+    /// </summary>
     private SemaphoreSlim GetRepoLock(string key)
     {
         lock (_gate)
@@ -330,6 +368,36 @@ public sealed class RepositoryMonitor
                 _repoLocks[key] = sem = new SemaphoreSlim(1, 1);
             return sem;
         }
+    }
+
+    /// <summary>The next compute-start stamp. Callers must NOT hold <see cref="_gate"/>.</summary>
+    private long NextComputeStamp()
+    {
+        lock (_gate)
+            return NextComputeStampLocked();
+    }
+
+    /// <summary>The next compute-start stamp. Callers MUST hold <see cref="_gate"/>.</summary>
+    private long NextComputeStampLocked() => ++_computeStampCounter;
+
+    /// <summary>
+    /// THE one guarded publish path (ruling R2-5) - every write of a computed status into the
+    /// model, from the full scan and from single recomputes alike, goes through here. Newest
+    /// compute start wins: when the key already carries a newer stamp (a newer compute
+    /// published, or a newer scan removed the key), this publish is DROPPED and null is
+    /// returned. Callers must hold <see cref="_gate"/>.
+    /// </summary>
+    private RepositoryStatus? PublishIfNewestLocked(string key, RepositoryStatus status, long computeStamp)
+    {
+        if (_publishStamps.TryGetValue(key, out var newest) && newest > computeStamp)
+        {
+            FileLog.Write($"[RepositoryMonitor] publish dropped for {status.Path}: a newer compute (stamp {newest}) already ruled this key (this compute started at stamp {computeStamp})");
+            return null;
+        }
+        _publishStamps[key] = computeStamp;
+        var enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
+        _byPath[key] = enriched;
+        return enriched;
     }
 
     private async Task<IReadOnlyList<LiveSessionRef>?> FetchLiveSessionsAsync(CancellationToken ct)
@@ -341,9 +409,9 @@ public sealed class RepositoryMonitor
             return _byPath.Values.SelectMany(s => s.Worktrees).Select(w => w.Path).ToList();
     }
 
-    private async Task DrainDeferredRecomputesAsync(CancellationToken ct)
+    private async Task DrainDeferredRecomputesAsync()
     {
-        List<string> deferred;
+        List<DeferredRecompute> deferred;
         lock (_gate)
         {
             if (_deferredRecomputes.Count == 0)
@@ -352,15 +420,28 @@ public sealed class RepositoryMonitor
             _deferredRecomputes.Clear();
         }
         FileLog.Write($"[RepositoryMonitor] running {deferred.Count} recompute(s) deferred during the scan");
-        foreach (var path in deferred)
+        foreach (var request in deferred)
         {
+            // The request runs under ITS OWN requester's token (ruling R2-5) - never the
+            // scan's. A requester that already gave up is skipped, not run on its behalf.
+            if (request.Token.IsCancellationRequested)
+            {
+                FileLog.Write($"[RepositoryMonitor] deferred recompute skipped - its requester cancelled: {request.Path}");
+                continue;
+            }
             try
             {
-                await RecomputeOneAsync(path, ct);
+                await RecomputeOneAsync(request.Path, request.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                FileLog.Write($"[RepositoryMonitor] deferred recompute cancelled by its requester: {request.Path}");
             }
             catch (Exception ex)
             {
-                FileLog.Write($"[RepositoryMonitor] deferred recompute FAILED for {path}: {ex.Message}");
+                // A deferred failure is an ERROR - the requester cannot observe it, so the log
+                // is the only place it can surface. Never absorbed into a success path.
+                FileLog.Write($"[RepositoryMonitor] ERROR: deferred recompute failed for {request.Path}: {ex}");
             }
         }
     }

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -76,7 +76,9 @@ public sealed class RepositoryMonitor
             {
                 foreach (var s in cached)
                     if (!string.IsNullOrWhiteSpace(s.Path))
-                        _byPath[WorktreeReaperService.NormalizePath(s.Path)] = s;
+                        // Cached entries are PROVISIONAL: shown dimmed as "verifying", never acted
+                        // on, until the live scan re-confirms them (the warm-start trust rule).
+                        _byPath[WorktreeReaperService.NormalizePath(s.Path)] = s with { Provisional = true };
             }
             FileLog.Write($"[RepositoryMonitor] warm-start: loaded {cached.Count} repositories from cache");
         }
@@ -114,6 +116,28 @@ public sealed class RepositoryMonitor
     }
 
     /// <summary>
+    /// Finds the repository entry a path belongs to: the repository itself, or the repository one of
+    /// whose worktrees IS that path. This is how a session sitting inside a worktree finds its repo's
+    /// entry (the one-brain rule: the per-session tab renders the same model as the Repositories home).
+    /// </summary>
+    public RepositoryStatus? FindForPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+        var key = WorktreeReaperService.NormalizePath(path);
+        lock (_gate)
+        {
+            if (_byPath.TryGetValue(key, out var direct))
+                return direct;
+            foreach (var s in _byPath.Values)
+                foreach (var w in s.Worktrees)
+                    if (string.Equals(WorktreeReaperService.NormalizePath(w.Path), key, StringComparison.OrdinalIgnoreCase))
+                        return s;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Rescan the given roots, streaming each repository's status into the model as it is computed.
     /// A new rescan supersedes any in-flight one.
     /// </summary>
@@ -143,8 +167,14 @@ public sealed class RepositoryMonitor
                 var status = await _compute(path, sessions, ct);
                 var key = WorktreeReaperService.NormalizePath(status.Path);
                 seen.Add(key);
-                lock (_gate) { _byPath[key] = status; ScanDone++; }
-                Upserted?.Invoke(status);
+                RepositoryStatus enriched;
+                lock (_gate)
+                {
+                    enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
+                    _byPath[key] = enriched;
+                    ScanDone++;
+                }
+                Upserted?.Invoke(enriched);
                 ProgressChanged?.Invoke();
             }
 
@@ -175,6 +205,64 @@ public sealed class RepositoryMonitor
 
         FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
         ScanCompleted?.Invoke();
+    }
+
+    /// <summary>
+    /// Recompute ONE repository and publish the result - the file watcher's path: a change under
+    /// one repo never re-scans the others. Removes the entry when the directory is gone.
+    /// </summary>
+    public async Task RecomputeOneAsync(string repoPath, IReadOnlyList<LiveSessionRef>? sessions = null, CancellationToken ct = default)
+    {
+        var key = WorktreeReaperService.NormalizePath(repoPath);
+
+        // "Gone" means the folder disappeared OR it is no longer a git repository (a root watcher
+        // fires for ANY subdirectory; a non-repo folder must never become a model entry).
+        bool isRepo = Directory.Exists(repoPath)
+                      && (Directory.Exists(Path.Combine(repoPath, ".git")) || File.Exists(Path.Combine(repoPath, ".git")));
+        if (!isRepo)
+        {
+            RepositoryStatus? gone = null;
+            lock (_gate)
+            {
+                if (_byPath.TryGetValue(key, out gone))
+                    _byPath.Remove(key);
+            }
+            if (gone != null)
+            {
+                FileLog.Write($"[RepositoryMonitor] recompute: {repoPath} is gone - removed");
+                Removed?.Invoke(gone);
+                SaveCache();
+            }
+            return;
+        }
+
+        var status = await _compute(repoPath, sessions, ct);
+        RepositoryStatus enriched;
+        lock (_gate)
+        {
+            enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
+            _byPath[key] = enriched;
+        }
+        FileLog.Write($"[RepositoryMonitor] recomputed one: {enriched.Name}");
+        Upserted?.Invoke(enriched);
+        SaveCache();
+    }
+
+    /// <summary>
+    /// Model-level enrichment applied on every upsert: a freshly computed status is never
+    /// provisional, and dirty-since is carried forward from the previous entry (or stamped now when
+    /// the tree just turned dirty), so "uncommitted work sitting for N days" survives rescans and -
+    /// via the cache - restarts.
+    /// </summary>
+    internal static RepositoryStatus Enrich(RepositoryStatus fresh, RepositoryStatus? previous)
+    {
+        DateTime? dirtySince = null;
+        if (!fresh.IsClean)
+            dirtySince = previous is { IsClean: false, DirtySinceUtc: not null }
+                ? previous.DirtySinceUtc
+                : DateTime.UtcNow;
+
+        return fresh with { Provisional = false, DirtySinceUtc = dirtySince };
     }
 
     private static IReadOnlyList<string> DefaultEnumerate(IEnumerable<string> roots)

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -379,18 +379,30 @@ public sealed class RepositoryMonitor
                 // newer scan owns the drain: every one of ITS exit paths runs this same block.
                 // Each drained request goes back through RecomputeOneAsync's own deferral check
                 // (ruling R4-4): when a newer scan has meanwhile started, it re-defers to that
-                // scan instead of running concurrently with it. The drain sits in a finally
-                // (round-5 finding): a THROWING ProgressChanged subscriber must not skip it -
-                // IsScanning is already cleared at this point, so a skipped drain would strand
-                // the deferred requests until some later scan happened to complete.
+                // scan instead of running concurrently with it. A THROWING ProgressChanged
+                // subscriber must not skip the drain (round-5 finding) - IsScanning is already
+                // cleared here, so a skipped drain would strand the deferred requests. The
+                // subscriber's exception is CAPTURED and rethrown with its type intact after
+                // the drain (round-6 finding: an awaited drain in a finally would let a drain
+                // failure silently replace it); if BOTH throw, both surface together.
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo? progressFailure = null;
                 try
                 {
                     ProgressChanged?.Invoke();
                 }
-                finally
+                catch (Exception ex)
+                {
+                    progressFailure = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex);
+                }
+                try
                 {
                     await DrainDeferredRecomputesAsync();
                 }
+                catch (Exception drainEx) when (progressFailure != null)
+                {
+                    throw new AggregateException(progressFailure.SourceException, drainEx);
+                }
+                progressFailure?.Throw();
             }
             if (raiseCompleted)
             {

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -13,17 +13,25 @@ namespace CcDirector.Core.Git;
 /// removed at the end (<see cref="Removed"/>). Events fire on the scanning thread; UI subscribers
 /// marshal to their dispatcher.
 ///
-/// This is phase 1 of the background service (devthrottle_internal#507): the model + progressive
-/// streaming. The warm-start cache, the file watcher, live session occupancy, and the Gateway push
-/// are later phases.
+/// Consistency rules (issue devthrottle_internal#510, inspection round 1):
+/// - The monitor owns the live-session source (<see cref="LiveSessionsProvider"/>) and consults it
+///   on EVERY compute, so no compute path can erase the in-use-by-session classification.
+/// - Computes are single-flight per repository, and a single-repository recompute requested while a
+///   full scan runs is deferred until the scan completes - so an older result can never overwrite a
+///   newer one.
+/// - A linked-worktree path is canonicalized to its PRIMARY checkout before computing, so a
+///   worktree path never becomes its own model entry.
 /// </summary>
 public sealed class RepositoryMonitor
 {
     private readonly Func<IEnumerable<string>, IReadOnlyList<string>> _enumerate;
     private readonly Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>> _compute;
+    private readonly Func<string, CancellationToken, Task<string?>> _resolvePrimary;
 
     private readonly object _gate = new();
     private readonly Dictionary<string, RepositoryStatus> _byPath = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, SemaphoreSlim> _repoLocks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _deferredRecomputes = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _cts;
     private readonly string? _cachePath;
 
@@ -48,14 +56,23 @@ public sealed class RepositoryMonitor
     /// <summary>Raised once when a scan finishes (not raised when a scan is superseded/cancelled).</summary>
     public event Action? ScanCompleted;
 
+    /// <summary>
+    /// THE live-session source for every compute this monitor runs - full scans and single-repository
+    /// recomputes alike. Wired once at startup by the host (the same source the panels use). When it
+    /// is null the computes run without session data (no host wired one up yet).
+    /// </summary>
+    public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider { get; set; }
+
     public RepositoryMonitor(
         Func<IEnumerable<string>, IReadOnlyList<string>>? enumerate = null,
         Func<string, IReadOnlyList<LiveSessionRef>?, CancellationToken, Task<RepositoryStatus>>? compute = null,
-        string? cachePath = null)
+        string? cachePath = null,
+        Func<string, CancellationToken, Task<string?>>? resolvePrimary = null)
     {
         _enumerate = enumerate ?? DefaultEnumerate;
         _compute = compute ?? DefaultCompute;
         _cachePath = cachePath;
+        _resolvePrimary = resolvePrimary ?? DefaultResolvePrimary;
     }
 
     /// <summary>
@@ -139,9 +156,10 @@ public sealed class RepositoryMonitor
 
     /// <summary>
     /// Rescan the given roots, streaming each repository's status into the model as it is computed.
-    /// A new rescan supersedes any in-flight one.
+    /// A new rescan supersedes any in-flight one. Live sessions come from
+    /// <see cref="LiveSessionsProvider"/> on every compute.
     /// </summary>
-    public async Task RescanAsync(IEnumerable<string> roots, IReadOnlyList<LiveSessionRef>? sessions = null, CancellationToken externalCt = default)
+    public async Task RescanAsync(IEnumerable<string> roots, CancellationToken externalCt = default)
     {
         CancellationTokenSource cts;
         lock (_gate)
@@ -164,15 +182,25 @@ public sealed class RepositoryMonitor
             foreach (var path in paths)
             {
                 ct.ThrowIfCancellationRequested();
-                var status = await _compute(path, sessions, ct);
-                var key = WorktreeReaperService.NormalizePath(status.Path);
-                seen.Add(key);
+                var repoLock = GetRepoLock(WorktreeReaperService.NormalizePath(path));
+                await repoLock.WaitAsync(ct);
                 RepositoryStatus enriched;
-                lock (_gate)
+                try
                 {
-                    enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
-                    _byPath[key] = enriched;
-                    ScanDone++;
+                    var sessions = await FetchLiveSessionsAsync(ct);
+                    var status = await _compute(path, sessions, ct);
+                    var key = WorktreeReaperService.NormalizePath(status.Path);
+                    seen.Add(key);
+                    lock (_gate)
+                    {
+                        enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
+                        _byPath[key] = enriched;
+                        ScanDone++;
+                    }
+                }
+                finally
+                {
+                    repoLock.Release();
                 }
                 Upserted?.Invoke(enriched);
                 ProgressChanged?.Invoke();
@@ -204,23 +232,40 @@ public sealed class RepositoryMonitor
         }
 
         FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
+
+        // Run the single-repository recomputes that arrived while this scan held the model.
+        await DrainDeferredRecomputesAsync(externalCt);
+
         ScanCompleted?.Invoke();
     }
 
     /// <summary>
     /// Recompute ONE repository and publish the result - the file watcher's path: a change under
-    /// one repo never re-scans the others. Removes the entry when the directory is gone.
+    /// one repo never re-scans the others. Removes the entry when the directory is gone. A linked
+    /// worktree path is canonicalized to its primary checkout first, so the PRIMARY entry is
+    /// recomputed and a worktree path never becomes a model entry of its own. While a full scan is
+    /// running the recompute is deferred and runs when the scan completes.
     /// </summary>
-    public async Task RecomputeOneAsync(string repoPath, IReadOnlyList<LiveSessionRef>? sessions = null, CancellationToken ct = default)
+    public async Task RecomputeOneAsync(string repoPath, CancellationToken ct = default)
     {
-        var key = WorktreeReaperService.NormalizePath(repoPath);
+        lock (_gate)
+        {
+            if (IsScanning)
+            {
+                _deferredRecomputes[WorktreeReaperService.NormalizePath(repoPath)] = repoPath;
+                FileLog.Write($"[RepositoryMonitor] recompute deferred until the running scan completes: {repoPath}");
+                return;
+            }
+        }
 
         // "Gone" means the folder disappeared OR it is no longer a git repository (a root watcher
         // fires for ANY subdirectory; a non-repo folder must never become a model entry).
+        bool gitIsFile = File.Exists(Path.Combine(repoPath, ".git"));
         bool isRepo = Directory.Exists(repoPath)
-                      && (Directory.Exists(Path.Combine(repoPath, ".git")) || File.Exists(Path.Combine(repoPath, ".git")));
+                      && (Directory.Exists(Path.Combine(repoPath, ".git")) || gitIsFile);
         if (!isRepo)
         {
+            var key = WorktreeReaperService.NormalizePath(repoPath);
             RepositoryStatus? gone = null;
             lock (_gate)
             {
@@ -236,16 +281,78 @@ public sealed class RepositoryMonitor
             return;
         }
 
-        var status = await _compute(repoPath, sessions, ct);
-        RepositoryStatus enriched;
-        lock (_gate)
+        // A .git FILE marks a linked worktree - canonicalize to the primary checkout and recompute
+        // THAT entry. Failing to resolve is a real error, not a reason to guess.
+        var targetPath = repoPath;
+        if (gitIsFile)
         {
-            enriched = Enrich(status, _byPath.TryGetValue(key, out var prev) ? prev : null);
-            _byPath[key] = enriched;
+            var primary = await _resolvePrimary(repoPath, ct);
+            if (string.IsNullOrWhiteSpace(primary))
+                throw new InvalidOperationException(
+                    $"could not resolve the primary repository for the linked worktree path: {repoPath}");
+            FileLog.Write($"[RepositoryMonitor] recompute: {repoPath} is a linked worktree of {primary}");
+            targetPath = primary;
+        }
+
+        var targetKey = WorktreeReaperService.NormalizePath(targetPath);
+        var repoLock = GetRepoLock(targetKey);
+        await repoLock.WaitAsync(ct);
+        RepositoryStatus enriched;
+        try
+        {
+            var sessions = await FetchLiveSessionsAsync(ct);
+            var status = await _compute(targetPath, sessions, ct);
+            lock (_gate)
+            {
+                enriched = Enrich(status, _byPath.TryGetValue(targetKey, out var prev) ? prev : null);
+                _byPath[targetKey] = enriched;
+            }
+        }
+        finally
+        {
+            repoLock.Release();
         }
         FileLog.Write($"[RepositoryMonitor] recomputed one: {enriched.Name}");
         Upserted?.Invoke(enriched);
         SaveCache();
+    }
+
+    /// <summary>One compute at a time per repository - publishes can never land out of order.</summary>
+    private SemaphoreSlim GetRepoLock(string key)
+    {
+        lock (_gate)
+        {
+            if (!_repoLocks.TryGetValue(key, out var sem))
+                _repoLocks[key] = sem = new SemaphoreSlim(1, 1);
+            return sem;
+        }
+    }
+
+    private async Task<IReadOnlyList<LiveSessionRef>?> FetchLiveSessionsAsync(CancellationToken ct)
+        => LiveSessionsProvider is { } provider ? await provider(ct) : null;
+
+    private async Task DrainDeferredRecomputesAsync(CancellationToken ct)
+    {
+        List<string> deferred;
+        lock (_gate)
+        {
+            if (_deferredRecomputes.Count == 0)
+                return;
+            deferred = _deferredRecomputes.Values.ToList();
+            _deferredRecomputes.Clear();
+        }
+        FileLog.Write($"[RepositoryMonitor] running {deferred.Count} recompute(s) deferred during the scan");
+        foreach (var path in deferred)
+        {
+            try
+            {
+                await RecomputeOneAsync(path, ct);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[RepositoryMonitor] deferred recompute FAILED for {path}: {ex.Message}");
+            }
+        }
     }
 
     /// <summary>
@@ -282,4 +389,21 @@ public sealed class RepositoryMonitor
 
     private static async Task<RepositoryStatus> DefaultCompute(string path, IReadOnlyList<LiveSessionRef>? sessions, CancellationToken ct)
         => await new RepositoryStatusService().GetStatusAsync(path, sessions, fetchPrune: false, ct);
+
+    /// <summary>
+    /// The primary checkout owning a linked worktree: git names the shared .git directory via
+    /// rev-parse --git-common-dir; its parent is the primary working tree. Null when git cannot
+    /// answer (not a repository, or a bare repository with no primary checkout).
+    /// </summary>
+    private static async Task<string?> DefaultResolvePrimary(string path, CancellationToken ct)
+    {
+        var result = await new GitCommandRunner().RunAsync(
+            path, new[] { "rev-parse", "--path-format=absolute", "--git-common-dir" }, ct);
+        if (!result.Success || string.IsNullOrWhiteSpace(result.Output))
+            return null;
+        var commonDir = result.Output.Trim();
+        if (!string.Equals(Path.GetFileName(commonDir.TrimEnd('/', '\\')), ".git", StringComparison.OrdinalIgnoreCase))
+            return null; // bare repository - no primary working tree
+        return Path.GetDirectoryName(commonDir.TrimEnd('/', '\\'));
+    }
 }

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -212,6 +212,13 @@ public sealed class RepositoryMonitor
                     seen.Add(key);
                     lock (_gate)
                     {
+                        // A cancelled or superseded scan never publishes (ruling R2-2):
+                        // cancellation can land in the narrow interval after the compute
+                        // returned, and the next loop iteration's check is too late. Re-check
+                        // the token AND that this scan still owns the model, under the gate,
+                        // before writing anything.
+                        if (ct.IsCancellationRequested || !ReferenceEquals(_cts, cts))
+                            throw new OperationCanceledException(ct);
                         published = PublishIfNewestLocked(key, status, computeStamp);
                         ScanDone++;
                     }
@@ -229,6 +236,10 @@ public sealed class RepositoryMonitor
             List<RepositoryStatus> removed;
             lock (_gate)
             {
+                // Same rule at the reconcile (ruling R2-2): only the owning, uncancelled scan
+                // may remove entries - a superseded scan's roots are not the truth any more.
+                if (ct.IsCancellationRequested || !ReferenceEquals(_cts, cts))
+                    throw new OperationCanceledException(ct);
                 removed = _byPath.Where(kv => !seen.Contains(kv.Key)).Select(kv => kv.Value).ToList();
                 foreach (var r in removed)
                 {

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -219,6 +219,10 @@ public sealed class RepositoryMonitor
 
             // Persist the verified model so the next launch warm-starts.
             SaveCache();
+
+            // The size cache only stays meaningful for worktrees that still exist: evict entries
+            // this completed scan did not see (reaped, moved, or deleted worktrees).
+            RepositoryStatusService.EvictSizeCacheExcept(CurrentWorktreePaths());
         }
         catch (OperationCanceledException)
         {
@@ -330,6 +334,12 @@ public sealed class RepositoryMonitor
 
     private async Task<IReadOnlyList<LiveSessionRef>?> FetchLiveSessionsAsync(CancellationToken ct)
         => LiveSessionsProvider is { } provider ? await provider(ct) : null;
+
+    private IReadOnlyList<string> CurrentWorktreePaths()
+    {
+        lock (_gate)
+            return _byPath.Values.SelectMany(s => s.Worktrees).Select(w => w.Path).ToList();
+    }
 
     private async Task DrainDeferredRecomputesAsync(CancellationToken ct)
     {

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -336,12 +336,12 @@ public sealed class RepositoryMonitor
             lock (_gate)
             {
                 if (_byPath.TryGetValue(key, out gone))
-                {
                     _byPath.Remove(key);
-                    // A removal is a publish of "absent" (ruling R2-5): stamp it so an older
-                    // compute still in flight cannot publish late and resurrect the entry.
-                    _publishStamps[key] = NextComputeStampLocked();
-                }
+                // Absence is ALWAYS stamped (ruling R3-4a) - whether or not a model row exists.
+                // A FIRST-TIME compute can be in flight for this key with no row published yet;
+                // without a tombstone its later publish would create the very repository this
+                // newer check just saw vanish. A removal is a publish of "absent" (ruling R2-5).
+                _publishStamps[key] = NextComputeStampLocked();
             }
             if (gone != null)
             {
@@ -415,7 +415,9 @@ public sealed class RepositoryMonitor
     ///
     /// Publish stamps are evicted for keys neither in the model nor removed by THIS scan: a
     /// removal stamp must survive until the next completed scan so it can still drop a late
-    /// publish from a compute that started before the removal.
+    /// publish from a compute that started before the removal. A stamp whose key's semaphore is
+    /// currently HELD is never evicted (ruling R3-4b) - the held semaphore proves a compute is
+    /// still in flight, and its tombstone must outlive that compute whatever the scan count.
     /// </summary>
     private void EvictStaleComputeState(IReadOnlySet<string> removedThisScan)
     {
@@ -434,6 +436,12 @@ public sealed class RepositoryMonitor
             foreach (var key in _publishStamps.Keys.ToList())
             {
                 if (_byPath.ContainsKey(key) || removedThisScan.Contains(key))
+                    continue;
+                // A held semaphore is proof a compute is still in flight for this key (ruling
+                // R3-4b): its stamp - a removal tombstone in particular - must survive until
+                // that compute has published and been dropped, however many scans complete in
+                // between. Eviction never removes stamp state out from under a live compute.
+                if (_repoLocks.TryGetValue(key, out var heldCheck) && heldCheck.CurrentCount == 0)
                     continue;
                 _publishStamps.Remove(key);
                 evictedStamps++;

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -76,10 +76,22 @@ public sealed class RepositoryMonitor
 
     /// <summary>
     /// THE live-session source for every compute this monitor runs - full scans and single-repository
-    /// recomputes alike. Wired once at startup by the host (the same source the panels use). When it
-    /// is null the computes run without session data (no host wired one up yet).
+    /// recomputes alike. The host MUST wire it before the first scan (ruling R2-8): scanning without
+    /// a session source would silently publish session-blind safety classifications, so
+    /// <see cref="RescanAsync"/> and <see cref="RecomputeOneAsync"/> throw while it is null - a
+    /// programming error fails loudly instead of degrading.
     /// </summary>
     public Func<CancellationToken, Task<IReadOnlyList<LiveSessionRef>>>? LiveSessionsProvider { get; set; }
+
+    /// <summary>Fails loudly when no live-session source is wired (ruling R2-8).</summary>
+    private void RequireLiveSessionsProvider(string operation)
+    {
+        if (LiveSessionsProvider is null)
+            throw new InvalidOperationException(
+                $"RepositoryMonitor.{operation} requires a LiveSessionsProvider - scanning without a " +
+                "session source would publish session-blind safety classifications. Wire the provider " +
+                "before triggering any scan or recompute.");
+    }
 
     public RepositoryMonitor(
         Func<IEnumerable<string>, IReadOnlyList<string>>? enumerate = null,
@@ -179,6 +191,7 @@ public sealed class RepositoryMonitor
     /// </summary>
     public async Task RescanAsync(IEnumerable<string> roots, CancellationToken externalCt = default)
     {
+        RequireLiveSessionsProvider(nameof(RescanAsync));
         CancellationTokenSource cts;
         lock (_gate)
         {
@@ -289,6 +302,7 @@ public sealed class RepositoryMonitor
     /// </summary>
     public async Task RecomputeOneAsync(string repoPath, CancellationToken ct = default)
     {
+        RequireLiveSessionsProvider(nameof(RecomputeOneAsync));
         lock (_gate)
         {
             if (IsScanning)
@@ -412,7 +426,13 @@ public sealed class RepositoryMonitor
     }
 
     private async Task<IReadOnlyList<LiveSessionRef>?> FetchLiveSessionsAsync(CancellationToken ct)
-        => LiveSessionsProvider is { } provider ? await provider(ct) : null;
+    {
+        // The entry points already refused to start unwired (ruling R2-8); this guard keeps the
+        // failure loud even if the provider were unset mid-flight.
+        var provider = LiveSessionsProvider
+            ?? throw new InvalidOperationException("RepositoryMonitor lost its LiveSessionsProvider mid-compute");
+        return await provider(ct);
+    }
 
     private IReadOnlyList<string> CurrentWorktreePaths()
     {

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -215,6 +215,7 @@ public sealed class RepositoryMonitor
         ProgressChanged?.Invoke();
         FileLog.Write($"[RepositoryMonitor] rescan started: {paths.Count} repositories");
 
+        bool completed = false;
         try
         {
             foreach (var path in paths)
@@ -293,24 +294,41 @@ public sealed class RepositoryMonitor
                 removed.Select(r => WorktreeReaperService.NormalizePath(r.Path)),
                 StringComparer.OrdinalIgnoreCase);
             EvictStaleComputeState(removedThisScan);
+            completed = true;
         }
         catch (OperationCanceledException)
         {
             FileLog.Write("[RepositoryMonitor] rescan superseded/cancelled");
-            return; // a newer scan owns the model now
         }
         finally
         {
-            lock (_gate) { IsScanning = false; }
-            ProgressChanged?.Invoke();
+            // Scan lifecycle state belongs to the CURRENT scan only (ruling R3-6): ownership is
+            // checked under the gate against the monitor's current cancellation source. A
+            // superseded scan exits without touching IsScanning or progress - its replacement is
+            // still scanning and owns both.
+            bool owner;
+            lock (_gate)
+            {
+                owner = ReferenceEquals(_cts, cts);
+                if (owner)
+                    IsScanning = false;
+            }
+            if (owner)
+            {
+                ProgressChanged?.Invoke();
+                // Deferred requests are drained on EVERY exit path of the OWNING scan (ruling
+                // R3-6) - completed, externally cancelled, or faulted - so a cancelled scan with
+                // no successor never strands them. Each deferred request kept its ORIGINAL
+                // requester's token (ruling R2-5). When a newer scan superseded this one, that
+                // newer scan owns the drain: every one of ITS exit paths runs this same block.
+                await DrainDeferredRecomputesAsync();
+            }
         }
 
+        if (!completed)
+            return; // superseded or cancelled - never reports completion
+
         FileLog.Write($"[RepositoryMonitor] rescan completed: {ScanDone}/{ScanTotal}");
-
-        // Run the single-repository recomputes that arrived while this scan held the model.
-        // Each deferred request kept its ORIGINAL requester's token (ruling R2-5).
-        await DrainDeferredRecomputesAsync();
-
         ScanCompleted?.Invoke();
     }
 

--- a/src/CcDirector.Core/Git/RepositoryMonitor.cs
+++ b/src/CcDirector.Core/Git/RepositoryMonitor.cs
@@ -272,6 +272,14 @@ public sealed class RepositoryMonitor
             // The size cache only stays meaningful for worktrees that still exist: evict entries
             // this completed scan did not see (reaped, moved, or deleted worktrees).
             RepositoryStatusService.EvictSizeCacheExcept(CurrentWorktreePaths());
+
+            // Per-repository compute state is evicted alongside it (ruling R2-11): semaphores
+            // and stale publish stamps for keys no longer in the model would otherwise
+            // accumulate for the process lifetime.
+            var removedThisScan = new HashSet<string>(
+                removed.Select(r => WorktreeReaperService.NormalizePath(r.Path)),
+                StringComparer.OrdinalIgnoreCase);
+            EvictStaleComputeState(removedThisScan);
         }
         catch (OperationCanceledException)
         {
@@ -393,6 +401,53 @@ public sealed class RepositoryMonitor
                 _repoLocks[key] = sem = new SemaphoreSlim(1, 1);
             return sem;
         }
+    }
+
+    /// <summary>
+    /// Evicts per-repository compute state after a completed scan (ruling R2-11): a semaphore is
+    /// removed when its key is no longer in the model AND it is currently un-held (a held one has
+    /// a compute in flight and is kept). Accepted and documented crossover: a compute that still
+    /// holds a REFERENCE to an evicted semaphore while the same key is re-created briefly gives
+    /// that key two semaphores - single-flight degrades to double-flight for one compute, and the
+    /// publish-stamp rule (R2-5) still guarantees the newest compute start wins. Evicted
+    /// semaphores are not disposed: a stale reference may still be awaited, and an un-disposed
+    /// SemaphoreSlim without a wait handle holds no operating system resources.
+    ///
+    /// Publish stamps are evicted for keys neither in the model nor removed by THIS scan: a
+    /// removal stamp must survive until the next completed scan so it can still drop a late
+    /// publish from a compute that started before the removal.
+    /// </summary>
+    private void EvictStaleComputeState(IReadOnlySet<string> removedThisScan)
+    {
+        lock (_gate)
+        {
+            int evictedLocks = 0, evictedStamps = 0;
+            foreach (var key in _repoLocks.Keys.ToList())
+            {
+                if (_byPath.ContainsKey(key))
+                    continue;
+                if (_repoLocks[key].CurrentCount == 0)
+                    continue; // held - a compute is in flight for this key right now
+                _repoLocks.Remove(key);
+                evictedLocks++;
+            }
+            foreach (var key in _publishStamps.Keys.ToList())
+            {
+                if (_byPath.ContainsKey(key) || removedThisScan.Contains(key))
+                    continue;
+                _publishStamps.Remove(key);
+                evictedStamps++;
+            }
+            if (evictedLocks > 0 || evictedStamps > 0)
+                FileLog.Write($"[RepositoryMonitor] evicted compute state for departed repositories: {evictedLocks} semaphore(s), {evictedStamps} stamp(s)");
+        }
+    }
+
+    /// <summary>Test probe: whether a per-repository semaphore exists for this path.</summary>
+    internal bool RepoLockExistsFor(string path)
+    {
+        lock (_gate)
+            return _repoLocks.ContainsKey(WorktreeReaperService.NormalizePath(path));
     }
 
     /// <summary>The next compute-start stamp. Callers must NOT hold <see cref="_gate"/>.</summary>

--- a/src/CcDirector.Core/Git/RepositoryStatus.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatus.cs
@@ -18,10 +18,11 @@ public enum RepoProvider
 
 /// <summary>
 /// The at-a-glance state of one on-disk repository: where its remote lives, how far its branch has
-/// drifted, how much is uncommitted, and a summary of its worktrees. Composed on the service side
-/// from the existing git providers plus the worktree detector; the UI renders it.
+/// drifted, how much is uncommitted, and its worktrees. Composed on the service side from the
+/// existing git providers plus the worktree detector; the UI renders it. A record so the monitor
+/// can derive updated copies (dirty-since carry-forward, provisional marking) without mutation.
 /// </summary>
-public sealed class RepositoryStatus
+public sealed record RepositoryStatus
 {
     public string Path { get; init; } = "";
     public string Name { get; init; } = "";
@@ -55,6 +56,28 @@ public sealed class RepositoryStatus
     public int WorktreesSafeToReap { get; init; }
     public int WorktreesInUse { get; init; }
     public int WorktreesNeedAttention { get; init; }
+
+    /// <summary>
+    /// The full worktree records (verdicts, sizes, ages) so every surface - the Repositories home,
+    /// the per-session Source Control tab, the Gateway push - renders from ONE model (the one-brain
+    /// rule). Excludes the primary checkout.
+    /// </summary>
+    public IReadOnlyList<WorktreeInfo> Worktrees { get; init; } = Array.Empty<WorktreeInfo>();
+
+    /// <summary>Total bytes held by linked worktrees - the reclaim opportunity ceiling.</summary>
+    public long WorktreeBytes { get; init; }
+
+    /// <summary>
+    /// When the tree FIRST became dirty (UTC), carried forward by the monitor across scans so the
+    /// "uncommitted work sitting for N days" signal survives restarts via the cache. Null when clean.
+    /// </summary>
+    public DateTime? DirtySinceUtc { get; init; }
+
+    /// <summary>
+    /// True when this entry came from the warm-start cache and has not yet been re-verified by a
+    /// live scan. Provisional entries are shown dimmed ("verifying") and never acted on.
+    /// </summary>
+    public bool Provisional { get; init; }
 
     public bool Success { get; init; }
     public string? Error { get; init; }

--- a/src/CcDirector.Core/Git/RepositoryStatusService.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatusService.cs
@@ -88,7 +88,7 @@ public sealed class RepositoryStatusService
             // every surface renders from this one model, and "reap N GB" is quoted from it.
             var worktrees = inventory.Worktrees
                 .Where(w => !w.IsPrimary)
-                .Select(w => w with { SizeBytes = MeasureWorktreeBytes(w) })
+                .Select(w => w with { SizeBytes = MeasureWorktreeBytes(w, ct) })
                 .ToList();
 
             return new RepositoryStatus
@@ -115,6 +115,12 @@ public sealed class RepositoryStatusService
                 Success = true,
             };
         }
+        catch (OperationCanceledException)
+        {
+            // A cancelled compute was superseded - the caller owns that outcome; never fold it
+            // into a failure status.
+            throw;
+        }
         catch (Exception ex)
         {
             FileLog.Write($"[RepositoryStatusService] GetStatusAsync FAILED: {ex.Message}");
@@ -128,7 +134,12 @@ public sealed class RepositoryStatusService
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (DateTime? Stamp, long Bytes)> SizeCache
         = new(StringComparer.OrdinalIgnoreCase);
 
-    private static long? MeasureWorktreeBytes(WorktreeInfo w)
+    /// <summary>
+    /// Measures a worktree's on-disk size, honoring cancellation DURING the walk: a superseded
+    /// compute stops immediately and stores nothing. Deliberately no file caps or byte budgets -
+    /// a silently truncated size would be a lie; either the walk finishes or it is cancelled.
+    /// </summary>
+    internal static long? MeasureWorktreeBytes(WorktreeInfo w, CancellationToken ct)
     {
         try
         {
@@ -148,12 +159,17 @@ public sealed class RepositoryStatusService
             };
             foreach (var file in Directory.EnumerateFiles(w.Path, "*", options))
             {
+                ct.ThrowIfCancellationRequested();
                 try { bytes += new FileInfo(file).Length; }
                 catch { /* transient file - skip */ }
             }
 
             SizeCache[key] = (w.LastActivityUtc, bytes);
             return bytes;
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // a partial measurement is never stored or returned
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Core/Git/RepositoryStatusService.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatusService.cs
@@ -84,6 +84,13 @@ public sealed class RepositoryStatusService
             var inUse = inventory.InUseBySession.Count;
             var needs = inventory.NeedsAttention.Count;
 
+            // Carry the full (non-primary) worktree records on the status, with measured sizes -
+            // every surface renders from this one model, and "reap N GB" is quoted from it.
+            var worktrees = inventory.Worktrees
+                .Where(w => !w.IsPrimary)
+                .Select(w => w with { SizeBytes = MeasureWorktreeBytes(w) })
+                .ToList();
+
             return new RepositoryStatus
             {
                 Path = repoPath,
@@ -103,6 +110,8 @@ public sealed class RepositoryStatusService
                 WorktreesSafeToReap = safe,
                 WorktreesInUse = inUse,
                 WorktreesNeedAttention = needs,
+                Worktrees = worktrees,
+                WorktreeBytes = worktrees.Sum(w => w.SizeBytes ?? 0),
                 Success = true,
             };
         }
@@ -110,6 +119,46 @@ public sealed class RepositoryStatusService
         {
             FileLog.Write($"[RepositoryStatusService] GetStatusAsync FAILED: {ex.Message}");
             return new RepositoryStatus { Path = repoPath, Success = false, Error = ex.Message };
+        }
+    }
+
+    // Size measurements are a full directory walk, so they are cached per worktree and re-measured
+    // only when the worktree's last activity changes. Process-wide: the monitor, the per-session
+    // tab, and the watcher all share one measurement.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (DateTime? Stamp, long Bytes)> SizeCache
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    private static long? MeasureWorktreeBytes(WorktreeInfo w)
+    {
+        try
+        {
+            var key = WorktreeReaperService.NormalizePath(w.Path);
+            if (SizeCache.TryGetValue(key, out var hit) && hit.Stamp == w.LastActivityUtc)
+                return hit.Bytes;
+
+            if (!Directory.Exists(w.Path))
+                return null;
+
+            long bytes = 0;
+            var options = new EnumerationOptions
+            {
+                RecurseSubdirectories = true,
+                IgnoreInaccessible = true,
+                AttributesToSkip = FileAttributes.ReparsePoint, // never follow junctions/symlinks
+            };
+            foreach (var file in Directory.EnumerateFiles(w.Path, "*", options))
+            {
+                try { bytes += new FileInfo(file).Length; }
+                catch { /* transient file - skip */ }
+            }
+
+            SizeCache[key] = (w.LastActivityUtc, bytes);
+            return bytes;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryStatusService] MeasureWorktreeBytes failed for {w.Path}: {ex.Message}");
+            return null;
         }
     }
 

--- a/src/CcDirector.Core/Git/RepositoryStatusService.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatusService.cs
@@ -138,6 +138,14 @@ public sealed class RepositoryStatusService
     /// Measures a worktree's on-disk size, honoring cancellation DURING the walk: a superseded
     /// compute stops immediately and stores nothing. Deliberately no file caps or byte budgets -
     /// a silently truncated size would be a lie; either the walk finishes or it is cancelled.
+    ///
+    /// KNOWN LIMITATION (inspection round 2, ruling R2-10 - accepted, no further code change):
+    /// cancellation is honored once per enumerated file, but a single blocked filesystem call
+    /// INSIDE Directory.EnumerateFiles - a stalled enumeration advancing to its next result, a
+    /// blocked metadata read - cannot be interrupted by any token. Bounding it would require a
+    /// timeout, and a timeout that silently truncates a size is exactly the lie the no-fallback
+    /// rule forbids. The compute runs on a background thread, so a blocked walk delays model
+    /// freshness for that repository; it never blocks the user interface.
     /// </summary>
     internal static long? MeasureWorktreeBytes(WorktreeInfo w, CancellationToken ct)
     {

--- a/src/CcDirector.Core/Git/RepositoryStatusService.cs
+++ b/src/CcDirector.Core/Git/RepositoryStatusService.cs
@@ -178,6 +178,30 @@ public sealed class RepositoryStatusService
         }
     }
 
+    /// <summary>
+    /// Evicts every cached size whose worktree path is not in <paramref name="worktreePathsSeen"/>.
+    /// Called by the monitor after each completed scan, so entries for reaped, moved, or deleted
+    /// worktrees do not accumulate forever in the process-wide cache.
+    /// </summary>
+    internal static void EvictSizeCacheExcept(IEnumerable<string> worktreePathsSeen)
+    {
+        var keep = new HashSet<string>(
+            worktreePathsSeen.Select(WorktreeReaperService.NormalizePath),
+            StringComparer.OrdinalIgnoreCase);
+        int evicted = 0;
+        foreach (var key in SizeCache.Keys)
+        {
+            if (!keep.Contains(key) && SizeCache.TryRemove(key, out _))
+                evicted++;
+        }
+        if (evicted > 0)
+            FileLog.Write($"[RepositoryStatusService] size cache: evicted {evicted} entr{(evicted == 1 ? "y" : "ies")} for worktrees no longer present");
+    }
+
+    /// <summary>Test probe: whether a size measurement is cached for this worktree path.</summary>
+    internal static bool SizeCacheContains(string worktreePath)
+        => SizeCache.ContainsKey(WorktreeReaperService.NormalizePath(worktreePath));
+
     /// <summary>Classifies an origin remote URL into a provider and its owner/org. Pure and testable.</summary>
     internal static (RepoProvider Provider, string? Org) ClassifyRemote(string? remoteUrl)
     {

--- a/src/CcDirector.Core/Git/RepositoryWatcher.cs
+++ b/src/CcDirector.Core/Git/RepositoryWatcher.cs
@@ -1,0 +1,192 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Watches the registered root directories and each known repository's git-state signals, and asks
+/// the <see cref="RepositoryMonitor"/> to recompute ONLY the affected repository - so after the
+/// first scan the model stays current by reacting to change instead of re-scanning everything
+/// (issue devthrottle_internal#510, phase A).
+///
+/// Deliberately narrow watch set:
+/// - each ROOT, non-recursive, directory events only: a repo folder appearing or vanishing;
+/// - each repo's .git, recursive, but FILTERED to HEAD, packed-refs, refs/, logs/HEAD, and
+///   worktrees/ - the signals that change repo/worktree state.
+/// It deliberately IGNORES .git/index and .git/objects: our own status scans touch the index, so
+/// watching it would feed the watcher its own echo, and object writes are covered by the reflog.
+/// Working-tree files are never watched (builds and node_modules would flood us).
+///
+/// Events are debounced per repository (a burst collapses to one recompute).
+/// </summary>
+public sealed class RepositoryWatcher : IDisposable
+{
+    private static readonly TimeSpan Debounce = TimeSpan.FromSeconds(2);
+
+    private readonly RepositoryMonitor _monitor;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, FileSystemWatcher> _rootWatchers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, FileSystemWatcher> _repoWatchers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, CancellationTokenSource> _pending = new(StringComparer.OrdinalIgnoreCase);
+    private bool _disposed;
+
+    /// <summary>Raised after a debounced change triggered a recompute (test observability).</summary>
+    public event Action<string>? Recomputed;
+
+    public RepositoryWatcher(RepositoryMonitor monitor)
+    {
+        _monitor = monitor;
+    }
+
+    /// <summary>
+    /// Bring the watch set in line with the current roots and known repositories. Idempotent - call
+    /// after every completed scan; new repos gain a watcher, vanished ones lose theirs.
+    /// </summary>
+    public void SyncWatches(IEnumerable<string> roots, IEnumerable<string> repoPaths)
+    {
+        if (_disposed) return;
+        lock (_gate)
+        {
+            var wantedRoots = roots.Where(Directory.Exists).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var wantedRepos = repoPaths.Where(Directory.Exists).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var stale in _rootWatchers.Keys.Where(k => !wantedRoots.Contains(k)).ToList())
+            {
+                _rootWatchers[stale].Dispose();
+                _rootWatchers.Remove(stale);
+            }
+            foreach (var stale in _repoWatchers.Keys.Where(k => !wantedRepos.Contains(k)).ToList())
+            {
+                _repoWatchers[stale].Dispose();
+                _repoWatchers.Remove(stale);
+            }
+
+            foreach (var root in wantedRoots.Where(r => !_rootWatchers.ContainsKey(r)))
+            {
+                try { _rootWatchers[root] = CreateRootWatcher(root); }
+                catch (Exception ex) { FileLog.Write($"[RepositoryWatcher] root watch failed for {root}: {ex.Message}"); }
+            }
+            foreach (var repo in wantedRepos.Where(r => !_repoWatchers.ContainsKey(r)))
+            {
+                var gitDir = Path.Combine(repo, ".git");
+                if (!Directory.Exists(gitDir))
+                    continue; // a worktree-style .git FILE has its real state under the primary's .git
+                try { _repoWatchers[repo] = CreateGitWatcher(repo, gitDir); }
+                catch (Exception ex) { FileLog.Write($"[RepositoryWatcher] git watch failed for {repo}: {ex.Message}"); }
+            }
+
+            FileLog.Write($"[RepositoryWatcher] watching {_rootWatchers.Count} roots, {_repoWatchers.Count} repositories");
+        }
+    }
+
+    private FileSystemWatcher CreateRootWatcher(string root)
+    {
+        var w = new FileSystemWatcher(root)
+        {
+            NotifyFilter = NotifyFilters.DirectoryName,
+            IncludeSubdirectories = false,
+            EnableRaisingEvents = true,
+        };
+        void OnDir(object _, FileSystemEventArgs e) => Schedule(Path.Combine(root, Path.GetFileName(e.Name ?? "")));
+        w.Created += OnDir;
+        w.Deleted += OnDir;
+        w.Renamed += (_, e) =>
+        {
+            Schedule(Path.Combine(root, Path.GetFileName(e.OldName ?? "")));
+            Schedule(Path.Combine(root, Path.GetFileName(e.Name ?? "")));
+        };
+        return w;
+    }
+
+    private FileSystemWatcher CreateGitWatcher(string repoPath, string gitDir)
+    {
+        var w = new FileSystemWatcher(gitDir)
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.LastWrite,
+            IncludeSubdirectories = true,
+            EnableRaisingEvents = true,
+        };
+        void OnGit(object _, FileSystemEventArgs e)
+        {
+            if (IsSignal(e.Name))
+                Schedule(repoPath);
+        }
+        w.Created += OnGit;
+        w.Deleted += OnGit;
+        w.Changed += OnGit;
+        w.Renamed += (_, e) => { if (IsSignal(e.Name) || IsSignal(e.OldName)) Schedule(repoPath); };
+        return w;
+    }
+
+    /// <summary>True when a path relative to .git is a state signal we react to. Pure and testable.</summary>
+    internal static bool IsSignal(string? relative)
+    {
+        if (string.IsNullOrEmpty(relative))
+            return false;
+        var p = relative.Replace('/', '\\');
+        return p.Equals("HEAD", StringComparison.OrdinalIgnoreCase)
+            || p.Equals("packed-refs", StringComparison.OrdinalIgnoreCase)
+            || p.StartsWith("refs\\", StringComparison.OrdinalIgnoreCase)
+            || p.Equals("logs\\HEAD", StringComparison.OrdinalIgnoreCase)
+            || p.StartsWith("worktrees\\", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Debounced per-repo: a burst of events collapses into one recompute.</summary>
+    private void Schedule(string repoPath)
+    {
+        if (_disposed || string.IsNullOrWhiteSpace(repoPath))
+            return;
+        var key = WorktreeReaperService.NormalizePath(repoPath);
+        CancellationTokenSource cts;
+        lock (_gate)
+        {
+            if (_pending.TryGetValue(key, out var old))
+                old.Cancel();
+            cts = new CancellationTokenSource();
+            _pending[key] = cts;
+        }
+        _ = DebouncedRecomputeAsync(repoPath, key, cts);
+    }
+
+    private async Task DebouncedRecomputeAsync(string repoPath, string key, CancellationTokenSource cts)
+    {
+        try
+        {
+            await Task.Delay(Debounce, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // superseded by a newer event for the same repo
+        }
+
+        lock (_gate)
+        {
+            if (_pending.TryGetValue(key, out var current) && current == cts)
+                _pending.Remove(key);
+        }
+
+        try
+        {
+            FileLog.Write($"[RepositoryWatcher] change settled - recomputing {repoPath}");
+            await _monitor.RecomputeOneAsync(repoPath);
+            Recomputed?.Invoke(repoPath);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepositoryWatcher] recompute failed for {repoPath}: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            foreach (var w in _rootWatchers.Values) w.Dispose();
+            foreach (var w in _repoWatchers.Values) w.Dispose();
+            _rootWatchers.Clear();
+            _repoWatchers.Clear();
+            foreach (var c in _pending.Values) c.Cancel();
+            _pending.Clear();
+        }
+    }
+}

--- a/src/CcDirector.Core/Git/WorktreeInventoryService.cs
+++ b/src/CcDirector.Core/Git/WorktreeInventoryService.cs
@@ -105,10 +105,16 @@ public sealed class WorktreeInventoryService
             }
             else if (entry.Branch != null)
             {
-                // C2: has the origin branch been deleted (after the prune above)?
+                // C2: has the origin branch been deleted (after the prune above)? "Gone" only means
+                // "merged" when the branch was ON origin in the first place - a never-pushed branch
+                // has no origin branch, and treating that absence as proof-of-merge would mark
+                // unpushed work safe to delete. Require a configured upstream before C2 counts.
+                var upstream = await _git.RunAsync(repositoryPath, new[] { "config", "--get", $"branch.{entry.Branch}.merge" }, ct);
+                bool hadUpstream = upstream.Success && !string.IsNullOrWhiteSpace(upstream.Output);
+
                 var lsRemote = await _git.RunAsync(repositoryPath, new[] { "ls-remote", "--heads", "origin", entry.Branch }, ct);
                 inspectionOk &= lsRemote.Success;
-                originGone = lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
+                originGone = hadUpstream && lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
 
                 // C3: does the branch add anything origin/main lacks? git cherry marks such commits with '+'.
                 var cherry = await _git.RunAsync(repositoryPath, new[] { "cherry", mainRef, entry.Branch }, ct);

--- a/src/CcDirector.Core/Git/WorktreeInventoryService.cs
+++ b/src/CcDirector.Core/Git/WorktreeInventoryService.cs
@@ -105,16 +105,14 @@ public sealed class WorktreeInventoryService
             }
             else if (entry.Branch != null)
             {
-                // C2: has the origin branch been deleted (after the prune above)? "Gone" only means
-                // "merged" when the branch was ON origin in the first place - a never-pushed branch
-                // has no origin branch, and treating that absence as proof-of-merge would mark
-                // unpushed work safe to delete. Require a configured upstream before C2 counts.
-                var upstream = await _git.RunAsync(repositoryPath, new[] { "config", "--get", $"branch.{entry.Branch}.merge" }, ct);
-                bool hadUpstream = upstream.Success && !string.IsNullOrWhiteSpace(upstream.Output);
-
-                var lsRemote = await _git.RunAsync(repositoryPath, new[] { "ls-remote", "--heads", "origin", entry.Branch }, ct);
-                inspectionOk &= lsRemote.Success;
-                originGone = hadUpstream && lsRemote.Success && string.IsNullOrWhiteSpace(lsRemote.Output);
+                // C2: has the CONFIGURED upstream been deleted (after the prune above)? "Gone" only
+                // means "merged" when the branch had a configured upstream in the first place - a
+                // never-pushed branch has no upstream, and treating that absence as proof-of-merge
+                // would mark unpushed work safe to delete. The probe asks the configured remote for
+                // the configured ref name, both of which can differ from origin/<local-name>.
+                var upstream = await ConfiguredUpstreamProbe.ProbeAsync(_git, repositoryPath, entry.Branch, ct);
+                inspectionOk &= upstream.InspectionSucceeded;
+                originGone = upstream.HasConfiguredUpstream && upstream.UpstreamGone;
 
                 // C3: does the branch add anything origin/main lacks? git cherry marks such commits with '+'.
                 var cherry = await _git.RunAsync(repositoryPath, new[] { "cherry", mainRef, entry.Branch }, ct);

--- a/src/CcDirector.Core/Git/WorktreeModels.cs
+++ b/src/CcDirector.Core/Git/WorktreeModels.cs
@@ -134,9 +134,10 @@ public sealed class RawWorktreeEntry
 
 /// <summary>
 /// The full, display-ready record for one worktree: its identity, its dirty/ahead/behind
-/// counts, and the computed safety verdict. The UI renders these verbatim.
+/// counts, and the computed safety verdict. The UI renders these verbatim. A record so services
+/// can derive enriched copies (e.g. stamping the measured size) without mutation.
 /// </summary>
-public sealed class WorktreeInfo
+public sealed record WorktreeInfo
 {
     public string Path { get; init; } = "";
 
@@ -164,6 +165,13 @@ public sealed class WorktreeInfo
 
     /// <summary>Labels of the live sessions running in this worktree (empty when none).</summary>
     public IReadOnlyList<string> OpenSessions { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Size of the worktree folder on disk in bytes, or null when not yet measured. Measured with a
+    /// cached walk (re-measured only when the worktree's last activity changes) because this is what
+    /// "reap and reclaim N GB" is quoted from.
+    /// </summary>
+    public long? SizeBytes { get; init; }
 
     public WorktreeSafety Safety { get; init; }
     public WorktreeSafetyReason Reason { get; init; }

--- a/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
@@ -81,4 +81,40 @@ public class FleetWorktreeDto
 
     /// <summary>How old the pushing Director's data is, in seconds, at serve time.</summary>
     public double DataAgeSeconds { get; set; }
+
+    /// <summary>True when the owning repository entry is still verifying (warm-start cache).</summary>
+    public bool Provisional { get; set; }
+}
+
+/// <summary>
+/// The one flatten fold for GET /worktrees rows, shared by the Gateway and the Director's local
+/// relay so no surface can flatten its own way. Fail closed: a worktree of a PROVISIONAL
+/// (still-verifying) repository is served as "verifying" - never "safe-to-reap" - because its
+/// verdict is cached, unverified data. Clients and the CLI key off the folded state string and
+/// need no logic of their own (the dumb-client rule).
+/// </summary>
+public static class FleetWorktreeFold
+{
+    /// <summary>The folded state for a worktree whose repository has not been re-verified yet.</summary>
+    public const string VerifyingState = "verifying";
+
+    public static List<FleetWorktreeDto> Flatten(IEnumerable<RepoStatusDto> repositories, double dataAgeSeconds = 0)
+        => repositories
+            .SelectMany(r => r.Worktrees.Select(w => new FleetWorktreeDto
+            {
+                RepoName = r.Name,
+                RepoPath = r.Path,
+                MachineName = r.MachineName,
+                DirectorId = r.DirectorId,
+                Path = w.Path,
+                Branch = w.Branch,
+                State = r.Provisional ? VerifyingState : w.State,
+                Reason = r.Provisional ? "Still verifying this repository - cached data is never acted on." : w.Reason,
+                SessionLabels = w.SessionLabels,
+                SizeBytes = w.SizeBytes,
+                LastActivityUtc = w.LastActivityUtc,
+                DataAgeSeconds = dataAgeSeconds,
+                Provisional = r.Provisional,
+            }))
+            .ToList();
 }

--- a/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
@@ -1,0 +1,84 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One repository on one machine, as pushed by its Director and served fleet-wide by the Gateway
+/// (GET /repositories). The verdict strings are folded on the Director side - clients and agents
+/// render them verbatim (the dumb-client rule). Read-only at the Gateway: any destructive action
+/// runs on the owning Director after a live re-verify (the trust rule).
+/// </summary>
+public class RepoStatusDto
+{
+    public string DirectorId { get; set; } = "";
+    public string MachineName { get; set; } = "";
+    public string Path { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string? RemoteUrl { get; set; }
+
+    /// <summary>"GitHub", "AzureDevOps", "Other", or "None".</summary>
+    public string Provider { get; set; } = "";
+    public string? Org { get; set; }
+
+    public string Branch { get; set; } = "";
+    public bool IsClean { get; set; }
+    public int UncommittedCount { get; set; }
+    public DateTime? DirtySinceUtc { get; set; }
+    public int AheadCount { get; set; }
+    public int BehindCount { get; set; }
+    public int BehindMainCount { get; set; }
+
+    public int WorktreeCount { get; set; }
+    public int WorktreesSafeToReap { get; set; }
+    public int WorktreesInUse { get; set; }
+    public int WorktreesNeedAttention { get; set; }
+    public long WorktreeBytes { get; set; }
+
+    /// <summary>True when the pushing Director had not yet re-verified this entry (warm-start cache).</summary>
+    public bool Provisional { get; set; }
+
+    public List<WorktreeDto> Worktrees { get; set; } = new();
+}
+
+/// <summary>One linked worktree of a repository. State strings are folded by the Director.</summary>
+public class WorktreeDto
+{
+    public string Path { get; set; } = "";
+    public string? Branch { get; set; }
+
+    /// <summary>"safe-to-reap", "in-use", or "needs-attention" - folded, rendered verbatim.</summary>
+    public string State { get; set; } = "";
+
+    /// <summary>The one-line reason for the state, folded by the Director.</summary>
+    public string Reason { get; set; } = "";
+
+    /// <summary>Labels of live sessions working in this worktree (empty when none).</summary>
+    public List<string> SessionLabels { get; set; } = new();
+
+    public long? SizeBytes { get; set; }
+    public DateTime? LastActivityUtc { get; set; }
+    public int AheadOfMain { get; set; }
+    public int BehindMain { get; set; }
+    public int DirtyFileCount { get; set; }
+    public bool IsDetachedHead { get; set; }
+}
+
+/// <summary>
+/// One flattened worktree row for GET /worktrees and `cc-devthrottle worktree list`: the whole
+/// fleet's worktrees, each carrying its repository, machine, verdict, and occupying sessions.
+/// </summary>
+public class FleetWorktreeDto
+{
+    public string RepoName { get; set; } = "";
+    public string RepoPath { get; set; } = "";
+    public string MachineName { get; set; } = "";
+    public string DirectorId { get; set; } = "";
+    public string Path { get; set; } = "";
+    public string? Branch { get; set; }
+    public string State { get; set; } = "";
+    public string Reason { get; set; } = "";
+    public List<string> SessionLabels { get; set; } = new();
+    public long? SizeBytes { get; set; }
+    public DateTime? LastActivityUtc { get; set; }
+
+    /// <summary>How old the pushing Director's data is, in seconds, at serve time.</summary>
+    public double DataAgeSeconds { get; set; }
+}

--- a/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/RepositoryDtos.cs
@@ -98,6 +98,9 @@ public static class FleetWorktreeFold
     /// <summary>The folded state for a worktree whose repository has not been re-verified yet.</summary>
     public const string VerifyingState = "verifying";
 
+    /// <summary>The folded reason for a worktree whose repository has not been re-verified yet.</summary>
+    public const string VerifyingReason = "Still verifying this repository - cached data is never acted on.";
+
     public static List<FleetWorktreeDto> Flatten(IEnumerable<RepoStatusDto> repositories, double dataAgeSeconds = 0)
         => repositories
             .SelectMany(r => r.Worktrees.Select(w => new FleetWorktreeDto
@@ -109,7 +112,7 @@ public static class FleetWorktreeFold
                 Path = w.Path,
                 Branch = w.Branch,
                 State = r.Provisional ? VerifyingState : w.State,
-                Reason = r.Provisional ? "Still verifying this repository - cached data is never acted on." : w.Reason,
+                Reason = r.Provisional ? VerifyingReason : w.Reason,
                 SessionLabels = w.SessionLabels,
                 SizeBytes = w.SizeBytes,
                 LastActivityUtc = w.LastActivityUtc,
@@ -117,4 +120,57 @@ public static class FleetWorktreeFold
                 Provisional = r.Provisional,
             }))
             .ToList();
+
+    /// <summary>
+    /// The one repository-level serve fold (inspection round 2, ruling R2-3): a PROVISIONAL
+    /// repository's safe count serves as ZERO and its nested worktree states serve as
+    /// "verifying", whatever the pushing Director sent - a pre-fix Director can push
+    /// Provisional=true with a stale safe count and stale state strings, and the Gateway owns
+    /// the verdict at serve time. Used by BOTH the Gateway's GET /repositories serve path and
+    /// the Director's outgoing mapper, so no surface can fold its own way. A verified
+    /// repository passes through unchanged. Returns a copy - the cached instance is never
+    /// mutated.
+    /// </summary>
+    public static RepoStatusDto FoldRepositoryForServe(RepoStatusDto r)
+    {
+        if (!r.Provisional)
+            return r;
+        return new RepoStatusDto
+        {
+            DirectorId = r.DirectorId,
+            MachineName = r.MachineName,
+            Path = r.Path,
+            Name = r.Name,
+            RemoteUrl = r.RemoteUrl,
+            Provider = r.Provider,
+            Org = r.Org,
+            Branch = r.Branch,
+            IsClean = r.IsClean,
+            UncommittedCount = r.UncommittedCount,
+            DirtySinceUtc = r.DirtySinceUtc,
+            AheadCount = r.AheadCount,
+            BehindCount = r.BehindCount,
+            BehindMainCount = r.BehindMainCount,
+            WorktreeCount = r.WorktreeCount,
+            WorktreesSafeToReap = 0, // fail closed: unverified work is never reclaimable
+            WorktreesInUse = r.WorktreesInUse,
+            WorktreesNeedAttention = r.WorktreesNeedAttention,
+            WorktreeBytes = r.WorktreeBytes,
+            Provisional = true,
+            Worktrees = r.Worktrees.Select(w => new WorktreeDto
+            {
+                Path = w.Path,
+                Branch = w.Branch,
+                State = VerifyingState,
+                Reason = VerifyingReason,
+                SessionLabels = w.SessionLabels,
+                SizeBytes = w.SizeBytes,
+                LastActivityUtc = w.LastActivityUtc,
+                AheadOfMain = w.AheadOfMain,
+                BehindMain = w.BehindMain,
+                DirtyFileCount = w.DirtyFileCount,
+                IsDetachedHead = w.IsDetachedHead,
+            }).ToList(),
+        };
+    }
 }

--- a/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
@@ -24,6 +24,7 @@ public class PushedRepositoryStoreTests
         var store = new PushedRepositoryStore();
         var tenant = TenantId.Local;
 
+        store.RegisterConnection(tenant, "d1", "conn1");
         Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 1, new[] { Repo("alpha") }));
 
         var fresh = store.TryGetFresh(tenant, "d1", Fresh);
@@ -38,6 +39,7 @@ public class PushedRepositoryStoreTests
         var store = new PushedRepositoryStore();
         var tenant = TenantId.Local;
 
+        store.RegisterConnection(tenant, "d1", "conn1");
         Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 5, new[] { Repo("alpha") }));
         Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 5, new[] { Repo("stale") }));   // duplicate
         Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 3, new[] { Repo("older") }));   // out of order
@@ -47,18 +49,71 @@ public class PushedRepositoryStoreTests
     }
 
     [Fact]
-    public void NewConnection_AlwaysWins_EvenWithALowerSequence()
+    public void NewConnection_AfterTakeover_WinsEvenWithALowerSequence()
     {
-        // A restarted Director begins a new sequence from 1 on a new connection - its snapshot is
-        // authoritative and must replace the old connection's state.
+        // A restarted Director re-Hellos (registering the new connection) and begins a new
+        // sequence from 1 - its snapshot is authoritative and must replace the old state.
         var store = new PushedRepositoryStore();
         var tenant = TenantId.Local;
 
+        store.RegisterConnection(tenant, "d1", "conn1");
         Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 900, new[] { Repo("old") }));
+        store.RegisterConnection(tenant, "d1", "conn2");
         Assert.True(store.ApplySnapshot(tenant, "d1", "conn2", 1, new[] { Repo("fresh") }));
 
         var fresh = store.TryGetFresh(tenant, "d1", Fresh);
         Assert.Equal("fresh", Assert.Single(fresh!.Value.Repositories).Name);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F9): only the CURRENT connection may push. After a new
+    // connection takes over, a late push from the superseded connection is dropped - even at a
+    // higher sequence - so two live connections can never alternate ownership of the store.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void LatePush_FromASupersededConnection_IsRejected()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        store.RegisterConnection(tenant, "d1", "conn1");
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 10, new[] { Repo("old-world") }));
+
+        // The Director reconnects: conn2 is now the current connection.
+        store.RegisterConnection(tenant, "d1", "conn2");
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn2", 1, new[] { Repo("current") }));
+
+        // A late (even higher-sequence) push from the superseded conn1 must be dropped.
+        Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 999, new[] { Repo("stale-late") }));
+
+        var fresh = store.TryGetFresh(tenant, "d1", Fresh);
+        Assert.Equal("current", Assert.Single(fresh!.Value.Repositories).Name);
+    }
+
+    [Fact]
+    public void Push_WithoutARegisteredConnection_IsRejected()
+    {
+        var store = new PushedRepositoryStore();
+        Assert.False(store.ApplySnapshot(TenantId.Local, "d1", "conn1", 1, new[] { Repo("alpha") }));
+        Assert.Null(store.TryGetFresh(TenantId.Local, "d1", Fresh));
+    }
+
+    [Fact]
+    public void Unregister_OnlyClearsTheCurrentConnection()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        store.RegisterConnection(tenant, "d1", "conn1");
+        store.RegisterConnection(tenant, "d1", "conn2");
+
+        // conn1's late disconnect must not clear conn2's ownership.
+        store.UnregisterConnection(tenant, "d1", "conn1");
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn2", 1, new[] { Repo("alpha") }));
+
+        // conn2's own disconnect does clear it - nothing may push afterwards.
+        store.UnregisterConnection(tenant, "d1", "conn2");
+        Assert.False(store.ApplySnapshot(tenant, "d1", "conn2", 2, new[] { Repo("beta") }));
     }
 
     [Fact]
@@ -68,6 +123,8 @@ public class PushedRepositoryStoreTests
         var tenantA = new TenantId("tenant-a");
         var tenantB = new TenantId("tenant-b");
 
+        store.RegisterConnection(tenantA, "dA", "cA");
+        store.RegisterConnection(tenantB, "dB", "cB");
         store.ApplySnapshot(tenantA, "dA", "cA", 1, new[] { Repo("a-repo") });
         store.ApplySnapshot(tenantB, "dB", "cB", 1, new[] { Repo("b-repo") });
 
@@ -85,6 +142,7 @@ public class PushedRepositoryStoreTests
     {
         var store = new PushedRepositoryStore();
         var tenant = TenantId.Local;
+        store.RegisterConnection(tenant, "d1", "conn1");
         store.ApplySnapshot(tenant, "d1", "conn1", 1, new[] { Repo("alpha") });
 
         // With a zero stale window everything is stale immediately.

--- a/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
@@ -1,0 +1,93 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+public class PushedRepositoryStoreTests
+{
+    private static RepoStatusDto Repo(string name, string machine = "M1") => new()
+    {
+        Name = name,
+        Path = $@"D:\repos\{name}",
+        MachineName = machine,
+        DirectorId = "d1",
+        Worktrees = new List<WorktreeDto> { new() { Path = $@"D:\repos\{name}-wt", Branch = "b", State = "safe-to-reap", Reason = "merged" } },
+    };
+
+    private static readonly TimeSpan Fresh = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public void Snapshot_RoundTrips_ForItsTenantAndDirector()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 1, new[] { Repo("alpha") }));
+
+        var fresh = store.TryGetFresh(tenant, "d1", Fresh);
+        Assert.NotNull(fresh);
+        Assert.Equal("alpha", Assert.Single(fresh!.Value.Repositories).Name);
+        Assert.Contains("d1", store.DirectorIdsFor(tenant));
+    }
+
+    [Fact]
+    public void SameConnection_StaleOrDuplicateSequence_IsRejected()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 5, new[] { Repo("alpha") }));
+        Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 5, new[] { Repo("stale") }));   // duplicate
+        Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 3, new[] { Repo("older") }));   // out of order
+
+        var fresh = store.TryGetFresh(tenant, "d1", Fresh);
+        Assert.Equal("alpha", Assert.Single(fresh!.Value.Repositories).Name); // the accepted one survived
+    }
+
+    [Fact]
+    public void NewConnection_AlwaysWins_EvenWithALowerSequence()
+    {
+        // A restarted Director begins a new sequence from 1 on a new connection - its snapshot is
+        // authoritative and must replace the old connection's state.
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 900, new[] { Repo("old") }));
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn2", 1, new[] { Repo("fresh") }));
+
+        var fresh = store.TryGetFresh(tenant, "d1", Fresh);
+        Assert.Equal("fresh", Assert.Single(fresh!.Value.Repositories).Name);
+    }
+
+    [Fact]
+    public void TenantPartition_NeitherDirectionLeaks()
+    {
+        var store = new PushedRepositoryStore();
+        var tenantA = new TenantId("tenant-a");
+        var tenantB = new TenantId("tenant-b");
+
+        store.ApplySnapshot(tenantA, "dA", "cA", 1, new[] { Repo("a-repo") });
+        store.ApplySnapshot(tenantB, "dB", "cB", 1, new[] { Repo("b-repo") });
+
+        // A sees only A's directors and repos; B only B's - the neighbour probe in both directions.
+        Assert.Equal(new[] { "dA" }, store.DirectorIdsFor(tenantA));
+        Assert.Equal(new[] { "dB" }, store.DirectorIdsFor(tenantB));
+        Assert.Null(store.TryGetFresh(tenantA, "dB", Fresh));
+        Assert.Null(store.TryGetFresh(tenantB, "dA", Fresh));
+        Assert.Equal("a-repo", Assert.Single(store.TryGetFresh(tenantA, "dA", Fresh)!.Value.Repositories).Name);
+        Assert.Equal("b-repo", Assert.Single(store.TryGetFresh(tenantB, "dB", Fresh)!.Value.Repositories).Name);
+    }
+
+    [Fact]
+    public void StaleData_IsWithheld_NotServed()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+        store.ApplySnapshot(tenant, "d1", "conn1", 1, new[] { Repo("alpha") });
+
+        // With a zero stale window everything is stale immediately.
+        Assert.Null(store.TryGetFresh(tenant, "d1", TimeSpan.Zero));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedRepositoryStoreTests.cs
@@ -90,6 +90,30 @@ public class PushedRepositoryStoreTests
         Assert.Equal("current", Assert.Single(fresh!.Value.Repositories).Name);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-4): a REPEATED Hello from the SAME connection
+    // must not reset the sequence baseline - otherwise a duplicate Hello lets an older
+    // sequence replay over newer data. The baseline resets only when ownership actually
+    // changes to a different connection.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void RepeatedHello_OnTheSameConnection_KeepsTheSequenceBaseline()
+    {
+        var store = new PushedRepositoryStore();
+        var tenant = TenantId.Local;
+
+        store.RegisterConnection(tenant, "d1", "conn1");
+        Assert.True(store.ApplySnapshot(tenant, "d1", "conn1", 100, new[] { Repo("newest") }));
+
+        // The same connection says Hello again - the baseline must survive.
+        store.RegisterConnection(tenant, "d1", "conn1");
+
+        Assert.False(store.ApplySnapshot(tenant, "d1", "conn1", 50, new[] { Repo("replayed") }));
+
+        var fresh = store.TryGetFresh(tenant, "d1", Fresh);
+        Assert.Equal("newest", Assert.Single(fresh!.Value.Repositories).Name); // no replay landed
+    }
+
     [Fact]
     public void Push_WithoutARegisteredConnection_IsRejected()
     {

--- a/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
@@ -1,0 +1,108 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+public sealed class RepoHistoryStoreTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), "ccd-repohist-" + Guid.NewGuid().ToString("N") + ".jsonl");
+
+    public void Dispose()
+    {
+        if (File.Exists(_path)) File.Delete(_path);
+    }
+
+    private static RepoStatusDto Repo(string name, int worktrees = 0, int safe = 0, long bytes = 0,
+        int uncommitted = 0, DateTime? dirtySince = null, bool provisional = false) => new()
+    {
+        Name = name,
+        MachineName = "M1",
+        Path = $@"D:\repos\{name}",
+        WorktreeCount = worktrees,
+        WorktreesSafeToReap = safe,
+        WorktreeBytes = bytes,
+        UncommittedCount = uncommitted,
+        IsClean = uncommitted == 0,
+        DirtySinceUtc = dirtySince,
+        Provisional = provisional,
+    };
+
+    [Fact]
+    public void Observe_IsIdempotentPerDay_LastWriteWins_AndPersists()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 23);
+
+        var store = new RepoHistoryStore(_path);
+        store.ObserveSnapshot(tenant, new[] { Repo("a", worktrees: 6, safe: 2) }, day);
+        store.ObserveSnapshot(tenant, new[] { Repo("a", worktrees: 4, safe: 1) }, day); // same day again
+
+        // A fresh store (new process) reads the persisted file: one row for the day, the LAST values.
+        var reloaded = new RepoHistoryStore(_path);
+        var trends = reloaded.WeeklyTrends(tenant, weeks: 1, today: day);
+        Assert.Equal(4, trends[^1].MaxWorktrees);
+        Assert.Equal(1, trends[^1].MaxSafeToReap);
+    }
+
+    [Fact]
+    public void WeeklyTrends_PeaksPerWeek_AndEmptyWeeksAreZero()
+    {
+        var tenant = TenantId.Local;
+        var store = new RepoHistoryStore(_path);
+        var monday = new DateOnly(2026, 07, 20); // a Monday
+
+        // Two weeks ago: heavy. This week: light. Last week: nothing.
+        store.ObserveSnapshot(tenant, new[] { Repo("a", worktrees: 30, safe: 9, bytes: 9_000) }, monday.AddDays(-14));
+        store.ObserveSnapshot(tenant, new[] { Repo("a", worktrees: 3, safe: 1, bytes: 1_000) }, monday);
+
+        var trends = store.WeeklyTrends(tenant, weeks: 3, today: monday);
+        Assert.Equal(3, trends.Count);
+        Assert.Equal(30, trends[0].MaxWorktrees);   // oldest week
+        Assert.Equal(0, trends[1].MaxWorktrees);    // the silent week reads as zero, not carried over
+        Assert.Equal(3, trends[2].MaxWorktrees);    // this week
+    }
+
+    [Fact]
+    public void DirtyOverThreshold_ListsOnlyTodaysOffenders()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 23);
+        var store = new RepoHistoryStore(_path);
+        store.ObserveSnapshot(tenant, new[]
+        {
+            Repo("old-mess", uncommitted: 434, dirtySince: DateTime.UtcNow.AddDays(-12)),
+            Repo("fresh", uncommitted: 3, dirtySince: DateTime.UtcNow.AddDays(-1)),
+        }, day);
+
+        var dirty = store.DirtyOverThreshold(tenant, day);
+        Assert.Equal("old-mess", Assert.Single(dirty).Name);
+        Assert.True(dirty[0].DirtyDays >= 12);
+    }
+
+    [Fact]
+    public void ProvisionalRows_NeverBecomeHistory()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 23);
+        var store = new RepoHistoryStore(_path);
+        store.ObserveSnapshot(tenant, new[] { Repo("cached", worktrees: 99, provisional: true) }, day);
+
+        Assert.Equal(0, store.WeeklyTrends(tenant, 1, day)[^1].MaxWorktrees);
+    }
+
+    [Fact]
+    public void TenantPartition_TrendsNeverMix()
+    {
+        var a = new TenantId("tenant-a");
+        var b = new TenantId("tenant-b");
+        var day = new DateOnly(2026, 07, 23);
+        var store = new RepoHistoryStore(_path);
+        store.ObserveSnapshot(a, new[] { Repo("a-repo", worktrees: 7) }, day);
+        store.ObserveSnapshot(b, new[] { Repo("b-repo", worktrees: 2) }, day);
+
+        Assert.Equal(7, store.WeeklyTrends(a, 1, day)[^1].MaxWorktrees);
+        Assert.Equal(2, store.WeeklyTrends(b, 1, day)[^1].MaxWorktrees);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
@@ -92,6 +92,62 @@ public sealed class RepoHistoryStoreTests : IDisposable
         Assert.Equal(0, store.WeeklyTrends(tenant, 1, day)[^1].MaxWorktrees);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F13): the history key is the repository PATH, not the leaf
+    // name. Two repositories sharing a folder name on one machine keep separate daily rows.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void SameLeafName_DifferentPaths_DoNotOverwriteEachOther()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 24);
+        var store = new RepoHistoryStore(_path);
+
+        var first = Repo("widget", worktrees: 5, safe: 2);
+        first.Path = @"D:\repos\widget";
+        var second = Repo("widget", worktrees: 3, safe: 1);
+        second.Path = @"D:\other\widget";
+
+        store.ObserveSnapshot(tenant, new[] { first, second }, day);
+
+        // Both rows survive: the day's fleet totals SUM the two same-named repositories.
+        var trends = store.WeeklyTrends(tenant, weeks: 1, today: day);
+        Assert.Equal(8, trends[^1].MaxWorktrees);
+        Assert.Equal(3, trends[^1].MaxSafeToReap);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection finding F13): legacy rows without a path (the pre-path file
+    // format, unreleased) cannot be keyed and are ignored on load - no migration.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void Load_IgnoresLegacyRowsWithoutAPath()
+    {
+        var day = new DateOnly(2026, 07, 24);
+        File.WriteAllLines(_path, new[]
+        {
+            // A legacy line: no Path property at all.
+            "{\"Tenant\":\"local\",\"Date\":\"2026-07-24\",\"MachineName\":\"M1\",\"Name\":\"widget\",\"WorktreeCount\":9}",
+        });
+
+        var store = new RepoHistoryStore(_path);
+        Assert.Equal(0, store.WeeklyTrends(TenantId.Local, 1, day)[^1].MaxWorktrees);
+    }
+
+    [Fact]
+    public void PathlessPushedRow_IsIgnored_NotKeyed()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 24);
+        var store = new RepoHistoryStore(_path);
+
+        var pathless = Repo("ghost", worktrees: 9);
+        pathless.Path = "";
+        store.ObserveSnapshot(tenant, new[] { pathless }, day);
+
+        Assert.Equal(0, store.WeeklyTrends(tenant, 1, day)[^1].MaxWorktrees);
+    }
+
     [Fact]
     public void TenantPartition_TrendsNeverMix()
     {

--- a/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoHistoryStoreTests.cs
@@ -19,6 +19,7 @@ public sealed class RepoHistoryStoreTests : IDisposable
     {
         Name = name,
         MachineName = "M1",
+        DirectorId = "d1",
         Path = $@"D:\repos\{name}",
         WorktreeCount = worktrees,
         WorktreesSafeToReap = safe,
@@ -146,6 +147,75 @@ public sealed class RepoHistoryStoreTests : IDisposable
         store.ObserveSnapshot(tenant, new[] { pathless }, day);
 
         Assert.Equal(0, store.WeeklyTrends(tenant, 1, day)[^1].MaxWorktrees);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-9): the history key includes the DirectorId.
+    // Two Directors reporting the same machine name and repository path (overlapping upgrades,
+    // duplicate registrations) must keep separate daily rows, not overwrite each other.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void SameMachineAndPath_TwoDirectors_KeepSeparateRows()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 24);
+        var store = new RepoHistoryStore(_path);
+
+        var fromDirector1 = Repo("widget", worktrees: 5, safe: 2);
+        var fromDirector2 = Repo("widget", worktrees: 3, safe: 1);
+        fromDirector2.DirectorId = "d2"; // same machine, same path, different Director
+
+        store.ObserveSnapshot(tenant, new[] { fromDirector1 }, day);
+        store.ObserveSnapshot(tenant, new[] { fromDirector2 }, day);
+
+        // Both rows survive: the day's fleet totals SUM the two Directors' rows.
+        var trends = store.WeeklyTrends(tenant, weeks: 1, today: day);
+        Assert.Equal(8, trends[^1].MaxWorktrees);
+        Assert.Equal(3, trends[^1].MaxSafeToReap);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-9): trailing path separators are trimmed
+    // before keying, so the same repository pushed as "...\widget" and "...\widget\" is ONE
+    // row (last write wins), never two rows double-counting the totals.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void TrailingSeparator_DoesNotSplitTheRow()
+    {
+        var tenant = TenantId.Local;
+        var day = new DateOnly(2026, 07, 24);
+        var store = new RepoHistoryStore(_path);
+
+        var bare = Repo("widget", worktrees: 5, safe: 2);
+        var trailing = Repo("widget", worktrees: 4, safe: 1);
+        trailing.Path = bare.Path + @"\";
+
+        store.ObserveSnapshot(tenant, new[] { bare }, day);
+        store.ObserveSnapshot(tenant, new[] { trailing }, day);
+
+        // One row, last write wins - never a double count.
+        var trends = store.WeeklyTrends(tenant, weeks: 1, today: day);
+        Assert.Equal(4, trends[^1].MaxWorktrees);
+        Assert.Equal(1, trends[^1].MaxSafeToReap);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-9): legacy rows without a DirectorId (the
+    // pre-DirectorId file format, unreleased) cannot be keyed and are ignored on load - the
+    // same no-migration rule as the pathless rows from finding F13.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void Load_IgnoresLegacyRowsWithoutADirectorId()
+    {
+        var day = new DateOnly(2026, 07, 24);
+        File.WriteAllLines(_path, new[]
+        {
+            // A legacy line: a Path but no DirectorId property.
+            "{\"Tenant\":\"local\",\"Date\":\"2026-07-24\",\"MachineName\":\"M1\",\"Path\":\"D:\\\\repos\\\\widget\",\"Name\":\"widget\",\"WorktreeCount\":9}",
+        });
+
+        var store = new RepoHistoryStore(_path);
+        Assert.Equal(0, store.WeeklyTrends(TenantId.Local, 1, day)[^1].MaxWorktrees);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
@@ -1,0 +1,154 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// REGRESSION (inspection round 3, ruling R3-7): the old-Director compatibility proof runs through
+/// the ACTUAL GET /repositories endpoint - a real HTTP request into the mapped Gateway route, the
+/// folded JSON out - not the fold helper alone. The shape a pre-fix Director pushes (Provisional
+/// set, a stale positive safe count, stale "safe-to-reap" worktree states) must serve folded:
+/// zero safe count, every worktree "verifying". A verified repository must pass through unchanged
+/// on the same route. Proven to have teeth by removing the endpoint's fold call and watching the
+/// old-Director assertion go red.
+/// </summary>
+public sealed class RepositoriesEndpointServeFoldTests
+{
+    [Fact]
+    public async Task GetRepositories_OldDirectorProvisionalShape_ServesFoldedJson()
+    {
+        var store = new PushedRepositoryStore();
+        store.RegisterConnection(TenantId.Local, "d-old", "conn-1");
+        Assert.True(store.ApplySnapshot(TenantId.Local, "d-old", "conn-1", 1, new[]
+        {
+            new RepoStatusDto
+            {
+                Name = "widget",
+                Path = @"D:\repos\widget",
+                MachineName = "M1",
+                DirectorId = "d-old",
+                Provisional = true,
+                WorktreeCount = 2,
+                WorktreesSafeToReap = 2, // the stale safe count a pre-fix Director pushes
+                WorktreeBytes = 8192,
+                Worktrees = new List<WorktreeDto>
+                {
+                    new() { Path = @"D:\repos\widget-wt1", Branch = "done", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+                    new() { Path = @"D:\repos\widget-wt2", Branch = "old", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+                },
+            },
+        }));
+
+        await WithGateway(store, async http =>
+        {
+            using var response = await http.GetAsync("repositories");
+            response.EnsureSuccessStatusCode();
+            using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+            var repo = Assert.Single(body.RootElement.EnumerateArray());
+            Assert.Equal("widget", repo.GetProperty("name").GetString());
+            Assert.True(repo.GetProperty("provisional").GetBoolean());
+            Assert.Equal(0, repo.GetProperty("worktreesSafeToReap").GetInt32()); // stale count never serves
+            var worktrees = repo.GetProperty("worktrees").EnumerateArray().ToList();
+            Assert.Equal(2, worktrees.Count);
+            Assert.All(worktrees, w => Assert.Equal("verifying", w.GetProperty("state").GetString()));
+        });
+    }
+
+    [Fact]
+    public async Task GetRepositories_VerifiedRepository_ServesAsPushed()
+    {
+        var store = new PushedRepositoryStore();
+        store.RegisterConnection(TenantId.Local, "d-new", "conn-1");
+        Assert.True(store.ApplySnapshot(TenantId.Local, "d-new", "conn-1", 1, new[]
+        {
+            new RepoStatusDto
+            {
+                Name = "widget",
+                Path = @"D:\repos\widget",
+                MachineName = "M1",
+                DirectorId = "d-new",
+                Provisional = false,
+                WorktreeCount = 1,
+                WorktreesSafeToReap = 1,
+                Worktrees = new List<WorktreeDto>
+                {
+                    new() { Path = @"D:\repos\widget-wt", Branch = "done", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+                },
+            },
+        }));
+
+        await WithGateway(store, async http =>
+        {
+            using var response = await http.GetAsync("repositories");
+            response.EnsureSuccessStatusCode();
+            using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+            var repo = Assert.Single(body.RootElement.EnumerateArray());
+            Assert.False(repo.GetProperty("provisional").GetBoolean());
+            Assert.Equal(1, repo.GetProperty("worktreesSafeToReap").GetInt32());
+            var worktree = Assert.Single(repo.GetProperty("worktrees").EnumerateArray());
+            Assert.Equal("safe-to-reap", worktree.GetProperty("state").GetString());
+        });
+    }
+
+    /// <summary>Hosts the real Gateway routes over HTTP with the given push cache - the same
+    /// production <see cref="GatewayEndpoints.Map"/> the shipped Gateway runs.</summary>
+    private static async Task WithGateway(PushedRepositoryStore store, Func<HttpClient, Task> assertion)
+    {
+        var instancesDirectory = Path.Combine(Path.GetTempPath(), "cc-repofold-" + Guid.NewGuid().ToString("N"));
+        var port = FreePort();
+        WebApplication? app = null;
+        DirectorRegistry? registry = null;
+        var started = false;
+        try
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
+            app = builder.Build();
+            registry = new DirectorRegistry(instancesDirectory);
+            GatewayEndpoints.Map(
+                app,
+                registry,
+                version: "test",
+                token: "test-token",
+                pushedRepositories: store);
+            await app.StartAsync();
+            started = true;
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+            await assertion(http);
+        }
+        finally
+        {
+            if (app is not null)
+            {
+                if (started)
+                    await app.StopAsync();
+                await app.DisposeAsync();
+            }
+            registry?.Dispose();
+        }
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepositoryDtoMapperTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoryDtoMapperTests.cs
@@ -1,0 +1,106 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.Git;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// REGRESSION (inspection finding F10): provisional (still-verifying) repositories fail closed at
+/// the fold. Their worktrees are never served as "safe-to-reap" and their safe count folds to
+/// zero, so cached, unverified data can never be counted as reclaimable by any client or the CLI.
+/// </summary>
+public class RepositoryDtoMapperTests
+{
+    private static RepositoryStatus StatusWithSafeWorktree(bool provisional) => new()
+    {
+        Path = @"D:\repos\widget",
+        Name = "widget",
+        Branch = "main",
+        IsClean = true,
+        WorktreeCount = 1,
+        WorktreesSafeToReap = 1,
+        Worktrees = new[]
+        {
+            new WorktreeInfo
+            {
+                Path = @"D:\repos\widget-wt",
+                Branch = "done",
+                Safety = WorktreeSafety.SafeToReap,
+                Explanation = "Origin branch deleted after merge.",
+                SizeBytes = 1024,
+            },
+        },
+        Provisional = provisional,
+        Success = true,
+    };
+
+    [Fact]
+    public void Map_ProvisionalRepository_FoldsSafeCountToZero_AndWorktreesToVerifying()
+    {
+        var dto = RepositoryDtoMapper.Map(StatusWithSafeWorktree(provisional: true), "d1", "M1");
+
+        Assert.True(dto.Provisional);
+        Assert.Equal(0, dto.WorktreesSafeToReap);
+        var wt = Assert.Single(dto.Worktrees);
+        Assert.Equal("verifying", wt.State);
+        Assert.DoesNotContain("safe", wt.State);
+    }
+
+    [Fact]
+    public void Map_VerifiedRepository_KeepsTheSafeCountAndState()
+    {
+        var dto = RepositoryDtoMapper.Map(StatusWithSafeWorktree(provisional: false), "d1", "M1");
+
+        Assert.False(dto.Provisional);
+        Assert.Equal(1, dto.WorktreesSafeToReap);
+        Assert.Equal("safe-to-reap", Assert.Single(dto.Worktrees).State);
+    }
+
+    [Fact]
+    public void Flatten_ProvisionalRepository_ServesVerifying_EvenWhenThePushedStateSaysSafe()
+    {
+        // The shape an OLDER Director could push: Provisional set, but the worktree state string
+        // still "safe-to-reap". The shared fold must fail closed at serve time.
+        var pushed = new RepoStatusDto
+        {
+            Name = "widget",
+            Path = @"D:\repos\widget",
+            MachineName = "M1",
+            DirectorId = "d1",
+            Provisional = true,
+            Worktrees = new List<WorktreeDto>
+            {
+                new() { Path = @"D:\repos\widget-wt", Branch = "done", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+            },
+        };
+
+        var row = Assert.Single(FleetWorktreeFold.Flatten(new[] { pushed }, dataAgeSeconds: 2));
+
+        Assert.Equal("verifying", row.State);
+        Assert.True(row.Provisional);
+        Assert.Equal(2, row.DataAgeSeconds);
+    }
+
+    [Fact]
+    public void Flatten_VerifiedRepository_PassesTheFoldedStateThrough()
+    {
+        var pushed = new RepoStatusDto
+        {
+            Name = "widget",
+            Path = @"D:\repos\widget",
+            MachineName = "M1",
+            DirectorId = "d1",
+            Provisional = false,
+            Worktrees = new List<WorktreeDto>
+            {
+                new() { Path = @"D:\repos\widget-wt", Branch = "done", State = "safe-to-reap", Reason = "merged" },
+            },
+        };
+
+        var row = Assert.Single(FleetWorktreeFold.Flatten(new[] { pushed }));
+
+        Assert.Equal("safe-to-reap", row.State);
+        Assert.False(row.Provisional);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepositoryDtoMapperTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoryDtoMapperTests.cs
@@ -82,6 +82,67 @@ public class RepositoryDtoMapperTests
         Assert.Equal(2, row.DataAgeSeconds);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // REGRESSION (inspection round 2, ruling R2-3): GET /repositories serves through the SAME
+    // repository-level fold as /worktrees. The shape a PRE-FIX Director can push - Provisional
+    // set but a stale positive safe count and stale "safe-to-reap" worktree states - must fold
+    // at serve time: safe count zero, worktrees "verifying". The Gateway owns the verdict.
+    // ---------------------------------------------------------------------------------------
+    [Fact]
+    public void FoldRepositoryForServe_OldDirectorProvisionalShape_ServesZeroSafeCount_AndVerifyingWorktrees()
+    {
+        var pushedByOldDirector = new RepoStatusDto
+        {
+            Name = "widget",
+            Path = @"D:\repos\widget",
+            MachineName = "M1",
+            DirectorId = "d1",
+            Provisional = true,
+            WorktreeCount = 2,
+            WorktreesSafeToReap = 2, // the stale safe count a pre-fix Director pushes
+            WorktreeBytes = 8192,
+            Worktrees = new List<WorktreeDto>
+            {
+                new() { Path = @"D:\repos\widget-wt1", Branch = "done", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+                new() { Path = @"D:\repos\widget-wt2", Branch = "old", State = "safe-to-reap", Reason = "merged", SizeBytes = 4096 },
+            },
+        };
+
+        var served = FleetWorktreeFold.FoldRepositoryForServe(pushedByOldDirector);
+
+        Assert.True(served.Provisional);
+        Assert.Equal(0, served.WorktreesSafeToReap); // the stale count never serves
+        Assert.Equal(2, served.Worktrees.Count);
+        Assert.All(served.Worktrees, w => Assert.Equal("verifying", w.State));
+        Assert.All(served.Worktrees, w => Assert.DoesNotContain("safe", w.State));
+
+        // The cached instance was never mutated - the fold serves a copy.
+        Assert.Equal(2, pushedByOldDirector.WorktreesSafeToReap);
+        Assert.Equal("safe-to-reap", pushedByOldDirector.Worktrees[0].State);
+    }
+
+    [Fact]
+    public void FoldRepositoryForServe_VerifiedRepository_PassesThroughUnchanged()
+    {
+        var pushed = new RepoStatusDto
+        {
+            Name = "widget",
+            Path = @"D:\repos\widget",
+            Provisional = false,
+            WorktreesSafeToReap = 1,
+            Worktrees = new List<WorktreeDto>
+            {
+                new() { Path = @"D:\repos\widget-wt", Branch = "done", State = "safe-to-reap", Reason = "merged" },
+            },
+        };
+
+        var served = FleetWorktreeFold.FoldRepositoryForServe(pushed);
+
+        Assert.Same(pushed, served); // verified data serves as pushed
+        Assert.Equal(1, served.WorktreesSafeToReap);
+        Assert.Equal("safe-to-reap", Assert.Single(served.Worktrees).State);
+    }
+
     [Fact]
     public void Flatten_VerifiedRepository_PassesTheFoldedStateThrough()
     {

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -770,7 +770,12 @@ internal static class GatewayEndpoints
                 var fresh = pushedRepositories.TryGetFresh(reqTenant.Value, directorId, streamStaleResolved);
                 if (fresh is null)
                     continue;
-                rows.AddRange(fresh.Value.Repositories);
+                // The one repository-level serve fold (ruling R2-3): a pre-fix Director can push
+                // Provisional=true with a stale safe count and stale worktree states - the
+                // Gateway owns the verdict at SERVE time, for /repositories exactly as for
+                // /worktrees. A provisional repository serves a zero safe count and "verifying"
+                // worktrees, whatever was pushed.
+                rows.AddRange(fresh.Value.Repositories.Select(FleetWorktreeFold.FoldRepositoryForServe));
             }
             if (!string.IsNullOrWhiteSpace(machine))
                 rows = rows.Where(r => string.Equals(r.MachineName, machine, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -71,6 +71,8 @@ internal static class GatewayEndpoints
         // of pulling it, whenever that Director's stream is connected and its last push is within
         // streamStaleAfter. Null (stream mode off) keeps the pull-only behaviour byte-identical to today.
         Streaming.PushedSessionStore? pushedSessions = null,
+        Streaming.PushedRepositoryStore? pushedRepositories = null,
+        Streaming.RepoHistoryStore? repoHistory = null,
         TimeSpan? streamStaleAfter = null,
         // Issue #1177 (Phase 1): when non-null, per-session commands are first tried DOWN the Director's
         // stream via this hook (GatewayHost.SendCommandAsync); a null return means the Director is not
@@ -750,6 +752,98 @@ internal static class GatewayEndpoints
         // the response: by default they're silently skipped (backward-compat flat list);
         // with ?envelope=true they're surfaced in machineErrors so the UI can render an
         // inline "unreachable" placeholder.
+        // GET /repositories + /worktrees - the fleet's repository/worktree fact (repositories mission,
+        // #510 phase C). Tenant-scoped exactly like /sessions: the caller sees only its own partition.
+        // Read-only: reaping runs on the owning Director after a live re-verify, never from here.
+        app.MapGet("/repositories", (HttpContext ctx, string? machine, string? repo) =>
+        {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (pushedRepositories is null)
+                return Results.Json(new List<RepoStatusDto>());
+
+            var rows = new List<RepoStatusDto>();
+            foreach (var directorId in pushedRepositories.DirectorIdsFor(reqTenant.Value))
+            {
+                var fresh = pushedRepositories.TryGetFresh(reqTenant.Value, directorId, streamStaleResolved);
+                if (fresh is null)
+                    continue;
+                rows.AddRange(fresh.Value.Repositories);
+            }
+            if (!string.IsNullOrWhiteSpace(machine))
+                rows = rows.Where(r => string.Equals(r.MachineName, machine, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (!string.IsNullOrWhiteSpace(repo))
+                rows = rows.Where(r => string.Equals(r.Name, repo, StringComparison.OrdinalIgnoreCase)).ToList();
+            return Results.Json(rows.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase).ToList());
+        });
+
+        app.MapGet("/worktrees", (HttpContext ctx, string? machine, string? repo, string? state) =>
+        {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (pushedRepositories is null)
+                return Results.Json(new List<FleetWorktreeDto>());
+
+            var rows = new List<FleetWorktreeDto>();
+            foreach (var directorId in pushedRepositories.DirectorIdsFor(reqTenant.Value))
+            {
+                var fresh = pushedRepositories.TryGetFresh(reqTenant.Value, directorId, streamStaleResolved);
+                if (fresh is null)
+                    continue;
+                foreach (var r in fresh.Value.Repositories)
+                    foreach (var w in r.Worktrees)
+                        rows.Add(new FleetWorktreeDto
+                        {
+                            RepoName = r.Name,
+                            RepoPath = r.Path,
+                            MachineName = r.MachineName,
+                            DirectorId = r.DirectorId,
+                            Path = w.Path,
+                            Branch = w.Branch,
+                            State = w.State,
+                            Reason = w.Reason,
+                            SessionLabels = w.SessionLabels,
+                            SizeBytes = w.SizeBytes,
+                            LastActivityUtc = w.LastActivityUtc,
+                            DataAgeSeconds = fresh.Value.DataAgeSeconds,
+                        });
+            }
+            if (!string.IsNullOrWhiteSpace(machine))
+                rows = rows.Where(w => string.Equals(w.MachineName, machine, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (!string.IsNullOrWhiteSpace(repo))
+                rows = rows.Where(w => string.Equals(w.RepoName, repo, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (!string.IsNullOrWhiteSpace(state))
+                rows = rows.Where(w => string.Equals(w.State, state, StringComparison.OrdinalIgnoreCase)).ToList();
+            return Results.Json(rows.OrderBy(w => w.RepoName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(w => w.Branch, StringComparer.OrdinalIgnoreCase).ToList());
+        });
+
+        // GET /reports/repositories-weekly - the memory turned into numbers (repositories mission,
+        // #510 phase D): weekly worktree/disk trends plus today's dirty-too-long callouts. Feeds the
+        // dev-effectiveness report; tenant-scoped like every read.
+        app.MapGet("/reports/repositories-weekly", (HttpContext ctx, int? weeks) =>
+        {
+            var reqTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (repoHistory is null)
+                return Results.Json(new { error = "repository history is not enabled on this Gateway" },
+                    statusCode: StatusCodes.Status404NotFound);
+            var trends = repoHistory.WeeklyTrends(reqTenant.Value, Math.Clamp(weeks ?? 8, 1, 26));
+            var dirty = repoHistory.DirtyOverThreshold(reqTenant.Value);
+            return Results.Json(new
+            {
+                weeks = trends,
+                dirtyOverThreshold = dirty,
+                dirtyThresholdDays = Streaming.RepoHistoryStore.DirtyThresholdDays,
+            });
+        });
+
         app.MapGet("/sessions", (HttpContext ctx, string? director, string? agent, string? state,
                                        string? statusColor, string? machine,
                                        bool? includeExited, string? q, bool? envelope) =>

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -794,23 +794,9 @@ internal static class GatewayEndpoints
                 var fresh = pushedRepositories.TryGetFresh(reqTenant.Value, directorId, streamStaleResolved);
                 if (fresh is null)
                     continue;
-                foreach (var r in fresh.Value.Repositories)
-                    foreach (var w in r.Worktrees)
-                        rows.Add(new FleetWorktreeDto
-                        {
-                            RepoName = r.Name,
-                            RepoPath = r.Path,
-                            MachineName = r.MachineName,
-                            DirectorId = r.DirectorId,
-                            Path = w.Path,
-                            Branch = w.Branch,
-                            State = w.State,
-                            Reason = w.Reason,
-                            SessionLabels = w.SessionLabels,
-                            SizeBytes = w.SizeBytes,
-                            LastActivityUtc = w.LastActivityUtc,
-                            DataAgeSeconds = fresh.Value.DataAgeSeconds,
-                        });
+                // The one shared flatten fold: a provisional repository's worktrees are served as
+                // "verifying" - never "safe-to-reap" - whatever the pushing Director sent.
+                rows.AddRange(FleetWorktreeFold.Flatten(fresh.Value.Repositories, fresh.Value.DataAgeSeconds));
             }
             if (!string.IsNullOrWhiteSpace(machine))
                 rows = rows.Where(w => string.Equals(w.MachineName, machine, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -60,6 +60,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public Streaming.PushedSessionStore PushedSessions { get; }
 
+    /// <summary>Pushed repository/worktree snapshots per Director (repositories mission, #510 phase C).</summary>
+    public Streaming.PushedRepositoryStore PushedRepositories { get; }
+
+    /// <summary>Daily repository history behind the weekly report (repositories mission, #510 phase D).</summary>
+    public Streaming.RepoHistoryStore RepoHistory { get; }
+
     /// <summary>
     /// Gateway Cleanup mission (Wave 4b): the Gateway's OWN store of Missions. Missions are a fleet-level
     /// concept (they span Directors and machines and nest), so the source of truth lives at the Gateway,
@@ -658,6 +664,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // so the release only ever touches the departed Director's own tenant partition.
         Registry.OnDirectorRemoved += removal => SessionNumbers.ReleaseForDirector(removal.Tenant, removal.DirectorId);
         PushedSessions = new Streaming.PushedSessionStore();
+        // Repositories mission (#510 phase C): the sibling store for pushed repository/worktree snapshots.
+        PushedRepositories = new Streaming.PushedRepositoryStore();
+        // Repositories mission (#510 phase D): the daily repository history behind the weekly report.
+        // File-backed v1 (see the store's remarks); Postgres is a follow-up that changes persistence, not shape.
+        RepoHistory = new Streaming.RepoHistoryStore(Path.Combine(CcStorage.Root(), "repo-history.jsonl"));
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, at a Gateway-side file path
         // (CcStorage.Root(), the same location the cron and snooze stores use), NOT the Director's tool-config
         // missions.json. Reuses Core.Sessions.MissionStore unchanged.
@@ -1592,6 +1603,8 @@ public sealed class GatewayHost : IAsyncDisposable
                 o.StreamBufferCapacity = Contracts.DirectorStreamLimits.StreamBufferCapacity;
             });
         builder.Services.AddSingleton(PushedSessions);
+        builder.Services.AddSingleton(PushedRepositories);
+        builder.Services.AddSingleton(RepoHistory);
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, so the mission endpoints and
         // spawn validation share the one instance.
         builder.Services.AddSingleton(Missions);
@@ -1943,6 +1956,11 @@ public sealed class GatewayHost : IAsyncDisposable
             // Issue #1176 (Phase 1a): serve /sessions from the Director-push cache when the stream is
             // fresh; null when stream mode is off, keeping /sessions byte-identical to today.
             pushedSessions: PushedSessions,
+            // Repositories mission (#510 phase C): serve GET /repositories and /worktrees from the
+            // pushed repository snapshots, tenant-scoped like everything else.
+            pushedRepositories: PushedRepositories,
+            // Repositories mission (#510 phase D): the weekly-report read.
+            repoHistory: RepoHistory,
             streamStaleAfter: _streamStaleAfter,
             // Issue #1177 (Phase 1): route per-session commands DOWN the Director's stream when stream mode
             // is on. Null when off, so every command endpoint stays on its HTTP path (byte-identical).

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -46,7 +46,8 @@ public sealed class DirectorHub : Hub
     public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats,
         GatewayStreamRegistry streamRegistry, Snooze.SnoozeLandingObserver? snoozeLandings = null,
         Fleet.FleetRoleObserver? fleetRoles = null, Fleet.FleetDisplayStateObserver? fleetDisplayState = null,
-        HostedTenantBoundary? tenantBoundary = null)
+        HostedTenantBoundary? tenantBoundary = null, PushedRepositoryStore? repositoryStore = null,
+        RepoHistoryStore? repoHistory = null)
     {
         _store = store;
         _registry = registry;
@@ -56,6 +57,27 @@ public sealed class DirectorHub : Hub
         _fleetRoles = fleetRoles;
         _fleetDisplayState = fleetDisplayState;
         _tenantBoundary = tenantBoundary;
+        _repositoryStore = repositoryStore;
+        _repoHistory = repoHistory;
+    }
+
+    private readonly PushedRepositoryStore? _repositoryStore;
+    private readonly RepoHistoryStore? _repoHistory;
+
+    /// <summary>
+    /// A full repository/worktree snapshot from the bound Director (repositories mission, #510
+    /// phase C). Snapshots only; tenant comes from the connection binding, never the payload.
+    /// Accepted pushes also fold into the daily history (phase D) - rejected/stale ones never do.
+    /// </summary>
+    public void PushRepoSnapshot(long sequence, RepoStatusDto[] repositories)
+    {
+        var directorId = RequireBoundDirector();
+        var set = repositories ?? Array.Empty<RepoStatusDto>();
+        var accepted = _repositoryStore?.ApplySnapshot(RequireBoundTenant(), directorId, Context.ConnectionId,
+            sequence, set) ?? false;
+        if (accepted)
+            _repoHistory?.ObserveSnapshot(RequireBoundTenant(), set);
+        FileLog.Write($"[DirectorHub] PushRepoSnapshot: director={directorId} seq={sequence} repos={set.Length} accepted={accepted}");
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -148,6 +148,9 @@ public sealed class DirectorHub : Hub
         Context.Items[DirectorIdItemKey] = directorId;
         Context.Items[TenantIdItemKey] = tenant;
         _store.RegisterConnection(tenant, directorId, Context.ConnectionId);
+        // The repository store follows the same ownership discipline: only this - the current -
+        // connection may push repository snapshots from now on.
+        _repositoryStore?.RegisterConnection(tenant, directorId, Context.ConnectionId);
         // Gateway Cleanup mission (tunnel-only): the stream IS the registration now (HTTP register is gone).
         // Register this Director from the Hello identity so registry.Get(tenant, id) - the gate on create-session
         // and the other director-level routes - resolves it. Source="stream", no dialable endpoint.
@@ -272,6 +275,7 @@ public sealed class DirectorHub : Hub
             // that stops refreshing LastSeen (HttpHeartbeatTimeout); a reconnect re-Hellos and refreshes it.
             // The tenant is the one bound at Hello (Hello sets both, so a bound director always has a tenant).
             _store.UnregisterConnection(t, directorId, Context.ConnectionId);
+            _repositoryStore?.UnregisterConnection(t, directorId, Context.ConnectionId);
         }
         FileLog.Write($"[DirectorHub] disconnected: conn={Short(Context.ConnectionId)}, director={directorId ?? "(unbound)"} ({exception?.Message ?? "clean"})");
         return base.OnDisconnectedAsync(exception);

--- a/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// The Gateway's in-memory cache of the repository/worktree snapshots each Director pushes up its
+/// stream (repositories mission, devthrottle_internal#510 phase C) - the sibling of
+/// <see cref="PushedSessionStore"/>, tenant-partitioned the same way: tenant first, then Director.
+///
+/// Acceptance rule (a simplified form of the session store's ownership discipline): a push from a
+/// NEW connection always wins (a restarted Director reseeds authoritatively); a push from the SAME
+/// connection must carry a higher sequence than the last accepted one (out-of-order or duplicate
+/// pushes are dropped). Snapshots only - repositories change slowly; there is no delta path.
+///
+/// READ-ONLY at the Gateway: this cache exists so agents and the Cockpit can ASK about the fleet's
+/// repositories in one call. Destructive actions always run on the owning Director after a live
+/// re-verify - never from this relayed state (the trust rule).
+/// </summary>
+public sealed class PushedRepositoryStore
+{
+    private sealed class Entry
+    {
+        public string ConnectionId = "";
+        public long LastSequence;
+        public DateTime ReceivedAtUtc;
+        public List<RepoStatusDto> Repositories = new();
+    }
+
+    private readonly ConcurrentDictionary<TenantId, ConcurrentDictionary<string, Entry>> _byTenant = new();
+
+    /// <summary>Apply a full snapshot for a Director. Returns false when the push was rejected as stale.</summary>
+    public bool ApplySnapshot(TenantId tenant, string directorId, string connectionId, long sequence, RepoStatusDto[] repositories)
+    {
+        var directors = _byTenant.GetOrAdd(tenant, _ => new ConcurrentDictionary<string, Entry>(StringComparer.OrdinalIgnoreCase));
+        var entry = directors.GetOrAdd(directorId, _ => new Entry());
+        lock (entry)
+        {
+            bool sameConnection = string.Equals(entry.ConnectionId, connectionId, StringComparison.Ordinal);
+            if (sameConnection && sequence <= entry.LastSequence)
+                return false; // duplicate or out-of-order from the same connection
+            entry.ConnectionId = connectionId;
+            entry.LastSequence = sequence;
+            entry.ReceivedAtUtc = DateTime.UtcNow;
+            entry.Repositories = repositories.ToList();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The repositories a Director last pushed, or null when it never pushed or its data is older
+    /// than <paramref name="staleAfter"/>. Also returns the data age for honesty at the surface.
+    /// </summary>
+    public (IReadOnlyList<RepoStatusDto> Repositories, double DataAgeSeconds)? TryGetFresh(TenantId tenant, string directorId, TimeSpan staleAfter)
+    {
+        if (!_byTenant.TryGetValue(tenant, out var directors) || !directors.TryGetValue(directorId, out var entry))
+            return null;
+        lock (entry)
+        {
+            var age = DateTime.UtcNow - entry.ReceivedAtUtc;
+            if (age > staleAfter)
+                return null;
+            // Shallow copy of the list; DTOs are treated as immutable after receive.
+            return (entry.Repositories.ToList(), age.TotalSeconds);
+        }
+    }
+
+    /// <summary>Director ids that have pushed repositories for this tenant.</summary>
+    public IReadOnlyList<string> DirectorIdsFor(TenantId tenant)
+        => _byTenant.TryGetValue(tenant, out var directors) ? directors.Keys.ToList() : Array.Empty<string>();
+}

--- a/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
@@ -36,7 +36,10 @@ public sealed class PushedRepositoryStore
     /// <summary>
     /// Mark <paramref name="connectionId"/> as the Director's current stream connection - the hub
     /// calls this at Hello, the same moment the session store learns it. The sequence baseline
-    /// resets so the new connection's first push, at any sequence, is authoritative.
+    /// resets ONLY when ownership actually changes to a different connection (so the new
+    /// connection's first push, at any sequence, is authoritative). A repeated Hello from the
+    /// CURRENT connection keeps the existing baseline (ruling R2-4) - resetting it would let an
+    /// older sequence replay over newer data.
     /// </summary>
     public void RegisterConnection(TenantId tenant, string directorId, string connectionId)
     {
@@ -44,6 +47,11 @@ public sealed class PushedRepositoryStore
         var entry = directors.GetOrAdd(directorId, _ => new Entry());
         lock (entry)
         {
+            if (string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
+            {
+                FileLog.Write($"[PushedRepositoryStore] repeated Hello from the current connection - sequence baseline kept: director={directorId}");
+                return;
+            }
             entry.ActiveConnectionId = connectionId;
             entry.LastSequence = -1;
         }

--- a/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedRepositoryStore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.Gateway.Streaming;
@@ -9,10 +10,12 @@ namespace CcDirector.Gateway.Streaming;
 /// stream (repositories mission, devthrottle_internal#510 phase C) - the sibling of
 /// <see cref="PushedSessionStore"/>, tenant-partitioned the same way: tenant first, then Director.
 ///
-/// Acceptance rule (a simplified form of the session store's ownership discipline): a push from a
-/// NEW connection always wins (a restarted Director reseeds authoritatively); a push from the SAME
-/// connection must carry a higher sequence than the last accepted one (out-of-order or duplicate
-/// pushes are dropped). Snapshots only - repositories change slowly; there is no delta path.
+/// Acceptance rule (the session store's ownership discipline): only the Director's CURRENT stream
+/// connection - the one bound at Hello, the same identity command routing trusts - may push. A push
+/// from any other connection is dropped, so a late push from a superseded connection can never
+/// overwrite the current connection's newer data. Within the current connection a push must carry a
+/// higher sequence than the last accepted one (out-of-order or duplicate pushes are dropped).
+/// Snapshots only - repositories change slowly; there is no delta path.
 ///
 /// READ-ONLY at the Gateway: this cache exists so agents and the Cockpit can ASK about the fleet's
 /// repositories in one call. Destructive actions always run on the owning Director after a live
@@ -22,25 +25,63 @@ public sealed class PushedRepositoryStore
 {
     private sealed class Entry
     {
-        public string ConnectionId = "";
-        public long LastSequence;
+        public string? ActiveConnectionId;
+        public long LastSequence = -1;
         public DateTime ReceivedAtUtc;
         public List<RepoStatusDto> Repositories = new();
     }
 
     private readonly ConcurrentDictionary<TenantId, ConcurrentDictionary<string, Entry>> _byTenant = new();
 
-    /// <summary>Apply a full snapshot for a Director. Returns false when the push was rejected as stale.</summary>
-    public bool ApplySnapshot(TenantId tenant, string directorId, string connectionId, long sequence, RepoStatusDto[] repositories)
+    /// <summary>
+    /// Mark <paramref name="connectionId"/> as the Director's current stream connection - the hub
+    /// calls this at Hello, the same moment the session store learns it. The sequence baseline
+    /// resets so the new connection's first push, at any sequence, is authoritative.
+    /// </summary>
+    public void RegisterConnection(TenantId tenant, string directorId, string connectionId)
     {
         var directors = _byTenant.GetOrAdd(tenant, _ => new ConcurrentDictionary<string, Entry>(StringComparer.OrdinalIgnoreCase));
         var entry = directors.GetOrAdd(directorId, _ => new Entry());
         lock (entry)
         {
-            bool sameConnection = string.Equals(entry.ConnectionId, connectionId, StringComparison.Ordinal);
-            if (sameConnection && sequence <= entry.LastSequence)
-                return false; // duplicate or out-of-order from the same connection
-            entry.ConnectionId = connectionId;
+            entry.ActiveConnectionId = connectionId;
+            entry.LastSequence = -1;
+        }
+    }
+
+    /// <summary>
+    /// Clear the current connection IF <paramref name="connectionId"/> is still it. A late
+    /// disconnect from a superseded connection is ignored so it cannot wipe a newer one.
+    /// </summary>
+    public void UnregisterConnection(TenantId tenant, string directorId, string connectionId)
+    {
+        if (!_byTenant.TryGetValue(tenant, out var directors) || !directors.TryGetValue(directorId, out var entry))
+            return;
+        lock (entry)
+        {
+            if (string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
+                entry.ActiveConnectionId = null;
+        }
+    }
+
+    /// <summary>
+    /// Apply a full snapshot for a Director. Returns false when the push was rejected: it did not
+    /// come from the Director's current connection, or its sequence is stale.
+    /// </summary>
+    public bool ApplySnapshot(TenantId tenant, string directorId, string connectionId, long sequence, RepoStatusDto[] repositories)
+    {
+        if (!_byTenant.TryGetValue(tenant, out var directors) || !directors.TryGetValue(directorId, out var entry))
+            return false; // never registered (no Hello bound this Director) - nothing may push
+
+        lock (entry)
+        {
+            if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
+            {
+                FileLog.Write($"[PushedRepositoryStore] push REJECTED (not the current connection): director={directorId}, seq={sequence}");
+                return false; // a superseded (or unknown) connection may never overwrite current data
+            }
+            if (sequence <= entry.LastSequence)
+                return false; // duplicate or out-of-order from the current connection
             entry.LastSequence = sequence;
             entry.ReceivedAtUtc = DateTime.UtcNow;
             entry.Repositories = repositories.ToList();

--- a/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
@@ -11,6 +11,12 @@ public sealed record RepoDailySnapshot
     public string Tenant { get; init; } = "";
     public DateOnly Date { get; init; }
     public string MachineName { get; init; } = "";
+
+    /// <summary>The repository's full path - part of the identity key. Two repositories can share a
+    /// leaf name on one machine; only the path tells them apart.</summary>
+    public string Path { get; init; } = "";
+
+    /// <summary>The leaf name, kept for display only - never part of the key.</summary>
     public string Name { get; init; } = "";
     public int UncommittedCount { get; init; }
     public int DirtyDays { get; init; }
@@ -65,6 +71,11 @@ public sealed class RepoHistoryStore
             {
                 if (r.Provisional)
                     continue; // unverified warm-start data never becomes history
+                if (string.IsNullOrWhiteSpace(r.Path))
+                {
+                    FileLog.Write($"[RepoHistoryStore] snapshot row without a path ignored (name={r.Name})");
+                    continue; // the path IS the identity - a pathless row cannot be keyed
+                }
                 int dirtyDays = r.DirtySinceUtc is { } since && !r.IsClean
                     ? (int)Math.Max(0, (DateTime.UtcNow - since).TotalDays)
                     : 0;
@@ -73,6 +84,7 @@ public sealed class RepoHistoryStore
                     Tenant = tenant.Value,
                     Date = date,
                     MachineName = r.MachineName,
+                    Path = r.Path,
                     Name = r.Name,
                     UncommittedCount = r.UncommittedCount,
                     DirtyDays = dirtyDays,
@@ -146,7 +158,12 @@ public sealed class RepoHistoryStore
     private static DateOnly StartOfWeek(DateOnly d)
         => d.AddDays(-(((int)d.DayOfWeek + 6) % 7)); // Monday
 
-    private static string Key(RepoDailySnapshot r) => $"{r.Tenant}|{r.Date:yyyy-MM-dd}|{r.MachineName}|{r.Name}".ToLowerInvariant();
+    /// <summary>
+    /// The row identity: tenant, day, machine, and the repository PATH (lowercased). The leaf name
+    /// is display only - two repositories sharing a folder name on one machine must never
+    /// overwrite each other's snapshots (inspection finding F13).
+    /// </summary>
+    private static string Key(RepoDailySnapshot r) => $"{r.Tenant}|{r.Date:yyyy-MM-dd}|{r.MachineName}|{r.Path}".ToLowerInvariant();
 
     private void Load()
     {
@@ -162,7 +179,9 @@ public sealed class RepoHistoryStore
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
                 var row = JsonSerializer.Deserialize<RepoDailySnapshot>(line);
-                if (row != null)
+                // Rows without a path predate the path-keyed format (days old, unreleased) and
+                // cannot be keyed - ignored rather than migrated.
+                if (row != null && !string.IsNullOrWhiteSpace(row.Path))
                     _rows[Key(row)] = row;
             }
         }

--- a/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>One repository's daily snapshot row - the Gateway's memory of drift over time.</summary>
+public sealed record RepoDailySnapshot
+{
+    public string Tenant { get; init; } = "";
+    public DateOnly Date { get; init; }
+    public string MachineName { get; init; } = "";
+    public string Name { get; init; } = "";
+    public int UncommittedCount { get; init; }
+    public int DirtyDays { get; init; }
+    public int BehindMainCount { get; init; }
+    public int WorktreeCount { get; init; }
+    public int WorktreesSafeToReap { get; init; }
+    public long WorktreeBytes { get; init; }
+}
+
+/// <summary>The weekly report's numbers for one week.</summary>
+public sealed record RepoWeekTrend
+{
+    public DateOnly WeekStart { get; init; }
+    public int MaxWorktrees { get; init; }
+    public int MaxSafeToReap { get; init; }
+    public long MaxWorktreeBytes { get; init; }
+    public int ReposDirtyOverThreshold { get; init; }
+}
+
+/// <summary>
+/// The repositories memory (devthrottle_internal#510 phase D): daily snapshots of every repository
+/// the fleet pushes, persisted as JSON lines on the Gateway's disk, aggregated into weekly trends
+/// for the dev-effectiveness report.
+///
+/// Deliberately FILE-backed in v1, not Postgres: EF migrations are serialized fleet-wide and a
+/// long-lived unmerged migration on a mission branch is a conflict magnet. The store is a seam -
+/// moving it to real tables later changes persistence, not shape. One row per (tenant, day,
+/// machine, repo); re-observing the same day upserts (last write wins), so the daily write is
+/// idempotent however often Directors push.
+/// </summary>
+public sealed class RepoHistoryStore
+{
+    public const int DirtyThresholdDays = 7;
+
+    private readonly string _path;
+    private readonly object _gate = new();
+    private Dictionary<string, RepoDailySnapshot>? _rows; // key: tenant|date|machine|repo
+
+    public RepoHistoryStore(string path)
+    {
+        _path = path;
+    }
+
+    /// <summary>Fold a pushed snapshot into today's rows. Idempotent per day; cheap on every push.</summary>
+    public void ObserveSnapshot(TenantId tenant, IReadOnlyList<RepoStatusDto> repositories, DateOnly? today = null)
+    {
+        var date = today ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        lock (_gate)
+        {
+            Load();
+            foreach (var r in repositories)
+            {
+                if (r.Provisional)
+                    continue; // unverified warm-start data never becomes history
+                int dirtyDays = r.DirtySinceUtc is { } since && !r.IsClean
+                    ? (int)Math.Max(0, (DateTime.UtcNow - since).TotalDays)
+                    : 0;
+                var row = new RepoDailySnapshot
+                {
+                    Tenant = tenant.Value,
+                    Date = date,
+                    MachineName = r.MachineName,
+                    Name = r.Name,
+                    UncommittedCount = r.UncommittedCount,
+                    DirtyDays = dirtyDays,
+                    BehindMainCount = r.BehindMainCount,
+                    WorktreeCount = r.WorktreeCount,
+                    WorktreesSafeToReap = r.WorktreesSafeToReap,
+                    WorktreeBytes = r.WorktreeBytes,
+                };
+                _rows![Key(row)] = row;
+            }
+            Save();
+        }
+    }
+
+    /// <summary>Weekly trends for the last <paramref name="weeks"/> weeks (oldest first).</summary>
+    public IReadOnlyList<RepoWeekTrend> WeeklyTrends(TenantId tenant, int weeks = 8, DateOnly? today = null)
+    {
+        var end = today ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        List<RepoDailySnapshot> rows;
+        lock (_gate)
+        {
+            Load();
+            rows = _rows!.Values.Where(r => r.Tenant == tenant.Value).ToList();
+        }
+
+        var trends = new List<RepoWeekTrend>();
+        for (int w = weeks - 1; w >= 0; w--)
+        {
+            var weekStart = StartOfWeek(end).AddDays(-7 * w);
+            var weekEnd = weekStart.AddDays(7);
+            var inWeek = rows.Where(r => r.Date >= weekStart && r.Date < weekEnd).ToList();
+            if (inWeek.Count == 0)
+            {
+                trends.Add(new RepoWeekTrend { WeekStart = weekStart });
+                continue;
+            }
+            // Per-day fleet totals, then the week's peak - so one busy day is not averaged away.
+            var perDay = inWeek.GroupBy(r => r.Date).Select(g => new
+            {
+                Worktrees = g.Sum(r => r.WorktreeCount),
+                Safe = g.Sum(r => r.WorktreesSafeToReap),
+                Bytes = g.Sum(r => r.WorktreeBytes),
+                Dirty = g.Count(r => r.DirtyDays >= DirtyThresholdDays),
+            }).ToList();
+            trends.Add(new RepoWeekTrend
+            {
+                WeekStart = weekStart,
+                MaxWorktrees = perDay.Max(d => d.Worktrees),
+                MaxSafeToReap = perDay.Max(d => d.Safe),
+                MaxWorktreeBytes = perDay.Max(d => d.Bytes),
+                ReposDirtyOverThreshold = perDay.Max(d => d.Dirty),
+            });
+        }
+        return trends;
+    }
+
+    /// <summary>Today's repositories dirty past the threshold - the report's callout list.</summary>
+    public IReadOnlyList<RepoDailySnapshot> DirtyOverThreshold(TenantId tenant, DateOnly? today = null)
+    {
+        var date = today ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        lock (_gate)
+        {
+            Load();
+            return _rows!.Values
+                .Where(r => r.Tenant == tenant.Value && r.Date == date && r.DirtyDays >= DirtyThresholdDays)
+                .OrderByDescending(r => r.DirtyDays)
+                .ToList();
+        }
+    }
+
+    private static DateOnly StartOfWeek(DateOnly d)
+        => d.AddDays(-(((int)d.DayOfWeek + 6) % 7)); // Monday
+
+    private static string Key(RepoDailySnapshot r) => $"{r.Tenant}|{r.Date:yyyy-MM-dd}|{r.MachineName}|{r.Name}".ToLowerInvariant();
+
+    private void Load()
+    {
+        if (_rows != null)
+            return;
+        _rows = new Dictionary<string, RepoDailySnapshot>(StringComparer.Ordinal);
+        try
+        {
+            if (!File.Exists(_path))
+                return;
+            foreach (var line in File.ReadAllLines(_path))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                var row = JsonSerializer.Deserialize<RepoDailySnapshot>(line);
+                if (row != null)
+                    _rows[Key(row)] = row;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepoHistoryStore] load failed (starting empty): {ex.Message}");
+        }
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (dir != null)
+                Directory.CreateDirectory(dir);
+            File.WriteAllLines(_path, _rows!.Values.Select(r => JsonSerializer.Serialize(r)));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepoHistoryStore] save failed: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
+++ b/src/CcDirector.Gateway/Streaming/RepoHistoryStore.cs
@@ -12,6 +12,11 @@ public sealed record RepoDailySnapshot
     public DateOnly Date { get; init; }
     public string MachineName { get; init; } = "";
 
+    /// <summary>The pushing Director's id - part of the identity key (ruling R2-9). Two Directors
+    /// can report the same machine name and repository path (overlapping upgrades, duplicate
+    /// registrations); only the Director id tells their rows apart.</summary>
+    public string DirectorId { get; init; } = "";
+
     /// <summary>The repository's full path - part of the identity key. Two repositories can share a
     /// leaf name on one machine; only the path tells them apart.</summary>
     public string Path { get; init; } = "";
@@ -76,6 +81,11 @@ public sealed class RepoHistoryStore
                     FileLog.Write($"[RepoHistoryStore] snapshot row without a path ignored (name={r.Name})");
                     continue; // the path IS the identity - a pathless row cannot be keyed
                 }
+                if (string.IsNullOrWhiteSpace(r.DirectorId))
+                {
+                    FileLog.Write($"[RepoHistoryStore] snapshot row without a Director id ignored (name={r.Name})");
+                    continue; // the Director id is part of the identity (ruling R2-9)
+                }
                 int dirtyDays = r.DirtySinceUtc is { } since && !r.IsClean
                     ? (int)Math.Max(0, (DateTime.UtcNow - since).TotalDays)
                     : 0;
@@ -84,6 +94,7 @@ public sealed class RepoHistoryStore
                     Tenant = tenant.Value,
                     Date = date,
                     MachineName = r.MachineName,
+                    DirectorId = r.DirectorId,
                     Path = r.Path,
                     Name = r.Name,
                     UncommittedCount = r.UncommittedCount,
@@ -159,11 +170,17 @@ public sealed class RepoHistoryStore
         => d.AddDays(-(((int)d.DayOfWeek + 6) % 7)); // Monday
 
     /// <summary>
-    /// The row identity: tenant, day, machine, and the repository PATH (lowercased). The leaf name
-    /// is display only - two repositories sharing a folder name on one machine must never
-    /// overwrite each other's snapshots (inspection finding F13).
+    /// The row identity: tenant, day, machine, DIRECTOR, and the repository PATH (trailing
+    /// separators trimmed, then lowercased). The leaf name is display only - two repositories
+    /// sharing a folder name on one machine must never overwrite each other's snapshots
+    /// (inspection finding F13), and two Directors reporting the same machine and path must
+    /// never overwrite each other's rows (ruling R2-9). The lowercasing stays deliberately: a
+    /// case-only path collision on a case-sensitive filesystem merges two history rows - an
+    /// accepted, documented inaccuracy that is never destructive (history is aggregate
+    /// reporting, not an acting surface).
     /// </summary>
-    private static string Key(RepoDailySnapshot r) => $"{r.Tenant}|{r.Date:yyyy-MM-dd}|{r.MachineName}|{r.Path}".ToLowerInvariant();
+    private static string Key(RepoDailySnapshot r)
+        => $"{r.Tenant}|{r.Date:yyyy-MM-dd}|{r.MachineName}|{r.DirectorId}|{r.Path.TrimEnd('\\', '/')}".ToLowerInvariant();
 
     private void Load()
     {
@@ -179,9 +196,9 @@ public sealed class RepoHistoryStore
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
                 var row = JsonSerializer.Deserialize<RepoDailySnapshot>(line);
-                // Rows without a path predate the path-keyed format (days old, unreleased) and
-                // cannot be keyed - ignored rather than migrated.
-                if (row != null && !string.IsNullOrWhiteSpace(row.Path))
+                // Rows without a path or without a Director id predate the current key format
+                // (days old, unreleased) and cannot be keyed - ignored rather than migrated.
+                if (row != null && !string.IsNullOrWhiteSpace(row.Path) && !string.IsNullOrWhiteSpace(row.DirectorId))
                     _rows[Key(row)] = row;
             }
         }

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -40,6 +40,8 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 session_app = typer.Typer(help="Manage running sessions.", add_completion=False)
+repo_app = typer.Typer(help="List the fleet's repositories.", add_completion=False)
+worktree_app = typer.Typer(help="List the fleet's worktrees and who is in them.", add_completion=False)
 mission_app = typer.Typer(
     help="Create and list Missions (the unit of work sessions attach to).",
     add_completion=False,
@@ -74,6 +76,8 @@ autostart_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(session_app, name="session")
+app.add_typer(repo_app, name="repo")
+app.add_typer(worktree_app, name="worktree")
 app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
 app.add_typer(settings_app, name="settings")
@@ -489,6 +493,29 @@ def session_list(
 ) -> None:
     """List every session running across the fleet."""
     list_sessions(json_output)
+
+
+@repo_app.command("list")
+def repo_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+    dirty: bool = typer.Option(False, "--dirty", help="Only repositories with uncommitted work."),
+) -> None:
+    """List the fleet's repositories with their state and worktree summary."""
+    from .repo_ops import list_repositories
+
+    list_repositories(json_output, dirty_only=dirty)
+
+
+@worktree_app.command("list")
+def worktree_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+    repo: str = typer.Option(None, "--repo", help="Only worktrees of this repository."),
+    state: str = typer.Option(None, "--state", help="Filter: safe-to-reap, in-use, or needs-attention."),
+) -> None:
+    """List the fleet's worktrees: verdicts, sizes, and which session is in each."""
+    from .repo_ops import list_worktrees
+
+    list_worktrees(json_output, repo=repo, state=state)
 
 
 @session_app.command()

--- a/tools/cc-devthrottle/src/repo_ops.py
+++ b/tools/cc-devthrottle/src/repo_ops.py
@@ -39,6 +39,21 @@ def _get(path: str) -> List[Dict[str, Any]]:
     return rows
 
 
+def _raw(dto: Dict[str, Any], *keys: str) -> Any:
+    """First present key's RAW value (director.field stringifies - wrong for bools/ints/lists)."""
+    for key in keys:
+        if key in dto and dto[key] is not None:
+            return dto[key]
+    return None
+
+
+def _int(dto: Dict[str, Any], *keys: str) -> int:
+    try:
+        return int(_raw(dto, *keys) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _gb(size: Any) -> str:
     try:
         bytes_ = int(size)
@@ -54,7 +69,7 @@ def _gb(size: Any) -> str:
 def list_repositories(json_output: bool, dirty_only: bool = False) -> None:
     rows = _get("fleet/repositories")
     if dirty_only:
-        rows = [r for r in rows if not director.field(r, "isClean", "IsClean")]
+        rows = [r for r in rows if not _raw(r, "isClean", "IsClean")]
     if json_output:
         print(json.dumps(rows, indent=2))
         return
@@ -63,11 +78,11 @@ def list_repositories(json_output: bool, dirty_only: bool = False) -> None:
     for col in ("REPOSITORY", "MACHINE", "PROVIDER", "BRANCH", "STATE", "WORKTREES", "SIZE(WT)"):
         table.add_column(col)
     for r in rows:
-        clean = director.field(r, "isClean", "IsClean")
-        uncommitted = director.field(r, "uncommittedCount", "UncommittedCount") or 0
+        clean = bool(_raw(r, "isClean", "IsClean"))
+        uncommitted = _int(r, "uncommittedCount", "UncommittedCount")
         state = "clean" if clean else f"{uncommitted} uncommitted"
-        wt_total = director.field(r, "worktreeCount", "WorktreeCount") or 0
-        wt_safe = director.field(r, "worktreesSafeToReap", "WorktreesSafeToReap") or 0
+        wt_total = _int(r, "worktreeCount", "WorktreeCount")
+        wt_safe = _int(r, "worktreesSafeToReap", "WorktreesSafeToReap")
         wt = "-" if not wt_total else f"{wt_total} ({wt_safe} safe)"
         table.add_row(
             str(director.field(r, "name", "Name") or "-"),
@@ -76,10 +91,10 @@ def list_repositories(json_output: bool, dirty_only: bool = False) -> None:
             str(director.field(r, "branch", "Branch") or "-"),
             state,
             wt,
-            _gb(director.field(r, "worktreeBytes", "WorktreeBytes")),
+            _gb(_raw(r, "worktreeBytes", "WorktreeBytes")),
         )
     console.print(table)
-    safe_total = sum(int(director.field(r, "worktreesSafeToReap", "WorktreesSafeToReap") or 0) for r in rows)
+    safe_total = sum(_int(r, "worktreesSafeToReap", "WorktreesSafeToReap") for r in rows)
     console.print(f"{len(rows)} repositories - {safe_total} worktrees safe to reap")
 
 
@@ -100,19 +115,16 @@ def list_worktrees(json_output: bool, repo: str | None = None, state: str | None
     reclaim = 0
     for w in rows:
         w_state = str(director.field(w, "state", "State") or "-")
-        sessions = director.field(w, "sessionLabels", "SessionLabels") or []
+        sessions = _raw(w, "sessionLabels", "SessionLabels") or []
         if w_state == "safe-to-reap":
-            try:
-                reclaim += int(director.field(w, "sizeBytes", "SizeBytes") or 0)
-            except (TypeError, ValueError):
-                pass
+            reclaim += _int(w, "sizeBytes", "SizeBytes")
         table.add_row(
             str(director.field(w, "repoName", "RepoName") or "-"),
             str(director.field(w, "branch", "Branch") or "(detached)"),
             str(director.field(w, "machineName", "MachineName") or "-"),
             w_state,
             ", ".join(sessions) if sessions else "-",
-            _gb(director.field(w, "sizeBytes", "SizeBytes")),
+            _gb(_raw(w, "sizeBytes", "SizeBytes")),
             str(director.field(w, "reason", "Reason") or "-"),
         )
     console.print(table)

--- a/tools/cc-devthrottle/src/repo_ops.py
+++ b/tools/cc-devthrottle/src/repo_ops.py
@@ -1,0 +1,123 @@
+"""Repository and worktree listing - the fleet fact any agent can ask for in one call.
+
+Backed by the Director's /fleet/repositories and /fleet/worktrees relays: with a Gateway the
+answer is fleet-wide (every machine); standalone it is this Director's own monitor model.
+Read-only - reaping always runs on the owning Director with a live re-verify.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import typer
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+# Make cc_shared importable when running from source, matching the existing cc-* tools.
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import director  # noqa: E402
+
+console = Console()
+
+
+def _get(path: str) -> List[Dict[str, Any]]:
+    try:
+        rows = director.get_json(path) or []
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+    if isinstance(rows, dict) and rows.get("error"):
+        console.print(f"[red]Error:[/red] {rows['error']}")
+        raise typer.Exit(1)
+    return rows
+
+
+def _gb(size: Any) -> str:
+    try:
+        bytes_ = int(size)
+    except (TypeError, ValueError):
+        return "-"
+    if bytes_ >= 1_073_741_824:
+        return f"{bytes_ / 1_073_741_824:.1f}G"
+    if bytes_ >= 1_048_576:
+        return f"{bytes_ / 1_048_576:.0f}M"
+    return f"{bytes_ / 1024:.0f}K" if bytes_ > 0 else "0"
+
+
+def list_repositories(json_output: bool, dirty_only: bool = False) -> None:
+    rows = _get("fleet/repositories")
+    if dirty_only:
+        rows = [r for r in rows if not director.field(r, "isClean", "IsClean")]
+    if json_output:
+        print(json.dumps(rows, indent=2))
+        return
+
+    table = Table(show_header=True, header_style="bold", box=box.ASCII)
+    for col in ("REPOSITORY", "MACHINE", "PROVIDER", "BRANCH", "STATE", "WORKTREES", "SIZE(WT)"):
+        table.add_column(col)
+    for r in rows:
+        clean = director.field(r, "isClean", "IsClean")
+        uncommitted = director.field(r, "uncommittedCount", "UncommittedCount") or 0
+        state = "clean" if clean else f"{uncommitted} uncommitted"
+        wt_total = director.field(r, "worktreeCount", "WorktreeCount") or 0
+        wt_safe = director.field(r, "worktreesSafeToReap", "WorktreesSafeToReap") or 0
+        wt = "-" if not wt_total else f"{wt_total} ({wt_safe} safe)"
+        table.add_row(
+            str(director.field(r, "name", "Name") or "-"),
+            str(director.field(r, "machineName", "MachineName") or "-"),
+            str(director.field(r, "provider", "Provider") or "-"),
+            str(director.field(r, "branch", "Branch") or "-"),
+            state,
+            wt,
+            _gb(director.field(r, "worktreeBytes", "WorktreeBytes")),
+        )
+    console.print(table)
+    safe_total = sum(int(director.field(r, "worktreesSafeToReap", "WorktreesSafeToReap") or 0) for r in rows)
+    console.print(f"{len(rows)} repositories - {safe_total} worktrees safe to reap")
+
+
+def list_worktrees(json_output: bool, repo: str | None = None, state: str | None = None) -> None:
+    path = "fleet/worktrees"
+    rows = _get(path)
+    if repo:
+        rows = [w for w in rows if str(director.field(w, "repoName", "RepoName") or "").lower() == repo.lower()]
+    if state:
+        rows = [w for w in rows if str(director.field(w, "state", "State") or "").lower() == state.lower()]
+    if json_output:
+        print(json.dumps(rows, indent=2))
+        return
+
+    table = Table(show_header=True, header_style="bold", box=box.ASCII)
+    for col in ("REPO", "BRANCH", "MACHINE", "STATE", "SESSION", "SIZE", "REASON"):
+        table.add_column(col)
+    reclaim = 0
+    for w in rows:
+        w_state = str(director.field(w, "state", "State") or "-")
+        sessions = director.field(w, "sessionLabels", "SessionLabels") or []
+        if w_state == "safe-to-reap":
+            try:
+                reclaim += int(director.field(w, "sizeBytes", "SizeBytes") or 0)
+            except (TypeError, ValueError):
+                pass
+        table.add_row(
+            str(director.field(w, "repoName", "RepoName") or "-"),
+            str(director.field(w, "branch", "Branch") or "(detached)"),
+            str(director.field(w, "machineName", "MachineName") or "-"),
+            w_state,
+            ", ".join(sessions) if sessions else "-",
+            _gb(director.field(w, "sizeBytes", "SizeBytes")),
+            str(director.field(w, "reason", "Reason") or "-"),
+        )
+    console.print(table)
+    safe = sum(1 for w in rows if str(director.field(w, "state", "State")) == "safe-to-reap")
+    console.print(
+        f"{len(rows)} worktrees - {safe} safe ({_gb(reclaim)} reclaimable) - "
+        "reap runs on the owning Director"
+    )


### PR DESCRIPTION
Lands the repositories mission (devthrottle_internal#510) in one squash: the Repositories home and per-repository detail screens (diff viewer with confirmed discard, branches with fail-closed safe deletion, pull requests, history, worktrees with the reaper), the background repository monitor with a filesystem watcher and warm-start cache, per-worktree sizes and dirty-since tracking, the Gateway push and tenant-scoped fleet endpoints (/repositories, /worktrees, /reports/repositories-weekly) with the command line to match, plain-language cleanup recommendations, and the hand-to-an-agent flow.

Why one squash and not slices: the branch went through eight rounds of independent adversarial inspection (recorded in docs/MISSION-repositories-full-INSPECTION-1 through -6), which found and forced fixes for two genuine data-loss defects and roughly twenty-five narrower correctness holes. The intermediate states of the branch are therefore known-defective by proof; only the final PASS-verdict tip belongs on main, and a squash lands exactly that.

Safety spine: every destructive action re-verifies at the moment it acts; deletion binds atomically to the verified commit; a branch checked out into a worktree in the race window is restored losslessly; unverified warm-start data cannot be clicked, recommended, or served as fact; worktrees occupied by live sessions cannot be reaped; discard asks first in plain words.

Proof at this exact tip, after merging current main in: Core 3493 passed, Avalonia 290 passed, Gateway 3684 passed, zero failures; live harness against a running Director on a real machine, eight of eight checks, API answers matching raw git exactly.