### PR TITLE
Cockpit: preview and clone straight from the workflows register

### DIFF
--- a/apps/cockpit/src/workflows/WorkflowsView.test.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import type { WorkflowDefinition } from "@devthrottle/client-core/workflows/workflowsClient";
+
+// Rendered proof for the register's preview + clone actions (owner ask, 2026-07-24). The Gateway
+// behavior (clone semantics, conduct reads) is proven server-side; what this pins is that the
+// register actually PAINTS the two actions on every row, that Preview opens a popup showing the
+// REAL fetched conduct pinned to the row's version, and that Clone asks first and then calls the
+// client with the suggested id and navigates to the clone. The Gateway client is mocked so the view
+// is driven without a running Gateway.
+
+const {
+  getWorkflows,
+  getWorkflowRuns,
+  getWorkflowInstructions,
+  cloneWorkflow,
+  setWorkflowEnabled,
+  createWorkflow,
+  suggestWorkflowId,
+  navigateSpy,
+} = vi.hoisted(() => ({
+  getWorkflows: vi.fn(),
+  getWorkflowRuns: vi.fn(),
+  getWorkflowInstructions: vi.fn(),
+  cloneWorkflow: vi.fn(),
+  setWorkflowEnabled: vi.fn(),
+  createWorkflow: vi.fn(),
+  suggestWorkflowId: vi.fn(() => "suggested-id"),
+  navigateSpy: vi.fn(),
+}));
+
+vi.mock("@devthrottle/client-core/workflows/workflowsClient", () => ({
+  getWorkflows,
+  getWorkflowRuns,
+  getWorkflowInstructions,
+  cloneWorkflow,
+  setWorkflowEnabled,
+  createWorkflow,
+  suggestWorkflowId,
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useNavigate: () => navigateSpy,
+}));
+
+import { WorkflowsView } from "./WorkflowsView";
+
+const MISSION: WorkflowDefinition = {
+  id: "mission",
+  name: "Mission",
+  summary: "An Architect settles the design.",
+  whenToUse: "Big work.",
+  humanCheckpoint: "Once, at the report.",
+  steps: [
+    { name: "Settle the design", description: "d", doer: "Architect", reviewer: null, done: "written" },
+    { name: "Build", description: "d", doer: "Worker", reviewer: "Manager", done: "merged" },
+  ],
+  version: 5,
+  isBuiltIn: true,
+  enabled: true,
+};
+
+describe("WorkflowsView register actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getWorkflows.mockResolvedValue([MISSION]);
+    getWorkflowRuns.mockResolvedValue([]);
+    getWorkflowInstructions.mockResolvedValue("# How a mission runs\n\nThe conduct body.");
+    cloneWorkflow.mockResolvedValue({ ...MISSION, id: "mission-copy", isBuiltIn: false, editable: true });
+  });
+  afterEach(cleanup);
+
+  it("paints Preview and Clone on the row", async () => {
+    render(<WorkflowsView />);
+    expect(await screen.findByRole("button", { name: "Preview Mission" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Clone Mission" })).toBeTruthy();
+  });
+
+  it("Preview opens the popup with the fetched conduct, pinned to the row's version", async () => {
+    render(<WorkflowsView />);
+    fireEvent.click(await screen.findByRole("button", { name: "Preview Mission" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Preview of Mission" });
+    expect(dialog).toBeTruthy();
+    // The shape: steps and the human checkpoint are visible in the popup.
+    expect(screen.getByText("Settle the design")).toBeTruthy();
+    expect(screen.getByText(/Once, at the report/)).toBeTruthy();
+    // The REAL conduct arrives (rendered markdown), fetched pinned to v5 - the torn-read and
+    // off-workflow discipline the detail page established.
+    await waitFor(() => expect(screen.getByText("How a mission runs")).toBeTruthy());
+    expect(getWorkflowInstructions).toHaveBeenCalledWith("mission", 5, expect.anything());
+  });
+
+  it("Clone from the popup asks first, then clones and navigates to the copy", async () => {
+    render(<WorkflowsView />);
+    fireEvent.click(await screen.findByRole("button", { name: "Preview Mission" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Clone" }));
+
+    // The confirm dialog names the suggested id; nothing has been cloned yet.
+    expect(screen.getAllByText(/mission-copy/).length).toBeGreaterThan(0);
+    expect(cloneWorkflow).not.toHaveBeenCalled();
+
+    // Confirm: the client is called with the suggested id and the cockpit actor, and the view
+    // navigates to the new clone's page.
+    const confirm = screen.getAllByRole("button", { name: "Clone" }).at(-1)!;
+    fireEvent.click(confirm);
+    await waitFor(() => expect(cloneWorkflow).toHaveBeenCalledWith("mission", "mission-copy", "cockpit"));
+    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/workflows/mission-copy"));
+  });
+
+  it("a failed clone lands in the page error state, never silent", async () => {
+    // A real Gateway refusal (409, id taken) - the formatter passes GatewayError statuses through
+    // as "rejected the request", and the page must SHOW it rather than swallow the failure.
+    const { GatewayError } = await import("@devthrottle/client-core/api/client");
+    cloneWorkflow.mockRejectedValue(new GatewayError(409, "id taken"));
+    render(<WorkflowsView />);
+    fireEvent.click(await screen.findByRole("button", { name: "Clone Mission" }));
+    const confirm = screen.getAllByRole("button", { name: "Clone" }).at(-1)!;
+    fireEvent.click(confirm);
+    await waitFor(() => expect(screen.getByText(/rejected the request \(error 409\)/)).toBeTruthy());
+  });
+});

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
+  cloneWorkflow,
   createWorkflow,
+  getWorkflowInstructions,
   getWorkflowRuns,
   getWorkflows,
   setWorkflowEnabled,
@@ -10,6 +12,7 @@ import {
   type WorkflowRunSummary,
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
 import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
 
 // The Workflows REGISTER (register redesign, approved mockup direction A). Workflows are the rules
@@ -28,6 +31,12 @@ export function WorkflowsView() {
   const [adding, setAdding] = useState(false);
   const [pendingOff, setPendingOff] = useState<WorkflowDefinition | null>(null);
   const [explainerOpen, setExplainerOpen] = useState(false);
+  // Preview + clone straight from the register (owner ask, 2026-07-24): reading a workflow's actual
+  // conduct and taking a copy of it are the two acts the register exists to invite, so both live on
+  // every row - built-ins included, because cloning IS the way to customize a built-in.
+  const [preview, setPreview] = useState<WorkflowDefinition | null>(null);
+  const [pendingClone, setPendingClone] = useState<WorkflowDefinition | null>(null);
+  const navigate = useNavigate();
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -119,6 +128,7 @@ export function WorkflowsView() {
             <div>State</div>
             <div>Provenance</div>
             <div>Recent activity</div>
+            <div>Actions</div>
           </div>
           {workflows.map((wf) => (
             <RegisterRow
@@ -130,6 +140,8 @@ export function WorkflowsView() {
                 if (!enabled) setPendingOff(wf);
                 else void flip(wf, true);
               }}
+              onPreview={() => setPreview(wf)}
+              onClone={() => setPendingClone(wf)}
             />
           ))}
           <div className="wf-reg-foot">
@@ -171,6 +183,129 @@ export function WorkflowsView() {
         }}
         onClose={() => setPendingOff(null)}
       />
+
+      {preview !== null ? (
+        <WorkflowPreviewDialog
+          workflow={preview}
+          onClose={() => setPreview(null)}
+          onClone={() => {
+            setPendingClone(preview);
+            setPreview(null);
+          }}
+        />
+      ) : null}
+
+      <ConfirmDialog
+        open={pendingClone !== null}
+        title={`Clone '${pendingClone?.name ?? ""}' as '${pendingClone?.id ?? ""}-copy'?`}
+        message={
+          <>
+            The published content - steps, instructions, helper files - is copied into a new
+            workflow <code>{pendingClone?.id}-copy</code> that is yours: published, fully editable,
+            and independent of the original.
+          </>
+        }
+        confirmLabel="Clone"
+        danger={false}
+        onConfirm={async () => {
+          if (pendingClone === null) return;
+          try {
+            const clone = await cloneWorkflow(pendingClone.id, `${pendingClone.id}-copy`, "cockpit");
+            navigate(`/workflows/${encodeURIComponent(clone.id)}`);
+          } catch (err) {
+            setError(gatewayErrorMessage(err));
+          }
+        }}
+        onClose={() => setPendingClone(null)}
+      />
+    </div>
+  );
+}
+
+// The conduct preview (owner ask, 2026-07-24): the popup that answers "what does this workflow
+// actually say" without leaving the register - the shape up top (badges, when to use, steps), then
+// the full instruction markdown, scrollable, through the same sanitized renderer the detail page
+// trusts. It is not a dead end: the clone decision happens right here, and the full page is one
+// click away. The conduct is fetched PINNED to the version the row reported, matching the detail
+// page's torn-read discipline (an unpinned read racing a publish could pair v1 steps with v2 text -
+// and the pinned read also keeps the preview working for an OFF workflow, whose unversioned read
+// the Gateway refuses).
+function WorkflowPreviewDialog({
+  workflow,
+  onClose,
+  onClone,
+}: {
+  workflow: WorkflowDefinition;
+  onClose: () => void;
+  onClone: () => void;
+}) {
+  const [instructions, setInstructions] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    getWorkflowInstructions(workflow.id, workflow.version, ctrl.signal).then(
+      (md) => setInstructions(md),
+      (err) => {
+        if (!ctrl.signal.aborted) setError(gatewayErrorMessage(err));
+      },
+    );
+    return () => ctrl.abort();
+  }, [workflow.id, workflow.version]);
+
+  return (
+    <div className="wf-dialog-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="wf-dialog wf-preview"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Preview of ${workflow.name}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="wf-dialog-title">
+          {workflow.name}
+          {workflow.isBuiltIn === true ? <span className="wf-badge wf-badge-builtin">Built-in</span> : null}
+          {typeof workflow.version === "number" ? <span className="wf-badge">v{workflow.version}</span> : null}
+        </h2>
+        <p className="wf-dialog-hint">{workflow.summary}</p>
+        {workflow.whenToUse !== undefined && workflow.whenToUse !== "" ? (
+          <p className="wf-preview-fact"><b>When to use it:</b> {workflow.whenToUse}</p>
+        ) : null}
+        {workflow.humanCheckpoint !== undefined && workflow.humanCheckpoint !== "" ? (
+          <p className="wf-preview-fact"><b>You are asked:</b> {workflow.humanCheckpoint}</p>
+        ) : null}
+        {workflow.steps !== undefined && workflow.steps.length > 0 ? (
+          <ol className="wf-preview-steps">
+            {workflow.steps.map((step, i) => (
+              <li key={step.name}>
+                <span className="wf-detail-step-num">{i + 1}.</span> <strong>{step.name}</strong> - {step.doer}
+                {step.reviewer !== null && step.reviewer !== undefined
+                  ? `, reviewed by ${step.reviewer}`
+                  : ", no review"}
+              </li>
+            ))}
+          </ol>
+        ) : null}
+        <div className="wf-preview-body">
+          {error !== null ? (
+            <p className="wf-dialog-error">{error}</p>
+          ) : instructions === null ? (
+            <LoadingState message="Loading the conduct..." />
+          ) : (
+            <div
+              className="wf-conduct-body"
+              dangerouslySetInnerHTML={{ __html: markdownToHtml(instructions) }}
+            />
+          )}
+        </div>
+        <div className="wf-dialog-actions">
+          <Link className="wf-preview-full-link" to={`/workflows/${encodeURIComponent(workflow.id)}`}>
+            Open full page
+          </Link>
+          <Button variant="secondary" onClick={onClose}>Close</Button>
+          <Button variant="primary" onClick={onClone}>Clone</Button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -180,11 +315,15 @@ function RegisterRow({
   activity,
   runsLoaded,
   onFlip,
+  onPreview,
+  onClone,
 }: {
   workflow: WorkflowDefinition;
   activity: { count: number; newestUtc: string } | undefined;
   runsLoaded: boolean;
   onFlip: (enabled: boolean) => void;
+  onPreview: () => void;
+  onClone: () => void;
 }) {
   const off = workflow.enabled === false;
   const spine = off ? "wf-spine-off" : workflow.hasDraft === true ? "wf-spine-draft" : "wf-spine-on";
@@ -240,6 +379,14 @@ function RegisterRow({
         ) : (
           <span className="wf-off-note">activity unavailable</span>
         )}
+      </div>
+      <div className="wf-cell-actions">
+        <button className="wf-linklike" onClick={onPreview} aria-label={`Preview ${workflow.name}`}>
+          Preview
+        </button>
+        <button className="wf-linklike" onClick={onClone} aria-label={`Clone ${workflow.name}`}>
+          Clone
+        </button>
       </div>
     </div>
   );

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -76,7 +76,7 @@
 .wf-reg-head,
 .wf-reg-row {
   display: grid;
-  grid-template-columns: 5px minmax(230px, 1.5fr) 160px minmax(150px, 1fr) 170px;
+  grid-template-columns: 5px minmax(230px, 1.5fr) 160px minmax(150px, 1fr) 170px 110px;
   gap: 0 16px;
   align-items: start;
 }
@@ -305,7 +305,13 @@
   }
 
   .wf-spine {
-    grid-row: 1 / span 4;
+    grid-row: 1 / span 5;
+  }
+
+  /* Stacked rows read better with the actions side by side. */
+  .wf-cell-actions {
+    flex-direction: row;
+    gap: 14px;
   }
 }
 
@@ -548,4 +554,54 @@
   margin: 10px 0;
   padding: 2px 14px;
   color: var(--text-dim);
+}
+
+/* Row actions (preview + clone from the register - owner ask, 2026-07-24). */
+.wf-cell-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  padding-top: 2px;
+}
+
+/* The conduct preview popup: wider than the form dialogs, with the conduct itself scrolling inside
+   a bounded body so the dialog never outgrows the viewport. The scrollbar is always visible when the
+   content overflows (scrollbars are load-bearing here, not decoration). */
+.wf-dialog.wf-preview {
+  width: min(760px, calc(100vw - 40px));
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+}
+
+.wf-preview-fact {
+  margin: 4px 0;
+  font-size: 13px;
+}
+
+.wf-preview-steps {
+  margin: 8px 0;
+  padding-left: 22px;
+  font-size: 13px;
+}
+
+.wf-preview-steps li {
+  margin: 3px 0;
+}
+
+.wf-preview-body {
+  flex: 1 1 auto;
+  min-height: 120px;
+  overflow-y: scroll;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin: 10px 0 4px;
+}
+
+.wf-preview-full-link {
+  margin-right: auto;
+  font-size: 13px;
+  align-self: center;
 }


### PR DESCRIPTION
Follow-up to the Shared Workflow Library (devthrottle_internal issue 514), owner ask of 2026-07-24: the register's rows now carry the two acts the page exists to invite.

- Preview: a popup showing the workflow's shape (badges, when to use, human checkpoint, steps) and the full conduct markdown, scrollable, sanitized by the same renderer the detail page trusts, fetched pinned to the row's version. The clone decision happens inside the popup and the full page is one click away.
- Clone on every row, built-ins included: confirm-then-copy with the suggested id, navigating to the new copy on success; failures land in the page error state.

Proof: four new rendered tests (actions painted on the row; preview shows the real fetched conduct pinned to the version; clone asks first then calls the client and navigates; a Gateway refusal is shown, never swallowed). Cockpit suite 174 passed / 0 failed, client-core 578/0, typecheck clean across all workspaces. Cockpit-only - no Gateway changes.