### PR TITLE
fix(assistant): harden the Assistant from independent review findings

### DIFF
--- a/packages/client-core/src/assistant/assistantApi.ts
+++ b/packages/client-core/src/assistant/assistantApi.ts
@@ -29,11 +29,23 @@ export async function assistantTurn(text: string, idempotencyKey?: string, signa
     if (res.status === 402) throw creditsErrorFrom(body);
     throw new GatewayError(res.status, body.error ?? `Assistant turn failed: ${res.status}`);
   }
-  const body = (await res.json().catch(() => ({}))) as Partial<CarModeTurnResult>;
+  // Codex review finding 7: a 2xx that does not carry the turn contract is a PROTOCOL failure and
+  // must throw specifically - synthesizing defaults would render a blank assistant answer and hide a
+  // broken Gateway. The brain never returns an empty spoken string, so empty is malformed too.
+  let body: Partial<CarModeTurnResult>;
+  try {
+    body = (await res.json()) as Partial<CarModeTurnResult>;
+  } catch {
+    throw new GatewayError(res.status, "The Assistant turn response was not JSON - Gateway and cockpit are out of step. Redeploy them together.");
+  }
+  const spoken = typeof body.spoken === "string" ? body.spoken.trim() : "";
+  if (typeof body.turnId !== "string" || body.turnId.length === 0 || spoken.length === 0 || !Array.isArray(body.actions)) {
+    throw new GatewayError(res.status, "The Assistant turn response was missing turnId, spoken, or actions - Gateway and cockpit are out of step. Redeploy them together.");
+  }
   return {
-    turnId: typeof body.turnId === "string" ? body.turnId : "",
-    spoken: (body.spoken ?? "").trim(),
-    actions: Array.isArray(body.actions) ? body.actions : [],
+    turnId: body.turnId,
+    spoken,
+    actions: body.actions,
     pendingConfirmation: Boolean(body.pendingConfirmation),
     timing: body.timing ?? null,
   };

--- a/packages/client-core/src/assistant/useAssistant.ts
+++ b/packages/client-core/src/assistant/useAssistant.ts
@@ -25,6 +25,14 @@ export type AssistantPhase = "idle" | "listening" | "transcribing" | "thinking" 
 /** Chat mode types (replies stay silent); voice mode talks and reads every reply aloud. */
 export type AssistantMode = "chat" | "voice";
 
+/** The one in-flight microphone capture: its recorder, its generation (stale-settle detection),
+ *  and the start() promise every teardown path must let settle before disposing. */
+interface TalkCapture {
+  recorder: MicRecorder;
+  generation: number;
+  started: Promise<void>;
+}
+
 export interface UseAssistant {
   entries: AssistantEntry[];
   phase: AssistantPhase;
@@ -57,23 +65,38 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
   const [phase, setPhase] = useState<AssistantPhase>("idle");
   const [mode, setMode] = useState<AssistantMode>("chat");
 
-  const recorderRef = useRef<MicRecorder | null>(null);
+  // One capture in flight, identified by its generation number (Codex review finding 3). The
+  // microphone permission prompt makes MicRecorder.start() genuinely asynchronous: a cancel, a
+  // quick second tap, or an unmount can all arrive while getUserMedia is still pending, and a
+  // recorder disposed at that moment would come alive afterwards as an invisible open microphone.
+  // Every settle path therefore checks its generation against the current one and disposes the
+  // recorder AFTER its start() promise settles - never before.
+  const talkRef = useRef<TalkCapture | null>(null);
+  const generationRef = useRef(0);
+
   const stopPlaybackRef = useRef<() => void>(() => {});
   // The mode at the moment a turn RUNS decides whether its reply is read aloud; a ref avoids the
   // stale-closure trap when the owner flips the toggle mid-turn.
   const modeRef = useRef<AssistantMode>("chat");
   modeRef.current = mode;
 
+  /** Abandon the in-flight capture, disposing the recorder only after its start() settles. */
+  const abandonCapture = useCallback(() => {
+    const talk = talkRef.current;
+    if (talk === null) return;
+    talkRef.current = null;
+    void talk.started.catch(() => {}).then(() => talk.recorder.dispose());
+  }, []);
+
   // Warm the hosted model + text-to-speech the moment the screen opens, so the first question does
   // not pay the cold start (the same keep-warm door Car Mode uses; best-effort, never throws).
   useEffect(() => {
     void postCarModeWarmup();
     return () => {
-      recorderRef.current?.dispose();
-      recorderRef.current = null;
+      abandonCapture();
       stopPlaybackRef.current();
     };
-  }, []);
+  }, [abandonCapture]);
 
   const push = useCallback((entry: AssistantEntry) => {
     setEntries((cur) => appendEntry(cur, entry));
@@ -87,7 +110,13 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
     const url = URL.createObjectURL(clip);
     try {
       await playClip(audio, url, (stop) => {
-        stopPlaybackRef.current = stop;
+        // Codex review finding 4: playClip's stop resolves the play promise but does NOT silence the
+        // element - pausing here is what actually stops the sound. Both halves belong to the one
+        // registered stop so every caller (the Stop reading button, a mode switch, unmount) gets both.
+        stopPlaybackRef.current = () => {
+          audio.pause();
+          stop();
+        };
       });
     } finally {
       URL.revokeObjectURL(url);
@@ -129,25 +158,39 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
   }, [phase, runTurn]);
 
   const startTalk = useCallback(() => {
-    if (phase !== "idle") return;
+    if (phase !== "idle" || talkRef.current !== null) return;
+    const generation = ++generationRef.current;
     const recorder = new MicRecorder();
-    recorderRef.current = recorder;
+    const started = recorder.start();
+    talkRef.current = { recorder, generation, started };
     setPhase("listening");
-    void recorder.start().catch((err: unknown) => {
-      recorderRef.current = null;
+    started.catch((err: unknown) => {
+      // Settle path for a start that failed (permission denied, no device). Act only if THIS capture
+      // is still the current one - endTalk/cancelTalk may have claimed it already, and their own
+      // settle handling owns the outcome then. A stale failure only disposes its own recorder.
+      if (talkRef.current?.generation !== generation) {
+        recorder.dispose();
+        return;
+      }
+      talkRef.current = null;
       setPhase("idle");
       push({ role: "error", text: err instanceof Error ? err.message : "The microphone could not be opened." });
     });
   }, [phase, push]);
 
   const endTalk = useCallback(() => {
-    const recorder = recorderRef.current;
-    if (recorder === null || phase !== "listening") return;
-    recorderRef.current = null;
+    const talk = talkRef.current;
+    if (talk === null || phase !== "listening") return;
+    // Claim the capture: from here the start-failure handler above sees a stale generation and
+    // stands down, so this path owns every outcome exactly once.
+    talkRef.current = null;
     setPhase("transcribing");
     void (async () => {
       try {
-        const captured = await recorder.stop();
+        // Let start() finish before stopping - stop() on a recorder whose getUserMedia is still
+        // pending would throw AND leave the microphone to open later, unowned (finding 3).
+        await talk.started;
+        const captured = await talk.recorder.stop();
         const { wav } = await blobToWav16kMono(captured);
         const transcript = await transcribeCarModeAudio(wav);
         if (transcript.length === 0) {
@@ -157,6 +200,7 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
         }
         await runTurn(transcript);
       } catch (err) {
+        talk.recorder.dispose();
         setPhase("idle");
         push({ role: "error", text: gatewayErrorMessage(err) });
       }
@@ -165,20 +209,26 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
 
   const cancelTalk = useCallback(() => {
     if (phase !== "listening") return;
-    recorderRef.current?.dispose();
-    recorderRef.current = null;
+    abandonCapture();
     setPhase("idle");
-  }, [phase]);
+  }, [abandonCapture, phase]);
 
   const stopSpeaking = useCallback(() => {
     stopPlaybackRef.current();
+  }, []);
+
+  // Leaving voice mode mid-readback removes the Stop reading button, so the mode switch itself
+  // must stop the audio (finding 4) - otherwise the reply keeps sounding with no way to silence it.
+  const setModeStopping = useCallback((next: AssistantMode) => {
+    if (next === "chat") stopPlaybackRef.current();
+    setMode(next);
   }, []);
 
   return {
     entries,
     phase,
     mode,
-    setMode,
+    setMode: setModeStopping,
     busy: phase !== "idle",
     confirmOffered: awaitingConfirmation(entries) && phase === "idle",
     sendText,

--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -1112,6 +1112,39 @@ public sealed class CarModeBrainTests
     }
 
     [Fact]
+    public async Task RunTurn_GetSpend_InvalidDays_IsAToolError_NotASilentSevenDayAnswer()
+    {
+        // Codex review finding 6: an explicitly supplied but invalid window must come back to the model
+        // as a tool error it can correct - never silently become the seven-day default, which would
+        // answer a question the owner did not ask.
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"three weeks\"}") }),
+            Speak("How many days did you mean?"));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for three weeks", CancellationToken.None);
+
+        Assert.Empty(fleet.SpendDays);                     // the fleet was never asked
+        Assert.Contains("days must be a whole number", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_GetCredits_SignedInWithNoBalance_FailsLoud_NeverZeroDollars()
+    {
+        // Codex review finding 6: a signed-in credits read with no balance is a malformed payload. The
+        // fleet contract is to throw before the brain ever sees it; if a (fake or future) fleet hands the
+        // brain that shape anyway, the brain itself must fail loud - zero dollars is the classic
+        // plausible fabricated number and must be impossible to produce.
+        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(true, null, null) };
+        var chat = new ScriptedChat(new CarModeAssistantTurn(null, new[] { Call("get_credits") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None));
+    }
+
+    [Fact]
     public async Task RunTurn_GetSpend_HonorsTheDaysArgument()
     {
         var fleet = new FakeFleet { SpendResult = new CarModeSpendSummary(0, 0, DateTime.UtcNow.AddDays(-30), DateTime.UtcNow) };

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -89,9 +89,22 @@ internal static class CarModeEndpoint
         MapDiagnosticsRoutes(app, diagnostics);
     }
 
+    /// <summary>
+    /// One gate per authenticated device, held for the WHOLE brain turn (Codex review of the Assistant
+    /// build, finding 5). A turn mutates ordered per-device state - the conversation history, the current
+    /// subject, and the armed-destructive-confirmation slot - and the confirmation consume is a get-then-
+    /// clear, so two turns entering the brain concurrently for the SAME device (two cockpit tabs, or a
+    /// phone and a desk at once) could both observe one armed delete and execute it twice, or interleave
+    /// their history writes. The turn cache only single-flights the SAME Idempotency-Key; this gate
+    /// serializes DIFFERENT turns of one device. Devices are few (each is an enrolled credential), so the
+    /// dictionary stays small; different devices are never queued behind each other.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim> TurnGates = new();
+
     /// <summary>Map one turn route over the given brain. Identical mechanics for every surface: tenant
-    ///  resolution, the authenticated-credential conversation key, Idempotency-Key single-flight, the shared
-    ///  402 money refusal, and the loud 502 failure whose message names the surface.</summary>
+    ///  resolution, the authenticated-credential conversation key, per-device turn serialization,
+    ///  Idempotency-Key single-flight, the shared 402 money refusal, and the loud 502 failure whose
+    ///  message names the surface.</summary>
     private static void MapTurnRoute(IEndpointRouteBuilder app, string pattern, string surfaceLabel,
         CarModeBrain brain, CarModeTurnCache turnCache, HostedTenantBoundary tenantBoundary)
     {
@@ -120,18 +133,35 @@ internal static class CarModeEndpoint
             try
             {
                 CarModeTurnResponse result;
-                if (string.IsNullOrEmpty(idemKey))
+                // Serialize this device's turns end-to-end (see TurnGates). The wait honors the request
+                // token, so a caller that gives up while queued does not hold a slot; the shared "" bucket
+                // (auth gate off in local debug) serializes anonymous callers together, matching how the
+                // conversation store already buckets them. Known residual window: on the Idempotency-Key
+                // path the brain runs detached (CancellationToken.None) so a client that DISCONNECTS
+                // mid-turn releases the gate while that detached work finishes - a deliberate trade, since
+                // holding the gate from a continuation could double-release on a same-key retry. The gate
+                // closes the two-tabs / double-confirm race, which never involves a disconnect.
+                var gate = TurnGates.GetOrAdd(deviceKey, static _ => new SemaphoreSlim(1, 1));
+                await gate.WaitAsync(ct);
+                try
                 {
-                    result = await brain.RunTurnAsync(tenant.Value, deviceKey, text, ct);
+                    if (string.IsNullOrEmpty(idemKey))
+                    {
+                        result = await brain.RunTurnAsync(tenant.Value, deviceKey, text, ct);
+                    }
+                    else
+                    {
+                        // Run the brain on CancellationToken.None (NOT the request token) inside the single-flight
+                        // cache, so a client that drops mid-turn does NOT abort the work - it completes and caches,
+                        // and the client's retry gets the cached result instead of re-acting. Await with the request
+                        // token so a disconnected client still returns promptly (the underlying work continues).
+                        var work = turnCache.GetOrRunAsync(deviceKey, idemKey, () => brain.RunTurnAsync(tenant.Value, deviceKey, text, CancellationToken.None));
+                        result = await work.WaitAsync(ct);
+                    }
                 }
-                else
+                finally
                 {
-                    // Run the brain on CancellationToken.None (NOT the request token) inside the single-flight
-                    // cache, so a client that drops mid-turn does NOT abort the work - it completes and caches,
-                    // and the client's retry gets the cached result instead of re-acting. Await with the request
-                    // token so a disconnected client still returns promptly (the underlying work continues).
-                    var work = turnCache.GetOrRunAsync(deviceKey, idemKey, () => brain.RunTurnAsync(tenant.Value, deviceKey, text, CancellationToken.None));
-                    result = await work.WaitAsync(ct);
+                    gate.Release();
                 }
                 return Results.Json(new
                 {

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -396,10 +396,15 @@ public sealed class CarModeBrain
                 var credits = await timer.TimeFleetAsync(() => _fleet.GetCreditsAsync(ct));
                 if (!credits.SignedIn)
                     return Result(new { signedIn = false, message = "The Gateway is not signed in to a DevThrottle account, so there is no balance to read." });
+                // The fleet guarantees a signed-in read carries a balance (it throws on a malformed
+                // payload); this throw is the same guarantee restated here so a fake fleet in a test -
+                // or a future second implementation - can never turn "no number" into zero dollars.
+                var balanceMicros = credits.BalanceMicros
+                    ?? throw new InvalidOperationException("get_credits: signed in but no balanceMicros - the fleet must fail loud on a malformed credits payload, never hand the brain a null balance.");
                 return Result(new
                 {
                     signedIn = true,
-                    balanceDollars = Math.Round((credits.BalanceMicros ?? 0) / 1_000_000.0, 2),
+                    balanceDollars = Math.Round(balanceMicros / 1_000_000.0, 2),
                     lastActionCostDollars = credits.LastDebitMicros is { } debit ? Math.Round(debit / 1_000_000.0, 4) : (double?)null,
                 });
             }
@@ -430,8 +435,15 @@ public sealed class CarModeBrain
             }
             case "get_spend":
             {
+                // Codex review finding 6: seven days is the default for an OMITTED argument only. An
+                // explicitly supplied but invalid days value goes back to the model as a tool error it can
+                // correct - silently substituting 7 would answer a question the owner did not ask.
                 var daysText = ReadStringArg(call.ArgumentsJson, "days");
-                var days = int.TryParse(daysText, out var parsed) && parsed > 0 && parsed <= 90 ? parsed : 7;
+                int days;
+                if (string.IsNullOrWhiteSpace(daysText))
+                    days = 7;
+                else if (!int.TryParse(daysText, out days) || days < 1 || days > 90)
+                    return Result(new { error = "days must be a whole number from 1 to 90, or omitted for the default 7." });
                 var spend = await timer.TimeFleetAsync(() => _fleet.GetSpendAsync(days, ct));
                 return Result(new
                 {

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -201,6 +201,11 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         var signedIn = root.TryGetProperty("signedIn", out var si) && si.ValueKind == JsonValueKind.True;
         var balance = GetInt64OrNull(root, "balanceMicros");
         var lastDebit = GetInt64OrNull(root, "lastDebitMicros");
+        // Codex review finding 6: a signed-in response with no balance is a MALFORMED payload, and turning
+        // it into a zero-dollar answer is exactly the plausible fabricated number the no-fallback rule
+        // exists to prevent. Fail loud; the turn reports a specific contract failure instead.
+        if (signedIn && balance is null)
+            throw new InvalidOperationException("The /account/credits response said signedIn but carried no balanceMicros - malformed payload.");
         _log($"[CarModeFleet] credits: signedIn={signedIn}");
         return new CarModeCredits(signedIn, balance, lastDebit);
     }
@@ -238,9 +243,11 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
     {
         // GET /cron/jobs returns { jobs: [CronJobDto...] }; map each to the compact speakable view.
         var root = await GetJsonObjectAsync("/cron/jobs", ct);
-        var jobs = root.TryGetProperty("jobs", out var arr) && arr.ValueKind == JsonValueKind.Array
-            ? arr.EnumerateArray().ToList()
-            : new List<JsonElement>();
+        // Codex review finding 6: a response without a jobs ARRAY is a contract failure, not an empty
+        // schedule list - "you have no scheduled jobs" from a malformed body is a confident false answer.
+        if (!root.TryGetProperty("jobs", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException("The /cron/jobs response carried no jobs array - malformed payload.");
+        var jobs = arr.EnumerateArray().ToList();
         var schedules = jobs.Select(j =>
         {
             var kind = GetString(j, "scheduleKind");
@@ -371,7 +378,9 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
     private static string? NullIfEmpty(string value) => string.IsNullOrWhiteSpace(value) ? null : value;
 
     /// <summary>GET a loopback endpoint that returns a JSON array and hand back its elements. Throws on a
-    ///  non-success status (no silent empty list).</summary>
+    ///  non-success status AND on a non-array body (Codex review finding 6): every caller's endpoint
+    ///  contract is a JSON array, so a non-array body is a malformed response - treating it as an empty
+    ///  list would turn a contract failure into a confident "there are none".</summary>
     private async Task<IReadOnlyList<JsonElement>> GetJsonArrayAsync(string path, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}{path}");
@@ -381,9 +390,9 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
             throw new InvalidOperationException($"GET {path} failed: {(int)response.StatusCode} {response.StatusCode}.");
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return doc.RootElement.ValueKind == JsonValueKind.Array
-            ? doc.RootElement.EnumerateArray().Select(e => e.Clone()).ToList()
-            : new List<JsonElement>();
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException($"GET {path} returned {doc.RootElement.ValueKind}, expected a JSON array.");
+        return doc.RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
     }
 
     /// <summary>POST a JSON body to a loopback endpoint with the Bearer, throwing on a non-success status


### PR DESCRIPTION
An independent review of the fleet Assistant merge (#2125) produced seven findings; this applies the five that are real defects in the new code. The two hosted-tenant architecture findings are tracked in thefrederiksen/devthrottle_internal#935. Details are in the commit message: per-device turn serialization (closes the double-confirm race), no fabricated fleet facts (loud failures instead of plausible zeros and empty lists), the microphone capture race on cancel/quick-tap/unmount, Stop reading now actually pauses audio (including on mode switch), and strict validation of the turn envelope. Verification: Car Mode test group 134/134 with two new regression tests, client-core 591/591, cockpit 176/176, all workspaces typecheck, and the previously flaky escape-endpoint test passes alone on this tree.