### PR TITLE
Serve the shared workflow library to every tenant (Shared Workflow Library, phase 1)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Architecture/TenantGateArchitectureTests.cs
+++ b/src/CcDirector.Gateway.Tests/Architecture/TenantGateArchitectureTests.cs
@@ -224,6 +224,31 @@ public sealed class TenantGateArchitectureTests
     }
 
     /// <summary>
+    /// The shared workflow library read (devthrottle_internal issue 514) is a deliberate cross-tenant
+    /// capability and must stay NAMED on the allowlist, bound to its real mechanism: the workflow
+    /// stores resolve a workflow id's owning partition through a library-scoped context (the private
+    /// owning-context resolver), never by entering the System scope. If either half disappears - the
+    /// name or the mechanism - this test goes red and the reach is no longer review-visible.
+    /// </summary>
+    [Fact]
+    public void System_capability_allowlist_names_the_shared_workflow_library_read()
+    {
+        Assert.Contains(SystemCapabilityAllowlist.SharedWorkflowLibraryRead, SystemCapabilityAllowlist.Names);
+
+        var catalogResolver = typeof(Workflows.WorkflowStore).GetMethod(
+            "OpenOwningContext", BindingFlags.NonPublic | BindingFlags.Instance);
+        var runResolver = typeof(Workflows.WorkflowRunStore).GetMethod(
+            "OpenOwningWorkflowContext", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.True(catalogResolver is not null,
+            "The 'shared-workflow-library-read' capability names WorkflowStore's owning-partition " +
+            "resolver (OpenOwningContext); that mechanism must exist for the allowlist entry to mean anything.");
+        Assert.True(runResolver is not null,
+            "The 'shared-workflow-library-read' capability names WorkflowRunStore's owning-partition " +
+            "resolver (OpenOwningWorkflowContext); that mechanism must exist for the allowlist entry to mean anything.");
+    }
+
+    /// <summary>
     /// The reserved <see cref="TenantId.System"/> scope may be ENTERED only at the sanctioned composition-root
     /// startup-seeding site (GatewayHost). System scope is reached ONLY by code that explicitly enters it and
     /// is NEVER the answer to "no tenant resolved"; a new site that enters it is a new cross-tenant reach that

--- a/src/CcDirector.Gateway.Tests/SharedWorkflowLibraryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SharedWorkflowLibraryTests.cs
@@ -1,0 +1,202 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The shared workflow library (devthrottle_internal issue 514, phase 1). The built-in DevThrottle
+/// workflows are seeded ONCE into the shared library partition (the reserved System tenant on the
+/// hosted Gateway) and served READ-ONLY to every tenant: a tenant's catalog is the shared built-ins
+/// UNION its own workflows. These tests run the stores hosted-style - an
+/// <see cref="AsyncLocalTenantContext"/> over one database, seeding under the System scope exactly as
+/// the composition root does, then reading under real account-tenant scopes.
+///
+/// The first test is the reproduction of the defect this phase fixes: before the shared-library
+/// read, a hosted tenant's catalog was EMPTY (built-ins sat in the System partition, requests read
+/// the account partition, and the two never met - no mission workflow anywhere on hosted).
+/// </summary>
+public sealed class SharedWorkflowLibraryTests : IDisposable
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly TenantId TenantB = new("bbbbbbbb-0000-0000-0000-000000000002");
+
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly AsyncLocalTenantContext _tenant = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    /// <summary>Open the database hosted-style and construct the stores under the reserved System
+    /// scope, exactly as the composition root does at startup (seeding lands in the System partition).</summary>
+    private (WorkflowStore Workflows, WorkflowRunStore Runs) OpenHostedStores()
+    {
+        var db = _harness.Open(_tenant);
+        using (_tenant.Enter(TenantId.System))
+        {
+            var workflows = new WorkflowStore(db);
+            var runs = new WorkflowRunStore(db);
+            return (workflows, runs);
+        }
+    }
+
+    private static WorkflowContentRequest PublishableContent(string id) => new()
+    {
+        Id = id,
+        Name = "Acme flow",
+        Summary = "Tenant-owned test workflow.",
+        Steps = new List<WorkflowStepDto>
+        {
+            new() { Name = "Do", Description = "Do the thing.", Doer = "Worker", Reviewer = null, Done = "Done." },
+        },
+        InstructionsMarkdown = "# Acme flow\n\nDo the thing.",
+        AuthoredBy = "test-session",
+    };
+
+    // ---- the defect reproduction, then the shared read ---------------------------------------------
+
+    [Fact]
+    public void HostedTenant_ListsTheBuiltInLibrary()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            var catalog = workflows.ListPublished();
+
+            // Before the shared-library read this catalog was EMPTY - the hosted defect.
+            Assert.Contains(catalog, w => w.Id == "mission");
+            Assert.Contains(catalog, w => w.Id == "standalone");
+            Assert.Contains(catalog, w => w.Id == "standalone-with-review");
+            Assert.All(catalog, w => Assert.True(w.IsBuiltIn));
+        }
+    }
+
+    [Fact]
+    public void HostedTenant_ReadsTheMissionConduct()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            var dto = workflows.GetPublished("mission");
+            Assert.NotNull(dto);
+            Assert.True(dto!.IsBuiltIn);
+            Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), workflows.GetInstructions("mission", null));
+        }
+    }
+
+    [Fact]
+    public void PinnedVersionRead_ResolvesFromTheLibrary()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            // A seated run pins an explicit version; the pinned read must resolve from the shared
+            // partition so a run's conduct never disappears under it.
+            Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), workflows.GetInstructions("mission", 1));
+            var versions = workflows.ListVersions("mission");
+            Assert.NotNull(versions);
+            Assert.Contains(versions!, v => v.Version == 1 && v.Status == "published");
+            var detail = workflows.GetVersionDetail("mission", 1);
+            Assert.NotNull(detail);
+            Assert.Equal("Mission", detail!.Name);
+        }
+    }
+
+    // ---- tenant isolation around the shared library ------------------------------------------------
+
+    [Fact]
+    public void TenantWorkflows_StayIsolated_WhileBuiltInsAreShared()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            workflows.CreateDraft(PublishableContent("acme-flow"));
+            workflows.Publish("acme-flow");
+
+            var mine = workflows.ListPublished();
+            Assert.Equal(4, mine.Count); // three shared built-ins + my own
+            Assert.Contains(mine, w => w.Id == "acme-flow" && !w.IsBuiltIn);
+        }
+
+        using (_tenant.Enter(TenantB))
+        {
+            var theirs = workflows.ListPublished();
+            Assert.Equal(3, theirs.Count); // the shared built-ins ONLY - never another tenant's workflow
+            Assert.DoesNotContain(theirs, w => w.Id == "acme-flow");
+            Assert.Null(workflows.GetPublished("acme-flow"));
+            Assert.Null(workflows.GetInstructions("acme-flow", null));
+        }
+    }
+
+    [Fact]
+    public void CreateDraft_RefusesABuiltInId_TheLibraryCanNeverBeShadowed()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            // Without this refusal a hosted tenant (whose own partition holds no built-ins) could
+            // mint its own "mission" and shadow the library.
+            Assert.Throws<WorkflowConflictException>(() => workflows.CreateDraft(PublishableContent("mission")));
+        }
+    }
+
+    // ---- runs: a hosted tenant can actually execute the library conduct ----------------------------
+
+    [Fact]
+    public void HostedTenant_CanRunTheMissionWorkflow()
+    {
+        var (_, runs) = OpenHostedStores();
+
+        Guid runId;
+        using (_tenant.Enter(TenantA))
+        {
+            var run = runs.Create("mission", "Shared library proof run");
+            runId = run.Id;
+            Assert.Equal("mission", run.WorkflowId);
+            Assert.Equal(1, run.WorkflowVersion); // pinned to the published library version
+            Assert.NotNull(runs.Get(runId));
+        }
+
+        using (_tenant.Enter(TenantB))
+        {
+            // The RUN is tenant data and stays isolated even though the WORKFLOW is shared.
+            Assert.Null(runs.Get(runId));
+        }
+    }
+
+    [Fact]
+    public void HostedTenant_MissionCreatePathAnswers_EnsureRunnableAndEnabled()
+    {
+        var (_, runs) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            // The Gateway's mission-create path asks these two questions before creating a mission;
+            // both must resolve the shared library on hosted.
+            runs.EnsureRunnable("mission"); // must not throw
+            Assert.True(runs.IsWorkflowEnabled("mission"));
+            Assert.True(runs.GetWorkflowEnabled("mission"));
+        }
+    }
+
+    // ---- self-host stays exactly as it was ---------------------------------------------------------
+
+    [Fact]
+    public void SelfHost_SingleTenant_ServesTheSameCatalogAsBefore()
+    {
+        var db = _harness.Open(); // SingleTenantContext - everything is the Local tenant
+        var workflows = new WorkflowStore(db);
+
+        var catalog = workflows.ListPublished();
+        Assert.Equal(3, catalog.Count);
+        Assert.Contains(catalog, w => w.Id == "mission");
+        Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), workflows.GetInstructions("mission", null));
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/SystemCapabilityAllowlist.cs
+++ b/src/CcDirector.Gateway/Tenancy/SystemCapabilityAllowlist.cs
@@ -37,10 +37,23 @@ public static class SystemCapabilityAllowlist
     /// </summary>
     public const string StartupSystemSeeding = "startup-system-seeding";
 
+    /// <summary>
+    /// The shared workflow library read (devthrottle_internal issue 514, phase 1): every tenant's
+    /// workflow catalog serves the DevThrottle-maintained BUILT-IN workflows from the shared library
+    /// partition (the reserved System tenant, where <see cref="StartupSystemSeeding"/> put them) in
+    /// UNION with the tenant's own workflows. The mechanism is <c>WorkflowStore</c> /
+    /// <c>WorkflowRunStore</c> resolving a workflow id's OWNING partition through an explicitly
+    /// library-scoped context captured at construction - never by entering the System scope. The
+    /// reach is deliberately narrow: exactly one foreign partition, built-in rows only, and
+    /// READ-ONLY on every request path (the boot-time seeder remains the sole library writer).
+    /// </summary>
+    public const string SharedWorkflowLibraryRead = "shared-workflow-library-read";
+
     private static readonly HashSet<string> _names = new(StringComparer.Ordinal)
     {
         FleetDirectorList,
         StartupSystemSeeding,
+        SharedWorkflowLibraryRead,
     };
 
     /// <summary>Every named cross-tenant / System-scope capability, in one review-gated place.</summary>

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data;
@@ -19,6 +20,13 @@ namespace CcDirector.Gateway.Workflows;
 /// abandoned; a terminal status is FINAL. Acceptance never gates lifecycle and lifecycle never
 /// implies acceptance.
 ///
+/// THE SHARED WORKFLOW LIBRARY (devthrottle_internal issue 514, phase 1): the WORKFLOW a run
+/// executes may be a built-in living in the shared library partition (System on hosted), while the
+/// RUN itself is tenant data and always lands in the ambient tenant's partition. Workflow lookups
+/// here therefore resolve the owning partition exactly as <see cref="WorkflowStore"/> does (the
+/// library wins by id), which is what lets a hosted tenant seat sessions on the built-in "mission"
+/// conduct. Library reads are read-only - this store never writes a workflow row anywhere.
+///
 /// Threading: the Gateway is a single writer. Every operation runs under this store's write lock
 /// over a fresh pooled context.
 /// </summary>
@@ -26,6 +34,10 @@ public sealed class WorkflowRunStore
 {
     private readonly object _gate = new();
     private readonly GatewayDatabase _db;
+
+    /// <summary>The shared library partition - the tenant ambient at construction (System on hosted,
+    /// Local on self-host), mirroring <see cref="WorkflowStore"/>.</summary>
+    private readonly string _libraryTenant;
 
     private static readonly Dictionary<string, string[]> LegalTransitions = new(StringComparer.Ordinal)
     {
@@ -60,6 +72,25 @@ public sealed class WorkflowRunStore
     public WorkflowRunStore(GatewayDatabase db)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
+
+        // Capture the library partition from the construction-time ambient tenant, exactly as
+        // WorkflowStore does (the composition root constructs both inside the startup System scope).
+        using var ctx = _db.CreateContext();
+        _libraryTenant = ctx.ActiveTenant!;
+    }
+
+    /// <summary>
+    /// Open the context for the partition that OWNS workflow <paramref name="key"/>: the shared
+    /// library when the id is a built-in there (the library wins by id), otherwise the ambient
+    /// tenant's partition. On self-host both are the same partition. Caller disposes.
+    /// </summary>
+    private GatewayDbContext OpenOwningWorkflowContext(string key)
+    {
+        var library = _db.CreateContext(new TenantId(_libraryTenant));
+        if (library.Workflows.AsNoTracking().Any(h => h.Id == key && h.IsBuiltIn))
+            return library;
+        library.Dispose();
+        return _db.CreateContext();
     }
 
     /// <summary>
@@ -80,18 +111,25 @@ public sealed class WorkflowRunStore
 
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
-            if (head is null || head.Archived || head.PublishedVersion is null)
-                throw new WorkflowValidationException(
-                    $"Workflow '{key}' has no published version to run.");
-            if (!head.Enabled)
-                throw new WorkflowValidationException(
-                    $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
-                    "it disabled. Re-enable it in the cockpit or with: cc-devthrottle workflow enable " + key);
-            var version = ctx.WorkflowVersions.AsNoTracking().First(
-                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+            // The WORKFLOW may live in the shared library partition; the RUN always lands in the
+            // ambient tenant's partition. Two contexts, deliberately: the workflow read resolves the
+            // owning partition, the run write stays tenant data.
+            WorkflowVersionEntity version;
+            using (var wfCtx = OpenOwningWorkflowContext(key))
+            {
+                var head = wfCtx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
+                if (head is null || head.Archived || head.PublishedVersion is null)
+                    throw new WorkflowValidationException(
+                        $"Workflow '{key}' has no published version to run.");
+                if (!head.Enabled)
+                    throw new WorkflowValidationException(
+                        $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
+                        "it disabled. Re-enable it in the cockpit or with: cc-devthrottle workflow enable " + key);
+                version = wfCtx.WorkflowVersions.AsNoTracking().First(
+                    v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
+            }
 
+            using var ctx = _db.CreateContext();
             var now = DateTime.UtcNow;
             var entity = new WorkflowRunEntity
             {
@@ -129,7 +167,7 @@ public sealed class WorkflowRunStore
         {
             using var ctx = _db.CreateContext();
             var entity = ctx.WorkflowRuns.AsNoTracking().FirstOrDefault(r => r.Id == id);
-            return entity is null ? null : ToDto(entity, WorkflowEnabledFor(ctx, entity.WorkflowId));
+            return entity is null ? null : ToDto(entity, WorkflowEnabledFor(entity.WorkflowId));
         }
     }
 
@@ -165,7 +203,7 @@ public sealed class WorkflowRunStore
                 .OrderByDescending(r => r.CreatedUtc)
                 .Take(take)
                 .ToList();
-            var enabledByWorkflow = WorkflowEnabledMap(ctx, page.Select(r => r.WorkflowId));
+            var enabledByWorkflow = WorkflowEnabledMap(page.Select(r => r.WorkflowId));
             return page
                 .Select(r => ToDto(r, enabledByWorkflow.GetValueOrDefault(r.WorkflowId, false)))
                 .ToList();
@@ -185,7 +223,7 @@ public sealed class WorkflowRunStore
         var key = workflowId.Trim().ToLowerInvariant();
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningWorkflowContext(key);
             var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
             if (head is null || head.Archived || head.PublishedVersion is null)
                 throw new WorkflowValidationException(
@@ -218,7 +256,7 @@ public sealed class WorkflowRunStore
         var key = workflowId.Trim().ToLowerInvariant();
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningWorkflowContext(key);
             return ctx.Workflows.AsNoTracking()
                 .Where(h => h.Id == key && !h.Archived)
                 .Select(h => (bool?)h.Enabled)
@@ -226,21 +264,39 @@ public sealed class WorkflowRunStore
         }
     }
 
-    private static bool WorkflowEnabledFor(GatewayDbContext ctx, string workflowId) =>
-        ctx.Workflows.AsNoTracking()
+    private bool WorkflowEnabledFor(string workflowId)
+    {
+        using var ctx = OpenOwningWorkflowContext(workflowId);
+        return ctx.Workflows.AsNoTracking()
             .Where(h => h.Id == workflowId && !h.Archived)
             .Select(h => (bool?)h.Enabled)
             .FirstOrDefault() ?? false;
+    }
 
-    private static Dictionary<string, bool> WorkflowEnabledMap(
-        GatewayDbContext ctx, IEnumerable<string> workflowIds)
+    /// <summary>Enabled flags for a page of runs' workflow ids: the ambient tenant's own heads first,
+    /// then the shared library's built-ins OVERRIDE by id (the library wins, matching the id-scoped
+    /// resolution everywhere else). On self-host both reads hit the same partition and agree.</summary>
+    private Dictionary<string, bool> WorkflowEnabledMap(IEnumerable<string> workflowIds)
     {
         var ids = workflowIds.Distinct(StringComparer.Ordinal).ToList();
-        return ctx.Workflows.AsNoTracking()
-            .Where(h => ids.Contains(h.Id) && !h.Archived)
-            .Select(h => new { h.Id, h.Enabled })
-            .ToList()
-            .ToDictionary(h => h.Id, h => h.Enabled, StringComparer.Ordinal);
+        var map = new Dictionary<string, bool>(StringComparer.Ordinal);
+        using (var ctx = _db.CreateContext())
+        {
+            foreach (var h in ctx.Workflows.AsNoTracking()
+                         .Where(h => ids.Contains(h.Id) && !h.Archived)
+                         .Select(h => new { h.Id, h.Enabled })
+                         .ToList())
+                map[h.Id] = h.Enabled;
+        }
+        using (var library = _db.CreateContext(new TenantId(_libraryTenant)))
+        {
+            foreach (var h in library.Workflows.AsNoTracking()
+                         .Where(h => ids.Contains(h.Id) && h.IsBuiltIn && !h.Archived)
+                         .Select(h => new { h.Id, h.Enabled })
+                         .ToList())
+                map[h.Id] = h.Enabled;
+        }
+        return map;
     }
 
     /// <summary>
@@ -306,7 +362,7 @@ public sealed class WorkflowRunStore
             ctx.SaveChanges();
             FileLog.Write($"[WorkflowRunStore] Patch: run={id}, status={entity.Status}, " +
                           $"acceptance={entity.AcceptanceStatus}");
-            return ToDto(entity, WorkflowEnabledFor(ctx, entity.WorkflowId));
+            return ToDto(entity, WorkflowEnabledFor(entity.WorkflowId));
         }
     }
 

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Data;
@@ -12,8 +13,17 @@ namespace CcDirector.Gateway.Workflows;
 /// literals: the head row is identity/lifecycle, every piece of content is an immutable version row,
 /// and the built-in set (<see cref="BuiltInWorkflows"/>) is written in by
 /// <see cref="BuiltInWorkflowSeeder"/> at construction. The read surface serves the exact legacy
-/// catalog shape (issue #1617) plus additive fields; authoring (drafts, publish, files) is the next
-/// phase on this store.
+/// catalog shape (issue #1617) plus additive fields.
+///
+/// THE SHARED WORKFLOW LIBRARY (devthrottle_internal issue 514). The built-ins are DevThrottle's:
+/// seeded once into the partition that is ambient at CONSTRUCTION (the reserved System tenant on the
+/// hosted Gateway, Local on self-host) and served READ-ONLY to every tenant from there. A tenant's
+/// catalog is the shared built-ins UNION the tenant's own workflows; id-scoped reads resolve the
+/// owning partition (the library always wins - it can never be shadowed by a tenant workflow, and
+/// creating a workflow under a built-in id is refused). This is the deliberate cross-tenant read
+/// named <see cref="Tenancy.SystemCapabilityAllowlist.SharedWorkflowLibraryRead"/>: it reaches
+/// exactly one foreign partition (the library), for built-in rows only, and never writes there on a
+/// request path - the ONLY writer of library content is the boot-time seeder.
 ///
 /// Threading: the Gateway is a single writer. Every operation runs under this store's write lock over
 /// a fresh pooled context, preserving the single-writer invariant.
@@ -22,6 +32,13 @@ public sealed class WorkflowStore
 {
     private readonly object _gate = new();
     private readonly GatewayDatabase _db;
+
+    /// <summary>The partition the built-in library lives in: the tenant that was ambient when this
+    /// store was constructed (System on hosted, Local on self-host). Captured rather than hard-coded
+    /// so self-host - where the single-tenant context answers Local for everything - keeps reading
+    /// the exact rows it always read, and the reserved System id never appears outside the hosted
+    /// composition root.</summary>
+    private readonly string _libraryTenant;
 
     /// <param name="db">The Gateway EF database this store reads and writes through.</param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
@@ -32,8 +49,35 @@ public sealed class WorkflowStore
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
+            _libraryTenant = ctx.ActiveTenant!;
             BuiltInWorkflowSeeder.Seed(ctx);
         }
+    }
+
+    /// <summary>A fresh context scoped to the shared library partition. Read-only by contract on
+    /// request paths (the seeder is the only library writer); caller disposes.</summary>
+    private GatewayDbContext CreateLibraryContext() => _db.CreateContext(new TenantId(_libraryTenant));
+
+    /// <summary>
+    /// Open the context for the partition that OWNS workflow <paramref name="key"/>: the shared
+    /// library when the id is a built-in there (the library always wins, so it can never be shadowed),
+    /// otherwise the ambient tenant's own partition. On self-host both are the same partition and this
+    /// degenerates to today's single read. Caller disposes.
+    /// </summary>
+    private GatewayDbContext OpenOwningContext(string key)
+    {
+        var library = CreateLibraryContext();
+        if (library.Workflows.AsNoTracking().Any(h => h.Id == key && h.IsBuiltIn))
+            return library;
+        library.Dispose();
+        return _db.CreateContext();
+    }
+
+    /// <summary>True when <paramref name="key"/> is a built-in living in the shared library.</summary>
+    private bool IsLibraryBuiltIn(string key)
+    {
+        using var library = CreateLibraryContext();
+        return library.Workflows.AsNoTracking().Any(h => h.Id == key && h.IsBuiltIn);
     }
 
     /// <summary>
@@ -46,30 +90,60 @@ public sealed class WorkflowStore
     {
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var heads = ctx.Workflows.AsNoTracking()
-                .Where(h => !h.Archived && h.PublishedVersion != null)
-                .ToList()
-                .OrderBy(h => h.CreatedUtc)
-                .ThenBy(h => h.Id, StringComparer.Ordinal)
-                .ToList();
-            if (heads.Count == 0)
-                return Array.Empty<WorkflowDto>();
+            // The shared library first (built-ins, in their shipped creation order), then the ambient
+            // tenant's own workflows. On self-host both passes read the same partition, split by
+            // IsBuiltIn, so the served set and order are exactly what the single read served before.
+            var result = new List<WorkflowDto>();
+            var builtInIds = new HashSet<string>(StringComparer.Ordinal);
 
-            var ids = heads.Select(h => h.Id).ToList();
-            var versions = ctx.WorkflowVersions.AsNoTracking()
-                .Where(v => ids.Contains(v.WorkflowId) && v.Status == WorkflowVersionStatus.Published)
-                .ToList()
-                .ToDictionary(v => v.WorkflowId, StringComparer.Ordinal);
-            var draftIds = ctx.WorkflowVersions.AsNoTracking()
-                .Where(v => v.Status == WorkflowVersionStatus.Draft)
-                .Select(v => v.WorkflowId)
-                .ToHashSet(StringComparer.Ordinal);
+            using (var library = CreateLibraryContext())
+            {
+                foreach (var dto in ReadPublished(library, builtIns: true, exclude: null))
+                {
+                    builtInIds.Add(dto.Id);
+                    result.Add(dto);
+                }
+            }
 
-            return heads
-                .Select(h => ToDto(h, versions[h.Id], draftIds.Contains(h.Id)))
-                .ToList();
+            using (var ctx = _db.CreateContext())
+            {
+                // The exclusion is the shadow guard's belt-and-suspenders: a tenant row that somehow
+                // shares a built-in id (created before the refusal existed) must not double-list.
+                result.AddRange(ReadPublished(ctx, builtIns: false, exclude: builtInIds));
+            }
+
+            return result;
         }
+    }
+
+    /// <summary>One catalog pass over one partition: published heads (built-ins or user workflows),
+    /// projected from their published versions, in creation order.</summary>
+    private static IReadOnlyList<WorkflowDto> ReadPublished(
+        GatewayDbContext ctx, bool builtIns, HashSet<string>? exclude)
+    {
+        var heads = ctx.Workflows.AsNoTracking()
+            .Where(h => h.IsBuiltIn == builtIns && !h.Archived && h.PublishedVersion != null)
+            .ToList()
+            .Where(h => exclude is null || !exclude.Contains(h.Id))
+            .OrderBy(h => h.CreatedUtc)
+            .ThenBy(h => h.Id, StringComparer.Ordinal)
+            .ToList();
+        if (heads.Count == 0)
+            return Array.Empty<WorkflowDto>();
+
+        var ids = heads.Select(h => h.Id).ToList();
+        var versions = ctx.WorkflowVersions.AsNoTracking()
+            .Where(v => ids.Contains(v.WorkflowId) && v.Status == WorkflowVersionStatus.Published)
+            .ToList()
+            .ToDictionary(v => v.WorkflowId, StringComparer.Ordinal);
+        var draftIds = ctx.WorkflowVersions.AsNoTracking()
+            .Where(v => v.Status == WorkflowVersionStatus.Draft)
+            .Select(v => v.WorkflowId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return heads
+            .Select(h => ToDto(h, versions[h.Id], draftIds.Contains(h.Id)))
+            .ToList();
     }
 
     /// <summary>
@@ -84,7 +158,7 @@ public sealed class WorkflowStore
 
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningContext(key);
             var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
             if (head is null || head.Archived || head.PublishedVersion is null)
                 return null;
@@ -119,6 +193,13 @@ public sealed class WorkflowStore
 
         lock (_gate)
         {
+            // The library can never be shadowed: a tenant creating "mission" would otherwise mint a
+            // workflow the resolution rules could not serve (the built-in always wins by id).
+            if (IsLibraryBuiltIn(id))
+                throw new WorkflowConflictException(
+                    $"'{id}' is a built-in DevThrottle workflow; its id is reserved. Create your " +
+                    "workflow under a different id.");
+
             using var ctx = _db.CreateContext();
             if (ctx.Workflows.Any(h => h.Id == id))
                 throw new WorkflowConflictException($"A workflow with id '{id}' already exists.");
@@ -313,7 +394,7 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningContext(key);
             if (!ctx.Workflows.Any(h => h.Id == key))
                 return null;
             return ctx.WorkflowVersions.AsNoTracking()
@@ -340,7 +421,7 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningContext(key);
             var row = ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
                 v => v.WorkflowId == key && v.Version == version);
             if (row is null)
@@ -368,7 +449,7 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningContext(key);
             if (version is null)
             {
                 var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
@@ -391,7 +472,7 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
+            using var ctx = OpenOwningContext(key);
             var row = ResolveVersionRow(ctx, key, version);
             if (row is null)
                 return null;


### PR DESCRIPTION
## Why

On the hosted multi-tenant Gateway every tenant's workflow catalog was EMPTY: the built-in workflows (mission, standalone, standalone-with-review) are seeded once at boot into the reserved System partition, while every request reads the authenticated tenant's own partition through the Entity Framework tenant filter - the two never met. No mission workflow to seat sessions on, no workflow index in any session's launch briefing, and the mission-create path could not resolve the "mission" workflow at all. New tenants were minted with nothing.

This is phase 1 of the Shared Workflow Library (devthrottle_internal issue 514): the built-ins are DevThrottle's, they live ONCE in the shared library partition, and every tenant's catalog serves them read-only in union with the tenant's own workflows. No per-tenant seeding exists at all - a brand-new tenant's first read serves the library, so there is nothing to forget to run.

## What changed

- `WorkflowStore`: the catalog list is a union read - shared library built-ins first (shipped order), then the ambient tenant's own workflows. Every id-scoped read (get by id, instructions head and pinned version, version history, version detail, helper files) resolves the OWNING partition through one helper; the library always wins by id, so it can never be shadowed. Creating a workflow under a built-in id is refused with a clear message. On self-host the library partition and the tenant partition are the same partition, so behavior is byte-identical to before.
- `WorkflowRunStore`: run creation, seat validation, and the mission-create path's runnable/enabled questions resolve the shared library the same way, while the RUN row itself stays tenant data in the ambient tenant's partition. This is what lets a hosted tenant seat sessions on the built-in mission conduct.
- `SystemCapabilityAllowlist`: the reach names itself - `shared-workflow-library-read`, a deliberate cross-tenant capability that touches exactly one foreign partition, built-in rows only, read-only on every request path (the boot-time seeder remains the sole library writer). A new architecture test binds the name to its mechanism, alongside the existing rule that the System scope itself is entered only at the composition root (this change never enters it - it reads through an explicitly library-scoped context captured at construction).

## Proof

- New `SharedWorkflowLibraryTests` run the stores hosted-style (real `AsyncLocalTenantContext`, seeding under the System scope exactly as the composition root does): two distinct tenants both list all three built-ins; each sees only its own user workflows; a tenant reads the mission conduct and creates a run seated on mission pinned to the published library version; the pinned-version read resolves from the library; the built-in-id refusal holds; runs stay tenant-isolated; self-host single-tenant serves the same catalog as before. The first test is the failing-first reproduction - it was red (empty catalog) before the store change and is green after.
- Full test sweep green (all seven test projects; counts in the checks below).

Test counts this branch: Gateway 3697 passed / 0 failed; Core 3493/0; Avalonia 290/0; HostedAgent 86/0; Engine 62/0; Launcher 27/0; Terminal.Avalonia 23/0.
