### PR TITLE
Morning report endpoint: one honest JSON report per account (#2119)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
@@ -1,0 +1,165 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The morning report for ONE account and ONE calendar day (issue #2119, slice 2 of #2096) - the JSON the
+/// website's 7:00 cron reads, renders into the approved email design, and sends. Three headline numbers, the
+/// needs-your-attention list, and the exact window every number was measured over.
+///
+/// THE HONESTY RULE IS STRUCTURAL, NOT EDITORIAL. Anything the Gateway has no data for is ABSENT from the
+/// JSON - never zero-filled, never estimated. A missing <see cref="MorningReportStatsDto.SessionsRan"/> means
+/// "this Gateway holds no session history for this account", which is a different statement from "no sessions
+/// ran", and the email must be able to tell them apart. Every optional member below is therefore
+/// <see cref="JsonIgnoreCondition.WhenWritingNull"/>: a null does not serialize at all.
+///
+/// The field names here are the CONTRACT the website sender is coded against (owner-relayed, 24 July 2026).
+/// They are camelCase on the wire (minimal-API web defaults). Renaming one breaks the email.
+/// </summary>
+public sealed class MorningReportDto
+{
+    /// <summary>The account this report is about, echoed back exactly as the caller asked for it, so the
+    /// sender can prove the report it is about to email belongs to the recipient it is emailing.</summary>
+    public string Account { get; set; } = "";
+
+    /// <summary>The exact coordinates every number below was measured over - the resolved UTC range, plus
+    /// the calendar day and zone it came from. Every number carries its coordinates.</summary>
+    public MorningReportWindowDto Window { get; set; } = new();
+
+    /// <summary>The three headline numbers. Each is individually optional (see the honesty rule).</summary>
+    public MorningReportStatsDto Stats { get; set; } = new();
+
+    /// <summary>
+    /// The needs-your-attention list, one typed item per row the email renders. ALWAYS PRESENT, possibly
+    /// empty: an empty list is real knowledge ("nothing is waiting on you"), unlike an absent stat.
+    /// Items are polymorphic and discriminated by their <c>type</c> string; the sender tolerates a type it
+    /// does not know (it logs and does not render it), so a new item type never breaks a sent email.
+    /// </summary>
+    public List<MorningAttentionItemDto> Attention { get; set; } = new();
+
+    /// <summary>
+    /// An optional single-sentence observation about the day. The Gateway EMITS NOTHING HERE TODAY - it
+    /// reports measurements and invents no prose. The member exists because the contract reserves the key;
+    /// it is absent from the JSON while null.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Observation { get; set; }
+}
+
+/// <summary>The resolved reporting window: the UTC range the calendar day covers in the caller's zone.</summary>
+public sealed class MorningReportWindowDto
+{
+    /// <summary>Inclusive start of the reported day, in UTC.</summary>
+    public DateTime StartUtc { get; set; }
+
+    /// <summary>EXCLUSIVE end of the reported day, in UTC. A day is [start, end).</summary>
+    public DateTime EndUtc { get; set; }
+
+    /// <summary>The calendar day being reported on, as the caller supplied it (yyyy-MM-dd).</summary>
+    public string Date { get; set; } = "";
+
+    /// <summary>The IANA zone the calendar day was resolved in, as the caller supplied it.</summary>
+    public string Tz { get; set; } = "";
+}
+
+/// <summary>
+/// The three headline numbers. Each is null - and therefore ABSENT from the JSON - when this Gateway holds
+/// no backing data at all for the account. A present zero is a measured zero and may be rendered as such.
+/// </summary>
+public sealed class MorningReportStatsDto
+{
+    /// <summary>Distinct sessions that recorded at least one state transition inside the window.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SessionsRan { get; set; }
+
+    /// <summary>Workflow runs ACCEPTED in the window - the outcome ledger's delivered count.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? WorkDelivered { get; set; }
+
+    /// <summary>Hosted-AI service dollars spent in the window, CEIL-rounded to the cent so the figure can
+    /// never undercount real money.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? HostedAiSpendUsd { get; set; }
+}
+
+/// <summary>
+/// One row of the needs-your-attention list. The <c>type</c> string is the discriminator the email renderer
+/// switches on; the derived shapes carry the fields that row needs plus its deep-link target.
+///
+/// Polymorphic serialization is declared WITHOUT a type-discriminator name, so System.Text.Json writes the
+/// runtime type's properties and adds no synthetic <c>$type</c> key - this class's own
+/// <see cref="Type"/> property is the discriminator, and it is the one the contract names.
+/// </summary>
+[JsonPolymorphic]
+[JsonDerivedType(typeof(WaitingSessionAttentionDto))]
+[JsonDerivedType(typeof(StaleWorktreesAttentionDto))]
+[JsonDerivedType(typeof(UnmergedBranchesAttentionDto))]
+public abstract class MorningAttentionItemDto
+{
+    /// <summary>The item's discriminator: "waiting-session", "stale-worktrees", "unmerged-branches".</summary>
+    public abstract string Type { get; }
+}
+
+/// <summary>Type strings for <see cref="MorningAttentionItemDto"/>, so producer and tests share one spelling.</summary>
+public static class MorningAttentionTypes
+{
+    public const string WaitingSession = "waiting-session";
+    public const string StaleWorktrees = "stale-worktrees";
+    public const string UnmergedBranches = "unmerged-branches";
+}
+
+/// <summary>A session whose last recorded state is waiting on the human, and how long it has been there.</summary>
+public sealed class WaitingSessionAttentionDto : MorningAttentionItemDto
+{
+    public override string Type => MorningAttentionTypes.WaitingSession;
+
+    /// <summary>The session's friendly name when the Gateway can see it live, otherwise its session id -
+    /// never blank, so the email always has something to name the row with.</summary>
+    public string Session { get; set; } = "";
+
+    /// <summary>The session's repository path, when a live record supplies one. Absent otherwise.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Repo { get; set; }
+
+    /// <summary>When the session entered its current waiting state, from the durable event ledger.</summary>
+    public DateTime WaitingSinceUtc { get; set; }
+
+    /// <summary>How long it has been waiting, in hours, at the moment the report was built.</summary>
+    public double AgeHours { get; set; }
+}
+
+/// <summary>Stale worktrees in one repository. Only worktrees whose branch is MERGED and whose tip is older
+/// than the staleness bar are ever marked <see cref="SafeToRemove"/>.</summary>
+public sealed class StaleWorktreesAttentionDto : MorningAttentionItemDto
+{
+    public override string Type => MorningAttentionTypes.StaleWorktrees;
+
+    public string Repo { get; set; } = "";
+    public int Count { get; set; }
+
+    /// <summary>The worktrees' directory BASE NAMES - never full paths.</summary>
+    public List<string> Worktrees { get; set; } = new();
+
+    public double OldestAgeDays { get; set; }
+
+    /// <summary>True only when every worktree in this item is old AND its branch is merged into the
+    /// default branch. An unmerged stale worktree is reported as its own item with this false.</summary>
+    public bool SafeToRemove { get; set; }
+}
+
+/// <summary>Branches in one repository that are unmerged to the default branch, oldest first.</summary>
+public sealed class UnmergedBranchesAttentionDto : MorningAttentionItemDto
+{
+    public override string Type => MorningAttentionTypes.UnmergedBranches;
+
+    public string Repo { get; set; } = "";
+    public List<UnmergedBranchDto> Branches { get; set; } = new();
+}
+
+/// <summary>One unmerged branch: its name, how old its tip is, and how many commits it carries.</summary>
+public sealed class UnmergedBranchDto
+{
+    public string Name { get; set; } = "";
+    public double AgeDays { get; set; }
+    public int Commits { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/MorningReportBuilderTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportBuilderTests.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Streaming;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The morning report's assembly (issue #2119). The claims under test are the ones an EMAIL depends on:
+///
+///  - THE HONESTY RULE. A stat whose backing store holds nothing for this tenant is ABSENT, not zero. A
+///    zero-filled stat would put a measurement the Gateway never made into a person's inbox. The pair of
+///    tests <c>*_is_absent_when_the_store_is_empty</c> / <c>*_is_zero_when_the_store_has_rows_outside_the_window</c>
+///    is the whole point: absent and zero are different answers and both must be reachable.
+///  - CEIL ROUNDING on money: a report about real dollars never claims less was spent than was.
+///  - THE WINDOW BOUNDS: inclusive start, EXCLUSIVE end, so a day's last event is not counted twice.
+///  - TENANT ISOLATION: one account's report can never contain another account's rows.
+/// </summary>
+public sealed class MorningReportBuilderTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    private static readonly TenantId Alice = new("tenant-alice");
+    private static readonly TenantId Bob = new("tenant-bob");
+
+    /// <summary>Noon UTC on the day the report is built - safely after the reported window closes.</summary>
+    private static readonly DateTime Now = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>The reported day: 23 July 2026 in Toronto = 2026-07-23T04:00Z .. 2026-07-24T04:00Z.</summary>
+    private static MorningReportWindow Window() => MorningReportWindow.Resolve("2026-07-23", "America/Toronto");
+
+    public void Dispose() => _h.Dispose();
+
+    /// <summary>A database whose AMBIENT tenant is <paramref name="tenant"/> - what the seeding stores write as.</summary>
+    private GatewayDatabase DbAs(TenantId tenant) => _h.Open(new FixedTenantContext(tenant));
+
+    private MorningReportBuilder NewBuilder(GatewayDatabase db, PushedSessionStore? sessions = null) =>
+        new(db, sessions, TimeSpan.FromMinutes(5), () => Now);
+
+    // ---- seeding ---------------------------------------------------------------------------------------
+
+    private static void SeedSessionEvent(GatewayDatabase db, TenantId tenant, string sessionId, string state, DateTime occurredUtc)
+    {
+        using var ctx = db.CreateContext(tenant);
+        ctx.GovernanceEvents.Add(new GovernanceEventEntity
+        {
+            TenantId = tenant.Value,
+            SubjectKind = GovernanceEventSubject.Session,
+            SessionId = sessionId,
+            State = state,
+            OccurredUtc = occurredUtc,
+            RecordedUtc = occurredUtc,
+        });
+        ctx.SaveChanges();
+    }
+
+    private static void SeedRun(GatewayDatabase db, TenantId tenant, string acceptance, DateTime? completedUtc)
+    {
+        using var ctx = db.CreateContext(tenant);
+        ctx.WorkflowRuns.Add(new WorkflowRunEntity
+        {
+            TenantId = tenant.Value,
+            WorkflowId = "mission",
+            Name = "a run",
+            Status = completedUtc is null ? WorkflowRunStatus.Active : WorkflowRunStatus.Succeeded,
+            AcceptanceStatus = acceptance,
+            CreatedUtc = completedUtc ?? Now,
+            CompletedUtc = completedUtc,
+        });
+        ctx.SaveChanges();
+    }
+
+    private static void SeedSpend(GatewayDatabase db, TenantId tenant, long micros, DateTime txUtc)
+    {
+        using var ctx = db.CreateContext(tenant);
+        ctx.AccountHostedAiSpend.Add(new AccountHostedAiSpendEntity
+        {
+            TenantId = tenant.Value,
+            AmountMicros = micros,
+            Kind = "debit",
+            TransactionCreatedUtc = txUtc,
+            ObservedUtc = txUtc,
+        });
+        ctx.SaveChanges();
+    }
+
+    // ---- the honesty rule: absent is not zero ----------------------------------------------------------
+
+    [Fact]
+    public void Every_stat_is_absent_when_this_tenant_has_no_data_at_all()
+    {
+        var db = DbAs(Alice);
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // Not 0 - ABSENT. The Gateway has measured nothing, and an email must be able to say so.
+        Assert.Null(report.Stats.SessionsRan);
+        Assert.Null(report.Stats.WorkDelivered);
+        Assert.Null(report.Stats.HostedAiSpendUsd);
+
+        // The attention list is always present, possibly empty: "nothing is waiting on you" IS knowledge.
+        Assert.NotNull(report.Attention);
+        Assert.Empty(report.Attention);
+
+        // And the coordinates always ride along.
+        Assert.Equal("2026-07-23", report.Window.Date);
+        Assert.Equal("America/Toronto", report.Window.Tz);
+        Assert.Equal(new DateTime(2026, 7, 23, 4, 0, 0, DateTimeKind.Utc), report.Window.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 24, 4, 0, 0, DateTimeKind.Utc), report.Window.EndUtc);
+        Assert.Equal("alice@example.com", report.Account);
+    }
+
+    [Fact]
+    public void A_stat_is_a_measured_zero_when_the_store_has_rows_but_none_in_the_window()
+    {
+        var db = DbAs(Alice);
+        // Rows exist for this tenant, but all of them fall a week before the reported day.
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.Active, new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc));
+        SeedRun(db, Alice, WorkflowRunAcceptance.Accepted, new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc));
+        SeedSpend(db, Alice, 500_000, new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // Present AND zero: the Gateway looked, and the answer is nothing happened that day.
+        Assert.Equal(0, report.Stats.SessionsRan);
+        Assert.Equal(0, report.Stats.WorkDelivered);
+        Assert.Equal(0m, report.Stats.HostedAiSpendUsd);
+    }
+
+    // ---- the three headline numbers --------------------------------------------------------------------
+
+    [Fact]
+    public void SessionsRan_counts_DISTINCT_sessions_inside_the_window()
+    {
+        var db = DbAs(Alice);
+        var inWindow = new DateTime(2026, 7, 23, 14, 0, 0, DateTimeKind.Utc);
+
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.Idle, inWindow.AddHours(1));   // same session again
+        SeedSessionEvent(db, Alice, "s2", GovernanceEventState.Active, inWindow.AddHours(2));
+        SeedSessionEvent(db, Alice, "s3", GovernanceEventState.Active, Window().EndUtc);      // the NEXT day
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // s1 and s2 - s1 counted once despite two transitions, s3 excluded by the exclusive end bound.
+        Assert.Equal(2, report.Stats.SessionsRan);
+    }
+
+    [Fact]
+    public void The_window_start_is_inclusive_and_the_end_is_exclusive()
+    {
+        var db = DbAs(Alice);
+        var w = Window();
+        SeedSessionEvent(db, Alice, "at-the-start", GovernanceEventState.Active, w.StartUtc);
+        SeedSessionEvent(db, Alice, "at-the-end", GovernanceEventState.Active, w.EndUtc);
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, w);
+
+        // A day is [start, end). The session at exactly the end instant belongs to the NEXT day's report -
+        // counting it in both would double-count every midnight.
+        Assert.Equal(1, report.Stats.SessionsRan);
+    }
+
+    [Fact]
+    public void WorkDelivered_counts_only_ACCEPTED_runs_completed_in_the_window()
+    {
+        var db = DbAs(Alice);
+        var inWindow = new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc);
+
+        SeedRun(db, Alice, WorkflowRunAcceptance.Accepted, inWindow);
+        SeedRun(db, Alice, WorkflowRunAcceptance.Accepted, inWindow.AddHours(1));
+        SeedRun(db, Alice, WorkflowRunAcceptance.Pending, inWindow);    // succeeded but unaccepted
+        SeedRun(db, Alice, WorkflowRunAcceptance.Rejected, inWindow);
+        SeedRun(db, Alice, WorkflowRunAcceptance.Accepted, null);       // never completed
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        Assert.Equal(2, report.Stats.WorkDelivered);
+    }
+
+    [Theory]
+    // A fraction of a cent becomes a whole cent - the report never undercounts real money.
+    [InlineData(1L, 0.01)]
+    [InlineData(9_999L, 0.01)]
+    [InlineData(10_000L, 0.01)]
+    [InlineData(10_001L, 0.02)]
+    [InlineData(1_000_000L, 1.00)]
+    [InlineData(1_234_567L, 1.24)]     // 1.234567 -> 1.24, not 1.23
+    [InlineData(0L, 0.00)]
+    public void Hosted_AI_spend_is_ceil_rounded_to_the_cent(long micros, double expectedUsd)
+    {
+        Assert.Equal((decimal)expectedUsd, MorningReportBuilder.CeilMicrosToUsd(micros));
+    }
+
+    [Fact]
+    public void Hosted_AI_spend_sums_the_window_and_rounds_the_TOTAL_up()
+    {
+        var db = DbAs(Alice);
+        var inWindow = new DateTime(2026, 7, 23, 16, 0, 0, DateTimeKind.Utc);
+        SeedSpend(db, Alice, 1_234_567, inWindow);
+        SeedSpend(db, Alice, 2_345, inWindow.AddMinutes(1));
+        SeedSpend(db, Alice, 9_000_000, Window().EndUtc); // next day - excluded
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // 1,236,912 micros = $1.236912 -> $1.24
+        Assert.Equal(1.24m, report.Stats.HostedAiSpendUsd);
+    }
+
+    // ---- the waiting-session attention rows -------------------------------------------------------------
+
+    [Fact]
+    public void A_session_whose_LAST_recorded_state_is_waiting_is_reported_with_a_real_age()
+    {
+        var db = DbAs(Alice);
+        var waitingSince = Now.AddHours(-6);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.Active, waitingSince.AddHours(-1));
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, waitingSince);
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        var item = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(report.Attention));
+        Assert.Equal(MorningAttentionTypes.WaitingSession, item.Type);
+        Assert.Equal(waitingSince, item.WaitingSinceUtc);
+        Assert.Equal(6.0, item.AgeHours);
+        // With no live roster to name it, the row still identifies itself - by session id, never blank.
+        Assert.Equal("s1", item.Session);
+        Assert.Null(item.Repo);
+    }
+
+    [Fact]
+    public void A_session_that_came_BACK_is_not_reported_as_waiting()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-6));
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.Active, Now.AddHours(-2));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // The ledger's LAST word wins. A report that read any waiting event ever recorded would nag the
+        // owner every morning about work they finished weeks ago.
+        Assert.Empty(report.Attention);
+    }
+
+    [Fact]
+    public void Waiting_rows_are_ordered_longest_wait_first()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "recent", GovernanceEventState.WaitingOnHuman, Now.AddHours(-2));
+        SeedSessionEvent(db, Alice, "oldest", GovernanceEventState.WaitingOnHuman, Now.AddHours(-30));
+        SeedSessionEvent(db, Alice, "middle", GovernanceEventState.WaitingOnPermission, Now.AddHours(-9));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        var names = report.Attention.Cast<WaitingSessionAttentionDto>().Select(i => i.Session).ToList();
+        Assert.Equal(new[] { "oldest", "middle", "recent" }, names);
+    }
+
+    [Fact]
+    public void A_live_roster_supplies_the_friendly_name_and_the_repository_path()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-3));
+
+        var sessions = new PushedSessionStore(() => Now);
+        sessions.RegisterConnection(Alice, "dir-1", "conn-1");
+        Assert.True(sessions.ApplySnapshot(Alice, "dir-1", "conn-1", 0, new List<SessionDto>
+        {
+            new() { SessionId = "s1", Name = "Morning report - Developer", RepoPath = "D:/ReposFred/devthrottle", ActivityState = "WaitingForInput" },
+        }));
+
+        var report = NewBuilder(db, sessions).Build("alice@example.com", Alice, Window());
+
+        var item = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(report.Attention));
+        Assert.Equal("Morning report - Developer", item.Session);
+        Assert.Equal("D:/ReposFred/devthrottle", item.Repo);
+        // The AGE still comes from the durable ledger, never from the live roster.
+        Assert.Equal(3.0, item.AgeHours);
+    }
+
+    [Fact]
+    public void A_session_the_owner_has_SNOOZED_is_not_this_mornings_problem()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-3));
+
+        var sessions = new PushedSessionStore(() => Now);
+        sessions.RegisterConnection(Alice, "dir-1", "conn-1");
+        Assert.True(sessions.ApplySnapshot(Alice, "dir-1", "conn-1", 0, new List<SessionDto>
+        {
+            new() { SessionId = "s1", Name = "parked", HoldState = HoldStates.Held },
+        }));
+
+        var report = NewBuilder(db, sessions).Build("alice@example.com", Alice, Window());
+
+        // The owner deliberately parked it. Putting it in the 7am email defeats the snooze.
+        Assert.Empty(report.Attention);
+    }
+
+    [Fact]
+    public void A_session_that_has_EXITED_is_not_waiting_on_anybody()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-3));
+
+        var sessions = new PushedSessionStore(() => Now);
+        sessions.RegisterConnection(Alice, "dir-1", "conn-1");
+        Assert.True(sessions.ApplySnapshot(Alice, "dir-1", "conn-1", 0, new List<SessionDto>
+        {
+            new() { SessionId = "s1", Name = "gone", ActivityState = "Exited" },
+        }));
+
+        var report = NewBuilder(db, sessions).Build("alice@example.com", Alice, Window());
+
+        Assert.Empty(report.Attention);
+    }
+
+    [Fact]
+    public void A_session_older_than_the_lookback_horizon_is_not_reported()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "ancient", GovernanceEventState.WaitingOnHuman,
+            Now.AddDays(-(MorningReportBuilder.WaitingLookbackDays + 1)));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // The Gateway will not assert the CURRENT state of something it has not heard about in a month.
+        Assert.Empty(report.Attention);
+    }
+
+    // ---- the hygiene sections are absent until the repo-state feed exists -------------------------------
+
+    [Fact]
+    public void No_hygiene_items_are_emitted_while_there_is_no_repo_state_store()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-3));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        // This is what makes this slice mergeable and shippable BEFORE the snapshot feed lands: no
+        // repo-state data means no stale-worktree / unmerged-branch rows at all - not empty ones.
+        Assert.DoesNotContain(report.Attention, i => i.Type == MorningAttentionTypes.StaleWorktrees);
+        Assert.DoesNotContain(report.Attention, i => i.Type == MorningAttentionTypes.UnmergedBranches);
+    }
+
+    // ---- tenant isolation ------------------------------------------------------------------------------
+
+    [Fact]
+    public void One_accounts_report_never_contains_another_accounts_rows()
+    {
+        // Two tenants, ONE database file - exactly the hosted shape.
+        var aliceDb = DbAs(Alice);
+        var bobDb = DbAs(Bob);
+        var inWindow = new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc);
+
+        SeedSessionEvent(aliceDb, Alice, "alice-1", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(aliceDb, Alice, "alice-2", GovernanceEventState.WaitingOnHuman, Now.AddHours(-4));
+        SeedRun(aliceDb, Alice, WorkflowRunAcceptance.Accepted, inWindow);
+        SeedSpend(aliceDb, Alice, 1_000_000, inWindow);
+
+        SeedSessionEvent(bobDb, Bob, "bob-1", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(bobDb, Bob, "bob-2", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(bobDb, Bob, "bob-3", GovernanceEventState.WaitingOnHuman, Now.AddHours(-40));
+        SeedRun(bobDb, Bob, WorkflowRunAcceptance.Accepted, inWindow);
+        SeedRun(bobDb, Bob, WorkflowRunAcceptance.Accepted, inWindow);
+        SeedSpend(bobDb, Bob, 9_000_000, inWindow);
+
+        // Build BOTH reports through the SAME builder instance, to prove the tenant argument - not some
+        // remembered ambient state - is what scopes the read.
+        var builder = NewBuilder(aliceDb);
+        var aliceReport = builder.Build("alice@example.com", Alice, Window());
+        var bobReport = builder.Build("bob@example.com", Bob, Window());
+
+        // Only alice-1 transitioned INSIDE the reported day; alice-2 has been waiting since after it closed,
+        // so it is an attention row without being a "ran yesterday" session. The two numbers answer different
+        // questions and are deliberately allowed to disagree.
+        Assert.Equal(1, aliceReport.Stats.SessionsRan);
+        Assert.Equal(1, aliceReport.Stats.WorkDelivered);
+        Assert.Equal(1.00m, aliceReport.Stats.HostedAiSpendUsd);
+        var aliceWaiting = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(aliceReport.Attention));
+        Assert.Equal("alice-2", aliceWaiting.Session);
+
+        Assert.Equal(2, bobReport.Stats.SessionsRan);     // bob-1 + bob-2; bob-3's wait began before the day
+        Assert.Equal(2, bobReport.Stats.WorkDelivered);
+        Assert.Equal(9.00m, bobReport.Stats.HostedAiSpendUsd);
+        var bobWaiting = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(bobReport.Attention));
+        Assert.Equal("bob-3", bobWaiting.Session);
+    }
+
+    [Fact]
+    public void A_tenant_with_no_rows_of_its_own_reports_ABSENT_even_when_another_tenant_has_plenty()
+    {
+        var aliceDb = DbAs(Alice);
+        var inWindow = new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc);
+        SeedSessionEvent(aliceDb, Alice, "alice-1", GovernanceEventState.Active, inWindow);
+        SeedRun(aliceDb, Alice, WorkflowRunAcceptance.Accepted, inWindow);
+        SeedSpend(aliceDb, Alice, 1_000_000, inWindow);
+
+        var bobReport = NewBuilder(aliceDb).Build("bob@example.com", Bob, Window());
+
+        // The "does this tenant have any data" probe must itself be tenant-scoped. If it were not, Bob would
+        // get a ZERO for every stat - a measurement made entirely out of Alice's rows.
+        Assert.Null(bobReport.Stats.SessionsRan);
+        Assert.Null(bobReport.Stats.WorkDelivered);
+        Assert.Null(bobReport.Stats.HostedAiSpendUsd);
+        Assert.Empty(bobReport.Attention);
+    }
+
+    [Fact]
+    public void A_live_roster_from_another_tenant_never_labels_this_tenants_row()
+    {
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "shared-id", GovernanceEventState.WaitingOnHuman, Now.AddHours(-3));
+
+        // Bob happens to run a session with the SAME raw id - a collision the tenant partition must absorb.
+        var sessions = new PushedSessionStore(() => Now);
+        sessions.RegisterConnection(Bob, "dir-bob", "conn-bob");
+        Assert.True(sessions.ApplySnapshot(Bob, "dir-bob", "conn-bob", 0, new List<SessionDto>
+        {
+            new() { SessionId = "shared-id", Name = "BOB'S SECRET PROJECT", RepoPath = "D:/bob/private" },
+        }));
+
+        var report = NewBuilder(db, sessions).Build("alice@example.com", Alice, Window());
+
+        var item = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(report.Attention));
+        Assert.Equal("shared-id", item.Session);   // the id, NOT Bob's session name
+        Assert.Null(item.Repo);                    // and certainly not Bob's repository path
+    }
+
+    // ---- argument discipline ---------------------------------------------------------------------------
+
+    [Fact]
+    public void An_invalid_tenant_is_refused_rather_than_read_as_something()
+    {
+        var db = DbAs(Alice);
+        Assert.Throws<ArgumentException>(() => NewBuilder(db).Build("a@b.c", default, Window()));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MorningReportEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportEndpointTests.cs
@@ -1,0 +1,440 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The morning-report endpoint's OWN gate (issue #2119). This route is exempt from the host-wide token
+/// middleware because its caller is a server with no device key - so everything that keeps one account's
+/// report out of another's inbox lives here, and every one of those rules is asserted below:
+///
+///   no token / wrong token / wrong scheme -> 401
+///   the service token not configured      -> 503 (refuse to serve, never serve unguarded)
+///   a valid token, an unknown account     -> 404
+///   a valid token, an AMBIGUOUS account   -> 409 (never pick one)
+///   a valid token, account A              -> A's rows only, proven against a second seeded tenant
+///
+/// The exemption itself is asserted too: if <c>AuthMiddleware.PublicPaths</c> stopped containing this route
+/// the cron would receive a 401 from the host gate at 07:00 and no email would go out - a failure that would
+/// otherwise only be discovered in production, once, silently.
+/// </summary>
+public sealed class MorningReportEndpointTests : IDisposable
+{
+    private const string Token = "test-service-token-4f2a";
+    private const string OtherToken = "test-service-token-4f2b";
+
+    private readonly GatewayDbTestHarness _h = new();
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"mr-dev-{Guid.NewGuid():N}.json");
+    private readonly string? _savedToken = Environment.GetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar);
+
+    private static readonly TenantId Alice = new("tenant-alice");
+    private static readonly TenantId Bob = new("tenant-bob");
+    private static readonly DateTime Now = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, _savedToken);
+        _h.Dispose();
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+    }
+
+    // ---- harness ---------------------------------------------------------------------------------------
+
+    private GatewayDatabase Db => _h.Open(new AsyncLocalTenantContext());
+
+    private HostedTenantBoundary HostedBoundary() =>
+        new(new AsyncLocalTenantContext(), new DeviceRegistry(_devPath));
+
+    private HostedTenantBoundary SelfHostBoundary() =>
+        new(new SingleTenantContext(), new DeviceRegistry(_devPath));
+
+    /// <summary>The services a minimal-API <c>IResult</c> needs to write itself out (JSON options +
+    /// logging). Built once: these tests execute the real result objects rather than inspecting them, so
+    /// the JSON asserted below is byte-for-byte what the website cron receives.</summary>
+    private static readonly IServiceProvider Services =
+        new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+
+    private static HttpContext Request(string? bearer)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = Services };
+        if (bearer is not null)
+            ctx.Request.Headers.Authorization = bearer;
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    private IResult Call(HttpContext ctx, string? account, GatewayDatabase db, HostedTenantBoundary boundary,
+        string date = "2026-07-23", string tz = "America/Toronto") =>
+        MorningReportEndpoint.Handle(
+            ctx, account, date, tz,
+            new MorningReportBuilder(db, pushedSessions: null, streamStale: TimeSpan.FromMinutes(5), utcNow: () => Now),
+            new TenantRegistry(db),
+            boundary);
+
+    /// <summary>Execute the result and read back the status and the JSON body the cron would actually receive.</summary>
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result, HttpContext ctx)
+    {
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Position = 0;
+        using var reader = new StreamReader(ctx.Response.Body);
+        var text = await reader.ReadToEndAsync();
+        using var doc = JsonDocument.Parse(text);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    /// <summary>Register a tenant in the account census, exactly as hosted enrollment would.</summary>
+    private static void SeedTenant(GatewayDatabase db, TenantId tenant, string subject, string? email)
+    {
+        using var ctx = db.CreateUnscopedContext();
+        ctx.Tenants.Add(new TenantEntity
+        {
+            Id = tenant.Value,
+            AccountSubject = subject,
+            Email = email,
+            CreatedAtUtc = Now,
+        });
+        ctx.SaveChanges();
+    }
+
+    private static void SeedSessionEvent(GatewayDatabase db, TenantId tenant, string sessionId, string state, DateTime occurredUtc)
+    {
+        using var ctx = db.CreateContext(tenant);
+        ctx.GovernanceEvents.Add(new GovernanceEventEntity
+        {
+            TenantId = tenant.Value,
+            SubjectKind = GovernanceEventSubject.Session,
+            SessionId = sessionId,
+            State = state,
+            OccurredUtc = occurredUtc,
+            RecordedUtc = occurredUtc,
+        });
+        ctx.SaveChanges();
+    }
+
+    // ---- the exemption is deliberate, and it must stay -------------------------------------------------
+
+    [Fact]
+    public async Task The_route_is_exempt_from_the_host_wide_token_gate()
+    {
+        // Not decoration: the website cron holds no device key and no shared machine token, so without this
+        // exemption every 07:00 call is a 401 and the email silently stops. Asserted through the middleware
+        // itself, not by peeking at a set - the claim is "a credential-less request reaches the endpoint".
+        var devices = new DeviceRegistry(_devPath);
+        var cfg = new AuthMiddleware.RequireToken { Token = "shared-machine-token", Devices = devices };
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = MorningReportEndpoint.Path;
+        ctx.Response.Body = new MemoryStream();
+
+        var reached = false;
+        await AuthMiddleware.Run(ctx, cfg, () => { reached = true; return Task.CompletedTask; });
+
+        Assert.True(reached);
+        Assert.NotEqual(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_NEIGHBOURING_report_route_is_still_gated()
+    {
+        // The exemption is EXACT-MATCH, not a prefix. If it were a prefix, adding any future
+        // /gateway/reports/* route would silently publish it - so prove a sibling path still 401s.
+        var devices = new DeviceRegistry(_devPath);
+        var cfg = new AuthMiddleware.RequireToken { Token = "shared-machine-token", Devices = devices };
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = MorningReportEndpoint.Path + "/everything";
+        ctx.Response.Body = new MemoryStream();
+
+        var reached = false;
+        await AuthMiddleware.Run(ctx, cfg, () => { reached = true; return Task.CompletedTask; });
+
+        Assert.False(reached);
+        Assert.Equal(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
+    }
+
+    // ---- authorization negatives -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task No_token_is_401()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        var ctx = Request(bearer: null);
+        var (status, body) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+        Assert.True(body.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task A_wrong_token_is_401()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        var ctx = Request($"Bearer {OtherToken}");
+        var (status, _) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Bearer")]
+    [InlineData("Bearer ")]
+    [InlineData("test-service-token-4f2a")]              // the right token, no scheme
+    [InlineData("Basic test-service-token-4f2a")]        // the right token, wrong scheme
+    [InlineData("Bearer test-service-token-4f2")]        // a PREFIX of the right token
+    [InlineData("Bearer test-service-token-4f2aa")]      // the right token plus a byte
+    public async Task A_malformed_or_near_miss_credential_is_401(string header)
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        var ctx = Request(header);
+        var (status, _) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task An_unconfigured_service_token_refuses_to_serve_it_does_not_open_the_door(string? configured)
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, configured);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        // Even a caller presenting SOMETHING gets nothing: an unset token is a deployment fault, and the
+        // tempting failure mode - "no token configured, so let everyone in" - would publish every account's
+        // report to the internet.
+        var ctx = Request("Bearer anything-at-all");
+        var (status, _) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, status);
+    }
+
+    // ---- account resolution ----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_valid_token_naming_an_unknown_account_is_404()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, _) = await ExecuteAsync(Call(ctx, "nobody@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status404NotFound, status);
+    }
+
+    [Fact]
+    public async Task An_AMBIGUOUS_account_is_refused_never_guessed()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        // Two DIFFERENT accounts (different subjects - the real key) that happen to carry the same display
+        // email. Picking either one would email one person the other person's day.
+        SeedTenant(db, Alice, "sub-alice", "shared@example.com");
+        SeedTenant(db, Bob, "sub-bob", "shared@example.com");
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, _) = await ExecuteAsync(Call(ctx, "shared@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status409Conflict, status);
+    }
+
+    [Fact]
+    public async Task An_account_resolves_by_email_case_insensitively_and_by_tenant_id()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "Alice@Example.com");
+
+        foreach (var account in new[] { "alice@example.com", "ALICE@EXAMPLE.COM", Alice.Value })
+        {
+            var ctx = Request($"Bearer {Token}");
+            var (status, body) = await ExecuteAsync(Call(ctx, account, db, HostedBoundary()), ctx);
+
+            Assert.Equal(StatusCodes.Status200OK, status);
+            Assert.Equal(account, body.GetProperty("account").GetString());
+        }
+    }
+
+    [Theory]
+    [InlineData(null, "2026-07-23", "America/Toronto")]   // no account
+    [InlineData("alice@example.com", "23-07-2026", "America/Toronto")]
+    [InlineData("alice@example.com", "2026-07-23", "Mars/Olympus_Mons")]
+    public async Task A_request_missing_or_malforming_its_coordinates_is_400(string? account, string date, string tz)
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, _) = await ExecuteAsync(Call(ctx, account, db, HostedBoundary(), date, tz), ctx);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, status);
+    }
+
+    // ---- the isolation the whole gate exists for -------------------------------------------------------
+
+    [Fact]
+    public async Task A_second_tenants_data_never_appears_in_the_first_tenants_report()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+        SeedTenant(db, Bob, "sub-bob", "bob@example.com");
+
+        var inWindow = new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc);
+        SeedSessionEvent(db, Alice, "alice-1", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(db, Bob, "bob-1", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(db, Bob, "bob-2", GovernanceEventState.Active, inWindow);
+        SeedSessionEvent(db, Bob, "bob-waiting", GovernanceEventState.WaitingOnHuman, Now.AddHours(-5));
+
+        var aliceCtx = Request($"Bearer {Token}");
+        var (aliceStatus, aliceBody) = await ExecuteAsync(Call(aliceCtx, "alice@example.com", db, HostedBoundary()), aliceCtx);
+
+        var bobCtx = Request($"Bearer {Token}");
+        var (bobStatus, bobBody) = await ExecuteAsync(Call(bobCtx, "bob@example.com", db, HostedBoundary()), bobCtx);
+
+        Assert.Equal(StatusCodes.Status200OK, aliceStatus);
+        Assert.Equal(StatusCodes.Status200OK, bobStatus);
+
+        Assert.Equal(1, aliceBody.GetProperty("stats").GetProperty("sessionsRan").GetInt32());
+        Assert.Equal(0, aliceBody.GetProperty("attention").GetArrayLength());
+
+        // bob-1 and bob-2 transitioned inside the reported day; bob-waiting started waiting after it closed,
+        // so it is an attention row without being counted as a session that ran yesterday.
+        Assert.Equal(2, bobBody.GetProperty("stats").GetProperty("sessionsRan").GetInt32());
+        Assert.Equal(1, bobBody.GetProperty("attention").GetArrayLength());
+
+        // The strongest form of the claim: Bob's session identifiers appear NOWHERE in Alice's payload.
+        Assert.DoesNotContain("bob-", aliceBody.GetRawText(), StringComparison.Ordinal);
+    }
+
+    // ---- the wire shape the website sender is coded against ---------------------------------------------
+
+    [Fact]
+    public async Task The_JSON_matches_the_agreed_contract_and_omits_what_the_Gateway_does_not_know()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+        // One session that ran INSIDE the reported day (the stat), and one that has been waiting since
+        // after the day closed (the attention row). Deliberately different sessions: the two answer
+        // different questions and the email shows them in different places.
+        SeedSessionEvent(db, Alice, "ran-yesterday", GovernanceEventState.Active,
+            new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc));
+        SeedSessionEvent(db, Alice, "s1", GovernanceEventState.WaitingOnHuman, Now.AddHours(-7));
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, body) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status200OK, status);
+        Assert.Equal("alice@example.com", body.GetProperty("account").GetString());
+
+        var window = body.GetProperty("window");
+        Assert.Equal("2026-07-23", window.GetProperty("date").GetString());
+        Assert.Equal("America/Toronto", window.GetProperty("tz").GetString());
+        Assert.True(window.TryGetProperty("startUtc", out _));
+        Assert.True(window.TryGetProperty("endUtc", out _));
+
+        // The session ledger has rows, so sessionsRan is present. Nothing has ever written a workflow run or
+        // a hosted-AI debit for this tenant, so those two keys are ABSENT - not zero.
+        var stats = body.GetProperty("stats");
+        Assert.Equal(1, stats.GetProperty("sessionsRan").GetInt32());
+        Assert.False(stats.TryGetProperty("workDelivered", out _));
+        Assert.False(stats.TryGetProperty("hostedAiSpendUsd", out _));
+
+        // The Gateway invents no prose.
+        Assert.False(body.TryGetProperty("observation", out _));
+
+        Assert.Equal(1, body.GetProperty("attention").GetArrayLength());
+        var item = body.GetProperty("attention")[0];
+        Assert.Equal("waiting-session", item.GetProperty("type").GetString());
+        Assert.Equal("s1", item.GetProperty("session").GetString());
+        Assert.Equal(7.0, item.GetProperty("ageHours").GetDouble());
+        Assert.True(item.TryGetProperty("waitingSinceUtc", out _));
+        // No live roster knows this session, so it has no repository path - and the key is absent, not "".
+        Assert.False(item.TryGetProperty("repo", out _));
+        // Polymorphism must not smuggle a synthetic discriminator into the contract.
+        Assert.False(item.TryGetProperty("$type", out _));
+    }
+
+    [Fact]
+    public async Task Money_reaches_the_wire_as_a_ceil_rounded_number()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = Db;
+        SeedTenant(db, Alice, "sub-alice", "alice@example.com");
+        using (var seed = db.CreateContext(Alice))
+        {
+            seed.AccountHostedAiSpend.Add(new AccountHostedAiSpendEntity
+            {
+                TenantId = Alice.Value,
+                AmountMicros = 1_234_567,
+                Kind = "debit",
+                TransactionCreatedUtc = new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc),
+                ObservedUtc = Now,
+            });
+            seed.SaveChanges();
+        }
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, body) = await ExecuteAsync(Call(ctx, "alice@example.com", db, HostedBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status200OK, status);
+        // A number, not a string - the sender formats it - and rounded UP to the cent.
+        var spend = body.GetProperty("stats").GetProperty("hostedAiSpendUsd");
+        Assert.Equal(JsonValueKind.Number, spend.ValueKind);
+        Assert.Equal(1.24m, spend.GetDecimal());
+    }
+
+    // ---- self-host -------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task On_self_host_the_single_local_tenant_answers_and_the_token_still_gates()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+        var db = _h.Open(); // SingleTenantContext -> everything is TenantId.Local
+        SeedSessionEvent(db, TenantId.Local, "s1", GovernanceEventState.Active,
+            new DateTime(2026, 7, 23, 15, 0, 0, DateTimeKind.Utc));
+
+        // A self-host install has no account census, so the account names the one install - but the service
+        // token is still required.
+        var denied = Request("Bearer wrong");
+        var (deniedStatus, _) = await ExecuteAsync(Call(denied, "whoever@example.com", db, SelfHostBoundary()), denied);
+        Assert.Equal(StatusCodes.Status401Unauthorized, deniedStatus);
+
+        var ctx = Request($"Bearer {Token}");
+        var (status, body) = await ExecuteAsync(Call(ctx, "whoever@example.com", db, SelfHostBoundary()), ctx);
+
+        Assert.Equal(StatusCodes.Status200OK, status);
+        Assert.Equal(1, body.GetProperty("stats").GetProperty("sessionsRan").GetInt32());
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MorningReportWindowTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportWindowTests.cs
@@ -1,0 +1,120 @@
+using System;
+using CcDirector.Gateway.Reports;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The window resolver (issue #2119): "the calendar day D in zone Z" -> the exact half-open UTC range the
+/// report measures over. Every number in the morning email carries these coordinates, so getting them wrong
+/// silently moves work between days.
+///
+/// The claim these tests exist for is the DAYLIGHT-SAVING one. A window computed as "start plus 24 hours"
+/// passes every ordinary-day test and is wrong twice a year: it puts an hour of a spring-forward day into
+/// the next report and drops an hour of an autumn-back day out of both. Revert-prove: change
+/// <c>MorningReportWindow</c> to compute the end as <c>startUtc.AddDays(1)</c> and the two transition tests
+/// below go RED while the ordinary-day tests stay green.
+/// </summary>
+public sealed class MorningReportWindowTests
+{
+    private const string Toronto = "America/Toronto";
+
+    [Fact]
+    public void An_ordinary_day_is_twenty_four_hours_and_starts_at_local_midnight()
+    {
+        var w = MorningReportWindow.Resolve("2026-07-23", Toronto);
+
+        // Toronto is UTC-4 in July, so local midnight on the 23rd is 04:00 UTC.
+        Assert.Equal(new DateTime(2026, 7, 23, 4, 0, 0, DateTimeKind.Utc), w.StartUtc);
+        Assert.Equal(new DateTime(2026, 7, 24, 4, 0, 0, DateTimeKind.Utc), w.EndUtc);
+        Assert.Equal(24, (w.EndUtc - w.StartUtc).TotalHours);
+        Assert.Equal("2026-07-23", w.Date);
+        Assert.Equal(Toronto, w.Tz);
+    }
+
+    [Fact]
+    public void A_winter_day_uses_the_standard_time_offset_not_the_summer_one()
+    {
+        var w = MorningReportWindow.Resolve("2026-01-15", Toronto);
+
+        // UTC-5 in January.
+        Assert.Equal(new DateTime(2026, 1, 15, 5, 0, 0, DateTimeKind.Utc), w.StartUtc);
+        Assert.Equal(24, (w.EndUtc - w.StartUtc).TotalHours);
+    }
+
+    [Fact]
+    public void The_spring_forward_day_is_twenty_three_hours_long()
+    {
+        // 8 March 2026: North American clocks go forward at 02:00 local. The day is 23 hours.
+        var w = MorningReportWindow.Resolve("2026-03-08", Toronto);
+
+        Assert.Equal(new DateTime(2026, 3, 8, 5, 0, 0, DateTimeKind.Utc), w.StartUtc);
+        Assert.Equal(new DateTime(2026, 3, 9, 4, 0, 0, DateTimeKind.Utc), w.EndUtc);
+        Assert.Equal(23, (w.EndUtc - w.StartUtc).TotalHours);
+    }
+
+    [Fact]
+    public void The_autumn_back_day_is_twenty_five_hours_long()
+    {
+        // 1 November 2026: clocks go back at 02:00 local. The day is 25 hours.
+        var w = MorningReportWindow.Resolve("2026-11-01", Toronto);
+
+        Assert.Equal(new DateTime(2026, 11, 1, 4, 0, 0, DateTimeKind.Utc), w.StartUtc);
+        Assert.Equal(new DateTime(2026, 11, 2, 5, 0, 0, DateTimeKind.Utc), w.EndUtc);
+        Assert.Equal(25, (w.EndUtc - w.StartUtc).TotalHours);
+    }
+
+    [Fact]
+    public void Consecutive_days_abut_exactly_across_a_transition()
+    {
+        // The end of one day IS the start of the next - no gap, no overlap - even across the transition.
+        // A gap loses work; an overlap reports the same work twice.
+        var before = MorningReportWindow.Resolve("2026-03-07", Toronto);
+        var during = MorningReportWindow.Resolve("2026-03-08", Toronto);
+        var after = MorningReportWindow.Resolve("2026-03-09", Toronto);
+
+        Assert.Equal(before.EndUtc, during.StartUtc);
+        Assert.Equal(during.EndUtc, after.StartUtc);
+    }
+
+    [Fact]
+    public void A_zone_whose_midnight_does_not_exist_starts_at_the_first_instant_that_does()
+    {
+        // Chile springs forward AT midnight, so 00:00 local simply does not occur on that date and the day
+        // begins at 01:00. Resolving it must not throw and must not silently produce a nonexistent instant.
+        var w = MorningReportWindow.Resolve("2026-09-06", "America/Santiago");
+
+        Assert.True(w.EndUtc > w.StartUtc);
+        Assert.Equal(23, (w.EndUtc - w.StartUtc).TotalHours);
+
+        var zone = TimeZoneInfo.FindSystemTimeZoneById("America/Santiago");
+        var localStart = TimeZoneInfo.ConvertTimeFromUtc(w.StartUtc, zone);
+        Assert.Equal(new DateTime(2026, 9, 6), localStart.Date);
+        Assert.Equal(1, localStart.Hour);
+    }
+
+    [Fact]
+    public void A_zone_far_from_UTC_resolves_its_own_midnight()
+    {
+        var w = MorningReportWindow.Resolve("2026-07-23", "Asia/Tokyo");
+
+        // UTC+9, no daylight saving: local midnight on the 23rd is 15:00 UTC on the 22nd.
+        Assert.Equal(new DateTime(2026, 7, 22, 15, 0, 0, DateTimeKind.Utc), w.StartUtc);
+        Assert.Equal(24, (w.EndUtc - w.StartUtc).TotalHours);
+    }
+
+    [Theory]
+    [InlineData(null, Toronto)]
+    [InlineData("2026-07-23", null)]
+    [InlineData("", Toronto)]
+    [InlineData("23-07-2026", Toronto)]
+    [InlineData("2026-07-23T00:00:00", Toronto)]
+    [InlineData("not-a-date", Toronto)]
+    [InlineData("2026-07-23", "Mars/Olympus_Mons")]
+    public void An_unusable_date_or_zone_is_refused_never_defaulted(string? date, string? tz)
+    {
+        // Defaulting a missing or unparseable coordinate would produce a report over a window nobody asked
+        // for - which is exactly the kind of confidently-wrong number this slice must not emit.
+        Assert.Throws<MorningReportWindowException>(() => MorningReportWindow.Resolve(date, tz));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TenantRegistryEmailBackfillTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantRegistryEmailBackfillTests.cs
@@ -1,0 +1,148 @@
+using System;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The tenant registry's account lookup and its display-email backfill (issue #2119).
+///
+/// WHY THE BACKFILL EXISTS. The email was recorded on a FRESH MINT ONLY, so every tenant minted before the
+/// email was captured - or from a token that carried none - was left permanently without one. That was
+/// harmless while nothing looked an account up by email. The morning report does exactly that, and the
+/// website's 07:00 cron sends to the same string it asks for, so a null email turns a real, fully enrolled
+/// account into "no such account" - a 404 about the data, dressed as a 404 about the endpoint.
+///
+/// It is a BACKFILL and not an overwrite, and the difference is the whole safety of it: an existing email
+/// is never replaced, so this cannot silently re-point an account's display identity, and the mapping key
+/// remains the subject and only the subject.
+/// </summary>
+public sealed class TenantRegistryEmailBackfillTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private TenantRegistry NewRegistry() => new(_h.Open());
+
+    private static string Subject() => "sub-" + Guid.NewGuid().ToString("N");
+
+    [Fact]
+    public void A_tenant_minted_without_an_email_gets_one_recorded_when_the_account_next_resolves()
+    {
+        var registry = NewRegistry();
+        var subject = Subject();
+
+        var minted = registry.MintOrLookupBySubject(subject, email: null);
+        Assert.Null(registry.EmailForTenant(minted));
+
+        // The same account resolves again, this time carrying its email.
+        var again = registry.MintOrLookupBySubject(subject, "soren@example.com");
+
+        Assert.Equal(minted, again);   // same tenant - the subject is still the only key
+        Assert.Equal("soren@example.com", registry.EmailForTenant(minted));
+    }
+
+    [Fact]
+    public void An_existing_email_is_NEVER_overwritten()
+    {
+        var registry = NewRegistry();
+        var subject = Subject();
+        var tenant = registry.MintOrLookupBySubject(subject, "first@example.com");
+
+        registry.MintOrLookupBySubject(subject, "second@example.com");
+
+        // A backfill fills a hole; it does not re-point an identity. Overwriting here would let a later
+        // token silently change where an account's morning report is addressed.
+        Assert.Equal("first@example.com", registry.EmailForTenant(tenant));
+    }
+
+    [Fact]
+    public void Resolving_without_an_email_leaves_a_null_alone_rather_than_blanking_anything()
+    {
+        var registry = NewRegistry();
+        var subject = Subject();
+        var tenant = registry.MintOrLookupBySubject(subject, "kept@example.com");
+
+        registry.MintOrLookupBySubject(subject, email: null);
+
+        Assert.Equal("kept@example.com", registry.EmailForTenant(tenant));
+    }
+
+    [Fact]
+    public void The_backfilled_email_is_what_makes_the_account_findable_by_email()
+    {
+        // The end-to-end point of the backfill, stated as the property the morning report depends on.
+        var registry = NewRegistry();
+        var subject = Subject();
+        var tenant = registry.MintOrLookupBySubject(subject, email: null);
+
+        var before = registry.LookupByAccount("findable@example.com");
+        Assert.Equal(TenantRegistry.AccountLookupOutcome.NotFound, before.Outcome);
+
+        registry.MintOrLookupBySubject(subject, "findable@example.com");
+
+        var after = registry.LookupByAccount("findable@example.com");
+        Assert.Equal(TenantRegistry.AccountLookupOutcome.Found, after.Outcome);
+        Assert.Equal(tenant, after.Tenant);
+    }
+
+    // ---- the lookup itself -----------------------------------------------------------------------------
+
+    [Fact]
+    public void An_account_is_findable_by_its_tenant_id_and_by_its_email_in_any_casing()
+    {
+        var registry = NewRegistry();
+        var tenant = registry.MintOrLookupBySubject(Subject(), "Mixed.Case@Example.com");
+
+        foreach (var identifier in new[] { tenant.Value, "mixed.case@example.com", "MIXED.CASE@EXAMPLE.COM", "  Mixed.Case@Example.com  " })
+        {
+            var (outcome, resolved) = registry.LookupByAccount(identifier);
+            Assert.Equal(TenantRegistry.AccountLookupOutcome.Found, outcome);
+            Assert.Equal(tenant, resolved);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("nobody@example.com")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void An_unknown_or_empty_identifier_is_NotFound(string? identifier)
+    {
+        var registry = NewRegistry();
+        registry.MintOrLookupBySubject(Subject(), "somebody@example.com");
+
+        Assert.Equal(TenantRegistry.AccountLookupOutcome.NotFound,
+            registry.LookupByAccount(identifier).Outcome);
+    }
+
+    [Fact]
+    public void Two_accounts_sharing_a_display_email_are_AMBIGUOUS_never_resolved_to_one_of_them()
+    {
+        // Two DIFFERENT accounts (different subjects - the real key) that happen to carry the same display
+        // email. Picking either would email one person the other person's day, so there is no answer.
+        var registry = NewRegistry();
+        registry.MintOrLookupBySubject(Subject(), "shared@example.com");
+        registry.MintOrLookupBySubject(Subject(), "shared@example.com");
+
+        var (outcome, resolved) = registry.LookupByAccount("shared@example.com");
+
+        Assert.Equal(TenantRegistry.AccountLookupOutcome.Ambiguous, outcome);
+        Assert.False(resolved.IsValid);
+    }
+
+    [Fact]
+    public void The_lookup_never_mints()
+    {
+        var registry = NewRegistry();
+
+        Assert.Equal(TenantRegistry.AccountLookupOutcome.NotFound,
+            registry.LookupByAccount("ghost@example.com").Outcome);
+        // Asking about an account must not bring it into existence - otherwise a service token could
+        // populate the census one guess at a time.
+        Assert.Empty(registry.AllTenantIds());
+    }
+}

--- a/src/CcDirector.Gateway/Api/MorningReportEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MorningReportEndpoint.cs
@@ -1,0 +1,186 @@
+using System.Security.Cryptography;
+using System.Text;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The morning-report surface (issue #2119, slice 2 of #2096):
+///
+///   GET /gateway/reports/morning?account=&amp;date=yyyy-MM-dd&amp;tz=IANA  ->  MorningReportDto
+///
+/// One honest JSON report per account per calendar day. The website's 7:00 cron calls this, renders the
+/// approved email design from it, and sends it. Read-only: it writes nothing.
+///
+/// AUTHORIZATION IS ITS OWN, AND IT IS NOT A DEVICE KEY. The caller is a SERVER (the website cron), which
+/// holds no Director/phone device credential, so this route is exempt from the host-wide token gate
+/// (<c>AuthMiddleware.PublicPaths</c>) and carries its own: a bearer service token supplied out of band as
+/// the <c>REPORT_SERVICE_TOKEN</c> environment variable. Exempt from that gate does NOT mean open - every
+/// path below denies by default:
+///   - the variable unset or blank    -> 503. The endpoint refuses to serve rather than serve unguarded.
+///   - no / malformed / wrong bearer  -> 401.
+///   - a valid token naming an account this Gateway does not know -> 404.
+///   - a valid token naming an ambiguous account                  -> 409, never a guess.
+/// The token comparison is fixed-time, so a wrong token cannot be discovered a byte at a time.
+///
+/// A VALID TOKEN IS NOT AUTHORITY OVER EVERY ACCOUNT'S DATA IN TURN - it is authority to ASK, and the answer
+/// is scoped to exactly the one tenant the named account resolves to. The tenant is resolved here, once, and
+/// handed to <see cref="MorningReportBuilder"/> explicitly; the builder reads through a context stamped with
+/// that tenant, so the global query filter makes another tenant's rows unreachable rather than merely unasked-for.
+/// </summary>
+internal static class MorningReportEndpoint
+{
+    /// <summary>The route. Exact-match public in <c>AuthMiddleware</c>; this endpoint carries its own gate.</summary>
+    public const string Path = "/gateway/reports/morning";
+
+    /// <summary>The environment variable holding the bearer service token the website cron presents.</summary>
+    public const string ServiceTokenEnvVar = "REPORT_SERVICE_TOKEN";
+
+    public static void Map(
+        IEndpointRouteBuilder app,
+        MorningReportBuilder reports,
+        TenantRegistry tenants,
+        HostedTenantBoundary boundary)
+    {
+        ArgumentNullException.ThrowIfNull(reports);
+        ArgumentNullException.ThrowIfNull(tenants);
+        ArgumentNullException.ThrowIfNull(boundary);
+
+        app.MapGet(Path, (HttpContext ctx, string? account, string? date, string? tz) =>
+            Handle(ctx, account, date, tz, reports, tenants, boundary));
+
+        FileLog.Write($"[MorningReportEndpoint] mapped {Path} (service-token authorized, read-only)");
+    }
+
+    /// <summary>Internal (not private) so the authorization and resolution rules can be unit-tested directly
+    /// through InternalsVisibleTo, without standing a Kestrel host up per case.</summary>
+    internal static IResult Handle(
+        HttpContext ctx,
+        string? account,
+        string? date,
+        string? tz,
+        MorningReportBuilder reports,
+        TenantRegistry tenants,
+        HostedTenantBoundary boundary)
+    {
+        var configured = Environment.GetEnvironmentVariable(ServiceTokenEnvVar);
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            // Fail loud and CLOSED. An unconfigured token is a deployment error, not a reason to serve the
+            // report to anyone who asks; and it is not a reason to invent an allow-anything mode either.
+            FileLog.Write($"[MorningReportEndpoint] DENIED: {ServiceTokenEnvVar} is not set on this Gateway - the report endpoint refuses to serve unguarded");
+            return Results.Json(
+                new { error = $"the morning report service token ({ServiceTokenEnvVar}) is not configured on this Gateway" },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!PresentedTokenMatches(ctx, configured))
+        {
+            FileLog.Write("[MorningReportEndpoint] DENIED: missing or incorrect service token");
+            return Results.Json(new { error = "a valid morning report service token is required" },
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        MorningReportWindow window;
+        try
+        {
+            window = MorningReportWindow.Resolve(date, tz);
+        }
+        catch (MorningReportWindowException ex)
+        {
+            FileLog.Write($"[MorningReportEndpoint] rejected: {ex.Message}");
+            return Results.BadRequest(new { error = ex.Message });
+        }
+
+        if (string.IsNullOrWhiteSpace(account))
+            return Results.BadRequest(new { error = "an 'account' is required (the account id or the account email)" });
+
+        if (!TryResolveTenant(account, tenants, boundary, out var tenant, out var denial))
+            return denial;
+
+        // Enter the resolved tenant's ambient scope for the duration of the build. The builder scopes its own
+        // reads explicitly (belt), and this makes any tenant-scoped collaborator it consults resolve to the
+        // same tenant rather than to nothing (braces). Inert on self-host.
+        using (boundary.EnterScope(tenant))
+        {
+            var report = reports.Build(account.Trim(), tenant, window);
+            FileLog.Write($"[MorningReportEndpoint] served a morning report: tenant={tenant.ToLogString()} " +
+                          $"date={window.Date} tz={window.Tz} attention={report.Attention.Count}");
+            return Results.Json(report);
+        }
+    }
+
+    /// <summary>
+    /// Resolve the named account to the tenant whose data the report will contain.
+    ///
+    /// SELF-HOST HAS EXACTLY ONE TENANT AND NO ACCOUNT CENSUS. There is no <c>tenants</c> mapping table to
+    /// look an account up in, and every row on the install belongs to <see cref="TenantId.Local"/>, so the
+    /// question "which account?" has one answer and it is not a guess. On HOSTED the census is authoritative
+    /// and an unknown or ambiguous identifier is refused.
+    /// </summary>
+    private static bool TryResolveTenant(
+        string account, TenantRegistry tenants, HostedTenantBoundary boundary,
+        out TenantId tenant, out IResult denial)
+    {
+        if (!boundary.IsHosted)
+        {
+            tenant = TenantId.Local;
+            denial = null!;
+            FileLog.Write("[MorningReportEndpoint] self-host: the report is served for the single local tenant");
+            return true;
+        }
+
+        var (outcome, resolved) = tenants.LookupByAccount(account);
+        switch (outcome)
+        {
+            case TenantRegistry.AccountLookupOutcome.Found:
+                tenant = resolved;
+                denial = null!;
+                return true;
+
+            case TenantRegistry.AccountLookupOutcome.Ambiguous:
+                tenant = default;
+                denial = Results.Json(
+                    new { error = "more than one account carries that identifier; name the account by its account id" },
+                    statusCode: StatusCodes.Status409Conflict);
+                return false;
+
+            default:
+                tenant = default;
+                denial = Results.NotFound(new { error = "no such account" });
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether the request presents the configured bearer token. Compared in FIXED TIME over the raw bytes:
+    /// an ordinary string comparison returns as soon as two bytes differ, which leaks the correct prefix
+    /// length to anyone who can time the response, and this token guards a person's whole account report.
+    /// The length difference is itself unavoidable and is handled by comparing fixed-size digests, so even
+    /// the length does not leak through the comparison.
+    /// </summary>
+    private static bool PresentedTokenMatches(HttpContext ctx, string configured)
+    {
+        var header = ctx.Request.Headers.Authorization.ToString();
+        if (string.IsNullOrWhiteSpace(header))
+            return false;
+
+        const string scheme = "Bearer ";
+        if (!header.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var presented = header[scheme.Length..].Trim();
+        if (presented.Length == 0)
+            return false;
+
+        var a = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var b = SHA256.HashData(Encoding.UTF8.GetBytes(configured.Trim()));
+        return CryptographicOperations.FixedTimeEquals(a, b);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -416,6 +416,7 @@ public sealed class GatewayHost : IAsyncDisposable
     // The weekly Outcome Ledger reporter (issue #1771, spine item 4): a read-only assembly over the run
     // tables, event ledger, spend, and audit trail - the first governance report that pays rent.
     private readonly Governance.OutcomeLedgerReporter _outcomeLedger;
+    private readonly Reports.MorningReportBuilder _morningReport;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -860,6 +861,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // The weekly Outcome Ledger reporter (issue #1771, spine item 4): read-only over the run tables +
         // event ledger + spend + audit trail. No store of its own.
         _outcomeLedger = new Governance.OutcomeLedgerReporter(_gatewayDb);
+        // The morning report (issue #2119): one honest report per account per day, assembled read-only from
+        // the stores above. The pushed-session cache is passed for LABELS ONLY (a waiting row's friendly name
+        // and repository path); the waiting fact itself comes from the durable governance ledger, so a
+        // Director that happens to be offline at 07:00 costs a row its name, never its place in the email.
+        _morningReport = new Reports.MorningReportBuilder(_gatewayDb, PushedSessions, _streamStaleAfter);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -2277,6 +2283,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // The weekly Outcome Ledger (issue #1771, spine item 4): the first report that pays rent - verified
         // yield, aging WIP, and high-effort/no-outcome runs with cost + attention-burden. Read-only.
         Api.GovernanceReportEndpoints.Map(_app, _outcomeLedger);
+
+        // The morning report (issue #2119, slice 2 of #2096): GET /gateway/reports/morning - the JSON the
+        // website's 07:00 cron renders into the daily email. Does NOT inherit the host-wide token middleware
+        // (the caller is a server with no device key); it carries its own bearer service token from
+        // REPORT_SERVICE_TOKEN and resolves the named account to exactly one tenant. Read-only.
+        Api.MorningReportEndpoint.Map(_app, _morningReport, TenantRegistry, _tenantBoundary);
 
         // Gateway Centralization Phase 2 (issue #638): GET /account/status answers "is the Gateway
         // signed in to DevThrottle, and as whom?" computed ENTIRELY LOCALLY from the Gateway-hosted

--- a/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
@@ -1,0 +1,255 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Reports;
+
+/// <summary>
+/// Assembles ONE account's morning report (issue #2119) from the Gateway's existing tenant-scoped stores.
+/// READ-ONLY: it writes nothing and needs no table of its own.
+///
+/// THE HONESTY RULE, STATED AS CODE. A number is emitted only when its backing store holds data for THIS
+/// tenant; otherwise the field is null and never reaches the JSON. The distinction the rule protects is
+/// between "no data" and "zero":
+///   - a tenant whose event ledger holds NO session rows at all gets NO <c>sessionsRan</c> - the Gateway
+///     genuinely does not know how many sessions ran;
+///   - a tenant whose ledger holds rows but none inside the window gets <c>sessionsRan: 0</c> - the Gateway
+///     looked and the answer is zero.
+/// A report that zero-filled the first case would state, in an email, a fact it had never measured. That is
+/// the failure this whole slice exists to avoid, and it is also what lets this slice merge and ship BEFORE
+/// the repo-state snapshot feed exists: with no repo-state store, the hygiene items are simply absent.
+///
+/// TENANCY IS EXPLICIT, NEVER AMBIENT. The tenant is resolved by the ROUTE (from the account the caller
+/// named) and passed in, and every read goes through <see cref="GatewayDatabase.CreateContext(TenantId)"/>
+/// with that exact tenant. There is no AsyncLocal inference here: a service-token request carries no device
+/// key, so there is no ambient tenant to accidentally read - and no way for one account's report to contain
+/// another account's rows.
+/// </summary>
+public sealed class MorningReportBuilder
+{
+    private readonly GatewayDatabase _db;
+    private readonly Streaming.PushedSessionStore? _pushedSessions;
+    private readonly TimeSpan _streamStale;
+    private readonly Func<DateTime> _utcNow;
+
+    /// <summary>
+    /// How far back the waiting-session scan reads the event ledger. A session whose last recorded
+    /// transition is older than this is NOT reported as waiting: the Gateway will not claim to know the
+    /// current state of something it has not heard about in a month.
+    /// </summary>
+    public const int WaitingLookbackDays = 30;
+
+    /// <summary>
+    /// The hard ceiling on ledger rows the waiting scan materializes. Reaching it is LOGGED (never silent):
+    /// a truncated scan can only under-report waiting sessions, and the log says so, so a short list is
+    /// never mistaken for a quiet fleet.
+    /// </summary>
+    public const int MaxLedgerRowsScanned = 20_000;
+
+    /// <summary>Micro-dollars per cent - the ceil-rounding divisor for hosted-AI spend.</summary>
+    private const long MicrosPerCent = 10_000;
+
+    /// <param name="db">The Gateway EF database.</param>
+    /// <param name="pushedSessions">The live pushed-session cache, used ONLY to put a friendly name and a
+    /// repository path on a waiting row. Null (or a session it has never seen) costs the row nothing but
+    /// those two labels - the waiting fact itself comes from the durable ledger.</param>
+    /// <param name="streamStale">How old a Director's pushed roster may be and still be believed.</param>
+    /// <param name="utcNow">Clock seam for tests.</param>
+    public MorningReportBuilder(
+        GatewayDatabase db,
+        Streaming.PushedSessionStore? pushedSessions = null,
+        TimeSpan? streamStale = null,
+        Func<DateTime>? utcNow = null)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _pushedSessions = pushedSessions;
+        _streamStale = streamStale ?? TimeSpan.FromMinutes(5);
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>Build the report for <paramref name="tenant"/> over <paramref name="window"/>.</summary>
+    /// <param name="account">The account string the caller named, echoed into the report.</param>
+    public MorningReportDto Build(string account, TenantId tenant, MorningReportWindow window)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        if (!tenant.IsValid)
+            throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
+
+        var now = _utcNow();
+        using var ctx = _db.CreateContext(tenant);
+
+        var report = new MorningReportDto
+        {
+            Account = account,
+            Window = new MorningReportWindowDto
+            {
+                StartUtc = window.StartUtc,
+                EndUtc = window.EndUtc,
+                Date = window.Date,
+                Tz = window.Tz,
+            },
+            Stats = new MorningReportStatsDto
+            {
+                SessionsRan = SessionsRan(ctx, window),
+                WorkDelivered = WorkDelivered(ctx, window),
+                HostedAiSpendUsd = HostedAiSpendUsd(ctx, window),
+            },
+            Attention = WaitingSessions(ctx, tenant, now),
+        };
+
+        FileLog.Write($"[MorningReportBuilder] Build: tenant={tenant.ToLogString()} window={window.StartUtc:o}..{window.EndUtc:o} " +
+                      $"sessionsRan={Describe(report.Stats.SessionsRan)} workDelivered={Describe(report.Stats.WorkDelivered)} " +
+                      $"spendUsd={Describe(report.Stats.HostedAiSpendUsd)} attention={report.Attention.Count}");
+        return report;
+    }
+
+    /// <summary>Distinct sessions with at least one recorded transition in the window, or null when this
+    /// tenant has no session history at all.</summary>
+    private static int? SessionsRan(GatewayDbContext ctx, MorningReportWindow window)
+    {
+        var anyHistory = ctx.GovernanceEvents.AsNoTracking()
+            .Any(e => e.SubjectKind == GovernanceEventSubject.Session && e.SessionId != null);
+        if (!anyHistory)
+            return null;
+
+        return ctx.GovernanceEvents.AsNoTracking()
+            .Where(e => e.SubjectKind == GovernanceEventSubject.Session &&
+                        e.SessionId != null &&
+                        e.OccurredUtc >= window.StartUtc && e.OccurredUtc < window.EndUtc)
+            .Select(e => e.SessionId)
+            .Distinct()
+            .Count();
+    }
+
+    /// <summary>Runs ACCEPTED in the window, or null when this tenant has no workflow runs at all.</summary>
+    private static int? WorkDelivered(GatewayDbContext ctx, MorningReportWindow window)
+    {
+        if (!ctx.WorkflowRuns.AsNoTracking().Any())
+            return null;
+
+        return ctx.WorkflowRuns.AsNoTracking()
+            .Count(r => r.AcceptanceStatus == WorkflowRunAcceptance.Accepted &&
+                        r.CompletedUtc != null &&
+                        r.CompletedUtc >= window.StartUtc && r.CompletedUtc < window.EndUtc);
+    }
+
+    /// <summary>
+    /// Hosted-AI dollars in the window, CEIL-rounded to the cent, or null when this tenant has no mirrored
+    /// spend at all. Rounding UP is deliberate (the cost-accuracy rule): a report about real money must
+    /// never claim the owner spent less than they did, so a fraction of a cent becomes a whole cent.
+    /// </summary>
+    private static decimal? HostedAiSpendUsd(GatewayDbContext ctx, MorningReportWindow window)
+    {
+        if (!ctx.AccountHostedAiSpend.AsNoTracking().Any())
+            return null;
+
+        var micros = ctx.AccountHostedAiSpend.AsNoTracking()
+            .Where(e => e.TransactionCreatedUtc >= window.StartUtc && e.TransactionCreatedUtc < window.EndUtc)
+            .Sum(e => (long?)e.AmountMicros) ?? 0L;
+
+        return CeilMicrosToUsd(micros);
+    }
+
+    /// <summary>Micro-dollars to dollars, rounded UP to the next whole cent. Never undercounts.</summary>
+    internal static decimal CeilMicrosToUsd(long micros)
+    {
+        if (micros <= 0)
+            return 0m;
+        var cents = (micros + MicrosPerCent - 1) / MicrosPerCent;
+        return cents / 100m;
+    }
+
+    /// <summary>
+    /// The waiting-session rows: every session whose LAST recorded transition is a wait on the human (or on
+    /// a permission grant), with the instant it entered that state and how long ago that was.
+    ///
+    /// The ledger appends only on a REAL transition, so the last event IS the start of the current state -
+    /// the waiting-since instant is read, not inferred. A session that has exited, recovered, gone active or
+    /// idle has a later event of that kind and so is not here.
+    /// </summary>
+    private List<MorningAttentionItemDto> WaitingSessions(GatewayDbContext ctx, TenantId tenant, DateTime now)
+    {
+        var lookback = now - TimeSpan.FromDays(WaitingLookbackDays);
+
+        // Newest first, capped. Grouping in memory after this ordering makes the FIRST row per session its
+        // latest event, which is the state it is in now.
+        var rows = ctx.GovernanceEvents.AsNoTracking()
+            .Where(e => e.SubjectKind == GovernanceEventSubject.Session &&
+                        e.SessionId != null &&
+                        e.OccurredUtc >= lookback)
+            .OrderByDescending(e => e.OccurredUtc)
+            .ThenByDescending(e => e.RecordedUtc)
+            .Take(MaxLedgerRowsScanned)
+            .Select(e => new { e.SessionId, e.State, e.OccurredUtc })
+            .ToList();
+
+        if (rows.Count == MaxLedgerRowsScanned)
+            FileLog.Write($"[MorningReportBuilder] WaitingSessions: the {MaxLedgerRowsScanned}-row scan cap was reached for " +
+                          $"tenant={tenant.ToLogString()}; sessions whose last transition falls outside the scanned rows are " +
+                          "NOT reported. The waiting list may be short - it is never padded.");
+
+        var live = LiveSessionsById(tenant);
+        var items = new List<MorningAttentionItemDto>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var row in rows)
+        {
+            var sessionId = row.SessionId!;
+            if (!seen.Add(sessionId))
+                continue; // an older event for a session whose latest we already ruled on
+
+            if (row.State != GovernanceEventState.WaitingOnHuman &&
+                row.State != GovernanceEventState.WaitingOnPermission)
+                continue;
+
+            // A session the Gateway can currently see is judged on what it can see: one that is HELD
+            // (snoozed) was deliberately parked by the owner and is not "waiting on you" this morning, and
+            // one that has EXITED is not waiting on anybody. A session the Gateway cannot see is reported
+            // from the ledger as-is - that is the whole point of a durable record.
+            if (live.TryGetValue(sessionId, out var liveSession))
+            {
+                if (HoldStates.IsHeld(liveSession.HoldState))
+                    continue;
+                if (string.Equals(liveSession.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+
+            var since = DateTime.SpecifyKind(row.OccurredUtc, DateTimeKind.Utc);
+            items.Add(new WaitingSessionAttentionDto
+            {
+                Session = string.IsNullOrWhiteSpace(liveSession?.Name) ? sessionId : liveSession!.Name!,
+                Repo = string.IsNullOrWhiteSpace(liveSession?.RepoPath) ? null : liveSession!.RepoPath,
+                WaitingSinceUtc = since,
+                AgeHours = Math.Round(Math.Max(0, (now - since).TotalHours), 1),
+            });
+        }
+
+        // Longest wait first - the row the owner most needs to see is the one at the top of the email.
+        items.Sort((a, b) => ((WaitingSessionAttentionDto)b).AgeHours.CompareTo(((WaitingSessionAttentionDto)a).AgeHours));
+        return items;
+    }
+
+    /// <summary>
+    /// The tenant's live sessions by id, from every Director that has pushed fresh data. Labels only - the
+    /// waiting VERDICT never comes from here, so an offline Director costs a row its name, not its place in
+    /// the report.
+    /// </summary>
+    private Dictionary<string, SessionDto> LiveSessionsById(TenantId tenant)
+    {
+        var map = new Dictionary<string, SessionDto>(StringComparer.Ordinal);
+        if (_pushedSessions is null)
+            return map;
+
+        foreach (var (_, session) in _pushedSessions.SnapshotFresh(tenant, _streamStale))
+        {
+            if (!string.IsNullOrEmpty(session.SessionId))
+                map[session.SessionId] = session;
+        }
+        return map;
+    }
+
+    private static string Describe(object? value) => value is null ? "absent" : value.ToString()!;
+}

--- a/src/CcDirector.Gateway/Reports/MorningReportWindow.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportWindow.cs
@@ -1,0 +1,133 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Reports;
+
+/// <summary>
+/// Thrown when a morning-report request cannot be resolved into a window: an unparseable date, an unknown
+/// IANA zone. The endpoint maps it to a 400 with the message, so a caller learns exactly what it got wrong
+/// instead of receiving a report over a window nobody asked for.
+/// </summary>
+public sealed class MorningReportWindowException : Exception
+{
+    public MorningReportWindowException(string message) : base(message) { }
+}
+
+/// <summary>
+/// Resolves "the calendar day <c>date</c> in zone <c>tz</c>" into the exact half-open UTC range
+/// [<see cref="StartUtc"/>, <see cref="EndUtc"/>) the report measures over. Every number in a morning report
+/// carries these coordinates, so the recipient can always check what "yesterday" meant.
+///
+/// DAYLIGHT SAVING IS HANDLED, NOT ASSUMED AWAY. The window is NOT "start plus 24 hours": the end is the
+/// start of the NEXT calendar day resolved independently in the same zone, so a spring-forward day is 23
+/// hours long and an autumn-back day is 25. Computing the end by adding a day to the UTC start would
+/// silently shift the boundary by an hour twice a year - an hour of work landing in the wrong report.
+///
+/// A calendar day whose local midnight DOES NOT EXIST (zones that spring forward at midnight, e.g.
+/// America/Santiago) starts at the first instant that day does exist. That is not a guess: it is the
+/// definition of when the day begins there, and <see cref="TimeZoneInfo.IsInvalidTime"/> is what tells us.
+/// </summary>
+public sealed class MorningReportWindow
+{
+    /// <summary>The wire format for the <c>date</c> parameter.</summary>
+    public const string DateFormat = "yyyy-MM-dd";
+
+    /// <summary>Inclusive start of the reported calendar day, in UTC.</summary>
+    public DateTime StartUtc { get; }
+
+    /// <summary>EXCLUSIVE end of the reported calendar day, in UTC.</summary>
+    public DateTime EndUtc { get; }
+
+    /// <summary>The calendar day, exactly as the caller supplied it.</summary>
+    public string Date { get; }
+
+    /// <summary>The zone identifier, exactly as the caller supplied it.</summary>
+    public string Tz { get; }
+
+    private MorningReportWindow(DateTime startUtc, DateTime endUtc, string date, string tz)
+    {
+        StartUtc = startUtc;
+        EndUtc = endUtc;
+        Date = date;
+        Tz = tz;
+    }
+
+    /// <summary>
+    /// Resolve a <paramref name="date"/> (yyyy-MM-dd) in <paramref name="tz"/> (an IANA zone id, e.g.
+    /// "America/Toronto") into its UTC range.
+    /// </summary>
+    /// <exception cref="MorningReportWindowException">The date or the zone is not usable.</exception>
+    public static MorningReportWindow Resolve(string? date, string? tz)
+    {
+        if (string.IsNullOrWhiteSpace(date))
+            throw new MorningReportWindowException(
+                $"A 'date' is required, in {DateFormat} form (the calendar day being reported on).");
+        if (string.IsNullOrWhiteSpace(tz))
+            throw new MorningReportWindowException(
+                "A 'tz' is required - the IANA zone the calendar day is measured in (e.g. America/Toronto).");
+
+        var dateText = date.Trim();
+        var tzText = tz.Trim();
+
+        if (!DateTime.TryParseExact(dateText, DateFormat, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var day))
+            throw new MorningReportWindowException($"'{dateText}' is not a date in {DateFormat} form.");
+
+        TimeZoneInfo zone;
+        try
+        {
+            zone = TimeZoneInfo.FindSystemTimeZoneById(tzText);
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            throw new MorningReportWindowException($"'{tzText}' is not a time zone this Gateway knows.");
+        }
+
+        var startUtc = StartOfLocalDayUtc(day.Date, zone);
+        var endUtc = StartOfLocalDayUtc(day.Date.AddDays(1), zone);
+
+        if (endUtc <= startUtc)
+            throw new MorningReportWindowException(
+                $"The window for {dateText} in {tzText} resolved to a non-positive range; refusing to report over it.");
+
+        FileLog.Write($"[MorningReportWindow] Resolve: date={dateText} tz={tzText} -> {startUtc:o}..{endUtc:o}");
+        return new MorningReportWindow(startUtc, endUtc, dateText, tzText);
+    }
+
+    /// <summary>
+    /// The UTC instant a local calendar day begins in <paramref name="zone"/>. Local midnight normally; the
+    /// first instant that exists when the zone skips midnight (a spring-forward at 00:00). An AMBIGUOUS local
+    /// midnight (an autumn-back that repeats 00:00) resolves to the EARLIER of the two instants, which is the
+    /// one the day actually starts at - <see cref="TimeZoneInfo.ConvertTimeToUtc"/> resolves ambiguity to
+    /// standard time, and standard time is the later offset, so the earlier instant is taken explicitly.
+    /// </summary>
+    private static DateTime StartOfLocalDayUtc(DateTime localDate, TimeZoneInfo zone)
+    {
+        var local = DateTime.SpecifyKind(localDate, DateTimeKind.Unspecified);
+
+        if (zone.IsInvalidTime(local))
+        {
+            // Midnight does not exist that day. Walk forward a minute at a time to the first instant that
+            // does - a skipped span is at most a couple of hours, so this terminates quickly and needs no
+            // assumption about how long the skip is.
+            var probe = local;
+            var limit = local.AddDays(1);
+            while (zone.IsInvalidTime(probe) && probe < limit)
+                probe = probe.AddMinutes(1);
+            if (zone.IsInvalidTime(probe))
+                throw new MorningReportWindowException(
+                    $"No instant of {localDate:yyyy-MM-dd} exists in {zone.Id}; refusing to guess a window.");
+            local = probe;
+        }
+
+        if (zone.IsAmbiguousTime(local))
+        {
+            // The local time happens twice (an autumn-back). The day starts at the FIRST of them, which is
+            // the one with the LARGEST UTC offset (daylight time, before the clocks go back).
+            var offsets = zone.GetAmbiguousTimeOffsets(local);
+            var earliest = offsets.Max();
+            return DateTime.SpecifyKind(local - earliest, DateTimeKind.Utc);
+        }
+
+        return DateTime.SpecifyKind(TimeZoneInfo.ConvertTimeToUtc(local, zone), DateTimeKind.Utc);
+    }
+}

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -55,9 +55,25 @@ public sealed class TenantRegistry
         {
             using var ctx = _db.CreateUnscopedContext();
 
-            var existing = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.AccountSubject == subject);
+            var existing = ctx.Tenants.FirstOrDefault(t => t.AccountSubject == subject);
             if (existing is not null)
             {
+                // Backfill the display email when the row has none and this resolution carries one (issue
+                // #2119). The email used to be recorded on a FRESH MINT ONLY, which left every tenant minted
+                // before the email was captured - or from a token that carried none - permanently without
+                // one. That is not a cosmetic gap: the morning report resolves an account BY EMAIL, so a
+                // null here makes a real, fully enrolled account look like no such account.
+                //
+                // It is a backfill, never an overwrite: a row that already has an email keeps it, so this
+                // cannot silently re-point an account's display identity, and the mapping KEY is still the
+                // subject and only the subject. The email is personally identifying and is never logged.
+                if (string.IsNullOrWhiteSpace(existing.Email) && !string.IsNullOrWhiteSpace(email))
+                {
+                    existing.Email = email.Trim();
+                    ctx.SaveChanges();
+                    FileLog.Write("[TenantRegistry] MintOrLookupBySubject: recorded the display email on an existing tenant that had none");
+                }
+
                 FileLog.Write("[TenantRegistry] MintOrLookupBySubject: resolved an existing tenant for a known account");
                 return new TenantId(existing.Id);
             }

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -152,6 +152,79 @@ public sealed class TenantRegistry
         return string.IsNullOrWhiteSpace(row?.AccountSubject) ? null : row!.AccountSubject;
     }
 
+    /// <summary>What <see cref="LookupByAccount"/> concluded. The three outcomes are deliberately distinct:
+    /// a caller that folded Ambiguous into NotFound would silently drop a real account, and one that folded
+    /// it into Found would have to PICK one of two tenants - which is guessing about whose data to send.</summary>
+    public enum AccountLookupOutcome
+    {
+        /// <summary>Exactly one tenant matched. <c>Tenant</c> carries it.</summary>
+        Found,
+
+        /// <summary>No tenant matched the identifier.</summary>
+        NotFound,
+
+        /// <summary>More than one tenant carries this email. There is no right answer, so there is no answer.</summary>
+        Ambiguous,
+    }
+
+    /// <summary>
+    /// Resolve the tenant an ACCOUNT identifier names, for a server-to-server caller that has no device key
+    /// to be recognized by (the morning-report endpoint, issue #2119). The identifier is either the tenant
+    /// id itself or the account's display email; the email match is case-insensitive because a person typing
+    /// their own address does not preserve case.
+    ///
+    /// THIS IS NOT AN AUTHENTICATION PATH AND MUST NEVER BE USED AS ONE. The email is display metadata, not
+    /// a credential - it is emphatically NOT the mapping key (the stable Supabase subject is; see
+    /// <see cref="MintOrLookupBySubject"/>). A caller reaching this method has ALREADY been authorized by
+    /// its own means (the report endpoint's service token); this only turns the account it named into the
+    /// partition to read. Nothing here mints, and nothing here decides whether the caller may look.
+    ///
+    /// A duplicate email across two tenants returns <see cref="AccountLookupOutcome.Ambiguous"/> rather than
+    /// picking one. Two accounts CAN share a display email (the mint records whatever the token carried), and
+    /// sending one person's report to the other is the exact harm the tenant boundary exists to prevent.
+    /// The subject and the email are personally identifying and are never logged.
+    /// </summary>
+    public (AccountLookupOutcome Outcome, TenantId Tenant) LookupByAccount(string? account)
+    {
+        if (string.IsNullOrWhiteSpace(account))
+            return (AccountLookupOutcome.NotFound, default);
+
+        var needle = account.Trim();
+        using var ctx = _db.CreateUnscopedContext();
+
+        var byId = ctx.Tenants.AsNoTracking().FirstOrDefault(t => t.Id == needle);
+        if (byId is not null)
+        {
+            FileLog.Write("[TenantRegistry] LookupByAccount: resolved a tenant by tenant id");
+            return (AccountLookupOutcome.Found, new TenantId(byId.Id));
+        }
+
+        // Matched in memory rather than in SQL: case-insensitive string comparison is provider- and
+        // collation-dependent (SQLite's NOCASE is ASCII-only, Postgres is case-sensitive by default), and a
+        // report must not resolve to a different tenant depending on which database it runs against. The
+        // tenant census is small - it is the account table, not a data table.
+        var byEmail = ctx.Tenants.AsNoTracking()
+            .Where(t => t.Email != null)
+            .Select(t => new { t.Id, t.Email })
+            .ToList()
+            .Where(t => string.Equals(t.Email, needle, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (byEmail.Count == 1)
+        {
+            FileLog.Write("[TenantRegistry] LookupByAccount: resolved a tenant by account email");
+            return (AccountLookupOutcome.Found, new TenantId(byEmail[0].Id));
+        }
+        if (byEmail.Count > 1)
+        {
+            FileLog.Write($"[TenantRegistry] LookupByAccount: AMBIGUOUS - {byEmail.Count} tenants carry the requested email; refusing to pick one");
+            return (AccountLookupOutcome.Ambiguous, default);
+        }
+
+        FileLog.Write("[TenantRegistry] LookupByAccount: no tenant carries the requested account identifier");
+        return (AccountLookupOutcome.NotFound, default);
+    }
+
     /// <summary>
     /// The display email recorded on a tenant's row, or null when there is none (issue #1856). Read-only:
     /// it neither mints nor writes.

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -157,6 +157,14 @@ internal static class AuthMiddleware
         // client-side routes the SPA fallback serves the React shell for; neither returns any data.
         CockpitSignInPath,
         CockpitDeviceCallbackPath,
+        // Issue #2119 (the morning report): the website's 7:00 cron is a SERVER, not a device - it holds no
+        // Director/phone device key and no shared machine token, so it cannot pass this gate. The route
+        // carries its OWN authorization instead: a bearer service token from REPORT_SERVICE_TOKEN, compared
+        // in fixed time, which the endpoint requires before it reads anything (an unset variable is a 503,
+        // never an open door). Exact-match, exactly like the enrollment and sign-in front doors above: only
+        // /gateway/reports/morning is exempt, and it is a read-only route that returns ONE named account's
+        // report, scoped to that account's tenant.
+        Api.MorningReportEndpoint.Path,
     };
 
     public static async Task Run(HttpContext ctx, RequireToken cfg, Func<Task> next)


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#2119. Second slice of thefrederiksen/devthrottle_internal#925 (the brain / morning report). The website's 07:00 cron reads this endpoint, renders the approved email design from it, and sends it - so this is the piece that makes tomorrow morning's first email possible.

## What this adds

`GET /gateway/reports/morning?account=&date=yyyy-MM-dd&tz=<IANA>` returning, for ONE account and ONE calendar day:

- `window` - the resolved UTC range, plus the date and zone it came from. Every number carries its coordinates.
- `stats` - `sessionsRan`, `workDelivered`, `hostedAiSpendUsd`, each individually optional.
- `attention[]` - typed rows, today `waiting-session` only.

Read-only. It writes nothing and needs no table of its own: the numbers come from the governance event ledger, the workflow-run table, and the mirrored hosted-AI spend, all of which already exist.

## The honesty rule, as code rather than as a promise

A stat whose backing store holds **no rows at all** for the account is ABSENT from the JSON. A store that holds rows but none inside the window reports a measured **zero**. Both are reachable and they mean different things - "we have never measured this" versus "we looked and it was nothing" - and an email that printed `0` for the first would state a measurement nobody made.

This is also what makes the slice shippable on its own: with no repo-state store yet (#2118), the stale-worktree and unmerged-branch rows are simply not present, rather than present and empty.

## The window

Resolved from `date` + IANA zone. The end is the start of the NEXT calendar day resolved independently in the same zone - **not** the start plus 24 hours. So the spring-forward day is 23 hours, the autumn-back day is 25, and consecutive days abut exactly across a transition. A zone whose local midnight does not exist that day (Santiago in September) starts at the first instant that does. An unparseable date or unknown zone is a 400, never a default.

## Authorization

The caller is a server with no device key, so the route is exact-match exempt from the host-wide token gate and carries its own: a bearer token from `REPORT_SERVICE_TOKEN`, compared in fixed time over digests. Every branch denies by default:

| condition | answer |
|---|---|
| `REPORT_SERVICE_TOKEN` unset or blank | 503 - refuse to serve, never serve unguarded |
| missing / malformed / wrong / near-miss credential | 401 |
| valid token, unknown account | 404 |
| valid token, an email two tenants share | 409 - never a guess about whose day to email |
| a sibling path under the route | still 401 from the host gate |

## Tenancy

The tenant is resolved ONCE from the named account (by tenant id, or by account email case-insensitively) and passed explicitly into the builder, which reads through a context stamped with that tenant. Another tenant's rows are therefore unreachable rather than merely unasked-for. Proven with two seeded tenants at the builder AND at the endpoint, including the case where both tenants run a session with the same raw id - the live roster of the other tenant never labels this tenant's row.

Self-host has one tenant and no account census, so there the report is served for the single local tenant; the service token still gates it.

## Waiting rows

Derived from the durable governance event ledger, not from a live connection - the ledger appends only on a real transition, so the last event IS the start of the current state and "waiting since" is read rather than inferred. A Director that happens to be offline at 07:00 costs a row its friendly name and repository path, never its place in the email. A session that came back, that exited, or that the owner deliberately snoozed is not reported. A session with no transition in 30 days is not reported either - the Gateway will not assert the current state of something it has not heard about in a month, and the scan cap is logged rather than silently truncating.

## Tests

63, all green.

- **Window**: ordinary day, winter offset, spring-forward (23h), autumn-back (25h), consecutive days abutting across a transition, a zone with no local midnight, a far-from-UTC zone, and seven malformed-input refusals. Revert-prove is written into the file: compute the end as `startUtc.AddDays(1)` and exactly the two transition tests go red.
- **Builder**: the absent-versus-zero pair for every stat; distinct-session counting; inclusive start / exclusive end; accepted-only delivery counting; ceil rounding across seven micro-dollar cases and on the summed total; waiting-row derivation, ordering, snooze and exit exclusions, and the lookback horizon; two-tenant isolation including a shared session id.
- **Endpoint**: the whole authorization matrix above, account resolution by id and by email casing, the exemption asserted through the middleware itself (and a sibling path proven still gated), the two-tenant negative with a raw-text assertion that the other tenant's identifiers appear nowhere, and the exact wire shape - camelCase keys, absent keys genuinely absent, money as a number, and no synthetic `$type` from the polymorphic attention list.
