### PR TITLE
Built-in workflows become read-only (Shared Workflow Library, phase 3)

### DIFF
--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -3,13 +3,12 @@ import { Link, useParams } from "react-router-dom";
 import {
   getWorkflow,
   getWorkflowInstructions,
-  resetWorkflow,
   setWorkflowEnabled,
   type WorkflowDefinition,
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
-import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
+import { ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 
 // One workflow, in full (Workflows mission, phase 7). The list row answered "what exists"; this page
 // answers "what does it actually say": the metadata and step summary up top (the machine-readable
@@ -23,7 +22,6 @@ export function WorkflowDetail() {
   const [instructions, setInstructions] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingOff, setPendingOff] = useState(false);
-  const [pendingReset, setPendingReset] = useState(false);
   // Every load claims a generation; a load that finishes after a newer one started (a mutation
   // refresh racing a route change to another workflow) drops its result instead of painting
   // workflow A's state under workflow B's URL.
@@ -58,7 +56,7 @@ export function WorkflowDetail() {
     return () => ctrl.abort();
   }, [load]);
 
-  // A failed flip or reset is never silent: it lands in the page's error state (with Retry).
+  // A failed flip is never silent: it lands in the page's error state (with Retry).
   const flip = async (enabled: boolean) => {
     if (id === undefined) return;
     try {
@@ -112,12 +110,16 @@ export function WorkflowDetail() {
                 </span>
               </span>
             ) : null}
-            {workflow.isBuiltIn === true ? (
-              <Button variant="secondary" onClick={() => setPendingReset(true)}>
-                Reset to shipped
-              </Button>
-            ) : null}
           </div>
+          {/* The Gateway's editability verdict, rendered verbatim (rule 7): built-ins are
+              DevThrottle-maintained and read-only; the sanctioned customization path is clone. */}
+          {workflow.editable === false ? (
+            <p className="wf-conduct-hint">
+              This is a built-in workflow, maintained by DevThrottle and updated with the Gateway
+              itself. It cannot be edited or deleted - to customize the conduct, clone it into your
+              own workflow.
+            </p>
+          ) : null}
           {workflow.enabled === false ? (
             <p className="wf-off-banner">
               This workflow is OFF: agents will not see it in their briefings, and it cannot start
@@ -172,29 +174,6 @@ export function WorkflowDetail() {
         onClose={() => setPendingOff(false)}
       />
 
-      <ConfirmDialog
-        open={pendingReset}
-        title={`Reset '${workflow?.name ?? id}' to the shipped content?`}
-        message={
-          <>
-            The content DevThrottle ships becomes a NEW published version, in force immediately.
-            Your customized versions stay as history and remain readable by version number.
-          </>
-        }
-        confirmLabel="Reset to shipped"
-        danger={false}
-        onConfirm={async () => {
-          if (id === undefined) return;
-          try {
-            await resetWorkflow(id);
-          } catch (err) {
-            setError(gatewayErrorMessage(err));
-            return;
-          }
-          await load();
-        }}
-        onClose={() => setPendingReset(false)}
-      />
     </div>
   );
 }

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -35,7 +35,7 @@ export interface WorkflowDefinition {
    *  reading an older Gateway that serves only the legacy shape. */
   /** The published version number this projection reflects. */
   version?: number;
-  /** True for the workflows the Gateway ships (mission, standalone, ...). Editable, never deletable. */
+  /** True for the workflows the Gateway ships (mission, standalone, ...). Read-only, never deletable. */
   isBuiltIn?: boolean;
   /** True when an unpublished draft exists beside the published version. */
   hasDraft?: boolean;
@@ -46,6 +46,10 @@ export interface WorkflowDefinition {
   /** The owner's switch: false = OFF (hidden from agents' briefings, no new runs or seats).
    *  Absent on an older Gateway, which means enabled. */
   enabled?: boolean;
+  /** The Gateway's verdict on whether this workflow's content can be changed by the caller (the
+   *  client renders this verbatim, never derives it): false for the built-in DevThrottle workflows,
+   *  true for tenant-owned ones. Absent on an older Gateway - treat as not editable. */
+  editable?: boolean;
 }
 
 /** The response of creating a workflow: the new draft's snapshot (subset this client reads). */
@@ -176,16 +180,8 @@ export async function setWorkflowEnabled(
   if (!res.ok) throw await gatewayErrorFrom(res, `POST /gateway/workflows/${id}/${verb}`);
 }
 
-// POST /gateway/workflows/{id}/reset - built-ins only: republish the shipped content as a new
-// version. The customized versions stay as history.
-export async function resetWorkflow(id: string, signal?: AbortSignal): Promise<void> {
-  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/reset`, {
-    method: "POST",
-    headers: { Accept: "application/json", ...authHeaders() },
-    signal,
-  });
-  if (!res.ok) throw await gatewayErrorFrom(res, `POST /gateway/workflows/${id}/reset`);
-}
+// resetWorkflow was RETIRED with the Shared Workflow Library phase 3: built-ins are read-only,
+// can never diverge from the shipped content, and have nothing to reset.
 
 /** A workflow id slug from a display name: "Release Train" -> "release-train". The Gateway enforces
  *  the same shape server-side; this just makes the dialog's default id readable. */

--- a/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/WorkflowDtos.cs
@@ -67,8 +67,16 @@ public sealed class WorkflowDto
     /// <summary>The owner's switch (register redesign): false = OFF - hidden from agents' launch
     /// briefings, default conduct reads refused, no new runs or seats; nothing deleted. The catalog
     /// still LISTS off workflows so the register can show and flip them. Defaults true so a reader
-    /// of an older Gateway that omits the field treats everything as in force.</summary>
+    /// of an older Gateway that omits the field treats everything as in force. On a built-in this is
+    /// the CALLING TENANT's effective state (the tenant's own choice folded over the library value).</summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>The Gateway's verdict on whether this workflow's CONTENT can be changed by the caller
+    /// (Shared Workflow Library phase 3): false for the built-in DevThrottle workflows (read-only,
+    /// maintained by DevThrottle, customize by cloning), true for tenant-owned workflows. Clients
+    /// render this verbatim (rule 7 - the client is dumb) and never derive editability themselves.
+    /// Defaults false: when in doubt, offer no edit affordance.</summary>
+    public bool Editable { get; set; }
 }
 
 /// <summary>A helper file carried by a workflow version, with full content (authoring payloads).</summary>

--- a/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowAuthoringTests.cs
@@ -8,7 +8,7 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// Store-level tests for workflow authoring (Workflows mission, phase 2): create-as-draft, the
 /// full-replacement draft write with If-Match concurrency, the strict publish gate, versioned reads
-/// (pinned history must resolve forever), reset-to-shipped on built-ins, and archive semantics.
+/// (pinned history must resolve forever), the read-only built-ins refusals, and archive semantics.
 /// </summary>
 public sealed class WorkflowAuthoringTests : IDisposable
 {
@@ -213,15 +213,14 @@ public sealed class WorkflowAuthoringTests : IDisposable
             store.GetInstructions("release-train", version: 2));
     }
 
-    // ---- built-ins: customize + reset --------------------------------------------------------------
+    // ---- built-ins: READ-ONLY (Shared Workflow Library phase 3, owner ruling 2026-07-24) ----------
 
     [Fact]
-    public void A_built_in_can_be_customized_and_then_reset_to_shipped()
+    public void A_built_in_refuses_every_authoring_write_with_the_clone_pointer()
     {
         var store = NewStore();
         var shipped = store.GetPublished("mission")!;
 
-        // Customize: draft from the published baseline, edit, publish.
         var edit = new WorkflowContentRequest
         {
             Name = "Mission",
@@ -232,28 +231,29 @@ public sealed class WorkflowAuthoringTests : IDisposable
             InstructionsMarkdown = "# Custom mission conduct",
             AuthoredBy = "test-session",
         };
-        store.UpdateDraft("mission", edit, ifMatchHash: shipped.ContentHash);
-        var customized = store.Publish("mission")!;
-        Assert.Equal(2, customized.Version);
-        Assert.Equal("# Custom mission conduct", store.GetInstructions("mission", null));
 
-        // Reset: the shipped conduct comes back as a NEW version; nothing is rewritten.
-        var reset = store.ResetToShipped("mission")!;
-        Assert.Equal(3, reset.Version);
+        var draftRefusal = Assert.Throws<WorkflowValidationException>(
+            () => store.UpdateDraft("mission", edit, ifMatchHash: shipped.ContentHash));
+        Assert.Contains("clone", draftRefusal.Message);
+        var publishRefusal = Assert.Throws<WorkflowValidationException>(() => store.Publish("mission"));
+        Assert.Contains("clone", publishRefusal.Message);
+        Assert.Throws<WorkflowValidationException>(() => store.Archive("mission"));
+
+        // Nothing changed: the shipped conduct still serves, at the shipped version.
         Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), store.GetInstructions("mission", null));
-        // The customized version remains pinned history.
-        Assert.Equal("# Custom mission conduct", store.GetInstructions("mission", version: 2));
+        Assert.Equal(shipped.Version, store.GetPublished("mission")!.Version);
     }
 
     [Fact]
-    public void Reset_only_applies_to_built_ins()
+    public void The_editability_verdict_is_stamped_on_the_catalog()
     {
         var store = NewStore();
         store.CreateDraft(Complete());
         store.Publish("release-train");
 
-        Assert.Throws<WorkflowValidationException>(() => store.ResetToShipped("release-train"));
-        Assert.Null(store.ResetToShipped("no-such-workflow"));
+        Assert.False(store.GetPublished("mission")!.Editable);
+        Assert.True(store.GetPublished("release-train")!.Editable);
+        Assert.All(store.ListPublished().Where(w => w.IsBuiltIn), w => Assert.False(w.Editable));
     }
 
     // ---- archive -----------------------------------------------------------------------------------

--- a/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowStoreTests.cs
@@ -118,8 +118,12 @@ public sealed class WorkflowStoreTests : IDisposable
     }
 
     [Fact]
-    public void Customized_built_in_is_left_alone_but_the_shipped_hash_is_recorded()
+    public void Previously_customized_built_in_is_republished_to_shipped_with_history_kept()
     {
+        // Built-ins are READ-ONLY (Shared Workflow Library phase 3, owner ruling 2026-07-24,
+        // reversing the 2026-07-17 editable-with-reset trade): a customization published under the
+        // OLD ruling is superseded by shipped content on the next seed - even when the binary's own
+        // content did not change - and the edit stays as forever-readable pinned history.
         var db = _h.Open();
         _ = new WorkflowStore(db);
 
@@ -129,25 +133,26 @@ public sealed class WorkflowStoreTests : IDisposable
             var head = ctx.Workflows.Single(h => h.Id == "mission");
             var published = ctx.WorkflowVersions.Single(
                 v => v.WorkflowId == "mission" && v.Status == WorkflowVersionStatus.Published);
-            // The user published an edit under an older binary: the published hash is theirs, and the
-            // head remembers the OLD shipped hash - both differ from what THIS binary ships.
             head.ShippedContentHash = "old-shipped-hash";
             published.ContentHash = customizedHash;
+            published.InstructionsMarkdown = "# The user's own conduct";
             ctx.SaveChanges();
         }
 
         var store = new WorkflowStore(_h.Open());
 
         var mission = store.GetPublished("mission")!;
-        Assert.Equal(1, mission.Version);
-        Assert.Equal(customizedHash, mission.ContentHash);
+        Assert.Equal(2, mission.Version); // shipped content took the head as a NEW version
+        Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), store.GetInstructions("mission", null));
+        // The customization is history, not gone: the pinned read still serves it.
+        Assert.Equal("# The user's own conduct", store.GetInstructions("mission", version: 1));
         using (var ctx = _h.Open().CreateContext())
         {
             var head = ctx.Workflows.Single(h => h.Id == "mission");
-            Assert.Equal(1, head.LatestVersion);
-            // The shipped hash still advances so a later reset-to-shipped knows what this binary ships.
-            Assert.NotEqual("old-shipped-hash", head.ShippedContentHash);
-            Assert.NotEqual(customizedHash, head.ShippedContentHash);
+            Assert.Equal(2, head.LatestVersion);
+            Assert.Equal(2, head.PublishedVersion);
+            Assert.Equal(head.ShippedContentHash,
+                ctx.WorkflowVersions.Single(v => v.WorkflowId == "mission" && v.Version == 2).ContentHash);
         }
     }
 

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -34,7 +34,6 @@ namespace CcDirector.Gateway.Api;
 ///   PUT    /gateway/workflows/{id}/draft             body WorkflowContentRequest, optional If-Match
 ///                                                    (content hash) -> 200 detail | 400 | 404 | 409
 ///   POST   /gateway/workflows/{id}/publish           -> 200 WorkflowDto | 400 | 404
-///   POST   /gateway/workflows/{id}/reset             built-ins: republish shipped -> 200 | 400 | 404
 ///   DELETE /gateway/workflows/{id}                   archive (never a built-in) -> 200 | 400 | 404
 ///   GET    /gateway/workflows/{id}/versions          -> { versions: [...] } | 404
 ///   GET    /gateway/workflows/{id}/versions/{n}      -> full content snapshot | 404
@@ -111,14 +110,8 @@ internal static class WorkflowEndpoints
             return Results.Json(published);
         }));
 
-        app.MapPost("/gateway/workflows/{id}/reset", (string id) => Guard(() =>
-        {
-            var reset = store.ResetToShipped(id);
-            if (reset is null)
-                return NotFound(id);
-            FileLog.Write($"[WorkflowEndpoints] reset to shipped: id={id}, v{reset.Version}");
-            return Results.Json(reset);
-        }));
+        // POST /gateway/workflows/{id}/reset was RETIRED in the Shared Workflow Library phase 3:
+        // built-ins are read-only, can never diverge from shipped content, and have nothing to reset.
 
         app.MapDelete("/gateway/workflows/{id}", (string id) => Guard(() =>
         {

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflowSeeder.cs
@@ -8,19 +8,18 @@ namespace CcDirector.Gateway.Workflows;
 
 /// <summary>
 /// Writes the shipped built-in workflows (<see cref="BuiltInWorkflows"/> + their embedded instruction
-/// bodies) into the persisted workflow store at startup. The rules are the injected-text ours/yours
-/// trade, applied per workflow (owner ruling, 2026-07-17: built-ins are editable with
-/// reset-to-shipped):
+/// bodies) into the persisted workflow store at startup. Built-ins are READ-ONLY (Shared Workflow
+/// Library phase 3, owner ruling 2026-07-24, reversing the 2026-07-17 editable-with-reset trade):
+/// they are DevThrottle's, this seeder is the ONLY writer of their content, and the catalog always
+/// tracks the RUNNING binary:
 ///
 ///  - Absent workflow: seeded as version 1, published, with the shipped content.
-///  - Present and UNCUSTOMIZED (its published content hash equals the shipped hash we last recorded):
-///    a binary that ships different content auto-publishes it as the next version - the user follows
-///    "ours" and the catalog tracks the RUNNING binary, in both directions. A rollback deliberately
-///    rolls the conduct back too (and mints a version recording that), exactly as the injected-text
-///    "ours" channel serves whatever the running binary carries.
-///  - Present and CUSTOMIZED (the user published their own edit): left completely alone. The newly
-///    shipped hash is still recorded on the head so a later "reset to shipped" knows what this binary
-///    ships, but no version is created and nothing the user wrote is touched.
+///  - Present with a different published hash than this binary ships: the shipped bundle is
+///    published as the next version and the previous one is superseded - in BOTH directions, so a
+///    rollback republishes the older conduct and the minted version row is the honest record of what
+///    the fleet was served. Superseded versions remain readable forever (pinned runs depend on it) -
+///    including any edit published under the OLD editable-built-ins ruling, which is preserved as
+///    history while shipped content takes over the head.
 ///
 /// Built-ins keep their shipped catalog order via deliberately staggered CreatedUtc stamps (the
 /// catalog lists in creation order).
@@ -51,8 +50,22 @@ public static class BuiltInWorkflowSeeder
                 continue;
             }
 
-            if (string.Equals(head.ShippedContentHash, shippedHash, StringComparison.Ordinal))
-                continue; // this binary ships exactly what was last recorded - nothing to do.
+            // Read-only built-ins (phase 3): the invariant is that the PUBLISHED version IS the
+            // shipped bundle. Compare the published hash - not merely the recorded shipped hash -
+            // so a customization published under the old editable-built-ins ruling is superseded by
+            // shipped content even when the binary's own content did not change across the upgrade.
+            var published = ctx.WorkflowVersions.AsNoTracking().FirstOrDefault(
+                v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Published);
+            if (published is not null &&
+                string.Equals(published.ContentHash, shippedHash, StringComparison.Ordinal))
+            {
+                if (!string.Equals(head.ShippedContentHash, shippedHash, StringComparison.Ordinal))
+                {
+                    head.ShippedContentHash = shippedHash; // heal a stale record; content already right
+                    ctx.SaveChanges();
+                }
+                continue; // the fleet is already served exactly what this binary ships.
+            }
 
             UpgradeShippedContent(ctx, head, definition, shippedHash);
         }
@@ -135,34 +148,23 @@ public static class BuiltInWorkflowSeeder
         WorkflowDefinition definition,
         string shippedHash)
     {
+        // Built-ins are read-only (phase 3): the catalog always tracks the RUNNING binary, so a hash
+        // difference - in either direction - publishes this binary's bundle as the next version. Any
+        // previously published content (including an edit made under the old editable-built-ins
+        // ruling) is preserved as a superseded, forever-readable version row, never rewritten.
         var published = ctx.WorkflowVersions.FirstOrDefault(
             v => v.WorkflowId == head.Id && v.Status == WorkflowVersionStatus.Published);
-        var uncustomized = published is not null &&
-            string.Equals(published.ContentHash, head.ShippedContentHash, StringComparison.Ordinal);
 
-        if (uncustomized)
-        {
-            // The user follows the shipped content - publish THIS binary's bundle as the next version
-            // so every Director picks it up, exactly like the injected-text "ours" channel. This is
-            // direction-agnostic on purpose: a rollback republishes the older conduct, and the minted
-            // version row is the honest record of what the fleet was served.
-            var now = DateTime.UtcNow;
-            published!.Status = WorkflowVersionStatus.Superseded;
-            var nextVersion = head.LatestVersion + 1;
-            ctx.WorkflowVersions.Add(BuildShippedVersion(ctx, definition, nextVersion, now));
-            head.LatestVersion = nextVersion;
-            head.PublishedVersion = nextVersion;
-            head.UpdatedUtc = now;
-            FileLog.Write($"[BuiltInWorkflowSeeder] Upgraded built-in workflow: id={head.Id}, " +
-                          $"v{nextVersion} published from shipped content, hash={shippedHash[..12]}");
-        }
-        else
-        {
-            // Customized: the user's published edit stays untouched. Record what this binary ships so
-            // a later reset-to-shipped can restore it.
-            FileLog.Write($"[BuiltInWorkflowSeeder] Built-in workflow {head.Id} is customized; shipped " +
-                          $"content NOT applied (recorded hash={shippedHash[..12]} for reset)");
-        }
+        var now = DateTime.UtcNow;
+        if (published is not null)
+            published.Status = WorkflowVersionStatus.Superseded;
+        var nextVersion = head.LatestVersion + 1;
+        ctx.WorkflowVersions.Add(BuildShippedVersion(ctx, definition, nextVersion, now));
+        head.LatestVersion = nextVersion;
+        head.PublishedVersion = nextVersion;
+        head.UpdatedUtc = now;
+        FileLog.Write($"[BuiltInWorkflowSeeder] Upgraded built-in workflow: id={head.Id}, " +
+                      $"v{nextVersion} published from shipped content, hash={shippedHash[..12]}");
 
         head.ShippedContentHash = shippedHash;
         ctx.SaveChanges();

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -108,6 +108,22 @@ public sealed class WorkflowStore
         head.IsBuiltIn ? TenantChoiceFor(head.Id) ?? head.Enabled : head.Enabled;
 
     /// <summary>
+    /// Built-ins are READ-ONLY (Shared Workflow Library phase 3, owner ruling 2026-07-24, reversing
+    /// the 2026-07-17 editable-with-reset ruling): they are DevThrottle's, maintained by shipping a
+    /// new binary, and the only writer of their content is the boot-time seeder. Every authoring
+    /// write refuses a built-in id with the pointer at the sanctioned customization path - clone.
+    /// </summary>
+    private void RefuseBuiltInEdit(string key, string verb)
+    {
+        if (IsLibraryBuiltIn(key))
+            throw new WorkflowValidationException(
+                $"'{key}' is a built-in DevThrottle workflow and cannot be {verb}. Built-ins are " +
+                "maintained by DevThrottle and update with the Gateway itself. To customize the " +
+                "conduct, clone it into your own workflow: cc-devthrottle workflow clone " + key +
+                " <new-id>");
+    }
+
+    /// <summary>
     /// Every workflow with a published version, projected from that published version, in stable
     /// catalog order (creation order; the seeder stamps the built-ins so they keep their shipped
     /// order). Draft-only and archived workflows are omitted - the catalog lists what the fleet can
@@ -281,6 +297,7 @@ public sealed class WorkflowStore
 
         lock (_gate)
         {
+            RefuseBuiltInEdit(key, "edited");
             using var ctx = _db.CreateContext();
             var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
             if (head is null)
@@ -332,6 +349,7 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
+            RefuseBuiltInEdit(key, "published over");
             using var ctx = _db.CreateContext();
             var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
             if (head is null)
@@ -363,46 +381,9 @@ public sealed class WorkflowStore
         }
     }
 
-    /// <summary>Built-ins only: publish the shipped content of the RUNNING binary as a new version
-    /// (the "reset to shipped" the ours/yours trade promises). Null when no such workflow exists.</summary>
-    public WorkflowDto? ResetToShipped(string id)
-    {
-        var key = NormalizeId(id);
-        lock (_gate)
-        {
-            using var ctx = _db.CreateContext();
-            var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
-            if (head is null)
-                return null;
-            if (!head.IsBuiltIn)
-                throw new WorkflowValidationException(
-                    $"Workflow '{key}' is not built in; reset-to-shipped only applies to built-ins.");
-
-            var definition = BuiltInWorkflows.All().FirstOrDefault(d => d.Id == key)
-                ?? throw new InvalidOperationException(
-                    $"Built-in workflow '{key}' is not shipped by this binary; cannot reset.");
-            var shippedRow = BuiltInWorkflowSeeder.BuildShippedVersion(ctx, definition,
-                versionNumber: head.LatestVersion + 1, DateTime.UtcNow);
-            shippedRow.AuthoredBy = "gateway:reset";
-            shippedRow.ChangeNote = "Reset to the shipped built-in content.";
-
-            var previous = ctx.WorkflowVersions.FirstOrDefault(
-                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Published);
-            if (previous is not null)
-                previous.Status = WorkflowVersionStatus.Superseded;
-            ctx.WorkflowVersions.Add(shippedRow);
-            head.LatestVersion = shippedRow.Version;
-            head.PublishedVersion = shippedRow.Version;
-            head.ShippedContentHash = shippedRow.ContentHash;
-            head.UpdatedUtc = shippedRow.CreatedUtc;
-            ctx.SaveChanges();
-
-            FileLog.Write($"[WorkflowStore] ResetToShipped: id={key}, v{shippedRow.Version} published from shipped content");
-            var hasDraft = ctx.WorkflowVersions.Any(
-                v => v.WorkflowId == key && v.Status == WorkflowVersionStatus.Draft);
-            return ToDto(head, shippedRow, hasDraft);
-        }
-    }
+    // Reset-to-shipped was RETIRED in the Shared Workflow Library phase 3 (owner ruling 2026-07-24):
+    // built-ins are read-only, so they can never diverge from shipped content and there is nothing to
+    // reset. The seeder always republishes the running binary's content on a hash change.
 
     /// <summary>Archive (soft-delete) a user-defined workflow. Its versions remain - a run that
     /// pinned one must always resolve. False when no such workflow exists.</summary>
@@ -411,6 +392,10 @@ public sealed class WorkflowStore
         var key = NormalizeId(id);
         lock (_gate)
         {
+            if (IsLibraryBuiltIn(key))
+                throw new WorkflowValidationException(
+                    $"Workflow '{key}' is built in and can never be deleted.");
+
             using var ctx = _db.CreateContext();
             var head = ctx.Workflows.FirstOrDefault(h => h.Id == key);
             if (head is null)
@@ -659,6 +644,9 @@ public sealed class WorkflowStore
         HasDraft = hasDraft,
         ContentHash = version.ContentHash,
         Enabled = head.Enabled,
+        // The Gateway's editability verdict (phase 3): built-ins are read-only, tenant-owned
+        // workflows are the caller's to edit. Clients render this verbatim.
+        Editable = !head.IsBuiltIn,
     };
 
     /// <summary>

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -399,13 +399,6 @@ _ACTIONS = [
         "args": [{"name": "id", "required": True}],
     },
     {
-        "id": "workflow-reset",
-        "description": "Reset a built-in Workflow to the shipped content (published as a new version).",
-        "command": "cc-devthrottle workflow reset <id>",
-        "mutatesState": True,
-        "args": [{"name": "id", "required": True}],
-    },
-    {
         "id": "workflow-delete",
         "description": "Archive a custom Workflow (built-ins can never be deleted; history remains).",
         "command": "cc-devthrottle workflow delete <id> --yes",
@@ -1140,12 +1133,8 @@ def workflow_disable(
     workflow_ops.set_workflow_enabled(workflow_id, False)
 
 
-@workflow_app.command("reset")
-def workflow_reset(
-    workflow_id: str = typer.Argument(..., help="The built-in workflow id (e.g. mission)."),
-) -> None:
-    """Reset a built-in Workflow to the shipped content (published as a new version)."""
-    workflow_ops.reset_workflow(workflow_id)
+# "workflow reset" was retired with the Shared Workflow Library phase 3: built-ins are read-only,
+# can never diverge from the shipped content, and have nothing to reset.
 
 
 @workflow_app.command("delete")

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -203,11 +203,6 @@ class WorkflowClient:
             self._request("POST", f"/gateway/workflows/{workflow_id}/publish")
         )
 
-    def reset(self, workflow_id: str) -> Dict[str, Any]:
-        return self._json_or_raise(
-            self._request("POST", f"/gateway/workflows/{workflow_id}/reset")
-        )
-
     def delete(self, workflow_id: str) -> Dict[str, Any]:
         return self._json_or_raise(
             self._request("DELETE", f"/gateway/workflows/{workflow_id}")
@@ -574,16 +569,8 @@ def publish_workflow(workflow_id: str) -> None:
     )
 
 
-def reset_workflow(workflow_id: str) -> None:
-    try:
-        result = _client().reset(workflow_id)
-    except GatewayError as ex:
-        _fail(str(ex))
-        return
-    console.print(
-        f"Reset '{workflow_id}' to the shipped content as v{result.get('version')}. "
-        "Earlier versions remain as history."
-    )
+# reset_workflow was retired with the Shared Workflow Library phase 3: built-ins are read-only,
+# can never diverge from the shipped content, and have nothing to reset.
 
 
 def set_workflow_enabled(workflow_id: str, enabled: bool) -> None:

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -66,7 +66,6 @@ class TestActionsDiscoverability:
             "workflow-push",
             "workflow-publish",
             "workflow-materialize",
-            "workflow-reset",
             "workflow-delete",
             "workflow-runs",
             "workflow-run-show",


### PR DESCRIPTION
## Why

Phase 3 of the Shared Workflow Library (devthrottle_internal issue 514). The built-in workflows are DevThrottle's: shipped in the binary, present for every tenant, updated by shipping a new Gateway. The owner ruling of 2026-07-24 makes them READ-ONLY everywhere - reversing the 2026-07-17 "editable with reset-to-shipped" ruling. A tenant who wants different conduct clones (phase 4); nobody edits the library.

## What changed

- Every authoring write refuses a built-in id with a clear message pointing at clone: draft create (already refused), draft update, publish, archive.
- Reset-to-shipped is retired end to end: the Gateway route, the store method, the command-line verb (and its actions-list entry), and the cockpit button. Content that cannot diverge has nothing to reset.
- The seeder now guarantees the invariant directly: the PUBLISHED version of a built-in is always the running binary's shipped bundle. It compares the PUBLISHED hash - not merely the recorded shipped hash - so a customization published under the old ruling is superseded by shipped content on the next boot even when the binary's own content did not change across the upgrade. Superseded versions stay readable forever; a pinned run never loses its conduct.
- The Gateway stamps an editability verdict on the workflow record (`editable`: false for built-ins, true for tenant-owned) and the cockpit renders it verbatim (rule 7 - the client is dumb), showing a maintained-by-DevThrottle notice instead of deriving anything.

Upgrade note for self-host installs that customized a built-in under the old ruling: the edit is preserved as version history (superseded, readable by version number forever) and the shipped content takes over the published head on first boot of this Gateway.

## Proof

- `WorkflowAuthoringTests`: every refused write returns the refusal with the clone pointer and changes nothing; the editability verdict is stamped false on every built-in and true on tenant-owned workflows.
- `WorkflowStoreTests`: a previously-customized built-in is republished to shipped content with the customization kept as pinned readable history - including the same-binary case the published-hash comparison exists for.
- Full workflow-suite filter green; cockpit tests, client-core tests, mobile typecheck, and the command-line tool's test suite all green (reset verb removed from the actions contract).
