### PR TITLE
Per-tenant on/off for built-in workflows (Shared Workflow Library, phase 2)

### DIFF
--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724141554_AddWorkflowTenantOverrides.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724141554_AddWorkflowTenantOverrides.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724141554_AddWorkflowTenantOverrides")]
+    partial class AddWorkflowTenantOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724141554_AddWorkflowTenantOverrides.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724141554_AddWorkflowTenantOverrides.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowTenantOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "workflow_tenant_overrides",
+                schema: "gateway",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "text", nullable: false),
+                    WorkflowId = table.Column<string>(type: "text", nullable: false, collation: "C"),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflow_tenant_overrides", x => new { x.tenant_id, x.WorkflowId });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_tenant_overrides_tenant_id",
+                schema: "gateway",
+                table: "workflow_tenant_overrides",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workflow_tenant_overrides",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowTenantOverrideTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowTenantOverrideTests.cs
@@ -1,0 +1,145 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Per-tenant on/off for BUILT-IN workflows (Shared Workflow Library phase 2, devthrottle_internal
+/// issue 514). The built-ins live once in the shared library partition and are read-only to tenants,
+/// so a tenant's switch flip lands in the tenant's own <c>workflow_tenant_overrides</c> row and the
+/// read paths fold it over the library state. The properties proven here:
+///
+///  - Off is PER TENANT: tenant A turning mission off hides it from A's briefings, refuses A's
+///    default conduct read and A's new runs - while tenant B is completely untouched.
+///  - Off never deletes: the flip back restores everything, and a pinned (explicit-version) read
+///    keeps resolving while off - a seated run's conduct never disappears under it.
+///  - The actor is recorded on the override row (a governance change has an actor, always).
+/// </summary>
+public sealed class WorkflowTenantOverrideTests : IDisposable
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly TenantId TenantB = new("bbbbbbbb-0000-0000-0000-000000000002");
+
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly AsyncLocalTenantContext _tenant = new();
+    private GatewayDatabase? _db;
+
+    public void Dispose() => _harness.Dispose();
+
+    private (WorkflowStore Workflows, WorkflowRunStore Runs) OpenHostedStores()
+    {
+        _db = _harness.Open(_tenant);
+        using (_tenant.Enter(TenantId.System))
+        {
+            return (new WorkflowStore(_db), new WorkflowRunStore(_db));
+        }
+    }
+
+    [Fact]
+    public void TenantOff_IsScopedToThatTenantOnly()
+    {
+        var (workflows, runs) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            Assert.True(workflows.SetEnabled("mission", false, "tenant-a-admin"));
+
+            var mission = workflows.ListPublished().Single(w => w.Id == "mission");
+            Assert.False(mission.Enabled);
+            Assert.False(workflows.GetPublished("mission")!.Enabled);
+            Assert.Throws<WorkflowValidationException>(() => workflows.GetInstructions("mission", null));
+            Assert.Throws<WorkflowValidationException>(() => runs.Create("mission", "Refused run"));
+            Assert.Throws<WorkflowValidationException>(() => runs.EnsureRunnable("mission"));
+            Assert.False(runs.IsWorkflowEnabled("mission"));
+            Assert.Equal(false, runs.GetWorkflowEnabled("mission"));
+        }
+
+        using (_tenant.Enter(TenantB))
+        {
+            // Tenant B never made a choice - the library's shipped state (ON) serves untouched.
+            var mission = workflows.ListPublished().Single(w => w.Id == "mission");
+            Assert.True(mission.Enabled);
+            Assert.NotNull(workflows.GetInstructions("mission", null));
+            var run = runs.Create("mission", "Tenant B still runs");
+            Assert.Equal("mission", run.WorkflowId);
+            Assert.True(runs.IsWorkflowEnabled("mission"));
+        }
+    }
+
+    [Fact]
+    public void TenantOff_NeverDeletes_AndFlippingBackRestoresEverything()
+    {
+        var (workflows, runs) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            Assert.True(workflows.SetEnabled("mission", false, "tenant-a-admin"));
+
+            // Pinned history keeps resolving while off - a seated run's conduct never disappears.
+            Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), workflows.GetInstructions("mission", 1));
+            // And the workflow is still LISTED (off, not gone).
+            Assert.Contains(workflows.ListPublished(), w => w.Id == "mission" && !w.Enabled);
+
+            Assert.True(workflows.SetEnabled("mission", true, "tenant-a-admin"));
+            Assert.True(workflows.ListPublished().Single(w => w.Id == "mission").Enabled);
+            Assert.NotNull(workflows.GetInstructions("mission", null));
+            var run = runs.Create("mission", "Restored run");
+            Assert.Equal(1, run.WorkflowVersion);
+        }
+    }
+
+    [Fact]
+    public void TheActorIsRecordedOnTheChoice()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            workflows.SetEnabled("mission", false, "qa-reviewer");
+
+            using var ctx = _db!.CreateContext();
+            var choice = ctx.WorkflowTenantOverrides.Single(o => o.WorkflowId == "mission");
+            Assert.Equal("qa-reviewer", choice.UpdatedBy);
+            Assert.False(choice.Enabled);
+            Assert.True(choice.UpdatedAtUtc > DateTime.UtcNow.AddMinutes(-5));
+        }
+    }
+
+    [Fact]
+    public void TheSharedLibraryRowIsNeverTouchedByATenantFlip()
+    {
+        var (workflows, _) = OpenHostedStores();
+
+        using (_tenant.Enter(TenantA))
+        {
+            workflows.SetEnabled("mission", false, "tenant-a-admin");
+        }
+
+        // The library head row keeps its shipped state - the flip landed in tenant A's partition only.
+        using (_tenant.Enter(TenantId.System))
+        {
+            using var ctx = _db!.CreateContext();
+            var head = ctx.Workflows.Single(h => h.Id == "mission");
+            Assert.True(head.Enabled);
+            Assert.Empty(ctx.WorkflowTenantOverrides.ToList()); // no override row in the System partition
+        }
+    }
+
+    [Fact]
+    public void SelfHost_SwitchStillWorks_ThroughTheOverride()
+    {
+        var db = _harness.Open(); // SingleTenantContext - the local single tenant
+        var workflows = new WorkflowStore(db);
+        var runs = new WorkflowRunStore(db);
+
+        Assert.True(workflows.SetEnabled("mission", false, "owner"));
+        Assert.False(workflows.ListPublished().Single(w => w.Id == "mission").Enabled);
+        Assert.Throws<WorkflowValidationException>(() => runs.Create("mission", "Refused"));
+
+        Assert.True(workflows.SetEnabled("mission", true, "owner"));
+        Assert.True(workflows.ListPublished().Single(w => w.Id == "mission").Enabled);
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/WorkflowTenantOverrideEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/WorkflowTenantOverrideEntity.cs
@@ -1,0 +1,35 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One tenant's on/off choice for a BUILT-IN workflow: a single (tenant, workflow id) -&gt; enabled row
+/// in the <c>workflow_tenant_overrides</c> table (Shared Workflow Library phase 2, devthrottle_internal
+/// issue 514). The built-ins live ONCE in the shared library partition and are read-only to tenants,
+/// so a tenant flipping one off cannot touch the shared head row - the flip lands here, in the
+/// tenant's own partition, and the read paths fold it over the library value. An ABSENT row means
+/// "no choice made" - the workflow serves with the library's shipped state, which is exactly what a
+/// brand-new tenant gets with zero provisioning.
+///
+/// User-owned workflows do NOT use this table: their head row lives in the tenant's own partition, so
+/// the existing head-row switch remains their single source of truth. One workflow id has exactly one
+/// authority for its switch - the head row when the tenant owns it, this override when the library does.
+///
+/// KEYING mirrors <see cref="TenantSettingEntity"/>: the workflow id is namespaced per tenant, so the
+/// primary key is the COMPOSITE (tenant_id, WorkflowId). <c>tenant_id</c> and the deny-by-default
+/// global query filter are inherited from <see cref="TenantScopedEntity"/>.
+/// </summary>
+public sealed class WorkflowTenantOverrideEntity : TenantScopedEntity
+{
+    /// <summary>The built-in workflow this choice applies to (e.g. "mission"). Part of the composite
+    /// primary key with <c>tenant_id</c>; ordinally compared (SQLite BINARY / Postgres "C").</summary>
+    public string WorkflowId { get; set; } = "";
+
+    /// <summary>The tenant's choice: false hides the built-in from briefings and refuses default
+    /// conduct reads and new runs FOR THIS TENANT ONLY; true restores it. Never deletes anything.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Who flipped it (a governance change has an actor, always - the run-acceptance posture).</summary>
+    public string UpdatedBy { get; set; } = "";
+
+    /// <summary>When the choice was last written (UTC).</summary>
+    public DateTime UpdatedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -105,6 +105,12 @@ public sealed class GatewayDbContext : DbContext
     /// default, never another tenant's value.</summary>
     public DbSet<TenantSettingEntity> TenantSettings => Set<TenantSettingEntity>();
 
+    /// <summary>Per-tenant on/off choices for BUILT-IN workflows (<c>workflow_tenant_overrides</c>, the Shared
+    /// Workflow Library phase 2). The built-ins live once in the shared library partition and are read-only to
+    /// tenants, so a tenant's switch flip lands here and the read paths fold it over the library value. An
+    /// absent row means "no choice made" - the workflow serves with the library's shipped state.</summary>
+    public DbSet<WorkflowTenantOverrideEntity> WorkflowTenantOverrides => Set<WorkflowTenantOverrideEntity>();
+
     /// <summary>The account-to-tenant mapping (<c>tenants</c>), keyed by the verified Supabase subject. This
     /// is the GLOBAL mapping table (Hosted Multi-Tenancy increment 1) - deliberately NOT tenant-scoped, so it
     /// has no <c>tenant_id</c> column and no query filter; it is the table the filter's tenant values come
@@ -358,6 +364,16 @@ public sealed class GatewayDbContext : DbContext
             b.HasKey(e => new { e.TenantId, e.Key });
         });
 
+        modelBuilder.Entity<WorkflowTenantOverrideEntity>(b =>
+        {
+            b.ToTable("workflow_tenant_overrides");
+            // COMPOSITE primary key (tenant_id, WorkflowId) - the Shared Workflow Library phase 2, mirroring
+            // tenant_settings. The workflow id is namespaced per tenant (every tenant may hold a choice for
+            // the same built-in), so scoping the key by tenant is what keeps two tenants' choices for
+            // "mission" from colliding at the database.
+            b.HasKey(e => new { e.TenantId, e.WorkflowId });
+        });
+
         modelBuilder.Entity<GovernanceAuditEventEntity>(b =>
         {
             b.ToTable("governance_audit_events");
@@ -464,6 +480,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<GovernanceAuditEventEntity>(modelBuilder);
         ApplyTenantScope<TenantSettingEntity>(modelBuilder);
         ApplyTenantScope<DictationTranscriptEntity>(modelBuilder);
+        ApplyTenantScope<WorkflowTenantOverrideEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
 
@@ -497,6 +514,9 @@ public sealed class GatewayDbContext : DbContext
             // tenant_settings.Key is a fixed ordinally-compared identifier (issue #2017), same byte-ordinal
             // equality requirement as mission_notes.Key - pin it to "C" so both providers agree exactly.
             modelBuilder.Entity<TenantSettingEntity>().Property(e => e.Key).UseCollation("C");
+            // workflow_tenant_overrides.WorkflowId is a workflow slug compared ordinally everywhere else
+            // (the stores normalize to lower-case and compare Ordinal), so pin it to "C" the same way.
+            modelBuilder.Entity<WorkflowTenantOverrideEntity>().Property(e => e.WorkflowId).UseCollation("C");
             // The tenants mapping table's natural-key string columns (the tenant id primary key and the
             // account_subject unique index) rely on byte-ordinal equality/uniqueness, same as the keys above,
             // so pin them to "C" too - the account subject in particular must match EXACTLY on both providers.

--- a/src/CcDirector.Gateway/Data/Migrations/20260724141545_AddWorkflowTenantOverrides.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724141545_AddWorkflowTenantOverrides.Designer.cs
@@ -3,48 +3,45 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724141545_AddWorkflowTenantOverrides")]
+    partial class AddWorkflowTenantOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasDefaultSchema("gateway")
-                .HasAnnotation("ProductVersion", "9.0.2")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -54,108 +51,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", "gateway");
+                    b.ToTable("account_hosted_ai_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", "gateway");
+                    b.ToTable("cron_jobs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -164,115 +161,112 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", "gateway");
+                    b.ToTable("cron_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", "gateway");
+                    b.ToTable("device_credentials", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", "gateway");
+                    b.ToTable("device_import_markers", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
@@ -280,43 +274,43 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", "gateway");
+                    b.ToTable("dictation_transcripts", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<Guid>("Subject")
-                        .HasColumnType("uuid")
+                    b.Property<string>("Subject")
+                        .HasColumnType("TEXT")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", "gateway", t =>
+                    b.ToTable("entitlements", null, t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -325,38 +319,38 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -369,40 +363,40 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", "gateway");
+                    b.ToTable("governance_audit_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -415,112 +409,109 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", "gateway");
+                    b.ToTable("governance_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", "gateway");
+                    b.ToTable("mission_notes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", "gateway");
+                    b.ToTable("push_subscriptions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Model")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -528,165 +519,161 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", "gateway");
+                    b.ToTable("session_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", "gateway");
+                    b.ToTable("snoozes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", "gateway");
+                    b.ToTable("tenants", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", "gateway");
+                    b.ToTable("tenant_settings", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", "gateway");
+                    b.ToTable("wingman_instructions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", "gateway");
+                    b.ToTable("worklists", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Area")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Position")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -694,75 +681,75 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", "gateway");
+                    b.ToTable("worklist_items", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", "gateway");
+                    b.ToTable("workflows", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -770,71 +757,71 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", "gateway");
+                    b.ToTable("workflow_files", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -844,93 +831,92 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", "gateway");
+                    b.ToTable("workflow_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", "gateway");
+                    b.ToTable("workflow_tenant_overrides", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -939,7 +925,7 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", "gateway");
+                    b.ToTable("workflow_versions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -947,28 +933,28 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("boolean");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Action");
 
@@ -979,18 +965,18 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Target");
 
@@ -1010,36 +996,36 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions", "gateway");
+                            b1.ToTable("wingman_instructions");
 
                             b1.ToJson("Versions");
 
@@ -1064,35 +1050,35 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1103,37 +1089,37 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("Participants");
 
@@ -1144,23 +1130,23 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("ProofLinks");
 
@@ -1180,26 +1166,26 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1210,34 +1196,34 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260724141545_AddWorkflowTenantOverrides.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724141545_AddWorkflowTenantOverrides.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowTenantOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "workflow_tenant_overrides",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    WorkflowId = table.Column<string>(type: "TEXT", nullable: false),
+                    Enabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "TEXT", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workflow_tenant_overrides", x => new { x.tenant_id, x.WorkflowId });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_workflow_tenant_overrides_tenant_id",
+                table: "workflow_tenant_overrides",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workflow_tenant_overrides");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
@@ -831,6 +831,32 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.ToTable("workflow_runs", (string)null);
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
+                {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("tenant_id");
+
+                    b.Property<string>("WorkflowId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<bool>("Enabled")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<DateTime>("UpdatedAtUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("UpdatedBy")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("TenantId", "WorkflowId");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("workflow_tenant_overrides", (string)null);
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -93,6 +93,21 @@ public sealed class WorkflowRunStore
         return _db.CreateContext();
     }
 
+    /// <summary>The ambient tenant's on/off choice for a built-in (phase 2), or null when none.</summary>
+    private bool? TenantChoiceFor(string key)
+    {
+        using var ctx = _db.CreateContext();
+        return ctx.WorkflowTenantOverrides.AsNoTracking()
+            .Where(o => o.WorkflowId == key)
+            .Select(o => (bool?)o.Enabled)
+            .FirstOrDefault();
+    }
+
+    /// <summary>A head's enabled state as THIS tenant sees it: for a built-in the tenant's own
+    /// choice wins over the library's state; a user-owned head keeps its head-row switch.</summary>
+    private bool EffectiveEnabled(WorkflowEntity head) =>
+        head.IsBuiltIn ? TenantChoiceFor(head.Id) ?? head.Enabled : head.Enabled;
+
     /// <summary>
     /// Open a run of a workflow, pinned to its currently published version, with criteria seeded
     /// pending from that version's declared outcome criteria.
@@ -121,7 +136,7 @@ public sealed class WorkflowRunStore
                 if (head is null || head.Archived || head.PublishedVersion is null)
                     throw new WorkflowValidationException(
                         $"Workflow '{key}' has no published version to run.");
-                if (!head.Enabled)
+                if (!EffectiveEnabled(head))
                     throw new WorkflowValidationException(
                         $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
                         "it disabled. Re-enable it in the cockpit or with: cc-devthrottle workflow enable " + key);
@@ -228,7 +243,7 @@ public sealed class WorkflowRunStore
             if (head is null || head.Archived || head.PublishedVersion is null)
                 throw new WorkflowValidationException(
                     $"Workflow '{key}' has no published version to run.");
-            if (!head.Enabled)
+            if (!EffectiveEnabled(head))
                 throw new WorkflowValidationException(
                     $"Workflow '{key}' is turned OFF on this fleet - no new runs while the owner has " +
                     "it disabled.");
@@ -257,20 +272,16 @@ public sealed class WorkflowRunStore
         lock (_gate)
         {
             using var ctx = OpenOwningWorkflowContext(key);
-            return ctx.Workflows.AsNoTracking()
-                .Where(h => h.Id == key && !h.Archived)
-                .Select(h => (bool?)h.Enabled)
-                .FirstOrDefault();
+            var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key && !h.Archived);
+            return head is null ? null : EffectiveEnabled(head);
         }
     }
 
     private bool WorkflowEnabledFor(string workflowId)
     {
         using var ctx = OpenOwningWorkflowContext(workflowId);
-        return ctx.Workflows.AsNoTracking()
-            .Where(h => h.Id == workflowId && !h.Archived)
-            .Select(h => (bool?)h.Enabled)
-            .FirstOrDefault() ?? false;
+        var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == workflowId && !h.Archived);
+        return head is not null && EffectiveEnabled(head);
     }
 
     /// <summary>Enabled flags for a page of runs' workflow ids: the ambient tenant's own heads first,
@@ -288,13 +299,26 @@ public sealed class WorkflowRunStore
                          .ToList())
                 map[h.Id] = h.Enabled;
         }
+        var builtInIds = new List<string>();
         using (var library = _db.CreateContext(new TenantId(_libraryTenant)))
         {
             foreach (var h in library.Workflows.AsNoTracking()
                          .Where(h => ids.Contains(h.Id) && h.IsBuiltIn && !h.Archived)
                          .Select(h => new { h.Id, h.Enabled })
                          .ToList())
+            {
                 map[h.Id] = h.Enabled;
+                builtInIds.Add(h.Id);
+            }
+        }
+        // Fold the ambient tenant's own choices over the library state for the built-ins (phase 2).
+        if (builtInIds.Count > 0)
+        {
+            using var ctx = _db.CreateContext();
+            foreach (var choice in ctx.WorkflowTenantOverrides.AsNoTracking()
+                         .Where(o => builtInIds.Contains(o.WorkflowId))
+                         .ToList())
+                map[choice.WorkflowId] = choice.Enabled;
         }
         return map;
     }

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -80,6 +80,33 @@ public sealed class WorkflowStore
         return library.Workflows.AsNoTracking().Any(h => h.Id == key && h.IsBuiltIn);
     }
 
+    /// <summary>The ambient tenant's on/off choice for a built-in, or null when the tenant has made
+    /// none (the workflow serves with the library's shipped state). Phase 2 of the shared library:
+    /// the choice lives in the TENANT's partition because the shared head row is read-only to tenants.</summary>
+    private bool? TenantChoiceFor(string key)
+    {
+        using var ctx = _db.CreateContext();
+        return ctx.WorkflowTenantOverrides.AsNoTracking()
+            .Where(o => o.WorkflowId == key)
+            .Select(o => (bool?)o.Enabled)
+            .FirstOrDefault();
+    }
+
+    /// <summary>The ambient tenant's on/off choices for a set of built-in ids, absent ids omitted.</summary>
+    private Dictionary<string, bool> TenantChoicesFor(IReadOnlyCollection<string> keys)
+    {
+        using var ctx = _db.CreateContext();
+        return ctx.WorkflowTenantOverrides.AsNoTracking()
+            .Where(o => keys.Contains(o.WorkflowId))
+            .ToList()
+            .ToDictionary(o => o.WorkflowId, o => o.Enabled, StringComparer.Ordinal);
+    }
+
+    /// <summary>A built-in head's enabled state as THIS tenant sees it: the tenant's own choice when
+    /// one exists, else the library's state. User-owned heads keep their head-row switch untouched.</summary>
+    private bool EffectiveEnabled(WorkflowEntity head) =>
+        head.IsBuiltIn ? TenantChoiceFor(head.Id) ?? head.Enabled : head.Enabled;
+
     /// <summary>
     /// Every workflow with a published version, projected from that published version, in stable
     /// catalog order (creation order; the seeder stamps the built-ins so they keep their shipped
@@ -103,6 +130,15 @@ public sealed class WorkflowStore
                     builtInIds.Add(dto.Id);
                     result.Add(dto);
                 }
+            }
+
+            // Fold this tenant's own on/off choices over the library's shipped state (phase 2): at
+            // this point the result holds ONLY the built-ins, so the stamp cannot touch a user row.
+            var choices = TenantChoicesFor(builtInIds);
+            foreach (var dto in result)
+            {
+                if (choices.TryGetValue(dto.Id, out var chosen))
+                    dto.Enabled = chosen;
             }
 
             using (var ctx = _db.CreateContext())
@@ -173,7 +209,10 @@ public sealed class WorkflowStore
 
             var hasDraft = ctx.WorkflowVersions.AsNoTracking().Any(
                 v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Draft);
-            return ToDto(head, version, hasDraft);
+            var dto = ToDto(head, version, hasDraft);
+            if (head.IsBuiltIn)
+                dto.Enabled = EffectiveEnabled(head); // fold the tenant's own choice (phase 2)
+            return dto;
         }
     }
 
@@ -453,7 +492,7 @@ public sealed class WorkflowStore
             if (version is null)
             {
                 var head = ctx.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == key);
-                if (head is { Archived: false, Enabled: false })
+                if (head is { Archived: false } && !EffectiveEnabled(head))
                     throw new WorkflowValidationException(
                         $"Workflow '{key}' is turned OFF on this fleet. The owner disabled it; its " +
                         "history remains readable by explicit version, and it can be re-enabled in " +
@@ -639,18 +678,46 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
-            if (head is null || head.Archived)
-                return false;
+            // A BUILT-IN's switch is per tenant (phase 2): the shared library head row is read-only
+            // to tenants, so the choice upserts into the tenant's own override row and the read
+            // paths fold it. One authority per id: the override for library workflows, the head row
+            // (below) for tenant-owned ones.
+            if (IsLibraryBuiltIn(key))
+            {
+                using var ctx = _db.CreateContext();
+                var choice = ctx.WorkflowTenantOverrides.FirstOrDefault(o => o.WorkflowId == key);
+                if (choice is null)
+                {
+                    choice = new WorkflowTenantOverrideEntity
+                    {
+                        TenantId = ctx.ActiveTenant!,
+                        WorkflowId = key,
+                    };
+                    ctx.WorkflowTenantOverrides.Add(choice);
+                }
+                choice.Enabled = enabled;
+                choice.UpdatedBy = by.Trim();
+                choice.UpdatedAtUtc = DateTime.UtcNow;
+                ctx.SaveChanges();
+                FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}, by={by.Trim()} " +
+                              "(built-in - per-tenant override)");
+                return true;
+            }
 
-            head.Enabled = enabled;
-            head.UpdatedUtc = DateTime.UtcNow;
-            ctx.SaveChanges();
-            // Attribution is log-based for now; the durable audit trail is governance's append-only
-            // event ledger (#1771), which will hang off these same ids.
-            FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}, by={by.Trim()}");
-            return true;
+            using (var ctx = _db.CreateContext())
+            {
+                var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
+                if (head is null || head.Archived)
+                    return false;
+
+                head.Enabled = enabled;
+                head.UpdatedUtc = DateTime.UtcNow;
+                ctx.SaveChanges();
+                // Attribution is log-based for now; the durable audit trail is governance's append-only
+                // event ledger (#1771), which will hang off these same ids.
+                FileLog.Write($"[WorkflowStore] SetEnabled: id={key}, enabled={enabled}, by={by.Trim()}");
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Why

Phase 2 of the Shared Workflow Library (devthrottle_internal issue 514). Phase 1 made the built-in DevThrottle workflows visible to every tenant from the shared library partition - but the on/off switch still targeted the workflow HEAD row, which for a built-in is the shared library row: on hosted a tenant flipping it would either fail (not their partition) or, worse, flip it for everyone. A tenant's choice to turn a built-in off must be that tenant's alone.

## What changed

- New `workflow_tenant_overrides` table: one (tenant, workflow id) -> enabled row, composite primary key, tenant-scoped with the deny-by-default global query filter (the architecture gate picks it up automatically). The actor and timestamp are recorded on the row - a governance change has an actor, always.
- `WorkflowStore.SetEnabled`: for a BUILT-IN the flip upserts the ambient tenant's override row and never touches the shared head; user-owned workflows keep the head-row switch. One authority per id.
- Read folding: the catalog list, get by id, the default instructions read (the OFF refusal), run creation, seat validation, and the mission-create path's enabled questions all serve the built-in's effective state - the tenant's own choice when one exists, else the library's shipped state. An absent row means "no choice made", which is exactly what a brand-new tenant gets with zero provisioning.
- Migrations in BOTH provider assemblies (SQLite `Data/Migrations`, PostgreSQL `Migrations.Postgres`), same pull request as the model change; `dotnet ef migrations has-pending-model-changes` reports clean on both.

Off stays exactly what it was: hidden from briefings, default conduct read refused, no new runs or seats - and it deletes NOTHING. Pinned (explicit-version) reads keep resolving while off, so a seated run's conduct never disappears under it.

## Proof

New `WorkflowTenantOverrideTests` (hosted-style, real `AsyncLocalTenantContext`): tenant A turns mission off - A's catalog shows it off, A's default conduct read and new runs are refused, while tenant B lists it on, reads it, and runs it untouched; flipping back restores everything; the actor lands on the override row; the shared library head row is proven untouched (and no override row leaks into the System partition); self-host still flips through the same public switch. Existing `WorkflowEnableSwitchTests` pass unchanged - the switch's observable behavior is identical, only its storage moved.
