### PR TITLE
feat(gateway+cockpit): fleet Assistant - chat/voice fleet questions from the cockpit

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -63,6 +63,7 @@ interface NavItem {
 // and it is next to the place you start work rather than filed away under settings.
 const NAV_MAIN: ReadonlyArray<NavItem> = [
   { to: "/fleet-map", label: "Fleet Map", icon: "fleet-map" },
+  { to: "/assistant", label: "Assistant", icon: "assistant" },
   { to: "/sessions", label: "Sessions", icon: "sessions", subtree: "/session" },
   { to: "/directors", label: "Directors", icon: "directors" },
   { to: "/schedule", label: "Schedule", icon: "schedule" },

--- a/apps/cockpit/src/assistant/AssistantView.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useLayoutEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useAssistant, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+import { PageHeader } from "../components";
+
+// The Assistant (fleet assistant build): a fleet-level chat + voice screen that is NOT tied to any
+// session. It drives the Gateway brain at POST /assistant/turn - the desk surface of the same brain
+// Car Mode uses - so every fact on screen came from a real Gateway tool call, never from the page.
+//
+// Two modes, one conversation: Chat types, Voice talks with a BUTTON (tap to talk, tap again to
+// send - no silence detection, no end phrase) and reads every reply aloud. The transcript, the turn
+// machine, and all Gateway calls live in client-core/assistant/useAssistant; this file is layout.
+
+const PHASE_LINE: Record<AssistantPhase, string> = {
+  idle: "",
+  listening: "Listening... tap again when you are done.",
+  transcribing: "Transcribing...",
+  thinking: "Checking the fleet...",
+  speaking: "Reading the answer aloud...",
+};
+
+/** The tap-to-talk microphone glyph, drawn on the shared 24x24 / 2px-stroke grid the rail icons use. */
+function MicGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+      strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <path d="M12 19v3" />
+    </svg>
+  );
+}
+
+export function AssistantView() {
+  // The permanently-mounted, hidden audio element read-aloud plays on (the mobile Voice pattern:
+  // never unmounted, so a mode switch or re-render cannot orphan live audio).
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const assistant = useAssistant(audioRef);
+  const { entries, phase, mode, setMode, busy, confirmOffered } = assistant;
+
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const atBottomRef = useRef(true);
+
+  // Sticky-bottom scrolling, same discipline as the session Chat tab: follow the conversation only
+  // while the reader is already at the bottom.
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [entries, phase]);
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  const send = useCallback(() => {
+    if (draft.trim().length === 0) return;
+    assistant.sendText(draft);
+    setDraft("");
+  }, [assistant, draft]);
+
+  const onComposerKeyDown = useCallback((e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }, [send]);
+
+  const toggleTalk = useCallback(() => {
+    if (phase === "listening") assistant.endTalk();
+    else assistant.startTalk();
+  }, [assistant, phase]);
+
+  return (
+    <div className="asst-page">
+      <PageHeader
+        title="Assistant"
+        subtitle="Ask about your whole fleet - sessions, machines, credits, schedules. Not tied to any session."
+        actions={
+          <div className="asst-mode" role="tablist" aria-label="Assistant mode">
+            <button type="button" role="tab" aria-selected={mode === "chat"}
+              className={mode === "chat" ? "asst-mode-btn active" : "asst-mode-btn"}
+              onClick={() => setMode("chat")}>Chat</button>
+            <button type="button" role="tab" aria-selected={mode === "voice"}
+              className={mode === "voice" ? "asst-mode-btn active" : "asst-mode-btn"}
+              onClick={() => setMode("voice")}>Voice</button>
+          </div>
+        }
+      />
+
+      <div className="asst-stage">
+        {entries.length === 0 ? (
+          <div className="asst-empty">
+            <p>Ask anything about your development fleet:</p>
+            <ul>
+              <li>"How many sessions do I have open, and is anything stuck?"</li>
+              <li>"Which sessions have been open too long?"</li>
+              <li>"How are we doing on credits?"</li>
+              <li>"Which machines are online?"</li>
+              <li>"What runs automatically tonight?"</li>
+            </ul>
+            <p>It can also act - message a session, snooze one, start one, or close one (closing always
+              asks you to confirm first).</p>
+          </div>
+        ) : (
+          <div className="asst-scroll" ref={scrollRef} onScroll={onScroll}>
+            {entries.map((entry, i) => (
+              entry.role === "user" ? (
+                <div className="asst-user" key={i}>{entry.text}</div>
+              ) : entry.role === "error" ? (
+                <div className="asst-error" role="alert" key={i}>{entry.text}</div>
+              ) : (
+                <div className="asst-turn" key={i}>
+                  {(entry.actions ?? []).map((action, j) => (
+                    <div className="asst-action" key={j}>
+                      <span className="asst-dot" aria-hidden="true" />
+                      <span className="asst-action-text">{action.summary}</span>
+                    </div>
+                  ))}
+                  <div className="asst-reply">{entry.text}</div>
+                </div>
+              )
+            ))}
+            {phase !== "idle" && <div className="asst-phase">{PHASE_LINE[phase]}</div>}
+          </div>
+        )}
+      </div>
+
+      {confirmOffered && (
+        <div className="asst-confirm">
+          <button type="button" className="asst-confirm-yes" onClick={() => assistant.sendText("confirm")}>
+            Yes, do it
+          </button>
+          <button type="button" className="asst-confirm-no" onClick={() => assistant.sendText("cancel")}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {mode === "chat" ? (
+        <div className="asst-composer">
+          <textarea
+            className="asst-input"
+            placeholder="Ask about your fleet..."
+            rows={1}
+            value={draft}
+            disabled={busy}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onComposerKeyDown}
+          />
+          <button
+            type="button"
+            className={phase === "listening" ? "asst-round listening" : "asst-round"}
+            title={phase === "listening" ? "Tap to send what you said" : "Tap to talk"}
+            disabled={busy && phase !== "listening"}
+            onClick={toggleTalk}
+          >
+            <MicGlyph />
+          </button>
+          <button type="button" className="asst-round send" title="Send" disabled={busy || draft.trim().length === 0}
+            onClick={send}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+              strokeLinejoin="round" aria-hidden="true" focusable="false">
+              <path d="M22 2L11 13" />
+              <path d="M22 2l-7 20-4-9-9-4 20-7z" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <div className="asst-talkdock">
+          {phase === "speaking" && (
+            <button type="button" className="asst-stopread" onClick={assistant.stopSpeaking}>
+              Stop reading
+            </button>
+          )}
+          <button
+            type="button"
+            className={phase === "listening" ? "asst-talkbtn listening" : "asst-talkbtn"}
+            disabled={busy && phase !== "listening"}
+            onClick={toggleTalk}
+          >
+            <MicGlyph />
+          </button>
+          <div className="asst-talkhint">
+            {phase === "listening"
+              ? "Tap again when you are done."
+              : "Tap to talk - tap again when done. Replies are read aloud."}
+          </div>
+        </div>
+      )}
+
+      {/* Read-aloud plays here; never unmounted (see useAssistant). */}
+      <audio ref={audioRef} className="asst-audio" />
+    </div>
+  );
+}

--- a/apps/cockpit/src/assistant/assistant.css
+++ b/apps/cockpit/src/assistant/assistant.css
@@ -1,0 +1,285 @@
+/* The Assistant screen (fleet assistant build). All colors are the shared tokens from styles.css;
+   nothing here hard-codes a color. The page is a column: header, scrolling conversation, then the
+   composer (chat) or the talk dock (voice) pinned at the bottom of the content region. */
+
+.asst-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.asst-mode {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.asst-mode-btn {
+  border: none;
+  background: var(--surface);
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 18px;
+  cursor: pointer;
+}
+
+.asst-mode-btn.active {
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.asst-stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.asst-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 4px 12px 0;
+}
+
+.asst-empty {
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 560px;
+  padding: 24px 0;
+}
+
+.asst-empty ul {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+/* The owner's question: a right-aligned bubble, the assistant side flows as plain text like a
+   Claude Code transcript. */
+.asst-user {
+  align-self: flex-end;
+  max-width: 70%;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px 14px 4px 14px;
+  padding: 9px 13px;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.asst-turn {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  max-width: 780px;
+}
+
+/* One fleet action the brain took, shown as a live-activity row: green dot + monospace summary. */
+.asst-action {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: Consolas, "Cascadia Mono", ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.asst-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #22c55e;
+  flex: 0 0 auto;
+  position: relative;
+  top: -1px;
+}
+
+.asst-reply {
+  font-size: 14px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.asst-error {
+  align-self: stretch;
+  max-width: 780px;
+  color: var(--attention);
+  border: 1px solid rgba(241, 76, 76, 0.4);
+  background: rgba(241, 76, 76, 0.08);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.asst-phase {
+  color: var(--text-dim);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.asst-confirm {
+  display: flex;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.asst-confirm-yes,
+.asst-confirm-no {
+  font: inherit;
+  font-size: 13px;
+  border-radius: 999px;
+  padding: 7px 16px;
+  cursor: pointer;
+}
+
+.asst-confirm-yes {
+  border: 1px solid rgba(241, 76, 76, 0.5);
+  background: rgba(241, 76, 76, 0.12);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.asst-confirm-no {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.asst-composer {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 0 4px;
+  border-top: 1px solid var(--border);
+}
+
+.asst-input {
+  flex: 1 1 auto;
+  resize: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 10px 14px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--text);
+  line-height: 1.4;
+  min-height: 40px;
+  max-height: 140px;
+}
+
+.asst-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.asst-round {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.asst-round svg {
+  width: 18px;
+  height: 18px;
+}
+
+.asst-round.send {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.asst-round:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.asst-round.listening {
+  background: var(--attention);
+  border-color: var(--attention);
+  color: #fff;
+}
+
+.asst-talkdock {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 0 20px;
+  border-top: 1px solid var(--border);
+}
+
+.asst-talkbtn {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 0 0 10px rgba(59, 130, 246, 0.12), 0 0 0 22px rgba(59, 130, 246, 0.05);
+}
+
+.asst-talkbtn svg {
+  width: 32px;
+  height: 32px;
+}
+
+.asst-talkbtn.listening {
+  background: var(--attention);
+  box-shadow: 0 0 0 10px rgba(241, 76, 76, 0.14), 0 0 0 22px rgba(241, 76, 76, 0.06);
+}
+
+.asst-talkbtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.asst-talkhint {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.asst-stopread {
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 5px 14px;
+  cursor: pointer;
+}
+
+/* The read-aloud element is functional, never visual. */
+.asst-audio {
+  display: none;
+}

--- a/apps/cockpit/src/components/NavIcon.tsx
+++ b/apps/cockpit/src/components/NavIcon.tsx
@@ -15,6 +15,7 @@
 
 export type NavIconName =
   | "fleet-map"
+  | "assistant"
   | "sessions"
   | "directors"
   | "schedule"
@@ -39,6 +40,15 @@ const PAINT: Record<NavIconName, JSX.Element> = {
       <path d="M14.1 5.55a2 2 0 0 1-1.79 0L8.1 3.45a2 2 0 0 0-1.79 0L3.55 4.83A1 1 0 0 0 3 5.72v12.76a1 1 0 0 0 1.45.9l2.86-1.43a2 2 0 0 1 1.79 0l4.21 2.11a2 2 0 0 0 1.79 0l3.66-1.83a1 1 0 0 0 .55-.9V4.62a1 1 0 0 0-1.45-.9z" />
       <path d="M9 3.24v15" />
       <path d="M15 5.76v15" />
+    </>
+  ),
+  // A speech bubble with text lines: the fleet-level chat + voice assistant. Rounded outline keeps
+  // it distinct from the square-cornered terminal beside it.
+  assistant: (
+    <>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      <path d="M8 8h8" />
+      <path d="M8 12h5" />
     </>
   ),
   // A terminal prompt: the thing a session actually is.

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -13,6 +13,7 @@ import { NotFound } from "./panes/NotFound";
 import { SessionsEmpty, SessionsView } from "./sessions/SessionsView";
 import { SessionDetail } from "./sessions/SessionDetail";
 import { SessionRedirect } from "./sessions/SessionRedirect";
+import { AssistantView } from "./assistant/AssistantView";
 import { FleetMapView } from "./fleet/FleetMapView";
 import { DirectorsView } from "./fleet/DirectorsView";
 import { DirectorDetailView } from "./fleet/DirectorDetailView";
@@ -30,6 +31,7 @@ import { SettingsView } from "./settings/SettingsView";
 import { InjectedTextView } from "./injectedtext/InjectedTextView";
 import "./styles.css";
 import "./components/components.css";
+import "./assistant/assistant.css";
 import "./fleet/fleet.css";
 import "./fleet/fleetmap.css";
 import "./missions/missions.css";
@@ -136,6 +138,10 @@ const router = createBrowserRouter(
             // page lists, pivotable by machine / repository / agent. Reads the same GET /sessions
             // envelope through client-core.
             { path: "/fleet-map", element: <FleetMapView /> },
+            // The Assistant (fleet assistant build): a fleet-level chat + voice screen that is not
+            // tied to any session. It drives the Gateway brain at POST /assistant/turn - the desk
+            // surface of the same brain Car Mode uses on the phone.
+            { path: "/assistant", element: <AssistantView /> },
             // Missions (issue #1405) is no longer its own page: it is the "Missions" pivot of the Fleet
             // Map (the fleet has one home). The old /missions route redirects there so existing bookmarks
             // still land on the map; the pivot the map opens on is the last one the browser chose.

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -51,6 +51,10 @@ const devProxy = proxyTarget
       "/fanout": { target: proxyTarget, changeOrigin: true },
       "/cron": { target: proxyTarget, changeOrigin: true },
       "/wingman": { target: proxyTarget, changeOrigin: true },
+      // The Assistant screen (fleet assistant build): its turn calls POST /assistant/turn, and its
+      // keep-warm ping reuses Car Mode's POST /carmode/warmup.
+      "/assistant": { target: proxyTarget, changeOrigin: true },
+      "/carmode": { target: proxyTarget, changeOrigin: true },
       "/lists": { target: proxyTarget, changeOrigin: true },
       "/account": { target: proxyTarget, changeOrigin: true },
       "/gateway": { target: proxyTarget, changeOrigin: true },

--- a/packages/client-core/src/assistant/assistantApi.ts
+++ b/packages/client-core/src/assistant/assistantApi.ts
@@ -1,0 +1,40 @@
+// The cockpit Assistant's Gateway call (fleet assistant build). The Assistant is the desk surface of
+// the SAME Gateway brain Car Mode drives: one loop, one tool set, one server-side conversation store,
+// reached at its own front door POST /assistant/turn so the reply arrives in the desk speech style
+// (a few full sentences) rather than the car style (one or two).
+//
+// Reuse, do not rebuild: speech-to-text is the shared POST /wingman/transcribe and read-aloud is the
+// shared POST /wingman/tts, both already wrapped in carmode/carModeApi.ts - the Assistant imports
+// those, and this file adds only the /assistant/turn door. Every call fails LOUD and specific.
+import { authHeaders, creditsErrorFrom, gatewayFetch, GatewayError } from "../api/client";
+import type { CarModeTurnResult } from "../carmode/carModeApi";
+
+/**
+ * Run one turn of the fleet brain through the Assistant's desk door (POST /assistant/turn). The typed
+ * or transcribed question goes up, the brain calls fleet tools server-side, and the final reply comes
+ * back with the actions it took. Conversation context is kept server-side keyed by this device, so
+ * multi-turn references resolve without the browser sending any history. A 402 is the shared credits
+ * error; any other non-2xx throws a specific GatewayError so the failure is shown, never silent.
+ */
+export async function assistantTurn(text: string, idempotencyKey?: string, signal?: AbortSignal): Promise<CarModeTurnResult> {
+  const idempotencyHeader: Record<string, string> = idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {};
+  const res = await gatewayFetch("/assistant/turn", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...idempotencyHeader, ...authHeaders() },
+    body: JSON.stringify({ text }),
+    signal,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 402) throw creditsErrorFrom(body);
+    throw new GatewayError(res.status, body.error ?? `Assistant turn failed: ${res.status}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as Partial<CarModeTurnResult>;
+  return {
+    turnId: typeof body.turnId === "string" ? body.turnId : "",
+    spoken: (body.spoken ?? "").trim(),
+    actions: Array.isArray(body.actions) ? body.actions : [],
+    pendingConfirmation: Boolean(body.pendingConfirmation),
+    timing: body.timing ?? null,
+  };
+}

--- a/packages/client-core/src/assistant/transcript.test.ts
+++ b/packages/client-core/src/assistant/transcript.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { appendEntry, awaitingConfirmation, MAX_ENTRIES, type AssistantEntry } from "./transcript";
+
+describe("assistant transcript", () => {
+  it("appends without mutating the original", () => {
+    const before: AssistantEntry[] = [{ role: "user", text: "hi" }];
+    const after = appendEntry(before, { role: "assistant", text: "hello" });
+    expect(before).toHaveLength(1);
+    expect(after).toHaveLength(2);
+    expect(after[1].text).toBe("hello");
+  });
+
+  it("caps the transcript at MAX_ENTRIES, dropping the oldest", () => {
+    let entries: AssistantEntry[] = [];
+    for (let i = 0; i < MAX_ENTRIES + 5; i++) {
+      entries = appendEntry(entries, { role: "user", text: `m${i}` });
+    }
+    expect(entries).toHaveLength(MAX_ENTRIES);
+    expect(entries[0].text).toBe("m5");
+    expect(entries[entries.length - 1].text).toBe(`m${MAX_ENTRIES + 4}`);
+  });
+
+  it("offers confirmation only while the LATEST entry is an assistant hold", () => {
+    let entries = appendEntry([], { role: "user", text: "close it" });
+    expect(awaitingConfirmation(entries)).toBe(false);
+    entries = appendEntry(entries, { role: "assistant", text: "This is permanent. Confirm?", pendingConfirmation: true });
+    expect(awaitingConfirmation(entries)).toBe(true);
+    entries = appendEntry(entries, { role: "user", text: "actually, list sessions" });
+    expect(awaitingConfirmation(entries)).toBe(false);
+  });
+
+  it("an error entry never reads as awaiting confirmation", () => {
+    const entries = appendEntry([], { role: "error", text: "The Gateway could not be reached." });
+    expect(awaitingConfirmation(entries)).toBe(false);
+  });
+});

--- a/packages/client-core/src/assistant/transcript.ts
+++ b/packages/client-core/src/assistant/transcript.ts
@@ -1,0 +1,37 @@
+// The Assistant screen's transcript model (fleet assistant build): the pure, framework-free shape of
+// the on-screen conversation and the operations the hook applies to it. Pulled out of the hook so the
+// transcript rules are unit-tested directly - the hook stays a thin stateful shell.
+//
+// The transcript is DISPLAY ONLY. The real conversation context lives server-side keyed by this
+// device (CarModeConversationStore), so the page sending nothing but the new turn is correct - this
+// list is what the owner sees, not what the model sees.
+
+import type { CarModeAction } from "../carmode/carModeApi";
+
+/** One entry in the on-screen conversation. `error` entries are failures shown in place (a failed
+ *  turn stays visible in context rather than vanishing into a toast). */
+export interface AssistantEntry {
+  role: "user" | "assistant" | "error";
+  text: string;
+  /** The fleet actions the brain reports having taken this turn (assistant entries only). */
+  actions?: CarModeAction[];
+  /** True when the brain is holding a destructive action and waits for a confirm/cancel next turn. */
+  pendingConfirmation?: boolean;
+}
+
+/** How many entries the on-screen transcript retains. Oldest fall off; the server-side conversation
+ *  context has its own, separate retention (last 16 messages) and is not affected by this. */
+export const MAX_ENTRIES = 200;
+
+/** Append one entry, dropping the oldest beyond MAX_ENTRIES. Pure - returns a new array. */
+export function appendEntry(entries: readonly AssistantEntry[], entry: AssistantEntry): AssistantEntry[] {
+  const next = [...entries, entry];
+  return next.length > MAX_ENTRIES ? next.slice(next.length - MAX_ENTRIES) : next;
+}
+
+/** True when the latest assistant entry is holding a destructive action for confirmation, so the
+ *  screen offers the explicit "Yes, do it" / "Cancel" buttons. Any entry after it clears the offer. */
+export function awaitingConfirmation(entries: readonly AssistantEntry[]): boolean {
+  const last = entries[entries.length - 1];
+  return last?.role === "assistant" && last.pendingConfirmation === true;
+}

--- a/packages/client-core/src/assistant/useAssistant.ts
+++ b/packages/client-core/src/assistant/useAssistant.ts
@@ -1,0 +1,190 @@
+// The Assistant turn machine (fleet assistant build), shared by any shell that mounts the screen
+// (the cockpit today, the phone later - issue #1213 pattern: logic in client-core, thin JSX views).
+//
+// Turn-taking is A BUTTON, deliberately: tap to talk, tap again to send. No silence detection, no
+// end-phrase keyword - both were tried in Car Mode and the owner rejected them for the desk. The
+// phases are linear and visible: listening -> transcribing -> thinking -> (voice mode) speaking.
+//
+// Reuse, do not rebuild: mic capture is the shared MicRecorder, transcode is the shared
+// blobToWav16kMono, speech-to-text is POST /wingman/transcribe, the brain is POST /assistant/turn,
+// and read-aloud is POST /wingman/tts played through the shared playClip discipline (one src
+// assignment per element, never a clobber).
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { MicRecorder } from "../dictation/recorder";
+import { blobToWav16kMono } from "../dictation/wav";
+import { playClip } from "../carmode/audioPlayback";
+import { postCarModeWarmup, speakCarModeText, transcribeCarModeAudio } from "../carmode/carModeApi";
+import { gatewayErrorMessage } from "../api/client";
+import { assistantTurn } from "./assistantApi";
+import { appendEntry, awaitingConfirmation, type AssistantEntry } from "./transcript";
+
+/** Where the machine is in one turn. Idle between turns; the rest are the visible stages. */
+export type AssistantPhase = "idle" | "listening" | "transcribing" | "thinking" | "speaking";
+
+/** Chat mode types (replies stay silent); voice mode talks and reads every reply aloud. */
+export type AssistantMode = "chat" | "voice";
+
+export interface UseAssistant {
+  entries: AssistantEntry[];
+  phase: AssistantPhase;
+  mode: AssistantMode;
+  setMode: (mode: AssistantMode) => void;
+  /** True while a turn is in flight (any phase but idle) - the composer disables itself on it. */
+  busy: boolean;
+  /** True when the brain is holding a destructive action; the screen offers Yes / Cancel. */
+  confirmOffered: boolean;
+  /** Send a typed question (chat mode's Send button / Enter). No-op on blank or while busy. */
+  sendText: (text: string) => void;
+  /** Start capturing a spoken question (the talk button). Throws never - a mic failure lands in
+   *  the transcript as an error entry. */
+  startTalk: () => void;
+  /** Stop capturing and run the turn (the talk button again). */
+  endTalk: () => void;
+  /** Abandon the capture without sending (Escape / leaving the screen). */
+  cancelTalk: () => void;
+  /** Stop the read-aloud playback immediately ("Stop reading"). */
+  stopSpeaking: () => void;
+}
+
+/**
+ * Drive the Assistant conversation against the Gateway. The caller owns a permanently-mounted,
+ * hidden `<audio>` element (the mobile Voice screen pattern) and hands it in by ref; read-aloud
+ * plays on that element so mode switches and re-renders never orphan live audio.
+ */
+export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseAssistant {
+  const [entries, setEntries] = useState<AssistantEntry[]>([]);
+  const [phase, setPhase] = useState<AssistantPhase>("idle");
+  const [mode, setMode] = useState<AssistantMode>("chat");
+
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const stopPlaybackRef = useRef<() => void>(() => {});
+  // The mode at the moment a turn RUNS decides whether its reply is read aloud; a ref avoids the
+  // stale-closure trap when the owner flips the toggle mid-turn.
+  const modeRef = useRef<AssistantMode>("chat");
+  modeRef.current = mode;
+
+  // Warm the hosted model + text-to-speech the moment the screen opens, so the first question does
+  // not pay the cold start (the same keep-warm door Car Mode uses; best-effort, never throws).
+  useEffect(() => {
+    void postCarModeWarmup();
+    return () => {
+      recorderRef.current?.dispose();
+      recorderRef.current = null;
+      stopPlaybackRef.current();
+    };
+  }, []);
+
+  const push = useCallback((entry: AssistantEntry) => {
+    setEntries((cur) => appendEntry(cur, entry));
+  }, []);
+
+  const speak = useCallback(async (text: string) => {
+    const audio = audioRef.current;
+    if (audio === null) return;
+    setPhase("speaking");
+    const clip = await speakCarModeText(text);
+    const url = URL.createObjectURL(clip);
+    try {
+      await playClip(audio, url, (stop) => {
+        stopPlaybackRef.current = stop;
+      });
+    } finally {
+      URL.revokeObjectURL(url);
+      stopPlaybackRef.current = () => {};
+    }
+  }, [audioRef]);
+
+  const runTurn = useCallback(async (text: string) => {
+    push({ role: "user", text });
+    setPhase("thinking");
+    try {
+      const result = await assistantTurn(text, crypto.randomUUID());
+      push({
+        role: "assistant",
+        text: result.spoken,
+        actions: result.actions,
+        pendingConfirmation: result.pendingConfirmation,
+      });
+      if (modeRef.current === "voice" && result.spoken.length > 0) {
+        // A read-aloud failure must not eat the answer that is already on screen: report it as its
+        // own error entry instead of failing the turn.
+        try {
+          await speak(result.spoken);
+        } catch (err) {
+          push({ role: "error", text: `The reply could not be read aloud: ${gatewayErrorMessage(err)}` });
+        }
+      }
+    } catch (err) {
+      push({ role: "error", text: gatewayErrorMessage(err) });
+    } finally {
+      setPhase("idle");
+    }
+  }, [push, speak]);
+
+  const sendText = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || phase !== "idle") return;
+    void runTurn(trimmed);
+  }, [phase, runTurn]);
+
+  const startTalk = useCallback(() => {
+    if (phase !== "idle") return;
+    const recorder = new MicRecorder();
+    recorderRef.current = recorder;
+    setPhase("listening");
+    void recorder.start().catch((err: unknown) => {
+      recorderRef.current = null;
+      setPhase("idle");
+      push({ role: "error", text: err instanceof Error ? err.message : "The microphone could not be opened." });
+    });
+  }, [phase, push]);
+
+  const endTalk = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recorder === null || phase !== "listening") return;
+    recorderRef.current = null;
+    setPhase("transcribing");
+    void (async () => {
+      try {
+        const captured = await recorder.stop();
+        const { wav } = await blobToWav16kMono(captured);
+        const transcript = await transcribeCarModeAudio(wav);
+        if (transcript.length === 0) {
+          setPhase("idle");
+          push({ role: "error", text: "Nothing was heard. Tap to talk and try again." });
+          return;
+        }
+        await runTurn(transcript);
+      } catch (err) {
+        setPhase("idle");
+        push({ role: "error", text: gatewayErrorMessage(err) });
+      }
+    })();
+  }, [phase, push, runTurn]);
+
+  const cancelTalk = useCallback(() => {
+    if (phase !== "listening") return;
+    recorderRef.current?.dispose();
+    recorderRef.current = null;
+    setPhase("idle");
+  }, [phase]);
+
+  const stopSpeaking = useCallback(() => {
+    stopPlaybackRef.current();
+  }, []);
+
+  return {
+    entries,
+    phase,
+    mode,
+    setMode,
+    busy: phase !== "idle",
+    confirmOffered: awaitingConfirmation(entries) && phase === "idle",
+    sendText,
+    startTalk,
+    endTalk,
+    cancelTalk,
+    stopSpeaking,
+  };
+}

--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -94,6 +94,29 @@ public sealed class CarModeBrainTests
             Snoozed.Add(sessionId);
             return Task.CompletedTask;
         }
+
+        // Fleet-overview read tools (the cockpit Assistant build).
+        public int CreditsCalls;
+        public CarModeCredits CreditsResult { get; set; } = new(false, null, null);
+        public IReadOnlyList<CarModeMachineInfo> Machines { get; set; } = new List<CarModeMachineInfo>();
+        public IReadOnlyList<CarModeScheduleInfo> Schedules { get; set; } = new List<CarModeScheduleInfo>();
+        public List<int> SpendDays { get; } = new();
+        public CarModeSpendSummary SpendResult { get; set; } = new(0, 0, DateTime.UtcNow, DateTime.UtcNow);
+
+        public Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
+        {
+            CreditsCalls++;
+            return Task.FromResult(CreditsResult);
+        }
+        public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
+            => Task.FromResult(Machines);
+        public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct)
+            => Task.FromResult(Schedules);
+        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
+        {
+            SpendDays.Add(days);
+            return Task.FromResult(SpendResult);
+        }
     }
 
     private static CarModeToolCall Call(string name, string args = "{}") => new("call_1", name, args);
@@ -988,5 +1011,161 @@ public sealed class CarModeBrainTests
         Assert.Equal("done", a.Spoken);
         Assert.Same(a, b);                                 // the very same cached response object
         Assert.Equal(1, cache.Count());
+    }
+
+    // ---- Fleet-overview read tools (the cockpit Assistant build) ----
+
+    [Fact]
+    public async Task RunTurn_GetCredits_SignedIn_ReturnsDollarsToTheModel()
+    {
+        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(true, 12_340_000, 5_600) };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
+            Speak("You have about twelve dollars and thirty four cents left."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how are we doing on credits", CancellationToken.None);
+
+        Assert.Equal(1, fleet.CreditsCalls);
+        Assert.Contains("twelve dollars", result.Spoken);
+        // The tool result the model saw carries real dollars, converted from micro-dollars.
+        Assert.Contains("12.34", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_GetCredits_SignedOut_TellsTheModelThereIsNoBalance()
+    {
+        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(false, null, null) };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
+            Speak("The Gateway is not signed in, so there is no balance to read."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None);
+
+        Assert.Contains("not signed in", chat.SeenMessages[1]);
+        Assert.Contains("no balance", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_ListMachines_ReturnsMachineFactsToTheModel()
+    {
+        var fleet = new FakeFleet
+        {
+            Machines = new[]
+            {
+                new CarModeMachineInfo { MachineName = "SOREN_NORTH", Version = "1.2.3", LastSeenMinutesAgo = 0, SessionCount = 9 },
+                new CarModeMachineInfo { MachineName = "dev-machine-1", Version = "1.2.3", LastSeenMinutesAgo = 4, SessionCount = 2 },
+            },
+        };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_machines") }),
+            Speak("Two machines are online."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "which machines are online", CancellationToken.None);
+
+        Assert.Contains("SOREN_NORTH", chat.SeenMessages[1]);
+        Assert.Contains("dev-machine-1", chat.SeenMessages[1]);
+        Assert.Contains("Two machines", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_ListSchedules_ReturnsScheduleFactsToTheModel()
+    {
+        var fleet = new FakeFleet
+        {
+            Schedules = new[]
+            {
+                new CarModeScheduleInfo
+                {
+                    Name = "Nightly hygiene", Enabled = true, Schedule = "0 3 * * *", Machine = "SOREN_NORTH",
+                    ActionSummary = "run \"/repo-hygiene\" in devthrottle", LastStatus = "succeeded",
+                },
+            },
+        };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_schedules") }),
+            Speak("One schedule: Nightly hygiene at three in the morning."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what runs automatically", CancellationToken.None);
+
+        Assert.Contains("Nightly hygiene", chat.SeenMessages[1]);
+        Assert.Contains("0 3 * * *", chat.SeenMessages[1]);
+        Assert.Contains("Nightly hygiene", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_GetSpend_DefaultsToSevenDays_AndConvertsDollars()
+    {
+        var fleet = new FakeFleet { SpendResult = new CarModeSpendSummary(2_500_000, 41, DateTime.UtcNow.AddDays(-7), DateTime.UtcNow) };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_spend") }),
+            Speak("About two and a half dollars this week."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "what have we spent", CancellationToken.None);
+
+        Assert.Equal(new[] { 7 }, fleet.SpendDays);
+        Assert.Contains("2.5", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_GetSpend_HonorsTheDaysArgument()
+    {
+        var fleet = new FakeFleet { SpendResult = new CarModeSpendSummary(0, 0, DateTime.UtcNow.AddDays(-30), DateTime.UtcNow) };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"30\"}") }),
+            Speak("Nothing in the last thirty days."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for the month", CancellationToken.None);
+
+        Assert.Equal(new[] { 30 }, fleet.SpendDays);
+    }
+
+    // ---- The desk surface (the cockpit Assistant screen) ----
+
+    [Fact]
+    public async Task DeskSurface_AppendsTheDeskOverridesToTheSystemPrompt()
+    {
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(Speak("Hello."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { }, CarModeSurface.Desk);
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "hello", CancellationToken.None);
+
+        Assert.Contains("DESK SURFACE OVERRIDES", chat.SeenMessages[0]);
+    }
+
+    [Fact]
+    public async Task CarSurface_DoesNotCarryTheDeskOverrides()
+    {
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(Speak("Hello."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "hello", CancellationToken.None);
+
+        Assert.DoesNotContain("DESK SURFACE OVERRIDES", chat.SeenMessages[0]);
+    }
+
+    [Fact]
+    public async Task ListSessions_CarriesAgeAndIdleFacts()
+    {
+        var session = Session("Old Timer", false) with { AgeHours = 31, IdleMinutes = 95 };
+        var fleet = new FakeFleet { Sessions = new[] { session } };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
+            Speak("Old Timer has been open thirty one hours."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "anything open too long", CancellationToken.None);
+
+        // The tool result rides inside the messages list as an escaped JSON string, and System.Text.Json's
+        // default encoder writes an embedded double-quote as the u0022 escape - match that exact form.
+        Assert.Contains("\\u0022AgeHours\\u0022:31", chat.SeenMessages[1]);
+        Assert.Contains("\\u0022IdleMinutes\\u0022:95", chat.SeenMessages[1]);
     }
 }

--- a/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
@@ -78,7 +78,7 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
         var requireToken = new AuthMiddleware.RequireToken { Token = SharedMachineToken, Devices = devices };
         _app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
 
-        CarModeEndpoint.Map(_app, brain, new CarModeTurnCache(_ => { }), diagnostics, warmup, null!);
+        CarModeEndpoint.Map(_app, brain, brain, new CarModeTurnCache(_ => { }), diagnostics, warmup, null!);
         await _app.StartAsync();
         _baseAddress = $"http://127.0.0.1:{port}";
     }
@@ -402,5 +402,9 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
         public Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
         public Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct) => throw Unexpected();
         public Task SnoozeSessionAsync(string sessionId, CancellationToken ct) => throw Unexpected();
+        public Task<CarModeCredits> GetCreditsAsync(CancellationToken ct) => throw Unexpected();
+        public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct) => throw Unexpected();
+        public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct) => throw Unexpected();
+        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct) => throw Unexpected();
     }
 }

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -40,8 +40,9 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class CarModeEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTurnCache turnCache,
-        CarModeDiagnosticsStore diagnostics, CarModeWarmup warmup, HostedTenantBoundary tenantBoundary)
+    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeBrain assistantBrain,
+        CarModeTurnCache turnCache, CarModeDiagnosticsStore diagnostics, CarModeWarmup warmup,
+        HostedTenantBoundary tenantBoundary)
     {
         // Keep-warm (Car Mode performance round): the browser calls this the instant the owner taps Start,
         // and every few minutes WHILE Car Mode is open, so the hosted model + text-to-speech are hot before
@@ -78,9 +79,25 @@ internal static class CarModeEndpoint
             },
         }));
 
-        app.MapPost("/carmode/turn", async (HttpContext ctx, CarModeTurnRequest? req, CancellationToken ct) =>
+        // The turn route, mapped twice over the SAME loop, stores, and cache: /carmode/turn drives the car
+        // brain (hands-free, one or two spoken sentences) and /assistant/turn drives the desk brain (the
+        // cockpit Assistant screen - same rules, desk speech style). One handler, so idempotency, tenant
+        // resolution, the 402 mapping, and the failure shape can never drift apart between the two doors.
+        MapTurnRoute(app, "/carmode/turn", "Car Mode", brain, turnCache, tenantBoundary);
+        MapTurnRoute(app, "/assistant/turn", "The Assistant", assistantBrain, turnCache, tenantBoundary);
+
+        MapDiagnosticsRoutes(app, diagnostics);
+    }
+
+    /// <summary>Map one turn route over the given brain. Identical mechanics for every surface: tenant
+    ///  resolution, the authenticated-credential conversation key, Idempotency-Key single-flight, the shared
+    ///  402 money refusal, and the loud 502 failure whose message names the surface.</summary>
+    private static void MapTurnRoute(IEndpointRouteBuilder app, string pattern, string surfaceLabel,
+        CarModeBrain brain, CarModeTurnCache turnCache, HostedTenantBoundary tenantBoundary)
+    {
+        app.MapPost(pattern, async (HttpContext ctx, CarModeTurnRequest? req, CancellationToken ct) =>
         {
-            FileLog.Write($"[CarModeEndpoint] turn: len={req?.Text?.Length ?? 0}");
+            FileLog.Write($"[CarModeEndpoint] {pattern} turn: len={req?.Text?.Length ?? 0}");
             var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (tenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
@@ -138,9 +155,9 @@ internal static class CarModeEndpoint
             }
             catch (CarModeUnavailableException ex)
             {
-                // A money refusal (out of credits / cap / no key): the ONE shared 402 state, so the phone
+                // A money refusal (out of credits / cap / no key): the ONE shared 402 state, so the client
                 // shows the consistent add-credit / add-key notice instead of a generic error.
-                FileLog.Write($"[CarModeEndpoint] turn unavailable: {ex.State}");
+                FileLog.Write($"[CarModeEndpoint] {pattern} turn unavailable: {ex.State}");
                 return HostedAiHttp.PaymentRequiredResult(ex.State);
             }
             catch (OperationCanceledException)
@@ -150,13 +167,17 @@ internal static class CarModeEndpoint
             }
             catch (Exception ex)
             {
-                // A loud, specific failure the phone speaks (decision 8), never a silent stall.
-                FileLog.Write($"[CarModeEndpoint] turn FAILED: {ex.Message}");
-                return Results.Json(new { error = "Car Mode could not complete that: " + ex.Message },
+                // A loud, specific failure the client shows and speaks (decision 8), never a silent stall.
+                FileLog.Write($"[CarModeEndpoint] {pattern} turn FAILED: {ex.Message}");
+                return Results.Json(new { error = surfaceLabel + " could not complete that: " + ex.Message },
                     statusCode: StatusCodes.Status502BadGateway);
             }
         });
+    }
 
+    /// <summary>The per-device diagnostics store routes (unchanged; Car Mode's phone page is the writer).</summary>
+    private static void MapDiagnosticsRoutes(IEndpointRouteBuilder app, CarModeDiagnosticsStore diagnostics)
+    {
         // The browser posts ONE merged timing record per turn here. It fills the client stamps and echoes
         // the server timing it received in the turn response; the SERVER fills the received-at time, the
         // device hash (from its own credential extraction, never trusting the client), and the Gateway

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -30,8 +30,12 @@ public sealed class CarModeBrain
     private readonly CarModePendingStore _pending;
     private readonly CarModeSubjectStore _subjects;
     private readonly Action<string> _log;
+    private readonly string _systemPrompt;
 
-    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null)
+    /// <param name="surface">Which surface this brain instance speaks to. Car (the default) keeps the
+    ///  hands-free one-or-two-sentence style; Desk (the cockpit Assistant screen) appends the desk-surface
+    ///  overrides. Everything else - loop, tools, stores, model - is identical.</param>
+    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null, CarModeSurface surface = CarModeSurface.Car)
     {
         _chat = chat ?? throw new ArgumentNullException(nameof(chat));
         _fleet = fleet ?? throw new ArgumentNullException(nameof(fleet));
@@ -39,6 +43,7 @@ public sealed class CarModeBrain
         _pending = pending ?? throw new ArgumentNullException(nameof(pending));
         _subjects = subjects ?? throw new ArgumentNullException(nameof(subjects));
         _log = log ?? FileLog.Write;
+        _systemPrompt = surface == CarModeSurface.Desk ? SystemPrompt + DeskAddendum : SystemPrompt;
     }
 
     /// <summary>
@@ -146,7 +151,7 @@ public sealed class CarModeBrain
         }
 
         var messages = new List<object>();
-        messages.Add(new { role = "system", content = SystemPrompt });
+        messages.Add(new { role = "system", content = _systemPrompt });
         foreach (var m in _conversations.GetHistory(deviceKey))
             messages.Add(new { role = m.Role, content = m.Content });
         messages.Add(new { role = "user", content = userText });
@@ -282,7 +287,7 @@ public sealed class CarModeBrain
                     sessions = sessions.Select(s => new
                     {
                         s.Name, s.Number, s.Repo, s.MachineName, mission = s.MissionName,
-                        s.State, s.NeedsYou, s.WaitingMinutes, s.Summary,
+                        s.State, s.NeedsYou, s.WaitingMinutes, s.Summary, s.AgeHours, s.IdleMinutes,
                     }),
                 });
             }
@@ -385,6 +390,55 @@ public sealed class CarModeBrain
                     }, ToolResultJson),
                     Action: null,
                     ArmedConfirmation: true);
+            }
+            case "get_credits":
+            {
+                var credits = await timer.TimeFleetAsync(() => _fleet.GetCreditsAsync(ct));
+                if (!credits.SignedIn)
+                    return Result(new { signedIn = false, message = "The Gateway is not signed in to a DevThrottle account, so there is no balance to read." });
+                return Result(new
+                {
+                    signedIn = true,
+                    balanceDollars = Math.Round((credits.BalanceMicros ?? 0) / 1_000_000.0, 2),
+                    lastActionCostDollars = credits.LastDebitMicros is { } debit ? Math.Round(debit / 1_000_000.0, 4) : (double?)null,
+                });
+            }
+            case "list_machines":
+            {
+                var machines = await timer.TimeFleetAsync(() => _fleet.ListMachinesAsync(ct));
+                return Result(new
+                {
+                    count = machines.Count,
+                    machines = machines.Select(m => new
+                    {
+                        machine = m.MachineName, m.Version, m.LastSeenMinutesAgo, m.SessionCount,
+                    }),
+                });
+            }
+            case "list_schedules":
+            {
+                var schedules = await timer.TimeFleetAsync(() => _fleet.ListSchedulesAsync(ct));
+                return Result(new
+                {
+                    count = schedules.Count,
+                    schedules = schedules.Select(s => new
+                    {
+                        s.Name, s.Enabled, s.Schedule, s.Machine, action = s.ActionSummary,
+                        s.NextRunUtc, s.LastFiredUtc, s.LastStatus,
+                    }),
+                });
+            }
+            case "get_spend":
+            {
+                var daysText = ReadStringArg(call.ArgumentsJson, "days");
+                var days = int.TryParse(daysText, out var parsed) && parsed > 0 && parsed <= 90 ? parsed : 7;
+                var spend = await timer.TimeFleetAsync(() => _fleet.GetSpendAsync(days, ct));
+                return Result(new
+                {
+                    days,
+                    totalDollars = Math.Round(spend.TotalMicros / 1_000_000.0, 2),
+                    hostedActionCount = spend.DebitCount,
+                });
             }
             default:
                 return Result(new { error = $"Unknown tool \"{call.Name}\"." });
@@ -490,6 +544,12 @@ public sealed class CarModeBrain
         + "- When a question is ABOUT THE FLEET - how many sessions there are, which need you, what a session "
         + "is doing, the latest one, or an action on a session - use the tools to get REAL facts first. Never "
         + "guess a count, a name, or a state.\n"
+        + "- Account and infrastructure questions have their own read tools: get_credits for the credit "
+        + "balance, get_spend for recent hosted AI spending, list_machines for which machines are online, and "
+        + "list_schedules for the scheduled jobs. Use them the same way - never guess a balance, a dollar "
+        + "figure, or a schedule. Sessions in list_sessions carry ageHours (how long open) and idleMinutes "
+        + "(how long since output), so \"open too long\" and \"is anything stuck\" are answered from those "
+        + "real numbers.\n"
         + "- When the owner asks for HELP or how this works - \"help\", \"what can you do\", \"what can you "
         + "help me with\", \"how does this work\", \"how do I talk to you\" - call get_help and nothing else. "
         + "It speaks a fixed guided explanation; do NOT write your own and do NOT read the fleet for it.\n"
@@ -558,6 +618,23 @@ public sealed class CarModeBrain
         + "in the message content; only speak_answer is heard.\n"
         + "- A normal turn is: call the tools you need to get facts or act, then call speak_answer once with the "
         + "final spoken sentence. Keep it to one or two short spoken sentences.";
+
+    // The desk-surface overlay (the cockpit Assistant screen): the SAME brain, tools, and rules, with only
+    // the speech-style constraints relaxed - the owner is at his computer, the reply is shown as text and
+    // may also be read aloud, so a fleet overview may run a few sentences. Appended AFTER the car prompt so
+    // every behavioural rule above still binds; only the style rules are overridden, explicitly.
+    private const string DeskAddendum =
+        "\n\nDESK SURFACE OVERRIDES - this conversation comes from the cockpit Assistant screen, not the car:\n"
+        + "- The owner is at his computer in the cockpit, typing or talking. Your reply is shown on screen as "
+        + "text and may also be read aloud.\n"
+        + "- The one-or-two-sentence limit is relaxed: use up to four or five plain sentences when the "
+        + "question genuinely needs them - a fleet overview, a recommendation with its reasons. Short is "
+        + "still better whenever short answers it.\n"
+        + "- Keep it plain spoken text all the same: no markdown, no bullet lists, no headings, no emoji, "
+        + "because the same words may be read aloud.\n"
+        + "- Include concrete numbers (counts, hours, dollars) when you have them from the tools.\n"
+        + "- Everything else is unchanged: every answer still goes through speak_answer, actions still mean "
+        + "calling the tool, and destructive actions still need the owner's confirmation.";
 
     // The tool catalog. Standard chat-completions function tools: reads, ordinary acts, and the
     // destructive delete (which the loop holds for a spoken confirmation - the model just requests it).
@@ -697,6 +774,44 @@ public sealed class CarModeBrain
             "function": {
               "name": "get_help",
               "description": "Explain to the owner what Car Mode can do and how to talk to it. Call this - and NOTHING else - when the owner asks for help or how this works: \"help\", \"what can you do\", \"what can you help me with\", \"how does this work\", \"how do I talk to you\". It speaks a fixed guided explanation of the two ways to talk to Car Mode; you do not write the words and you do not read the fleet for it.",
+              "parameters": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "get_credits",
+              "description": "Read the account's current credit balance in dollars, and what the last hosted action cost. Use for questions about credits, balance, subscription money, or \"are we running low\". Never guess a balance.",
+              "parameters": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "get_spend",
+              "description": "Read the total hosted AI spend in dollars over the trailing window, and how many hosted actions it covers. Use for \"what have we spent\", \"how fast are we burning credits\", or pace questions. Defaults to the last 7 days.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "days": { "type": "string", "description": "The trailing window in days, 1 to 90. Omit for 7." }
+                },
+                "required": []
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "list_machines",
+              "description": "List the machines running Directors right now: each machine's name, how many minutes since the Gateway last heard from it, and how many sessions it is running. Use for \"which machines are online\" or \"where is everything running\".",
+              "parameters": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "list_schedules",
+              "description": "List the scheduled jobs: each job's name, whether it is enabled, when it runs, on which machine, what it does, the next due time, and how its last run went. Use for questions about schedules, cron jobs, nightly runs, or \"what runs automatically\".",
               "parameters": { "type": "object", "properties": {}, "required": [] }
             }
           },

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -25,7 +25,65 @@ public sealed record CarModeSessionInfo
     /// <summary>The &lt;=8-word one-line summary of what it is doing (SessionDto.RailLine), or the short
     ///  status reason when there is no rail line. Empty when neither is available.</summary>
     public required string Summary { get; init; }
+
+    /// <summary>Whole hours since the session was created; 0 when it is under an hour old. Carried so the
+    ///  brain can answer "which sessions have been open too long" with a real age, never a guess.</summary>
+    public int AgeHours { get; init; }
+
+    /// <summary>Whole minutes since the session last produced output (SessionDto.IdleSeconds); 0 when it is
+    ///  active right now. Carried so the brain can tell an active session from an abandoned one.</summary>
+    public int IdleMinutes { get; init; }
 }
+
+/// <summary>
+/// Which surface a brain instance speaks to (Assistant on the cockpit build). The SAME loop, tools, stores,
+/// and model serve both; only the system prompt's speech-style rules differ. Car is the hands-free phone
+/// surface (one or two short spoken sentences); Desk is the cockpit Assistant screen (the owner is at his
+/// computer, typing or talking, and the reply is shown as text and may also be read aloud).
+/// </summary>
+public enum CarModeSurface
+{
+    Car,
+    Desk,
+}
+
+/// <summary>The account credit balance for the get_credits read tool, from GET /account/credits. SignedIn
+/// false means the Gateway holds no account credential - there IS no balance, and the brain says so rather
+/// than inventing a zero (the endpoint never fabricates a balance and neither does the tool).</summary>
+public sealed record CarModeCredits(bool SignedIn, long? BalanceMicros, long? LastDebitMicros);
+
+/// <summary>One machine running Directors, for the list_machines read tool: the machine name the owner says
+/// out loud, how recently the Gateway heard from it, and how many fleet sessions it is running now.</summary>
+public sealed record CarModeMachineInfo
+{
+    public required string MachineName { get; init; }
+    public required string Version { get; init; }
+    /// <summary>Whole minutes since the Gateway last reached a Director on this machine; null when the
+    ///  registry carries no last-seen time for it.</summary>
+    public int? LastSeenMinutesAgo { get; init; }
+    /// <summary>How many roster sessions are on this machine right now.</summary>
+    public int SessionCount { get; init; }
+}
+
+/// <summary>One scheduled job for the list_schedules read tool, from GET /cron/jobs: what it is called,
+/// whether it is on, when it runs (a cron expression or a one-off time), where, and what it does.</summary>
+public sealed record CarModeScheduleInfo
+{
+    public required string Name { get; init; }
+    public bool Enabled { get; init; }
+    /// <summary>The human schedule: the cron expression for a recurring job, or "once at ..." for a one-off.</summary>
+    public required string Schedule { get; init; }
+    public required string Machine { get; init; }
+    /// <summary>A one-line summary of what the fire does (the seed prompt or the work list it drains).</summary>
+    public required string ActionSummary { get; init; }
+    public DateTime? NextRunUtc { get; init; }
+    public DateTime? LastFiredUtc { get; init; }
+    public string? LastStatus { get; init; }
+}
+
+/// <summary>The hosted AI spend total over a trailing window, for the get_spend read tool, from
+/// GET /gateway/governance/hosted-ai-spend/summary.</summary>
+public sealed record CarModeSpendSummary(long TotalMicros, int DebitCount, DateTime SinceUtc, DateTime UntilUtc);
 
 /// <summary>What one session is doing, for the "read me that one" / "what is X doing" read tool. For v1
 /// this is the roster's own summary fields (name + repo + short line), which already answer the mission's

--- a/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
@@ -57,4 +57,22 @@ public interface ICarModeFleet
     ///  Gateway records a snooze-until from the per-user default length, so the session RETURNS to "needs
     ///  you" on its own when the timer fires (Snooze Length mission). Addressed by session id.</summary>
     Task SnoozeSessionAsync(string sessionId, CancellationToken ct);
+
+    /// <summary>The account credit balance, exactly what the Settings account section shows
+    ///  (GET /account/credits). SignedIn false means there is no account credential and no balance -
+    ///  the brain says so plainly rather than inventing a number.</summary>
+    Task<CarModeCredits> GetCreditsAsync(CancellationToken ct);
+
+    /// <summary>The machines running Directors right now (GET /directors grouped by machine), each with how
+    ///  recently the Gateway heard from it and how many roster sessions it carries. Answers "which machines
+    ///  are online" without touching the hosted-denied /machines and /launchers surfaces.</summary>
+    Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct);
+
+    /// <summary>The scheduled jobs (GET /cron/jobs) as compact speakable views: name, on/off, when, where,
+    ///  and what each fire does, plus the next due time and the last outcome.</summary>
+    Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct);
+
+    /// <summary>The hosted AI spend total over the trailing <paramref name="days"/> days
+    ///  (GET /gateway/governance/hosted-ai-spend/summary). Real ledger dollars, never an estimate.</summary>
+    Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct);
 }

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -193,6 +193,108 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         _log($"[CarModeFleet] snoozed session {sessionId}");
     }
 
+    public async Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
+    {
+        // The SAME token-free proxy the Settings account section reads (GET /account/credits). A signed-out
+        // Gateway answers signedIn=false explicitly; a cloud failure is a non-success status and throws loud.
+        var root = await GetJsonObjectAsync("/account/credits", ct);
+        var signedIn = root.TryGetProperty("signedIn", out var si) && si.ValueKind == JsonValueKind.True;
+        var balance = GetInt64OrNull(root, "balanceMicros");
+        var lastDebit = GetInt64OrNull(root, "lastDebitMicros");
+        _log($"[CarModeFleet] credits: signedIn={signedIn}");
+        return new CarModeCredits(signedIn, balance, lastDebit);
+    }
+
+    public async Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
+    {
+        // Machines = the Director registry grouped by machine name (GET /directors), which serves hosted
+        // per-tenant too - never the hosted-denied /machines or /launchers surfaces. Session counts come
+        // from the same aggregated roster every client sees.
+        var directors = await GetJsonArrayAsync("/directors", ct);
+        var sessions = await GetSessionsAsync(ct);
+        var machines = directors
+            .Select(d => new
+            {
+                Machine = GetString(d, "machineName"),
+                Version = GetString(d, "version"),
+                LastSeen = GetDateTimeOrNull(d, "lastSeen"),
+            })
+            .Where(d => !string.IsNullOrWhiteSpace(d.Machine))
+            .GroupBy(d => d.Machine, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new CarModeMachineInfo
+            {
+                MachineName = g.Key,
+                Version = g.Select(d => d.Version).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v)) ?? "",
+                LastSeenMinutesAgo = MinutesAgo(g.Max(d => d.LastSeen)),
+                SessionCount = sessions.Count(s => string.Equals(s.MachineName, g.Key, StringComparison.OrdinalIgnoreCase)),
+            })
+            .OrderBy(m => m.MachineName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        _log($"[CarModeFleet] machines -> {machines.Count}");
+        return machines;
+    }
+
+    public async Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct)
+    {
+        // GET /cron/jobs returns { jobs: [CronJobDto...] }; map each to the compact speakable view.
+        var root = await GetJsonObjectAsync("/cron/jobs", ct);
+        var jobs = root.TryGetProperty("jobs", out var arr) && arr.ValueKind == JsonValueKind.Array
+            ? arr.EnumerateArray().ToList()
+            : new List<JsonElement>();
+        var schedules = jobs.Select(j =>
+        {
+            var kind = GetString(j, "scheduleKind");
+            var schedule = string.Equals(kind, "oneOff", StringComparison.OrdinalIgnoreCase)
+                ? $"once at {GetString(j, "runAt")}"
+                : GetString(j, "cronExpression");
+            var machine = j.TryGetProperty("target", out var target) ? GetString(target, "machine") : "";
+            var actionSummary = "";
+            if (j.TryGetProperty("action", out var action))
+            {
+                var repoLeaf = RepoLeaf(GetString(action, "repoPath"));
+                var workList = GetString(action, "workListName");
+                var seed = GetString(action, "seed");
+                actionSummary = !string.IsNullOrWhiteSpace(workList)
+                    ? $"drain the {workList} work list in {repoLeaf}"
+                    : $"run \"{Truncate(seed, 80)}\" in {repoLeaf}";
+            }
+            return new CarModeScheduleInfo
+            {
+                Name = GetString(j, "name"),
+                Enabled = j.TryGetProperty("enabled", out var en) && en.ValueKind == JsonValueKind.True,
+                Schedule = schedule,
+                Machine = machine,
+                ActionSummary = actionSummary,
+                NextRunUtc = GetDateTimeOrNull(j, "nextRunUtc"),
+                LastFiredUtc = GetDateTimeOrNull(j, "lastFiredUtc"),
+                LastStatus = NullIfEmpty(GetString(j, "lastStatus")),
+            };
+        }).ToList();
+        _log($"[CarModeFleet] schedules -> {schedules.Count}");
+        return schedules;
+    }
+
+    public async Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
+    {
+        if (days <= 0) throw new ArgumentOutOfRangeException(nameof(days), "The spend window must be at least one day.");
+        var until = DateTime.UtcNow;
+        var since = until.AddDays(-days);
+        var root = await GetJsonObjectAsync(
+            $"/gateway/governance/hosted-ai-spend/summary?since={Uri.EscapeDataString(since.ToString("o"))}&until={Uri.EscapeDataString(until.ToString("o"))}", ct);
+        // A summary with no total is a malformed response, not a zero - zero dollars is exactly the kind of
+        // plausible fabricated number that ships unnoticed, so it fails loud instead.
+        var total = GetInt64OrNull(root, "totalMicros")
+            ?? throw new InvalidOperationException("The hosted-AI spend summary came back without a totalMicros field.");
+        var summary = new CarModeSpendSummary(
+            total,
+            (int)(GetInt64OrNull(root, "debitCount")
+                ?? throw new InvalidOperationException("The hosted-AI spend summary came back without a debitCount field.")),
+            GetDateTimeOrNull(root, "sinceUtc") ?? since,
+            GetDateTimeOrNull(root, "untilUtc") ?? until);
+        _log($"[CarModeFleet] spend over {days}d -> {summary.DebitCount} debits");
+        return summary;
+    }
+
     /// <summary>Read THIS Gateway's aggregated roster, reusing a read taken within the last
     ///  <see cref="RosterCacheTtl"/> so one turn's several roster reads (and back-to-back turns) collapse to
     ///  a single loopback aggregation. A cache miss does one real GET and refills the cache.</summary>
@@ -227,6 +329,46 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         var sessions = JsonSerializer.Deserialize<List<SessionDto>>(json, JsonOptions);
         return sessions ?? new List<SessionDto>();
     }
+
+    /// <summary>GET a loopback endpoint that returns a JSON object and hand back its root element (a clone,
+    ///  safe after the document is disposed). Throws on a non-success status or a non-object body, so a
+    ///  malformed response is a loud failure rather than a silently empty read.</summary>
+    private async Task<JsonElement> GetJsonObjectAsync(string path, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}{path}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"GET {path} failed: {(int)response.StatusCode} {response.StatusCode}.");
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException($"GET {path} returned {doc.RootElement.ValueKind}, expected a JSON object.");
+        return doc.RootElement.Clone();
+    }
+
+    private static long? GetInt64OrNull(JsonElement el, string name) =>
+        el.ValueKind == JsonValueKind.Object && el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.Number
+            ? p.GetInt64()
+            : null;
+
+    private static DateTime? GetDateTimeOrNull(JsonElement el, string name) =>
+        el.ValueKind == JsonValueKind.Object && el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            && p.TryGetDateTime(out var t)
+            ? t
+            : null;
+
+    private static int? MinutesAgo(DateTime? utc)
+    {
+        if (utc is not { } t) return null;
+        var minutes = (DateTime.UtcNow - t.ToUniversalTime()).TotalMinutes;
+        return minutes <= 0 ? 0 : (int)Math.Round(minutes);
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max].TrimEnd() + "...";
+
+    private static string? NullIfEmpty(string value) => string.IsNullOrWhiteSpace(value) ? null : value;
 
     /// <summary>GET a loopback endpoint that returns a JSON array and hand back its elements. Throws on a
     ///  non-success status (no silent empty list).</summary>
@@ -399,7 +541,16 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
             NeedsYou = needsYou,
             WaitingMinutes = WaitingMinutes(s.NeedsYouSince),
             Summary = summary,
+            AgeHours = AgeHours(s.CreatedAt),
+            IdleMinutes = s.IdleSeconds <= 0 ? 0 : (int)Math.Round(s.IdleSeconds / 60.0),
         };
+    }
+
+    /// <summary>Whole hours since a session was created; 0 when under an hour (or the clock skewed).</summary>
+    private static int AgeHours(DateTime createdAt)
+    {
+        var hours = (DateTime.UtcNow - createdAt.ToUniversalTime()).TotalHours;
+        return hours <= 0 ? 0 : (int)Math.Floor(hours);
     }
 
     /// <summary>The last path segment of a repository path (the human name a person calls a repo), for

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2155,6 +2155,10 @@ public sealed class GatewayHost : IAsyncDisposable
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get, _tenantSettingsResolver));
         var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
         var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending, _carModeSubjects);
+        // The cockpit Assistant (POST /assistant/turn): the SAME loop, tools, stores, model, and turn cache
+        // as Car Mode, with only the desk-surface speech style. Sharing the stores means a device that uses
+        // both surfaces keeps one conversation and one armed-confirmation state - no split-brain.
+        var assistantBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending, _carModeSubjects, surface: CarMode.CarModeSurface.Desk);
         // Keep-warm (Car Mode performance round): warm the SAME hosted model the brain uses and the SAME
         // text-to-speech target /wingman/tts uses, resolved fresh each warmup so a settings change applies.
         var carModeWarmup = new CarMode.CarModeWarmup(
@@ -2166,7 +2170,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 var key = _keyVault.Get(tts.KeyName) ?? "";
                 return (tts.BaseUrl, _tenantSettingsResolver.TtsVoice(tenant, mode), _tenantSettingsResolver.TtsModel(tenant, mode), key);
             });
-        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTurnCache, _carModeDiagnostics, carModeWarmup, _tenantBoundary);
+        Api.CarModeEndpoint.Map(_app, carModeBrain, assistantBrain, _carModeTurnCache, _carModeDiagnostics, carModeWarmup, _tenantBoundary);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, WingmanBrainAsync);


### PR DESCRIPTION
## What this is

The Assistant: a fleet-level chat + voice screen in the cockpit, not tied to any session. Ask "how many sessions do I have open, and is anything stuck?", "which sessions have been open too long?", "how are we doing on credits?", "which machines are online?", "what runs automatically?" - and it answers from real Gateway tool calls, never a guess. It can also act (message, snooze, start, approve, close a session), with closing held behind an explicit confirmation.

It is the desk surface of the same Gateway brain Car Mode drives on the phone: one tool-calling loop, one tool catalog, one per-device server-side conversation store, one deterministic confirmation gate. Only the speech style differs.

## Gateway

- Four new read tools on the brain, all backed by existing endpoints through the loopback fleet: `get_credits` (GET /account/credits), `get_spend` (governance hosted-AI spend summary), `list_machines` (GET /directors grouped by machine, plus roster session counts), `list_schedules` (GET /cron/jobs). A malformed spend summary fails loud rather than fabricating a zero.
- `list_sessions` now carries `ageHours` and `idleMinutes` per session, so "open too long" and "stuck" questions are answered from real numbers.
- `CarModeBrain` takes a surface (Car or Desk). Desk appends explicit style overrides to the system prompt; the loop, tools, relay rules, and confirmation rules are unchanged, so Car Mode behavior is untouched.
- `POST /assistant/turn`: the desk front door, mapped through the same handler as the Car Mode turn route - same tenant resolution, same idempotency single-flight cache, same 402 money mapping, same loud failure shape.

## Cockpit

- New `/assistant` screen with a left-rail entry (speech-bubble icon). Chat mode types (Enter sends); voice mode is tap-to-talk, tap-again-to-send - the button is the turn, no silence detection, no end phrase - and replies are read aloud through the shared text-to-speech door with a "Stop reading" control.
- Actions the brain took render as activity rows above the reply; a destructive hold offers explicit "Yes, do it" / "Cancel" buttons.
- The turn machine and transcript rules live in client-core (`assistant/useAssistant`, `assistant/transcript`), so the phone can mount the same logic later with a thin view (the issue #1213 pattern).
- Dev proxy additions for `/assistant` and `/carmode` so `npm run dev` fronts a live Gateway.

## Known limits (deliberate, for the first cut)

- No mobile screens yet - cockpit first, phone next.
- The new read tools inherit Car Mode's loopback-with-machine-token pattern, which is self-host correct; hosted per-tenant parity for the whole Car Mode/Assistant tool surface is a pre-existing, separate piece of work.
- Replies are plain text (they can be read aloud verbatim); no markdown rendering by design for now.

## Verification

- Ten new brain unit tests (each new tool, the desk prompt overlay, the age/idle facts) - the Car Mode test group passes 132/132.
- New transcript unit tests; client-core suite 582/582, cockpit suite 174/174, all three workspaces typecheck.
- Release publish of the Gateway exe and a production cockpit build both succeed from this branch.
