### PR TITLE
feat(cockpit): new-session button on each Fleet Map Director

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.test.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import type { DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
 import type { SharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
@@ -20,6 +20,20 @@ vi.mock("@devthrottle/client-core/fleet/rosterStore", () => ({
   useSharedRoster: () => rosterValue.current,
 }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+
+// The Fleet Map "+ New session" button opens the SAME NewSessionDialog the Sessions tab uses, which
+// loads its machine / repo / agent pickers from the Gateway. Mock those data calls so the dialog renders
+// against a fixed fleet without a real Gateway. getDirectors is what proves the pre-selection: the dialog
+// default-selects the NEWEST-started Director, so we make "soren-1" newest and assert the CLICKED
+// "north-1" is selected instead - which can only happen if the Fleet Map passed it through.
+const getDirectorsMock = vi.fn();
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  getDirectors: (...args: unknown[]) => getDirectorsMock(...args),
+  getRepos: () => Promise.resolve([]),
+  getAgents: () => Promise.resolve([]),
+  createSession: () => Promise.resolve({ sessionId: "new" }),
+  gatewayErrorMessage: (e: unknown) => String(e),
+}));
 
 import { FleetMapView } from "./FleetMapView";
 
@@ -129,5 +143,52 @@ describe("FleetMapView - By machine free slots", () => {
     expect(screen.queryByText(/free slot/i)).toBeNull();
     // Only the one reachable machine is counted; the offline one is not "available capacity".
     expect(screen.getAllByText(/\b1 machine\b/).length).toBeGreaterThan(0);
+  });
+});
+
+describe("FleetMapView - Director sub-header new-session button", () => {
+  it("opens the shared dialog pre-targeted to the clicked Director, not the newest one", async () => {
+    // The dialog would otherwise default to the NEWEST-started Director. Make "soren-bbb" newest, so if
+    // the Fleet Map failed to pass the clicked Director through, the dialog would select SOREN_SOUTH.
+    getDirectorsMock.mockResolvedValue([
+      {
+        directorId: "north-aaa",
+        machineName: "SOREN_NORTH",
+        version: "1",
+        startedAt: "2026-07-20T00:00:00Z",
+        lastSeen: "",
+        controlEndpoint: "http://127.0.0.1:7880",
+      },
+      {
+        directorId: "soren-bbb",
+        machineName: "SOREN_SOUTH",
+        version: "1",
+        startedAt: "2026-07-24T00:00:00Z", // newest -> the dialog's default pick
+        lastSeen: "",
+        controlEndpoint: "http://127.0.0.1:7990",
+      },
+    ]);
+
+    rosterValue.current = {
+      sessions: [session({ directorId: "north-aaa", machineName: "SOREN_NORTH" })],
+      machineErrors: [],
+      directors: [director({ directorId: "north-aaa", machineName: "SOREN_NORTH", state: "online" })],
+      error: null,
+      refreshNow: () => {},
+    };
+
+    render(<FleetMapView />);
+
+    // The machine pivot renders a "+ New session" button on the Director sub-header (top-right).
+    const newBtn = screen.getByRole("button", { name: /Start a new session on Director/ });
+    fireEvent.click(newBtn);
+
+    // The SAME dialog the Sessions tab opens appears, and it default-selects the clicked Director's
+    // machine (SOREN_NORTH) rather than the newest-started one (SOREN_SOUTH).
+    const dialog = await screen.findByRole("dialog", { name: /Start a new session/ });
+    await waitFor(() => {
+      const north = dialog.querySelector("button.newsess-machine.sel");
+      expect(north?.textContent).toContain("SOREN_NORTH");
+    });
   });
 });

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -20,6 +20,7 @@ import {
   shortDir,
 } from "./fleetMapFormat";
 import { MissionsBoard, missionCounts } from "../missions/MissionsBoard";
+import { NewSessionDialog } from "../sessions/NewSessionDialog";
 
 // Per-Director reachability for the Online / Wobbly / Offline node rendering (issue #1215), provided at
 // the Fleet Map root and read by each NodeCard so the cards dim in place without prop-drilling.
@@ -127,6 +128,19 @@ export function FleetMapView() {
   // non-matches and NEVER reorders what remains (see the lanes memo below). Not persisted across
   // reloads.
   const [query, setQuery] = useState("");
+
+  // The Fleet Map "new session" button (top-right of each Director sub-header on the machine pivot):
+  // holds the Director id to pre-target while the shared New Session dialog is open, or null when it is
+  // closed. It reuses the EXACT same dialog the Sessions tab opens - the only difference is that the
+  // clicked Director is already selected.
+  const [newSessionDirectorId, setNewSessionDirectorId] = useState<string | null>(null);
+  const onCreated = useCallback(
+    (sessionId: string) => {
+      setNewSessionDirectorId(null);
+      navigate(`/session/${encodeURIComponent(sessionId)}`);
+    },
+    [navigate],
+  );
 
   const list = useMemo(() => sessions ?? [], [sessions]);
   // Build the lanes from the WHOLE fleet first, so lane order and each card's slot are fixed. The title
@@ -308,6 +322,7 @@ export function FleetMapView() {
               sessionCount={query.trim().length > 0 ? matchCount : list.length}
               machineCount={machineCount}
               onOpen={(sid) => navigate(`/session/${encodeURIComponent(sid)}`)}
+              onNewSession={(directorId) => setNewSessionDirectorId(directorId)}
             />
           )}
 
@@ -320,6 +335,14 @@ export function FleetMapView() {
         <LegendDot color="supporting" label="Sub-agent" />
         <LegendDot color="grey" label="Snoozed" />
       </div>
+
+      {newSessionDirectorId !== null && (
+        <NewSessionDialog
+          initialDirectorId={newSessionDirectorId}
+          onClose={() => setNewSessionDirectorId(null)}
+          onCreated={onCreated}
+        />
+      )}
     </div>
     </ReachabilityContext.Provider>
   );
@@ -340,13 +363,15 @@ interface CanvasProps {
   sessionCount: number;
   machineCount: number;
   onOpen: (sessionId: string) => void;
+  // Start a new session on a specific Director (the machine-pivot sub-header "+ New session" button).
+  onNewSession: (directorId: string) => void;
 }
 
 // The node canvas: a root node above a horizontal row of lane panels, joined by SVG elbow connectors
 // measured from the live DOM (so the wiring tracks whatever width the panels lay out at). The lanes
 // scroll horizontally inside their own container; the SVG is sized to the scrollable content so the
 // wires stay attached when the row is wider than the pane.
-function Canvas({ lanes, pivot, sessionCount, machineCount, onOpen }: CanvasProps) {
+function Canvas({ lanes, pivot, sessionCount, machineCount, onOpen, onNewSession }: CanvasProps) {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const headRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -416,6 +441,7 @@ function Canvas({ lanes, pivot, sessionCount, machineCount, onOpen }: CanvasProp
                 lane={lane}
                 pivot={pivot}
                 onOpen={onOpen}
+                onNewSession={onNewSession}
                 headRef={(el) => {
                   if (el === null) headRefs.current.delete(lane.key);
                   else headRefs.current.set(lane.key, el);
@@ -433,10 +459,11 @@ interface LanePanelProps {
   lane: Lane;
   pivot: Pivot;
   onOpen: (sessionId: string) => void;
+  onNewSession: (directorId: string) => void;
   headRef: (el: HTMLDivElement | null) => void;
 }
 
-function LanePanel({ lane, pivot, onOpen, headRef }: LanePanelProps) {
+function LanePanel({ lane, pivot, onOpen, onNewSession, headRef }: LanePanelProps) {
   const agg = aggregateColors(lane.sessions);
 
   // Machine pivot: sub-group the lane's sessions by Director so the panel reads machine -> Director ->
@@ -461,7 +488,23 @@ function LanePanel({ lane, pivot, onOpen, headRef }: LanePanelProps) {
         {directorGroups !== null
           ? directorGroups.map((dg) => (
               <div key={dg.key} className="fmap-dgroup">
-                <div className="fmap-subhead">{dg.label}</div>
+                <div className="fmap-subhead">
+                  <span className="fmap-subhead-label">{dg.label}</span>
+                  {/* Start a new session on THIS Director, using the same dialog the Sessions tab opens
+                      (only pre-targeted here). Hidden for an unidentified Director - it is not an
+                      addressable slot, so there is nothing to start a session on. */}
+                  {dg.key !== "(unknown)" && (
+                    <button
+                      type="button"
+                      className="fmap-subhead-new"
+                      title="Start a new session on this Director"
+                      aria-label={`Start a new session on ${dg.label}`}
+                      onClick={() => onNewSession(dg.key)}
+                    >
+                      + New session
+                    </button>
+                  )}
+                </div>
                 {dg.sessions.length > 0 ? (
                   <LaneCards sessions={dg.sessions} pivot={pivot} onOpen={onOpen} />
                 ) : (

--- a/apps/cockpit/src/fleet/fleetmap.css
+++ b/apps/cockpit/src/fleet/fleetmap.css
@@ -334,6 +334,35 @@
   background: var(--border);
 }
 
+/* The "+ New session" button on a Director sub-header (machine pivot). `order: 1` floats it to the far
+   right, AFTER the flex-1 divider rule (the ::after pseudo, order 0), so the row reads
+   label - rule - button. A quiet chip by default that brightens on hover, so it reads as an available
+   action without competing with the session cards. */
+.fmap-subhead-new {
+  order: 1;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+.fmap-subhead-new:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.fmap-subhead-new:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 /* An idle Director on the machine pivot: no sessions, so the sub-group renders this "free slot" line
    instead of cards. A dashed, muted placeholder so it reads as available capacity, not a real node. */
 .fmap-freeslot {

--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -34,6 +34,13 @@ export interface NewSessionDialogProps {
   onClose: () => void;
   /** A session was created; the parent refreshes the roster and opens it. */
   onCreated: (sessionId: string) => void;
+  /**
+   * The Director to pre-select (issue: Fleet Map "new session" button). When set and that Director is
+   * present in the loaded list, machine step 1 opens on it instead of the newest-started Director, so
+   * the Fleet Map card the owner clicked is already the target. When absent, or the id is not in the
+   * list, the dialog falls back to the newest-started Director exactly as before.
+   */
+  initialDirectorId?: string;
 }
 
 // Permission choices, mapped to the desktop dialog's "Bypass permission prompts" checkbox. "Skip
@@ -104,7 +111,7 @@ function launchSummary(agent: AgentChoice | null, bypass: boolean): string {
   return `${agent.displayName} . ${model} . ${permission}`;
 }
 
-export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) {
+export function NewSessionDialog({ onClose, onCreated, initialDirectorId }: NewSessionDialogProps) {
   const [directors, setDirectors] = useState<DirectorInfo[] | null>(null);
   const [directorsError, setDirectorsError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -149,7 +156,12 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
       .then((list) => {
         setDirectors(list);
         setDirectorsError(null);
-        const pick = newestDirector(list);
+        // Pre-select the Director the caller asked for (the Fleet Map card that was clicked), but only
+        // when it is actually in the list; otherwise fall back to the newest-started Director.
+        const requested = (initialDirectorId ?? "").trim();
+        const preselected =
+          requested.length > 0 ? list.find((d) => d.directorId === requested) ?? null : null;
+        const pick = preselected ?? newestDirector(list);
         if (pick) setSelectedId(pick.directorId);
       })
       .catch((err) => {
@@ -157,7 +169,7 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
         setDirectorsError(gatewayErrorMessage(err));
       });
     return () => controller.abort();
-  }, []);
+  }, [initialDirectorId]);
 
   // Step 2: whenever the selected machine changes, load THAT machine's recent repos.
   useEffect(() => {


### PR DESCRIPTION
## What

Adds a **"+ New session"** button to the top-right of each Director sub-header on the **Fleet Map** (machine pivot). Clicking it opens the **same New Session dialog the Sessions tab already uses** - no new or duplicate screen - pre-targeted to the Director whose card was clicked.

## Why

The Fleet Map is where the whole fleet is actually watched, but there was no way to start a session from it - you had to leave for the Sessions tab and re-pick the machine. Now you start a session right where you see the Director.

## How

- `NewSessionDialog` gains an optional `initialDirectorId`. When set and present in the loaded list, machine step 1 opens on that Director instead of the newest-started one; when absent or unknown it falls back to the previous newest-started default. The dialog is otherwise unchanged, so both entry points share one screen and one Gateway front door.
- `FleetMapView` renders the button on each identified Director sub-header, threads the target Director id up, and opens the shared dialog. An unidentified Director shows no button (it is not an addressable slot).

## Proof

- New integration test renders the Fleet Map, clicks the button, and asserts the dialog opens pre-selected to the *clicked* Director rather than the newest-started one (the test fails if the id is not threaded through).
- Full cockpit suite: 165 tests pass. Typecheck, eslint, and production build all clean.