### PR TITLE
feat(gateway): tenant-scoped activity ledger with 30-day retention (trustworthy Working start, increment 1)

### DIFF
--- a/docs/PLAN-trustworthy-working-start-2026-07-24.md
+++ b/docs/PLAN-trustworthy-working-start-2026-07-24.md
@@ -1,0 +1,186 @@
+# Plan - trustworthy "Working" start (reviewed from the 2026-07-24 handover)
+
+## The problem, precisely
+
+Today the Director decides a session is "Working" from one rule in
+`src/CcDirector.Core/Wingman/TerminalStateDetector.cs`: any byte out of the terminal means
+Working, and ten seconds of silence means "needs you". That rule cannot tell the difference
+between the agent doing real work and a background shell or the agent's own status footer
+repainting the screen. On 24 July that difference cost an armed eight-hour snooze: a periodic
+background repaint was read as "Working", and the Gateway's snooze observer correctly applied
+its policy ("work ends a snooze") to a fact that was false.
+
+The truthful definition we want: a session is Working while a TURN IS OPEN. A turn is opened by
+a real submission or an explicit backend signal, kept alive by terminal output, and closed by
+quiet. Terminal output alone must never open a turn from a settled state - for a driver we have
+verified.
+
+The one genuine hazard with that definition: some real turns start WITHOUT a submission the
+Director can see - an agent re-invoked by a finishing background task, a scheduled self-wakeup,
+a hook. If we gate turn starts on submissions before measuring how often that happens, we trade
+a false-positive bug (phantom Working) for a worse false-negative one (real work shown as
+"needs you", voice interrupting a busy agent, snoozes surviving real work). That is why the
+evidence phase comes first and why the rule ships per driver behind a verified opt-in.
+
+## Owner rulings (2026-07-24)
+
+- The activity history IS stored on the hosted Gateway, tenant scoped, from the first
+  increment. The Gateway is becoming the fleet's brain; why turns start is signal it should
+  keep, combined across all customers. This supersedes the earlier draft of this plan that
+  proposed Director-local storage.
+- Retention is 30 DAYS, enforced by a sweeper from day one. The handover's "unbounded, decide
+  later" is replaced by deciding now. If long-term learning is wanted later, derive small
+  aggregates from the raw events before they age out - a future feature, not built now.
+
+## Verification against origin/main (2026-07-24, commit 9fde3414)
+
+The handover's code claims were checked and hold, with one correction:
+
+- The byte rule, the ten-second quiet threshold, the resize-suppression window, the brand-new
+  suppression, and the screen-body rule for continuous-idle drivers all exist as described in
+  `TerminalStateDetector.cs`.
+- `Session.SendInput` and `Session.SendTextAsync` are real choke points that already set
+  Working on submission, and `LastOwnerTurnAtUtc` already separates owner identity from turn
+  existence.
+- `SnoozeLandingObserver` deletes an armed snooze on any Working observation, exactly as
+  described, and its own comments acknowledge the repaint false-positive risk.
+- Correction: the handover repeatedly refers to a "transcript generation" counter. No such
+  signal exists in the code. The equivalent ground truth is `ConversationIngestor` storing a
+  new assistant reply; use that.
+
+## What the handover gets right - kept
+
+1. Fix the fact, not the policy. The snooze rule is fine; the "Working" input to it is a lie.
+   Do not touch snooze arithmetic or the Gateway's snooze policy.
+2. Agent-specific behavior lives behind the driver abstraction, never as agent conditionals in
+   shared code. The existing `EmitsContinuousIdleOutput` trait is the precedent.
+3. Prove the new rule in shadow before it becomes authoritative, and opt drivers in one at a
+   time with the raw-byte rule as the safe default for everyone unverified.
+4. The Gateway owns the durable, tenant-scoped activity ledger; the Director captures and
+   pushes through a durable outbox, following the existing prompt-log ingestion pattern.
+5. Capture bounded terminal evidence when output arrives while settled. The July incident
+   cannot be fully explained today because nobody kept the repaint content; that gap should
+   never repeat. Never store the raw byte stream.
+6. Uncertainty during an open turn preserves Working. A doubt must never hide active work.
+7. The hold-endpoint race is real but separate. Do not bundle it.
+
+## What is cut from the handover - and why
+
+1. CUT unbounded retention. Raw activity events are purged after 30 days by a sweeper that
+   ships with the table.
+2. CUT the twelve-scenario live harness across all nine drivers. Only Claude needs to pass
+   initially, and days of real fleet usage in shadow mode exercise the scenarios that matter
+   better than a synthetic harness. Keep a short targeted checklist for the scenarios real
+   usage may not cover (a long silent reasoning interval, a permission request, cancel,
+   restart, resize).
+3. CUT the recorded-terminal replay infrastructure for now. Build it only if shadow
+   disagreements appear that cannot be diagnosed from the captured evidence.
+4. CUT any new Cockpit page. A tenant-scoped read endpoint filtered by session and time range
+   is enough for diagnosis in this feature.
+
+## The plan
+
+### Phase 1 - the Gateway activity ledger, then the Director producer (no behavior change)
+
+Two pull requests. Nothing in this phase changes any state transition.
+
+Pull request 1 - Gateway ledger:
+
+- A contract in `CcDirector.Gateway.Contracts` for one activity event: who (director, session,
+  machine, agent kind), when (occurred UTC, a per-director sequence), what (a closed event-type
+  set), why (a closed cause set), plus the optional evidence fields (previous and new state,
+  input origin, send source, detector mode and version, output byte count, before and after
+  screen hashes, a bounded changed-row diff).
+- Event types cover: turn submitted, backend activity started, terminal output while settled,
+  activity transition, turn observed in transcript, session exited, and the snooze lifecycle
+  (created, landed, ended).
+- A tenant-scoped `activity_events` table through the Gateway database (entity derived from
+  the tenant-scoped base, added to the context and the tenant filter), with SQLite and
+  PostgreSQL migrations. Indexes on (tenant, session, occurred), (tenant, director, sequence),
+  and (tenant, event type, occurred). Idempotent per tenant: a retried batch must not
+  duplicate events.
+- An authenticated batch write endpoint. Hosted with an unresolved tenant is refused, never
+  mapped to Local. Bounded field lengths and batch size. Duplicates acknowledged as successful
+  replays. A tenant-scoped read endpoint filtered by session and UTC range.
+- A 30-day retention sweeper.
+- The Gateway writes its OWN snooze lifecycle events into the same ledger: created (with
+  requested minutes and deadline), landed, and ended - with the prior state and the reason
+  (timer expiry, owner turn, manual release, session exit, working observation). This alone
+  would have made the July 24 incident self-explanatory.
+- Tests: store behavior on SQLite, PostgreSQL migration checks, hostile two-tenant isolation,
+  endpoint authentication and validation, idempotent replay, sweeper.
+
+Pull request 2 - Director producer and shadow classification:
+
+- Stamp the last submission on the session at the two existing choke points: `SendInput` when
+  it carries a submit byte, and `SendTextAsync` after the submit protocol succeeds - time,
+  send source, input origin. (`LastOwnerTurnAtUtc` stays untouched; this is the turn-exists
+  fact, not the owner-identity fact.)
+- A shadow classifier at the terminal state detector: every time the current rule flips a
+  session into Working, classify the evidence - a submission within a short window, an
+  explicit backend signal, terminal output only from a settled state, or unknown - and emit
+  an event. The classifier consumes facts; it must not switch on the agent kind.
+- When output arrives while the session is settled and no submission explains it, capture the
+  bounded evidence fields (byte count, body hashes, bounded changed-row diff, inside the
+  resize-suppression window, brand new).
+- Emit an event when the conversation ingestor stores a new assistant reply for a session.
+  That is the ground truth that a real turn happened, used to judge the shadow rule in
+  Phase 2.
+- A durable Director outbox: events are minted once (id and sequence), persisted locally,
+  pushed in batches, and deleted only on Gateway acknowledgement. The Gateway is the only
+  durable history; the outbox is delivery state.
+
+### Phase 2 - judge the shadow rule on real usage (no product code)
+
+Deploy Phase 1 hosted, run normal fleet work for several days, then evaluate against these
+gates for Claude, by querying the ledger:
+
+- Every stored assistant reply has a recognized turn start (submission or backend signal)
+  before it. Specifically hunt for real turns with NO submission - self-wakeups, background
+  task completions, hooks - because those are what a submission-gated rule would wrongly
+  suppress. Count them; if they exist, the rule needs a rescue signal (for example the
+  ingestor's new-reply observation promoting the turn) before it can be authoritative.
+- Every terminal-output-only classification while settled produced no stored reply afterward -
+  confirming they were genuinely idle noise.
+- Long silent reasoning intervals did not produce a false settled verdict inside an open turn.
+
+The classifier's own answer is never its own oracle; the stored replies and the submission
+stamps are the oracle.
+
+### Phase 3 - authoritative opt-in per driver, plus the snooze regression proof
+
+Two pull requests: the mechanism, then the opt-in with its evidence.
+
+- Add a driver trait, an activity-start policy: terminal-output-fallback (the default,
+  today's behavior) or submission-gated. Under submission-gated: terminal output maintains an
+  already-open turn and re-arms the quiet countdown, but never opens a turn from a settled
+  state; a submission or explicit backend signal opens the turn; an unknown verdict during an
+  open turn preserves Working. The quiet-end rule stays exactly as it is today.
+- Opt Claude in only after Phase 2's gates pass, citing the collected ledger evidence in the
+  pull request. All other drivers keep the fallback until they earn their own opt-in.
+- Add the end-to-end snooze regression test: arm a long snooze, emit periodic background
+  output, assert the session stays snoozed and the ledger records the ignored output; then
+  submit a genuine turn and assert the session goes Working and the armed snooze ends with the
+  durable reason "working observation". Separately prove normal timer expiry and manual
+  release still work.
+
+### Explicitly out of scope
+
+- The hold-endpoint race (separate, later change; the Phase 1 evidence will make it visible).
+- Any change to snooze durations, deadlines, or the "work ends a snooze" policy.
+- Any completion-detection rewrite; quiet-end behavior is untouched.
+- Long-term aggregates for the Gateway brain (derive from raw events later if wanted).
+- Storing raw terminal byte streams, or logging tenant identifiers and terminal content to
+  hosted application logs.
+
+## Definition of done
+
+- The hosted Gateway durably retains tenant-scoped activity and snooze lifecycle events,
+  purged after 30 days; retry and reconnect can neither lose nor duplicate events.
+- Phantom Working from background or footer output no longer occurs for Claude sessions, and
+  a recurrence would be diagnosable from the ledger alone, without free-text log archaeology.
+- No real Claude turn is missed: every stored reply is preceded by a recognized turn start,
+  measured over real usage, before and after the opt-in.
+- Every other driver behaves exactly as today.
+- Snooze timer behavior is unchanged and covered by the new end-to-end test, and every snooze
+  end has a durable recorded reason.

--- a/src/CcDirector.Gateway.Contracts/ActivityEventDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/ActivityEventDtos.cs
@@ -1,0 +1,217 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One activity-ledger event on its way from a producer to the Gateway's durable activity ledger, and the
+/// shape the Gateway serves back (the trustworthy-Working-start plan,
+/// docs/PLAN-trustworthy-working-start-2026-07-24.md).
+///
+/// The ledger answers, from structured history alone: what caused a session to enter or leave Working, was
+/// there a submitted turn or only terminal output, which detector decided, did a transcript later prove a
+/// real turn, and why did a snooze end. Two producers write it: a DIRECTOR pushes what it observed
+/// (submissions, terminal output, state transitions, transcript observations), and the GATEWAY appends its
+/// own snooze lifecycle decisions.
+///
+/// IDEMPOTENCY: <see cref="EventId"/> is minted ONCE by the producer before the event enters its outbox and
+/// is preserved across retries; the Gateway treats a replayed id as an already-acknowledged duplicate, never
+/// an error and never a second row. <see cref="DirectorSequence"/> is the producer's own monotonic ordering
+/// (0 on Gateway-origin events), so a batch that retries after a partial failure cannot reorder history.
+/// </summary>
+public sealed record ActivityEventRecord
+{
+    /// <summary>The producer-minted identity of this event. The idempotency key: replaying it is a no-op.</summary>
+    [JsonPropertyName("eventId")] public required Guid EventId { get; init; }
+
+    /// <summary>The producer's own monotonic sequence for this event (0 on Gateway-origin events).</summary>
+    [JsonPropertyName("directorSequence")] public required long DirectorSequence { get; init; }
+
+    /// <summary>When the event actually happened (UTC, producer-stamped).</summary>
+    [JsonPropertyName("occurredUtc")] public required DateTime OccurredUtc { get; init; }
+
+    /// <summary>The Director the event belongs to ("gateway" on Gateway-origin snooze events whose owning
+    /// Director is unknown).</summary>
+    [JsonPropertyName("directorId")] public required string DirectorId { get; init; }
+
+    /// <summary>The Director session (the window/slot) the event is about.</summary>
+    [JsonPropertyName("sessionId")] public required string SessionId { get; init; }
+
+    /// <summary>Which machine the session runs on, when known.</summary>
+    [JsonPropertyName("machine")] public string? Machine { get; init; }
+
+    /// <summary>The agent kind of the session's driver (e.g. "Claude"), when known.</summary>
+    [JsonPropertyName("agentKind")] public string? AgentKind { get; init; }
+
+    /// <summary>The agent's own context id at the time, when known (groups events with the prompt log).</summary>
+    [JsonPropertyName("contextId")] public string? ContextId { get; init; }
+
+    /// <summary>What happened - one of <see cref="ActivityEventTypes"/>.</summary>
+    [JsonPropertyName("eventType")] public required string EventType { get; init; }
+
+    /// <summary>The state before the event (an <c>ActivityState</c> name, or a hold state on snooze
+    /// events), when the event is a transition.</summary>
+    [JsonPropertyName("previousState")] public string? PreviousState { get; init; }
+
+    /// <summary>The state after the event, when the event is a transition.</summary>
+    [JsonPropertyName("newState")] public string? NewState { get; init; }
+
+    /// <summary>Why it happened - one of <see cref="ActivityCauses"/>.</summary>
+    [JsonPropertyName("cause")] public required string Cause { get; init; }
+
+    /// <summary>A short structured control-flow note (a deadline, a requested length, a retired-edge note).
+    /// NEVER prompt or terminal content.</summary>
+    [JsonPropertyName("detail")] public string? Detail { get; init; }
+
+    /// <summary>Where the input came from on a submission event (e.g. "desktop", "cockpit", "voice").</summary>
+    [JsonPropertyName("inputOrigin")] public string? InputOrigin { get; init; }
+
+    /// <summary>The send source on a submission event (the Director's <c>SendSource</c> name).</summary>
+    [JsonPropertyName("sendSource")] public string? SendSource { get; init; }
+
+    /// <summary>The detector mode that ruled (e.g. "byte", "body", "shadow"), on detector events.</summary>
+    [JsonPropertyName("detectorMode")] public string? DetectorMode { get; init; }
+
+    /// <summary>The detector version that ruled, so shadow results stay interpretable across upgrades.</summary>
+    [JsonPropertyName("detectorVersion")] public string? DetectorVersion { get; init; }
+
+    /// <summary>How many terminal bytes were seen, on terminal-output evidence events.</summary>
+    [JsonPropertyName("outputByteCount")] public long? OutputByteCount { get; init; }
+
+    /// <summary>Normalized screen-body hash BEFORE the output burst, on terminal-output evidence events.</summary>
+    [JsonPropertyName("beforeScreenHash")] public string? BeforeScreenHash { get; init; }
+
+    /// <summary>Normalized screen-body hash AFTER the output burst.</summary>
+    [JsonPropertyName("afterScreenHash")] public string? AfterScreenHash { get; init; }
+
+    /// <summary>A BOUNDED normalized changed-row diff (never the raw byte stream, never unbounded). May
+    /// contain terminal content, so it is tenant-scoped customer data - never logged to process logs.</summary>
+    [JsonPropertyName("boundedScreenDiff")] public string? BoundedScreenDiff { get; init; }
+}
+
+/// <summary>
+/// The closed set of activity-ledger event types. Wire values are string constants, not enums - the
+/// contracts assembly is reference-free and old readers must tolerate new writers (the <see cref="HoldStates"/>
+/// convention). The Gateway validates every appended event against this set.
+/// </summary>
+public static class ActivityEventTypes
+{
+    /// <summary>A real submission entered the session (typed Enter, Cockpit, voice, queue, agent-to-agent).</summary>
+    public const string TurnSubmitted = "turn-submitted";
+
+    /// <summary>A remote backend explicitly reported activity started (e.g. a run began).</summary>
+    public const string BackendActivityStarted = "backend-activity-started";
+
+    /// <summary>Terminal output arrived while the session was SETTLED and no submission explains it - the
+    /// evidence row for a candidate phantom turn (carries the bounded terminal evidence fields).</summary>
+    public const string TerminalOutputWhileSettled = "terminal-output-while-settled";
+
+    /// <summary>The session's authoritative <c>ActivityState</c> actually changed.</summary>
+    public const string ActivityTransition = "activity-transition";
+
+    /// <summary>The conversation ingest observed a new assistant reply - ground truth that a real turn
+    /// happened, used to judge the shadow rule.</summary>
+    public const string TurnObservedInTranscript = "turn-observed-in-transcript";
+
+    /// <summary>The session exited.</summary>
+    public const string SessionExited = "session-exited";
+
+    /// <summary>A snooze was created or refreshed (armed with a deadline, or deferred with a length).</summary>
+    public const string SnoozeCreated = "snooze-created";
+
+    /// <summary>A deferred snooze landed: the work ended and its clock started.</summary>
+    public const string SnoozeLanded = "snooze-landed";
+
+    /// <summary>A snooze entry was retired - the cause says why (the July 24 question).</summary>
+    public const string SnoozeEnded = "snooze-ended";
+
+    /// <summary>Every legal event type, for validation.</summary>
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        TurnSubmitted, BackendActivityStarted, TerminalOutputWhileSettled, ActivityTransition,
+        TurnObservedInTranscript, SessionExited, SnoozeCreated, SnoozeLanded, SnoozeEnded,
+    };
+}
+
+/// <summary>
+/// The closed set of activity-ledger causes - WHY an event happened. String constants on the wire, same
+/// convention as <see cref="ActivityEventTypes"/>.
+/// </summary>
+public static class ActivityCauses
+{
+    /// <summary>The owner submitted the turn.</summary>
+    public const string OwnerSubmit = "owner-submit";
+
+    /// <summary>Another agent submitted the turn (agent-to-agent prompt).</summary>
+    public const string AgentSubmit = "agent-submit";
+
+    /// <summary>A framework/queue path submitted the turn.</summary>
+    public const string FrameworkSubmit = "framework-submit";
+
+    /// <summary>An explicit backend activity signal (remote run status), not terminal bytes.</summary>
+    public const string BackendSignal = "backend-signal";
+
+    /// <summary>Only terminal output was observed - no submission, no backend signal.</summary>
+    public const string TerminalOutputOnly = "terminal-output-only";
+
+    /// <summary>The quiet threshold elapsed (the settle edge).</summary>
+    public const string QuietThreshold = "quiet-threshold";
+
+    /// <summary>The driver reported positive completion.</summary>
+    public const string DriverCompletion = "driver-completion";
+
+    /// <summary>The owner drove a turn (supersedes a hold).</summary>
+    public const string OwnerTurn = "owner-turn";
+
+    /// <summary>A manual release (the owner turned the alarm off).</summary>
+    public const string ManualRelease = "manual-release";
+
+    /// <summary>The snooze deadline elapsed - the timer itself ended the snooze.</summary>
+    public const string TimerExpired = "timer-expired";
+
+    /// <summary>The session exited.</summary>
+    public const string SessionExit = "session-exit";
+
+    /// <summary>The session was reported Working - the "work ends a snooze" policy fired. THE July 24
+    /// cause: whether that Working was real is what the rest of the ledger proves.</summary>
+    public const string WorkingObservation = "working-observation";
+
+    /// <summary>A snooze was asked for (created or refreshed).</summary>
+    public const string SnoozeRequested = "snooze-requested";
+
+    /// <summary>The work a deferred snooze was waiting on settled, landing it.</summary>
+    public const string WorkSettled = "work-settled";
+
+    /// <summary>The owning Director was removed from the fleet.</summary>
+    public const string DirectorRemoved = "director-removed";
+
+    /// <summary>The session is no longer in its Director's authoritative live list.</summary>
+    public const string SessionNotLive = "session-not-live";
+
+    /// <summary>The producer could not decide (the shadow classifier's honest "unknown").</summary>
+    public const string Unknown = "unknown";
+
+    /// <summary>Every legal cause, for validation.</summary>
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        OwnerSubmit, AgentSubmit, FrameworkSubmit, BackendSignal, TerminalOutputOnly, QuietThreshold,
+        DriverCompletion, OwnerTurn, ManualRelease, TimerExpired, SessionExit, WorkingObservation,
+        SnoozeRequested, WorkSettled, DirectorRemoved, SessionNotLive, Unknown,
+    };
+}
+
+/// <summary>A producer's push of activity events to the Gateway's ledger.</summary>
+public sealed record ActivityEventIngestRequest
+{
+    [JsonPropertyName("events")] public required IReadOnlyList<ActivityEventRecord> Events { get; init; }
+}
+
+/// <summary>
+/// What the Gateway durably holds after the batch, so the producer can drop acknowledged outbox records
+/// honestly: an event is acknowledged when it was <see cref="Written"/> now or was already there
+/// (<see cref="Duplicates"/> - a successful idempotent replay, not an error).
+/// </summary>
+public sealed record ActivityEventIngestResponse
+{
+    [JsonPropertyName("written")] public required int Written { get; init; }
+    [JsonPropertyName("duplicates")] public required int Duplicates { get; init; }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724165917_AddActivityEvents.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724165917_AddActivityEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724165917_AddActivityEvents")]
+    partial class AddActivityEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724165917_AddActivityEvents.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724165917_AddActivityEvents.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActivityEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "activity_events",
+                schema: "gateway",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "text", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DirectorSequence = table.Column<long>(type: "bigint", nullable: false),
+                    OccurredUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RecordedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DirectorId = table.Column<string>(type: "text", nullable: false),
+                    SessionId = table.Column<string>(type: "text", nullable: false),
+                    Machine = table.Column<string>(type: "text", nullable: true),
+                    AgentKind = table.Column<string>(type: "text", nullable: true),
+                    ContextId = table.Column<string>(type: "text", nullable: true),
+                    EventType = table.Column<string>(type: "text", nullable: false),
+                    PreviousState = table.Column<string>(type: "text", nullable: true),
+                    NewState = table.Column<string>(type: "text", nullable: true),
+                    Cause = table.Column<string>(type: "text", nullable: false),
+                    Detail = table.Column<string>(type: "text", nullable: true),
+                    InputOrigin = table.Column<string>(type: "text", nullable: true),
+                    SendSource = table.Column<string>(type: "text", nullable: true),
+                    DetectorMode = table.Column<string>(type: "text", nullable: true),
+                    DetectorVersion = table.Column<string>(type: "text", nullable: true),
+                    OutputByteCount = table.Column<long>(type: "bigint", nullable: true),
+                    BeforeScreenHash = table.Column<string>(type: "text", nullable: true),
+                    AfterScreenHash = table.Column<string>(type: "text", nullable: true),
+                    BoundedScreenDiff = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_activity_events", x => new { x.tenant_id, x.EventId });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id",
+                schema: "gateway",
+                table: "activity_events",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_DirectorId_DirectorSequence",
+                schema: "gateway",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "DirectorId", "DirectorSequence" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_EventType_OccurredUtc",
+                schema: "gateway",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "EventType", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_SessionId_OccurredUtc",
+                schema: "gateway",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "SessionId", "OccurredUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "activity_events",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Activity/ActivityEventEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/ActivityEventEndpointsTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Net.Http.Json;
+using CcDirector.Gateway.Activity;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Activity;
+
+/// <summary>
+/// End-to-end tests for the activity ledger's front door over a real HTTP pipeline: a producer POSTs
+/// observed events (idempotent by producer-minted id), and diagnosis GETs them back. Mapped without a
+/// tenant boundary, exactly like the prompt endpoint tests - the self-host Local path; the hosted
+/// two-tenant behavior is proven separately over a full GatewayHost.
+/// </summary>
+public sealed class ActivityEventEndpointsTests : IAsyncLifetime
+{
+    private WebApplication _app = null!;
+    private HttpClient _client = null!;
+    private GatewayDbTestHarness _harness = null!;
+
+    public async Task InitializeAsync()
+    {
+        _harness = new GatewayDbTestHarness();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        _app = builder.Build();
+        _app.Urls.Add("http://127.0.0.1:0");
+
+        ActivityEventEndpoints.Map(_app, new ActivityEventStore(_harness.Open()));
+        await _app.StartAsync();
+
+        _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_app is not null) { await _app.StopAsync(); await _app.DisposeAsync(); }
+        _harness?.Dispose();
+    }
+
+    private static ActivityEventRecord Rec(Guid? id = null, DateTime? occurredUtc = null) => new()
+    {
+        EventId = id ?? Guid.NewGuid(),
+        DirectorSequence = 7,
+        OccurredUtc = occurredUtc ?? DateTime.UtcNow,
+        DirectorId = "dir-1",
+        SessionId = "s1",
+        AgentKind = "Claude",
+        EventType = ActivityEventTypes.TerminalOutputWhileSettled,
+        Cause = ActivityCauses.TerminalOutputOnly,
+        OutputByteCount = 96,
+    };
+
+    [Fact]
+    public async Task A_producer_pushes_and_diagnosis_reads_it_back()
+    {
+        var post = await _client.PostAsJsonAsync("/activity-events/batch",
+            new ActivityEventIngestRequest { Events = new[] { Rec(), Rec() } });
+
+        Assert.Equal(HttpStatusCode.OK, post.StatusCode);
+        var ack = await post.Content.ReadFromJsonAsync<ActivityEventIngestResponse>();
+        Assert.Equal(2, ack!.Written);
+        Assert.Equal(0, ack.Duplicates);
+
+        var body = await _client.GetFromJsonAsync<EventsResponse>("/activity-events?sessionId=s1");
+        Assert.Equal(2, body!.Count);
+        Assert.All(body.Events, e => Assert.Equal(ActivityCauses.TerminalOutputOnly, e.Cause));
+    }
+
+    [Fact]
+    public async Task A_retried_batch_is_acknowledged_as_duplicates_not_an_error()
+    {
+        var batch = new ActivityEventIngestRequest { Events = new[] { Rec() } };
+
+        await _client.PostAsJsonAsync("/activity-events/batch", batch);
+        var retry = await _client.PostAsJsonAsync("/activity-events/batch", batch);
+
+        Assert.Equal(HttpStatusCode.OK, retry.StatusCode);
+        var ack = await retry.Content.ReadFromJsonAsync<ActivityEventIngestResponse>();
+        Assert.Equal(0, ack!.Written);
+        Assert.Equal(1, ack.Duplicates);
+
+        var body = await _client.GetFromJsonAsync<EventsResponse>("/activity-events?sessionId=s1");
+        Assert.Equal(1, body!.Count);
+    }
+
+    [Fact]
+    public async Task An_empty_push_is_rejected()
+    {
+        var resp = await _client.PostAsJsonAsync("/activity-events/batch",
+            new ActivityEventIngestRequest { Events = Array.Empty<ActivityEventRecord>() });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_malformed_event_is_rejected_with_the_validation_message()
+    {
+        var resp = await _client.PostAsJsonAsync("/activity-events/batch",
+            new ActivityEventIngestRequest { Events = new[] { Rec() with { EventType = "nonsense" } } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("not an activity event type", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task A_backwards_range_is_rejected()
+    {
+        var resp = await _client.GetAsync(
+            $"/activity-events?from={DateTime.UtcNow:O}&to={DateTime.UtcNow.AddHours(-1):O}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    /// <summary>The GET /activity-events body shape.</summary>
+    private sealed record EventsResponse(int Count, IReadOnlyList<ActivityEventRecord> Events);
+}

--- a/src/CcDirector.Gateway.Tests/Activity/ActivityEventStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/ActivityEventStoreTests.cs
@@ -1,0 +1,229 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Activity;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Activity;
+
+/// <summary>
+/// The durable activity ledger's store contract (the trustworthy-Working-start plan): idempotent append by
+/// producer-minted event id, whole-batch fail-loud validation, chronological tenant-scoped reads, and the
+/// 30-day purge. Runs over the real EF store on a throwaway SQLite file (the data-layer harness), exactly
+/// as the Gateway runs it locally.
+/// </summary>
+public sealed class ActivityEventStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    private ActivityEventStore NewStore(ITenantContext? tenant = null)
+        => new(_harness.Open(tenant));
+
+    private static ActivityEventRecord Rec(
+        Guid? id = null, string sessionId = "s1", string eventType = ActivityEventTypes.ActivityTransition,
+        string cause = ActivityCauses.TerminalOutputOnly, DateTime? occurredUtc = null, long sequence = 1) => new()
+    {
+        EventId = id ?? Guid.NewGuid(),
+        DirectorSequence = sequence,
+        OccurredUtc = occurredUtc ?? DateTime.UtcNow,
+        DirectorId = "dir-1",
+        SessionId = sessionId,
+        Machine = "SOREN_NORTH",
+        AgentKind = "Claude",
+        EventType = eventType,
+        PreviousState = "WaitingForInput",
+        NewState = "Working",
+        Cause = cause,
+        DetectorMode = "byte",
+        DetectorVersion = "v1",
+        OutputByteCount = 512,
+        BeforeScreenHash = "aaa",
+        AfterScreenHash = "bbb",
+        BoundedScreenDiff = "row 41: [watcher] tick",
+    };
+
+    [Fact]
+    public void Append_and_read_roundtrip_preserves_the_facts()
+    {
+        var store = NewStore();
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var first = Rec(occurredUtc: t0, sequence: 1);
+        var second = Rec(occurredUtc: t0.AddMinutes(1), sequence: 2,
+            eventType: ActivityEventTypes.TurnSubmitted, cause: ActivityCauses.OwnerSubmit);
+
+        var (written, duplicates) = store.AppendBatch(new[] { first, second });
+
+        Assert.Equal(2, written);
+        Assert.Equal(0, duplicates);
+
+        var events = store.Read(sessionId: "s1");
+        Assert.Equal(2, events.Count);
+        // Chronological (OccurredUtc ascending) - the diagnosis order.
+        Assert.Equal(first.EventId, events[0].EventId);
+        Assert.Equal(second.EventId, events[1].EventId);
+        // The evidence facts survive the roundtrip.
+        Assert.Equal("Claude", events[0].AgentKind);
+        Assert.Equal("byte", events[0].DetectorMode);
+        Assert.Equal(512, events[0].OutputByteCount);
+        Assert.Equal("row 41: [watcher] tick", events[0].BoundedScreenDiff);
+        Assert.Equal(ActivityCauses.OwnerSubmit, events[1].Cause);
+    }
+
+    [Fact]
+    public void A_replayed_batch_is_acknowledged_without_duplicating_rows()
+    {
+        var store = NewStore();
+        var batch = new[] { Rec(), Rec(sequence: 2) };
+
+        var firstPush = store.AppendBatch(batch);
+        var retry = store.AppendBatch(batch);
+
+        Assert.Equal((2, 0), firstPush);
+        // The retry is a SUCCESSFUL idempotent replay: fully acknowledged, zero new rows.
+        Assert.Equal((0, 2), retry);
+        Assert.Equal(2, store.Read(sessionId: "s1").Count);
+    }
+
+    [Fact]
+    public void An_id_repeated_within_one_batch_lands_once()
+    {
+        var store = NewStore();
+        var id = Guid.NewGuid();
+
+        var (written, duplicates) = store.AppendBatch(new[] { Rec(id: id), Rec(id: id) });
+
+        Assert.Equal(1, written);
+        Assert.Equal(1, duplicates);
+        Assert.Single(store.Read(sessionId: "s1"));
+    }
+
+    [Fact]
+    public void One_invalid_event_rejects_the_whole_batch_and_writes_nothing()
+    {
+        var store = NewStore();
+        var good = Rec();
+        var bad = Rec() with { EventType = "not-a-real-type" };
+
+        Assert.Throws<ActivityValidationException>(() => store.AppendBatch(new[] { good, bad }));
+
+        // The ledger never lands a half-batch: the valid event did not sneak in.
+        Assert.Empty(store.Read(sessionId: "s1"));
+    }
+
+    [Fact]
+    public void An_unknown_cause_is_rejected()
+    {
+        var store = NewStore();
+        Assert.Throws<ActivityValidationException>(
+            () => store.AppendBatch(new[] { Rec() with { Cause = "vibes" } }));
+    }
+
+    [Fact]
+    public void An_over_length_diff_is_rejected_not_truncated()
+    {
+        var store = NewStore();
+        var oversized = Rec() with { BoundedScreenDiff = new string('x', ActivityEventStore.MaxDiffChars + 1) };
+        Assert.Throws<ActivityValidationException>(() => store.AppendBatch(new[] { oversized }));
+    }
+
+    [Fact]
+    public void A_batch_over_the_size_ceiling_is_rejected()
+    {
+        var store = NewStore();
+        var tooMany = Enumerable.Range(0, ActivityEventStore.MaxBatchSize + 1).Select(_ => Rec()).ToList();
+        Assert.Throws<ActivityValidationException>(() => store.AppendBatch(tooMany));
+    }
+
+    [Fact]
+    public void A_missing_session_id_is_rejected()
+    {
+        var store = NewStore();
+        Assert.Throws<ActivityValidationException>(
+            () => store.AppendBatch(new[] { Rec(sessionId: " ") }));
+    }
+
+    [Fact]
+    public void An_empty_event_id_is_rejected()
+    {
+        var store = NewStore();
+        Assert.Throws<ActivityValidationException>(
+            () => store.AppendBatch(new[] { Rec(id: Guid.Empty) }));
+    }
+
+    [Fact]
+    public void Reads_filter_by_event_type_and_window()
+    {
+        var store = NewStore();
+        var t0 = DateTime.UtcNow.AddHours(-2);
+        store.AppendBatch(new[]
+        {
+            Rec(occurredUtc: t0, eventType: ActivityEventTypes.TurnSubmitted, cause: ActivityCauses.OwnerSubmit),
+            Rec(occurredUtc: t0.AddMinutes(30)),
+            Rec(occurredUtc: t0.AddMinutes(60), eventType: ActivityEventTypes.SnoozeEnded, cause: ActivityCauses.WorkingObservation),
+        });
+
+        var submits = store.Read(sessionId: "s1", eventType: ActivityEventTypes.TurnSubmitted);
+        Assert.Equal(ActivityCauses.OwnerSubmit, Assert.Single(submits).Cause);
+
+        var window = store.Read(sessionId: "s1", fromUtc: t0.AddMinutes(15), toUtc: t0.AddMinutes(45));
+        Assert.Equal(ActivityCauses.TerminalOutputOnly, Assert.Single(window).Cause);
+    }
+
+    [Fact]
+    public void A_future_occurred_time_is_clamped_to_the_append_time()
+    {
+        var store = NewStore();
+        store.AppendBatch(new[] { Rec(occurredUtc: DateTime.UtcNow.AddDays(2)) });
+
+        var stored = Assert.Single(store.Read(sessionId: "s1"));
+        Assert.True(stored.OccurredUtc <= DateTime.UtcNow.AddSeconds(5));
+    }
+
+    [Fact]
+    public void Purge_removes_only_events_older_than_the_cutoff()
+    {
+        var store = NewStore();
+        var old = Rec(occurredUtc: DateTime.UtcNow.AddDays(-40));
+        var recent = Rec(occurredUtc: DateTime.UtcNow.AddDays(-1));
+        store.AppendBatch(new[] { old, recent });
+
+        var deleted = store.PurgeOlderThan(DateTime.UtcNow.AddDays(-30));
+
+        Assert.Equal(1, deleted);
+        var remaining = Assert.Single(store.Read(sessionId: "s1"));
+        Assert.Equal(recent.EventId, remaining.EventId);
+    }
+
+    [Fact]
+    public void Two_tenants_never_see_each_other_and_the_same_id_cannot_collide()
+    {
+        // Two tenants over the SAME database file - the hosted shape. The same producer-minted event id
+        // appended by both must be TWO rows (the composite key scopes the id space per tenant): no
+        // cross-tenant squat, no existence oracle, and the replay dedup of one tenant must never swallow
+        // the other's event.
+        var tenantA = new TenantId("tenant-aaaa");
+        var tenantB = new TenantId("tenant-bbbb");
+        var storeA = NewStore(new FixedTenantContext(tenantA));
+        var storeB = NewStore(new FixedTenantContext(tenantB));
+
+        var sharedId = Guid.NewGuid();
+        var secretA = Rec(id: sharedId) with { BoundedScreenDiff = "alpha-account-secret-rows" };
+        var secretB = Rec(id: sharedId) with { BoundedScreenDiff = "bravo-account-secret-rows" };
+
+        Assert.Equal((1, 0), storeA.AppendBatch(new[] { secretA }));
+        Assert.Equal((1, 0), storeB.AppendBatch(new[] { secretB }));   // NOT a duplicate: B owns its own id space
+
+        // Positive control first, then the bidirectional absence claims.
+        var readA = Assert.Single(storeA.Read(sessionId: "s1"));
+        var readB = Assert.Single(storeB.Read(sessionId: "s1"));
+        Assert.Equal("alpha-account-secret-rows", readA.BoundedScreenDiff);
+        Assert.Equal("bravo-account-secret-rows", readB.BoundedScreenDiff);
+
+        // And one tenant's purge never touches the other's rows.
+        Assert.Equal(1, storeA.PurgeOlderThan(DateTime.UtcNow.AddDays(1)));
+        Assert.Empty(storeA.Read(sessionId: "s1"));
+        Assert.Equal("bravo-account-secret-rows", Assert.Single(storeB.Read(sessionId: "s1")).BoundedScreenDiff);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Activity/ActivityLedgerTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/ActivityLedgerTenantIsolationTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Activity;
+
+/// <summary>
+/// The activity ledger is TENANT-SCOPED on the hosted Gateway, proven over real HTTP with two accounts -
+/// the hostile two-tenant proof the trustworthy-Working-start plan requires before any hosted deploy.
+///
+/// The ledger's <c>BoundedScreenDiff</c> can carry TERMINAL CONTENT, which can carry secrets, so this is a
+/// content-disclosure surface exactly like the prompt log: every canary is BIDIRECTIONAL and every absence
+/// claim has a POSITIVE CONTROL in front of it. The two accounts also push THE SAME producer-minted event
+/// id: the composite (tenant, event id) key must store TWO rows - no cross-tenant squat, no existence
+/// oracle, and no cross-tenant "duplicate" acknowledgement that would silently swallow one account's
+/// evidence.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and the storage root
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class ActivityLedgerTenantIsolationTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    private const string SecretDiffA = "alpha-account-secret-terminal-rows";
+    private const string SecretDiffB = "bravo-account-secret-terminal-rows";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-activity-iso-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-activity-iso-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        // Isolate the storage root BEFORE the Gateway starts so its database binds the temp root, never the
+        // developer's real one.
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            promptLogPath: Path.Combine(_instancesDir, "prompt-log"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts: two device keys, each bound to its OWN tenant minted by the real registry, plus one
+        // registered-but-unbound key for the deny-by-default check.
+        _keyA = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+        _keyB = _gateway.Devices.Register("dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+        var tenantA = _gateway.TenantRegistry.MintOrLookupBySubject("sub-alice", "alice@example.com");
+        var tenantB = _gateway.TenantRegistry.MintOrLookupBySubject("sub-bob", "bob@example.com");
+        _gateway.Devices.SetAccountBinding("dev-a", "sub-alice", tenantA.Value);
+        _gateway.Devices.SetAccountBinding("dev-b", "sub-bob", tenantB.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* best-effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task One_account_never_reads_anothers_terminal_evidence_and_the_same_id_cannot_collide()
+    {
+        // Both accounts push THE SAME producer-minted event id, each carrying its own secret diff.
+        var sharedId = Guid.NewGuid();
+        var postA = await PostEvent(_keyA, sharedId, SecretDiffA);
+        var postB = await PostEvent(_keyB, sharedId, SecretDiffB);
+        Assert.Equal(HttpStatusCode.OK, postA.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, postB.StatusCode);
+
+        // B's push of A's id is NOT a duplicate: B owns its own id space. A "duplicates=1" here would mean
+        // one account's evidence was silently swallowed by the other's - the cross-tenant squat.
+        var ackB = await postB.Content.ReadFromJsonAsync<ActivityEventIngestResponse>();
+        Assert.Equal(1, ackB!.Written);
+        Assert.Equal(0, ackB.Duplicates);
+
+        var bodyA = await ReadEventsBody(_keyA);
+        var bodyB = await ReadEventsBody(_keyB);
+
+        // Positive control in FRONT of each absence claim: each account reads its own evidence back.
+        Assert.Contains(SecretDiffA, bodyA);
+        Assert.Contains(SecretDiffB, bodyB);
+
+        // The absence claims, both directions.
+        Assert.DoesNotContain(SecretDiffB, bodyA);
+        Assert.DoesNotContain(SecretDiffA, bodyB);
+
+        // And neither read merely filtered a shared set down: each account sees exactly its one record.
+        using var docA = JsonDocument.Parse(bodyA);
+        using var docB = JsonDocument.Parse(bodyB);
+        Assert.Equal(1, docA.RootElement.GetProperty("count").GetInt32());
+        Assert.Equal(1, docB.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public async Task Both_verbs_deny_a_device_key_with_no_bound_tenant()
+    {
+        Assert.Equal(HttpStatusCode.Unauthorized, (await ReadEvents(_keyUnbound)).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await PostEvent(_keyUnbound, Guid.NewGuid(), "should never land")).StatusCode);
+    }
+
+    private Task<HttpResponseMessage> PostEvent(string deviceKey, Guid eventId, string diff)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "activity-events/batch")
+        {
+            Content = JsonContent.Create(new ActivityEventIngestRequest
+            {
+                Events = new List<ActivityEventRecord>
+                {
+                    new()
+                    {
+                        EventId = eventId,
+                        DirectorSequence = 1,
+                        OccurredUtc = DateTime.UtcNow,
+                        DirectorId = "dir-1",
+                        SessionId = "s1",
+                        EventType = ActivityEventTypes.TerminalOutputWhileSettled,
+                        Cause = ActivityCauses.TerminalOutputOnly,
+                        BoundedScreenDiff = diff,
+                    },
+                },
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> ReadEvents(string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "activity-events?sessionId=s1");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<string> ReadEventsBody(string deviceKey)
+    {
+        var resp = await ReadEvents(deviceKey);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Activity/SnoozeLifecycleLedgerTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/SnoozeLifecycleLedgerTests.cs
@@ -1,0 +1,158 @@
+using CcDirector.Gateway.Activity;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Snooze;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Activity;
+
+/// <summary>
+/// The Gateway records its OWN snooze decisions in the durable activity ledger - created, landed, ended,
+/// each with the WHY. This is the direct product of the July 24 incident: an armed eight-hour snooze was
+/// deleted by a working observation and the deletion's reason existed only in free-text logs. With these
+/// events, that incident is self-explanatory from structured history.
+///
+/// One honesty rule is proven here specifically: when an ARMED entry whose deadline has already ELAPSED is
+/// retired by some edge, the recorded cause is TIMER-EXPIRED (the timer ended that snooze; the edge only
+/// cleaned up the tombstone), with the retiring edge preserved in the detail.
+/// </summary>
+public sealed class SnoozeLifecycleLedgerTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly ActivityEventStore _ledger;
+    private readonly SnoozeRegistry _registry;
+
+    public SnoozeLifecycleLedgerTests()
+    {
+        var db = _harness.Open();
+        _ledger = new ActivityEventStore(db);
+        _registry = new SnoozeRegistry(db, _harness.LegacyPath("snooze.json"), _ledger);
+    }
+
+    public void Dispose() => _harness.Dispose();
+
+    private IReadOnlyList<ActivityEventRecord> EventsFor(string sessionId)
+        => _ledger.Read(sessionId: sessionId);
+
+    [Fact]
+    public void Arming_a_snooze_records_created_with_the_deadline()
+    {
+        var until = DateTime.UtcNow.AddHours(8);
+        _registry.Snooze("s1", until, "dir-1");
+
+        var e = Assert.Single(EventsFor("s1"));
+        Assert.Equal(ActivityEventTypes.SnoozeCreated, e.EventType);
+        Assert.Equal(ActivityCauses.SnoozeRequested, e.Cause);
+        Assert.Equal(HoldStates.None, e.PreviousState);
+        Assert.Equal(HoldStates.Held, e.NewState);
+        Assert.Equal("dir-1", e.DirectorId);
+        Assert.Contains(until.ToUniversalTime().ToString("O"), e.Detail);
+    }
+
+    [Fact]
+    public void Deferring_a_snooze_records_created_with_the_length()
+    {
+        _registry.SnoozeDeferred("s1", 480, "dir-1");
+
+        var e = Assert.Single(EventsFor("s1"));
+        Assert.Equal(ActivityEventTypes.SnoozeCreated, e.EventType);
+        Assert.Equal(HoldStates.DeferredHold, e.NewState);
+        Assert.Equal("minutes=480", e.Detail);
+    }
+
+    [Fact]
+    public void Landing_a_deferral_records_landed_with_the_started_clock()
+    {
+        _registry.SnoozeDeferred("s1", 60, "dir-1");
+        _registry.Land("s1", DateTime.UtcNow);
+
+        var landed = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeLanded);
+        Assert.Equal(ActivityCauses.WorkSettled, landed.Cause);
+        Assert.Equal(HoldStates.DeferredHold, landed.PreviousState);
+        Assert.Equal(HoldStates.Held, landed.NewState);
+        Assert.Contains("minutes=60", landed.Detail);
+    }
+
+    [Fact]
+    public void A_working_observation_deleting_an_armed_snooze_records_the_july_24_cause()
+    {
+        // The incident shape: an armed snooze with hours still on the clock, deleted because the session
+        // was reported Working. The durable reason must say exactly that.
+        _registry.Snooze("s1", DateTime.UtcNow.AddHours(8), "dir-1");
+        Assert.True(_registry.ClearIfArmed("s1"));
+
+        var ended = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded);
+        Assert.Equal(ActivityCauses.WorkingObservation, ended.Cause);
+        Assert.Equal(HoldStates.Held, ended.PreviousState);
+        Assert.Equal(HoldStates.None, ended.NewState);
+    }
+
+    [Fact]
+    public void Retiring_an_already_elapsed_snooze_records_timer_expired_not_the_retiring_edge()
+    {
+        // The snooze ended at its deadline; a later working observation only cleans up the tombstone. The
+        // cause is the timer, and the edge is preserved as detail - the distinction the incident's
+        // "waiting 1h 5m" confusion needed.
+        _registry.Snooze("s1", DateTime.UtcNow.AddMinutes(-5), "dir-1");
+        Assert.True(_registry.ClearIfArmed("s1"));
+
+        var ended = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded);
+        Assert.Equal(ActivityCauses.TimerExpired, ended.Cause);
+        Assert.Contains($"retired-by={ActivityCauses.WorkingObservation}", ended.Detail);
+    }
+
+    [Fact]
+    public void A_manual_release_records_manual_release()
+    {
+        _registry.Snooze("s1", DateTime.UtcNow.AddHours(1), "dir-1");
+        Assert.True(_registry.Clear("s1", ActivityCauses.ManualRelease));
+
+        var ended = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded);
+        Assert.Equal(ActivityCauses.ManualRelease, ended.Cause);
+    }
+
+    [Fact]
+    public void An_owner_turn_records_owner_turn()
+    {
+        var baseline = DateTime.UtcNow.AddMinutes(-30);
+        _registry.Snooze("s1", DateTime.UtcNow.AddHours(1), "dir-1", ownerTurnBaselineUtc: baseline);
+        Assert.True(_registry.ClearIfSupersededByOwnerTurn("s1", baseline.AddMinutes(1)));
+
+        var ended = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded);
+        Assert.Equal(ActivityCauses.OwnerTurn, ended.Cause);
+    }
+
+    [Fact]
+    public void A_session_exit_clear_records_session_exit()
+    {
+        _registry.Snooze("s1", DateTime.UtcNow.AddHours(1), "dir-1");
+        Assert.True(_registry.Clear("s1", ActivityCauses.SessionExit));
+
+        var ended = Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded);
+        Assert.Equal(ActivityCauses.SessionExit, ended.Cause);
+    }
+
+    [Fact]
+    public void A_director_removal_records_one_ended_event_per_entry()
+    {
+        _registry.Snooze("s1", DateTime.UtcNow.AddHours(1), "dir-1");
+        _registry.Snooze("s2", DateTime.UtcNow.AddHours(2), "dir-1");
+        Assert.Equal(2, _registry.ClearForDirector("dir-1"));
+
+        Assert.Equal(ActivityCauses.DirectorRemoved,
+            Assert.Single(EventsFor("s1"), e => e.EventType == ActivityEventTypes.SnoozeEnded).Cause);
+        Assert.Equal(ActivityCauses.DirectorRemoved,
+            Assert.Single(EventsFor("s2"), e => e.EventType == ActivityEventTypes.SnoozeEnded).Cause);
+    }
+
+    [Fact]
+    public void A_registry_without_a_ledger_still_works()
+    {
+        // The ledger OBSERVES the snooze machine; a registry built without one (older tests, callers that
+        // opted out) behaves exactly as before.
+        var bare = new SnoozeRegistry(_harness.Open(), _harness.LegacyPath("snooze-bare.json"));
+        bare.Snooze("s9", DateTime.UtcNow.AddHours(1), "dir-9");
+        Assert.True(bare.Clear("s9", ActivityCauses.ManualRelease));
+        Assert.False(bare.Contains("s9"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -59,13 +59,14 @@ public sealed class PostgresProviderProofTests
     /// were created. Dropping first (EnsureDeleted) makes the migrate a genuine from-nothing run so the schema
     /// creation is really exercised, not just found already present.
     /// </summary>
-    /// <summary>The 18 mapped tables, all expected under the gateway schema and NONE under public.</summary>
+    /// <summary>The 22 mapped tables, all expected under the gateway schema and NONE under public.</summary>
     private static readonly string[] MappedTables =
     {
         "cron_jobs", "cron_runs", "worklists", "worklist_items", "workflows", "workflow_versions",
         "workflow_files", "workflow_runs", "snoozes", "governance_events", "push_subscriptions",
         "wingman_instructions", "session_spend", "account_hosted_ai_spend", "mission_notes",
         "governance_audit_events", "device_credentials", "device_import_markers",
+        "dictation_transcripts", "tenant_settings", "workflow_tenant_overrides", "activity_events",
     };
 
     [RequiresPostgresFact]

--- a/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
@@ -96,9 +96,9 @@ public sealed class SnoozeRegistryTests : IDisposable
         var reg = NewReg();
         reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
 
-        Assert.True(reg.Clear("s1"));
+        Assert.True(reg.Clear("s1", ActivityCauses.ManualRelease));
         Assert.False(reg.Contains("s1"));
-        Assert.False(reg.Clear("s1"));   // already gone
+        Assert.False(reg.Clear("s1", ActivityCauses.ManualRelease));   // already gone
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public sealed class SnoozeRegistryTests : IDisposable
         reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
 
         var snapshot = reg.Entries();
-        reg.Clear("s1");   // mutate after snapshotting
+        reg.Clear("s1", ActivityCauses.ManualRelease);   // mutate after snapshotting
 
         Assert.Single(snapshot);              // the snapshot did not change under us
         Assert.False(reg.Contains("s1"));     // the live store did

--- a/src/CcDirector.Gateway/Activity/ActivityEventEndpoints.cs
+++ b/src/CcDirector.Gateway/Activity/ActivityEventEndpoints.cs
@@ -1,0 +1,107 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Activity;
+
+/// <summary>
+/// The activity ledger's front door (the trustworthy-Working-start plan).
+///
+/// POST /activity-events/batch - a producer pushes observed events. Acknowledged with what the ledger
+/// durably holds (written + duplicates) so the Director-side outbox can drop acknowledged records honestly;
+/// a replayed event id is a successful idempotent replay, never an error.
+///
+/// GET /activity-events - the tenant-scoped diagnosis read, filtered by session, event type, and UTC range.
+/// Deliberately no Cockpit page in this increment; this read is the diagnosis surface.
+///
+/// TENANT-SCOPED exactly like <see cref="Prompts.PromptEndpoints"/>: both verbs resolve the request's
+/// tenant from the authenticated device key. On hosted, a request whose key has no bound tenant is DENIED
+/// (403) - it is never served the Local partition. Self-host (no boundary) is always Local.
+/// </summary>
+public static class ActivityEventEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, ActivityEventStore store,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+
+        app.MapPost("/activity-events/batch", (HttpContext ctx, ActivityEventIngestRequest? request) =>
+        {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            if (request?.Events is null || request.Events.Count == 0)
+                return Results.BadRequest(new { error = "events is required and must not be empty" });
+
+            try
+            {
+                using (EnterScope(tenant.Value, tenantBoundary))
+                {
+                    var (written, duplicates) = store.AppendBatch(request.Events);
+                    FileLog.Write($"[ActivityEventEndpoints] POST /activity-events/batch: tenant={tenant.Value.ToLogString()}, " +
+                                  $"received {request.Events.Count}, wrote {written}, duplicates {duplicates}");
+                    return Results.Ok(new ActivityEventIngestResponse { Written = written, Duplicates = duplicates });
+                }
+            }
+            catch (ActivityValidationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        app.MapGet("/activity-events", (HttpContext ctx, string? sessionId, string? eventType,
+            string? from, string? to, int? limit) =>
+        {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var fromUtc = ParseUtc(from);
+            var toUtc = ParseUtc(to);
+            if (fromUtc.HasValue && toUtc.HasValue && toUtc < fromUtc)
+                return Results.BadRequest(new { error = "'to' is earlier than 'from'" });
+
+            using (EnterScope(tenant.Value, tenantBoundary))
+            {
+                var events = store.Read(sessionId, eventType, fromUtc, toUtc, limit ?? 1000);
+                return Results.Ok(new { count = events.Count, events });
+            }
+        });
+    }
+
+    /// <summary>
+    /// Resolve the request's tenant from the AUTHENTICATED device key the auth middleware stashed - the same
+    /// seam the prompt log uses. Null means DENY on hosted; self-host, or no boundary (tests), is Local.
+    /// </summary>
+    private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+
+    /// <summary>
+    /// Enter the resolved tenant's ambient scope for the store call: the store reaches the database through
+    /// <c>GatewayDatabase.CreateContext()</c>, which reads the ambient tenant. With no boundary (tests,
+    /// self-host callers that never registered one) the ambient tenant is already Local and no scope is
+    /// needed.
+    /// </summary>
+    private static IDisposable EnterScope(TenantId tenant, Tenancy.HostedTenantBoundary? boundary)
+        => boundary is null ? NoScope.Instance : boundary.EnterScope(tenant);
+
+    private sealed class NoScope : IDisposable
+    {
+        public static readonly NoScope Instance = new();
+        public void Dispose() { }
+    }
+
+    /// <summary>Parse a full UTC instant (ISO 8601), or null when absent/unparseable.</summary>
+    private static DateTime? ParseUtc(string? value)
+        => DateTime.TryParse(value, null,
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : null;
+}

--- a/src/CcDirector.Gateway/Activity/ActivityEventStore.cs
+++ b/src/CcDirector.Gateway/Activity/ActivityEventStore.cs
@@ -1,0 +1,294 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Activity;
+
+/// <summary>
+/// The Gateway's durable, tenant-scoped activity ledger over the <c>activity_events</c> table (the
+/// trustworthy-Working-start plan, docs/PLAN-trustworthy-working-start-2026-07-24.md). Append-only: every
+/// row is one observed fact - a submission, an explicit backend signal, terminal output on a settled
+/// session, an authoritative state transition, a transcript-proven turn, or a Gateway snooze lifecycle
+/// decision - so the July 24 class of incident ("why did this session read Working, and why did its snooze
+/// die") is answerable from structured history instead of free-text log archaeology.
+///
+/// IDEMPOTENT APPEND: the producer mints <see cref="ActivityEventRecord.EventId"/> once, before its outbox,
+/// and preserves it across retries; a replayed id is acknowledged as a duplicate and never becomes a second
+/// row. Validation is fail-loud and whole-batch (<see cref="ActivityValidationException"/>): a malformed
+/// event is a producer bug to surface, and a half-landed batch would make the ledger lie.
+///
+/// RETENTION is 30 days (the owner's ruling, 2026-07-24 - deliberately replacing the earlier "unbounded,
+/// decide later"): <see cref="PurgeOlderThan"/> is called per tenant by <c>ActivityRetentionSweep</c>.
+///
+/// Threading matches the rest of the data layer: single writer, write lock, fresh pooled context per
+/// operation, tenant resolved from the ambient scope by <see cref="GatewayDatabase.CreateContext()"/>.
+/// </summary>
+public sealed class ActivityEventStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>The hard ceiling on one appended batch.</summary>
+    public const int MaxBatchSize = 500;
+
+    /// <summary>The hard ceiling on one read; the default page is 1000.</summary>
+    public const int MaxListLimit = 5000;
+
+    /// <summary>Identity fields (director, session, context id): bounded, they are ids not prose.</summary>
+    public const int MaxIdChars = 128;
+
+    /// <summary>Name fields (machine, agent kind).</summary>
+    public const int MaxNameChars = 128;
+
+    /// <summary>State/origin/detector fields - single tokens from closed vocabularies.</summary>
+    public const int MaxTokenChars = 64;
+
+    /// <summary>A detail is a short structured control-flow note; cap it.</summary>
+    public const int MaxDetailChars = 500;
+
+    /// <summary>Screen hashes are fixed-size digests; cap generously.</summary>
+    public const int MaxHashChars = 128;
+
+    /// <summary>The bounded changed-row diff - the largest field, and still a hard cap: the ledger stores
+    /// evidence, never the byte stream.</summary>
+    public const int MaxDiffChars = 4000;
+
+    public ActivityEventStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Append a batch of events in one unit of work, validated first: one invalid event rejects the whole
+    /// batch (the ledger never lands a half-batch). An event whose id this tenant already holds is a
+    /// successful idempotent replay - counted in <c>Duplicates</c>, never re-written, never an error.
+    /// Returns what the ledger durably holds so the producer can drop acknowledged outbox records honestly.
+    /// </summary>
+    /// <exception cref="ActivityValidationException">The batch or an event in it is malformed.</exception>
+    public (int Written, int Duplicates) AppendBatch(IReadOnlyList<ActivityEventRecord> events)
+    {
+        if (events is null)
+            throw new ActivityValidationException("An events list is required.");
+        if (events.Count == 0)
+            return (0, 0);
+        if (events.Count > MaxBatchSize)
+            throw new ActivityValidationException(
+                $"A batch carries at most {MaxBatchSize} events (got {events.Count}).");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var now = DateTime.UtcNow;
+            var tenant = ctx.ActiveTenant!;
+
+            // Validate the WHOLE batch before touching the database, and collapse an id repeated within the
+            // batch itself (a producer replaying inside one push) to its first occurrence - same identity,
+            // same idempotent outcome as a cross-batch replay.
+            var fresh = new Dictionary<Guid, ActivityEventEntity>(events.Count);
+            var withinBatchDuplicates = 0;
+            foreach (var record in events)
+            {
+                if (record is null)
+                    throw new ActivityValidationException("The events list contains a null entry.");
+                var entity = BuildEntity(record, tenant, now);
+                if (!fresh.TryAdd(entity.EventId, entity))
+                    withinBatchDuplicates++;
+            }
+
+            // The replay check: which of these ids does this tenant already hold? Reads through the global
+            // tenant query filter, so tenant A replaying tenant B's id sees nothing and simply writes its
+            // own row under its own composite key.
+            var ids = fresh.Keys.ToList();
+            var existing = ctx.ActivityEvents.AsNoTracking()
+                .Where(e => ids.Contains(e.EventId))
+                .Select(e => e.EventId)
+                .ToHashSet();
+
+            var toInsert = fresh.Values.Where(e => !existing.Contains(e.EventId)).ToList();
+
+            if (toInsert.Count > 0)
+            {
+                var previousAutoDetect = ctx.ChangeTracker.AutoDetectChangesEnabled;
+                ctx.ChangeTracker.AutoDetectChangesEnabled = false;
+                try
+                {
+                    ctx.ActivityEvents.AddRange(toInsert);
+                    ctx.SaveChanges();
+                }
+                finally
+                {
+                    ctx.ChangeTracker.AutoDetectChangesEnabled = previousAutoDetect;
+                }
+            }
+
+            var duplicates = existing.Count + withinBatchDuplicates;
+            FileLog.Write($"[ActivityEventStore] AppendBatch: wrote {toInsert.Count}, duplicates {duplicates}");
+            return (toInsert.Count, duplicates);
+        }
+    }
+
+    /// <summary>
+    /// Events for diagnosis, in chronological order (OccurredUtc ascending, RecordedUtc as the tie-breaker),
+    /// optionally filtered by session, event type, and UTC window (<paramref name="fromUtc"/> inclusive,
+    /// <paramref name="toUtc"/> exclusive).
+    /// </summary>
+    public IReadOnlyList<ActivityEventRecord> Read(
+        string? sessionId = null, string? eventType = null,
+        DateTime? fromUtc = null, DateTime? toUtc = null, int limit = 1000)
+    {
+        var take = Math.Clamp(limit, 1, MaxListLimit);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            IQueryable<ActivityEventEntity> query = ctx.ActivityEvents.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                var sid = sessionId.Trim();
+                query = query.Where(e => e.SessionId == sid);
+            }
+            if (!string.IsNullOrWhiteSpace(eventType))
+            {
+                var type = eventType.Trim().ToLowerInvariant();
+                query = query.Where(e => e.EventType == type);
+            }
+            if (fromUtc.HasValue)
+            {
+                var from = DateTime.SpecifyKind(fromUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc >= from);
+            }
+            if (toUtc.HasValue)
+            {
+                var to = DateTime.SpecifyKind(toUtc.Value, DateTimeKind.Utc);
+                query = query.Where(e => e.OccurredUtc < to);
+            }
+
+            return query
+                .OrderBy(e => e.OccurredUtc)
+                .ThenBy(e => e.RecordedUtc)
+                .Take(take)
+                .ToList()
+                .Select(ToRecord)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Delete every event of the CURRENT tenant older than <paramref name="cutoffUtc"/> (on OccurredUtc).
+    /// The 30-day retention's workhorse, called per tenant by the retention sweep. Returns the number of
+    /// rows deleted.
+    /// </summary>
+    public int PurgeOlderThan(DateTime cutoffUtc)
+    {
+        var cutoff = DateTime.SpecifyKind(cutoffUtc.ToUniversalTime(), DateTimeKind.Utc);
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            // ExecuteDelete applies the global tenant query filter, so this deletes only the ambient
+            // tenant's expired rows - a set-based delete, no need to materialize thousands of old events.
+            var deleted = ctx.ActivityEvents.Where(e => e.OccurredUtc < cutoff).ExecuteDelete();
+            if (deleted > 0)
+                FileLog.Write($"[ActivityEventStore] PurgeOlderThan: removed {deleted} events older than {cutoff:O}");
+            return deleted;
+        }
+    }
+
+    /// <summary>Validate one record and build the immutable row (tenant + recorded time stamped here).</summary>
+    private static ActivityEventEntity BuildEntity(ActivityEventRecord record, string tenant, DateTime now)
+    {
+        if (record.EventId == Guid.Empty)
+            throw new ActivityValidationException("An activity event needs a non-empty eventId.");
+
+        var directorId = Required(record.DirectorId, "directorId", MaxIdChars);
+        var sessionId = Required(record.SessionId, "sessionId", MaxIdChars);
+
+        var eventType = (record.EventType ?? "").Trim().ToLowerInvariant();
+        if (!ActivityEventTypes.All.Contains(eventType, StringComparer.Ordinal))
+            throw new ActivityValidationException(
+                $"'{record.EventType}' is not an activity event type. Legal values: " +
+                string.Join(", ", ActivityEventTypes.All) + ".");
+
+        var cause = (record.Cause ?? "").Trim().ToLowerInvariant();
+        if (!ActivityCauses.All.Contains(cause, StringComparer.Ordinal))
+            throw new ActivityValidationException(
+                $"'{record.Cause}' is not an activity cause. Legal values: " +
+                string.Join(", ", ActivityCauses.All) + ".");
+
+        var occurred = DateTime.SpecifyKind(record.OccurredUtc.ToUniversalTime(), DateTimeKind.Utc);
+        if (occurred > now)
+            occurred = now;
+
+        return new ActivityEventEntity
+        {
+            TenantId = tenant,
+            EventId = record.EventId,
+            DirectorSequence = record.DirectorSequence,
+            OccurredUtc = occurred,
+            RecordedUtc = now,
+            DirectorId = directorId,
+            SessionId = sessionId,
+            Machine = Optional(record.Machine, "machine", MaxNameChars),
+            AgentKind = Optional(record.AgentKind, "agentKind", MaxNameChars),
+            ContextId = Optional(record.ContextId, "contextId", MaxIdChars),
+            EventType = eventType,
+            PreviousState = Optional(record.PreviousState, "previousState", MaxTokenChars),
+            NewState = Optional(record.NewState, "newState", MaxTokenChars),
+            Cause = cause,
+            Detail = Optional(record.Detail, "detail", MaxDetailChars),
+            InputOrigin = Optional(record.InputOrigin, "inputOrigin", MaxTokenChars),
+            SendSource = Optional(record.SendSource, "sendSource", MaxTokenChars),
+            DetectorMode = Optional(record.DetectorMode, "detectorMode", MaxTokenChars),
+            DetectorVersion = Optional(record.DetectorVersion, "detectorVersion", MaxTokenChars),
+            OutputByteCount = record.OutputByteCount,
+            BeforeScreenHash = Optional(record.BeforeScreenHash, "beforeScreenHash", MaxHashChars),
+            AfterScreenHash = Optional(record.AfterScreenHash, "afterScreenHash", MaxHashChars),
+            BoundedScreenDiff = Optional(record.BoundedScreenDiff, "boundedScreenDiff", MaxDiffChars),
+        };
+    }
+
+    private static string Required(string? value, string field, int maxChars)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ActivityValidationException($"An activity event needs a {field}.");
+        var trimmed = value.Trim();
+        if (trimmed.Length > maxChars)
+            throw new ActivityValidationException($"The {field} is too long (limit {maxChars} characters).");
+        return trimmed;
+    }
+
+    private static string? Optional(string? value, string field, int maxChars)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        if (value.Length > maxChars)
+            throw new ActivityValidationException($"The {field} is too long (limit {maxChars} characters).");
+        return value;
+    }
+
+    private static ActivityEventRecord ToRecord(ActivityEventEntity e) => new()
+    {
+        EventId = e.EventId,
+        DirectorSequence = e.DirectorSequence,
+        OccurredUtc = e.OccurredUtc,
+        DirectorId = e.DirectorId,
+        SessionId = e.SessionId,
+        Machine = e.Machine,
+        AgentKind = e.AgentKind,
+        ContextId = e.ContextId,
+        EventType = e.EventType,
+        PreviousState = e.PreviousState,
+        NewState = e.NewState,
+        Cause = e.Cause,
+        Detail = e.Detail,
+        InputOrigin = e.InputOrigin,
+        SendSource = e.SendSource,
+        DetectorMode = e.DetectorMode,
+        DetectorVersion = e.DetectorVersion,
+        OutputByteCount = e.OutputByteCount,
+        BeforeScreenHash = e.BeforeScreenHash,
+        AfterScreenHash = e.AfterScreenHash,
+        BoundedScreenDiff = e.BoundedScreenDiff,
+    };
+}

--- a/src/CcDirector.Gateway/Activity/ActivityRetentionSweep.cs
+++ b/src/CcDirector.Gateway/Activity/ActivityRetentionSweep.cs
@@ -1,0 +1,43 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
+
+namespace CcDirector.Gateway.Activity;
+
+/// <summary>
+/// The activity ledger's 30-day retention (the owner's ruling, 2026-07-24: raw activity events are kept 30
+/// days, not forever - deciding retention now instead of "later" is the point). Runs through the per-tenant
+/// worker seam (<see cref="TenantScopedSweep"/>): on hosted it enters each tenant's scope and purges that
+/// tenant's expired rows in isolation; on self-host it fires once under Local. Driven by a timer in
+/// <c>GatewayHost</c>.
+///
+/// Long-term learning ("the Gateway brain") is served by deriving aggregates BEFORE rows age out - a future
+/// feature, deliberately not built here; this sweep only enforces the raw-event window.
+/// </summary>
+public sealed class ActivityRetentionSweep : TenantScopedSweep
+{
+    /// <summary>How long a raw activity event lives (the owner's 30-day ruling).</summary>
+    public static readonly TimeSpan RetentionPeriod = TimeSpan.FromDays(30);
+
+    private readonly ActivityEventStore _store;
+
+    public ActivityRetentionSweep(HostedTenantBoundary boundary, TenantRegistry tenants, ActivityEventStore store)
+        : base(boundary, tenants)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>Purge every tenant's events older than the retention window. One pass over the census.</summary>
+    public async Task SweepAsync(CancellationToken ct = default)
+    {
+        var cutoffUtc = DateTime.UtcNow - RetentionPeriod;
+        var total = 0;
+        await ForEachTenantAsync(() =>
+        {
+            total += _store.PurgeOlderThan(cutoffUtc);
+            return Task.CompletedTask;
+        }, ct).ConfigureAwait(false);
+
+        if (total > 0)
+            FileLog.Write($"[ActivityRetentionSweep] purged {total} events older than {cutoffUtc:O}");
+    }
+}

--- a/src/CcDirector.Gateway/Activity/ActivityValidationException.cs
+++ b/src/CcDirector.Gateway/Activity/ActivityValidationException.cs
@@ -1,0 +1,14 @@
+namespace CcDirector.Gateway.Activity;
+
+/// <summary>
+/// A caller handed the activity ledger an event it must not store: a missing required fact, an event type
+/// or cause outside the closed sets, an over-length field, or an over-size batch. Thrown loudly (the
+/// repository's no-fallback rule - a malformed event is a producer bug to surface, never something to
+/// quietly coerce) and mapped to HTTP 400 at the endpoint boundary.
+/// </summary>
+public sealed class ActivityValidationException : Exception
+{
+    public ActivityValidationException(string message) : base(message)
+    {
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1725,7 +1725,7 @@ internal static class GatewayEndpoints
             else
             {
                 // Manual unsnooze: drop the timer (an alarm turned off).
-                snoozeRegistry.Clear(sid);
+                snoozeRegistry.Clear(sid, ActivityCauses.ManualRelease);
             }
 
             // The hold is now a FACT, recorded and persisted in the registry. Round 4 finding 1: the desktop

--- a/src/CcDirector.Gateway/Data/Entities/ActivityEventEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/ActivityEventEntity.cs
@@ -1,0 +1,92 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One durable activity-ledger event, in the <c>activity_events</c> table - the trustworthy-Working-start
+/// plan's evidence spine (docs/PLAN-trustworthy-working-start-2026-07-24.md). Append-only: a row records
+/// what a producer OBSERVED (a submission, a state transition, terminal output on a settled session, a
+/// transcript-proven turn, a snooze lifecycle decision) and is never updated or rewritten.
+///
+/// This is a DISTINCT ledger from <see cref="GovernanceEventEntity"/> (the governance duration spine) and
+/// <see cref="GovernanceAuditEventEntity"/> (decisions and interventions): those record governance outcomes;
+/// this one records the low-level activity EVIDENCE the shadow Working classifier is judged against, at a
+/// different cardinality and with a bounded 30-day retention (the others keep governance history).
+///
+/// KEY: composite <c>(tenant_id, EventId)</c>. <see cref="EventId"/> is CALLER-SUPPLIED (the producer mints
+/// it once before its outbox so a retried batch replays the same identity), so per the caller-supplied-key
+/// doctrine the tenant must be in the primary key: one tenant replaying or colliding on an id can never
+/// squat on, overwrite, or learn about another tenant's row.
+///
+/// <see cref="BoundedScreenDiff"/> may contain terminal content, which can contain secrets: it is
+/// tenant-scoped customer data, bounded at the store boundary, and must never be written to ordinary
+/// process logs.
+/// </summary>
+public sealed class ActivityEventEntity : TenantScopedEntity
+{
+    /// <summary>The producer-minted event identity (idempotency key). Part of the composite primary key.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>The producer's own monotonic sequence (0 on Gateway-origin events).</summary>
+    public long DirectorSequence { get; set; }
+
+    /// <summary>When the event actually happened (UTC, producer-stamped, clamped to the append time).</summary>
+    public DateTime OccurredUtc { get; set; }
+
+    /// <summary>When the Gateway appended the row (server-stamped) - the tie-breaker and the fact of when
+    /// we learned.</summary>
+    public DateTime RecordedUtc { get; set; }
+
+    /// <summary>The Director the event belongs to ("gateway" on Gateway-origin events with no known owner).</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>The Director session the event is about.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>Which machine the session runs on, when known.</summary>
+    public string? Machine { get; set; }
+
+    /// <summary>The agent kind of the session's driver, when known.</summary>
+    public string? AgentKind { get; set; }
+
+    /// <summary>The agent's own context id at the time, when known.</summary>
+    public string? ContextId { get; set; }
+
+    /// <summary>What happened - a value of <c>ActivityEventTypes</c> (validated at the store).</summary>
+    public string EventType { get; set; } = "";
+
+    /// <summary>The state before the event, when the event is a transition.</summary>
+    public string? PreviousState { get; set; }
+
+    /// <summary>The state after the event, when the event is a transition.</summary>
+    public string? NewState { get; set; }
+
+    /// <summary>Why - a value of <c>ActivityCauses</c> (validated at the store).</summary>
+    public string Cause { get; set; } = "";
+
+    /// <summary>A short structured control-flow note. NEVER prompt or terminal content.</summary>
+    public string? Detail { get; set; }
+
+    /// <summary>Where the input came from on a submission event.</summary>
+    public string? InputOrigin { get; set; }
+
+    /// <summary>The send source on a submission event.</summary>
+    public string? SendSource { get; set; }
+
+    /// <summary>The detector mode that ruled, on detector events.</summary>
+    public string? DetectorMode { get; set; }
+
+    /// <summary>The detector version that ruled.</summary>
+    public string? DetectorVersion { get; set; }
+
+    /// <summary>How many terminal bytes were seen, on terminal-output evidence events.</summary>
+    public long? OutputByteCount { get; set; }
+
+    /// <summary>Normalized screen-body hash before the output burst.</summary>
+    public string? BeforeScreenHash { get; set; }
+
+    /// <summary>Normalized screen-body hash after the output burst.</summary>
+    public string? AfterScreenHash { get; set; }
+
+    /// <summary>The bounded normalized changed-row diff. Tenant-scoped customer data; may contain secrets;
+    /// bounded at the store; never process-logged.</summary>
+    public string? BoundedScreenDiff { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -104,6 +104,11 @@ public sealed class GatewayDbContext : DbContext
     /// intervention and permission/sandbox decisions, never inferred from transcripts (issue #1771).</summary>
     public DbSet<GovernanceAuditEventEntity> GovernanceAuditEvents => Set<GovernanceAuditEventEntity>();
 
+    /// <summary>The append-only activity ledger (<c>activity_events</c>) - submission, terminal-output,
+    /// state-transition, transcript and snooze lifecycle evidence, per tenant, retained 30 days (the
+    /// trustworthy-Working-start plan, docs/PLAN-trustworthy-working-start-2026-07-24.md).</summary>
+    public DbSet<ActivityEventEntity> ActivityEvents => Set<ActivityEventEntity>();
+
     /// <summary>Per-tenant setting overrides (<c>tenant_settings</c>, issue #2017) - the per-tenant home the
     /// AI / voice / car-mode / notification settings needed before they could be served on the hosted Gateway.
     /// Tenant-scoped: an absent row means "no override" and the typed resolver returns the operator global
@@ -374,6 +379,24 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.DismissedAtUtc });
         });
 
+        modelBuilder.Entity<ActivityEventEntity>(b =>
+        {
+            b.ToTable("activity_events");
+            // COMPOSITE primary key (tenant_id, EventId): the EventId is CALLER-SUPPLIED (the producer mints
+            // it once before its outbox, so a retried batch replays the same identity and the append is
+            // idempotent). A caller-supplied key must carry the tenant in the primary key - one tenant
+            // replaying an id another tenant holds must neither collide (a squat) nor learn of the
+            // collision (an existence oracle).
+            b.HasKey(e => new { e.TenantId, e.EventId });
+            b.Property(e => e.EventId);
+            // The read paths, each tenant-leading so they ride the global filter's "tenant_id = @t" prefix:
+            // a session's timeline (diagnosis + the 30-day retention scan on OccurredUtc), a Director's
+            // sequence range (retry/reorder checks), and a shadow-analysis scan by event type over a window.
+            b.HasIndex(e => new { e.TenantId, e.SessionId, e.OccurredUtc });
+            b.HasIndex(e => new { e.TenantId, e.DirectorId, e.DirectorSequence });
+            b.HasIndex(e => new { e.TenantId, e.EventType, e.OccurredUtc });
+        });
+
         modelBuilder.Entity<TenantSettingEntity>(b =>
         {
             b.ToTable("tenant_settings");
@@ -502,6 +525,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<DictationTranscriptEntity>(modelBuilder);
         ApplyTenantScope<WorkflowTenantOverrideEntity>(modelBuilder);
         ApplyTenantScope<DictationSuggestionDismissalEntity>(modelBuilder);
+        ApplyTenantScope<ActivityEventEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260724165908_AddActivityEvents.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724165908_AddActivityEvents.Designer.cs
@@ -3,48 +3,45 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724165908_AddActivityEvents")]
+    partial class AddActivityEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasDefaultSchema("gateway")
-                .HasAnnotation("ProductVersion", "9.0.2")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -54,84 +51,84 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", "gateway");
+                    b.ToTable("account_hosted_ai_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -143,108 +140,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", "gateway");
+                    b.ToTable("activity_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", "gateway");
+                    b.ToTable("cron_jobs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -253,112 +250,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", "gateway");
+                    b.ToTable("cron_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", "gateway");
+                    b.ToTable("device_credentials", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", "gateway");
+                    b.ToTable("device_import_markers", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("TenantId", "Term");
 
@@ -366,38 +359,38 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", "gateway");
+                    b.ToTable("dictation_suggestion_dismissals", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
@@ -405,43 +398,43 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", "gateway");
+                    b.ToTable("dictation_transcripts", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<Guid>("Subject")
-                        .HasColumnType("uuid")
+                    b.Property<string>("Subject")
+                        .HasColumnType("TEXT")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", "gateway", t =>
+                    b.ToTable("entitlements", null, t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -450,38 +443,38 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -494,40 +487,40 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", "gateway");
+                    b.ToTable("governance_audit_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -540,112 +533,109 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", "gateway");
+                    b.ToTable("governance_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", "gateway");
+                    b.ToTable("mission_notes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", "gateway");
+                    b.ToTable("push_subscriptions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Model")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -653,165 +643,161 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", "gateway");
+                    b.ToTable("session_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", "gateway");
+                    b.ToTable("snoozes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", "gateway");
+                    b.ToTable("tenants", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", "gateway");
+                    b.ToTable("tenant_settings", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", "gateway");
+                    b.ToTable("wingman_instructions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", "gateway");
+                    b.ToTable("worklists", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Area")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Position")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -819,75 +805,75 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", "gateway");
+                    b.ToTable("worklist_items", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", "gateway");
+                    b.ToTable("workflows", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -895,71 +881,71 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", "gateway");
+                    b.ToTable("workflow_files", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -969,93 +955,92 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", "gateway");
+                    b.ToTable("workflow_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", "gateway");
+                    b.ToTable("workflow_tenant_overrides", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -1064,7 +1049,7 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", "gateway");
+                    b.ToTable("workflow_versions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1072,28 +1057,28 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("boolean");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Action");
 
@@ -1104,18 +1089,18 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Target");
 
@@ -1135,36 +1120,36 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions", "gateway");
+                            b1.ToTable("wingman_instructions");
 
                             b1.ToJson("Versions");
 
@@ -1189,35 +1174,35 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1228,37 +1213,37 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("Participants");
 
@@ -1269,23 +1254,23 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("ProofLinks");
 
@@ -1305,26 +1290,26 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1335,34 +1320,34 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260724165908_AddActivityEvents.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724165908_AddActivityEvents.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActivityEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "activity_events",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    EventId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    DirectorSequence = table.Column<long>(type: "INTEGER", nullable: false),
+                    OccurredUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RecordedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DirectorId = table.Column<string>(type: "TEXT", nullable: false),
+                    SessionId = table.Column<string>(type: "TEXT", nullable: false),
+                    Machine = table.Column<string>(type: "TEXT", nullable: true),
+                    AgentKind = table.Column<string>(type: "TEXT", nullable: true),
+                    ContextId = table.Column<string>(type: "TEXT", nullable: true),
+                    EventType = table.Column<string>(type: "TEXT", nullable: false),
+                    PreviousState = table.Column<string>(type: "TEXT", nullable: true),
+                    NewState = table.Column<string>(type: "TEXT", nullable: true),
+                    Cause = table.Column<string>(type: "TEXT", nullable: false),
+                    Detail = table.Column<string>(type: "TEXT", nullable: true),
+                    InputOrigin = table.Column<string>(type: "TEXT", nullable: true),
+                    SendSource = table.Column<string>(type: "TEXT", nullable: true),
+                    DetectorMode = table.Column<string>(type: "TEXT", nullable: true),
+                    DetectorVersion = table.Column<string>(type: "TEXT", nullable: true),
+                    OutputByteCount = table.Column<long>(type: "INTEGER", nullable: true),
+                    BeforeScreenHash = table.Column<string>(type: "TEXT", nullable: true),
+                    AfterScreenHash = table.Column<string>(type: "TEXT", nullable: true),
+                    BoundedScreenDiff = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_activity_events", x => new { x.tenant_id, x.EventId });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id",
+                table: "activity_events",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_DirectorId_DirectorSequence",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "DirectorId", "DirectorSequence" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_EventType_OccurredUtc",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "EventType", "OccurredUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_activity_events_tenant_id_SessionId_OccurredUtc",
+                table: "activity_events",
+                columns: new[] { "tenant_id", "SessionId", "OccurredUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "activity_events");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
@@ -51,6 +51,95 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.ToTable("account_hosted_ai_spend", (string)null);
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
+                {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("tenant_id");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("AfterScreenHash")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("AgentKind")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("BeforeScreenHash")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("BoundedScreenDiff")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Cause")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("ContextId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Detail")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("DetectorMode")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("DetectorVersion")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("DirectorId")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("DirectorSequence")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("InputOrigin")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Machine")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("NewState")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("OccurredUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long?>("OutputByteCount")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("PreviousState")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("RecordedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("SendSource")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("SessionId")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("TenantId", "EventId");
+
+                    b.HasIndex("TenantId");
+
+                    b.HasIndex("TenantId", "DirectorId", "DirectorSequence");
+
+                    b.HasIndex("TenantId", "EventType", "OccurredUtc");
+
+                    b.HasIndex("TenantId", "SessionId", "OccurredUtc");
+
+                    b.ToTable("activity_events", (string)null);
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -335,6 +335,8 @@ public sealed class GatewayHost : IAsyncDisposable
     // tombstone and is retired only by an edge that ends a snooze (work, an owner turn, an exit, a
     // re-snooze), bounded by the live-session prune paths.
     private readonly Snooze.SnoozeRegistry _snoozeRegistry;
+    private readonly Activity.ActivityEventStore _activityEvents;
+    private Activity.ActivityRetentionSweep? _activityRetentionSweep;
     // Fills account_hosted_ai_spend by periodically mirroring the cloud credit-debit ledger (issue #1771).
     private Governance.HostedAiSpendSweep? _hostedAiSpendSweep;
     // Mission Screen mission (Phase 1b, issue #1405): the Gateway-owned, restart-surviving store of each
@@ -439,6 +441,14 @@ public sealed class GatewayHost : IAsyncDisposable
     // StartAsync, disposed in StopAsync.
     private System.Threading.Timer? _cronTimer;
     private static readonly TimeSpan CronSweepInterval = TimeSpan.FromMinutes(1);
+
+    // The activity ledger's 30-day retention purge (docs/PLAN-trustworthy-working-start-2026-07-24.md):
+    // wakes a few times a day and deletes each tenant's events older than the retention window. Guarded
+    // against overlap the same way the cron sweep is. Created in StartAsync, disposed in StopAsync.
+    private System.Threading.Timer? _activityRetentionTimer;
+    private int _activityRetentionInFlight;
+    private static readonly TimeSpan ActivityRetentionInterval = TimeSpan.FromHours(6);
+    private static readonly TimeSpan ActivityRetentionStartupDelay = TimeSpan.FromMinutes(5);
 
     // Scheduled-run auto-dismiss (issue #1200): wakes ~every 15s and closes automated runs that declared
     // themselves done, over the Director stream. Created in StartAsync only when stream mode is on (the
@@ -843,7 +853,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // LEGACY snooze.json, imported once on first upgrade then renamed aside. Tests MUST pass an isolated
         // path so they never touch the real legacy file. The registry is bounded by dropping a removed
         // Director's entries so they do not accumulate.
-        _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
+        // The durable activity ledger (docs/PLAN-trustworthy-working-start-2026-07-24.md): tenant-scoped
+        // evidence of why sessions enter/leave Working and why snoozes end, retained 30 days. Constructed
+        // before the snooze registry because the registry appends its lifecycle decisions to it.
+        _activityEvents = new Activity.ActivityEventStore(_gatewayDb);
+        _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"), _activityEvents);
         // Editable/versioned wingman instructions (issue #537) now persist in the wingman_instructions table
         // of the EF data layer. The path argument is the LEGACY wingman-instructions.json, imported once on
         // first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real file.
@@ -1072,6 +1086,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // G8 increment 2: wrap the cron engine in the per-tenant worker seam so the background sweep enters
         // each tenant's scope before it reads the tenant-scoped cron_jobs store.
         _cronSweep = new Running.CronTenantSweep(_tenantBoundary, TenantRegistry, _cronEngine);
+
+        // The activity ledger's 30-day retention, on the same per-tenant worker seam.
+        _activityRetentionSweep = new Activity.ActivityRetentionSweep(_tenantBoundary, TenantRegistry, _activityEvents);
 
         // Web Push (mobile app-icon "needs you" dot): load (or generate on first run) the VAPID key
         // pair and the set of subscribed devices. The notifier that fans out to these is built and
@@ -2416,6 +2433,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // across machines - and because the Gateway is what moves to the server.
         Prompts.PromptEndpoints.Map(_app, _promptLog, _tenantBoundary);
 
+        // The activity ledger (docs/PLAN-trustworthy-working-start-2026-07-24.md): producers push observed
+        // activity/snooze evidence to POST /activity-events/batch (idempotent by producer-minted event id),
+        // and diagnosis reads GET /activity-events. Tenant-scoped exactly like the prompt log.
+        Activity.ActivityEventEndpoints.Map(_app, _activityEvents, _tenantBoundary);
+
         Mobile.MobileApp.Map(_app, Token);
         // The legacy /m mount: 301 to the canonical /mobile equivalent so installed phone PWAs and
         // bookmarks (and the sign-in callback devthrottle.com still hands back to /m/device-callback) keep
@@ -2460,6 +2482,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // self-host the seam fires once under Local - the same single fire as before.
         _cronTimer = new System.Threading.Timer(_ => SweepCron(), null, CronSweepInterval, CronSweepInterval);
         FileLog.Write($"[GatewayHost] cron sweep started: every {CronSweepInterval.TotalSeconds:0}s ({(GatewayHostedMode.IsHosted ? "hosted, per-tenant via TenantScopedSweep" : "self-host, single Local tenant")})");
+
+        // The activity ledger's 30-day retention purge. A daily window enforced a few times a day is ample;
+        // the first pass is delayed so startup work is never contended by a bulk delete.
+        _activityRetentionTimer = new System.Threading.Timer(_ => SweepActivityRetention(), null,
+            ActivityRetentionStartupDelay, ActivityRetentionInterval);
+        FileLog.Write($"[GatewayHost] activity retention sweep started: every {ActivityRetentionInterval.TotalHours:0}h, retention {Activity.ActivityRetentionSweep.RetentionPeriod.TotalDays:0} days");
 
         // MTR-15 cancellation cutoff: the hosted active-tenant entitlement sweep. Forces a fresh entitlement
         // read for every tenant with a live lease every ~60s and revokes any that has become NotEntitled, so a
@@ -2706,6 +2734,35 @@ public sealed class GatewayHost : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// The activity-retention timer callback (a boundary - it owns the overlap guard and the try/catch so a
+    /// purge failure never crashes the timer thread). One sweep at a time; a skipped tick simply purges on
+    /// the next one, which retention granularity is indifferent to.
+    /// </summary>
+    private void SweepActivityRetention()
+    {
+        if (Interlocked.CompareExchange(ref _activityRetentionInFlight, 1, 0) != 0)
+            return;
+        _ = RunActivityRetentionSweepAsync();
+    }
+
+    private async Task RunActivityRetentionSweepAsync()
+    {
+        try
+        {
+            if (_activityRetentionSweep is not null)
+                await _activityRetentionSweep.SweepAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHost] activity retention sweep FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _activityRetentionInFlight, 0);
+        }
+    }
+
     private void SweepEntitlementLeases()
     {
         // Skip this tick if the previous entitlement sweep is still running (many active tenants). One at a
@@ -2872,6 +2929,8 @@ public sealed class GatewayHost : IAsyncDisposable
 
         try { _cronTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] cron timer dispose error: {ex.Message}"); }
         _cronTimer = null;
+        try { _activityRetentionTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] activity retention timer dispose error: {ex.Message}"); }
+        _activityRetentionTimer = null;
         try { _leaseSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] lease sweep timer dispose error: {ex.Message}"); }
         _leaseSweepTimer = null;
         try { _autoDismissTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] auto-dismiss timer dispose error: {ex.Message}"); }

--- a/src/CcDirector.Gateway/Snooze/SnoozeLandingObserver.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeLandingObserver.cs
@@ -108,7 +108,7 @@ public sealed class SnoozeLandingObserver
 
         if (string.Equals(activity, nameof(ActivityState.Exited), StringComparison.OrdinalIgnoreCase))
         {
-            if (_registry.Clear(session.SessionId))
+            if (_registry.Clear(session.SessionId, ActivityCauses.SessionExit))
                 FileLog.Write($"[SnoozeLandingObserver] sid={session.SessionId}: session exited -> hold dropped");
             return;
         }

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -43,6 +43,7 @@ public sealed class SnoozeRegistry
     private readonly object _gate = new();
     private readonly GatewayDatabase _db;
     private readonly string _legacyJsonPath;
+    private readonly Activity.ActivityEventStore? _activityEvents;
 
     private static readonly JsonSerializerOptions FileJsonOptions = new()
     {
@@ -53,14 +54,19 @@ public sealed class SnoozeRegistry
     /// <param name="db">The Gateway EF database this registry reads and writes through.</param>
     /// <param name="legacyJsonPath">The legacy <c>snooze.json</c> path to import ONCE if it exists and the
     /// table is empty. REQUIRED (no silent default).</param>
+    /// <param name="activityEvents">The durable activity ledger this registry appends its snooze lifecycle
+    /// decisions to (created / landed / ended, each with the durable WHY - the July 24 requirement that a
+    /// deleted snooze be self-explanatory from structured history). Optional: null means no ledger (older
+    /// tests), and a ledger fault never fails the snooze operation it observes.</param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
     /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
-    public SnoozeRegistry(GatewayDatabase db, string legacyJsonPath)
+    public SnoozeRegistry(GatewayDatabase db, string legacyJsonPath, Activity.ActivityEventStore? activityEvents = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         if (string.IsNullOrWhiteSpace(legacyJsonPath))
             throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
         _legacyJsonPath = legacyJsonPath;
+        _activityEvents = activityEvents;
 
         lock (_gate)
             ImportLegacyJsonIfNeeded();
@@ -147,10 +153,17 @@ public sealed class SnoozeRegistry
 
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            Upsert(ctx, sessionId, untilUtc.ToUniversalTime(), directorId ?? "", null, ownerTurnBaselineUtc);
-            ctx.SaveChanges();
+            string previousState;
+            using (var ctx = _db.CreateContext())
+            {
+                previousState = StateOf(Find(ctx, sessionId, tracking: false));
+                Upsert(ctx, sessionId, untilUtc.ToUniversalTime(), directorId ?? "", null, ownerTurnBaselineUtc);
+                ctx.SaveChanges();
+            }
             FileLog.Write($"[SnoozeRegistry] Snooze: sid={sessionId}, untilUtc={untilUtc.ToUniversalTime():O}, director={directorId}");
+            RecordLifecycleEvent(Contracts.ActivityEventTypes.SnoozeCreated, sessionId, directorId,
+                Contracts.ActivityCauses.SnoozeRequested, previousState, HoldStates.Held,
+                $"until={untilUtc.ToUniversalTime():O}");
         }
     }
 
@@ -174,10 +187,17 @@ public sealed class SnoozeRegistry
 
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            Upsert(ctx, sessionId, null, directorId ?? "", minutes, ownerTurnBaselineUtc);
-            ctx.SaveChanges();
+            string previousState;
+            using (var ctx = _db.CreateContext())
+            {
+                previousState = StateOf(Find(ctx, sessionId, tracking: false));
+                Upsert(ctx, sessionId, null, directorId ?? "", minutes, ownerTurnBaselineUtc);
+                ctx.SaveChanges();
+            }
             FileLog.Write($"[SnoozeRegistry] SnoozeDeferred: sid={sessionId}, minutes={minutes} (clock starts when the work ends), director={directorId}");
+            RecordLifecycleEvent(Contracts.ActivityEventTypes.SnoozeCreated, sessionId, directorId,
+                Contracts.ActivityCauses.SnoozeRequested, previousState, HoldStates.DeferredHold,
+                $"minutes={minutes}");
         }
     }
 
@@ -212,8 +232,12 @@ public sealed class SnoozeRegistry
             var untilUtc = nowUtc.ToUniversalTime().AddMinutes(minutes);
             e.SnoozeUntilUtc = untilUtc;
             e.PendingMinutes = null;
+            var directorId = e.DirectorId;
             ctx.SaveChanges();
             FileLog.Write($"[SnoozeRegistry] Land: sid={sessionId}, deferred hold landed -> clock started, untilUtc={untilUtc:O} ({minutes} min)");
+            RecordLifecycleEvent(Contracts.ActivityEventTypes.SnoozeLanded, sessionId, directorId,
+                Contracts.ActivityCauses.WorkSettled, HoldStates.DeferredHold, HoldStates.Held,
+                $"until={untilUtc:O}; minutes={minutes}");
             return true;
         }
     }
@@ -222,18 +246,27 @@ public sealed class SnoozeRegistry
     /// Remove the snooze entry for <paramref name="sessionId"/>. Returns true when an entry was
     /// removed (and persisted), false when there was none. This is the ONE clear path - a manual
     /// unsnooze, the #470 early return, and the post-expiry confirm all funnel through it.
+    /// <paramref name="cause"/> is REQUIRED - the caller must say WHY the snooze is ending (an
+    /// <c>ActivityCauses</c> value, e.g. manual-release or session-exit), because "why did this snooze
+    /// end" is the durable fact the July 24 incident was missing. The registry itself records
+    /// timer-expired instead when the entry's clock had already elapsed - the timer ended that snooze,
+    /// this clear only retired the tombstone.
     /// </summary>
-    public bool Clear(string sessionId)
+    public bool Clear(string sessionId, string cause)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var e = Find(ctx, sessionId);
-            if (e is null) return false;
-            ctx.Snoozes.Remove(e);
-            ctx.SaveChanges();
-            FileLog.Write($"[SnoozeRegistry] Clear: sid={sessionId}");
+            SnoozeEntity? removed;
+            using (var ctx = _db.CreateContext())
+            {
+                removed = Find(ctx, sessionId);
+                if (removed is null) return false;
+                ctx.Snoozes.Remove(removed);
+                ctx.SaveChanges();
+            }
+            FileLog.Write($"[SnoozeRegistry] Clear: sid={sessionId}, cause={cause}");
+            RecordSnoozeEnded(removed, cause);
             return true;
         }
     }
@@ -257,13 +290,17 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var e = Find(ctx, sessionId);
-            if (e is null || e.SnoozeUntilUtc is null) // no entry, or DEFERRED (no deadline yet) -> spare it
-                return false;
-            ctx.Snoozes.Remove(e);
-            ctx.SaveChanges();
+            SnoozeEntity? removed;
+            using (var ctx = _db.CreateContext())
+            {
+                removed = Find(ctx, sessionId);
+                if (removed is null || removed.SnoozeUntilUtc is null) // no entry, or DEFERRED (no deadline yet) -> spare it
+                    return false;
+                ctx.Snoozes.Remove(removed);
+                ctx.SaveChanges();
+            }
             FileLog.Write($"[SnoozeRegistry] ClearIfArmed: sid={sessionId} (armed snooze deleted - the session is working again, and work ends a snooze)");
+            RecordSnoozeEnded(removed, Contracts.ActivityCauses.WorkingObservation);
             return true;
         }
     }
@@ -278,14 +315,19 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(directorId)) return 0;
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList();
-            if (gone.Count > 0)
+            List<SnoozeEntity> gone;
+            using (var ctx = _db.CreateContext())
             {
-                ctx.Snoozes.RemoveRange(gone);
-                ctx.SaveChanges();
-                FileLog.Write($"[SnoozeRegistry] ClearForDirector: director={directorId}, removed={gone.Count}");
+                gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList();
+                if (gone.Count > 0)
+                {
+                    ctx.Snoozes.RemoveRange(gone);
+                    ctx.SaveChanges();
+                    FileLog.Write($"[SnoozeRegistry] ClearForDirector: director={directorId}, removed={gone.Count}");
+                }
             }
+            foreach (var e in gone)
+                RecordSnoozeEnded(e, Contracts.ActivityCauses.DirectorRemoved);
             return gone.Count;
         }
     }
@@ -304,16 +346,21 @@ public sealed class SnoozeRegistry
         liveSessionIds ??= new HashSet<string>(StringComparer.Ordinal);
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList()
-                .Where(e => !liveSessionIds.Contains(e.SessionId))
-                .ToList();
-            if (gone.Count > 0)
+            List<SnoozeEntity> gone;
+            using (var ctx = _db.CreateContext())
             {
-                ctx.Snoozes.RemoveRange(gone);
-                ctx.SaveChanges();
-                FileLog.Write($"[SnoozeRegistry] PruneNotLive: director={directorId}, removed={gone.Count}");
+                gone = ctx.Snoozes.Where(e => e.DirectorId == directorId).ToList()
+                    .Where(e => !liveSessionIds.Contains(e.SessionId))
+                    .ToList();
+                if (gone.Count > 0)
+                {
+                    ctx.Snoozes.RemoveRange(gone);
+                    ctx.SaveChanges();
+                    FileLog.Write($"[SnoozeRegistry] PruneNotLive: director={directorId}, removed={gone.Count}");
+                }
             }
+            foreach (var e in gone)
+                RecordSnoozeEnded(e, Contracts.ActivityCauses.SessionNotLive);
             return gone.Count;
         }
     }
@@ -405,13 +452,17 @@ public sealed class SnoozeRegistry
         if (string.IsNullOrWhiteSpace(sessionId) || lastOwnerTurnAtUtc is null) return false;
         lock (_gate)
         {
-            using var ctx = _db.CreateContext();
-            var e = Find(ctx, sessionId);
-            if (e is null) return false;
-            if (!ToRecord(e).SupersededByOwnerTurn(lastOwnerTurnAtUtc)) return false;
-            ctx.Snoozes.Remove(e);
-            ctx.SaveChanges();
-            FileLog.Write($"[SnoozeRegistry] ClearIfSupersededByOwnerTurn: sid={sessionId}, owner drove a turn at {lastOwnerTurnAtUtc:O}, past the baseline {e.OwnerTurnBaselineUtc:O} captured when the hold was set -> hold dropped");
+            SnoozeEntity? removed;
+            using (var ctx = _db.CreateContext())
+            {
+                removed = Find(ctx, sessionId);
+                if (removed is null) return false;
+                if (!ToRecord(removed).SupersededByOwnerTurn(lastOwnerTurnAtUtc)) return false;
+                ctx.Snoozes.Remove(removed);
+                ctx.SaveChanges();
+            }
+            FileLog.Write($"[SnoozeRegistry] ClearIfSupersededByOwnerTurn: sid={sessionId}, owner drove a turn at {lastOwnerTurnAtUtc:O}, past the baseline {removed.OwnerTurnBaselineUtc:O} captured when the hold was set -> hold dropped");
+            RecordSnoozeEnded(removed, Contracts.ActivityCauses.OwnerTurn);
             return true;
         }
     }
@@ -494,6 +545,70 @@ public sealed class SnoozeRegistry
     // same way). The null-forgiving operator only silences the nullable-reference warning; the value flows as-is.
     private static SnoozeEntry ToRecord(SnoozeEntity e)
         => new(e.SessionId, e.SnoozeUntilUtc, e.DirectorId!, e.PendingMinutes, e.OwnerTurnBaselineUtc);
+
+    /// <summary>The hold state an entry represents (None for no entry) - the previous/new state fields of
+    /// the lifecycle events this registry appends to the activity ledger.</summary>
+    private static string StateOf(SnoozeEntity? e)
+        => e is null ? HoldStates.None
+            : e.SnoozeUntilUtc is null ? HoldStates.DeferredHold
+            : HoldStates.Held;
+
+    /// <summary>
+    /// Record that a snooze entry was RETIRED, with the durable why. One honesty rule lives here: when the
+    /// removed entry was ARMED and its deadline had already ELAPSED, the snooze was ended by its TIMER - the
+    /// retiring edge (a working observation, an exit, a manual release) only cleaned up the tombstone - so
+    /// the recorded cause is timer-expired and the edge moves to the detail. That is exactly the distinction
+    /// the July 24 incident needed: "waiting 1h 5m" was the age of the red state, not the snooze ending
+    /// early.
+    /// </summary>
+    private void RecordSnoozeEnded(SnoozeEntity removed, string cause)
+    {
+        var previousState = StateOf(removed);
+        var effectiveCause = cause;
+        string? detail = removed.SnoozeUntilUtc is DateTime untilUtc ? $"until={untilUtc:O}" : null;
+        if (removed.SnoozeUntilUtc is DateTime deadline && DateTime.UtcNow >= deadline)
+        {
+            effectiveCause = Contracts.ActivityCauses.TimerExpired;
+            detail = $"until={deadline:O}; retired-by={cause}";
+        }
+        RecordLifecycleEvent(Contracts.ActivityEventTypes.SnoozeEnded, removed.SessionId, removed.DirectorId,
+            effectiveCause, previousState, HoldStates.None, detail);
+    }
+
+    /// <summary>
+    /// Append one snooze lifecycle event to the durable activity ledger. The ledger OBSERVES the snooze
+    /// machine, it does not participate in it: a ledger fault is logged loudly and never turns a snooze
+    /// operation that already persisted into a failure. Gateway-origin events carry sequence 0 and the
+    /// owning Director's id (or "gateway" when a legacy entry never recorded one).
+    /// </summary>
+    private void RecordLifecycleEvent(string eventType, string sessionId, string? directorId,
+        string cause, string? previousState, string newState, string? detail)
+    {
+        if (_activityEvents is null) return;
+        try
+        {
+            _activityEvents.AppendBatch(new[]
+            {
+                new Contracts.ActivityEventRecord
+                {
+                    EventId = Guid.NewGuid(),
+                    DirectorSequence = 0,
+                    OccurredUtc = DateTime.UtcNow,
+                    DirectorId = string.IsNullOrWhiteSpace(directorId) ? "gateway" : directorId,
+                    SessionId = sessionId,
+                    EventType = eventType,
+                    Cause = cause,
+                    PreviousState = previousState,
+                    NewState = newState,
+                    Detail = detail,
+                },
+            });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SnoozeRegistry] activity ledger append FAILED for {eventType}/{cause} sid={sessionId}: {ex.Message}");
+        }
+    }
 
     // ---- one-time legacy JSON import --------------------------------------------------------------
 


### PR DESCRIPTION
## Why

On 24 July an armed eight-hour snooze was deleted because a background terminal repaint was classified as real agent work. The deletion was policy-correct ("work ends a snooze") applied to a false fact, and the reason survived only in free-text logs. The plan in docs/PLAN-trustworthy-working-start-2026-07-24.md (included in this pull request) fixes the fact in phases; this is increment 1: the durable evidence store, with no behavior change to any state transition, snooze duration, or display.

## What

- **Contract** (CcDirector.Gateway.Contracts/ActivityEventDtos.cs): one activity event record with closed event-type and cause vocabularies as wire string constants, a batch ingest request, and an acknowledgement carrying written plus duplicate counts so a producer outbox can drop acknowledged records honestly.
- **Table** activity_events: tenant-scoped, composite (tenant_id, EventId) primary key because the event id is producer-minted and therefore caller-supplied (idempotent replay across retries; no cross-tenant squat or existence oracle), with tenant-leading indexes for session timelines, director sequences, and event-type scans. SQLite and PostgreSQL migration pairs, generated on top of the dictation-suggestion-dismissals migration that landed on main during development.
- **Store** ActivityEventStore: whole-batch fail-loud validation, idempotent append (a replayed id is an acknowledged duplicate, never an error and never a second row), chronological reads, set-based purge.
- **Endpoints** POST /activity-events/batch and GET /activity-events, tenant-resolved from the authenticated device key exactly like the prompt log; a hosted request with no bound tenant is refused, never served the Local partition.
- **Retention** ActivityRetentionSweep on the per-tenant worker seam, driven by a Gateway timer: raw events older than 30 days are purged, by ruling - no unbounded retention.
- **Snooze lifecycle events**: the snooze registry appends its own decisions to the ledger - created, landed, and ended with the durable why (working observation, owner turn, manual release, session exit, director removed, session not live). Clear now requires the caller to state the cause. When an already-elapsed armed entry is retired, the recorded cause is timer-expired and the retiring edge moves to the detail - exactly the distinction the incident lacked.

## Proof

- Full Gateway suite on the rebased branch: 3766 passed, 0 failed, 17 skipped (the environment-gated PostgreSQL proofs).
- Full Core suite: 3493 passed, 0 failed.
- New coverage: store contract (idempotency, whole-batch validation, filters, purge, future-time clamp), endpoint behavior over real HTTP, hostile two-tenant isolation over a full hosted GatewayHost (bidirectional canaries with positive controls, same event id in two tenants stores two rows, unbound key denied on both verbs), and one test per snooze lifecycle cause.
- Both providers report no pending model changes after the migrations.

Increment 2 (Director producer, durable outbox, shadow Working classification) follows as its own pull request per the plan.