### PR TITLE
Clone - the customization path for workflows (Shared Workflow Library, phase 4)

### DIFF
--- a/apps/cockpit/src/workflows/WorkflowDetail.tsx
+++ b/apps/cockpit/src/workflows/WorkflowDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
+  cloneWorkflow,
   getWorkflow,
   getWorkflowInstructions,
   setWorkflowEnabled,
@@ -8,7 +9,7 @@ import {
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
-import { ConfirmDialog, ErrorBanner, LoadingState } from "../components";
+import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 
 // One workflow, in full (Workflows mission, phase 7). The list row answered "what exists"; this page
 // answers "what does it actually say": the metadata and step summary up top (the machine-readable
@@ -18,10 +19,12 @@ import { ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 // authoring is agent-driven and a half-editable page would lie about where edits really happen.
 export function WorkflowDetail() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [workflow, setWorkflow] = useState<WorkflowDefinition | null>(null);
   const [instructions, setInstructions] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingOff, setPendingOff] = useState(false);
+  const [pendingClone, setPendingClone] = useState(false);
   // Every load claims a generation; a load that finishes after a newer one started (a mutation
   // refresh racing a route change to another workflow) drops its result instead of painting
   // workflow A's state under workflow B's URL.
@@ -110,6 +113,9 @@ export function WorkflowDetail() {
                 </span>
               </span>
             ) : null}
+            <Button variant="secondary" onClick={() => setPendingClone(true)}>
+              Clone
+            </Button>
           </div>
           {/* The Gateway's editability verdict, rendered verbatim (rule 7): built-ins are
               DevThrottle-maintained and read-only; the sanctioned customization path is clone. */}
@@ -174,6 +180,30 @@ export function WorkflowDetail() {
         onClose={() => setPendingOff(false)}
       />
 
+      <ConfirmDialog
+        open={pendingClone}
+        title={`Clone '${workflow?.name ?? id}' as '${id}-copy'?`}
+        message={
+          <>
+            The published content - steps, instructions, helper files - is copied into a new
+            workflow <code>{id}-copy</code> that is yours: published, fully editable, and
+            independent of the original. Agents edit it with{" "}
+            <code>cc-devthrottle workflow pull {id}-copy</code>.
+          </>
+        }
+        confirmLabel="Clone"
+        danger={false}
+        onConfirm={async () => {
+          if (id === undefined) return;
+          try {
+            const clone = await cloneWorkflow(id, `${id}-copy`, "cockpit");
+            navigate(`/workflows/${encodeURIComponent(clone.id)}`);
+          } catch (err) {
+            setError(gatewayErrorMessage(err));
+          }
+        }}
+        onClose={() => setPendingClone(false)}
+      />
     </div>
   );
 }

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -183,6 +183,24 @@ export async function setWorkflowEnabled(
 // resetWorkflow was RETIRED with the Shared Workflow Library phase 3: built-ins are read-only,
 // can never diverge from the shipped content, and have nothing to reset.
 
+// POST /gateway/workflows/{id}/clone - copy a workflow's published content into a new tenant-owned,
+// fully editable workflow (the sanctioned way to customize a read-only built-in). Returns the clone.
+export async function cloneWorkflow(
+  id: string,
+  newId: string,
+  by: string,
+  signal?: AbortSignal,
+): Promise<WorkflowDefinition> {
+  const query = new URLSearchParams({ newId, by });
+  const res = await fetch(`/gateway/workflows/${encodeURIComponent(id)}/clone?${query.toString()}`, {
+    method: "POST",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, `POST /gateway/workflows/${id}/clone`);
+  return (await res.json()) as WorkflowDefinition;
+}
+
 /** A workflow id slug from a display name: "Release Train" -> "release-train". The Gateway enforces
  *  the same shape server-side; this just makes the dialog's default id readable. */
 export function suggestWorkflowId(name: string): string {

--- a/src/CcDirector.Gateway.Tests/WorkflowCloneTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowCloneTests.cs
@@ -1,0 +1,162 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Clone (Shared Workflow Library phase 4, devthrottle_internal issue 514) - the sanctioned
+/// customization path for the read-only built-ins. A clone copies the source's PUBLISHED content
+/// (steps, instructions, outcome criteria, helper files) into version 1 of a fresh tenant-owned id:
+/// born published (immediately runnable), fully editable, provenance recorded, and completely
+/// independent of the original - editing the clone never moves the built-in, and the clone is
+/// invisible to every other tenant.
+/// </summary>
+public sealed class WorkflowCloneTests : IDisposable
+{
+    private static readonly TenantId TenantA = new("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly TenantId TenantB = new("bbbbbbbb-0000-0000-0000-000000000002");
+
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly AsyncLocalTenantContext _tenant = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    private WorkflowStore OpenHostedStore()
+    {
+        var db = _harness.Open(_tenant);
+        using (_tenant.Enter(TenantId.System))
+        {
+            return new WorkflowStore(db);
+        }
+    }
+
+    [Fact]
+    public void CloningABuiltIn_MakesAnEditableTenantOwnedCopy()
+    {
+        var store = OpenHostedStore();
+
+        using (_tenant.Enter(TenantA))
+        {
+            var clone = store.Clone("mission", "acme-mission", "test-session")!;
+
+            Assert.Equal("acme-mission", clone.Id);
+            Assert.Equal(1, clone.Version);
+            Assert.False(clone.IsBuiltIn);
+            Assert.True(clone.Editable);
+            Assert.True(clone.Enabled);
+            Assert.Equal("Mission", clone.Name);
+            // The conduct is the shipped mission conduct, byte for byte.
+            Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"),
+                store.GetInstructions("acme-mission", null));
+            // Provenance is recorded on the version row.
+            var v1 = store.GetVersionDetail("acme-mission", 1)!;
+            Assert.Equal("Cloned from 'mission' v1.", v1.ChangeNote);
+            Assert.Equal("test-session", v1.AuthoredBy);
+        }
+    }
+
+    [Fact]
+    public void EditingTheClone_NeverMovesTheBuiltIn()
+    {
+        var store = OpenHostedStore();
+
+        using (_tenant.Enter(TenantA))
+        {
+            var clone = store.Clone("mission", "acme-mission", "test-session")!;
+
+            var edit = new WorkflowContentRequest
+            {
+                Name = "Acme Mission",
+                Summary = "Our own mission conduct.",
+                Steps = new List<WorkflowStepDto>
+                {
+                    new() { Name = "Build", Description = "Build it our way.", Doer = "Worker", Done = "Merged." },
+                },
+                InstructionsMarkdown = "# The Acme way",
+                AuthoredBy = "test-session",
+            };
+            store.UpdateDraft("acme-mission", edit, ifMatchHash: clone.ContentHash);
+            store.Publish("acme-mission");
+
+            Assert.Equal("# The Acme way", store.GetInstructions("acme-mission", null));
+            // The built-in still serves the shipped conduct, untouched.
+            Assert.Equal(BuiltInWorkflows.InstructionsFor("mission"), store.GetInstructions("mission", null));
+            Assert.False(store.GetPublished("mission")!.Editable);
+        }
+    }
+
+    [Fact]
+    public void TheClone_IsInvisibleToOtherTenants()
+    {
+        var store = OpenHostedStore();
+
+        using (_tenant.Enter(TenantA))
+        {
+            store.Clone("mission", "acme-mission", "test-session");
+        }
+
+        using (_tenant.Enter(TenantB))
+        {
+            Assert.Null(store.GetPublished("acme-mission"));
+            Assert.DoesNotContain(store.ListPublished(), w => w.Id == "acme-mission");
+        }
+    }
+
+    [Fact]
+    public void CloneRefusals_AreExact()
+    {
+        var store = OpenHostedStore();
+
+        using (_tenant.Enter(TenantA))
+        {
+            // A built-in id can never be the clone's id - the library can never be shadowed.
+            Assert.Throws<WorkflowConflictException>(() => store.Clone("mission", "standalone", "t"));
+            // A taken id is refused.
+            store.Clone("mission", "acme-mission", "t");
+            Assert.Throws<WorkflowConflictException>(() => store.Clone("mission", "acme-mission", "t"));
+            // A bad slug is refused.
+            Assert.Throws<WorkflowValidationException>(() => store.Clone("mission", "Not A Slug", "t"));
+            // A missing source is a null (the route's 404), never an invented workflow.
+            Assert.Null(store.Clone("no-such-workflow", "fresh-id", "t"));
+        }
+    }
+
+    [Fact]
+    public void CloningOwnWorkflow_CopiesHelperFiles()
+    {
+        var store = OpenHostedStore();
+
+        using (_tenant.Enter(TenantA))
+        {
+            store.CreateDraft(new WorkflowContentRequest
+            {
+                Id = "release-train",
+                Name = "Release train",
+                Summary = "Cut and announce.",
+                Steps = new List<WorkflowStepDto>
+                {
+                    new() { Name = "Cut", Description = "Cut it.", Doer = "Worker", Done = "Tagged." },
+                },
+                InstructionsMarkdown = "# Release train",
+                Files = new List<WorkflowFileDto>
+                {
+                    new() { FileName = "verify.py", Content = "print('verify')" },
+                },
+                AuthoredBy = "test-session",
+            });
+            store.Publish("release-train");
+
+            var clone = store.Clone("release-train", "release-train-v2", "test-session")!;
+
+            Assert.Equal(1, clone.Version);
+            Assert.Equal("print('verify')",
+                store.GetFileContent("release-train-v2", "verify.py", version: null));
+            Assert.Equal("Cloned from 'release-train' v1.",
+                store.GetVersionDetail("release-train-v2", 1)!.ChangeNote);
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -34,6 +34,8 @@ namespace CcDirector.Gateway.Api;
 ///   PUT    /gateway/workflows/{id}/draft             body WorkflowContentRequest, optional If-Match
 ///                                                    (content hash) -> 200 detail | 400 | 404 | 409
 ///   POST   /gateway/workflows/{id}/publish           -> 200 WorkflowDto | 400 | 404
+///   POST   /gateway/workflows/{id}/clone             ?newId=&by= copy published content into a new
+///                                                    tenant-owned editable workflow -> 201 | 400 | 404 | 409
 ///   DELETE /gateway/workflows/{id}                   archive (never a built-in) -> 200 | 400 | 404
 ///   GET    /gateway/workflows/{id}/versions          -> { versions: [...] } | 404
 ///   GET    /gateway/workflows/{id}/versions/{n}      -> full content snapshot | 404
@@ -112,6 +114,18 @@ internal static class WorkflowEndpoints
 
         // POST /gateway/workflows/{id}/reset was RETIRED in the Shared Workflow Library phase 3:
         // built-ins are read-only, can never diverge from shipped content, and have nothing to reset.
+
+        // Clone (Shared Workflow Library phase 4): copy a workflow's published content into a new
+        // tenant-owned, fully editable workflow - the sanctioned customization path for the
+        // read-only built-ins. ?newId names the clone; ?by records who cloned (the authoring actor).
+        app.MapPost("/gateway/workflows/{id}/clone", (string id, string? newId, string? by) => Guard(() =>
+        {
+            var clone = store.Clone(id, newId ?? "", by ?? "");
+            if (clone is null)
+                return NotFound(id);
+            FileLog.Write($"[WorkflowEndpoints] clone: '{id}' -> '{clone.Id}' v{clone.Version}");
+            return Results.Json(clone, statusCode: StatusCodes.Status201Created);
+        }));
 
         app.MapDelete("/gateway/workflows/{id}", (string id) => Guard(() =>
         {

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -385,6 +385,113 @@ public sealed class WorkflowStore
     // built-ins are read-only, so they can never diverge from shipped content and there is nothing to
     // reset. The seeder always republishes the running binary's content on a hash change.
 
+    /// <summary>
+    /// Clone a workflow's PUBLISHED content into a new tenant-owned workflow (Shared Workflow
+    /// Library phase 4 - the sanctioned customization path for the read-only built-ins, and equally
+    /// usable on the tenant's own workflows). The clone copies everything the published version
+    /// carries - steps, instructions, outcome criteria, helper files - into version 1 of a fresh id,
+    /// born PUBLISHED (the content just came off a published bundle, so it is immediately runnable)
+    /// and fully editable; provenance (source id and version) is recorded on the version row's
+    /// change note. Null when the source does not exist or has no published version.
+    /// </summary>
+    /// <exception cref="WorkflowValidationException">The new id is invalid.</exception>
+    /// <exception cref="WorkflowConflictException">The new id is taken or is a built-in id.</exception>
+    public WorkflowDto? Clone(string sourceId, string newId, string authoredBy)
+    {
+        var sourceKey = NormalizeId(sourceId);
+        WorkflowValidation.ValidateId(newId);
+        var id = newId.Trim();
+
+        lock (_gate)
+        {
+            // The clone's id obeys the same rules as create: never a built-in id (the library can
+            // never be shadowed), never a taken id.
+            if (IsLibraryBuiltIn(id))
+                throw new WorkflowConflictException(
+                    $"'{id}' is a built-in DevThrottle workflow; its id is reserved. Pick a different id.");
+
+            WorkflowVersionEntity sourceVersion;
+            List<WorkflowFileEntity> sourceFiles;
+            using (var src = OpenOwningContext(sourceKey))
+            {
+                var sourceHead = src.Workflows.AsNoTracking().FirstOrDefault(h => h.Id == sourceKey);
+                if (sourceHead is null || sourceHead.Archived || sourceHead.PublishedVersion is null)
+                    return null;
+                sourceVersion = src.WorkflowVersions.AsNoTracking().First(
+                    v => v.WorkflowId == sourceKey && v.Status == WorkflowVersionStatus.Published);
+                sourceFiles = src.WorkflowFiles.AsNoTracking()
+                    .Where(f => f.VersionId == sourceVersion.Id)
+                    .ToList();
+            }
+
+            using var ctx = _db.CreateContext();
+            if (ctx.Workflows.Any(h => h.Id == id))
+                throw new WorkflowConflictException($"A workflow with id '{id}' already exists.");
+
+            var now = DateTime.UtcNow;
+            var head = new WorkflowEntity
+            {
+                Id = id,
+                TenantId = ctx.ActiveTenant!,
+                IsBuiltIn = false,
+                Archived = false,
+                LatestVersion = 1,
+                PublishedVersion = 1,
+                ShippedContentHash = null,
+                CreatedUtc = now,
+                UpdatedUtc = now,
+            };
+            var version = new WorkflowVersionEntity
+            {
+                TenantId = ctx.ActiveTenant!,
+                WorkflowId = id,
+                Version = 1,
+                Status = WorkflowVersionStatus.Published,
+                Name = sourceVersion.Name,
+                Summary = sourceVersion.Summary,
+                WhenToUse = sourceVersion.WhenToUse,
+                HumanCheckpoint = sourceVersion.HumanCheckpoint,
+                Steps = sourceVersion.Steps.Select(s => new WorkflowStepDto
+                {
+                    Name = s.Name,
+                    Description = s.Description,
+                    Doer = s.Doer,
+                    Reviewer = s.Reviewer,
+                    Done = s.Done,
+                }).ToList(),
+                InstructionsMarkdown = sourceVersion.InstructionsMarkdown,
+                OutcomeCriteria = sourceVersion.OutcomeCriteria.Select(c => new WorkflowOutcomeCriterionDto
+                {
+                    CriterionId = c.CriterionId,
+                    Description = c.Description,
+                    ProofHint = c.ProofHint,
+                }).ToList(),
+                ContentHash = sourceVersion.ContentHash, // identical content, identical bundle hash
+                AuthoredBy = string.IsNullOrWhiteSpace(authoredBy) ? "unknown" : authoredBy.Trim(),
+                ChangeNote = $"Cloned from '{sourceKey}' v{sourceVersion.Version}.",
+                CreatedUtc = now,
+                PublishedUtc = now,
+            };
+            var files = sourceFiles.Select(f => new WorkflowFileEntity
+            {
+                TenantId = ctx.ActiveTenant!,
+                VersionId = version.Id,
+                FileName = f.FileName,
+                Content = f.Content,
+                ContentHash = f.ContentHash,
+            }).ToList();
+
+            ctx.Workflows.Add(head);
+            ctx.WorkflowVersions.Add(version);
+            ctx.WorkflowFiles.AddRange(files);
+            ctx.SaveChanges();
+
+            FileLog.Write($"[WorkflowStore] Clone: '{sourceKey}' v{sourceVersion.Version} -> '{id}' v1 " +
+                          $"({files.Count} files), authoredBy={version.AuthoredBy}");
+            return ToDto(head, version, hasDraft: false);
+        }
+    }
+
     /// <summary>Archive (soft-delete) a user-defined workflow. Its versions remain - a run that
     /// pinned one must always resolve. False when no such workflow exists.</summary>
     public bool Archive(string id)

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -399,6 +399,13 @@ _ACTIONS = [
         "args": [{"name": "id", "required": True}],
     },
     {
+        "id": "workflow-clone",
+        "description": "Clone a Workflow's published content into a new editable Workflow you own (the way to customize a built-in).",
+        "command": "cc-devthrottle workflow clone <id> <new-id>",
+        "mutatesState": True,
+        "args": [{"name": "id", "required": True}, {"name": "new-id", "required": True}],
+    },
+    {
         "id": "workflow-delete",
         "description": "Archive a custom Workflow (built-ins can never be deleted; history remains).",
         "command": "cc-devthrottle workflow delete <id> --yes",
@@ -1135,6 +1142,20 @@ def workflow_disable(
 
 # "workflow reset" was retired with the Shared Workflow Library phase 3: built-ins are read-only,
 # can never diverge from the shipped content, and have nothing to reset.
+
+
+@workflow_app.command("clone")
+def workflow_clone(
+    workflow_id: str = typer.Argument(..., help="The source workflow id (e.g. mission)."),
+    new_id: str = typer.Argument(..., help="The id for the clone (a fresh slug, never a built-in id)."),
+) -> None:
+    """Clone a Workflow's published content into a new editable Workflow you own.
+
+    The sanctioned way to customize a built-in: the clone copies the steps, instructions, and
+    helper files into version 1 of the new id, immediately published and fully editable, with
+    where-it-came-from recorded. The built-in itself stays exactly as DevThrottle ships it.
+    """
+    workflow_ops.clone_workflow(workflow_id, new_id)
 
 
 @workflow_app.command("delete")

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -20,6 +20,7 @@ import socket
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 import requests
 import typer
@@ -201,6 +202,12 @@ class WorkflowClient:
     def publish(self, workflow_id: str) -> Dict[str, Any]:
         return self._json_or_raise(
             self._request("POST", f"/gateway/workflows/{workflow_id}/publish")
+        )
+
+    def clone(self, workflow_id: str, new_id: str) -> Dict[str, Any]:
+        query = urlencode({"newId": new_id, "by": default_authored_by()})
+        return self._json_or_raise(
+            self._request("POST", f"/gateway/workflows/{workflow_id}/clone?{query}")
         )
 
     def delete(self, workflow_id: str) -> Dict[str, Any]:
@@ -571,6 +578,18 @@ def publish_workflow(workflow_id: str) -> None:
 
 # reset_workflow was retired with the Shared Workflow Library phase 3: built-ins are read-only,
 # can never diverge from the shipped content, and have nothing to reset.
+
+
+def clone_workflow(workflow_id: str, new_id: str) -> None:
+    try:
+        result = _client().clone(workflow_id, new_id)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+    console.print(
+        f"Cloned '{workflow_id}' into '{result.get('id')}' v{result.get('version')}. "
+        "The clone is yours: published, editable, and independent of the original."
+    )
 
 
 def set_workflow_enabled(workflow_id: str, enabled: bool) -> None:

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -66,6 +66,7 @@ class TestActionsDiscoverability:
             "workflow-push",
             "workflow-publish",
             "workflow-materialize",
+            "workflow-clone",
             "workflow-delete",
             "workflow-runs",
             "workflow-run-show",


### PR DESCRIPTION
## Why

Phase 4 of the Shared Workflow Library (devthrottle_internal issue 514) - the final code phase. Built-ins became read-only in phase 3; clone is the sanctioned way to customize one, and it works on tenant-owned workflows too ("copy mine as a starting point").

## What changed

- `WorkflowStore.Clone(sourceId, newId, authoredBy)`: copies the source's PUBLISHED content - steps, instructions, outcome criteria, helper files - into version 1 of a fresh tenant-owned id. The clone is born PUBLISHED (the content just came off a published bundle, so it is immediately runnable), fully editable, and completely independent of the original; provenance (source id and version) is recorded on the version row's change note, and the authoring actor is recorded. The clone's id obeys the same rules as create: never a built-in id (the library can never be shadowed), never a taken id, always a valid slug.
- Gateway route: `POST /gateway/workflows/{id}/clone?newId=<slug>&by=<actor>` -> 201 with the clone, 404 unknown source, 409 taken or built-in id, 400 bad slug.
- Command line: `cc-devthrottle workflow clone <id> <new-id>`, listed in the agent-discoverable actions so agents find the customization path themselves.
- Cockpit: a Clone action on the workflow page (suggested id `<id>-copy`), navigating to the clone on success.

## Proof

`WorkflowCloneTests` (hosted-style, real `AsyncLocalTenantContext`): cloning mission under tenant A yields an editable, enabled, non-built-in copy serving the shipped conduct byte for byte with provenance recorded; editing and publishing the clone serves the edited conduct while the built-in stays untouched and read-only; the clone is invisible to tenant B; the refusals are exact (built-in id, taken id, bad slug, missing source); helper files ride the clone. Cockpit tests, client-core tests, typecheck, and the command-line tool's suite all green.
