### PR TITLE
feat(director): activity-evidence producer with durable outbox (trustworthy Working start, increment 2)

### DIFF
--- a/src/CcDirector.ControlApi/ActivityEventUploader.cs
+++ b/src/CcDirector.ControlApi/ActivityEventUploader.cs
@@ -1,0 +1,101 @@
+using CcDirector.Core.Activity;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Drains the Director's durable activity-event outbox to the Gateway ledger
+/// (docs/PLAN-trustworthy-working-start-2026-07-24.md, increment 2). A timer wakes every
+/// <see cref="Interval"/>, pushes the oldest batch through the current <see cref="GatewayClient"/>, and
+/// deletes from the outbox exactly the events the Gateway confirmed it durably holds - written now or an
+/// already-held duplicate; both are acknowledgement. A failed or partial push deletes nothing and simply
+/// retries on the next tick with the SAME minted identities, which is what keeps the ledger loss-free and
+/// duplicate-free across crashes and reconnects.
+///
+/// The Gateway client is resolved per tick (the same late-binding the prompt sink uses) so a Gateway
+/// reconfigure is picked up without rewiring.
+/// </summary>
+public sealed class ActivityEventUploader : IDisposable
+{
+    /// <summary>How often the outbox is drained. Evidence is diagnostic, not interactive - half a minute
+    /// of delivery lag is invisible to its consumers, and the tick is a no-op when the outbox is empty.</summary>
+    public static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    /// <summary>The Gateway's own batch ceiling (ActivityEventStore.MaxBatchSize).</summary>
+    public const int BatchSize = 500;
+
+    private readonly Func<GatewayClient?> _gateway;
+    private readonly ActivityEventOutbox _outbox;
+    private readonly System.Threading.Timer _timer;
+    private int _inFlight;
+    private int _disposed;
+
+    public ActivityEventUploader(Func<GatewayClient?> gateway, ActivityEventOutbox outbox)
+    {
+        _gateway = gateway ?? throw new ArgumentNullException(nameof(gateway));
+        _outbox = outbox ?? throw new ArgumentNullException(nameof(outbox));
+        _timer = new System.Threading.Timer(_ => OnTick(), null, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    public void Start()
+    {
+        _timer.Change(Interval, Interval);
+        FileLog.Write($"[ActivityEventUploader] started: every {Interval.TotalSeconds:0}s, batch {BatchSize}, pending {_outbox.PendingCount}");
+    }
+
+    private void OnTick()
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        if (Interlocked.CompareExchange(ref _inFlight, 1, 0) != 0) return;
+        _ = DrainAsync();
+    }
+
+    private async Task DrainAsync()
+    {
+        try
+        {
+            // Keep pushing while full batches clear, so a backlog after an outage drains in one tick
+            // rather than one batch per 30 seconds.
+            while (true)
+            {
+                var batch = _outbox.PendingBatch(BatchSize);
+                if (batch.Count == 0) return;
+
+                var gateway = _gateway();
+                if (gateway is null) return;
+
+                var ack = await gateway.PushActivityEventsAsync(batch).ConfigureAwait(false);
+                if (ack is null)
+                    return; // not acknowledged - keep everything, retry next tick
+
+                if (ack.Written + ack.Duplicates < batch.Count)
+                {
+                    // The Gateway answered but did not account for the whole batch. Keep everything and
+                    // retry - the minted ids make the replay idempotent - and say so loudly, because a
+                    // persistent shortfall means a producer bug worth diagnosing.
+                    FileLog.Write($"[ActivityEventUploader] partial acknowledgement: sent {batch.Count}, " +
+                                  $"written {ack.Written}, duplicates {ack.Duplicates}; retrying the batch");
+                    return;
+                }
+
+                _outbox.Acknowledge(batch.Select(e => e.EventId));
+                if (batch.Count < BatchSize)
+                    return; // the outbox is drained
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ActivityEventUploader] drain FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _inFlight, 0);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _timer.Dispose();
+    }
+}

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -193,6 +193,9 @@ public sealed class ControlApiHost : IAsyncDisposable
     private SessionStatusWingman? _statusWingman;
     private ProactiveExplainService? _proactiveExplain;
     private TerminalStateDetector? _terminalStateDetector;
+    private Core.Activity.ActivityEventOutbox? _activityOutbox;
+    private Core.Activity.ActivityEventProducer? _activityProducer;
+    private ActivityEventUploader? _activityUploader;
     private TransientErrorAutoResume? _transientErrorAutoResume;
     private TerminalSessionRecorder? _sessionRecorder;
     private Core.Storage.TurnReviewLogger? _turnReviewLogger;
@@ -690,7 +693,15 @@ public sealed class ControlApiHost : IAsyncDisposable
         // Terminal-driven state: the detector's only rule is byte -> working, plus the idle
         // clock (time since the last ConPTY character). No footer/grid/LLM guesswork, and no
         // Claude Code hooks - the detector is the single authority for session state.
-        _terminalStateDetector = new TerminalStateDetector(_sessionManager, driveState: true);
+        // The activity-evidence producer (docs/PLAN-trustworthy-working-start-2026-07-24.md, increment 2):
+        // records submissions, state transitions with shadow causes, unexplained terminal wakes, and
+        // transcript-proven turns into a durable outbox the uploader below drains to the Gateway ledger.
+        // OBSERVE-ONLY - it changes no session state and gates nothing.
+        _activityOutbox = new Core.Activity.ActivityEventOutbox();
+        _activityProducer = new Core.Activity.ActivityEventProducer(_sessionManager, _activityOutbox);
+        _activityProducer.Start();
+
+        _terminalStateDetector = new TerminalStateDetector(_sessionManager, driveState: true, _activityProducer);
         _terminalStateDetector.Start();
         FileLog.Write("[ControlApiHost] Session state source: terminal (byte->working)");
 
@@ -733,8 +744,13 @@ public sealed class ControlApiHost : IAsyncDisposable
         // or knows its origin; the Gateway stores because it is what the whole fleet reports to and what
         // moves to the server. The Director keeps no copy.
         _conversationIngestor = new Core.Storage.ConversationIngestor(
-            _sessionManager, new GatewayPromptSink(() => _gatewayClient));
+            _sessionManager, new GatewayPromptSink(() => _gatewayClient), _activityProducer);
         _conversationIngestor.Start();
+
+        // Drain the activity outbox to the Gateway ledger. Late-binds the Gateway client per tick (the
+        // prompt sink's pattern) and deletes an outbox record only on the Gateway's acknowledgement.
+        _activityUploader = new ActivityEventUploader(() => _gatewayClient, _activityOutbox);
+        _activityUploader.Start();
     }
 
     /// <summary>
@@ -1065,6 +1081,11 @@ public sealed class ControlApiHost : IAsyncDisposable
 
         _terminalStateDetector?.Dispose();
         _terminalStateDetector = null;
+        _activityUploader?.Dispose();
+        _activityUploader = null;
+        _activityProducer?.Dispose();
+        _activityProducer = null;
+        _activityOutbox = null;
         _transientErrorAutoResume?.Dispose();
         _transientErrorAutoResume = null;
         _turnReviewLogger?.Dispose();

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -353,6 +353,38 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Push one activity-event batch to the Gateway ledger (docs/PLAN-trustworthy-working-start-
+    /// 2026-07-24.md). Returns the Gateway's acknowledgement, or null when the push did not land
+    /// (disabled, HTTP failure, transport fault) - the caller keeps the outbox records and retries.
+    /// A duplicate in the response is a SUCCESSFUL replay: the Gateway already durably holds that
+    /// event, which acknowledges it exactly as a fresh write does.
+    /// </summary>
+    public async Task<ActivityEventIngestResponse?> PushActivityEventsAsync(
+        IReadOnlyList<ActivityEventRecord> events, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled) return null;
+        if (events.Count == 0) return new ActivityEventIngestResponse { Written = 0, Duplicates = 0 };
+
+        try
+        {
+            var body = new ActivityEventIngestRequest { Events = events };
+            using var resp = await _http.PostAsJsonAsync("activity-events/batch", body, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                FileLog.Write($"[GatewayClient] PushActivityEventsAsync: POST /activity-events/batch returned HTTP {(int)resp.StatusCode}");
+                return null;
+            }
+
+            return await resp.Content.ReadFromJsonAsync<ActivityEventIngestResponse>(ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayClient] PushActivityEventsAsync FAILED: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Rename a session anywhere in the fleet via the Gateway's PATCH /sessions/{sid}, which routes the
     /// rename to the owning Director over the tunnel and returns the updated <see cref="SessionDto"/>.
     /// Issue #1490: the Director's loopback POST /fleet/rename relays here for a non-local target. Throws

--- a/src/CcDirector.Core.Tests/Activity/ActivityEventOutboxTests.cs
+++ b/src/CcDirector.Core.Tests/Activity/ActivityEventOutboxTests.cs
@@ -1,0 +1,137 @@
+using CcDirector.Core.Activity;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Activity;
+
+/// <summary>
+/// The durable outbox contract (docs/PLAN-trustworthy-working-start-2026-07-24.md, increment 2): an event
+/// is minted ONCE - id and monotonic sequence - before it is persisted, survives a Director restart, and
+/// leaves the outbox only on Gateway acknowledgement. The identities surviving retry and restart is what
+/// makes the Gateway's append idempotent end to end.
+/// </summary>
+public sealed class ActivityEventOutboxTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-activity-outbox-tests-" + Guid.NewGuid().ToString("N"));
+
+    private string OutboxPath => Path.Combine(_dir, "outbox.jsonl");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static ActivityEventRecord Draft(Guid? id = null) => new()
+    {
+        EventId = id ?? Guid.Empty,
+        DirectorSequence = 0,
+        OccurredUtc = DateTime.UtcNow,
+        DirectorId = "dir-1",
+        SessionId = "s1",
+        EventType = ActivityEventTypes.ActivityTransition,
+        Cause = ActivityCauses.Unknown,
+    };
+
+    [Fact]
+    public void Enqueue_mints_a_fresh_id_and_a_monotonic_sequence()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath);
+
+        var first = outbox.Enqueue(Draft());
+        var second = outbox.Enqueue(Draft());
+
+        Assert.NotEqual(Guid.Empty, first.EventId);
+        Assert.NotEqual(first.EventId, second.EventId);
+        Assert.Equal(1, first.DirectorSequence);
+        Assert.Equal(2, second.DirectorSequence);
+    }
+
+    [Fact]
+    public void A_producer_supplied_deterministic_id_is_kept()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath);
+        var deterministic = Guid.NewGuid();
+
+        var minted = outbox.Enqueue(Draft(id: deterministic));
+
+        Assert.Equal(deterministic, minted.EventId);
+    }
+
+    [Fact]
+    public void Pending_events_survive_a_restart_with_their_minted_identities()
+    {
+        var first = new ActivityEventOutbox(OutboxPath);
+        var a = first.Enqueue(Draft());
+        var b = first.Enqueue(Draft());
+
+        // A new outbox over the same file is the restarted Director.
+        var restarted = new ActivityEventOutbox(OutboxPath);
+
+        Assert.Equal(2, restarted.PendingCount);
+        var pending = restarted.PendingBatch(10);
+        Assert.Equal(new[] { a.EventId, b.EventId }, pending.Select(e => e.EventId));
+        Assert.Equal(new[] { 1L, 2L }, pending.Select(e => e.DirectorSequence));
+
+        // The sequence RESUMES - a post-restart event never reuses a pre-restart sequence.
+        Assert.Equal(3, restarted.Enqueue(Draft()).DirectorSequence);
+    }
+
+    [Fact]
+    public void Acknowledge_deletes_exactly_the_confirmed_events_durably()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath);
+        var a = outbox.Enqueue(Draft());
+        var b = outbox.Enqueue(Draft());
+        var c = outbox.Enqueue(Draft());
+
+        outbox.Acknowledge(new[] { a.EventId, c.EventId });
+
+        Assert.Equal(b.EventId, Assert.Single(outbox.PendingBatch(10)).EventId);
+        // Durably: the survivor is what a restart loads.
+        Assert.Equal(b.EventId, Assert.Single(new ActivityEventOutbox(OutboxPath).PendingBatch(10)).EventId);
+    }
+
+    [Fact]
+    public void An_unacknowledged_batch_is_returned_again_with_the_same_identities()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath);
+        var minted = outbox.Enqueue(Draft());
+
+        var firstTry = outbox.PendingBatch(10);
+        var secondTry = outbox.PendingBatch(10);   // the failed-push retry path
+
+        Assert.Equal(minted.EventId, Assert.Single(firstTry).EventId);
+        Assert.Equal(minted.EventId, Assert.Single(secondTry).EventId);
+        Assert.Equal(minted.DirectorSequence, secondTry[0].DirectorSequence);
+    }
+
+    [Fact]
+    public void A_corrupt_line_is_skipped_and_the_rest_of_the_evidence_loads()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath);
+        var kept = outbox.Enqueue(Draft());
+        File.AppendAllText(OutboxPath, "{not json" + Environment.NewLine);
+        var alsoKept = outbox.Enqueue(Draft());
+
+        var restarted = new ActivityEventOutbox(OutboxPath);
+
+        Assert.Equal(new[] { kept.EventId, alsoKept.EventId },
+            restarted.PendingBatch(10).Select(e => e.EventId));
+    }
+
+    [Fact]
+    public void Past_the_cap_the_oldest_events_are_dropped_not_the_disk_filled()
+    {
+        var outbox = new ActivityEventOutbox(OutboxPath, maxPending: 3);
+        var a = outbox.Enqueue(Draft());
+        var b = outbox.Enqueue(Draft());
+        var c = outbox.Enqueue(Draft());
+        var d = outbox.Enqueue(Draft());
+
+        Assert.Equal(3, outbox.PendingCount);
+        Assert.Equal(new[] { b.EventId, c.EventId, d.EventId },
+            outbox.PendingBatch(10).Select(e => e.EventId));
+        Assert.DoesNotContain(a.EventId, outbox.PendingBatch(10).Select(e => e.EventId));
+    }
+}

--- a/src/CcDirector.Core.Tests/Activity/ActivityEventProducerTests.cs
+++ b/src/CcDirector.Core.Tests/Activity/ActivityEventProducerTests.cs
@@ -1,0 +1,222 @@
+using CcDirector.Core.Activity;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Activity;
+
+/// <summary>
+/// The shadow producer's contract (docs/PLAN-trustworthy-working-start-2026-07-24.md, increment 2): every
+/// submission and every authoritative transition lands in the outbox with an honest shadow cause, and
+/// nothing the producer does changes the session's behavior. Sessions are built directly over the
+/// recording backend (the SessionInteractiveTests harness) and wired by hand - the manager fan-out is the
+/// same Wire call.
+/// </summary>
+public sealed class ActivityEventProducerTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-activity-producer-tests-" + Guid.NewGuid().ToString("N"));
+
+    private readonly SessionManager _manager;
+    private readonly ActivityEventOutbox _outbox;
+    private readonly ActivityEventProducer _producer;
+
+    public ActivityEventProducerTests()
+    {
+        _manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path })
+        {
+            DirectorId = "dir-test",
+        };
+        _outbox = new ActivityEventOutbox(Path.Combine(_dir, "outbox.jsonl"));
+        _producer = new ActivityEventProducer(_manager, _outbox);
+    }
+
+    public void Dispose()
+    {
+        _producer.Dispose();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private Session NewWiredSession(ActivityState initial = ActivityState.WaitingForInput)
+    {
+        var s = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\repo",
+            workingDirectory: @"C:\test\repo",
+            claudeArgs: null,
+            backend: new FakeBackend(),
+            claudeSessionId: "claude-test",
+            activityState: initial,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: null,
+            customColor: null);
+        s.MarkRunning();
+        _producer.Wire(s);
+        return s;
+    }
+
+    private IReadOnlyList<ActivityEventRecord> Events() => _outbox.PendingBatch(100);
+
+    [Fact]
+    public async Task An_owner_submission_records_the_turn_and_explains_the_working_transition()
+    {
+        using var s = NewWiredSession();
+
+        await s.SendTextAsync("make the button blue", SendSource.UserInput, InputOrigin.DesktopTyped);
+
+        var submitted = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.TurnSubmitted);
+        Assert.Equal(ActivityCauses.OwnerSubmit, submitted.Cause);
+        Assert.Equal("UserInput", submitted.SendSource);
+        Assert.Equal("typed/desktop", submitted.InputOrigin);
+        Assert.Equal("dir-test", submitted.DirectorId);
+        Assert.Equal(s.Id.ToString(), submitted.SessionId);
+
+        var transition = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.ActivityTransition
+                                                      && e.NewState == nameof(ActivityState.Working));
+        Assert.Equal(ActivityCauses.OwnerSubmit, transition.Cause);
+        Assert.Equal(nameof(ActivityState.WaitingForInput), transition.PreviousState);
+        Assert.Equal(ActivityEventProducer.DetectorVersion, transition.DetectorVersion);
+    }
+
+    [Fact]
+    public async Task An_agent_submission_is_attributed_to_the_agent_not_the_owner()
+    {
+        using var s = NewWiredSession();
+
+        await s.SendTextAsync("fleet message", SendSource.Agent);
+
+        var submitted = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.TurnSubmitted);
+        Assert.Equal(ActivityCauses.AgentSubmit, submitted.Cause);
+
+        var transition = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.ActivityTransition);
+        Assert.Equal(ActivityCauses.AgentSubmit, transition.Cause);
+    }
+
+    [Fact]
+    public void A_raw_submit_byte_with_no_origin_is_an_honestly_unknown_submitter()
+    {
+        using var s = NewWiredSession();
+
+        s.SendInput(new[] { (byte)'x', (byte)0x0D });
+
+        var submitted = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.TurnSubmitted);
+        Assert.Equal(ActivityCauses.Unknown, submitted.Cause);
+        Assert.Null(submitted.SendSource);
+        Assert.Null(submitted.InputOrigin);
+    }
+
+    [Fact]
+    public void A_working_flip_with_no_submission_at_all_is_not_credited_to_one()
+    {
+        using var s = NewWiredSession();
+
+        // The detector's write path, with no submission anywhere near it - the phantom-turn shape.
+        s.ApplyTerminalActivityState(ActivityState.Working);
+
+        var transition = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.ActivityTransition);
+        Assert.NotEqual(ActivityCauses.OwnerSubmit, transition.Cause);
+        Assert.NotEqual(ActivityCauses.AgentSubmit, transition.Cause);
+        Assert.NotEqual(ActivityCauses.FrameworkSubmit, transition.Cause);
+    }
+
+    [Fact]
+    public void Settling_after_work_is_the_quiet_threshold()
+    {
+        using var s = NewWiredSession(ActivityState.Working);
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+
+        var transition = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.ActivityTransition);
+        Assert.Equal(ActivityCauses.QuietThreshold, transition.Cause);
+    }
+
+    [Fact]
+    public void Exit_is_recorded_as_its_own_event_type()
+    {
+        using var s = NewWiredSession(ActivityState.Working);
+
+        s.ApplyTerminalActivityState(ActivityState.Exited);
+
+        var exited = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.SessionExited);
+        Assert.Equal(ActivityCauses.SessionExit, exited.Cause);
+    }
+
+    [Fact]
+    public void Terminal_evidence_rides_the_output_while_settled_event()
+    {
+        using var s = NewWiredSession();
+
+        _producer.RecordTerminalOutputWhileSettled(s, outputByteCount: 96,
+            beforeScreenHash: "aaa", afterScreenHash: "bbb", boundedScreenDiff: "row 41: [watcher] tick",
+            detectorMode: "byte");
+
+        var evidence = Assert.Single(Events(), e => e.EventType == ActivityEventTypes.TerminalOutputWhileSettled);
+        Assert.Equal(ActivityCauses.TerminalOutputOnly, evidence.Cause);
+        Assert.Equal(96, evidence.OutputByteCount);
+        Assert.Equal("byte", evidence.DetectorMode);
+        Assert.Equal("row 41: [watcher] tick", evidence.BoundedScreenDiff);
+    }
+
+    [Fact]
+    public void A_transcript_observation_replays_the_same_identity_on_re_detection()
+    {
+        using var s = NewWiredSession();
+        var ts = DateTime.UtcNow;
+
+        _producer.RecordTurnObserved(s, ts, contextId: "ctx-1", dedupKey: "scope|ts|the reply text");
+        _producer.RecordTurnObserved(s, ts, contextId: "ctx-1", dedupKey: "scope|ts|the reply text");
+
+        var observed = Events().Where(e => e.EventType == ActivityEventTypes.TurnObservedInTranscript).ToList();
+        Assert.Equal(2, observed.Count);
+        // Same content identity -> same event id: the Gateway stores one row and acknowledges the replay.
+        Assert.Equal(observed[0].EventId, observed[1].EventId);
+        Assert.Equal(ts, observed[0].OccurredUtc);
+        Assert.Equal("ctx-1", observed[0].ContextId);
+    }
+
+    [Fact]
+    public void An_unwired_session_records_nothing()
+    {
+        using var s = NewWiredSession();
+        _producer.Unwire(s);
+
+        s.ApplyTerminalActivityState(ActivityState.Working);
+
+        Assert.Empty(Events());
+    }
+
+    /// <summary>A backend that accepts input and text without a process - enough for the choke points.</summary>
+    private sealed class FakeBackend : ISessionBackend
+    {
+        public int ProcessId => 0;
+        public string Status => "Fake";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    [Theory]
+    [InlineData(null, true, ActivityCauses.OwnerSubmit)]                  // tagged human origin
+    [InlineData(SendSource.UserInput, false, ActivityCauses.OwnerSubmit)] // owner-driven source
+    [InlineData(SendSource.Delivery, false, ActivityCauses.OwnerSubmit)]  // queued owner message
+    [InlineData(SendSource.Agent, false, ActivityCauses.AgentSubmit)]
+    [InlineData(SendSource.Framework, false, ActivityCauses.FrameworkSubmit)]
+    [InlineData(null, false, ActivityCauses.Unknown)]                     // raw bytes, nobody tagged
+    public void Submission_causes_mirror_the_owner_turn_rule(SendSource? source, bool withOrigin, string expected)
+        => Assert.Equal(expected,
+            ActivityEventProducer.SubmissionCause(source, withOrigin ? InputOrigin.DesktopTyped : null));
+}

--- a/src/CcDirector.Core.Tests/Activity/ActivityEvidenceTests.cs
+++ b/src/CcDirector.Core.Tests/Activity/ActivityEvidenceTests.cs
@@ -1,0 +1,78 @@
+using CcDirector.Core.Activity;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Activity;
+
+/// <summary>
+/// The bounded terminal evidence helpers: the hash treats trailing padding as presentation, and the diff
+/// quotes only a bounded head while never claiming to be complete when it is not.
+/// </summary>
+public sealed class ActivityEvidenceTests
+{
+    [Fact]
+    public void The_hash_ignores_trailing_whitespace_but_not_content()
+    {
+        Assert.Equal(ActivityEvidence.BodyHash("hello\nworld"), ActivityEvidence.BodyHash("hello   \nworld  "));
+        Assert.NotEqual(ActivityEvidence.BodyHash("hello\nworld"), ActivityEvidence.BodyHash("hello\nworld!"));
+    }
+
+    [Fact]
+    public void An_empty_body_hashes_stably()
+    {
+        Assert.Equal(ActivityEvidence.BodyHash(""), ActivityEvidence.BodyHash(""));
+        Assert.Equal(32, ActivityEvidence.BodyHash("").Length);
+    }
+
+    [Fact]
+    public void The_diff_quotes_only_the_changed_rows()
+    {
+        var before = "one\ntwo\nthree";
+        var after = "one\nTWO\nthree\nfour";
+
+        var diff = ActivityEvidence.BoundedRowDiff(before, after);
+
+        Assert.Equal("row 1: TWO\nrow 3: four", diff);
+    }
+
+    [Fact]
+    public void A_removed_row_is_named_not_silently_absent()
+    {
+        var diff = ActivityEvidence.BoundedRowDiff("one\ntwo", "one");
+        Assert.Equal("row 1: <removed>", diff);
+    }
+
+    [Fact]
+    public void Identical_bodies_diff_to_nothing()
+    {
+        Assert.Equal("", ActivityEvidence.BoundedRowDiff("same\nbody", "same\nbody"));
+        // Trailing padding is presentation, not change.
+        Assert.Equal("", ActivityEvidence.BoundedRowDiff("same\nbody", "same   \nbody  "));
+    }
+
+    [Fact]
+    public void A_diff_larger_than_the_bound_says_how_much_it_left_out()
+    {
+        var before = string.Join('\n', Enumerable.Range(0, 20).Select(i => $"row-{i}"));
+        var after = string.Join('\n', Enumerable.Range(0, 20).Select(i => $"changed-{i}"));
+
+        var diff = ActivityEvidence.BoundedRowDiff(before, after);
+
+        var quoted = diff.Split('\n');
+        Assert.Equal(ActivityEvidence.MaxDiffRows + 1, quoted.Length); // the quoted head + the tail note
+        Assert.Contains("more changed row(s) not quoted", quoted[^1]);
+        Assert.Contains("12", quoted[^1]); // 20 changed, 8 quoted
+    }
+
+    [Fact]
+    public void The_diff_never_exceeds_its_character_cap_by_more_than_the_tail_note()
+    {
+        var wide = new string('x', 900);
+        var before = string.Join('\n', Enumerable.Range(0, 10).Select(_ => "short"));
+        var after = string.Join('\n', Enumerable.Range(0, 10).Select(i => wide + i));
+
+        var diff = ActivityEvidence.BoundedRowDiff(before, after);
+
+        Assert.True(diff.Length <= ActivityEvidence.MaxDiffChars + 100,
+            $"diff length {diff.Length} exceeds the cap plus the tail note");
+    }
+}

--- a/src/CcDirector.Core/Activity/ActivityEventOutbox.cs
+++ b/src/CcDirector.Core/Activity/ActivityEventOutbox.cs
@@ -1,0 +1,165 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Activity;
+
+/// <summary>
+/// The Director's durable activity-event outbox (docs/PLAN-trustworthy-working-start-2026-07-24.md,
+/// increment 2). Activity evidence cannot always be reconstructed from an agent transcript, so "keep the
+/// history" requires the events to survive a Director crash between capture and Gateway acknowledgement -
+/// an in-memory retry queue is not enough. The GATEWAY remains the only durable history; this file is
+/// nothing but the not-yet-acknowledged tail, and an acknowledged event is deleted here the moment the
+/// Gateway confirms it holds it.
+///
+/// MINTED ONCE: <see cref="Enqueue"/> stamps the event's id (a fresh GUID unless the producer supplied a
+/// deterministic one) and this Director's monotonic sequence exactly once, BEFORE the event is persisted.
+/// A retried batch replays the same identities, which is what makes the Gateway's append idempotent - a
+/// crash between push and acknowledgement re-sends the same events and the Gateway answers "duplicates",
+/// never a second row.
+///
+/// Format: one JSON <see cref="ActivityEventRecord"/> per line at <see cref="CcStorage.ActivityOutbox"/>.
+/// Enqueue appends one line (cheap, called from event threads); acknowledgement rewrites the file
+/// atomically (temp file + move, the <c>IngestState</c> pattern). Load-on-start restores the pending tail
+/// and resumes the sequence from the highest value seen; a corrupt line is logged and skipped, never
+/// fatal - one bad line must not cost the rest of the evidence.
+///
+/// BOUNDED: a Gateway that stays unreachable must not grow this file forever. Past
+/// <see cref="MaxPending"/> events the OLDEST are dropped, loudly. That is a deliberate, visible safety
+/// valve on delivery state - losing the oldest shadow evidence in a multi-day outage is acceptable;
+/// filling the disk is not.
+/// </summary>
+public sealed class ActivityEventOutbox
+{
+    /// <summary>The hard ceiling on pending events; beyond it the oldest are dropped loudly.</summary>
+    public const int MaxPending = 20_000;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
+
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly List<ActivityEventRecord> _pending = new();
+    private long _lastSequence;
+
+    /// <param name="path">The outbox file. Defaults to <see cref="CcStorage.ActivityOutbox"/>; tests pass
+    /// an isolated path.</param>
+    public ActivityEventOutbox(string? path = null) : this(path, MaxPending)
+    {
+    }
+
+    /// <summary>Test seam: a small cap so the overflow valve is provable without 20,000 writes.</summary>
+    internal ActivityEventOutbox(string? path, int maxPending)
+    {
+        _maxPending = maxPending;
+        _path = string.IsNullOrWhiteSpace(path) ? CcStorage.ActivityOutbox() : path!;
+        lock (_gate)
+            Load();
+    }
+
+    private readonly int _maxPending;
+
+    /// <summary>How many events are waiting for acknowledgement right now.</summary>
+    public int PendingCount { get { lock (_gate) return _pending.Count; } }
+
+    /// <summary>
+    /// Mint the event's identity and persist it. <paramref name="record"/> arrives with
+    /// <c>DirectorSequence = 0</c> and either <see cref="Guid.Empty"/> (mint a fresh id) or a
+    /// producer-supplied DETERMINISTIC id (kept as-is - the transcript observer derives ids from content
+    /// so a re-detection of the same reply replays the same identity instead of duplicating it). Returns
+    /// the minted record.
+    /// </summary>
+    public ActivityEventRecord Enqueue(ActivityEventRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        lock (_gate)
+        {
+            var minted = record with
+            {
+                EventId = record.EventId == Guid.Empty ? Guid.NewGuid() : record.EventId,
+                DirectorSequence = ++_lastSequence,
+            };
+            _pending.Add(minted);
+            AppendLine(minted);
+
+            if (_pending.Count > _maxPending)
+            {
+                var overflow = _pending.Count - _maxPending;
+                _pending.RemoveRange(0, overflow);
+                Rewrite();
+                FileLog.Write($"[ActivityEventOutbox] OVERFLOW: dropped the {overflow} oldest unacknowledged " +
+                              $"events (cap {_maxPending}) - the Gateway has been unreachable too long");
+            }
+            return minted;
+        }
+    }
+
+    /// <summary>The oldest pending events, up to <paramref name="max"/>, in mint order - one push batch.</summary>
+    public IReadOnlyList<ActivityEventRecord> PendingBatch(int max)
+    {
+        lock (_gate)
+            return _pending.Take(Math.Max(0, max)).ToList();
+    }
+
+    /// <summary>
+    /// The Gateway confirmed it durably holds these events (written now, or already-held duplicates -
+    /// both are acknowledgement): delete them from the delivery tail. Persists the survivors atomically.
+    /// </summary>
+    public void Acknowledge(IEnumerable<Guid> eventIds)
+    {
+        var acked = eventIds as HashSet<Guid> ?? new HashSet<Guid>(eventIds);
+        if (acked.Count == 0) return;
+        lock (_gate)
+        {
+            var before = _pending.Count;
+            _pending.RemoveAll(e => acked.Contains(e.EventId));
+            if (_pending.Count != before)
+                Rewrite();
+        }
+    }
+
+    // ---- persistence -------------------------------------------------------------------------------
+
+    private void Load()
+    {
+        if (!File.Exists(_path)) return;
+        var kept = 0;
+        var dropped = 0;
+        foreach (var line in File.ReadAllLines(_path))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                var record = JsonSerializer.Deserialize<ActivityEventRecord>(line, JsonOptions);
+                if (record is null || record.EventId == Guid.Empty) { dropped++; continue; }
+                _pending.Add(record);
+                if (record.DirectorSequence > _lastSequence)
+                    _lastSequence = record.DirectorSequence;
+                kept++;
+            }
+            catch (JsonException)
+            {
+                dropped++; // one corrupt line must not cost the rest of the evidence
+            }
+        }
+        if (kept > 0 || dropped > 0)
+            FileLog.Write($"[ActivityEventOutbox] loaded {kept} pending event(s)" +
+                          (dropped > 0 ? $", skipped {dropped} corrupt line(s)" : "") +
+                          $", sequence resumes at {_lastSequence + 1}");
+    }
+
+    private void AppendLine(ActivityEventRecord record)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        File.AppendAllText(_path, JsonSerializer.Serialize(record, JsonOptions) + Environment.NewLine);
+    }
+
+    /// <summary>Rewrite the whole file atomically (temp + move) - the acknowledgement/overflow path.</summary>
+    private void Rewrite()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        var tmp = _path + ".tmp";
+        File.WriteAllLines(tmp, _pending.Select(e => JsonSerializer.Serialize(e, JsonOptions)));
+        File.Move(tmp, _path, overwrite: true);
+    }
+}

--- a/src/CcDirector.Core/Activity/ActivityEventProducer.cs
+++ b/src/CcDirector.Core/Activity/ActivityEventProducer.cs
@@ -1,0 +1,238 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Activity;
+
+/// <summary>
+/// The Director's activity-evidence producer (docs/PLAN-trustworthy-working-start-2026-07-24.md,
+/// increment 2). OBSERVE-ONLY: it changes no state, gates nothing, and its faults never propagate into the
+/// paths it watches. It records, into the durable outbox bound for the Gateway's activity ledger:
+///
+///  - every SUBMISSION at the session choke points (turn-submitted, with who and from where);
+///  - every authoritative <see cref="ActivityState"/> TRANSITION, each with a SHADOW CAUSE - the evidence
+///    that existed at the moment the current byte-rule made its decision: a submission inside
+///    <see cref="SubmissionWindow"/>, an explicit remote-backend signal, terminal output alone, or an
+///    honest unknown;
+///  - the detector's TERMINAL-OUTPUT-WHILE-SETTLED evidence rows (via
+///    <see cref="RecordTerminalOutputWhileSettled"/>);
+///  - each NEW ASSISTANT REPLY the conversation ingest stores (via <see cref="RecordTurnObserved"/>) -
+///    the ground truth a real turn happened, under a DETERMINISTIC event id so a re-detection of the same
+///    reply replays the same identity instead of duplicating it.
+///
+/// Phase 2 judges the shadow causes against the stored replies; only a driver whose evidence passes the
+/// acceptance gates ever opts into submission-gated authoritative behavior. Nothing here switches on the
+/// agent kind - the kind is recorded as a fact, never branched on.
+/// </summary>
+public sealed class ActivityEventProducer : IDisposable
+{
+    /// <summary>Stamped on every produced event so shadow results stay interpretable across upgrades.</summary>
+    public const string DetectorVersion = "shadow-v1";
+
+    /// <summary>How close a submission must be to a Working start to count as its explanation. Wide enough
+    /// for the submit-protocol round trip, far narrower than any human think-time gap.</summary>
+    internal static readonly TimeSpan SubmissionWindow = TimeSpan.FromSeconds(5);
+
+    /// <summary>How recent terminal output must be for a transition to be attributed to it.</summary>
+    internal static readonly TimeSpan TerminalEchoWindow = TimeSpan.FromSeconds(2);
+
+    private readonly SessionManager _sessionManager;
+    private readonly ActivityEventOutbox _outbox;
+    private readonly ConcurrentDictionary<Guid, Action<ActivityState, ActivityState>> _transitionHandlers = new();
+    private readonly ConcurrentDictionary<Guid, Action<SendSource?, InputOrigin?>> _submitHandlers = new();
+    private readonly ConcurrentDictionary<Guid, string> _lastSubmissionCause = new();
+    private bool _started;
+    private bool _disposed;
+
+    public ActivityEventProducer(SessionManager sessionManager, ActivityEventOutbox outbox)
+    {
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+        _outbox = outbox ?? throw new ArgumentNullException(nameof(outbox));
+    }
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+        _sessionManager.OnSessionCreated += Wire;
+        _sessionManager.OnSessionRemoved += Unwire;
+        foreach (var s in _sessionManager.ListSessions())
+            Wire(s);
+        FileLog.Write($"[ActivityEventProducer] Start (observe-only, version={DetectorVersion})");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _sessionManager.OnSessionCreated -= Wire;
+        _sessionManager.OnSessionRemoved -= Unwire;
+        foreach (var s in _sessionManager.ListSessions())
+            Unwire(s);
+        _transitionHandlers.Clear();
+        _submitHandlers.Clear();
+    }
+
+    internal void Wire(Session session)
+    {
+        Action<ActivityState, ActivityState> onTransition = (old, @new) => Guarded(() => RecordTransition(session, old, @new));
+        Action<SendSource?, InputOrigin?> onSubmit = (source, origin) => Guarded(() => RecordTurnSubmitted(session, source, origin));
+        if (_transitionHandlers.TryAdd(session.Id, onTransition))
+            session.OnActivityStateChanged += onTransition;
+        if (_submitHandlers.TryAdd(session.Id, onSubmit))
+            session.OnTurnSubmitted += onSubmit;
+    }
+
+    internal void Unwire(Session session)
+    {
+        if (_transitionHandlers.TryRemove(session.Id, out var t))
+            session.OnActivityStateChanged -= t;
+        if (_submitHandlers.TryRemove(session.Id, out var s))
+            session.OnTurnSubmitted -= s;
+        _lastSubmissionCause.TryRemove(session.Id, out _);
+    }
+
+    /// <summary>Observation must never break the observed path: every producer entry point is guarded.</summary>
+    private static void Guarded(Action record)
+    {
+        try { record(); }
+        catch (Exception ex) { FileLog.Write($"[ActivityEventProducer] record failed: {ex.Message}"); }
+    }
+
+    // ---- the producers -----------------------------------------------------------------------------
+
+    private void RecordTurnSubmitted(Session session, SendSource? source, InputOrigin? origin)
+    {
+        var cause = SubmissionCause(source, origin);
+        _lastSubmissionCause[session.Id] = cause;
+        _outbox.Enqueue(Base(session) with
+        {
+            EventType = ActivityEventTypes.TurnSubmitted,
+            Cause = cause,
+            SendSource = source?.ToString(),
+            InputOrigin = origin is InputOrigin o ? $"{o.ModalityToken}/{o.SurfaceToken}" : null,
+        });
+    }
+
+    private void RecordTransition(Session session, ActivityState old, ActivityState @new)
+    {
+        _outbox.Enqueue(Base(session) with
+        {
+            EventType = @new == ActivityState.Exited ? ActivityEventTypes.SessionExited : ActivityEventTypes.ActivityTransition,
+            Cause = ClassifyTransition(session, old, @new),
+            PreviousState = old.ToString(),
+            NewState = @new.ToString(),
+        });
+    }
+
+    /// <summary>
+    /// The detector saw terminal output on a SETTLED session that no submission explains - the candidate
+    /// phantom turn, with its bounded evidence. Called by <c>TerminalStateDetector</c> at the flip site.
+    /// </summary>
+    public void RecordTerminalOutputWhileSettled(
+        Session session, long outputByteCount, string? beforeScreenHash, string? afterScreenHash,
+        string? boundedScreenDiff, string detectorMode)
+        => Guarded(() => _outbox.Enqueue(Base(session) with
+        {
+            EventType = ActivityEventTypes.TerminalOutputWhileSettled,
+            Cause = ActivityCauses.TerminalOutputOnly,
+            DetectorMode = detectorMode,
+            OutputByteCount = outputByteCount,
+            BeforeScreenHash = beforeScreenHash,
+            AfterScreenHash = afterScreenHash,
+            BoundedScreenDiff = boundedScreenDiff,
+        }));
+
+    /// <summary>
+    /// The conversation ingest detected a NEW assistant reply - the ground truth that a real turn
+    /// happened. <paramref name="dedupKey"/> is the ingest's own content watermark key; the event id is
+    /// derived from it DETERMINISTICALLY, so the retry path (a reply re-detected because an earlier
+    /// prompt push failed) replays the same identity and the Gateway acknowledges a duplicate instead of
+    /// storing a second observation.
+    /// </summary>
+    public void RecordTurnObserved(Session session, DateTime replyTsUtc, string? contextId, string dedupKey)
+        => Guarded(() => _outbox.Enqueue(Base(session) with
+        {
+            EventId = DeterministicEventId(session.Id, dedupKey),
+            OccurredUtc = replyTsUtc,
+            ContextId = contextId ?? session.ClaudeSessionId,
+            EventType = ActivityEventTypes.TurnObservedInTranscript,
+            Cause = ActivityCauses.DriverCompletion,
+        }));
+
+    // ---- classification ----------------------------------------------------------------------------
+
+    /// <summary>
+    /// The shadow cause of one authoritative transition - the evidence that existed at the moment the
+    /// current rule decided. Recorded, never acted on.
+    /// </summary>
+    internal string ClassifyTransition(Session session, ActivityState old, ActivityState @new)
+    {
+        var now = DateTime.UtcNow;
+        var wasRunning = old is ActivityState.Working or ActivityState.Starting;
+        var isRunning = @new is ActivityState.Working or ActivityState.Starting;
+
+        if (@new == ActivityState.Exited)
+            return ActivityCauses.SessionExit;
+
+        if (isRunning && !wasRunning)
+        {
+            if (session.LastSubmissionAtUtc is DateTime submitted && now - submitted <= SubmissionWindow)
+                return _lastSubmissionCause.TryGetValue(session.Id, out var cause) ? cause : ActivityCauses.OwnerSubmit;
+            if (session.IsRemote)
+                return ActivityCauses.BackendSignal;
+            if (session.Buffer is { } buffer && now - buffer.LastWriteAtUtc <= TerminalEchoWindow)
+                return ActivityCauses.TerminalOutputOnly;
+            return ActivityCauses.Unknown;
+        }
+
+        if (wasRunning && @new is ActivityState.WaitingForInput or ActivityState.WaitingForPerm)
+            return ActivityCauses.QuietThreshold;
+
+        return ActivityCauses.Unknown;
+    }
+
+    /// <summary>Who drove a submission, from the same facts the owner-turn rule reads: a tagged human
+    /// origin or an owner-driven source is the owner; agent and framework name themselves; a raw submit
+    /// byte with no origin and no source is honestly unknown.</summary>
+    internal static string SubmissionCause(SendSource? source, InputOrigin? origin)
+    {
+        if (origin is not null || source is SendSource.UserInput or SendSource.Delivery)
+            return ActivityCauses.OwnerSubmit;
+        return source switch
+        {
+            SendSource.Agent => ActivityCauses.AgentSubmit,
+            SendSource.Framework => ActivityCauses.FrameworkSubmit,
+            _ => ActivityCauses.Unknown,
+        };
+    }
+
+    // ---- record plumbing ---------------------------------------------------------------------------
+
+    /// <summary>The shared facts of every event this Director produces. The outbox mints the identity.</summary>
+    private ActivityEventRecord Base(Session session) => new()
+    {
+        EventId = Guid.Empty,
+        DirectorSequence = 0,
+        OccurredUtc = DateTime.UtcNow,
+        DirectorId = string.IsNullOrWhiteSpace(_sessionManager.DirectorId) ? "unknown-director" : _sessionManager.DirectorId,
+        SessionId = session.Id.ToString(),
+        Machine = Environment.MachineName,
+        AgentKind = session.AgentKind.ToString(),
+        ContextId = session.ClaudeSessionId,
+        EventType = ActivityEventTypes.ActivityTransition,
+        Cause = ActivityCauses.Unknown,
+        DetectorVersion = DetectorVersion,
+    };
+
+    /// <summary>A stable event id from the observation's content key: the same reply always derives the
+    /// same id, which is what makes transcript re-detection idempotent end to end.</summary>
+    internal static Guid DeterministicEventId(Guid sessionId, string dedupKey)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"turn-observed|{sessionId:N}|{dedupKey}"));
+        return new Guid(bytes.AsSpan(0, 16));
+    }
+}

--- a/src/CcDirector.Core/Activity/ActivityEvidence.cs
+++ b/src/CcDirector.Core/Activity/ActivityEvidence.cs
@@ -1,0 +1,72 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CcDirector.Core.Activity;
+
+/// <summary>
+/// Pure helpers for the BOUNDED terminal evidence an output-while-settled event carries. The July 24
+/// incident could not be fully explained because nobody kept what the repaint changed; these keep exactly
+/// enough to answer that next time - a normalized body hash on each side and the first few changed rows -
+/// and never the raw byte stream. Pure and allocation-light so they can run on the PTY producer thread
+/// and be unit tested directly.
+/// </summary>
+public static class ActivityEvidence
+{
+    /// <summary>At most this many changed rows are quoted in a diff.</summary>
+    public const int MaxDiffRows = 8;
+
+    /// <summary>The hard character cap on one bounded diff (inside the ledger's own 4000 cap).</summary>
+    public const int MaxDiffChars = 2000;
+
+    /// <summary>A normalized 128-bit content hash of a screen body (trailing whitespace per row ignored,
+    /// so a repaint that only re-pads columns hashes identically). Empty input hashes too - "no body" and
+    /// "blank body" must still compare stably across events.</summary>
+    public static string BodyHash(string body)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Normalize(body))))[..32].ToLowerInvariant();
+
+    /// <summary>
+    /// The first changed rows between two screen bodies, each quoted as "row N: text", bounded by
+    /// <see cref="MaxDiffRows"/> and <see cref="MaxDiffChars"/>. A row present before and gone after is
+    /// quoted as removed. When more rows changed than are quoted, the tail says how many were left out -
+    /// a bounded diff that reads as complete would lie about coverage.
+    /// </summary>
+    public static string BoundedRowDiff(string beforeBody, string afterBody)
+    {
+        var before = Normalize(beforeBody).Split('\n');
+        var after = Normalize(afterBody).Split('\n');
+        var rows = Math.Max(before.Length, after.Length);
+
+        var quoted = new StringBuilder();
+        var changed = 0;
+        var quotedRows = 0;
+        for (var i = 0; i < rows; i++)
+        {
+            var b = i < before.Length ? before[i] : null;
+            var a = i < after.Length ? after[i] : null;
+            if (string.Equals(b, a, StringComparison.Ordinal)) continue;
+            changed++;
+            if (quotedRows >= MaxDiffRows || quoted.Length >= MaxDiffChars) continue;
+            var line = a is null ? $"row {i}: <removed>" : $"row {i}: {a}";
+            if (quoted.Length + line.Length + 1 > MaxDiffChars) continue;
+            if (quoted.Length > 0) quoted.Append('\n');
+            quoted.Append(line);
+            quotedRows++;
+        }
+
+        if (changed == 0)
+            return "";
+        if (changed > quotedRows)
+            quoted.Append('\n').Append($"({changed - quotedRows} more changed row(s) not quoted)");
+        return quoted.ToString();
+    }
+
+    /// <summary>Trailing whitespace per row is presentation, not content - strip it before comparing.</summary>
+    private static string Normalize(string body)
+    {
+        if (string.IsNullOrEmpty(body)) return "";
+        var rows = body.Split('\n');
+        for (var i = 0; i < rows.Length; i++)
+            rows[i] = rows[i].TrimEnd();
+        return string.Join('\n', rows);
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -2033,6 +2033,7 @@ public sealed class Session : IDisposable
             // session the owner parked. See IsOwnerDriven for the same rule on the text path.
             if (origin is not null)
                 StampOwnerTurn();
+            StampSubmission(source: null, origin);
             SetActivityState(ActivityState.Working);
         }
     }
@@ -2163,6 +2164,33 @@ public sealed class Session : IDisposable
         FileLog.Write($"[Session] Owner drove a turn: session={Id}, atUtc={LastOwnerTurnAtUtc:O}");
     }
 
+    /// <summary>
+    /// When ANY successful submission last entered this session - typed Enter, Cockpit, voice, a queue
+    /// drain, an agent-to-agent prompt - or null if none has. A FACT, like <see cref="LastOwnerTurnAtUtc"/>,
+    /// but answering a different question: that one says whether the OWNER drove a turn (it gates holds);
+    /// this one says whether A TURN EXISTS AT ALL, whoever drove it. The activity shadow classifier
+    /// (docs/PLAN-trustworthy-working-start-2026-07-24.md) reads it to tell a submission-explained Working
+    /// start from one explained only by terminal output. Do not conflate the two.
+    /// </summary>
+    public DateTime? LastSubmissionAtUtc { get; private set; }
+
+    /// <summary>
+    /// Fires when a submission enters this session, at the same choke points that set
+    /// <see cref="LastSubmissionAtUtc"/>. Args: the send source (null on the raw-byte path -
+    /// <see cref="SendInput"/> carries no <see cref="SendSource"/>) and the input origin (null when no
+    /// human surface tagged it). The activity producer subscribes to record turn-submitted evidence.
+    /// </summary>
+    public event Action<SendSource?, InputOrigin?>? OnTurnSubmitted;
+
+    /// <summary>Stamp the submission fact and notify observers. An observer's fault must never break the
+    /// submission that already happened, so the fan-out is guarded like every other session event.</summary>
+    private void StampSubmission(SendSource? source, InputOrigin? origin)
+    {
+        LastSubmissionAtUtc = DateTime.UtcNow;
+        try { OnTurnSubmitted?.Invoke(source, origin); }
+        catch (Exception ex) { FileLog.Write($"[Session] OnTurnSubmitted handler failed: session={Id}, {ex.Message}"); }
+    }
+
     public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
@@ -2190,6 +2218,7 @@ public sealed class Session : IDisposable
         // hold die 90 seconds later when another agent messaged it. See IsOwnerDriven.
         if (IsOwnerDriven(source, origin))
             StampOwnerTurn();
+        StampSubmission(source, origin);
         SetActivityState(ActivityState.Working);
         // DevThrottle Stats: a SendTextAsync is exactly one submitted turn. Count it (plus its character
         // volume) for the tagged origin. Null origin = not a human turn - either another agent (counted on

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -115,6 +115,15 @@ public static class CcStorage
     public static string StateChanges() => Path.Combine(Base(), "state-changes");
 
     /// <summary>
+    /// The durable activity-event outbox: base/activity-outbox/outbox.jsonl. Delivery state for the
+    /// Gateway activity ledger (docs/PLAN-trustworthy-working-start-2026-07-24.md): events wait here,
+    /// each minted ONCE with its id and sequence, until the Gateway acknowledges the batch - the Gateway
+    /// is the only durable history, this file is only the not-yet-acknowledged tail. Composes the path
+    /// without touching disk; the outbox creates the directory.
+    /// </summary>
+    public static string ActivityOutbox() => Path.Combine(Base(), "activity-outbox", "outbox.jsonl");
+
+    /// <summary>
     /// Per-utterance resumable voice-chunk staging: base/voice-utterances/&lt;uploadId&gt;/. Transient - the
     /// service deletes each utterance directory after transcription, and creates them itself, so this
     /// composes the path without touching disk. Resolved here for the same reason as

--- a/src/CcDirector.Core/Storage/ConversationIngestor.cs
+++ b/src/CcDirector.Core/Storage/ConversationIngestor.cs
@@ -75,11 +75,19 @@ public sealed class ConversationIngestor : IDisposable
 
     /// <param name="sessionManager">The sessions to watch.</param>
     /// <param name="sink">Where captured messages go - the Gateway in production.</param>
-    public ConversationIngestor(SessionManager sessionManager, IPromptSink sink)
+    /// <param name="activityProducer">The activity-evidence producer (docs/PLAN-trustworthy-working-start-
+    /// 2026-07-24.md): each NEW assistant reply detected here is also recorded as a
+    /// turn-observed-in-transcript event - the ground truth that a real turn happened, which the shadow
+    /// Working classifier is judged against. Optional; null means no evidence is recorded.</param>
+    public ConversationIngestor(SessionManager sessionManager, IPromptSink sink,
+        Activity.ActivityEventProducer? activityProducer = null)
     {
         _sessionManager = sessionManager;
         _sink = sink;
+        _activityProducer = activityProducer;
     }
+
+    private readonly Activity.ActivityEventProducer? _activityProducer;
 
     public void Start()
     {
@@ -202,6 +210,15 @@ public sealed class ConversationIngestor : IDisposable
                 Text = text,
             });
             pushed.Add((ts, message.Role, text, fromAgent));
+
+            // Ground truth for the shadow Working classifier: a NEW assistant reply proves a real turn
+            // happened. Recorded at DETECTION time, not after the prompt push - the event id derives
+            // deterministically from the same content identity this loop dedupes on, so a re-detection
+            // (an earlier prompt push failed and the message comes around again) replays the same
+            // identity and the Gateway acknowledges a duplicate instead of storing a second observation.
+            if (!isUser)
+                _activityProducer?.RecordTurnObserved(session, ts, ContextIdFor(session, message),
+                    $"{scope}|{(fromAgent ? ts.ToString("O") : "no-ts")}|{text}");
         }
 
         if (toPush.Count == 0) return;

--- a/src/CcDirector.Core/Wingman/TerminalStateDetector.cs
+++ b/src/CcDirector.Core/Wingman/TerminalStateDetector.cs
@@ -50,6 +50,7 @@ public sealed class TerminalStateDetector : IDisposable
 
     private readonly SessionManager _sessionManager;
     private readonly bool _driveState;
+    private readonly Activity.ActivityEventProducer? _activityProducer;
     private readonly ConcurrentDictionary<Guid, Watcher> _watchers = new();
     private bool _started;
     private bool _disposed;
@@ -58,10 +59,19 @@ public sealed class TerminalStateDetector : IDisposable
     /// When true the detector is authoritative and sets <see cref="Session.ActivityState"/> to
     /// Working on byte activity. When false it is observe-only (logs, writes nothing).
     /// </param>
-    public TerminalStateDetector(SessionManager sessionManager, bool driveState)
+    /// <param name="activityProducer">
+    /// The shadow-evidence producer (docs/PLAN-trustworthy-working-start-2026-07-24.md). When present,
+    /// a flip from settled to active that NO recent submission explains records a
+    /// terminal-output-while-settled evidence event - the candidate phantom turn - with the bounded
+    /// screen evidence. Purely observational: the detector's rules and writes are byte-for-byte
+    /// unchanged whether this is null or not.
+    /// </param>
+    public TerminalStateDetector(SessionManager sessionManager, bool driveState,
+        Activity.ActivityEventProducer? activityProducer = null)
     {
         _sessionManager = sessionManager;
         _driveState = driveState;
+        _activityProducer = activityProducer;
     }
 
     public void Start()
@@ -97,7 +107,7 @@ public sealed class TerminalStateDetector : IDisposable
         // (a queued run emits no bytes yet is genuinely Working), so skip them entirely.
         if (session.BackendType == Backends.SessionBackendType.GitHubActions) return;
         if (_watchers.ContainsKey(session.Id)) return;
-        var w = new Watcher(session, _driveState);
+        var w = new Watcher(session, _driveState, _activityProducer);
         if (_watchers.TryAdd(session.Id, w))
             w.Start();
         else
@@ -127,8 +137,16 @@ public sealed class TerminalStateDetector : IDisposable
         private readonly Session _session;
         private readonly CircularTerminalBuffer _buffer;
         private readonly bool _driveState;
+        private readonly Activity.ActivityEventProducer? _activityProducer;
         private readonly Action<byte[]> _onBytes;
         private readonly System.Threading.Timer _quietTimer;
+
+        // The screen body captured at the last flip to settled, and its normalized hash - the "before"
+        // side of the bounded evidence an unexplained wake records. Touched only on the PTY producer
+        // thread and the quiet-timer thread, which never race the same flip (the flip direction decides
+        // which side reads/writes it).
+        private string? _settledBody;
+        private string? _settledBodyHash;
 
         // True for agents whose idle terminal never goes byte-silent (Grok): an animated footer
         // keeps repainting forever. For these the byte rule is replaced by a screen-body rule.
@@ -144,11 +162,12 @@ public sealed class TerminalStateDetector : IDisposable
         private string? _lastBody;
         private long _lastBodyCheckTicks;
 
-        public Watcher(Session session, bool driveState)
+        public Watcher(Session session, bool driveState, Activity.ActivityEventProducer? activityProducer)
         {
             _session = session;
             _buffer = session.Buffer!;
             _driveState = driveState;
+            _activityProducer = activityProducer;
             _continuousIdle = session.Driver.EmitsContinuousIdleOutput;
             _onBytes = OnBytes;
             _quietTimer = new System.Threading.Timer(OnQuiet, null, Timeout.Infinite, Timeout.Infinite);
@@ -218,6 +237,7 @@ public sealed class TerminalStateDetector : IDisposable
             {
                 _active = true;
                 FileLog.Write($"[TerminalStateDetector] {_session.Id} terminal=ACTIVE (byte) | hook={_session.ActivityState}");
+                RecordUnexplainedWakeEvidence(bytes.Length, "byte");
                 if (_driveState) _session.ApplyTerminalActivityState(ActivityState.Working);
             }
             ArmQuietTimer(); // restart the idle countdown on every byte
@@ -273,9 +293,34 @@ public sealed class TerminalStateDetector : IDisposable
             {
                 _active = true;
                 FileLog.Write($"[TerminalStateDetector] {_session.Id} terminal=ACTIVE (body) | hook={_session.ActivityState}");
+                RecordUnexplainedWakeEvidence(byteCount: 0, "body");
                 if (_driveState) _session.ApplyTerminalActivityState(ActivityState.Working);
             }
             ArmQuietTimer();
+        }
+
+        /// <summary>
+        /// Shadow evidence at the flip from settled to active (docs/PLAN-trustworthy-working-start-
+        /// 2026-07-24.md): when NO recent submission explains this wake, record a terminal-output-while-
+        /// settled event carrying the bounded before/after evidence - the candidate phantom turn the
+        /// July 24 snooze died to. A wake inside the submission window is the ordinary echo of a
+        /// submitted turn and records nothing. Observational only; the state write that follows is
+        /// untouched, and the producer guards its own faults.
+        /// </summary>
+        private void RecordUnexplainedWakeEvidence(long byteCount, string mode)
+        {
+            if (_activityProducer is null) return;
+            if (_session.LastSubmissionAtUtc is DateTime submitted
+                && DateTime.UtcNow - submitted <= Activity.ActivityEventProducer.SubmissionWindow)
+                return;
+
+            string? afterBody = TryReadScreenBody(out var body) ? body : null;
+            var afterHash = afterBody is null ? null : Activity.ActivityEvidence.BodyHash(afterBody);
+            var diff = afterBody is not null && _settledBody is not null
+                ? Activity.ActivityEvidence.BoundedRowDiff(_settledBody, afterBody)
+                : null;
+            _activityProducer.RecordTerminalOutputWhileSettled(
+                _session, byteCount, _settledBodyHash, afterHash, diff, mode);
         }
 
         private void OnQuiet(object? state)
@@ -314,6 +359,15 @@ public sealed class TerminalStateDetector : IDisposable
             // badge. This is the dumb time-based rule -- we do not try to tell "finished cleanly"
             // apart from "blocked on a question"; a long silence means "needs you".
             _active = false;
+
+            // Capture the settled screen body - the "before" side of the evidence a later
+            // unexplained wake records. Only when the shadow producer is wired; the snapshot is
+            // locked, and paying for it every settle with nobody reading it would be waste.
+            if (_activityProducer is not null && TryReadScreenBody(out var settledBody))
+            {
+                _settledBody = settledBody;
+                _settledBodyHash = Activity.ActivityEvidence.BodyHash(settledBody);
+            }
             FileLog.Write($"[TerminalStateDetector] {_session.Id} terminal=NEEDS-YOU after {idle.TotalSeconds:F1}s silent | hook={_session.ActivityState}");
             if (_driveState) _session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
         }


### PR DESCRIPTION
## Why

Increment 2 of docs/PLAN-trustworthy-working-start-2026-07-24.md. The Gateway's tenant-scoped activity ledger shipped in the previous pull request; this makes the Director actually produce the evidence: what caused each Working start, whether a submission or only terminal output explains it, and the transcript ground truth the shadow classifier will be judged against in phase 2. Observe-only - no state transition, detector rule, snooze, or display behavior changes.

## What

- **Session**: stamps LastSubmissionAtUtc and raises a turn-submitted notification at both input choke points (raw submit byte, text path). Deliberately separate from the owner-turn fact that gates holds.
- **ActivityEventProducer**: records every submission and every authoritative activity-state transition with a shadow cause - a submission within five seconds, an explicit remote backend, terminal output alone, or an honest unknown. Session exits are their own event type. Never branches on agent kind; records it as a fact.
- **TerminalStateDetector**: at a flip from settled to active that no recent submission explains, records the candidate phantom turn with bounded evidence - byte count, before and after normalized screen-body hashes, first changed rows. Never the raw byte stream. Detector rules and writes byte-for-byte unchanged.
- **ConversationIngestor**: records each new assistant reply as turn-observed-in-transcript with a deterministic event id derived from the reply's content identity, so a re-detection after a failed prompt push replays the same identity and the Gateway acknowledges a duplicate instead of storing a second observation.
- **ActivityEventOutbox**: durable JSONL delivery tail under the Director root. Event ids and the monotonic per-director sequence are minted once, survive restarts and corrupt lines, and are deleted only on Gateway acknowledgement. Capped at 20,000 events with a loud oldest-first overflow drop.
- **ActivityEventUploader**: drains the outbox to POST /activity-events/batch every 30 seconds through the current Gateway client, treating written-plus-duplicates as full acknowledgement; a partial or failed push keeps everything and retries with the same identities.

## Proof

- Full Core suite on the branch: 3536 passed, 0 failed (29 new tests: outbox mint/restart/acknowledge/corruption/cap, producer shadow causes at every choke point, deterministic transcript-observation identity, bounded-evidence helpers).
- Full Gateway suite on the branch: 3766 passed, 0 failed.
- The two commits that landed on main during the runs touch only Cockpit TypeScript and a documentation page - no overlap with this change; rebased cleanly on top.

Phase 2 (judging the shadow rule on real fleet usage) needs this deployed; the hosted Gateway release follows the merge.
