### PR TITLE
Dictionary suggestions: model-screened daily scan replaces the two-minute heuristic recompute

### DIFF
--- a/apps/cockpit/src/dictionary/DictionaryView.test.tsx
+++ b/apps/cockpit/src/dictionary/DictionaryView.test.tsx
@@ -5,28 +5,40 @@ import type {
   Dictionary,
   DictionarySuggestion,
   DismissedTerm,
+  SuggestionsResult,
 } from "@devthrottle/client-core/dictation/dictionaryClient";
 
-// Rendered proof for the dictionary-suggestions panel (devthrottle #2075). The mining, the API and the
-// tenant scoping are proven on the server; this proves the Cockpit page actually PAINTS the suggestions
-// with their evidence, adds the ticked ones on one press, and dismisses a row - the three acts the screen
-// exists for. The Gateway client is mocked so the view is driven without a running Gateway.
+// Rendered proof for the dictionary-suggestions panel (devthrottle #2075, redesigned in #2115). The
+// scanning, screening, the API and the tenant scoping are proven on the server; this proves the Cockpit
+// page actually PAINTS the stored scan - the suggestions with their evidence, the last-scan time, the
+// Scan-now button, and the screening-unavailable notice - adds the ticked ones on one press, and
+// dismisses a row. The Gateway client is mocked so the view is driven without a running Gateway.
 
-const { getDictionary, saveDictionary, getSuggestions, applySuggestions, dismissSuggestion, getDismissed, restoreDismissed } =
-  vi.hoisted(() => ({
-    getDictionary: vi.fn(),
-    saveDictionary: vi.fn(),
-    getSuggestions: vi.fn(),
-    applySuggestions: vi.fn(),
-    dismissSuggestion: vi.fn(),
-    getDismissed: vi.fn(),
-    restoreDismissed: vi.fn(),
-  }));
+const {
+  getDictionary,
+  saveDictionary,
+  getSuggestions,
+  scanSuggestions,
+  applySuggestions,
+  dismissSuggestion,
+  getDismissed,
+  restoreDismissed,
+} = vi.hoisted(() => ({
+  getDictionary: vi.fn(),
+  saveDictionary: vi.fn(),
+  getSuggestions: vi.fn(),
+  scanSuggestions: vi.fn(),
+  applySuggestions: vi.fn(),
+  dismissSuggestion: vi.fn(),
+  getDismissed: vi.fn(),
+  restoreDismissed: vi.fn(),
+}));
 
 vi.mock("@devthrottle/client-core/dictation/dictionaryClient", () => ({
   getDictionary,
   saveDictionary,
   getSuggestions,
+  scanSuggestions,
   applySuggestions,
   dismissSuggestion,
   getDismissed,
@@ -54,17 +66,28 @@ const MINDZIE: DictionarySuggestion = {
   totalCount: 91,
 };
 
+function scanResult(overrides?: Partial<SuggestionsResult>): SuggestionsResult {
+  return {
+    suggestions: [MINDZIE],
+    count: 1,
+    scannedAtUtc: "2026-07-24T00:05:00Z",
+    screeningOk: true,
+    screeningError: "",
+    ...overrides,
+  };
+}
+
 describe("DictionaryView suggestions panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getDictionary.mockResolvedValue(EMPTY_DICT);
     saveDictionary.mockResolvedValue(EMPTY_DICT);
-    getSuggestions.mockResolvedValue({ suggestions: [MINDZIE], count: 1 });
+    getSuggestions.mockResolvedValue(scanResult());
     getDismissed.mockResolvedValue([] as DismissedTerm[]);
   });
   afterEach(() => cleanup());
 
-  it("renders each suggestion with its evidence and counts", async () => {
+  it("renders each suggestion with its evidence, counts, and the last-scan time", async () => {
     render(<DictionaryView />);
 
     expect(await screen.findByText("1 suggestion from your recent dictations")).toBeTruthy();
@@ -74,6 +97,9 @@ describe("DictionaryView suggestions panel", () => {
     expect(screen.getByText("wrong 47 of 91 times")).toBeTruthy();
     // Pre-ticked, so the Add button offers all of them.
     expect(screen.getByText("Add 1 selected to dictionary")).toBeTruthy();
+    // The scan row: when the stored scan ran, and the Scan-now doorway.
+    expect(screen.getByText(/Last scan:/)).toBeTruthy();
+    expect(screen.getByText("Scan now")).toBeTruthy();
   });
 
   it("adds the ticked terms on one press", async () => {
@@ -106,7 +132,7 @@ describe("DictionaryView suggestions panel", () => {
     await screen.findByText("mindzie");
 
     // After dismiss, the refresh returns no suggestions and one dismissed term.
-    getSuggestions.mockResolvedValue({ suggestions: [], count: 0 });
+    getSuggestions.mockResolvedValue(scanResult({ suggestions: [], count: 0 }));
     getDismissed.mockResolvedValue([
       { term: "mindzie", variants: [{ heard: "Mindsee", count: 20 }], wrongCount: 47, totalCount: 91, dismissedAtUtc: "2026-07-24T12:00:00Z" },
     ]);
@@ -118,12 +144,43 @@ describe("DictionaryView suggestions panel", () => {
     expect(await screen.findByText("Dismissed terms (1)")).toBeTruthy();
   });
 
-  it("shows the quiet zero state when there are no suggestions", async () => {
-    getSuggestions.mockResolvedValue({ suggestions: [], count: 0 });
+  it("shows the never-scanned zero state with a Scan now doorway before any scan", async () => {
+    getSuggestions.mockResolvedValue(
+      scanResult({ suggestions: [], count: 0, scannedAtUtc: null }),
+    );
     render(<DictionaryView />);
 
-    expect(await screen.findByText(/No suggestions right now/)).toBeTruthy();
+    expect(await screen.findByText(/No scan has run yet/)).toBeTruthy();
+    expect(screen.getByText("Never scanned")).toBeTruthy();
+    expect(screen.getByText("Scan now")).toBeTruthy();
     // No panel header, no Add button.
     expect(screen.queryByText(/suggestions from your recent dictations/)).toBeNull();
+  });
+
+  it("Scan now runs a scan and paints its result", async () => {
+    getSuggestions.mockResolvedValue(
+      scanResult({ suggestions: [], count: 0, scannedAtUtc: null }),
+    );
+    scanSuggestions.mockResolvedValue(scanResult());
+    render(<DictionaryView />);
+
+    fireEvent.click(await screen.findByText("Scan now"));
+
+    await waitFor(() => expect(scanSuggestions).toHaveBeenCalled());
+    expect(await screen.findByText("mindzie")).toBeTruthy();
+    expect(screen.getByText(/Last scan:/)).toBeTruthy();
+  });
+
+  it("says so when the screening model was unreachable on the last scan", async () => {
+    getSuggestions.mockResolvedValue(
+      scanResult({ screeningOk: false, screeningError: "model unreachable" }),
+    );
+    render(<DictionaryView />);
+
+    await screen.findByText("mindzie");
+    expect(
+      screen.getByText(/The screening service could not be reached on the last scan/),
+    ).toBeTruthy();
+    expect(screen.getByText(/model unreachable/)).toBeTruthy();
   });
 });

--- a/apps/cockpit/src/dictionary/DictionaryView.tsx
+++ b/apps/cockpit/src/dictionary/DictionaryView.tsx
@@ -4,6 +4,7 @@ import {
   getDictionary,
   saveDictionary,
   getSuggestions,
+  scanSuggestions,
   applySuggestions,
   dismissSuggestion,
   getDismissed,
@@ -11,6 +12,7 @@ import {
   type Dictionary,
   type DictionarySuggestion,
   type DismissedTerm,
+  type SuggestionsResult,
 } from "@devthrottle/client-core/dictation/dictionaryClient";
 import {
   addMistranscriptionTerm,
@@ -28,6 +30,14 @@ import { ConfirmDialog } from "../components";
 //
 // The Gateway is the single source of truth for this glossary: it is used by phone-recording
 // transcription and by live dictation/Speak on every Director connected to this Gateway.
+// The "Last scan: ..." label, in the viewer's local time. Null means no scan has ever run.
+function scanLabel(scannedAtUtc: string | null): string {
+  if (scannedAtUtc === null) return "Never scanned";
+  const when = new Date(scannedAtUtc);
+  if (Number.isNaN(when.getTime())) return "Never scanned";
+  return `Last scan: ${when.toLocaleString()}`;
+}
+
 export function DictionaryView() {
   const [dict, setDict] = useState<Dictionary | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -46,13 +56,19 @@ export function DictionaryView() {
   const [termNotice, setTermNotice] = useState("");
   const [variantNotices, setVariantNotices] = useState<Record<string, string>>({});
 
-  // ---- suggestions (devthrottle #2075) ----
-  // The server-mined terms the model keeps getting wrong that are not yet in the glossary. The client is
-  // dumb: it renders the ranked list, the evidence, and the count exactly as the Gateway computed them.
+  // ---- suggestions (devthrottle #2075, redesigned in #2115) ----
+  // The stored result of the latest scan (daily per tenant, or the Scan-now button). The client is dumb:
+  // it renders the list, the evidence, the count, the scan time, and the screening state exactly as the
+  // Gateway computed them.
   const [suggestions, setSuggestions] = useState<DictionarySuggestion[]>([]);
-  // Which suggested terms are ticked (pre-ticked, since the ranked list is already high-confidence).
+  // When the latest scan ran (null = no scan has ever run), and the Gateway-ruled screening state.
+  const [scannedAtUtc, setScannedAtUtc] = useState<string | null>(null);
+  const [screeningOk, setScreeningOk] = useState(true);
+  const [screeningError, setScreeningError] = useState("");
+  // Which suggested terms are ticked (pre-ticked, since the screened list is already high-confidence).
   const [selected, setSelected] = useState<Record<string, boolean>>({});
   const [suggestBusy, setSuggestBusy] = useState(false);
+  const [scanning, setScanning] = useState(false);
   const [suggestMsg, setSuggestMsg] = useState("");
   // The dismissed terms and whether the (initially collapsed) Dismissed section is open.
   const [dismissed, setDismissed] = useState<DismissedTerm[]>([]);
@@ -97,23 +113,30 @@ export function DictionaryView() {
     };
   }, []);
 
-  // Load the suggestions and dismissed terms separately from the glossary (devthrottle #2075). A failure
-  // here must not break the glossary editor - the panel just stays empty - so it is swallowed.
+  // Fold one scan result (a fresh read or a Scan-now response) into the panel state. Pre-tick every
+  // suggested term - the screened list is already high-confidence, so the happy path is one press -
+  // while preserving any explicit user un-ticks for terms still present.
+  const applyScanResult = useCallback((result: SuggestionsResult) => {
+    setSuggestions(result.suggestions);
+    setScannedAtUtc(result.scannedAtUtc);
+    setScreeningOk(result.screeningOk);
+    setScreeningError(result.screeningError);
+    setSelected((prev) => {
+      const next: Record<string, boolean> = {};
+      for (const s of result.suggestions) next[s.term] = prev[s.term] ?? true;
+      return next;
+    });
+  }, []);
+
+  // Load the stored suggestions and dismissed terms separately from the glossary (devthrottle #2075).
+  // A failure here must not break the glossary editor - the panel just stays empty - so it is swallowed.
   const refreshSuggestions = useCallback(async () => {
     try {
-      const result = await getSuggestions();
-      setSuggestions(result.suggestions);
-      // Pre-tick every suggested term: the ranked list is already filtered to high-confidence terms, so
-      // the happy path is one press. Preserve any explicit user un-ticks for terms still present.
-      setSelected((prev) => {
-        const next: Record<string, boolean> = {};
-        for (const s of result.suggestions) next[s.term] = prev[s.term] ?? true;
-        return next;
-      });
+      applyScanResult(await getSuggestions());
     } catch {
       /* leave the panel empty if suggestions cannot be loaded */
     }
-  }, []);
+  }, [applyScanResult]);
 
   const refreshDismissed = useCallback(async () => {
     try {
@@ -233,8 +256,24 @@ export function DictionaryView() {
     markDirty();
   };
 
-  // ---- suggestions (devthrottle #2075) ----
+  // ---- suggestions (devthrottle #2075 / #2115) ----
   const selectedCount = suggestions.filter((s) => selected[s.term]).length;
+
+  // Run a scan NOW: mine the stored transcripts and have the screening model judge any new candidates.
+  // The scheduled scan runs daily just after midnight in this account's time zone; this button is for
+  // "I just dictated new vocabulary all day and want the suggestions now".
+  const scanNow = async () => {
+    setScanning(true);
+    setSuggestMsg("Scanning your recent dictations...");
+    try {
+      applyScanResult(await scanSuggestions());
+      setSuggestMsg("");
+    } catch (err) {
+      setSuggestMsg(`scan failed: ${gatewayErrorMessage(err)}`);
+    } finally {
+      setScanning(false);
+    }
+  };
 
   const toggleSelected = (term: string) =>
     setSelected((prev) => ({ ...prev, [term]: !prev[term] }));
@@ -354,9 +393,28 @@ export function DictionaryView() {
                   </h2>
                 </div>
                 <p className="dc-hint">
-                  We compared what the model heard against your corrected text. These terms keep coming out
-                  wrong and are not in your dictionary yet. Nothing changes until you press Add.
+                  We scanned your recent dictations for distinctive terms the speech model keeps
+                  misspelling, and screened out ordinary words. Nothing changes until you press Add.
                 </p>
+
+                <div className="dc-scanrow">
+                  <span className="dc-fineprint">{scanLabel(scannedAtUtc)}</span>
+                  <button
+                    className="dc-textlink"
+                    type="button"
+                    disabled={scanning || suggestBusy}
+                    onClick={() => void scanNow()}
+                  >
+                    {scanning ? "Scanning..." : "Scan now"}
+                  </button>
+                </div>
+
+                {!screeningOk && (
+                  <p className="dc-notice" role="status">
+                    The screening service could not be reached on the last scan, so new candidates are not
+                    shown yet ({screeningError}). The terms below were screened earlier.
+                  </p>
+                )}
 
                 {suggestions.map((s) => (
                   <div className="dc-srow" key={s.term}>
@@ -413,10 +471,20 @@ export function DictionaryView() {
                 <div className="dc-quiet-line">
                   <span className="dc-tick">OK</span>
                   <span>
-                    No suggestions right now. We keep comparing your dictations against your dictionary and
-                    will flag terms the model keeps getting wrong.
+                    {scannedAtUtc === null
+                      ? "No scan has run yet. A scan runs every night, or press Scan now."
+                      : "No suggestions right now. We scan your dictations nightly for distinctive terms the model keeps getting wrong."}
                   </span>
                   <div className="dc-spacer" />
+                  <span className="dc-fineprint">{scanLabel(scannedAtUtc)}</span>
+                  <button
+                    className="dc-textlink"
+                    type="button"
+                    disabled={scanning}
+                    onClick={() => void scanNow()}
+                  >
+                    {scanning ? "Scanning..." : "Scan now"}
+                  </button>
                   {dismissed.length > 0 && (
                     <button
                       className="dc-textlink"
@@ -427,6 +495,12 @@ export function DictionaryView() {
                     </button>
                   )}
                 </div>
+                {!screeningOk && (
+                  <p className="dc-notice" role="status">
+                    The screening service could not be reached on the last scan, so new candidates are not
+                    shown yet ({screeningError}).
+                  </p>
+                )}
                 {suggestMsg !== "" && (
                   <p className="dc-notice" role="status">
                     {suggestMsg}

--- a/apps/cockpit/src/dictionary/dictionary.css
+++ b/apps/cockpit/src/dictionary/dictionary.css
@@ -310,6 +310,14 @@
   font-size: 12px;
 }
 
+/* The "Last scan: ... / Scan now" row under the suggestions hint (devthrottle #2115). */
+.dc-scanrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
 /* Zero state: one quiet reassuring line, no badge, no nag. */
 .dc-quiet-line {
   display: flex;

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -18,6 +18,7 @@ import {
 } from "@devthrottle/client-core/fleet/fleetClient";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { getGatewaySettings } from "@devthrottle/client-core/settings/settingsClient";
 import { classify, dotHex, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { useVisiblePolling } from "@devthrottle/client-core/polling/useVisiblePolling";
 import { clockLabel, relativeTime, repoBasename } from "../fleet/format";
@@ -206,9 +207,27 @@ export function ScheduleView() {
     [loadDirectors],
   );
 
+  // The account's time zone (the Settings page value), read once so a NEW job's time zone defaults to
+  // it instead of starting empty - the account setting is the one place time zone lives (issue #2115).
+  // Editing an existing job keeps that job's own stored zone.
+  const [accountTimeZone, setAccountTimeZone] = useState("");
+  useEffect(() => {
+    let cancelled = false;
+    void getGatewaySettings()
+      .then((s) => {
+        if (!cancelled) setAccountTimeZone(s.timeZone);
+      })
+      .catch(() => {
+        /* the form simply starts with an empty zone when settings cannot be read */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const openCreate = useCallback(() => {
-    openForm(EMPTY_FORM);
-  }, [openForm]);
+    openForm({ ...EMPTY_FORM, timeZone: accountTimeZone });
+  }, [openForm, accountTimeZone]);
 
   const openEdit = useCallback(
     (job: CronJob) => {

--- a/docs/reviews/dictionary-screened-scan-proof-2026-07-24.md
+++ b/docs/reviews/dictionary-screened-scan-proof-2026-07-24.md
@@ -1,0 +1,58 @@
+# Dictionary suggestions: model-screened daily scan - validation record (issue #2115)
+
+Date: 2026-07-24. Corpus: the owner's real dictation logs, 4,107 utterances
+(`dictation/sessions/*.jsonl`, RawTranscript field). Method: the SHIPPED miner
+(`MistranscriptionMiner`, unchanged policy) and the SHIPPED screening pass
+(`DictionarySuggestionScreen`, the exact prompt in the code) against the REAL hosted inference
+endpoint, run exactly as `DictionarySuggestionService.RunScanAsync` runs them (the mine-screen-
+exclude-re-mine loop). Harness: a throwaway console program referencing the repository projects;
+nothing was mocked on the model side.
+
+## Before: what the heuristic alone suggests (the shipped #2075 behavior)
+
+50 candidates, effectively all garbage. The top of the list, verbatim:
+
+```
+this      wrong 14462 of 18499  heard as: that, then, think, them, there, they, these, tell
+should    wrong  8780 of 10566  heard as: session, start, some, sure, Soren, show, something, screen
+create    wrong  6576 of  7309  heard as: changes, code, could, can't, cockpit, change, commit, clean
+want      wrong  6268 of  8192  heard as: what, with, we're, where, when, What, what's, we've
+from      wrong  2943 of  3404  heard as: first, figure, find, fuck, files, feature, full, fixed
+...
+```
+
+These are DISTINCT ordinary words chained together by phonetic nearness - not mistranscriptions.
+This is the screen the owner rejected outright (25 suggestions, zero acceptable).
+
+The real terms never even reached the list: "Frederiksen" sat at rank 35 and "mindzie"-class
+terms below the 50-candidate cap, crowded out by garbage. That finding produced the scan's
+mine-screen LOOP (screen a round, exclude the rejected, re-mine).
+
+## Findings the validation forced back into the design
+
+1. **Crowding-out**: the miner's 50-candidate cap was filled entirely by garbage, so screening a
+   single batch could never surface the real terms. Fix: the scan loops (bounded by
+   `MaxScreeningRoundsPerScan`), excluding rejected terms from the next mine.
+2. **Single-batch timeout**: one 50-candidate prompt blew the inference call's 60-second
+   deadline. Fix: `DictionarySuggestionScreen.ChunkSize` = 20 candidates per call, and the
+   screening brain gets a 3-minute per-call deadline.
+3. **Fast-model leniency**: the fast model approved inflection clusters ("issue heard as
+   issues", "kill heard as killed") and mixed clusters ("open" approved because its variants
+   contained OpenAI/OpenCode - a mapping that would CORRUPT text). Fix: screening uses the
+   THINKING model (nightly background work; judgment quality is the product), and the prompt
+   names both failure modes explicitly.
+
+## After: the shipped design, converged
+
+Four screening rounds, 169 candidates judged, every verdict persisted. Result:
+
+```
+APPROVE  Frederiksen  wrong 116 of 364  heard as: Fredriksson, Fredriksen, Fredrickson, Fredrikson, Fredericksen, fredriksen
+APPROVE  DuxRevo      wrong   3 of   6  heard as: duxurivo, ducksrevo
+```
+
+Two suggestions, both genuinely distinctive proper names with genuine near-phonetic
+misspellings - exactly what the dictionary exists to hold. Every ordinary-word cluster from the
+"before" list was rejected with a reason, and each of those verdicts is stored so it is never
+paid for again: the steady-state daily scan makes zero model calls until new vocabulary appears
+in the dictations.

--- a/packages/client-core/src/dictation/dictionaryClient.ts
+++ b/packages/client-core/src/dictation/dictionaryClient.ts
@@ -81,11 +81,13 @@ export async function saveDictionary(dict: Dictionary, signal?: AbortSignal): Pr
   return normalize((await res.json()) as Partial<Dictionary>);
 }
 
-// ===== Dictionary suggestions (devthrottle #2075) =========================================
-// The server mines this tenant's stored dictation transcripts for terms the speech model keeps
-// getting wrong that are not yet in the glossary, and offers them for one-press addition. The
-// client is DUMB here: it renders the ranked list, the evidence, and the count exactly as the
-// Gateway computed them, and never re-derives which terms to suggest or how many are pending.
+// ===== Dictionary suggestions (devthrottle #2075, redesigned in #2115) ====================
+// The server SCANS this tenant's stored dictation transcripts - daily just after midnight in the
+// tenant's own time zone, or on the page's explicit "Scan now" - mines candidate terms, has a
+// language model screen out ordinary vocabulary (in any language), and stores the approved
+// result. Reads serve that STORED result; they never mine and never call the model. The client
+// is DUMB here: it renders the list, the evidence, the count, the scan time, and the screening
+// state exactly as the Gateway computed them, and never re-derives any of them.
 
 /** One wrong spelling and how many times it was seen - the "heard as X (n)" evidence. */
 export interface SuggestionVariant {
@@ -102,10 +104,15 @@ export interface DictionarySuggestion {
   totalCount: number;
 }
 
-/** GET /ingest/dictionary/suggestions - the ranked pending suggestions and their count. */
+/** GET /ingest/dictionary/suggestions and POST .../scan - the stored scan's approved suggestions,
+ *  their count, when the scan ran (null = never scanned), and the Gateway-ruled screening state
+ *  (screeningOk false = the screening model was unreachable; screeningError says why). */
 export interface SuggestionsResult {
   suggestions: DictionarySuggestion[];
   count: number;
+  scannedAtUtc: string | null;
+  screeningOk: boolean;
+  screeningError: string;
 }
 
 /** A dismissed term with its snapshotted evidence and when it was dismissed. */
@@ -119,10 +126,16 @@ export interface DismissedTerm {
 
 function normalizeSuggestions(body: Partial<SuggestionsResult> | null | undefined): SuggestionsResult {
   const suggestions = body?.suggestions ?? [];
-  return { suggestions, count: body?.count ?? suggestions.length };
+  return {
+    suggestions,
+    count: body?.count ?? suggestions.length,
+    scannedAtUtc: body?.scannedAtUtc ?? null,
+    screeningOk: body?.screeningOk ?? true,
+    screeningError: body?.screeningError ?? "",
+  };
 }
 
-// GET /ingest/dictionary/suggestions - the ranked pending suggestions with evidence.
+// GET /ingest/dictionary/suggestions - the stored scan's suggestions with evidence.
 export async function getSuggestions(signal?: AbortSignal): Promise<SuggestionsResult> {
   const res = await fetch("/ingest/dictionary/suggestions", {
     method: "GET",
@@ -130,6 +143,19 @@ export async function getSuggestions(signal?: AbortSignal): Promise<SuggestionsR
     signal,
   });
   if (!res.ok) throw await gatewayErrorFrom(res, "GET /ingest/dictionary/suggestions");
+  return normalizeSuggestions((await res.json()) as Partial<SuggestionsResult>);
+}
+
+// POST /ingest/dictionary/suggestions/scan - run a scan NOW (the page's "Scan now" button). May take
+// seconds when there are new candidates to screen (one model call); instant when there is nothing
+// new. Throws on failure so the button can show the real reason.
+export async function scanSuggestions(signal?: AbortSignal): Promise<SuggestionsResult> {
+  const res = await fetch("/ingest/dictionary/suggestions/scan", {
+    method: "POST",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, "POST /ingest/dictionary/suggestions/scan");
   return normalizeSuggestions((await res.json()) as Partial<SuggestionsResult>);
 }
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724182054_AddDictionarySuggestionScreening.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724182054_AddDictionarySuggestionScreening.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724182054_AddDictionarySuggestionScreening")]
+    partial class AddDictionarySuggestionScreening
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,84 +57,84 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -137,108 +146,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", (string)null);
+                    b.ToTable("activity_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -247,108 +256,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", (string)null);
+                    b.ToTable("device_credentials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", (string)null);
+                    b.ToTable("device_import_markers", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("TenantId", "Term");
 
@@ -356,99 +369,100 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", (string)null);
+                    b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", (string)null);
+                    b.ToTable("dictation_suggestion_scans", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", (string)null);
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
@@ -456,43 +470,43 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", (string)null);
+                    b.ToTable("dictation_transcripts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
+                    b.Property<Guid>("Subject")
+                        .HasColumnType("uuid")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", null, t =>
+                    b.ToTable("entitlements", "gateway", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -501,38 +515,38 @@ namespace CcDirector.Gateway.Data.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -545,40 +559,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -591,109 +605,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -701,161 +718,165 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", (string)null);
+                    b.ToTable("tenant_settings", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -863,75 +884,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -939,71 +960,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1013,92 +1034,93 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", (string)null);
+                    b.ToTable("workflow_tenant_overrides", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -1107,7 +1129,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1115,28 +1137,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -1147,18 +1169,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -1178,36 +1200,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -1232,35 +1254,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1271,37 +1293,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -1312,23 +1334,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -1348,26 +1370,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1378,34 +1400,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724182054_AddDictionarySuggestionScreening.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724182054_AddDictionarySuggestionScreening.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDictionarySuggestionScreening : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "dictation_suggestion_scans",
+                schema: "gateway",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "text", nullable: false),
+                    ScannedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ScreeningOk = table.Column<bool>(type: "boolean", nullable: false),
+                    ScreeningError = table.Column<string>(type: "text", nullable: false),
+                    SuggestionsJson = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dictation_suggestion_scans", x => x.tenant_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dictation_suggestion_verdicts",
+                schema: "gateway",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "text", nullable: false),
+                    Term = table.Column<string>(type: "text", nullable: false, collation: "C"),
+                    DisplayTerm = table.Column<string>(type: "text", nullable: false),
+                    Approved = table.Column<bool>(type: "boolean", nullable: false),
+                    Reason = table.Column<string>(type: "text", nullable: false),
+                    Model = table.Column<string>(type: "text", nullable: false),
+                    JudgedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dictation_suggestion_verdicts", x => new { x.tenant_id, x.Term });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_dictation_suggestion_scans_tenant_id",
+                schema: "gateway",
+                table: "dictation_suggestion_scans",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_dictation_suggestion_verdicts_tenant_id",
+                schema: "gateway",
+                table: "dictation_suggestion_verdicts",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dictation_suggestion_scans",
+                schema: "gateway");
+
+            migrationBuilder.DropTable(
+                name: "dictation_suggestion_verdicts",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -369,6 +369,68 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
+                {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
+                    b.Property<DateTime>("ScannedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ScreeningError")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<bool>("ScreeningOk")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("SuggestionsJson")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("TenantId");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("dictation_suggestion_scans", "gateway");
+                });
+
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
+                {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
+                    b.Property<string>("Term")
+                        .HasColumnType("text")
+                        .UseCollation("C");
+
+                    b.Property<bool>("Approved")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("DisplayTerm")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("JudgedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Model")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Reason")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("TenantId", "Term");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionDailySweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionDailySweepTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using CcDirector.AgentBrain;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Settings;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The daily suggestion sweep (devthrottle #2115). The due rule is pure and pinned first: a tenant is due
+/// when it never scanned, or when the next tenant-local 00:05 after its last scan is in the past - so the
+/// SAME timer tick scans Sydney at Sydney's midnight and Copenhagen at Copenhagen's, and running the sweep
+/// twice in one day does not scan twice. Then one self-host integration proof: the sweep actually runs the
+/// scan through the seam and stores the result, and a second sweep the same day is a no-op.
+/// </summary>
+public sealed class DictionarySuggestionDailySweepTests
+{
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+    private static readonly TimeZoneInfo Sydney = TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney");
+
+    private static DateTime Utc_(int y, int mo, int d, int h, int mi)
+        => new(y, mo, d, h, mi, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void IsDue_NeverScanned_IsDueImmediately()
+        => Assert.True(DictionarySuggestionDailySweep.IsDue(null, Utc, Utc_(2026, 7, 24, 12, 0)));
+
+    [Fact]
+    public void IsDue_ScannedEarlierToday_NotDueUntilTomorrowsLocalMidnight()
+    {
+        var lastScan = Utc_(2026, 7, 24, 0, 10);
+        Assert.False(DictionarySuggestionDailySweep.IsDue(lastScan, Utc, Utc_(2026, 7, 24, 23, 59)));
+        Assert.True(DictionarySuggestionDailySweep.IsDue(lastScan, Utc, Utc_(2026, 7, 25, 0, 5)));
+    }
+
+    [Fact]
+    public void IsDue_JustBeforeLocal0005_NotDue_JustAfter_Due()
+    {
+        var lastScan = Utc_(2026, 7, 23, 12, 0);
+        Assert.False(DictionarySuggestionDailySweep.IsDue(lastScan, Utc, Utc_(2026, 7, 24, 0, 4)));
+        Assert.True(DictionarySuggestionDailySweep.IsDue(lastScan, Utc, Utc_(2026, 7, 24, 0, 5)));
+    }
+
+    [Fact]
+    public void IsDue_HonorsTheTenantsOwnZone()
+    {
+        // Last scan 2026-07-23 13:00 UTC = 23:00 that day in Sydney (winter, UTC+10). At 14:10 UTC it is
+        // already 00:10 of JULY 24 in Sydney - past Sydney's 00:05, so the Sydney tenant is due - while a
+        // UTC tenant's midnight is still ten hours away.
+        var lastScan = Utc_(2026, 7, 23, 13, 0);
+        var now = Utc_(2026, 7, 23, 14, 10);
+        Assert.True(DictionarySuggestionDailySweep.IsDue(lastScan, Sydney, now));
+        Assert.False(DictionarySuggestionDailySweep.IsDue(lastScan, Utc, now));
+    }
+
+    // ---- integration: the sweep runs the scan through the seam and stores the result ----
+
+    private sealed class CountingBrain : IAgentBrain
+    {
+        public int Calls;
+        public string? SessionId => null;
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Calls++;
+            // Approve every candidate line in the prompt (lines like: 1. "term" heard as: ...).
+            var verdicts = new List<object>();
+            foreach (var line in prompt.Split('\n'))
+            {
+                var t = line.Trim();
+                var dot = t.IndexOf(". \"", StringComparison.Ordinal);
+                if (dot < 0 || dot > 4) continue;
+                var start = dot + 3;
+                var end = t.IndexOf('"', start);
+                if (end < 0) continue;
+                verdicts.Add(new { term = t[start..end], approved = true, reason = "stub" });
+            }
+            return Task.FromResult(new AskResult { Text = JsonSerializer.Serialize(verdicts) });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task Sweep_SelfHost_SeedsTheFirstScan_AndDoesNotRescanTheSameDay()
+    {
+        using var h = new GatewayDbTestHarness();
+        var ctx = new SingleTenantContext();
+        var registry = new TenantRegistry(h.Open(ctx));
+        var boundary = new HostedTenantBoundary(ctx, new DeviceRegistry());
+
+        var transcripts = new TranscriptStore(h.Open(ctx));
+        var scans = new DictionarySuggestionScanStore(h.Open(ctx));
+        var brain = new CountingBrain();
+        var clock = new DateTime(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+        var emptyDict = new DictationDictionary(
+            Array.Empty<string>(), new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile> { ["default"] = new("default", true) });
+
+        var i = 0;
+        foreach (var (spelling, times) in new[] { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15) })
+            for (var n = 0; n < times; n++)
+                transcripts.Append(TenantId.Local, "dictation", $"the {spelling} change", null, false,
+                    turnId: null, nowUtc: clock.AddSeconds(i++));
+
+        var service = new DictionarySuggestionService(
+            transcripts,
+            new DictionarySuggestionDismissalStore(h.Open(ctx)),
+            new DictionarySuggestionVerdictStore(h.Open(ctx)),
+            scans,
+            _ => emptyDict,
+            (_, _) => Task.FromResult<(IAgentBrain, string)>((brain, "stub-model")),
+            now: () => clock);
+        var sweep = new DictionarySuggestionDailySweep(
+            boundary, registry, ctx, service,
+            new TenantSettingsResolver(new TenantSettingsStore(h.Open(ctx))),
+            now: () => clock);
+
+        // No stored scan: the first sweep is due immediately and seeds the stored result.
+        await sweep.SweepAsync();
+        Assert.Equal(1, brain.Calls);
+        var stored = scans.Get(TenantId.Local);
+        Assert.NotNull(stored);
+        Assert.Equal("mindzie", Assert.Single(stored!.Suggestions).Term);
+
+        // Same day, later tick: not due, nothing runs.
+        clock = clock.AddHours(3);
+        await sweep.SweepAsync();
+        Assert.Equal(1, brain.Calls);
+        Assert.Equal(stored.ScannedAtUtc, scans.Get(TenantId.Local)!.ScannedAtUtc);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionDailySweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionDailySweepTests.cs
@@ -105,8 +105,10 @@ public sealed class DictionarySuggestionDailySweepTests
             Array.Empty<string>(), new Dictionary<string, IReadOnlyList<string>>(),
             new Dictionary<string, DictationProfile> { ["default"] = new("default", true) });
 
+        // The full chained corpus (Mindzee bridges mindzie ~ Mindsee below the direct-link threshold),
+        // matching the canonical corpus the miner and service tests pin.
         var i = 0;
-        foreach (var (spelling, times) in new[] { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15) })
+        foreach (var (spelling, times) in new[] { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15), ("Mindzee", 12) })
             for (var n = 0; n < times; n++)
                 transcripts.Append(TenantId.Local, "dictation", $"the {spelling} change", null, false,
                     turnId: null, nowUtc: clock.AddSeconds(i++));

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionScanStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionScanStoreTests.cs
@@ -1,0 +1,107 @@
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The scan-result store (devthrottle #2115): one row per tenant holding the latest scan (its time, the
+/// screening outcome, and the approved suggestions with evidence), overwritten per scan, edited in place by
+/// apply/dismiss, tenant-isolated. The badge and the page read this row - so its round-trip fidelity IS the
+/// page's correctness.
+/// </summary>
+public sealed class DictionarySuggestionScanStoreTests
+{
+    private static readonly TenantId TenantA = new("tenant-a");
+    private static readonly TenantId TenantB = new("tenant-b");
+    private static readonly DateTime Base = new(2026, 7, 24, 0, 5, 0, DateTimeKind.Utc);
+
+    private static MistranscriptionSuggestion Suggestion(string term, params (string heard, int count)[] variants)
+        => new(term, variants.Select(v => new MistranscriptionVariant(v.heard, v.count)).ToList(),
+            variants.Sum(v => v.count), variants.Sum(v => v.count) + 10);
+
+    [Fact]
+    public void SaveThenGet_RoundTripsEverything()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionScanStore(h.Open());
+
+        store.Save(TenantA, new DictionarySuggestionScanStore.ScanResult(
+            Base, false, "model unreachable",
+            new[] { Suggestion("mindzie", ("Mindsee", 20), ("Mindzee", 12)) }));
+
+        var got = store.Get(TenantA);
+        Assert.NotNull(got);
+        Assert.Equal(Base, got!.ScannedAtUtc);
+        Assert.Equal(DateTimeKind.Utc, got.ScannedAtUtc.Kind);
+        Assert.False(got.ScreeningOk);
+        Assert.Equal("model unreachable", got.ScreeningError);
+        var s = Assert.Single(got.Suggestions);
+        Assert.Equal("mindzie", s.Term);
+        Assert.Equal(32, s.WrongCount);
+        Assert.Equal(42, s.TotalCount);
+        Assert.Equal(2, s.Variants.Count);
+        Assert.Equal("Mindsee", s.Variants[0].Heard);
+        Assert.Equal(20, s.Variants[0].Count);
+    }
+
+    [Fact]
+    public void Get_NoScanEver_ReturnsNull()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionScanStore(h.Open());
+        Assert.Null(store.Get(TenantA));
+    }
+
+    [Fact]
+    public void Save_OverwritesThePreviousScan()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionScanStore(h.Open());
+
+        store.Save(TenantA, new DictionarySuggestionScanStore.ScanResult(
+            Base, true, "", new[] { Suggestion("mindzie", ("Mindsee", 20)) }));
+        store.Save(TenantA, new DictionarySuggestionScanStore.ScanResult(
+            Base.AddDays(1), true, "", new[] { Suggestion("ConPty", ("Con-TY", 9)) }));
+
+        var got = store.Get(TenantA)!;
+        Assert.Equal(Base.AddDays(1), got.ScannedAtUtc);
+        Assert.Equal("ConPty", Assert.Single(got.Suggestions).Term);
+    }
+
+    [Fact]
+    public void RemoveSuggestion_EditsTheStoredListInPlace()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionScanStore(h.Open());
+        store.Save(TenantA, new DictionarySuggestionScanStore.ScanResult(
+            Base, true, "",
+            new[] { Suggestion("mindzie", ("Mindsee", 20)), Suggestion("ConPty", ("Con-TY", 9)) }));
+
+        store.RemoveSuggestion(TenantA, "MIND-ZIE"); // normalized match
+        Assert.Equal("ConPty", Assert.Single(store.Get(TenantA)!.Suggestions).Term);
+
+        store.RemoveSuggestion(TenantA, "notthere"); // no-op, no throw
+        Assert.Single(store.Get(TenantA)!.Suggestions);
+
+        // The scan time is NOT touched by an in-place edit (it still answers "when did we last scan").
+        Assert.Equal(Base, store.Get(TenantA)!.ScannedAtUtc);
+    }
+
+    [Fact]
+    public void Scans_AreTenantIsolated()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionScanStore(h.Open());
+        store.Save(TenantA, new DictionarySuggestionScanStore.ScanResult(
+            Base, true, "", new[] { Suggestion("mindzie", ("Mindsee", 20)) }));
+
+        Assert.Null(store.Get(TenantB));
+        store.Save(TenantB, new DictionarySuggestionScanStore.ScanResult(
+            Base.AddHours(1), true, "", Array.Empty<MistranscriptionSuggestion>()));
+        Assert.Equal("mindzie", Assert.Single(store.Get(TenantA)!.Suggestions).Term);
+        Assert.Empty(store.Get(TenantB)!.Suggestions);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionScreenTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionScreenTests.cs
@@ -1,0 +1,128 @@
+using CcDirector.AgentBrain;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The model screening pass (devthrottle #2115): the prompt carries every candidate with its evidence and
+/// demands a strict JSON verdict array; the parser accepts exactly that (tolerating a fenced wrapper) and
+/// THROWS on anything unusable - an unparseable answer or a candidate left unjudged - because the caller
+/// must record "screening unavailable" rather than guess.
+/// </summary>
+public sealed class DictionarySuggestionScreenTests
+{
+    private static MistranscriptionSuggestion Candidate(string term, params string[] heard)
+        => new(term, heard.Select(v => new MistranscriptionVariant(v, 2)).ToList(), heard.Length * 2, heard.Length * 2 + 5);
+
+    private sealed class FixedBrain : IAgentBrain
+    {
+        private readonly string _text;
+        public string? LastPrompt;
+        public FixedBrain(string text) => _text = text;
+        public string? SessionId => null;
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            LastPrompt = prompt;
+            return Task.FromResult(new AskResult { Text = _text });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void BuildPrompt_CarriesEveryCandidateAndItsEvidence()
+    {
+        var prompt = DictionarySuggestionScreen.BuildPrompt(new[]
+        {
+            Candidate("mindzie", "Mindsee", "Mindzee"),
+            Candidate("ConPty", "Con-TY"),
+        });
+
+        Assert.Contains("1. \"mindzie\" heard as: Mindsee, Mindzee", prompt);
+        Assert.Contains("2. \"ConPty\" heard as: Con-TY", prompt);
+        // The judgment framing: ordinary words in ANY language are rejected; unsure means reject.
+        Assert.Contains("ANY language", prompt);
+        Assert.Contains("When unsure, REJECT", prompt);
+        Assert.Contains("ONLY a JSON array", prompt);
+    }
+
+    [Fact]
+    public async Task JudgeAsync_MapsVerdictsBackInCandidateOrder()
+    {
+        var brain = new FixedBrain(
+            """
+            [{"term":"ConPty","approved":true,"reason":"jargon"},
+             {"term":"that","approved":false,"reason":"ordinary word"}]
+            """);
+        var verdicts = await DictionarySuggestionScreen.JudgeAsync(brain, new[]
+        {
+            Candidate("that", "then", "them"),
+            Candidate("ConPty", "Con-TY"),
+        });
+
+        Assert.Equal(2, verdicts.Count);
+        Assert.Equal("that", verdicts[0].Term);
+        Assert.False(verdicts[0].Approved);
+        Assert.Equal("ordinary word", verdicts[0].Reason);
+        Assert.Equal("ConPty", verdicts[1].Term);
+        Assert.True(verdicts[1].Approved);
+    }
+
+    [Fact]
+    public void ParseVerdicts_ToleratesAFencedCodeBlock()
+    {
+        var text = "```json\n[{\"term\":\"mindzie\",\"approved\":true,\"reason\":\"brand\"}]\n```";
+        var verdicts = DictionarySuggestionScreen.ParseVerdicts(text, new[] { Candidate("mindzie", "Mindsee") });
+        Assert.True(Assert.Single(verdicts).Approved);
+    }
+
+    [Fact]
+    public void ParseVerdicts_MatchesTermsCaseInsensitively()
+    {
+        var text = "[{\"term\":\"MINDZIE\",\"approved\":true,\"reason\":\"brand\"}]";
+        var verdicts = DictionarySuggestionScreen.ParseVerdicts(text, new[] { Candidate("mindzie", "Mindsee") });
+        Assert.Equal("mindzie", Assert.Single(verdicts).Term); // the CANDIDATE's spelling, not the model's
+    }
+
+    [Fact]
+    public void ParseVerdicts_ProseAnswer_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            DictionarySuggestionScreen.ParseVerdicts(
+                "These all look like fine dictionary terms to me.",
+                new[] { Candidate("mindzie", "Mindsee") }));
+        Assert.Contains("no JSON array", ex.Message);
+    }
+
+    [Fact]
+    public void ParseVerdicts_MalformedJson_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            DictionarySuggestionScreen.ParseVerdicts(
+                "[{\"term\":\"mindzie\",\"approved\":tr",
+                new[] { Candidate("mindzie", "Mindsee") }));
+    }
+
+    [Fact]
+    public void ParseVerdicts_MissingCandidate_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            DictionarySuggestionScreen.ParseVerdicts(
+                "[{\"term\":\"mindzie\",\"approved\":true,\"reason\":\"brand\"}]",
+                new[] { Candidate("mindzie", "Mindsee"), Candidate("ConPty", "Con-TY") }));
+        Assert.Contains("ConPty", ex.Message);
+    }
+
+    [Fact]
+    public async Task JudgeAsync_EmptyCandidates_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            DictionarySuggestionScreen.JudgeAsync(new FixedBrain("[]"), Array.Empty<MistranscriptionSuggestion>()));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using CcDirector.AgentBrain;
+using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Tests.Data;
@@ -7,11 +10,13 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The Gateway suggestion service (devthrottle #2075) wired to real per-tenant stores: it mines a tenant's
-/// stored transcripts against that tenant's glossary and dismissed terms, caches the result on a TTL, and
-/// keeps every tenant's suggestions built only from - and served only to - that tenant. The mining policy
-/// itself is proven in MistranscriptionMinerTests; these tests prove the WIRING: tenant scoping, dismissal
-/// honoring, cache TTL and invalidation.
+/// The Gateway suggestion SCAN engine (devthrottle #2075, redesigned in #2115) wired to real per-tenant
+/// stores and a stub screening brain: a scan mines the tenant's transcripts, sends never-judged candidates
+/// to the model, persists the verdicts (a term is judged at most once, ever), and stores the approved
+/// result; reads serve the stored result and never mine. The mining policy itself is proven in
+/// MistranscriptionMinerTests and the prompt/parse in DictionarySuggestionScreenTests; these tests prove the
+/// WIRING: judge-once persistence, rejected terms hidden, the loud screening-failure path, tenant scoping,
+/// and the stored-result read model.
 /// </summary>
 public sealed class DictionarySuggestionServiceTests
 {
@@ -37,108 +42,280 @@ public sealed class DictionarySuggestionServiceTests
     private static readonly (string, int)[] MindzieCorpus =
         { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15), ("Mindzee", 12), ("Mindsea", 6) };
 
+    /// <summary>A screening brain whose verdict policy is a delegate; counts AskAsync calls. The default
+    /// policy approves everything (each prompt's terms are parsed back out of the candidate lines).</summary>
+    private sealed class StubBrain : IAgentBrain
+    {
+        private readonly Func<string, string> _answer;
+        public int Calls;
+
+        public StubBrain(Func<string, string>? answer = null)
+            => _answer = answer ?? (prompt => ApproveAll(prompt));
+
+        public static string ApproveAll(string prompt) => AnswerFor(prompt, approved: true);
+        public static string RejectAll(string prompt) => AnswerFor(prompt, approved: false);
+
+        /// <summary>Build a well-formed verdict array for every candidate line in the prompt (lines like
+        /// <c>1. "term" heard as: ...</c>), approving or rejecting all of them.</summary>
+        private static string AnswerFor(string prompt, bool approved)
+        {
+            var verdicts = new List<object>();
+            foreach (var line in prompt.Split('\n'))
+            {
+                var t = line.Trim();
+                var dot = t.IndexOf(". \"", StringComparison.Ordinal);
+                if (dot < 0 || dot > 4) continue;
+                var start = dot + 3;
+                var end = t.IndexOf('"', start);
+                if (end < 0) continue;
+                verdicts.Add(new { term = t[start..end], approved, reason = "stub" });
+            }
+            return JsonSerializer.Serialize(verdicts);
+        }
+
+        public string? SessionId => null;
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(new AskResult { Text = _answer(prompt) });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
+    private static DictionarySuggestionService Build(
+        GatewayDbTestHarness h, TranscriptStore transcripts, StubBrain brain,
+        Func<TenantId, DictationDictionary>? glossary = null, Func<DateTime>? now = null)
+        => new(
+            transcripts,
+            new DictionarySuggestionDismissalStore(h.Open()),
+            new DictionarySuggestionVerdictStore(h.Open()),
+            new DictionarySuggestionScanStore(h.Open()),
+            glossary ?? (_ => EmptyDict),
+            (_, _) => Task.FromResult<(IAgentBrain, string)>((brain, "stub-model")),
+            now: now ?? (() => Base));
+
     [Fact]
-    public void GetSuggestions_MinesTheTenantsTranscripts()
+    public async Task RunScan_MinesScreensAndStoresTheApprovedResult()
     {
         using var h = new GatewayDbTestHarness();
         var transcripts = new TranscriptStore(h.Open());
-        var dismissals = new DictionarySuggestionDismissalStore(h.Open());
         SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
+        var brain = new StubBrain();
+        var svc = Build(h, transcripts, brain);
 
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => EmptyDict, now: () => Base);
+        // Before any scan: nothing stored, nothing served, no mining behind the read.
+        Assert.Null(svc.GetStored(TenantA));
+        Assert.Empty(svc.GetSuggestions(TenantA));
+        Assert.Equal(0, svc.GetSuggestionCount(TenantA));
 
-        var s = Assert.Single(svc.GetSuggestions(TenantA));
+        var result = await svc.RunScanAsync(TenantA);
+
+        Assert.True(result.ScreeningOk);
+        Assert.Equal(Base, result.ScannedAtUtc);
+        var s = Assert.Single(result.Suggestions);
         Assert.Equal("mindzie", s.Term);
         Assert.Equal(53, s.WrongCount);
         Assert.Equal(97, s.TotalCount);
+
+        // The stored result serves the reads (including after a service rebuild - it is in the database).
         Assert.Equal(1, svc.GetSuggestionCount(TenantA));
+        var reloaded = Build(h, transcripts, brain);
+        Assert.Equal("mindzie", Assert.Single(reloaded.GetSuggestions(TenantA)).Term);
     }
 
     [Fact]
-    public void GetSuggestions_IsPerTenant()
+    public async Task RunScan_RejectedTermIsNeverShown()
     {
         using var h = new GatewayDbTestHarness();
         var transcripts = new TranscriptStore(h.Open());
-        var dismissals = new DictionarySuggestionDismissalStore(h.Open());
+        // The screenshot regression: a cluster of DISTINCT common words the miner chains together.
+        SeedTerm(transcripts, TenantA, Base,
+            new[] { ("that", 50), ("then", 30), ("them", 25), ("there", 22) });
+        var brain = new StubBrain(StubBrain.RejectAll);
+        var svc = Build(h, transcripts, brain);
+
+        var result = await svc.RunScanAsync(TenantA);
+
+        Assert.True(result.ScreeningOk);
+        Assert.Empty(result.Suggestions);
+        Assert.Equal(0, svc.GetSuggestionCount(TenantA));
+    }
+
+    [Fact]
+    public async Task RunScan_JudgesEachTermAtMostOnceEver()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
         SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
-        // Tenant B has its own, different mistranscription and none of A's.
+        var brain = new StubBrain();
+        var svc = Build(h, transcripts, brain);
+
+        await svc.RunScanAsync(TenantA);
+        Assert.Equal(1, brain.Calls);
+
+        // Same corpus, second scan: the verdict is stored, so NO second model call.
+        await svc.RunScanAsync(TenantA);
+        Assert.Equal(1, brain.Calls);
+
+        // Even through a fresh service instance (the persistence, not the instance, is the memory).
+        var svc2 = Build(h, transcripts, brain);
+        await svc2.RunScanAsync(TenantA);
+        Assert.Equal(1, brain.Calls);
+    }
+
+    [Fact]
+    public async Task RunScan_ScreeningFailure_IsLoudAndHidesUnjudgedTerms()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
+        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
+        var approving = new StubBrain();
+        var svc = Build(h, transcripts, approving);
+        await svc.RunScanAsync(TenantA); // mindzie is judged and approved
+
+        // New evidence arrives for a NEW term, but the screening model is now down.
+        SeedTerm(transcripts, TenantA, Base.AddHours(1),
+            new[] { ("Kubernetes", 20), ("Kubernetis", 6), ("Kubernettes", 4) });
+        var down = new StubBrain(_ => throw new InvalidOperationException("model unreachable"));
+        var svcDown = Build(h, transcripts, down);
+
+        var result = await svcDown.RunScanAsync(TenantA);
+
+        // Loud: the stored result says screening failed and why. The unjudged term is HIDDEN (never shown
+        // unscreened); the previously-approved term still serves - it WAS screened.
+        Assert.False(result.ScreeningOk);
+        Assert.Contains("model unreachable", result.ScreeningError);
+        Assert.Equal("mindzie", Assert.Single(result.Suggestions).Term);
+    }
+
+    [Fact]
+    public async Task RunScan_UnparseableModelAnswer_IsAScreeningFailure()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
+        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
+        var svc = Build(h, transcripts, new StubBrain(_ => "I think these all look fine to me!"));
+
+        var result = await svc.RunScanAsync(TenantA);
+
+        Assert.False(result.ScreeningOk);
+        Assert.NotEqual("", result.ScreeningError);
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public async Task RunScan_RejectedGarbageCannotCrowdARealTermOutOfTheCap()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
+        // Two high-frequency garbage clusters and one real term. With the miner capped at TWO suggestions,
+        // the first mining round is ALL garbage - the real term is over the cap. The scan must loop: screen,
+        // reject, exclude, re-mine - so the real term surfaces and is approved within ONE scan. This is the
+        // crowding-out found on the owner's real corpus (50 of 50 capped candidates were garbage).
+        SeedTerm(transcripts, TenantA, Base, new[] { ("wanted", 300), ("wanting", 200), ("wants", 150) });
+        SeedTerm(transcripts, TenantA, Base.AddMinutes(30), new[] { ("started", 250), ("starting", 180), ("starts", 120) });
+        SeedTerm(transcripts, TenantA, Base.AddHours(1), MindzieCorpus);
+
+        // The stub rejects garbage and approves only mindzie's cluster.
+        var brain = new StubBrain(prompt =>
+        {
+            var approveMindzie = StubBrain.RejectAll(prompt);
+            return approveMindzie.Replace("\"term\":\"mindzie\",\"approved\":false", "\"term\":\"mindzie\",\"approved\":true");
+        });
+        var svc = new DictionarySuggestionService(
+            transcripts,
+            new DictionarySuggestionDismissalStore(h.Open()),
+            new DictionarySuggestionVerdictStore(h.Open()),
+            new DictionarySuggestionScanStore(h.Open()),
+            _ => EmptyDict,
+            (_, _) => Task.FromResult<(IAgentBrain, string)>((brain, "stub-model")),
+            options: MistranscriptionMiner.Options.Default with { MaxSuggestions = 2 },
+            now: () => Base);
+
+        var result = await svc.RunScanAsync(TenantA);
+
+        Assert.True(result.ScreeningOk);
+        Assert.Equal("mindzie", Assert.Single(result.Suggestions).Term);
+        Assert.True(brain.Calls >= 2); // it took more than one round to reach the real term
+    }
+
+    [Fact]
+    public async Task RunScan_IsPerTenant()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
+        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
         SeedTerm(transcripts, TenantB, Base,
             new[] { ("Frederiksen", 60), ("Fredriksson", 18), ("Fredrickson", 12) });
+        var brain = new StubBrain();
+        var svc = Build(h, transcripts, brain);
 
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => EmptyDict, now: () => Base);
+        await svc.RunScanAsync(TenantA);
+        await svc.RunScanAsync(TenantB);
 
         Assert.Equal("mindzie", Assert.Single(svc.GetSuggestions(TenantA)).Term);
         Assert.Equal("Frederiksen", Assert.Single(svc.GetSuggestions(TenantB)).Term);
     }
 
     [Fact]
-    public void GetSuggestions_ExcludesTermsAlreadyInTheGlossary()
+    public async Task RunScan_ExcludesGlossaryAndDismissedTerms()
     {
         using var h = new GatewayDbTestHarness();
         var transcripts = new TranscriptStore(h.Open());
         var dismissals = new DictionarySuggestionDismissalStore(h.Open());
         SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
-
-        var dictWithTerm = new DictationDictionary(
-            new[] { "mindzie" }, new Dictionary<string, IReadOnlyList<string>>(),
-            new Dictionary<string, DictationProfile> { ["default"] = new("default", true) });
-
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => dictWithTerm, now: () => Base);
-
-        Assert.Empty(svc.GetSuggestions(TenantA));
-    }
-
-    [Fact]
-    public void GetSuggestions_ExcludesDismissedTerms()
-    {
-        using var h = new GatewayDbTestHarness();
-        var transcripts = new TranscriptStore(h.Open());
-        var dismissals = new DictionarySuggestionDismissalStore(h.Open());
-        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => EmptyDict, now: () => Base);
-
-        // Dismiss the term, invalidate, and it is gone; restore, invalidate, and it returns.
-        dismissals.Dismiss(TenantA, svc.FindSuggestion(TenantA, "mindzie")!, Base);
-        svc.Invalidate(TenantA);
-        Assert.Empty(svc.GetSuggestions(TenantA));
-
-        dismissals.Restore(TenantA, "mindzie");
-        svc.Invalidate(TenantA);
-        Assert.Single(svc.GetSuggestions(TenantA));
-    }
-
-    [Fact]
-    public void GetSuggestions_CachesWithinTtl_AndInvalidateForcesRecompute()
-    {
-        using var h = new GatewayDbTestHarness();
-        var transcripts = new TranscriptStore(h.Open());
-        var dismissals = new DictionarySuggestionDismissalStore(h.Open());
-        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
-
-        var clock = Base;
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => EmptyDict, now: () => clock);
-
-        Assert.Single(svc.GetSuggestions(TenantA)); // computes and caches
-
-        // Add a NEW batch that would create a second suggestion; still within the TTL, the cache hides it.
         SeedTerm(transcripts, TenantA, Base.AddHours(1),
             new[] { ("Kubernetes", 20), ("Kubernetis", 6), ("Kubernettes", 4) });
-        clock = Base.AddSeconds(30);
-        Assert.Single(svc.GetSuggestions(TenantA)); // cached
+        var brain = new StubBrain();
+        var glossaryWithMindzie = new DictationDictionary(
+            new[] { "mindzie" }, new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile> { ["default"] = new("default", true) });
+        var svc = new DictionarySuggestionService(
+            transcripts, dismissals,
+            new DictionarySuggestionVerdictStore(h.Open()),
+            new DictionarySuggestionScanStore(h.Open()),
+            _ => glossaryWithMindzie,
+            (_, _) => Task.FromResult<(IAgentBrain, string)>((brain, "stub-model")),
+            now: () => Base);
 
-        // Past the TTL, it recomputes and sees both.
-        clock = Base + DictionarySuggestionService.CacheTtl + TimeSpan.FromSeconds(1);
-        Assert.Equal(2, svc.GetSuggestions(TenantA).Count);
+        // mindzie is already in the glossary; Kubernetes gets dismissed; a scan then offers neither.
+        dismissals.Dismiss(TenantA,
+            new MistranscriptionSuggestion("Kubernetes", Array.Empty<MistranscriptionVariant>(), 0, 0), Base);
+        var result = await svc.RunScanAsync(TenantA);
+        Assert.Empty(result.Suggestions);
     }
 
     [Fact]
-    public void FindSuggestion_MatchesCaseAndPunctuationInsensitively()
+    public async Task RemoveFromStored_ReflectsApplyOrDismissWithoutARescan()
     {
         using var h = new GatewayDbTestHarness();
         var transcripts = new TranscriptStore(h.Open());
-        var dismissals = new DictionarySuggestionDismissalStore(h.Open());
         SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
-        var svc = new DictionarySuggestionService(transcripts, dismissals, _ => EmptyDict, now: () => Base);
+        SeedTerm(transcripts, TenantA, Base.AddHours(1),
+            new[] { ("Kubernetes", 20), ("Kubernetis", 6), ("Kubernettes", 4) });
+        var brain = new StubBrain();
+        var svc = Build(h, transcripts, brain);
+        await svc.RunScanAsync(TenantA);
+        Assert.Equal(2, svc.GetSuggestionCount(TenantA));
+
+        svc.RemoveFromStored(TenantA, "MINDZIE"); // normalized match, like the endpoints use
+
+        Assert.Equal("Kubernetes", Assert.Single(svc.GetSuggestions(TenantA)).Term);
+    }
+
+    [Fact]
+    public async Task FindSuggestion_MatchesCaseAndPunctuationInsensitively()
+    {
+        using var h = new GatewayDbTestHarness();
+        var transcripts = new TranscriptStore(h.Open());
+        SeedTerm(transcripts, TenantA, Base, MindzieCorpus);
+        var svc = Build(h, transcripts, new StubBrain());
+        await svc.RunScanAsync(TenantA);
 
         Assert.NotNull(svc.FindSuggestion(TenantA, "MINDZIE"));
         Assert.Null(svc.FindSuggestion(TenantA, "nothinghere"));

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionVerdictStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionVerdictStoreTests.cs
@@ -1,0 +1,72 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The verdict store (devthrottle #2115): one row per tenant per normalized term, upserted, tenant-isolated.
+/// This persistence is what makes "a term is judged at most once, ever" true across restarts.
+/// </summary>
+public sealed class DictionarySuggestionVerdictStoreTests
+{
+    private static readonly TenantId TenantA = new("tenant-a");
+    private static readonly TenantId TenantB = new("tenant-b");
+    private static readonly DateTime Base = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Record_ThenRead_RoundTripsByNormalizedTerm()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionVerdictStore(h.Open());
+
+        store.Record(TenantA, new[]
+        {
+            new DictionarySuggestionVerdictStore.Verdict("mindzie", true, "brand"),
+            new DictionarySuggestionVerdictStore.Verdict("that", false, "ordinary word"),
+        }, "model-x", Base);
+
+        var verdicts = store.VerdictsByNorm(TenantA);
+        Assert.Equal(2, verdicts.Count);
+        Assert.True(verdicts["mindzie"]);
+        Assert.False(verdicts["that"]);
+    }
+
+    [Fact]
+    public void Record_UpsertsByNormalizedTerm_NoDuplicateForCasing()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionVerdictStore(h.Open());
+
+        store.Record(TenantA, new[] { new DictionarySuggestionVerdictStore.Verdict("ConPty", false, "first") }, "m", Base);
+        // Re-judged under different casing/punctuation: same normalized key, so the row is REPLACED.
+        store.Record(TenantA, new[] { new DictionarySuggestionVerdictStore.Verdict("Con-Pty", true, "second") }, "m", Base.AddDays(1));
+
+        var verdicts = store.VerdictsByNorm(TenantA);
+        Assert.True(Assert.Single(verdicts).Value);
+        Assert.Equal("conpty", Assert.Single(verdicts).Key);
+    }
+
+    [Fact]
+    public void Verdicts_AreTenantIsolated()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionVerdictStore(h.Open());
+
+        store.Record(TenantA, new[] { new DictionarySuggestionVerdictStore.Verdict("mindzie", true, "") }, "m", Base);
+        store.Record(TenantB, new[] { new DictionarySuggestionVerdictStore.Verdict("mindzie", false, "") }, "m", Base);
+
+        Assert.True(store.VerdictsByNorm(TenantA)["mindzie"]);
+        Assert.False(store.VerdictsByNorm(TenantB)["mindzie"]);
+    }
+
+    [Fact]
+    public void Record_SkipsTermsThatNormalizeToEmpty()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new DictionarySuggestionVerdictStore(h.Open());
+        store.Record(TenantA, new[] { new DictionarySuggestionVerdictStore.Verdict("--- ", true, "") }, "m", Base);
+        Assert.Empty(store.VerdictsByNorm(TenantA));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using CcDirector.AgentBrain;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Tests.Data;
@@ -12,14 +13,14 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// HTTP end-to-end for the dictionary-suggestions API (devthrottle #2075). Boots the real
-/// <see cref="RecordingEndpoints"/> - with the suggestion service and dismissal store wired over an isolated
-/// SQLite database and an isolated CC_DIRECTOR_ROOT - on an ephemeral loopback port, then drives the whole
-/// customer flow over HTTP: read the suggestions, apply a term (which must land in the glossary FILE as both
-/// a vocabulary term and its wrong spellings), see it disappear from the suggestions, dismiss another, list
-/// the dismissed, and restore it. This proves the acceptance criterion that everything the page does is
-/// available over the API and that Apply writes the real glossary. Self-host (no tenant boundary) resolves
-/// the single Local tenant throughout, exactly as a self-hosted install runs.
+/// HTTP end-to-end for the dictionary-suggestions API (devthrottle #2075, redesigned in #2115). Boots the
+/// real <see cref="RecordingEndpoints"/> - with the scan-based suggestion service (stub screening brain),
+/// verdict, scan, and dismissal stores over an isolated SQLite database and an isolated CC_DIRECTOR_ROOT -
+/// on an ephemeral loopback port, then drives the whole customer flow over HTTP: empty before any scan,
+/// scan-now produces the screened suggestions, apply a term (which must land in the glossary FILE as both a
+/// vocabulary term and its wrong spellings) and see it leave the stored list at once, dismiss another, list
+/// the dismissed, restore it, and rescan to see it return WITHOUT a second model call (the verdict is
+/// persisted). Self-host (no tenant boundary) resolves the single Local tenant throughout.
 /// </summary>
 public sealed class DictionarySuggestionsEndpointTests : IDisposable
 {
@@ -54,14 +55,50 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
                     turnId: null, nowUtc: at.AddSeconds(i++));
     }
 
+    /// <summary>A screening brain that approves every candidate in the prompt; counts calls so the test can
+    /// pin "a term is judged at most once, ever" through the HTTP surface.</summary>
+    private sealed class ApprovingBrain : IAgentBrain
+    {
+        public int Calls;
+        public string? SessionId => null;
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Calls++;
+            var verdicts = new List<object>();
+            foreach (var line in prompt.Split('\n'))
+            {
+                var t = line.Trim();
+                var dot = t.IndexOf(". \"", StringComparison.Ordinal);
+                if (dot < 0 || dot > 4) continue;
+                var start = dot + 3;
+                var end = t.IndexOf('"', start);
+                if (end < 0) continue;
+                verdicts.Add(new { term = t[start..end], approved = true, reason = "stub" });
+            }
+            return Task.FromResult(new AskResult { Text = JsonSerializer.Serialize(verdicts) });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
     [Fact]
-    public async Task FullApiFlow_ReadApplyDismissRestore()
+    public async Task FullApiFlow_ScanApplyDismissRestoreRescan()
     {
         var db = _dbh.Open();
         var transcripts = new TranscriptStore(db);
         var dismissals = new DictionarySuggestionDismissalStore(db);
+        var brain = new ApprovingBrain();
         var suggestions = new DictionarySuggestionService(
-            transcripts, dismissals, TenantGlossary.Load, now: () => Base);
+            transcripts, dismissals,
+            new DictionarySuggestionVerdictStore(db),
+            new DictionarySuggestionScanStore(db),
+            TenantGlossary.Load,
+            (_, _) => Task.FromResult<(IAgentBrain, string)>((brain, "stub-model")),
+            now: () => Base);
 
         // Two terms the model keeps getting wrong, neither in the (empty) glossary.
         SeedTerm(transcripts, Base, new[] { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15), ("Mindzee", 12) });
@@ -82,21 +119,32 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
         {
             using var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
 
-            // 1. Read the suggestions - both terms, ranked, with evidence and counts.
-            var list = await http.GetFromJsonAsync<SuggestionsBody>("/ingest/dictionary/suggestions", Json);
-            Assert.NotNull(list);
-            Assert.Equal(2, list!.Count);
-            var mindzie = list.Suggestions.Single(s => s.Term == "mindzie");
+            // 1. Before any scan: empty, never scanned, no model call was spent behind the read.
+            var before = await http.GetFromJsonAsync<SuggestionsBody>("/ingest/dictionary/suggestions", Json);
+            Assert.Equal(0, before!.Count);
+            Assert.Null(before.ScannedAtUtc);
+            Assert.True(before.ScreeningOk);
+            Assert.Equal(0, brain.Calls);
+
+            // 2. Scan now: both terms are mined, screened in ONE model call, and stored.
+            var scanResp = await http.PostAsync("/ingest/dictionary/suggestions/scan", null);
+            scanResp.EnsureSuccessStatusCode();
+            var scanned = await scanResp.Content.ReadFromJsonAsync<SuggestionsBody>(Json);
+            Assert.Equal(2, scanned!.Count);
+            Assert.Equal(Base, scanned.ScannedAtUtc);
+            Assert.True(scanned.ScreeningOk);
+            Assert.Equal(1, brain.Calls);
+            var mindzie = scanned.Suggestions.Single(s => s.Term == "mindzie");
             Assert.Equal(47, mindzie.WrongCount);
             Assert.Equal(91, mindzie.TotalCount);
             Assert.Contains(mindzie.Variants, v => v.Heard == "Mindsee");
 
-            // The count route (the nav badge) agrees.
+            // The count route (the nav badge) reads the same stored result.
             var count = await http.GetFromJsonAsync<CountBody>("/ingest/dictionary/suggestions/count", Json);
             Assert.Equal(2, count!.Count);
 
-            // 2. Apply "mindzie" - it must land in the glossary as a vocabulary term AND its wrong spellings
-            //    must land as Common mistranscriptions, in one call.
+            // 3. Apply "mindzie" - it must land in the glossary as a vocabulary term AND its wrong spellings
+            //    must land as Common mistranscriptions, in one call; the stored list reflects it at once.
             var applyResp = await http.PostAsJsonAsync("/ingest/dictionary/suggestions/apply",
                 new { terms = new[] { "mindzie" } });
             applyResp.EnsureSuccessStatusCode();
@@ -105,35 +153,43 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
             Assert.Contains("mindzie", apply.Dictionary.Vocabulary);
             Assert.True(apply.Dictionary.CommonMistranscriptions.ContainsKey("mindzie"));
             Assert.Contains("Mindsee", apply.Dictionary.CommonMistranscriptions["mindzie"]);
+            Assert.Equal(1, apply.Count);
 
-            // 3. The glossary the editor route reads now shows the applied term too (same file).
+            // 4. The glossary the editor route reads now shows the applied term too (same file).
             var glossary = await http.GetFromJsonAsync<DictionaryBody>("/ingest/dictionary", Json);
             Assert.Contains("mindzie", glossary!.Vocabulary);
 
-            // 4. "mindzie" is now in the dictionary, so it is no longer suggested; only Frederiksen remains.
+            // 5. Only Frederiksen remains in the stored suggestions.
             var afterApply = await http.GetFromJsonAsync<SuggestionsBody>("/ingest/dictionary/suggestions", Json);
-            Assert.Equal(1, afterApply!.Count);
-            Assert.Equal("Frederiksen", afterApply.Suggestions.Single().Term);
+            Assert.Equal("Frederiksen", afterApply!.Suggestions.Single().Term);
 
-            // 5. Dismiss Frederiksen - it disappears and the count goes to zero.
+            // 6. Dismiss Frederiksen - it disappears at once and the count goes to zero.
             var dismissResp = await http.PostAsJsonAsync("/ingest/dictionary/suggestions/dismiss",
                 new { term = "Frederiksen" });
             dismissResp.EnsureSuccessStatusCode();
             var afterDismiss = await http.GetFromJsonAsync<SuggestionsBody>("/ingest/dictionary/suggestions", Json);
             Assert.Equal(0, afterDismiss!.Count);
 
-            // 6. The dismissed list shows it with its evidence snapshot.
+            // 7. The dismissed list shows it with its evidence snapshot.
             var dismissed = await http.GetFromJsonAsync<DismissedBody>("/ingest/dictionary/dismissed", Json);
             var d = Assert.Single(dismissed!.Dismissed);
             Assert.Equal("Frederiksen", d.Term);
             Assert.Contains(d.Variants, v => v.Heard == "Fredriksson");
 
-            // 7. Restore it - it becomes eligible again and is mined back into the suggestions.
+            // 8. Restore it - the stored list stays as-is until a scan runs...
             var restoreResp = await http.PostAsJsonAsync("/ingest/dictionary/dismissed/restore",
                 new { term = "Frederiksen" });
             restoreResp.EnsureSuccessStatusCode();
             var afterRestore = await http.GetFromJsonAsync<SuggestionsBody>("/ingest/dictionary/suggestions", Json);
-            Assert.Equal("Frederiksen", afterRestore!.Suggestions.Single().Term);
+            Assert.Equal(0, afterRestore!.Count);
+
+            // ...and the next scan brings it back WITHOUT a second model call: its verdict is persisted,
+            // so the term is judged at most once, ever (through the HTTP surface too).
+            var rescanResp = await http.PostAsync("/ingest/dictionary/suggestions/scan", null);
+            rescanResp.EnsureSuccessStatusCode();
+            var rescanned = await rescanResp.Content.ReadFromJsonAsync<SuggestionsBody>(Json);
+            Assert.Equal("Frederiksen", rescanned!.Suggestions.Single().Term);
+            Assert.Equal(1, brain.Calls);
         }
         finally
         {
@@ -152,7 +208,8 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
     // Response shapes (camelCase from the endpoint; case-insensitive binding).
     private sealed record VariantBody(string Heard, int Count);
     private sealed record SuggestionBody(string Term, List<VariantBody> Variants, int WrongCount, int TotalCount);
-    private sealed record SuggestionsBody(List<SuggestionBody> Suggestions, int Count);
+    private sealed record SuggestionsBody(
+        List<SuggestionBody> Suggestions, int Count, DateTime? ScannedAtUtc, bool ScreeningOk, string ScreeningError);
     private sealed record CountBody(int Count);
     private sealed record DictionaryBody(
         List<string> Vocabulary, Dictionary<string, List<string>> CommonMistranscriptions);

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -481,11 +481,14 @@ internal static class RecordingEndpoints
     /// the same tenant idiom as the glossary routes above:
     ///   GET  /dictionary/suggestions          the ranked pending suggestions with evidence, plus the count
     ///   GET  /dictionary/suggestions/count     just the count (the nav-badge poll)
+    ///   POST /dictionary/suggestions/scan      run a scan NOW (mine + model-screen; the page's button)
     ///   POST /dictionary/suggestions/apply     add the chosen terms to the glossary (term + wrong spellings)
     ///   POST /dictionary/suggestions/dismiss   stop suggesting a term (remembered, evidence snapshotted)
     ///   GET  /dictionary/dismissed             the dismissed terms with their evidence, for the Restore screen
     ///   POST /dictionary/dismissed/restore     make a dismissed term eligible again
-    /// Every write invalidates this tenant's cached suggestions so the next read reflects the change at once.
+    /// Reads serve the STORED result of the latest scan (daily per tenant, or scan-now) - they never mine and
+    /// never call the screening model (devthrottle #2115). Apply and dismiss edit the stored result in place
+    /// so the page and the badge reflect the action at once; a restored term reappears on the next scan.
     /// </summary>
     private static void MapSuggestionRoutes(
         IEndpointRouteBuilder app,
@@ -497,8 +500,7 @@ internal static class RecordingEndpoints
         {
             var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (t is null) return TenantRequired();
-            var list = suggestions.GetSuggestions(t.Value);
-            return Results.Json(new SuggestionsResponse(list.Select(ToSuggestionDto).ToList(), list.Count));
+            return Results.Json(ToSuggestionsResponse(suggestions.GetStored(t.Value)));
         });
 
         app.MapGet("/dictionary/suggestions/count", (HttpContext ctx) =>
@@ -506,6 +508,17 @@ internal static class RecordingEndpoints
             var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (t is null) return TenantRequired();
             return Results.Json(new { count = suggestions.GetSuggestionCount(t.Value) });
+        });
+
+        // The Dictionary page's "Scan now" button: run the full scan (mine + screen the never-judged
+        // candidates) for this tenant and return the fresh stored result. May take seconds when there are
+        // new candidates (one model call); instant when there is nothing new to judge.
+        app.MapPost("/dictionary/suggestions/scan", async (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            var result = await suggestions.RunScanAsync(t.Value, ctx.RequestAborted);
+            return Results.Json(ToSuggestionsResponse(result));
         });
 
         app.MapPost("/dictionary/suggestions/apply", async (HttpContext ctx) =>
@@ -542,7 +555,8 @@ internal static class RecordingEndpoints
             }
 
             var updated = TenantGlossary.AddTerms(t.Value, vocab, mistranscriptions);
-            suggestions.Invalidate(t.Value); // the glossary changed, so the pending set changed
+            foreach (var term in applied)
+                suggestions.RemoveFromStored(t.Value, term); // reflect the apply at once, no rescan
             var remaining = suggestions.GetSuggestions(t.Value);
             return Results.Json(new SuggestionApplyResponse(
                 ToDto(updated), applied, remaining.Select(ToSuggestionDto).ToList(), remaining.Count));
@@ -572,7 +586,7 @@ internal static class RecordingEndpoints
             var match = suggestions.FindSuggestion(t.Value, req.Term)
                 ?? new MistranscriptionSuggestion(req.Term.Trim(), Array.Empty<MistranscriptionVariant>(), 0, 0);
             dismissals.Dismiss(t.Value, match, DateTime.UtcNow);
-            suggestions.Invalidate(t.Value);
+            suggestions.RemoveFromStored(t.Value, match.Term); // reflect the dismissal at once, no rescan
             return Results.Json(new { ok = true, dismissed = match.Term, count = suggestions.GetSuggestionCount(t.Value) });
         });
 
@@ -603,7 +617,8 @@ internal static class RecordingEndpoints
                 return Results.BadRequest(new { error = "provide 'term' (the term to restore)" });
 
             var restored = dismissals.Restore(t.Value, req.Term);
-            suggestions.Invalidate(t.Value); // the term is eligible again, so recompute on next read
+            // The term is eligible again on the NEXT scan (daily, or the page's "Scan now"); the stored
+            // result is not edited here because a restored term has no fresh mining evidence to show yet.
             return Results.Json(new { ok = true, restored });
         });
     }
@@ -613,6 +628,15 @@ internal static class RecordingEndpoints
         s.Variants.Select(v => new VariantDto(v.Heard, v.Count)).ToList(),
         s.WrongCount,
         s.TotalCount);
+
+    /// <summary>Fold a stored scan (or null = never scanned) into the wire response. Null folds to an empty
+    /// list with ScreeningOk true and no timestamp - the page's "no scan yet" state, not an error.</summary>
+    private static SuggestionsResponse ToSuggestionsResponse(DictionarySuggestionScanStore.ScanResult? scan)
+        => scan is null
+            ? new SuggestionsResponse(new List<SuggestionDto>(), 0, null, true, "")
+            : new SuggestionsResponse(
+                scan.Suggestions.Select(ToSuggestionDto).ToList(), scan.Suggestions.Count,
+                scan.ScannedAtUtc, scan.ScreeningOk, scan.ScreeningError);
 
     private static DismissedTermDto ToDismissedDto(DismissedTerm d) => new(
         d.Term,
@@ -841,9 +865,13 @@ internal sealed record VariantDto(string Heard, int Count);
 /// "wrong 53 of 97 times".</summary>
 internal sealed record SuggestionDto(string Term, List<VariantDto> Variants, int WrongCount, int TotalCount);
 
-/// <summary>GET /ingest/dictionary/suggestions - the ranked pending suggestions plus their count (the count
-/// the nav badge renders; the client never re-derives it).</summary>
-internal sealed record SuggestionsResponse(List<SuggestionDto> Suggestions, int Count);
+/// <summary>GET /ingest/dictionary/suggestions and POST .../scan - the stored scan's approved suggestions
+/// plus their count (the count the nav badge renders; the client never re-derives it), when the scan ran
+/// (null = never scanned), and the Gateway-ruled screening state the page renders VERBATIM (rule 7 - the
+/// client never derives a verdict): ScreeningOk false means the screening model was unreachable, the shown
+/// list is previously-screened only, and ScreeningError says why.</summary>
+internal sealed record SuggestionsResponse(
+    List<SuggestionDto> Suggestions, int Count, DateTime? ScannedAtUtc, bool ScreeningOk, string ScreeningError);
 
 /// <summary>POST /ingest/dictionary/suggestions/apply request: the canonical terms the customer chose to add.</summary>
 internal sealed record SuggestionApplyRequest(List<string>? Terms);

--- a/src/CcDirector.Gateway/Data/Entities/DictationSuggestionScanEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/DictationSuggestionScanEntity.cs
@@ -1,0 +1,37 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The stored RESULT of a tenant's most recent dictionary-suggestion scan (devthrottle issue #2115). One row
+/// per tenant, overwritten by each scan.
+///
+/// WHY STORED: scanning is a scheduled daily job (just after midnight in the tenant's own time zone) or an
+/// explicit "Scan now" - it mines up to 5,000 transcripts and may spend a model call. The navigation badge
+/// and the Dictionary page must NOT trigger that work; they read this row. This replaces the old design
+/// where a 45-second badge poll recomputed the mining every two minutes.
+///
+/// The row also carries the screening outcome: when the screening model could not be reached the scan says
+/// so here (<see cref="ScreeningOk"/>, <see cref="ScreeningError"/>) and the page shows it - unjudged
+/// candidates are NEVER shown unscreened.
+///
+/// <c>tenant_id</c> + the global query filter are inherited from <see cref="TenantScopedEntity"/>.
+/// </summary>
+public sealed class DictationSuggestionScanEntity : TenantScopedEntity
+{
+    /// <summary>When the scan ran (UTC). The daily sweep's due check reads this - the row IS the durable
+    /// "last ran" marker, so a Gateway restart never double-runs or skips a day.</summary>
+    public DateTime ScannedAtUtc { get; set; }
+
+    /// <summary>True when every candidate that needed screening got a verdict (including the trivial case of
+    /// nothing new to screen). False when the screening model was unreachable or answered unusably - the
+    /// scan still stored previously-approved suggestions, and the page says screening is unavailable.</summary>
+    public bool ScreeningOk { get; set; }
+
+    /// <summary>When <see cref="ScreeningOk"/> is false: the operator-readable reason (exception message).
+    /// Empty when screening succeeded.</summary>
+    public string ScreeningError { get; set; } = "";
+
+    /// <summary>The approved, evidence-carrying suggestions as a JSON array (term, variants, counts) - the
+    /// exact list the Dictionary page and the badge serve. A bounded sub-document (at most the miner's
+    /// MaxSuggestions entries), so it does not need its own table.</summary>
+    public string SuggestionsJson { get; set; } = "[]";
+}

--- a/src/CcDirector.Gateway/Data/Entities/DictationSuggestionVerdictEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/DictationSuggestionVerdictEntity.cs
@@ -1,0 +1,40 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One model VERDICT on a mined dictionary-suggestion candidate (devthrottle issue #2115): whether the
+/// screening model judged the candidate a distinctive term worth suggesting (a name, a brand, a piece of
+/// jargon the speech model keeps misspelling) or ordinary vocabulary that must never be suggested.
+///
+/// WHY PERSISTED: the screening call costs real model spend, and a term's nature does not change - "that"
+/// will never become jargon, "mindzie" will never become ordinary English. So a term is judged AT MOST ONCE
+/// per tenant, ever; every later scan reads the stored verdict instead of asking the model again. That is
+/// what keeps the steady-state screening cost per tenant near zero.
+///
+/// KEY: composite <c>(tenant_id, Term)</c>. <see cref="Term"/> is the NORMALIZED canonical spelling (lower-
+/// cased letters and digits, the same fold the miner clusters on), so the same term re-mined under different
+/// casing or punctuation maps onto its one verdict, exactly as the dismissal store matches.
+///
+/// <c>tenant_id</c> + the global query filter are inherited from <see cref="TenantScopedEntity"/>.
+/// </summary>
+public sealed class DictationSuggestionVerdictEntity : TenantScopedEntity
+{
+    /// <summary>The normalized canonical spelling (lower-cased alphanumerics). Part of the composite key.</summary>
+    public string Term { get; set; } = "";
+
+    /// <summary>The canonical spelling as the miner surfaced it (original casing), for display/diagnosis.</summary>
+    public string DisplayTerm { get; set; } = "";
+
+    /// <summary>True when the screening model approved the candidate as a distinctive term worth suggesting;
+    /// false when it judged the candidate ordinary vocabulary (or an inflection cluster) to suppress.</summary>
+    public bool Approved { get; set; }
+
+    /// <summary>The model's one-line reason, verbatim - kept so a surprising verdict can be diagnosed later
+    /// without re-asking the model. Display-only; nothing branches on it.</summary>
+    public string Reason { get; set; } = "";
+
+    /// <summary>The model id that judged this candidate (for diagnosis when screening quality is questioned).</summary>
+    public string Model { get; set; } = "";
+
+    /// <summary>When the verdict was recorded (UTC).</summary>
+    public DateTime JudgedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -100,6 +100,16 @@ public sealed class GatewayDbContext : DbContext
     /// "Dismissed terms" screen can still explain why it was once offered. Tenant-scoped.</summary>
     public DbSet<DictationSuggestionDismissalEntity> DictationSuggestionDismissals => Set<DictationSuggestionDismissalEntity>();
 
+    /// <summary>Model verdicts on mined dictionary-suggestion candidates (<c>dictation_suggestion_verdicts</c>,
+    /// devthrottle #2115) - one row per tenant per term, judged at most once ever; scans read stored verdicts
+    /// instead of re-asking the screening model. Tenant-scoped.</summary>
+    public DbSet<DictationSuggestionVerdictEntity> DictationSuggestionVerdicts => Set<DictationSuggestionVerdictEntity>();
+
+    /// <summary>The stored result of each tenant's most recent dictionary-suggestion scan
+    /// (<c>dictation_suggestion_scans</c>, devthrottle #2115) - one row per tenant; the badge and the
+    /// Dictionary page read this row instead of triggering mining. Tenant-scoped.</summary>
+    public DbSet<DictationSuggestionScanEntity> DictationSuggestionScans => Set<DictationSuggestionScanEntity>();
+
     /// <summary>The append-only governance audit trail (<c>governance_audit_events</c>) - structured
     /// intervention and permission/sandbox decisions, never inferred from transcripts (issue #1771).</summary>
     public DbSet<GovernanceAuditEventEntity> GovernanceAuditEvents => Set<GovernanceAuditEventEntity>();
@@ -379,6 +389,23 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.DismissedAtUtc });
         });
 
+        modelBuilder.Entity<DictationSuggestionVerdictEntity>(b =>
+        {
+            b.ToTable("dictation_suggestion_verdicts");
+            // COMPOSITE primary key (tenant_id, Term) - the per-tenant key pattern, mirroring the dismissal
+            // table exactly: Term is the NORMALIZED canonical spelling (lower-cased alphanumerics), derived
+            // not caller-supplied, compared ordinally (SQLite BINARY / Postgres "C"). One verdict per tenant
+            // per term is the whole point - the upsert reads through the tenant query filter.
+            b.HasKey(e => new { e.TenantId, e.Term });
+        });
+
+        modelBuilder.Entity<DictationSuggestionScanEntity>(b =>
+        {
+            b.ToTable("dictation_suggestion_scans");
+            // ONE row per tenant (the latest scan result), so the tenant id alone is the primary key.
+            b.HasKey(e => e.TenantId);
+        });
+
         modelBuilder.Entity<ActivityEventEntity>(b =>
         {
             b.ToTable("activity_events");
@@ -525,6 +552,8 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<DictationTranscriptEntity>(modelBuilder);
         ApplyTenantScope<WorkflowTenantOverrideEntity>(modelBuilder);
         ApplyTenantScope<DictationSuggestionDismissalEntity>(modelBuilder);
+        ApplyTenantScope<DictationSuggestionVerdictEntity>(modelBuilder);
+        ApplyTenantScope<DictationSuggestionScanEntity>(modelBuilder);
         ApplyTenantScope<ActivityEventEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
@@ -566,6 +595,9 @@ public sealed class GatewayDbContext : DbContext
             // like the keys above (the miner folds a spelling and compares exactly), so pin it to "C" so both
             // providers agree on uniqueness and the miner's dismissed-exclusion check matches identically.
             modelBuilder.Entity<DictationSuggestionDismissalEntity>().Property(e => e.Term).UseCollation("C");
+            // dictation_suggestion_verdicts.Term is the same normalized canonical spelling as the dismissal
+            // Term above, with the same byte-ordinal equality requirement - pin it to "C" identically.
+            modelBuilder.Entity<DictationSuggestionVerdictEntity>().Property(e => e.Term).UseCollation("C");
             // The tenants mapping table's natural-key string columns (the tenant id primary key and the
             // account_subject unique index) rely on byte-ordinal equality/uniqueness, same as the keys above,
             // so pin them to "C" too - the account subject in particular must match EXACTLY on both providers.

--- a/src/CcDirector.Gateway/Data/Migrations/20260724181957_AddDictionarySuggestionScreening.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724181957_AddDictionarySuggestionScreening.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724181957_AddDictionarySuggestionScreening")]
+    partial class AddDictionarySuggestionScreening
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260724181957_AddDictionarySuggestionScreening.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724181957_AddDictionarySuggestionScreening.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDictionarySuggestionScreening : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "dictation_suggestion_scans",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    ScannedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ScreeningOk = table.Column<bool>(type: "INTEGER", nullable: false),
+                    ScreeningError = table.Column<string>(type: "TEXT", nullable: false),
+                    SuggestionsJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dictation_suggestion_scans", x => x.tenant_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dictation_suggestion_verdicts",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    Term = table.Column<string>(type: "TEXT", nullable: false),
+                    DisplayTerm = table.Column<string>(type: "TEXT", nullable: false),
+                    Approved = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", nullable: false),
+                    Model = table.Column<string>(type: "TEXT", nullable: false),
+                    JudgedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dictation_suggestion_verdicts", x => new { x.tenant_id, x.Term });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_dictation_suggestion_scans_tenant_id",
+                table: "dictation_suggestion_scans",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_dictation_suggestion_verdicts_tenant_id",
+                table: "dictation_suggestion_verdicts",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dictation_suggestion_scans");
+
+            migrationBuilder.DropTable(
+                name: "dictation_suggestion_verdicts");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -450,6 +450,16 @@ public sealed class GatewayHost : IAsyncDisposable
     private static readonly TimeSpan ActivityRetentionInterval = TimeSpan.FromHours(6);
     private static readonly TimeSpan ActivityRetentionStartupDelay = TimeSpan.FromMinutes(5);
 
+    // The daily dictionary-suggestion scan (devthrottle #2115): the timer ticks every few minutes; the sweep
+    // decides PER TENANT whether that tenant's local 00:05 has passed since its last stored scan, so each
+    // tenant scans at its own midnight from one timer. Cheap when nothing is due (one stored-row read per
+    // tenant per tick). Guarded against overlap like the cron sweep. Created in StartAsync, disposed in
+    // StopAsync.
+    private System.Threading.Timer? _suggestionSweepTimer;
+    private int _suggestionSweepInFlight;
+    private static readonly TimeSpan SuggestionSweepInterval = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan SuggestionSweepStartupDelay = TimeSpan.FromMinutes(2);
+
     // Scheduled-run auto-dismiss (issue #1200): wakes ~every 15s and closes automated runs that declared
     // themselves done, over the Director stream. Created in StartAsync only when stream mode is on (the
     // feature has no REST fallback), disposed in StopAsync. Freshness matches the aggregation's pushed-cache
@@ -565,7 +575,10 @@ public sealed class GatewayHost : IAsyncDisposable
     // devthrottle #2075: the dismissed-suggestions store and the suggestions engine that mines the stored
     // transcripts per tenant. Both are tenant-scoped and constructed after _transcripts / _gatewayDb below.
     private readonly Transcription.DictionarySuggestionDismissalStore _dictionaryDismissals;
+    private readonly Transcription.DictionarySuggestionVerdictStore _dictionaryVerdicts;
+    private readonly Transcription.DictionarySuggestionScanStore _dictionaryScans;
     private readonly Transcription.DictionarySuggestionService _dictionarySuggestions;
+    private Transcription.DictionarySuggestionDailySweep? _suggestionDailySweep;
     // The voice-turn staging root, likewise bound to an explicitly-named partition. This path stages a clip
     // for the duration of one turn and then deletes it; it writes no delivery record and performs no
     // cross-request lookup by upload id, so it is unchanged by the dictation partition work. Per-tenant
@@ -982,13 +995,34 @@ public sealed class GatewayHost : IAsyncDisposable
         // no IsHosted branch; self-host is just the single Local tenant. No legacy file to import here (the old
         // flat dictation/sessions/*.jsonl log is retired, not migrated - it had no readers).
         _transcripts = new Transcription.TranscriptStore(_gatewayDb);
-        // devthrottle #2075: the dictionary-suggestions engine. It mines the tenant's stored transcripts
-        // (_transcripts) against that tenant's glossary (TenantGlossary.Load) and its dismissed terms
-        // (_dictionaryDismissals) to produce ranked, evidence-carrying suggestions. Tenant-scoped throughout;
-        // same store on SQLite (self-host) and Postgres (hosted), no IsHosted branch.
+        // devthrottle #2075 / #2115: the dictionary-suggestions engine. A SCAN (daily per tenant, or the
+        // page's "Scan now") mines the tenant's stored transcripts (_transcripts) against that tenant's
+        // glossary (TenantGlossary.Load) and its dismissed terms (_dictionaryDismissals), sends never-judged
+        // candidates to the screening model (the same hosted inference path as Wingman's fast leg, resolved
+        // at call time so a settings change is honored without restart), persists the verdicts
+        // (_dictionaryVerdicts - a term is judged at most once per tenant, ever), and stores the approved
+        // result (_dictionaryScans - what the page and the badge read). Tenant-scoped throughout; same
+        // stores on SQLite (self-host) and Postgres (hosted), no IsHosted branch.
         _dictionaryDismissals = new Transcription.DictionarySuggestionDismissalStore(_gatewayDb);
+        _dictionaryVerdicts = new Transcription.DictionarySuggestionVerdictStore(_gatewayDb);
+        _dictionaryScans = new Transcription.DictionarySuggestionScanStore(_gatewayDb);
         _dictionarySuggestions = new Transcription.DictionarySuggestionService(
-            _transcripts, _dictionaryDismissals, Transcription.TenantGlossary.Load);
+            _transcripts, _dictionaryDismissals, _dictionaryVerdicts, _dictionaryScans,
+            Transcription.TenantGlossary.Load,
+            (tenant, ct) =>
+            {
+                // The screening brain: the same endpoint as Wingman, on the tenant's THINKING model (the
+                // fast model was measured approving inflection clusters like "issue heard as issues" on the
+                // owner's real corpus - judgment quality decides this feature, and a nightly background scan
+                // does not care about speed), with a longer per-call deadline than a voice turn.
+                var mode = Core.Configuration.TranscriptionModeConfig.Get();
+                var ep = Core.Configuration.TranscriptionEndpointResolver.ResolveWingman(mode);
+                var key = _keyVault.Get(ep.KeyName) ?? "";
+                var model = _tenantSettingsResolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Thinking);
+                CcDirector.AgentBrain.IAgentBrain brain = new Wingman.HostedInferenceBrain(
+                    ep.BaseUrl, key, model, log: FileLog.Write, callTimeout: TimeSpan.FromMinutes(3));
+                return Task.FromResult((brain, model));
+            });
         // Cron-job definitions persist across a Gateway restart (epic #479, #482) in the cron_jobs table
         // (next-run times recomputed on load). The path argument is the LEGACY cronjobs.json, imported once
         // on first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real
@@ -1089,6 +1123,12 @@ public sealed class GatewayHost : IAsyncDisposable
 
         // The activity ledger's 30-day retention, on the same per-tenant worker seam.
         _activityRetentionSweep = new Activity.ActivityRetentionSweep(_tenantBoundary, TenantRegistry, _activityEvents);
+
+        // The daily dictionary-suggestion scan (devthrottle #2115), on the same per-tenant worker seam. The
+        // per-tenant body reads the tenant the seam entered from _tenantContext (the seam's sanctioned
+        // pattern) and the tenant's time zone from the settings resolver.
+        _suggestionDailySweep = new Transcription.DictionarySuggestionDailySweep(
+            _tenantBoundary, TenantRegistry, _tenantContext, _dictionarySuggestions, _tenantSettingsResolver);
 
         // Web Push (mobile app-icon "needs you" dot): load (or generate on first run) the VAPID key
         // pair and the set of subscribed devices. The notifier that fans out to these is built and
@@ -2489,6 +2529,14 @@ public sealed class GatewayHost : IAsyncDisposable
             ActivityRetentionStartupDelay, ActivityRetentionInterval);
         FileLog.Write($"[GatewayHost] activity retention sweep started: every {ActivityRetentionInterval.TotalHours:0}h, retention {Activity.ActivityRetentionSweep.RetentionPeriod.TotalDays:0} days");
 
+        // The daily dictionary-suggestion scan (devthrottle #2115): each tick asks, per tenant, whether that
+        // tenant's local 00:05 has passed since its last stored scan; only then does it mine and screen. The
+        // first pass is delayed so startup is never contended, and a tenant with no stored scan yet is seeded
+        // on that first pass.
+        _suggestionSweepTimer = new System.Threading.Timer(_ => SweepSuggestions(), null,
+            SuggestionSweepStartupDelay, SuggestionSweepInterval);
+        FileLog.Write($"[GatewayHost] dictionary-suggestion sweep started: tick every {SuggestionSweepInterval.TotalMinutes:0}m, daily per tenant at local 00:05");
+
         // MTR-15 cancellation cutoff: the hosted active-tenant entitlement sweep. Forces a fresh entitlement
         // read for every tenant with a live lease every ~60s and revokes any that has become NotEntitled, so a
         // cancelled tenant loses access within roughly one sweep cycle (never past the paid period end).
@@ -2763,6 +2811,35 @@ public sealed class GatewayHost : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// The dictionary-suggestion timer callback (a boundary - it owns the overlap guard and the try/catch so
+    /// a scan failure never crashes the timer thread). One sweep at a time; a skipped tick simply checks on
+    /// the next one, which a daily schedule is indifferent to.
+    /// </summary>
+    private void SweepSuggestions()
+    {
+        if (Interlocked.CompareExchange(ref _suggestionSweepInFlight, 1, 0) != 0)
+            return;
+        _ = RunSuggestionSweepAsync();
+    }
+
+    private async Task RunSuggestionSweepAsync()
+    {
+        try
+        {
+            if (_suggestionDailySweep is not null)
+                await _suggestionDailySweep.SweepAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHost] dictionary-suggestion sweep FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _suggestionSweepInFlight, 0);
+        }
+    }
+
     private void SweepEntitlementLeases()
     {
         // Skip this tick if the previous entitlement sweep is still running (many active tenants). One at a
@@ -2930,6 +3007,7 @@ public sealed class GatewayHost : IAsyncDisposable
         try { _cronTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] cron timer dispose error: {ex.Message}"); }
         _cronTimer = null;
         try { _activityRetentionTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] activity retention timer dispose error: {ex.Message}"); }
+        try { _suggestionSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] dictionary-suggestion timer dispose error: {ex.Message}"); }
         _activityRetentionTimer = null;
         try { _leaseSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] lease sweep timer dispose error: {ex.Message}"); }
         _leaseSweepTimer = null;

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionDailySweep.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionDailySweep.cs
@@ -1,0 +1,97 @@
+using Cronos;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Settings;
+using CcDirector.Gateway.Tenancy;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The DAILY dictionary-suggestion scan (devthrottle issue #2115): for each tenant, run one suggestion scan
+/// just after midnight in that tenant's OWN time zone (the per-account time zone setting on the Settings
+/// page). The timer in <c>GatewayHost</c> ticks this sweep every few minutes; the sweep itself decides, per
+/// tenant, whether that tenant's local 00:05 has passed since its last scan - so a tenant in Copenhagen and a
+/// tenant in Sydney each get their scan at their own midnight from the same timer.
+///
+/// THE STORED SCAN ROW IS THE DURABLE MARKER: "has this tenant's daily scan run" is answered by the scan
+/// store's <c>ScannedAtUtc</c>, so a Gateway restart never double-runs a tenant's day and never skips one. A
+/// tenant with NO stored scan at all is due immediately - the first sweep after this feature ships (or after
+/// a new tenant enrolls) seeds the stored result instead of leaving the badge dark until midnight. An
+/// explicit "Scan now" also refreshes the marker, which simply means the daily run happens at most once per
+/// local day across both triggers.
+///
+/// Runs through <see cref="TenantScopedSweep"/> (the G8 worker seam) so hosted fan-out, per-tenant scope
+/// entry, and per-tenant failure isolation are inherited, not re-implemented.
+/// </summary>
+public sealed class DictionarySuggestionDailySweep : TenantScopedSweep
+{
+    /// <summary>Five past midnight, tenant-local: past the midnight boundary (never ON it, so day-rollover
+    /// work like log rotation is done) but early enough that the result is waiting in the morning.</summary>
+    internal const string DailyCron = "5 0 * * *";
+
+    private static readonly CronExpression DailySchedule = CronExpression.Parse(DailyCron);
+
+    private readonly ITenantContext _tenantContext;
+    private readonly DictionarySuggestionService _suggestions;
+    private readonly TenantSettingsResolver _settings;
+    private readonly Func<DateTime> _now;
+
+    /// <param name="boundary">The hosted tenant boundary (the seam's scope mechanism). Required.</param>
+    /// <param name="tenants">The tenant census the seam fans out over. Required.</param>
+    /// <param name="tenantContext">The ambient tenant context; the per-tenant body reads the tenant the seam
+    /// entered from here (the seam's sanctioned pattern). Required.</param>
+    /// <param name="suggestions">The scan engine. Required.</param>
+    /// <param name="settings">The per-tenant settings resolver the time zone is read from. Required.</param>
+    /// <param name="now">Clock, injected so tests are deterministic; <see cref="DateTime.UtcNow"/> when null.</param>
+    public DictionarySuggestionDailySweep(
+        HostedTenantBoundary boundary,
+        TenantRegistry tenants,
+        ITenantContext tenantContext,
+        DictionarySuggestionService suggestions,
+        TenantSettingsResolver settings,
+        Func<DateTime>? now = null)
+        : base(boundary, tenants)
+    {
+        _tenantContext = tenantContext ?? throw new ArgumentNullException(nameof(tenantContext));
+        _suggestions = suggestions ?? throw new ArgumentNullException(nameof(suggestions));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _now = now ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>One sweep tick: for each tenant, scan if that tenant's daily run is due, otherwise do nothing.
+    /// Cheap when nothing is due (one stored-row read per tenant).</summary>
+    public Task SweepAsync(CancellationToken ct = default)
+        => ForEachTenantAsync(async () =>
+        {
+            var tenant = _tenantContext.Current;
+            var stored = _suggestions.GetStored(tenant);
+            var zone = ResolveZone(tenant);
+            if (!IsDue(stored?.ScannedAtUtc, zone, _now().ToUniversalTime()))
+                return;
+
+            FileLog.Write($"[SuggestionDailySweep] daily scan due: tenant={tenant.ToLogString()} zone={zone.Id}");
+            await _suggestions.RunScanAsync(tenant, ct).ConfigureAwait(false);
+        }, ct);
+
+    /// <summary>
+    /// Whether a tenant's daily scan is due: true when it never ran, or when the next tenant-local 00:05
+    /// after its last run is now in the past. Pure and DST-correct (Cronos does the zone arithmetic), so the
+    /// schedule is unit-testable without a host.
+    /// </summary>
+    internal static bool IsDue(DateTime? lastScanUtc, TimeZoneInfo zone, DateTime nowUtc)
+    {
+        if (lastScanUtc is null) return true;
+        var next = DailySchedule.GetNextOccurrence(
+            DateTime.SpecifyKind(lastScanUtc.Value, DateTimeKind.Utc), zone);
+        return next is not null && next.Value <= nowUtc;
+    }
+
+    private TimeZoneInfo ResolveZone(TenantId tenant)
+    {
+        // The resolver only returns a validated id (the tenant's setting or the operator default), so this
+        // resolves; an unknown id here means the machine's zone database changed and SHOULD fail this
+        // tenant's body loudly (the seam isolates it and the next tick retries).
+        var id = _settings.TimeZone(tenant);
+        return TimeZoneInfo.FindSystemTimeZoneById(id);
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionScanStore.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionScanStore.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The Gateway-owned, restart-surviving store of each tenant's LATEST dictionary-suggestion scan result
+/// (devthrottle issue #2115): one <c>dictation_suggestion_scans</c> row per tenant, overwritten by each scan.
+/// The navigation badge and the Dictionary page read this row - they never trigger mining or screening. The
+/// row's <see cref="ScanResult.ScannedAtUtc"/> doubles as the daily sweep's durable "last ran" marker, so a
+/// Gateway restart never double-runs or skips a tenant's day.
+///
+/// EXPLICIT TENANT ON EVERY CALL, mirroring <see cref="DictionarySuggestionDismissalStore"/>; every operation
+/// goes through <see cref="GatewayDatabase.CreateContext(TenantId)"/> under this store's write lock.
+/// </summary>
+public sealed class DictionarySuggestionScanStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <param name="db">The Gateway EF database this store reads and writes through. Required.</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    public DictionarySuggestionScanStore(GatewayDatabase db)
+        => _db = db ?? throw new ArgumentNullException(nameof(db));
+
+    /// <summary>A stored scan result: when it ran, whether screening completed, and the approved suggestions.</summary>
+    public sealed record ScanResult(
+        DateTime ScannedAtUtc,
+        bool ScreeningOk,
+        string ScreeningError,
+        IReadOnlyList<MistranscriptionSuggestion> Suggestions);
+
+    /// <summary>
+    /// Overwrite the tenant's stored scan result with a fresh one (one row per tenant).
+    /// </summary>
+    /// <param name="tenant">The tenant the caller resolved. Required and valid.</param>
+    /// <param name="result">The scan outcome to store. Required.</param>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The result is null.</exception>
+    public void Save(TenantId tenant, ScanResult result)
+    {
+        if (result is null) throw new ArgumentNullException(nameof(result));
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            var json = SerializeSuggestions(result.Suggestions);
+            var existing = ctx.DictationSuggestionScans.FirstOrDefault();
+            if (existing is null)
+            {
+                ctx.DictationSuggestionScans.Add(new DictationSuggestionScanEntity
+                {
+                    TenantId = tenant.Value,
+                    ScannedAtUtc = result.ScannedAtUtc.ToUniversalTime(),
+                    ScreeningOk = result.ScreeningOk,
+                    ScreeningError = result.ScreeningError,
+                    SuggestionsJson = json,
+                });
+            }
+            else
+            {
+                existing.ScannedAtUtc = result.ScannedAtUtc.ToUniversalTime();
+                existing.ScreeningOk = result.ScreeningOk;
+                existing.ScreeningError = result.ScreeningError;
+                existing.SuggestionsJson = json;
+            }
+            ctx.SaveChanges();
+            FileLog.Write($"[SuggestionScanStore] Save: tenant={tenant.ToLogString()} suggestions={result.Suggestions.Count} screeningOk={result.ScreeningOk}");
+        }
+    }
+
+    /// <summary>The tenant's stored scan result, or null when no scan has ever run for it.</summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public ScanResult? Get(TenantId tenant)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            var row = ctx.DictationSuggestionScans.AsNoTracking().FirstOrDefault();
+            if (row is null) return null;
+            return new ScanResult(
+                DateTime.SpecifyKind(row.ScannedAtUtc, DateTimeKind.Utc),
+                row.ScreeningOk,
+                row.ScreeningError,
+                DeserializeSuggestions(row.SuggestionsJson));
+        }
+    }
+
+    /// <summary>
+    /// Remove one term from the tenant's stored suggestion list in place (after an apply or a dismiss), so the
+    /// page and the badge reflect the action immediately without waiting for the next scan. Matched on the
+    /// normalized term; a no-op when there is no stored scan or the term is not in it.
+    /// </summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public void RemoveSuggestion(TenantId tenant, string term)
+    {
+        var norm = Normalize(term ?? "");
+        if (norm.Length == 0) return;
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            var existing = ctx.DictationSuggestionScans.FirstOrDefault();
+            if (existing is null) return;
+            var suggestions = DeserializeSuggestions(existing.SuggestionsJson);
+            var kept = suggestions.Where(s => Normalize(s.Term) != norm).ToList();
+            if (kept.Count == suggestions.Count) return;
+            existing.SuggestionsJson = SerializeSuggestions(kept);
+            ctx.SaveChanges();
+            FileLog.Write($"[SuggestionScanStore] RemoveSuggestion: tenant={tenant.ToLogString()} term={norm} remaining={kept.Count}");
+        }
+    }
+
+    private static string SerializeSuggestions(IReadOnlyList<MistranscriptionSuggestion> suggestions)
+        => JsonSerializer.Serialize(suggestions.Select(s => new SuggestionJson
+        {
+            term = s.Term,
+            wrong = s.WrongCount,
+            total = s.TotalCount,
+            variants = s.Variants.Select(v => new VariantJson { heard = v.Heard, count = v.Count }).ToList(),
+        }));
+
+    private static IReadOnlyList<MistranscriptionSuggestion> DeserializeSuggestions(string json)
+    {
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<List<SuggestionJson>>(json) ?? new();
+            return parsed
+                .Where(s => !string.IsNullOrWhiteSpace(s.term))
+                .Select(s => new MistranscriptionSuggestion(
+                    s.term!,
+                    (s.variants ?? new()).Where(v => !string.IsNullOrWhiteSpace(v.heard))
+                        .Select(v => new MistranscriptionVariant(v.heard!, v.count)).ToList(),
+                    s.wrong,
+                    s.total))
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            // A malformed stored row must not break the page; the next scan overwrites it wholesale.
+            return Array.Empty<MistranscriptionSuggestion>();
+        }
+    }
+
+    private sealed class SuggestionJson
+    {
+        public string? term { get; set; }
+        public int wrong { get; set; }
+        public int total { get; set; }
+        public List<VariantJson>? variants { get; set; }
+    }
+
+    private sealed class VariantJson
+    {
+        public string? heard { get; set; }
+        public int count { get; set; }
+    }
+
+    /// <summary>Lower-cased letters and digits only - identical to the miner's normalization.</summary>
+    private static string Normalize(string s)
+    {
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (var c in s)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionScreen.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionScreen.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using System.Text.Json;
+using CcDirector.AgentBrain;
+using CcDirector.Core.Dictation.Models;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The model SCREENING pass over mined dictionary-suggestion candidates (devthrottle issue #2115). The
+/// heuristic miner is good at FINDING clusters and provably bad at JUDGING them: it chained distinct common
+/// words ("that" ~ "then" ~ "them") into "mistranscriptions" and topped the list with them. Judging whether
+/// a cluster is a distinctive term (a name, a brand, jargon) or ordinary vocabulary is exactly the judgment
+/// a language model already has - in EVERY language, which is what makes this multilingual out of the box
+/// with no per-language word list to build or maintain.
+///
+/// CHUNKED CALLS: candidates go to the model <see cref="ChunkSize"/> at a time (a 50-candidate single batch
+/// was measured blowing the model call's deadline on the owner's real corpus, and shorter answers also keep
+/// the strict-JSON contract reliable). The caller persists every verdict (a term is judged at most once per
+/// tenant, ever), so the steady-state cost is near zero.
+///
+/// FAIL LOUD: a model failure (unreachable, empty, unparseable, or missing terms) THROWS - the caller records
+/// "screening unavailable" on the scan. Unjudged candidates are never guessed at and never shown unscreened;
+/// the standing "no language model in the dictation path" rule is untouched because this never runs during
+/// live dictation - only inside the daily scan or an explicit "Scan now".
+/// </summary>
+public static class DictionarySuggestionScreen
+{
+    /// <summary>Candidates per model call. Sized so one answer (a verdict object per candidate) stays well
+    /// inside the inference call's deadline and the model holds the strict-JSON contract.</summary>
+    public const int ChunkSize = 20;
+
+    /// <summary>
+    /// Judge <paramref name="candidates"/> with <paramref name="brain"/>, in chunks of <see cref="ChunkSize"/>.
+    /// Returns one verdict per candidate, in candidate order.
+    /// </summary>
+    /// <param name="brain">The model to ask (the hosted inference brain in production; a stub in tests).</param>
+    /// <param name="candidates">The unjudged candidates, each with its wrong-spelling evidence. Non-empty.</param>
+    /// <param name="ct">Cancellation for the model call.</param>
+    /// <exception cref="ArgumentNullException">The brain or candidates are null.</exception>
+    /// <exception cref="ArgumentException">The candidate list is empty.</exception>
+    /// <exception cref="InvalidOperationException">The model answered unusably (empty, unparseable JSON, or
+    /// verdicts missing for some candidates). The model's own transport errors propagate as thrown by it.</exception>
+    public static async Task<IReadOnlyList<DictionarySuggestionVerdictStore.Verdict>> JudgeAsync(
+        IAgentBrain brain,
+        IReadOnlyList<MistranscriptionSuggestion> candidates,
+        CancellationToken ct = default)
+    {
+        if (brain is null) throw new ArgumentNullException(nameof(brain));
+        if (candidates is null) throw new ArgumentNullException(nameof(candidates));
+        if (candidates.Count == 0) throw new ArgumentException("at least one candidate is required", nameof(candidates));
+
+        var verdicts = new List<DictionarySuggestionVerdictStore.Verdict>(candidates.Count);
+        for (var offset = 0; offset < candidates.Count; offset += ChunkSize)
+        {
+            var chunk = candidates.Skip(offset).Take(ChunkSize).ToList();
+            var prompt = BuildPrompt(chunk);
+            var answer = await brain.AskAsync(prompt, ct);
+            verdicts.AddRange(ParseVerdicts(answer.Text, chunk));
+        }
+        return verdicts;
+    }
+
+    /// <summary>Build the one-batch judgment prompt. Internal so tests can pin its shape.</summary>
+    internal static string BuildPrompt(IReadOnlyList<MistranscriptionSuggestion> candidates)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("You are screening candidate terms for a speech-to-text personal dictionary.");
+        sb.AppendLine("The dictionary biases a speech model toward distinctive terms it keeps misspelling:");
+        sb.AppendLine("product names, company names, people's names, and technical jargon.");
+        sb.AppendLine();
+        sb.AppendLine("A clustering pass over the user's dictation transcripts produced the candidates below.");
+        sb.AppendLine("The clustering is naive: it groups near-identical spellings, so many candidates are");
+        sb.AppendLine("actually clusters of DIFFERENT ordinary words (for example \"that\" grouped with");
+        sb.AppendLine("\"then\", \"them\", \"there\") or one ordinary word with its grammatical forms (for");
+        sb.AppendLine("example \"want\" with \"wanted\", \"wants\"). Those are NOT mistranscriptions and must");
+        sb.AppendLine("be rejected. The user may dictate in any language; ordinary words of ANY language are");
+        sb.AppendLine("rejected the same way.");
+        sb.AppendLine();
+        sb.AppendLine("APPROVE a candidate only when BOTH hold:");
+        sb.AppendLine("1. The TERM ITSELF is a distinctive term - a proper noun, a brand, a person's name, or");
+        sb.AppendLine("   a piece of domain jargon. An ordinary everyday word is never approved, however its");
+        sb.AppendLine("   cluster looks.");
+        sb.AppendLine("2. Its variants look like a speech model's MISSPELLINGS of that exact term - near-");
+        sb.AppendLine("   phonetic non-words or rare words. The following are NOT misspellings and count as");
+        sb.AppendLine("   evidence AGAINST a candidate:");
+        sb.AppendLine("   - grammatical forms of the term (a plural, a past tense, an -ing form: \"issues\"");
+        sb.AppendLine("     for \"issue\", \"killed\" for \"kill\") - the model heard those words correctly;");
+        sb.AppendLine("   - DIFFERENT real words (\"project\" is not a misspelling of \"product\",");
+        sb.AppendLine("     \"important\" is not a misspelling of \"implement\");");
+        sb.AppendLine("   - DIFFERENT names or products (\"GPT-5\" is not a misspelling of \"GPT-4\",");
+        sb.AppendLine("     \"OpenAI\" is not a misspelling of \"open\") - rewriting one into the other would");
+        sb.AppendLine("     corrupt the user's text.");
+        sb.AppendLine("REJECT everything else. When unsure, REJECT - a wrong approval corrupts every future");
+        sb.AppendLine("dictation, a wrong rejection costs nothing.");
+        sb.AppendLine();
+        sb.AppendLine("Candidates (term, then the variant spellings heard for it):");
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var c = candidates[i];
+            var variants = string.Join(", ", c.Variants.Select(v => v.Heard));
+            sb.AppendLine($"{i + 1}. \"{c.Term}\" heard as: {variants}");
+        }
+        sb.AppendLine();
+        sb.AppendLine("Answer with ONLY a JSON array, no other text, one object per candidate, in order:");
+        sb.AppendLine("[{\"term\":\"<the term exactly as listed>\",\"approved\":true|false,\"reason\":\"<one short sentence>\"}]");
+        return sb.ToString();
+    }
+
+    /// <summary>Parse the model's JSON verdicts, tolerating a fenced code block around the array but nothing
+    /// else. Internal so tests can drive it directly.</summary>
+    /// <exception cref="InvalidOperationException">The text has no parseable JSON array, or a candidate got
+    /// no verdict.</exception>
+    internal static IReadOnlyList<DictionarySuggestionVerdictStore.Verdict> ParseVerdicts(
+        string text, IReadOnlyList<MistranscriptionSuggestion> candidates)
+    {
+        var json = ExtractJsonArray(text);
+        List<VerdictJson> parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<List<VerdictJson>>(
+                json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new();
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"The screening model did not answer with valid JSON verdicts: {ex.Message}");
+        }
+
+        var byNorm = new Dictionary<string, VerdictJson>(StringComparer.Ordinal);
+        foreach (var v in parsed)
+            if (!string.IsNullOrWhiteSpace(v.term))
+                byNorm[Normalize(v.term!)] = v;
+
+        var verdicts = new List<DictionarySuggestionVerdictStore.Verdict>(candidates.Count);
+        var missing = new List<string>();
+        foreach (var candidate in candidates)
+        {
+            if (byNorm.TryGetValue(Normalize(candidate.Term), out var v))
+                verdicts.Add(new DictionarySuggestionVerdictStore.Verdict(
+                    candidate.Term, v.approved, (v.reason ?? "").Trim()));
+            else
+                missing.Add(candidate.Term);
+        }
+        if (missing.Count > 0)
+            throw new InvalidOperationException(
+                $"The screening model returned no verdict for: {string.Join(", ", missing)}");
+        return verdicts;
+    }
+
+    /// <summary>The JSON array in the model's answer: the whole trimmed text, or the first bracketed span when
+    /// the model wrapped it (a code fence, a leading sentence). Anything without a bracketed span fails.</summary>
+    private static string ExtractJsonArray(string text)
+    {
+        var trimmed = (text ?? "").Trim();
+        var start = trimmed.IndexOf('[');
+        var end = trimmed.LastIndexOf(']');
+        if (start < 0 || end <= start)
+            throw new InvalidOperationException("The screening model's answer contained no JSON array.");
+        return trimmed.Substring(start, end - start + 1);
+    }
+
+    private sealed class VerdictJson
+    {
+        public string? term { get; set; }
+        public bool approved { get; set; }
+        public string? reason { get; set; }
+    }
+
+    private static string Normalize(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        foreach (var c in s)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionService.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CcDirector.AgentBrain;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
 using CcDirector.Core.Tenancy;
@@ -7,90 +8,203 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Gateway.Transcription;
 
 /// <summary>
-/// The server-side dictionary-suggestions engine (devthrottle issue #2075): for a tenant, read what the
-/// speech model heard (the stored transcripts), read that tenant's current glossary and its dismissed terms,
-/// run the pure <see cref="MistranscriptionMiner"/>, and return the ranked suggestions with evidence. It is a
-/// thin read-compute-cache shell around the miner - all the mining policy lives in the pure miner, so this
-/// class only wires the three tenant-scoped inputs together and caches the result.
+/// The server-side dictionary-suggestions engine, redesigned in devthrottle issue #2115: a SCAN - run daily
+/// just after midnight in the tenant's own time zone, or on the Dictionary page's explicit "Scan now" - that
+/// mines the tenant's stored transcripts for candidate terms, sends the never-judged candidates to the
+/// screening model in one batch, persists the verdicts, and stores the approved suggestions. Reads (the page,
+/// the navigation badge) serve the STORED result and never trigger mining or a model call.
 ///
-/// TENANT-SCOPED THROUGHOUT. Every input is read for the EXPLICIT tenant the endpoint resolved: the
-/// transcripts through <see cref="TranscriptStore.RawTexts"/> (global query filter), the glossary through
-/// <see cref="TenantGlossary.Load"/> (per-tenant file), the dismissals through
-/// <see cref="DictionarySuggestionDismissalStore.DismissedTermNorms"/> (global query filter). The cache is
-/// keyed by tenant. So a suggestion computed for one tenant can never be built from, or served to, another.
+/// WHY THE REDESIGN. The first version recomputed the mining every two minutes behind a badge poll and
+/// surfaced whatever the heuristic clustering produced - which in practice was ordinary words ("that",
+/// "want", "your") chained together by phonetic nearness. Two fixes, both here: judgment moved to a language
+/// model that knows ordinary vocabulary in every language (see <see cref="DictionarySuggestionScreen"/>),
+/// and the cadence moved to a daily scan whose result is stored (see <see cref="DictionarySuggestionScanStore"/>),
+/// because suggestion-worthy evidence accumulates over days, not minutes.
 ///
-/// CACHED WITH A SHORT TTL, INVALIDATED ON CHANGE. Mining scans up to <see cref="MaxTranscriptsMined"/>
-/// transcripts, so the result is memoized per tenant for <see cref="CacheTtl"/> to keep the nav-badge poll
-/// and the page load cheap. The cache is invalidated for a tenant whenever its glossary or dismissals change
-/// (apply, dismiss, restore), so a change is reflected on the next read rather than after the TTL. There is
-/// NO clock injection into the miner (it is pure); the only clock here is the injected <see cref="_now"/>
-/// used for the TTL, so tests stay deterministic.
+/// SCREENING FAILURE IS LOUD, NOT SILENT: when the model cannot be reached the scan stores
+/// "screening unavailable" with the reason and serves only PREVIOUSLY-approved suggestions - a candidate
+/// that has never been judged is never shown. There is no heuristic fallback; the unscreened list is known
+/// garbage.
+///
+/// TENANT-SCOPED THROUGHOUT, like every store on this layer: every input is read for the EXPLICIT tenant the
+/// caller resolved, and the per-tenant scan lock keeps a button press and the daily sweep from mining the
+/// same tenant twice concurrently.
 /// </summary>
 public sealed class DictionarySuggestionService
 {
-    /// <summary>The most-recent transcripts mined per tenant. Bounds the mining cost; the store's own 30-day /
+    /// <summary>The most-recent transcripts mined per scan. Bounds the mining cost; the store's own 30-day /
     /// 10,000-row retention (issue #509) already bounds what exists, and the newest slice is the relevant one
     /// for "what is the model getting wrong lately".</summary>
     public const int MaxTranscriptsMined = 5_000;
 
-    /// <summary>How long a computed suggestion set is memoized per tenant before it is recomputed.</summary>
-    public static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(2);
+    /// <summary>Bound on screening rounds within ONE scan. A scan LOOPS - mine, screen, exclude the rejected,
+    /// re-mine - because the miner caps its output (MaxSuggestions) and, on a first run, ordinary-word garbage
+    /// fills that cap and would otherwise crowd every real term out of the model's sight (proven on the
+    /// owner's real corpus: "mindzie" was rank ~55 behind 50 rejected clusters). The loop converges when a
+    /// round yields no never-judged candidate; this bound is the cost ceiling for pathological corpora - a
+    /// scan makes at most this many model calls, and later scans make almost none (verdicts persist).</summary>
+    public const int MaxScreeningRoundsPerScan = 10;
+
+    /// <summary>Resolves the screening brain and its model id for a tenant. Production builds the hosted
+    /// inference brain the same way Wingman's fast leg does; tests pass a stub. The brain is disposed by the
+    /// scan after the call.</summary>
+    public delegate Task<(IAgentBrain Brain, string Model)> ScreeningBrainFactory(TenantId tenant, CancellationToken ct);
 
     private readonly TranscriptStore _transcripts;
     private readonly DictionarySuggestionDismissalStore _dismissals;
+    private readonly DictionarySuggestionVerdictStore _verdicts;
+    private readonly DictionarySuggestionScanStore _scans;
     private readonly Func<TenantId, DictationDictionary> _glossaryProvider;
+    private readonly ScreeningBrainFactory _brainFactory;
     private readonly MistranscriptionMiner.Options _options;
     private readonly Func<DateTime> _now;
 
-    private sealed record CacheEntry(IReadOnlyList<MistranscriptionSuggestion> Suggestions, DateTime ComputedUtc);
-    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _scanLocks = new(StringComparer.Ordinal);
 
     /// <param name="transcripts">The store the raw transcripts are mined from. Required.</param>
     /// <param name="dismissals">The store the dismissed terms are read from. Required.</param>
+    /// <param name="verdicts">The store the model verdicts are read from and recorded to. Required.</param>
+    /// <param name="scans">The store the scan result is stored in and served from. Required.</param>
     /// <param name="glossaryProvider">Resolves a tenant's current glossary; production passes
     /// <see cref="TenantGlossary.Load"/>. Required.</param>
+    /// <param name="brainFactory">Resolves the screening brain per tenant. Required.</param>
     /// <param name="options">Mining policy; <see cref="MistranscriptionMiner.Options.Default"/> when null.</param>
-    /// <param name="now">Clock for the cache TTL; <see cref="DateTime.UtcNow"/> when null.</param>
+    /// <param name="now">Clock for scan timestamps; <see cref="DateTime.UtcNow"/> when null.</param>
     public DictionarySuggestionService(
         TranscriptStore transcripts,
         DictionarySuggestionDismissalStore dismissals,
+        DictionarySuggestionVerdictStore verdicts,
+        DictionarySuggestionScanStore scans,
         Func<TenantId, DictationDictionary> glossaryProvider,
+        ScreeningBrainFactory brainFactory,
         MistranscriptionMiner.Options? options = null,
         Func<DateTime>? now = null)
     {
         _transcripts = transcripts ?? throw new ArgumentNullException(nameof(transcripts));
         _dismissals = dismissals ?? throw new ArgumentNullException(nameof(dismissals));
+        _verdicts = verdicts ?? throw new ArgumentNullException(nameof(verdicts));
+        _scans = scans ?? throw new ArgumentNullException(nameof(scans));
         _glossaryProvider = glossaryProvider ?? throw new ArgumentNullException(nameof(glossaryProvider));
+        _brainFactory = brainFactory ?? throw new ArgumentNullException(nameof(brainFactory));
         _options = options ?? MistranscriptionMiner.Options.Default;
         _now = now ?? (() => DateTime.UtcNow);
     }
 
-    /// <summary>The ranked suggestions for a tenant, from cache when fresh, otherwise recomputed. Never throws
-    /// for a mining problem - an empty transcript set simply yields an empty list.</summary>
+    /// <summary>
+    /// Run a full scan for a tenant: mine, screen the never-judged candidates, persist verdicts, store and
+    /// return the result. Serialized per tenant - a concurrent second call waits, then runs (its screening is
+    /// a no-op because the verdicts are already persisted).
+    /// </summary>
     /// <exception cref="ArgumentException">The tenant is invalid.</exception>
-    public IReadOnlyList<MistranscriptionSuggestion> GetSuggestions(TenantId tenant)
+    /// <exception cref="OperationCanceledException">The caller cancelled.</exception>
+    public async Task<DictionarySuggestionScanStore.ScanResult> RunScanAsync(TenantId tenant, CancellationToken ct = default)
     {
-        var nowUtc = _now().ToUniversalTime();
-        if (_cache.TryGetValue(tenant.Value, out var cached) && nowUtc - cached.ComputedUtc < CacheTtl)
-            return cached.Suggestions;
+        var gate = _scanLocks.GetOrAdd(tenant.Value, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            return await RunScanCoreAsync(tenant, ct);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
 
+    private async Task<DictionarySuggestionScanStore.ScanResult> RunScanCoreAsync(TenantId tenant, CancellationToken ct)
+    {
         var raw = _transcripts.RawTexts(tenant, MaxTranscriptsMined);
         var dictionary = _glossaryProvider(tenant);
         var dismissed = _dismissals.DismissedTermNorms(tenant);
-        var suggestions = MistranscriptionMiner.Mine(raw, dictionary, dismissed, _options);
 
-        _cache[tenant.Value] = new CacheEntry(suggestions, nowUtc);
-        FileLog.Write($"[SuggestionService] computed tenant={tenant.ToLogString()} transcripts={raw.Count} suggestions={suggestions.Count}");
-        return suggestions;
+        var verdicts = new Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var kv in _verdicts.VerdictsByNorm(tenant))
+            verdicts[kv.Key] = kv.Value;
+
+        // The mine-screen loop. Each round mines with the REJECTED terms excluded (they occupy the miner's
+        // capped output otherwise - the crowding-out proven on the owner's real corpus), screens whatever is
+        // still never-judged, and re-mines. Converges when a round has nothing unjudged; bounded by
+        // MaxScreeningRoundsPerScan as the cost ceiling. Steady state is one round and zero model calls.
+        var screeningOk = true;
+        var screeningError = "";
+        IReadOnlyList<MistranscriptionSuggestion> mined;
+        var rounds = 0;
+        while (true)
+        {
+            var excluded = dismissed
+                .Concat(verdicts.Where(kv => !kv.Value).Select(kv => kv.Key))
+                .ToList();
+            mined = MistranscriptionMiner.Mine(raw, dictionary, excluded, _options);
+
+            var unjudged = mined.Where(s => !verdicts.ContainsKey(Normalize(s.Term))).ToList();
+            if (unjudged.Count == 0)
+                break;
+            if (rounds >= MaxScreeningRoundsPerScan)
+            {
+                // The bound hit with candidates still unjudged: say so rather than pretend the scan is
+                // complete. The next scan resumes where this one stopped (verdicts persist).
+                screeningOk = false;
+                screeningError = $"stopped after {rounds} screening rounds with {unjudged.Count} candidates still unjudged; the next scan continues";
+                FileLog.Write($"[SuggestionScan] tenant={tenant.ToLogString()} round cap hit: {screeningError}");
+                break;
+            }
+            rounds++;
+
+            try
+            {
+                var (brain, model) = await _brainFactory(tenant, ct);
+                IReadOnlyList<DictionarySuggestionVerdictStore.Verdict> judged;
+                using (brain)
+                {
+                    judged = await DictionarySuggestionScreen.JudgeAsync(brain, unjudged, ct);
+                }
+                _verdicts.Record(tenant, judged, model, _now().ToUniversalTime());
+                foreach (var v in judged)
+                    verdicts[Normalize(v.Term)] = v.Approved;
+                FileLog.Write($"[SuggestionScan] tenant={tenant.ToLogString()} round={rounds} screened={judged.Count} approved={judged.Count(v => v.Approved)}");
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Fail loud on the stored result: the page says screening is unavailable and the unjudged
+                // candidates stay hidden. Previously-approved suggestions were screened, so they still serve.
+                screeningOk = false;
+                screeningError = ex.Message;
+                FileLog.Write($"[SuggestionScan] tenant={tenant.ToLogString()} screening FAILED: {ex.Message}");
+                break;
+            }
+        }
+
+        var approved = mined
+            .Where(s => verdicts.TryGetValue(Normalize(s.Term), out var ok) && ok)
+            .ToList();
+
+        var result = new DictionarySuggestionScanStore.ScanResult(
+            _now().ToUniversalTime(), screeningOk, screeningError, approved);
+        _scans.Save(tenant, result);
+        return result;
     }
 
-    /// <summary>The number of pending suggestions for a tenant - the nav-badge count. Reuses the cached
-    /// computation, so polling the badge is as cheap as reading the list.</summary>
+    /// <summary>The tenant's stored scan result, or null when no scan has ever run. Never mines, never calls
+    /// the model - this is what the page and the badge read.</summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public DictionarySuggestionScanStore.ScanResult? GetStored(TenantId tenant) => _scans.Get(tenant);
+
+    /// <summary>The stored suggestions for a tenant (empty when no scan has run).</summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public IReadOnlyList<MistranscriptionSuggestion> GetSuggestions(TenantId tenant)
+        => GetStored(tenant)?.Suggestions ?? Array.Empty<MistranscriptionSuggestion>();
+
+    /// <summary>The stored suggestion count for a tenant - the navigation badge number.</summary>
     /// <exception cref="ArgumentException">The tenant is invalid.</exception>
     public int GetSuggestionCount(TenantId tenant) => GetSuggestions(tenant).Count;
 
-    /// <summary>Find one pending suggestion by its (case/punctuation-insensitive) term - what the dismiss route
-    /// needs to snapshot the evidence being dismissed. Null when the term is not currently suggested.</summary>
+    /// <summary>Find one stored suggestion by its (case/punctuation-insensitive) term, or null. The apply and
+    /// dismiss endpoints resolve each requested term against this, so a caller can only act on what the scan
+    /// actually offered.</summary>
     /// <exception cref="ArgumentException">The tenant is invalid.</exception>
     public MistranscriptionSuggestion? FindSuggestion(TenantId tenant, string term)
     {
@@ -99,10 +213,12 @@ public sealed class DictionarySuggestionService
         return GetSuggestions(tenant).FirstOrDefault(s => Normalize(s.Term) == norm);
     }
 
-    /// <summary>Drop a tenant's cached suggestions so the next read recomputes. Called after any change that
-    /// alters the result - a glossary edit (apply), a dismissal, or a restore.</summary>
-    public void Invalidate(TenantId tenant) => _cache.TryRemove(tenant.Value, out _);
+    /// <summary>Remove one term from the tenant's stored suggestions in place (after an apply or a dismiss),
+    /// so the page and the badge reflect the action immediately without a rescan.</summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public void RemoveFromStored(TenantId tenant, string term) => _scans.RemoveSuggestion(tenant, term);
 
+    /// <summary>Lower-cased letters and digits only - identical to the miner's clustering fold.</summary>
     private static string Normalize(string s)
     {
         var sb = new System.Text.StringBuilder(s.Length);

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionVerdictStore.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionVerdictStore.cs
@@ -1,0 +1,113 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The Gateway-owned, restart-surviving store of screening-model VERDICTS on mined dictionary-suggestion
+/// candidates (devthrottle issue #2115): one <c>dictation_suggestion_verdicts</c> row per tenant per term.
+/// A term is judged by the model AT MOST ONCE per tenant, ever - the scan reads <see cref="VerdictsByNorm"/>
+/// to split mined candidates into already-judged (serve the stored verdict) and new (send to the model), and
+/// records the model's answers through <see cref="Record"/>. That persistence is what keeps the steady-state
+/// screening cost per tenant near zero.
+///
+/// EXPLICIT TENANT ON EVERY CALL, mirroring <see cref="DictionarySuggestionDismissalStore"/>: the tenant is
+/// passed in by the caller that resolved it; this layer performs NO ambient or static tenant inference. It
+/// goes through <see cref="GatewayDatabase.CreateContext(TenantId)"/>, so the global query filter scopes
+/// every read and write and one tenant can never read or shape another's verdicts.
+///
+/// Threading: the Gateway is a single writer; every operation runs under this store's write lock over a
+/// fresh pooled context, preserving the single-writer invariant every store on this layer keeps.
+/// </summary>
+public sealed class DictionarySuggestionVerdictStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <param name="db">The Gateway EF database this store reads and writes through. Required.</param>
+    /// <exception cref="ArgumentNullException">The database is null.</exception>
+    public DictionarySuggestionVerdictStore(GatewayDatabase db)
+        => _db = db ?? throw new ArgumentNullException(nameof(db));
+
+    /// <summary>One verdict as the scan consumes it: approved or not, with the model's reason for diagnosis.</summary>
+    public sealed record Verdict(string Term, bool Approved, string Reason);
+
+    /// <summary>
+    /// Record a batch of model verdicts for a tenant, upserting by normalized term. Upsert (rather than
+    /// insert-only) keeps a re-judge deliberate and possible - a future "re-screen" action can overwrite -
+    /// while the normal scan path never re-submits a judged term in the first place.
+    /// </summary>
+    /// <param name="tenant">The tenant the caller resolved. Required and valid.</param>
+    /// <param name="verdicts">The model's answers. Terms that normalize to empty are skipped.</param>
+    /// <param name="model">The model id that judged the batch (stamped on each row for diagnosis).</param>
+    /// <param name="nowUtc">The judgment time (UTC), injected so tests are deterministic.</param>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The verdicts are null.</exception>
+    public void Record(TenantId tenant, IEnumerable<Verdict> verdicts, string model, DateTime nowUtc)
+    {
+        if (verdicts is null) throw new ArgumentNullException(nameof(verdicts));
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            var written = 0;
+            foreach (var verdict in verdicts)
+            {
+                var norm = Normalize(verdict.Term);
+                if (norm.Length == 0) continue;
+                var existing = ctx.DictationSuggestionVerdicts.FirstOrDefault(e => e.Term == norm);
+                if (existing is null)
+                {
+                    ctx.DictationSuggestionVerdicts.Add(new DictationSuggestionVerdictEntity
+                    {
+                        TenantId = tenant.Value,
+                        Term = norm,
+                        DisplayTerm = verdict.Term,
+                        Approved = verdict.Approved,
+                        Reason = verdict.Reason,
+                        Model = model ?? "",
+                        JudgedAtUtc = nowUtc.ToUniversalTime(),
+                    });
+                }
+                else
+                {
+                    existing.DisplayTerm = verdict.Term;
+                    existing.Approved = verdict.Approved;
+                    existing.Reason = verdict.Reason;
+                    existing.Model = model ?? "";
+                    existing.JudgedAtUtc = nowUtc.ToUniversalTime();
+                }
+                written++;
+            }
+            ctx.SaveChanges();
+            FileLog.Write($"[VerdictStore] Record: tenant={tenant.ToLogString()} verdicts={written} model={model}");
+        }
+    }
+
+    /// <summary>Every stored verdict for a tenant, keyed by the NORMALIZED term (true = approved). The scan
+    /// reads this once and splits mined candidates into judged and unjudged.</summary>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public IReadOnlyDictionary<string, bool> VerdictsByNorm(TenantId tenant)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            return ctx.DictationSuggestionVerdicts.AsNoTracking()
+                .ToDictionary(e => e.Term, e => e.Approved, StringComparer.Ordinal);
+        }
+    }
+
+    /// <summary>Lower-cased letters and digits only - identical to the miner's normalization, so a mined
+    /// candidate and its stored verdict compare on the exact same key.</summary>
+    private static string Normalize(string s)
+    {
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (var c in s)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
Closes #2115.

## What this changes

The dictionary suggestions shipped in #2109 offered ordinary words ("that", "want", "your") because the heuristic clustering chains distinct common words together, and it recomputed that garbage every two minutes behind the badge poll. This pull request replaces the judging and the cadence while keeping the miner as the candidate generator.

**A language model now screens every candidate.** Never-judged candidates go to the screening model (the tenant's thinking model over the same hosted inference path Wingman uses) in chunks of 20, with a prompt that rejects ordinary words of any language, grammatical forms ("issue" heard as "issues"), and mixed clusters ("open" grouped with "OpenAI"). Verdicts are persisted per tenant per term - a term is judged at most once, ever - so steady-state model cost is near zero. This is multilingual by construction: no word lists exist to maintain.

**The scan loops until it converges.** Mine, screen, exclude the rejected, re-mine - because the miner caps its output and, on a first run, garbage fills the cap and would crowd every real term out of the model's sight (measured on the owner's real corpus: "Frederiksen" sat at rank 35 behind rejected clusters). Bounded by ten rounds per scan; an unfinished scan says so and the next scan resumes.

**Scanning is daily, in the tenant's own time zone.** A sweep on the tenant-scoped worker seam runs each tenant's scan just after midnight local (00:05, DST-correct via the existing cron primitives), reading the account time zone setting. The stored scan row is the durable "last ran" marker. The Dictionary page gains a "Scan now" button; the badge and page read the stored result and never trigger mining.

**Screening failure is loud.** If the model is unreachable, the scan stores "screening unavailable" with the reason, the page says so, and unjudged candidates are never shown. Previously-approved suggestions still serve - they were screened.

**Small fold-in:** new scheduled jobs default their time zone to the account setting instead of starting empty.

## Validation on the real corpus

Ran the shipped miner and the shipped screening prompt against the owner's 4,107 real dictation utterances with the real hosted model (`docs/reviews/dictionary-screened-scan-proof-2026-07-24.md`):

- Before: 50 candidates, effectively all garbage ("this" heard as "that, then, think, them...").
- After: 4 screening rounds, 169 candidates judged, 2 approved - **Frederiksen** and **DuxRevo**, both genuinely distinctive names with genuine phonetic misspellings.

The validation also caught three flaws that are fixed here: cap crowding (hence the loop), a single 50-candidate batch blowing the 60-second inference deadline (hence chunking plus a 3-minute screening deadline), and the fast model approving inflection clusters (hence the thinking model).

## Storage

Two new tenant-scoped tables with the migration pair in this pull request (SQLite + Postgres, snapshots verified in sync): `dictation_suggestion_verdicts` (one verdict per tenant per term) and `dictation_suggestion_scans` (one stored scan result per tenant).

## Tests

- 8 screen tests (prompt shape, chunking, strict JSON parsing, fail-loud on prose/malformed/missing verdicts)
- 10 service tests (judge-once persistence, rejected-hidden, loud failure path, crowding regression from the real corpus, tenant isolation, stored-result reads)
- 9 store tests (verdict upsert and isolation; scan round-trip, overwrite, in-place removal)
- 5 daily-sweep tests (pure due-rule incl. per-tenant zones, self-host integration seeding and same-day no-op)
- HTTP end-to-end: scan, apply, dismiss, restore, rescan without a second model call
- Cockpit: 176 tests including the new scan-row, never-scanned, and screening-unavailable states; client-core 578; typecheck clean
