### PR TITLE
Voice-mode queue: big buttons on top, auto-speak, first-in-first-out

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -48,8 +48,12 @@ with `npm run lint` at the root.
 ## Local dev
 
 ```bash
-npm run dev --workspace @devthrottle/mobile   # Vite dev server; proxy /sessions to a running Gateway
+$env:MOBILE_PROXY_TARGET = "https://gateway.devthrottle.com" # PowerShell example
+npm run dev --workspace @devthrottle/mobile
 ```
+
+`MOBILE_PROXY_TARGET` is opt-in. When set, Vite forwards the Gateway API prefixes (including the
+exact `/mobile/enroll` endpoint) while continuing to serve the app itself under `/mobile`.
 
 ## Layout
 

--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -43,9 +43,12 @@ export interface SessionAppBarProps {
   showSwitchToVoice?: boolean;
   /** Screen-specific menu entries, rendered above Remove. Use <button className="menu-item">. */
   extraMenuItems?: ReactNode;
+  /** Router state for the Back to Sessions navigation. When supplied, the session route is replaced
+   *  by the roster route so browser Back cannot reopen the session that was just left. */
+  backState?: Record<string, unknown>;
 }
 
-export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToVoice = false, extraMenuItems }: SessionAppBarProps) {
+export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToVoice = false, extraMenuItems, backState }: SessionAppBarProps) {
   const navigate = useNavigate();
   const { sessionId } = useParams<{ sessionId: string }>();
   const [open, setOpen] = useState(false);
@@ -84,7 +87,9 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
         <button
           type="button"
           className="back-link session-back"
-          onClick={() => navigate("/")}
+          onClick={() =>
+            navigate("/", backState !== undefined ? { state: backState, replace: true } : undefined)
+          }
           aria-label="Back to sessions"
         >
           &larr; Sessions

--- a/apps/mobile/src/components/useSessionManage.ts
+++ b/apps/mobile/src/components/useSessionManage.ts
@@ -44,7 +44,9 @@ export interface SessionManage {
   busy: boolean;
   error: string | null;
   setError: (message: string | null) => void;
-  toggleHold: () => Promise<void>;
+  /** Resolves true when the hold change was accepted by the Gateway, false when it failed (the error
+   *  is already surfaced) - so a caller that navigates away after a snooze can stay put on failure. */
+  toggleHold: () => Promise<boolean>;
   removeSession: () => Promise<void>;
 }
 
@@ -100,8 +102,8 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
     };
   }, [sessionId, refresh]);
 
-  const toggleHold = useCallback(async () => {
-    if (!sessionId || busy) return;
+  const toggleHold = useCallback(async (): Promise<boolean> => {
+    if (!sessionId || busy) return false;
     // The pre-tap state: both what the toggle flips FROM and what a FAILED /hold must roll back to.
     const preTap: HoldUiState = { held: onHold === true, deferred };
     const desired = !isSnoozing(preTap);
@@ -135,6 +137,7 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
     setOnHold(settled.held);
     setDeferred(settled.deferred);
     if (outcome.ok) void refresh();
+    return outcome.ok;
   }, [sessionId, busy, onHold, deferred, working, refresh]);
 
   const removeSession = useCallback(async () => {

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
+import { getAutoSpeak, inVoiceQueueOrder, queueTouchMs, setAutoSpeak } from "@devthrottle/client-core/voice/queueTouch";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
 import { classify, contextLine, deletionReason, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
@@ -27,6 +28,12 @@ import { enablePush, notificationPermission, pushSupported, reconcileBadge } fro
 // session and back) without churning React state.
 const POLL_INTERVAL_MS = 5000;
 
+// Voice-mode queue flow: how long the roster sits still before auto-speak jumps into the next
+// waiting session (a beat to see the list and to uncheck the box), and how recently-listened a
+// session must be to be passed over for now (it comes around again on a later pass).
+const AUTO_SPEAK_DELAY_MS = 1500;
+const AUTO_SPEAK_COOLDOWN_MS = 20000;
+
 /** The roster's two lenses: the full roster, or only the sessions that can speak to you right now. */
 type RosterTab = "all" | "voice";
 
@@ -48,7 +55,42 @@ export function Home() {
   // Transient by design: it is a lens you pick up for a minute, not a mode you can get stranded in.
   // Persisting it (as the machine/repo filter is persisted) would mean coming back to the app hours
   // later, during an outage, to an empty roster and no memory of why.
-  const [tab, setTab] = useState<RosterTab>("all");
+  //
+  // The one exception is router state: the Voice screen's Respond and Snooze return here with
+  // { tab: "voice" } so the voice queue flow lands back on the queue it is worked from, not on All.
+  // That state lives only in the navigation that carried it - a fresh open still starts on All.
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<RosterTab>(() =>
+    (location.state as { tab?: string } | null)?.tab === "voice" ? "voice" : "all",
+  );
+  // Keep the selected lens on THIS history entry. A row navigation followed by browser/system Back
+  // must restore the Voice queue the owner was working, not remount the older default ("All") lens.
+  // This remains transient across a fresh app open because it is router history, not durable storage.
+  const selectTab = useCallback(
+    (next: RosterTab) => {
+      setTab(next);
+      const current = (location.state as Record<string, unknown> | null) ?? {};
+      navigate(location.pathname + location.search, {
+        replace: true,
+        state: { ...current, tab: next },
+      });
+    },
+    [location.pathname, location.search, location.state, navigate],
+  );
+  useEffect(() => {
+    const historyTab =
+      (location.state as { tab?: string } | null)?.tab === "voice" ? "voice" : "all";
+    setTab(historyTab);
+  }, [location.key, location.state]);
+  // Auto-speak (voice-mode queue flow): when checked, the Voice tab jumps into the oldest waiting
+  // voice-ready session by itself and reads it aloud - the hands-free queue. Persisted per device.
+  const [autoSpeak, setAutoSpeakState] = useState<boolean>(getAutoSpeak);
+  const toggleAutoSpeak = () => {
+    const next = !autoSpeak;
+    setAutoSpeak(next);
+    setAutoSpeakState(next);
+  };
 
   // Re-render the roster when a voice clip finishes downloading (a card flips from the yellow
   // working state to the play-triangle the moment its audio is phone-ready).
@@ -115,8 +157,19 @@ export function Home() {
   // unreachable machine keeps its last-known voiceAudioReady and its already-downloaded clip, so it
   // would otherwise sit in this tab claiming it can speak. This tab is the hands-free lens - the one
   // place a false "ready" is read out loud rather than looked at - so it must not list a dead machine.
+  //
+  // Ordered as a first-in-first-out QUEUE (voice-mode queue flow): oldest waiting at the top, new
+  // arrivals at the bottom - and a session you listened to but did not respond to or snooze drops to
+  // the BOTTOM (the device-local listened-touch counts as re-entering the line), so everything not
+  // yet heard is read first and the unhandled one comes around again.
   const voiceReady = filtered
-    ? inWaitingOrder(filtered.filter((s) => isVoiceReady(rowVoiceInputs(s, isWorking(s), !marks.has(s.sessionId ?? "")))))
+    ? inVoiceQueueOrder(
+        filtered.filter(
+          (s) =>
+            classify(s) === "needsYou" &&
+            isVoiceReady(rowVoiceInputs(s, isWorking(s), !marks.has(s.sessionId ?? ""))),
+        ),
+      )
     : [];
   // The "Needs you" group is a waiting line: the session that has been waiting for you the longest
   // sits at the top, and a session that only just started needing you drops in at the bottom
@@ -129,6 +182,27 @@ export function Home() {
   const total = sessions ? sessions.length : 0;
   const shownTotal = filtered ? filtered.length : 0;
   const active = filterIsActive(filter);
+
+  // AUTO-SPEAK (voice-mode queue flow): with the box checked and the Voice tab open, the roster
+  // jumps into the next session in the queue BY ITSELF and reads it aloud - hands-free driving mode.
+  // The next session is the oldest waiting one not listened to in the last few seconds (a session
+  // just left unhandled sits out one beat rather than instantly re-trapping the listener; with
+  // nothing else waiting it comes around on a later poll - deliberately, unhandled keeps coming
+  // back). The short delay leaves a moment to see the list, switch tabs, or uncheck the box - both
+  // of which stop the loop.
+  useEffect(() => {
+    if (tab !== "voice" || !autoSpeak || showFilter || voiceReady.length === 0) return;
+    const now = Date.now();
+    const next = voiceReady.find((s) => now - queueTouchMs(s.sessionId ?? "") > AUTO_SPEAK_COOLDOWN_MS);
+    if (!next) return;
+    const sid = encodeURIComponent(next.sessionId ?? "");
+    const timer = window.setTimeout(() => {
+      navigate(`/session/${sid}/voice`, {
+        state: { voiceMode: true, autoSpeak: true, fromTab: "voice" },
+      });
+    }, AUTO_SPEAK_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [tab, autoSpeak, showFilter, voiceReady, navigate]);
 
   return (
     <div className="screen">
@@ -191,7 +265,7 @@ export function Home() {
           role="tab"
           aria-selected={tab === "all"}
           className={`view-tab${tab === "all" ? " active" : ""}`}
-          onClick={() => setTab("all")}
+          onClick={() => selectTab("all")}
         >
           All
         </button>
@@ -200,7 +274,7 @@ export function Home() {
           role="tab"
           aria-selected={tab === "voice"}
           className={`view-tab${tab === "voice" ? " active" : ""}`}
-          onClick={() => setTab("voice")}
+          onClick={() => selectTab("voice")}
         >
           Voice mode
         </button>
@@ -237,12 +311,29 @@ export function Home() {
         <VoiceAllControl sessions={sessions} />
       )}
 
+      {/* Auto-speak (voice-mode queue flow): the hands-free switch. One checkbox; when on, the queue
+          below is read to you session by session without a single tap on a row. */}
+      {tab === "voice" && sessions !== null && total > 0 && (
+        <label className="autospeak-row">
+          <input type="checkbox" checked={autoSpeak} onChange={toggleAutoSpeak} />
+          <span className="autospeak-label">
+            Auto-speak
+            <span className="autospeak-hint">Jump into the next waiting session and read it aloud</span>
+          </span>
+        </label>
+      )}
+
+      {/* Honest feedback while auto-speak idles: the loop is armed, there is just nothing to read. */}
+      {tab === "voice" && autoSpeak && sessions !== null && total > 0 && voiceReady.length === 0 && (
+        <p className="status-line">Auto-speak is on. Waiting for a session to need you...</p>
+      )}
+
       {/* The Voice tab, empty. Said plainly and without alarm: nothing is ready to listen to yet. The
           way out is one tap, so an empty voice roster is never a dead end. */}
-      {tab === "voice" && sessions !== null && total > 0 && voiceReady.length === 0 && (
+      {tab === "voice" && !autoSpeak && sessions !== null && total > 0 && voiceReady.length === 0 && (
         <p className="status-line">
           Nothing to listen to right now.{" "}
-          <button type="button" className="link-btn" onClick={() => setTab("all")}>
+          <button type="button" className="link-btn" onClick={() => selectTab("all")}>
             Show all sessions
           </button>
         </p>
@@ -253,7 +344,7 @@ export function Home() {
           <h2 className="group-title">Ready to play</h2>
           <ul className="roster">
             {voiceReady.map((s) => (
-              <SessionRow key={`voice-${s.sessionId}`} session={s} mark={marks.get(s.sessionId ?? "")} />
+              <SessionRow key={`voice-${s.sessionId}`} session={s} mark={marks.get(s.sessionId ?? "")} fromTab="voice" />
             ))}
           </ul>
         </section>
@@ -395,7 +486,7 @@ function unreachableNote(mark: RosterSessionMark): string {
   return mark.lastSeenLabel.length > 0 ? `${base} - ${mark.lastSeenLabel}` : base;
 }
 
-function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessionMark }) {
+function SessionRow({ session, mark, fromTab = "all" }: { session: SessionDto; mark?: RosterSessionMark; fromTab?: RosterTab }) {
   const name = session.name && session.name.trim().length > 0 ? session.name : "(unnamed session)";
   const repo = repoLeaf(session);
   const machine = machineName(session);
@@ -420,7 +511,7 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
     <li className={`row${attention ? " row-attention" : ""}${unreachable ? " row-unreachable" : ""}`}>
       {/* Hand the known voice-mode state to the destination (issue #1015) so the Voice screen paints
           the right state on the first render instead of flashing OFF while its first poll resolves. */}
-      <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode) }}>
+      <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode), fromTab }}>
         {/* The dot always paints the Gateway-stamped colour - even when the owning machine is unreachable,
             the dot keeps telling the truth about the session's last-known state. Unreachability is shown by
             the row treatment (the .row-unreachable dashed border + dimming opacity + the "Unreachable" note),

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
+import { touchQueue } from "@devthrottle/client-core/voice/queueTouch";
 import { formatClock, useVoiceMode } from "@devthrottle/client-core/voice/useVoiceMode";
 import { DictationStatusStrip } from "../components/DictationStatusStrip";
 import { SessionAppBar } from "../components/SessionAppBar";
@@ -27,10 +28,31 @@ export function VoiceMode() {
   // knows how to enter voice mode stays the one place that does it.
   const location = useLocation();
   const navigate = useNavigate();
-  const navState = location.state as { voiceMode?: boolean; switchOn?: boolean } | null;
+  const navState = location.state as {
+    voiceMode?: boolean;
+    switchOn?: boolean;
+    // Voice-mode queue flow: the auto-speak queue navigated here by itself (read from the beginning),
+    // and which roster tab to return to after Respond / Snooze.
+    autoSpeak?: boolean;
+    fromTab?: string;
+  } | null;
   const seededVoiceOn = navState?.voiceMode;
 
-  // switchOn is a ONE-SHOT COMMAND, so it is read once and then scrubbed off the history entry.
+  // Captured once at mount, like switchOn below: whether the auto-speak queue drove this entry.
+  // The mount effect below consumes this one-shot command from the history entry, so a service-worker
+  // reload cannot unexpectedly restart the same narration from the beginning.
+  const [autoSpeakEntry] = useState(() => navState?.autoSpeak === true);
+
+  // Ordinary Back preserves the roster lens the session was opened from. Completing a voice action
+  // is different: Respond and Snooze always return to the Voice queue, replace this history entry,
+  // and let Auto-speak select the next waiting session.
+  const backTab = navState?.fromTab === "all" ? "all" : "voice";
+  const goBackToList = useCallback(() => {
+    navigate("/", { replace: true, state: { tab: "voice" } });
+  }, [navigate]);
+
+  // switchOn and autoSpeak are ONE-SHOT COMMANDS, so they are read once and then scrubbed off the
+  // history entry.
   //
   // It cannot be read straight from location.state on every render: router state is persisted in the
   // history entry and survives a reload, while the hook's "already did it" guard is only a ref, which a
@@ -40,13 +62,13 @@ export function VoiceMode() {
   // #1631.
   //
   // useState's initializer captures the command exactly once, at mount; the effect then rewrites the
-  // entry with switchOn cleared, so any later remount reads a spent command and does nothing.
+  // entry with both commands cleared, so any later remount reads spent commands and does nothing.
   const [autoSwitchOn] = useState(() => navState?.switchOn === true);
   useEffect(() => {
-    if (navState?.switchOn !== true) return;
+    if (navState?.switchOn !== true && navState?.autoSpeak !== true) return;
     navigate(location.pathname + location.search, {
       replace: true,
-      state: { ...navState, switchOn: false },
+      state: { ...navState, switchOn: false, autoSpeak: false },
     });
     // Mount-only: this consumes the arriving command. Re-running it on navState changes would fight
     // the very rewrite it performs.
@@ -61,6 +83,7 @@ export function VoiceMode() {
     narrative,
     title,
     error,
+    autoPlayBlocked,
     resumed,
     playing,
     pos,
@@ -83,7 +106,14 @@ export function VoiceMode() {
     onTogglePlay,
     onRespondSend,
     onRespondSendAudio,
-  } = useVoiceMode(sessionId, { seededVoiceOn, autoSwitchOn });
+  } = useVoiceMode(sessionId, {
+    seededVoiceOn,
+    autoSwitchOn,
+    // Voice-mode queue flow: dropping into a voice session always STARTS the narration by itself.
+    // An auto-speak entry reads from the beginning (the queue reads every item out in full); a
+    // manual tap resumes from where it left off (never rewinds a half-listened clip).
+    autoPlayOnEntry: autoSpeakEntry ? "restart" : "resume",
+  });
 
   // Dumb-renderer mapping: the Gateway's voiceDisplay verdict decides which card shows. The view only
   // maps its kind to a layout and renders its label / message / actions VERBATIM - it derives no state.
@@ -97,9 +127,47 @@ export function VoiceMode() {
     voiceOn && !speaking && vd != null &&
     vd.kind !== "ready" && vd.kind !== "preparing" && vd.kind !== "working" && vd.kind !== "off";
 
-  // Snooze and Remove share this one live held-state, so the bottom bar and the overflow menu can
-  // never disagree about it.
+  // Snooze and Remove share this one live held-state, so the action buttons and the overflow menu
+  // can never disagree about it.
   const manage = useSessionManage(sessionId);
+
+  // A queue touch means LISTENED, not merely opened. Record the first real playback start so a hard
+  // reload still remembers it, then refresh the stamp on leave so a long narration receives the full
+  // cooldown and cannot immediately trap Auto-speak back in the same one-item queue.
+  const listenedRef = useRef(false);
+  const markListened = useCallback(() => {
+    if (!sessionId) return;
+    listenedRef.current = true;
+    touchQueue(sessionId);
+  }, [sessionId]);
+  useEffect(() => {
+    return () => {
+      if (listenedRef.current && sessionId) touchQueue(sessionId);
+    };
+  }, [sessionId]);
+
+  // Snooze, then BACK TO THE LIST: once the snooze is accepted there is nothing left to do on this
+  // screen, so the flow returns to the queue (owner's flow, 2026-07-24). Unsnoozing stays put - that
+  // is a "wake it back up and look at it" action, not a "done with it" action. On failure the screen
+  // stays too, so the surfaced error is actually seen.
+  const onSnoozeTap = useCallback(async () => {
+    const wasSnoozed = manage.held || manage.deferred;
+    const ok = await manage.toggleHold();
+    if (ok && !wasSnoozed) goBackToList();
+  }, [manage, goBackToList]);
+
+  // Respond sent, BACK TO THE LIST: the reply is cached and delivered in the background, so there is
+  // no reason to sit on this session's page once it is answered - the queue has the next one. The
+  // text path waits for the send to be accepted (stays put on failure, error visible); the audio
+  // path is fire-and-forget by design and its progress/failures show on the roster rows.
+  const onRespondText = useCallback(
+    (text: string) => {
+      void (async () => {
+        if (await onRespondSend(text)) goBackToList();
+      })();
+    },
+    [onRespondSend, goBackToList],
+  );
 
   return (
     <div className="terminal-screen">
@@ -108,6 +176,7 @@ export function VoiceMode() {
       <SessionAppBar
         title={title}
         manage={manage}
+        backState={{ tab: backTab }}
         extraMenuItems={
           voiceOn ? (
             <>
@@ -148,7 +217,10 @@ export function VoiceMode() {
         preload="auto"
         onLoadedMetadata={onLoadedMeta}
         onTimeUpdate={onTimeUpdate}
-        onPlay={() => setPlaying(true)}
+        onPlay={() => {
+          setPlaying(true);
+          markListened();
+        }}
         onPause={() => setPlaying(false)}
         onEnded={onEndedAudio}
         style={{ display: "none" }}
@@ -158,8 +230,42 @@ export function VoiceMode() {
           scrolls, in its own window below them (voice-body-speaking). In the other states the body
           scrolls normally. */}
       <div className={`voice-body${speaking ? " voice-body-speaking" : ""}`}>
+        {/* THE BUTTONS COME FIRST (owner's layout rule, 2026-07-24): in voice mode the buttons are
+            the important part - the text below is a nice-to-have. Two big targets at the top of the
+            screen, in the same place in every state: Respond (only while there is a narration to
+            answer, exactly when it was offered before) and Snooze, which also returns to the list -
+            the arrow says so. */}
+        <div className="voice-actions">
+          {speaking && (
+            <button type="button" className="voice-action-respond" onClick={() => setResponding(true)}>
+              Respond
+            </button>
+          )}
+          <button
+            type="button"
+            className="voice-action-snooze"
+            onClick={() => void onSnoozeTap()}
+            disabled={manage.busy || manage.onHold === null}
+          >
+            {manage.held || manage.deferred ? (
+              "Unsnooze"
+            ) : (
+              <>
+                Snooze
+                <span className="voice-back-arrow" aria-hidden="true" />
+              </>
+            )}
+          </button>
+        </div>
+
         {error !== null && (
           <div className="banner banner-error" role="alert">{error}</div>
+        )}
+
+        {autoPlayBlocked && (
+          <div className="banner" role="status">
+            Automatic playback was blocked. Tap play to continue.
+          </div>
         )}
 
         {/* TTS fallback: the Gateway folded a generic "switched to a backup voice" notice onto this turn's
@@ -309,32 +415,21 @@ export function VoiceMode() {
             onSwitchOff (ViewMode -> Text) calls. */}
       </div>
 
-      {/* The bottom bar: the two controls the owner touches most, pinned in the thumb zone and in the
-          same place on every visit. Respond appears in the speaking state only - exactly the state it
-          appeared in before this layout change, so nothing about WHEN you can reply has moved. */}
-      <div className="voice-bottom-bar">
-        <button
-          type="button"
-          className="voice-snooze-btn"
-          onClick={() => void manage.toggleHold()}
-          disabled={manage.busy || manage.onHold === null}
-        >
-          {manage.held || manage.deferred ? "Unsnooze" : "Snooze"}
-        </button>
-        {speaking && (
-          <button type="button" className="voice-respond" onClick={() => setResponding(true)}>
-            Respond
-          </button>
-        )}
-      </div>
+      {/* The old bottom bar is gone: Respond and Snooze moved to the TOP of the body as the big
+          voice-actions block (owner's layout rule - the buttons are the important part). */}
 
       {/* F. Reply: the shared dictation interface with NO Insert - Send goes straight into the
-          session. There is no hold-to-talk; you tap Respond, speak, then Send. */}
+          session. There is no hold-to-talk; you tap Respond, speak, then Send. After a successful
+          send the screen returns to the session list - the reply is cached and delivered in the
+          background, so the queue is the next stop, not this page. */}
       {responding && (
         <DictationDialog
           showInsert={false}
-          onSend={(text) => void onRespondSend(text)}
-          onSendAudio={onRespondSendAudio}
+          onSend={onRespondText}
+          onSendAudio={(captured) => {
+            onRespondSendAudio(captured);
+            goBackToList();
+          }}
           onClose={() => setResponding(false)}
         />
       )}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1490,30 +1490,45 @@ a.banner-btn {
   margin-top: 0;
 }
 
-/* The Voice mode bottom bar (owner design review, "Option A"): the two controls used on almost every
-   turn - Snooze ("I press the snooze button a lot") and Respond ("clicked on almost every single
-   turn") - pinned in the thumb zone, in the same place on every visit.
-
-   Respond used to sit in the fixed header at the TOP of a tall phone, the hardest place to reach,
-   while rarely-used buttons (Regenerate response, Turn voice off) sat comfortably at the bottom.
-   Those two moved into the app bar's overflow menu and this bar took their place. */
-.voice-bottom-bar {
+/* Voice-mode queue flow (2026-07-24): THE BUTTONS COME FIRST. Respond and Snooze are the two verbs
+   of every voice turn, so they are the first, biggest things on the screen - stacked full-width at
+   the TOP of the body, with the narration text below them as the nice-to-have. This replaced the old
+   bottom bar (the buttons themselves and their verbs are unchanged, only bigger and at the top). */
+.voice-actions {
   flex: 0 0 auto;
   display: flex;
-  gap: 8px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 12px;
 }
 
-/* Secondary weight: frequent, but never the thing you reach for first. */
-.voice-snooze-btn {
-  flex: 0 0 auto;
-  min-width: 104px;
-  min-height: 52px;
+/* The primary verb: answer the session by voice. The biggest target on the screen. */
+.voice-action-respond {
+  width: 100%;
+  min-height: 64px;
+  border: none;
+  border-radius: 12px;
+  padding: 16px 0;
+  font-size: 19px;
+  font-weight: 800;
+  color: #ffffff;
+  background: #0e7c6b;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* The second verb: park it for a while - and go back to the list (the arrow says so). */
+.voice-action-snooze {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 56px;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 13px 12px;
-  font-size: 15px;
+  border-radius: 12px;
+  padding: 13px 0;
+  font-size: 17px;
   font-weight: 700;
   color: var(--text);
   background: var(--surface-2);
@@ -1521,26 +1536,42 @@ a.banner-btn {
   touch-action: manipulation;
 }
 
-.voice-snooze-btn:disabled {
+.voice-action-snooze:disabled {
   opacity: 0.5;
   cursor: default;
 }
 
-/* The one saturated control on the screen, and the biggest target on it. When Respond is absent (any
-   state that is not "speaking"), Snooze keeps its own width rather than stretching to fill - a
-   control must not change shape depending on what happens to be beside it. */
-.voice-respond {
-  flex: 1 1 auto;
-  min-height: 52px;
-  border: none;
-  border-radius: 10px;
-  padding: 13px 0;
-  font-size: 16px;
-  font-weight: 700;
-  color: #ffffff;
-  background: #0e7c6b;
-  cursor: pointer;
-  touch-action: manipulation;
+/* CSS-only back-to-the-list arrow on the Snooze button (no unicode glyphs): a leftwards chevron with
+   a tail, saying "this also takes you back". */
+.voice-back-arrow {
+  position: relative;
+  display: inline-block;
+  width: 18px;
+  height: 12px;
+}
+
+.voice-back-arrow::before {
+  content: "";
+  position: absolute;
+  left: 1px;
+  top: 50%;
+  width: 9px;
+  height: 9px;
+  border-left: 3px solid var(--text-dim);
+  border-bottom: 3px solid var(--text-dim);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.voice-back-arrow::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  right: 0;
+  top: 50%;
+  height: 3px;
+  margin-top: -1.5px;
+  border-radius: 2px;
+  background: var(--text-dim);
 }
 
 /* D. Waiting on a choice: option buttons (single, or multi-select with Submit). */
@@ -2161,6 +2192,44 @@ a.banner-btn {
   font-size: 13px;
   color: var(--attention);
   font-weight: 600;
+}
+
+/* Auto-speak (voice-mode queue flow): the hands-free switch under the fleet voice button. A big
+   touch row - the whole label toggles the checkbox. */
+.autospeak-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 10px 14px 4px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.autospeak-row input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  accent-color: #0e7c6b;
+  cursor: pointer;
+}
+
+.autospeak-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.autospeak-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-dim);
 }
 
 /* Machine / repo picker rows on the add screen. The row chrome reuses .row; .picker-link is the

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -2,6 +2,44 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 
+// Dev-only: the mobile shell calls the Gateway through root-relative URLs, so a local Vite run
+// needs an explicit Gateway front door for enrollment and the real app APIs. Without this proxy,
+// POST /mobile/enroll falls through to Vite's SPA shell and returns <!doctype html>; the enrollment
+// callback then tries to parse that as JSON and strands a fresh visitor on "Something went wrong".
+//
+// Opt in with MOBILE_PROXY_TARGET (for example https://gateway.devthrottle.com). Production is
+// unchanged: the Gateway serves the built app and all of these routes same-origin. /mobile/enroll is
+// intentionally exact; proxying all of /mobile would steal the local app, its assets, and its routes.
+const proxyTarget = process.env.MOBILE_PROXY_TARGET;
+const devProxy = proxyTarget
+  ? {
+      "/sessions": { target: proxyTarget, changeOrigin: true, ws: true },
+      "/directors": { target: proxyTarget, changeOrigin: true },
+      "/interrupted": { target: proxyTarget, changeOrigin: true },
+      "/fanout": { target: proxyTarget, changeOrigin: true },
+      "/cron": { target: proxyTarget, changeOrigin: true },
+      "/wingman": { target: proxyTarget, changeOrigin: true },
+      "/lists": { target: proxyTarget, changeOrigin: true },
+      "/account": { target: proxyTarget, changeOrigin: true },
+      "/gateway": { target: proxyTarget, changeOrigin: true },
+      "/ingest": { target: proxyTarget, changeOrigin: true },
+      "/dictation": { target: proxyTarget, changeOrigin: true },
+      "/transcription": { target: proxyTarget, changeOrigin: true },
+      "/turnbriefs": { target: proxyTarget, changeOrigin: true },
+      "/vault": { target: proxyTarget, changeOrigin: true },
+      "/push": { target: proxyTarget, changeOrigin: true },
+      "/carmode": { target: proxyTarget, changeOrigin: true },
+      "/stats": { target: proxyTarget, changeOrigin: true },
+      "/healthz": { target: proxyTarget, changeOrigin: true },
+      "/diag": { target: proxyTarget, changeOrigin: true },
+      // The enrollment mint shares the app's prefix, so proxy only the API leaf.
+      "/mobile/enroll": { target: proxyTarget, changeOrigin: true },
+      // The public site still returns mobile enrollment through the legacy callback path. The
+      // Gateway redirects it to /mobile/device-callback, preserving the URL fragment.
+      "/m/device-callback": { target: proxyTarget, changeOrigin: true },
+    }
+  : undefined;
+
 // The app is served by the Gateway under /mobile, so every asset URL must be /mobile-rooted.
 // (The Gateway 301-redirects the old /m mount to /mobile so installed PWAs and bookmarks keep working.)
 // The PWA service worker caches the app shell (Issue 1, AC7) so the roster opens offline
@@ -9,6 +47,9 @@ import { VitePWA } from "vite-plugin-pwa";
 // MSBuild target copies into wwwroot/mobile/.
 export default defineConfig({
   base: "/mobile/",
+  server: {
+    proxy: devProxy,
+  },
   plugins: [
     react(),
     VitePWA({

--- a/packages/client-core/src/voice/queueTouch.test.ts
+++ b/packages/client-core/src/voice/queueTouch.test.ts
@@ -1,0 +1,107 @@
+// The voice queue's ordering rule (voice-mode queue flow, 2026-07-24): first-in-first-out by when
+// each session last ENTERED the line - the Gateway's needsYouSince, or the device-local
+// listened-touch when that is later. A listened-but-unhandled session must drop to the BOTTOM and
+// come around again; sessions never heard keep their Gateway wait order.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionDto } from "../api/client";
+import { getAutoSpeak, inVoiceQueueOrder, queueTouchMs, setAutoSpeak, touchQueue } from "./queueTouch";
+
+function session(id: string, needsYouSince: string | null, createdAt = "2026-07-24T00:00:00Z"): SessionDto {
+  return { sessionId: id, needsYouSince, createdAt } as unknown as SessionDto;
+}
+
+// Each test uses its own session ids so the module-level in-memory touch mirror (deliberately
+// page-lifetime state in production) cannot bleed between tests.
+let n = 0;
+function freshId(tag: string): string {
+  n += 1;
+  return `${tag}-${n}`;
+}
+
+beforeEach(() => {
+  // node is vitest's default environment here (there is no vitest config), so localStorage does not
+  // exist and every touch would silently live only in the in-memory mirror - the durable half of the
+  // store would go untested. Stub a real one, the same way rowVoiceInputs.test.ts does.
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  });
+});
+
+describe("inVoiceQueueOrder", () => {
+  it("orders untouched sessions oldest-waiting first (the Gateway wait order)", () => {
+    const oldest = session(freshId("a"), "2026-07-24T10:00:00Z");
+    const middle = session(freshId("b"), "2026-07-24T11:00:00Z");
+    const newest = session(freshId("c"), "2026-07-24T12:00:00Z");
+    const ordered = inVoiceQueueOrder([newest, oldest, middle]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([oldest.sessionId, middle.sessionId, newest.sessionId]);
+  });
+
+  it("drops a listened-but-unhandled session to the bottom of the queue", () => {
+    const heard = session(freshId("heard"), "2026-07-24T10:00:00Z");
+    const waiting = session(freshId("waiting"), "2026-07-24T11:00:00Z");
+    // The oldest session was listened to and left unhandled AFTER the other one started waiting: it
+    // re-enters the line at the back.
+    touchQueue(heard.sessionId ?? "", Date.parse("2026-07-24T12:00:00Z"));
+    const ordered = inVoiceQueueOrder([heard, waiting]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([waiting.sessionId, heard.sessionId]);
+  });
+
+  it("a NEW turn after the touch puts the session back in line by its fresh wait time", () => {
+    // Listened at 12:00, but the session came back needing you again at 13:00: the newer
+    // needsYouSince governs, so it queues as a fresh arrival, not as its old touched self.
+    const again = session(freshId("again"), "2026-07-24T13:00:00Z");
+    const older = session(freshId("older"), "2026-07-24T12:30:00Z");
+    touchQueue(again.sessionId ?? "", Date.parse("2026-07-24T12:00:00Z"));
+    const ordered = inVoiceQueueOrder([again, older]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([older.sessionId, again.sessionId]);
+  });
+
+  it("a session with no needsYouSince and no touch sorts to the bottom", () => {
+    const placed = session(freshId("placed"), "2026-07-24T10:00:00Z");
+    const unplaced = session(freshId("unplaced"), null);
+    const ordered = inVoiceQueueOrder([unplaced, placed]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([placed.sessionId, unplaced.sessionId]);
+  });
+
+  it("a touched session with no needsYouSince is still placeable (by its touch)", () => {
+    const touched = session(freshId("touched"), null);
+    const later = session(freshId("later"), "2026-07-24T12:00:00Z");
+    touchQueue(touched.sessionId ?? "", Date.parse("2026-07-24T10:00:00Z"));
+    const ordered = inVoiceQueueOrder([later, touched]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([touched.sessionId, later.sessionId]);
+  });
+
+  it("breaks ties by createdAt so equal stamps never jitter", () => {
+    const first = session(freshId("t1"), "2026-07-24T10:00:00Z", "2026-07-24T01:00:00Z");
+    const second = session(freshId("t2"), "2026-07-24T10:00:00Z", "2026-07-24T02:00:00Z");
+    const ordered = inVoiceQueueOrder([second, first]);
+    expect(ordered.map((s) => s.sessionId)).toEqual([first.sessionId, second.sessionId]);
+  });
+});
+
+describe("touchQueue / queueTouchMs", () => {
+  it("round-trips the touch stamp", () => {
+    const sid = freshId("round");
+    expect(queueTouchMs(sid)).toBe(0);
+    touchQueue(sid, 1234567890);
+    expect(queueTouchMs(sid)).toBe(1234567890);
+  });
+
+  it("ignores an empty session id", () => {
+    touchQueue("", 42);
+    expect(queueTouchMs("")).toBe(0);
+  });
+});
+
+describe("auto-speak setting", () => {
+  it("defaults off, persists on, and clears off", () => {
+    expect(getAutoSpeak()).toBe(false);
+    setAutoSpeak(true);
+    expect(getAutoSpeak()).toBe(true);
+    setAutoSpeak(false);
+    expect(getAutoSpeak()).toBe(false);
+  });
+});

--- a/packages/client-core/src/voice/queueTouch.ts
+++ b/packages/client-core/src/voice/queueTouch.ts
@@ -1,0 +1,106 @@
+// The voice queue's local "listened" marker (voice-mode queue flow, 2026-07-24).
+//
+// The Voice tab is worked by ear as a first-in-first-out queue: the session that has been waiting
+// the longest is read first. When the owner listens to a session and then leaves WITHOUT responding
+// or snoozing, that session must drop to the BOTTOM of the queue - it was heard, so everything not
+// yet heard goes first, and the unhandled session comes around again later (deliberately: an
+// unhandled session keeps coming back until it is dealt with).
+//
+// The Gateway owns needsYouSince (when the session started needing you); this store owns only the
+// phone-local "when did THIS device last open it in voice mode" stamp. That is playback-side state
+// in the same family as playbackPositions.ts - which device listened, and when, is a fact only the
+// device knows - so it lives on the device, not on the Gateway. The queue position is then
+// max(needsYouSince, local touch): untouched sessions keep their Gateway wait order, and a touched
+// session re-enters the line as if it had just arrived.
+
+import type { SessionDto } from "../api/client";
+
+const KEY_PREFIX = "dt.voice.touch.";
+const _mem = new Map<string, number>();
+
+function storageKey(sid: string): string {
+  return KEY_PREFIX + sid;
+}
+
+/** Record that this device just opened the session in voice mode (it was listened to, or at least
+ *  brought to the ear). Called when leaving the voice screen; also harmless on respond/snooze,
+ *  because those remove the session from the needs-you queue anyway. */
+export function touchQueue(sid: string, nowMs: number = Date.now()): void {
+  if (sid.length === 0) return;
+  _mem.set(sid, nowMs);
+  try {
+    if (typeof localStorage !== "undefined") localStorage.setItem(storageKey(sid), String(nowMs));
+  } catch {
+    // Storage unavailable/full; the in-memory mirror still holds it for the life of the page.
+  }
+}
+
+/** The last time this device opened the session in voice mode, in epoch ms, or 0 when never. */
+export function queueTouchMs(sid: string): number {
+  const mem = _mem.get(sid);
+  if (mem !== undefined) return mem;
+  try {
+    if (typeof localStorage === "undefined") return 0;
+    const raw = localStorage.getItem(storageKey(sid));
+    if (raw === null) return 0;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return 0;
+    _mem.set(sid, parsed);
+    return parsed;
+  } catch {
+    return 0;
+  }
+}
+
+// The queue position stamp: when this session last entered the line. The later of the Gateway's
+// needsYouSince (it just started needing you) and the local touch (you just listened and moved on).
+// A missing/unparseable needsYouSince with no touch sorts to the bottom - we cannot place it in the
+// line, so it never jumps ahead of a session with a real wait time (same rule as inWaitingOrder).
+function queuePositionMs(s: SessionDto): number {
+  const raw = String(s.needsYouSince ?? "").trim();
+  const since = raw.length > 0 ? Date.parse(raw) : Number.NaN;
+  const sinceMs = Number.isNaN(since) ? Number.POSITIVE_INFINITY : since;
+  const touched = queueTouchMs(s.sessionId ?? "");
+  if (touched > 0 && touched !== Number.POSITIVE_INFINITY) {
+    // A touch is a real, placeable stamp even when needsYouSince is missing.
+    return sinceMs === Number.POSITIVE_INFINITY ? touched : Math.max(sinceMs, touched);
+  }
+  return sinceMs;
+}
+
+/** The voice queue's order: first-in-first-out by when each session last ENTERED the line - the
+ *  Gateway's needsYouSince, or the device-local listened-touch when that is later. Oldest first, so
+ *  the queue is worked top to bottom by ear; a listened-but-unhandled session drops to the bottom
+ *  and comes around again. Ties break by createdAt then sessionId so equal stamps never jitter. */
+export function inVoiceQueueOrder(sessions: SessionDto[]): SessionDto[] {
+  return [...sessions].sort((a, b) => {
+    const pa = queuePositionMs(a);
+    const pb = queuePositionMs(b);
+    if (pa !== pb) return pa - pb;
+    const created = String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? ""));
+    if (created !== 0) return created;
+    return String(a.sessionId ?? "").localeCompare(String(b.sessionId ?? ""));
+  });
+}
+
+/** The auto-speak setting (device-local): when on, the roster's Voice tab jumps into the oldest
+ *  waiting voice-ready session by itself and reads it aloud - the hands-free queue. */
+const AUTO_SPEAK_KEY = "dt.voice.autospeak";
+
+export function getAutoSpeak(): boolean {
+  try {
+    return typeof localStorage !== "undefined" && localStorage.getItem(AUTO_SPEAK_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setAutoSpeak(on: boolean): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    if (on) localStorage.setItem(AUTO_SPEAK_KEY, "1");
+    else localStorage.removeItem(AUTO_SPEAK_KEY);
+  } catch {
+    // Storage unavailable; the checkbox simply will not persist across reloads.
+  }
+}

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -99,6 +99,9 @@ export interface VoiceModeView {
   title: string;
   name: string | null;
   error: string | null;
+  /** The browser rejected an automatic play attempt. The clip is still ready and the visible Play
+   *  control is the recovery path. */
+  autoPlayBlocked: boolean;
   resumed: boolean;
   playing: boolean;
   pos: number;
@@ -123,13 +126,25 @@ export interface VoiceModeView {
   onSeek: (e: ChangeEvent<HTMLInputElement>) => void;
   onRestart: () => void;
   onTogglePlay: () => void;
-  onRespondSend: (text: string) => Promise<void>;
+  /** Sends the reply into the session. Resolves true when the send succeeded, false when it failed
+   *  (the error is already surfaced) - so a caller that navigates away after a reply can stay put on
+   *  failure instead of leaving the error behind on an abandoned screen. */
+  onRespondSend: (text: string) => Promise<boolean>;
   onRespondSendAudio: (captured: CapturedUtterance) => void;
 }
 
 export function useVoiceMode(
   sessionId: string | undefined,
-  opts?: { seededVoiceOn?: boolean; autoSwitchOn?: boolean },
+  opts?: {
+    seededVoiceOn?: boolean;
+    autoSwitchOn?: boolean;
+    /** Voice-mode queue flow: start the narration BY ITSELF when this screen is entered and the clip
+     *  is phone-ready, instead of waiting for a play tap. "resume" continues from the remembered
+     *  position (never rewinds a half-listened clip); "restart" always reads from the beginning (the
+     *  auto-speak queue's rule: every auto-entry is read out in full). Undefined keeps the old
+     *  behavior: only a genuinely new clip auto-plays. */
+    autoPlayOnEntry?: "resume" | "restart";
+  },
 ): VoiceModeView {
   const sid = sessionId ?? "";
 
@@ -142,12 +157,14 @@ export function useVoiceMode(
   // calls itself - onSwitchOn below is the ONE implementation of that verb, and a second copy in a menu
   // handler would be free to drift from it.
   const autoSwitchOn = opts?.autoSwitchOn;
+  const autoPlayOnEntry = opts?.autoPlayOnEntry;
 
   const [name, setName] = useState<string | null>(null);
   const [session, setSession] = useState<SessionDto | null>(null);
   // Seed the narration state + text from the on-device cache so it shows instantly (issue #1015).
   const [voice, setVoice] = useState<WingmanVoice | null>(() => getVoiceMeta(sid));
   const [error, setError] = useState<string | null>(null);
+  const [autoPlayBlocked, setAutoPlayBlocked] = useState(false);
   // Whether a real poll has resolved the true state yet. Until it has, we never paint the OFF card -
   // the screen starts blank (or ON when the roster seeded it) and only shows OFF once confirmed.
   // NOTE: this is knowledge of the SESSION only - set as soon as listSessions resolves. The Voice
@@ -280,6 +297,10 @@ export function useVoiceMode(
   // stale and must not be spoken or offered, exactly like the roster play-triangle (Home.tsx). A null
   // session (not yet loaded) is treated as not-working.
   const agentWorking = session !== null && isWorking(session);
+  // Until the first poll resolves, trust the roster's seed for rendering only. Playback itself waits
+  // for the authoritative session so a cached narration cannot speak while the real session is off
+  // or has already started working again.
+  const voiceOn = localEnabled || Boolean(session?.voiceMode) || (!pollDone && seededVoiceOn === true);
 
   // Retire a stale narration the moment the agent starts working again: stop this screen's own
   // playback and any shared roster clip. The speaking-state play-triangle is hidden below while
@@ -295,11 +316,17 @@ export function useVoiceMode(
     stopPlayback();
   }, [agentWorking]);
 
+  const entryPlayedRef = useRef(false);
+
   // Auto-play a freshly downloaded clip exactly once, and only while the voice screen is foreground
   // (decision 4: never auto-play from the list, never while the app is hidden). Never auto-play while
   // the agent is working again - that narration is stale (the same rule the roster triangle follows).
   useEffect(() => {
-    if (agentWorking) return;
+    if (!pollDone || session === null || !voiceOn || agentWorking) return;
+    // When this page was entered with an explicit resume/restart command, that entry effect owns the
+    // first play. Once it has done so, this effect resumes responsibility for genuinely new clips
+    // that arrive while the same screen stays open.
+    if (autoPlayOnEntry !== undefined && !entryPlayedRef.current) return;
     // NEVER speak while the listener is answering. This effect fires when a NEW clip finishes
     // downloading, and it had no idea the Respond dialog was open - so a turn that landed mid-dictation
     // played straight over the owner while their microphone was live, which is both maddening and an
@@ -318,11 +345,65 @@ export function useVoiceMode(
       stopPlayback(); // never overlap a roster clip with this screen's playback
       el.currentTime = 0;
       saveMark(sid, { generatedAt, pos: 0, dur: el.duration || 0, autoPlayed: true });
+      setAutoPlayBlocked(false);
       void el.play().catch(() => {
-        /* autoplay policy may require a gesture; the play-triangle covers it */
+        setAutoPlayBlocked(true);
       });
     }
-  }, [phoneReady, generatedAt, agentWorking, sid, responding]);
+  }, [
+    phoneReady,
+    generatedAt,
+    agentWorking,
+    sid,
+    responding,
+    pollDone,
+    session,
+    voiceOn,
+    autoPlayOnEntry,
+  ]);
+
+  // Voice-mode queue flow: entering this screen in voice mode STARTS THE NARRATION BY ITSELF, once
+  // per mount, the moment the clip is phone-ready. In "resume" mode (a manual tap into the session)
+  // playback continues from the remembered position - onLoadedMeta has already restored it, so play
+  // never rewinds a half-listened clip. In "restart" mode (the auto-speak queue jumped in) the clip
+  // is read from the beginning every time - the queue's rule is that an auto-entry is read out in
+  // full. Guarded by the same courtesies as the new-clip auto-play above: never over a working agent
+  // (stale narration), never while the owner is answering, never while the app is hidden.
+  useEffect(() => {
+    if (autoPlayOnEntry === undefined || entryPlayedRef.current) return;
+    if (!pollDone || session === null || !voiceOn || agentWorking || responding) return;
+    if (!phoneReady || generatedAt.length === 0) return;
+    if (typeof document !== "undefined" && document.hidden) return;
+    const el = audioRef.current;
+    if (el === null) return;
+    entryPlayedRef.current = true;
+    stopPlayback(); // never overlap a roster clip with this screen's playback
+    if (autoPlayOnEntry === "restart") {
+      // From the top, and stop onLoadedMeta from seeking back to a remembered spot afterwards.
+      restoredForRef.current = generatedAt;
+      el.currentTime = 0;
+      setPos(0);
+    }
+    // Marked autoPlayed so the new-clip effect above never fires a second, competing play. In resume
+    // mode the remembered position is preserved (this can run before metadata loads, when
+    // el.currentTime is still 0 - writing that back would erase the very position resume needs).
+    const keepPos = autoPlayOnEntry === "restart" ? 0 : Math.max(el.currentTime, positionFor(sid, generatedAt));
+    saveMark(sid, { generatedAt, pos: keepPos, dur: el.duration || 0, autoPlayed: true });
+    setAutoPlayBlocked(false);
+    void el.play().catch(() => {
+      setAutoPlayBlocked(true);
+    });
+  }, [
+    phoneReady,
+    generatedAt,
+    agentWorking,
+    responding,
+    autoPlayOnEntry,
+    sid,
+    pollDone,
+    session,
+    voiceOn,
+  ]);
 
   // Tapping Respond SILENCES whatever is already speaking, at once. The guard above stops a new clip
   // from starting, but a clip already mid-sentence when Respond is tapped would otherwise keep talking
@@ -516,6 +597,7 @@ export function useVoiceMode(
     setPos(0);
     setResumed(false);
     persist(el, { started: true });
+    setAutoPlayBlocked(false);
     void el.play().catch(() => {
       /* ignore - a tap already gestured */
     });
@@ -536,22 +618,25 @@ export function useVoiceMode(
     stopPlayback(); // never let two clips play at once
     if (el.ended || (el.duration > 0 && el.currentTime >= el.duration)) el.currentTime = 0;
     persist(el, { started: true });
+    setAutoPlayBlocked(false);
     void el.play().catch(() => {
       /* ignore - a tap already gestured */
     });
   }, [persist]);
 
   const onRespondSend = useCallback(
-    async (text: string) => {
+    async (text: string): Promise<boolean> => {
       setResponding(false);
       const trimmed = text.trim();
-      if (sid.length === 0 || trimmed.length === 0) return;
+      if (sid.length === 0 || trimmed.length === 0) return false;
       try {
         // Same write path the Send button uses; the transcript is already dictionary-corrected by
         // the Gateway and is sent verbatim (transcript integrity, CodingStyle s16).
         await sendPrompt(sid, trimmed, true);
+        return true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Send failed");
+        return false;
       }
     },
     [sid],
@@ -576,9 +661,6 @@ export function useVoiceMode(
     [sid, session],
   );
 
-  // Until the first poll resolves, trust the roster's seed so a voice session drops straight into the
-  // ON state; once the poll has spoken, the real session flag governs (a stale seed cannot stick).
-  const voiceOn = localEnabled || Boolean(session?.voiceMode) || (!pollDone && seededVoiceOn === true);
   // The speaking state (and its play-triangle) is suppressed while the agent is working again: the
   // finished-turn narration is stale, so the screen falls back to the working card instead of
   // offering a replay of it.
@@ -618,6 +700,7 @@ export function useVoiceMode(
     title,
     name,
     error,
+    autoPlayBlocked,
     resumed,
     playing,
     pos,


### PR DESCRIPTION
The mobile Voice tab becomes a hands-free queue worked by ear.

What changes:

- **First-in-first-out queue.** Oldest waiting session on top, new arrivals at the bottom. A session listened to but left unhandled re-enters the line at the back (device-local listened-touch, recorded when playback actually starts) and keeps coming around until dealt with.
- **Buttons first.** The session voice screen leads with a big Respond and a big Snooze (with a back arrow); the narration text scrolls below them. The old bottom bar is gone.
- **Actions return to the queue.** Respond and Snooze land back on the Voice tab; ordinary back returns to the tab the session was opened from.
- **Auto-speak.** A checkbox on the Voice tab: the roster jumps into the oldest waiting voice-ready session by itself and reads it aloud from the beginning. A manual tap into a voice session auto-plays too, resuming where it left off. A blocked automatic play shows a tap-play recovery banner, never a silent screen.
- **Dev proxy.** Opt-in MOBILE_PROXY_TARGET for the Vite dev server so local enrollment reaches a real Gateway instead of falling through to the SPA shell.

Verification: typecheck clean across client-core, cockpit, and mobile; 591 client-core tests green (including new queue-ordering tests); the full flow driven end-to-end against the live hosted Gateway in a real browser - queue order, requeue-on-listen, Respond and Snooze round trips, auto-speak jumps, and the blocked-playback recovery banner. Final audio confirmation on the phone follows the deploy.