### PR TITLE
Director repo-state snapshots: branches and worktrees to the Gateway (#2118)

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Fleet;
 using CcDirector.Core.Sessions;
@@ -196,6 +196,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     private Core.Activity.ActivityEventOutbox? _activityOutbox;
     private Core.Activity.ActivityEventProducer? _activityProducer;
     private ActivityEventUploader? _activityUploader;
+    private RepoStatePusher? _repoStatePusher;
     private TransientErrorAutoResume? _transientErrorAutoResume;
     private TerminalSessionRecorder? _sessionRecorder;
     private Core.Storage.TurnReviewLogger? _turnReviewLogger;
@@ -751,6 +752,20 @@ public sealed class ControlApiHost : IAsyncDisposable
         // prompt sink's pattern) and deletes an outbox record only on the Gateway's acknowledgement.
         _activityUploader = new ActivityEventUploader(() => _gatewayClient, _activityOutbox);
         _activityUploader.Start();
+        // The repo-state feed (issue #2118): every six hours, ship this machine's branches and worktrees
+        // to the Gateway so the morning report can make its stale-worktree and unmerged-branch
+        // recommendations. Only when a repository registry exists - with none there is nothing to report.
+        // Late-binds the Gateway client per cycle, exactly like the uploader above.
+        if (_repositoryRegistry is not null)
+        {
+            _repoStatePusher = new RepoStatePusher(
+                // Late-bound per cycle: the Gateway client is created after this and can be replaced when the
+                // configuration changes. A null client is an install with no Gateway - nowhere to report to.
+                (req, ct) => _gatewayClient is { } c ? c.PushRepoStateAsync(req, ct) : Task.FromResult<RepoStatePushResponse?>(null),
+                _repositoryRegistry, DirectorId, Environment.MachineName,
+                liveSessions: LiveSessionRefs);
+            _repoStatePusher.Start();
+        }
     }
 
     /// <summary>
@@ -829,6 +844,22 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// </summary>
     private List<SessionDto> SnapshotFullSessions()
         => _sessionManager.ListSessions().Select(s => ControlEndpoints.Map(s, DirectorId)).ToList();
+
+    /// <summary>
+    /// This machine's live sessions as the worktree classifier wants them (issue #2118): a worktree a
+    /// session is genuinely working in must be reported as occupied, never as abandoned work someone
+    /// could delete. Read fresh on every collection rather than captured once, so a session that started
+    /// since the last cycle still protects its worktree.
+    /// </summary>
+    private IReadOnlyList<Core.Git.LiveSessionRef> LiveSessionRefs()
+        => _sessionManager.ListSessions()
+            .Where(s => !string.IsNullOrWhiteSpace(s.RepoPath))
+            .Select(s => new Core.Git.LiveSessionRef
+            {
+                RepoPath = s.RepoPath,
+                Label = string.IsNullOrWhiteSpace(s.CustomName) ? s.Id.ToString() : s.CustomName!,
+            })
+            .ToList();
 
     private readonly Core.Git.RepositoryMonitor? _repositoryMonitor;
     private Timer? _repoPushDebounce;
@@ -1083,6 +1114,8 @@ public sealed class ControlApiHost : IAsyncDisposable
         _terminalStateDetector = null;
         _activityUploader?.Dispose();
         _activityUploader = null;
+        _repoStatePusher?.Dispose();
+        _repoStatePusher = null;
         _activityProducer?.Dispose();
         _activityProducer = null;
         _activityOutbox = null;

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -385,6 +385,43 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Push this Director's repo-state snapshots to the Gateway (issue #2118) - the branches and worktrees
+    /// of its registered repositories, which is the one git-hygiene fact the Gateway cannot observe for
+    /// itself. Returns the Gateway's acknowledgement, or NULL when the push did not land (Gateway disabled,
+    /// HTTP failure, transport fault).
+    ///
+    /// FAIL-SAFE, exactly like <see cref="PushActivityEventsAsync"/>: a failed push is logged and returns
+    /// null, and the caller simply tries again on its next cycle. It never throws into the Director, because
+    /// a hygiene feed for a morning email must not be able to disturb the sessions a person is working in.
+    /// There is no outbox and no retry queue: this pushes the CURRENT state of the repositories, so a lost
+    /// push is not lost data - the next cycle's snapshot supersedes it entirely.
+    /// </summary>
+    public async Task<RepoStatePushResponse?> PushRepoStateAsync(
+        RepoStatePushRequest request, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled) return null;
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Repositories.Count == 0) return new RepoStatePushResponse { Stored = 0 };
+
+        try
+        {
+            using var resp = await _http.PostAsJsonAsync("gateway/repostate", request, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                FileLog.Write($"[GatewayClient] PushRepoStateAsync: POST /gateway/repostate returned HTTP {(int)resp.StatusCode}");
+                return null;
+            }
+
+            return await resp.Content.ReadFromJsonAsync<RepoStatePushResponse>(ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayClient] PushRepoStateAsync FAILED: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Rename a session anywhere in the fleet via the Gateway's PATCH /sessions/{sid}, which routes the
     /// rename to the owning Director over the tunnel and returns the updated <see cref="SessionDto"/>.
     /// Issue #1490: the Director's loopback POST /fleet/rename relays here for a non-local target. Throws

--- a/src/CcDirector.ControlApi/RepoStatePusher.cs
+++ b/src/CcDirector.ControlApi/RepoStatePusher.cs
@@ -1,0 +1,170 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Ships this Director's repo-state snapshots to the Gateway on a schedule (issue #2118): once shortly
+/// after startup, then every <see cref="CycleHours"/> hours. The Gateway keeps the newest snapshot per
+/// repository, and the morning report reads it for the stale-worktree and unmerged-branch rows - the
+/// flagship content of the daily email, and the one part of it that no Gateway-side store can supply.
+///
+/// FAIL-SAFE IS THE WHOLE DESIGN, and it is stronger than "wrapped in a try/catch". This is a background
+/// feed for an email; it must never be able to disturb the sessions a person is working in. So:
+///   - the collection and the push both run off the Director's threads on a timer, never on a UI or session
+///     path;
+///   - every cycle is wrapped, and a failure is LOGGED and dropped - the next cycle simply tries again;
+///   - there is NO outbox and no retry queue, deliberately. This pushes the CURRENT state of the
+///     repositories, so a lost push is not lost data: the next cycle's snapshot supersedes it entirely.
+///     An outbox here would replay a stale picture of the repositories on top of a fresher one.
+///
+/// It is not started at all when the Director has no repository registry - there is nothing to report - and
+/// its push delegate is a no-op when no Gateway is configured, so an install with no Gateway does no work.
+/// </summary>
+public sealed class RepoStatePusher : IDisposable
+{
+    /// <summary>How long after start the first snapshot goes out. Long enough to be behind the Director's
+    /// own startup work (including the repository rescan) rather than competing with it.</summary>
+    public static readonly TimeSpan StartupDelay = TimeSpan.FromMinutes(2);
+
+    /// <summary>The cycle: every six hours, per the issue. Repository hygiene changes over days.</summary>
+    public const int CycleHours = 6;
+
+    private readonly Func<RepoStatePushRequest, CancellationToken, Task<RepoStatePushResponse?>> _push;
+    private readonly RepositoryRegistry _repositories;
+    private readonly RepoStateSnapshotCollector _collector;
+    private readonly string _directorId;
+    private readonly string _machineName;
+    private readonly Func<IReadOnlyList<LiveSessionRef>>? _liveSessions;
+    private readonly TimeSpan _startupDelay;
+    private readonly TimeSpan _cycle;
+
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+    private int _disposed;
+
+    /// <param name="push">The push itself, as a delegate rather than a Gateway client. Late-bound (the
+    /// uploader pattern - the client is created after this and can be replaced when the Gateway configuration
+    /// changes), and it is the seam a test drives, so the fail-safe promise below is PROVEN rather than
+    /// asserted in a comment. Returning null means the push did not land.</param>
+    /// <param name="liveSessions">This machine's live sessions, so a worktree someone is working in is
+    /// reported as occupied rather than as abandoned. Null means none are known.</param>
+    public RepoStatePusher(
+        Func<RepoStatePushRequest, CancellationToken, Task<RepoStatePushResponse?>> push,
+        RepositoryRegistry repositories,
+        string directorId,
+        string machineName,
+        Func<IReadOnlyList<LiveSessionRef>>? liveSessions = null,
+        RepoStateSnapshotCollector? collector = null,
+        TimeSpan? startupDelay = null,
+        TimeSpan? cycle = null)
+    {
+        _push = push ?? throw new ArgumentNullException(nameof(push));
+        _repositories = repositories ?? throw new ArgumentNullException(nameof(repositories));
+        _directorId = directorId ?? "";
+        _machineName = machineName ?? "";
+        _liveSessions = liveSessions;
+        _collector = collector ?? new RepoStateSnapshotCollector();
+        _startupDelay = startupDelay ?? StartupDelay;
+        _cycle = cycle ?? TimeSpan.FromHours(CycleHours);
+    }
+
+    /// <summary>Start the background loop. Idempotent.</summary>
+    public void Start()
+    {
+        if (_loop is not null) return;
+        _cts = new CancellationTokenSource();
+        _loop = Task.Run(() => RunAsync(_cts.Token));
+        FileLog.Write($"[RepoStatePusher] Start: first push in {_startupDelay.TotalMinutes:0} minutes, then every {_cycle.TotalHours:0} hours");
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(_startupDelay, ct).ConfigureAwait(false);
+            while (!ct.IsCancellationRequested)
+            {
+                await PushOnceAsync(ct).ConfigureAwait(false);
+                await Task.Delay(_cycle, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ordinary shutdown.
+        }
+        catch (Exception ex)
+        {
+            // The loop itself dying is the one failure a per-cycle catch cannot cover, and it would silently
+            // end the feed for the life of the process - so it is logged as loudly as anything here gets.
+            FileLog.Write($"[RepoStatePusher] the push loop ENDED unexpectedly; no further repo state will be reported until this Director restarts: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Collect and push once. Internal (not private) so a test can drive one cycle deterministically instead
+    /// of waiting on the timer. Returns the number of repositories the Gateway acknowledged, or null when
+    /// the cycle did not land.
+    /// </summary>
+    internal async Task<int?> PushOnceAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var repositories = _repositories.Repositories;
+            if (repositories.Count == 0)
+            {
+                FileLog.Write("[RepoStatePusher] PushOnce: no registered repositories, nothing to report");
+                return 0;
+            }
+
+            var snapshots = await _collector
+                .CollectAsync(repositories, _liveSessions?.Invoke(), ct)
+                .ConfigureAwait(false);
+
+            if (snapshots.Count == 0)
+            {
+                // Every repository failed to collect. Pushing an EMPTY batch would be harmless (the Gateway
+                // overwrites nothing), but saying so in the log matters: silence here would look identical
+                // to a healthy machine with no repositories.
+                FileLog.Write("[RepoStatePusher] PushOnce: collected 0 snapshots from " +
+                              $"{repositories.Count} registered repositories - nothing pushed this cycle");
+                return 0;
+            }
+
+            var response = await _push(new RepoStatePushRequest
+            {
+                DirectorId = _directorId,
+                MachineName = _machineName,
+                Repositories = snapshots,
+            }, ct).ConfigureAwait(false);
+
+            if (response is null)
+            {
+                FileLog.Write("[RepoStatePusher] PushOnce: the Gateway did not accept the push; retrying next cycle");
+                return null;
+            }
+
+            FileLog.Write($"[RepoStatePusher] PushOnce: the Gateway stored {response.Stored} repository snapshots");
+            return response.Stored;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepoStatePusher] PushOnce FAILED, retrying next cycle: {ex.Message}");
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        try { _cts?.Cancel(); } catch { /* best effort */ }
+        _cts?.Dispose();
+        FileLog.Write("[RepoStatePusher] Dispose: stopped");
+    }
+}

--- a/src/CcDirector.Core.Tests/RepoStateSnapshotCollectorTests.cs
+++ b/src/CcDirector.Core.Tests/RepoStateSnapshotCollectorTests.cs
@@ -1,0 +1,217 @@
+using System.Diagnostics;
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The Director's repo-state collector (issue #2118), against REAL git repositories rather than a stub -
+/// the whole value of this feed is that it reports what git actually says, and a faked git proves nothing
+/// about "is this branch merged".
+///
+/// The claims that matter, and why:
+///  - MERGED VERSUS UNMERGED must be right in both directions. A false "merged" recommends deleting the
+///    owner's only copy of unmerged work; a false "unmerged" turns the email into noise.
+///  - AN UNDETECTABLE DEFAULT BRANCH RECORDS NULL. There is nothing to be merged INTO, so every merged-ness
+///    is null - not false, which would read as "definitely not merged" about branches nobody inspected.
+///  - THE PAYLOAD CARRIES NO CONTENT. Asserted on the SERIALIZED snapshot of a repository whose files and
+///    commit messages contain a distinctive marker: if any of it ever reaches the wire, the marker shows up.
+/// </summary>
+public sealed class RepoStateSnapshotCollectorTests : IDisposable
+{
+    /// <summary>A string that appears ONLY in file contents and commit messages, never in a name or path.
+    /// Its presence anywhere in the serialized payload is proof that content leaked.</summary>
+    private const string SecretMarker = "TOP-SECRET-CONTENT-MARKER-9f3a";
+
+    private readonly string _root;
+    private readonly string _origin;
+    private readonly string _repo;
+
+    public RepoStateSnapshotCollectorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-repostate-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _origin = Path.Combine(_root, "origin.git");
+        _repo = Path.Combine(_root, "repo");
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", "--bare", _origin);
+        RunGit(_root, "-c", "init.defaultBranch=main", "clone", _origin, _repo);
+        RunGit(_repo, "config", "user.email", "test@cc-director.local");
+        RunGit(_repo, "config", "user.name", "CC Director Test");
+        RunGit(_repo, "config", "commit.gpgsign", "false");
+        WriteFile("README.md", $"init {SecretMarker}\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", $"initial commit mentioning {SecretMarker}");
+        RunGit(_repo, "branch", "-M", "main");
+        RunGit(_repo, "push", "-u", "origin", "main");
+    }
+
+    public void Dispose()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    private RepositoryConfig Repo(string? path = null) =>
+        new() { Name = "repo-under-test", Path = path ?? _repo };
+
+    [Fact]
+    public async Task Merged_and_unmerged_branches_are_told_apart_in_both_directions()
+    {
+        // merged: pushed, then fast-forwarded into main - every commit is contained in the default branch.
+        RunGit(_repo, "checkout", "-b", "merged-branch");
+        WriteFile("m.txt", $"m {SecretMarker}\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", $"merged work {SecretMarker}");
+        RunGit(_repo, "push", "-u", "origin", "merged-branch");
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "merge", "--ff-only", "merged-branch");
+        RunGit(_repo, "push", "origin", "main");
+
+        // unmerged: two commits main does not have.
+        RunGit(_repo, "checkout", "-b", "unmerged-branch");
+        WriteFile("u1.txt", "u1\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "first");
+        WriteFile("u2.txt", "u2\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "second");
+        RunGit(_repo, "checkout", "main");
+
+        var snapshot = Assert.Single(await new RepoStateSnapshotCollector().CollectAsync(new[] { Repo() }));
+
+        Assert.Equal("origin/main", snapshot.DefaultBranch);
+        Assert.Equal("main", snapshot.CurrentBranch);
+
+        var merged = Assert.Single(snapshot.Branches, b => b.Name == "merged-branch");
+        Assert.True(merged.MergedIntoDefault);
+        Assert.Equal(0, merged.CommitsAheadOfDefault);
+        Assert.NotNull(merged.TipCommitUtc);
+
+        var unmerged = Assert.Single(snapshot.Branches, b => b.Name == "unmerged-branch");
+        Assert.False(unmerged.MergedIntoDefault);
+        Assert.Equal(2, unmerged.CommitsAheadOfDefault);
+
+        var main = Assert.Single(snapshot.Branches, b => b.Name == "main");
+        Assert.True(main.CheckedOut);
+    }
+
+    [Fact]
+    public async Task An_undetectable_default_branch_records_null_and_never_guesses()
+    {
+        // A repository with no origin at all: there is no origin/main and no origin/master, so there is
+        // nothing to be merged into. Every merged-ness must be null - NOT false, which a downstream reader
+        // would legitimately treat as "this branch definitely has unmerged work".
+        var lonely = Path.Combine(_root, "lonely");
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", lonely);
+        RunGit(lonely, "config", "user.email", "test@cc-director.local");
+        RunGit(lonely, "config", "user.name", "CC Director Test");
+        RunGit(lonely, "config", "commit.gpgsign", "false");
+        File.WriteAllText(Path.Combine(lonely, "a.txt"), "a\n");
+        RunGit(lonely, "add", "-A");
+        RunGit(lonely, "commit", "-m", "only commit");
+
+        var snapshot = Assert.Single(
+            await new RepoStateSnapshotCollector().CollectAsync(new[] { Repo(lonely) }));
+
+        Assert.Null(snapshot.DefaultBranch);
+        Assert.NotEmpty(snapshot.Branches);
+        Assert.All(snapshot.Branches, b => Assert.Null(b.MergedIntoDefault));
+    }
+
+    [Fact]
+    public async Task Linked_worktrees_are_reported_and_the_primary_checkout_is_not_one_of_them()
+    {
+        RunGit(_repo, "branch", "wt-branch");
+        var worktreePath = Path.Combine(_root, "wt-one");
+        RunGit(_repo, "worktree", "add", worktreePath, "wt-branch");
+
+        var snapshot = Assert.Single(await new RepoStateSnapshotCollector().CollectAsync(new[] { Repo() }));
+
+        var worktree = Assert.Single(snapshot.Worktrees);
+        Assert.Equal("wt-branch", worktree.Branch);
+        Assert.Contains("wt-one", worktree.Path);
+        // The primary checkout IS the repository; listing it as one of its own worktrees would make every
+        // repository look like it had one more stale checkout than it has.
+        Assert.DoesNotContain(snapshot.Worktrees, w => w.Path.TrimEnd('\\', '/') == _repo.TrimEnd('\\', '/'));
+        // Its branch is unmerged (it carries no commits main lacks, so in fact it IS contained) - the point
+        // here is only that the verdict is carried across from the one branch inventory, never recomputed.
+        var branch = Assert.Single(snapshot.Branches, b => b.Name == "wt-branch");
+        Assert.Equal(branch.MergedIntoDefault, worktree.BranchMergedIntoDefault);
+    }
+
+    [Fact]
+    public async Task A_repository_that_cannot_be_collected_is_OMITTED_never_pushed_empty()
+    {
+        // A path that is not a git repository at all. An empty snapshot for it would reach the Gateway as
+        // "no branches, no worktrees" - a clean bill of health invented out of a failure - so it must not
+        // appear in the batch, while the healthy repository beside it still does.
+        var notARepo = Path.Combine(_root, "not-a-repo");
+        Directory.CreateDirectory(notARepo);
+
+        var snapshots = await new RepoStateSnapshotCollector()
+            .CollectAsync(new[] { Repo(), Repo(notARepo) });
+
+        Assert.Single(snapshots);
+        Assert.Equal(_repo, snapshots[0].Path);
+    }
+
+    [Fact]
+    public async Task A_registered_path_that_no_longer_exists_is_skipped_without_failing_the_batch()
+    {
+        var snapshots = await new RepoStateSnapshotCollector()
+            .CollectAsync(new[] { Repo(Path.Combine(_root, "gone")), Repo() });
+
+        Assert.Single(snapshots);
+        Assert.Equal(_repo, snapshots[0].Path);
+    }
+
+    [Fact]
+    public async Task The_serialized_payload_carries_no_file_content_and_no_commit_message()
+    {
+        // The repository's files AND its commit messages contain the marker; a worktree and a second branch
+        // widen the surface. If the collector ever grows a field that carries content, the marker appears.
+        RunGit(_repo, "checkout", "-b", "another");
+        WriteFile("secret.txt", $"{SecretMarker}\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", $"a commit message containing {SecretMarker}");
+        RunGit(_repo, "checkout", "main");
+        RunGit(_repo, "worktree", "add", Path.Combine(_root, "wt-two"), "another");
+
+        var snapshots = await new RepoStateSnapshotCollector().CollectAsync(new[] { Repo() });
+        var json = JsonSerializer.Serialize(snapshots, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.DoesNotContain(SecretMarker, json, StringComparison.Ordinal);
+        // And prove the assertion above can actually fail - a payload that carried the branch name would
+        // contain "another", so the marker check is testing content specifically, not an empty payload.
+        Assert.Contains("another", json, StringComparison.Ordinal);
+    }
+
+    private void WriteFile(string rel, string content)
+        => File.WriteAllText(Path.Combine(_repo, rel), content);
+
+    private static string RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {stderr}");
+        return stdout;
+    }
+}

--- a/src/CcDirector.Core/Git/GitBranchService.cs
+++ b/src/CcDirector.Core/Git/GitBranchService.cs
@@ -21,6 +21,37 @@ public sealed record BranchInfo
 
     public bool SafeToDelete { get; init; }
     public string Explanation { get; init; } = "";
+
+    /// <summary>
+    /// Whether every commit on this branch is already contained in the default branch (issue #2118).
+    /// NULL means NOT DETERMINED - there was no detectable default branch, or the containment inspection
+    /// failed - and it must never be read as either true or false.
+    ///
+    /// DELIBERATELY NARROWER THAN <see cref="SafeToDelete"/>, and the two must not be substituted for one
+    /// another. Safe-to-delete is a DISPOSAL verdict that also accepts "the origin branch is gone" and "the
+    /// pull request merged", and refuses whenever the branch is checked out. Containment is a plain
+    /// statement about commits. The morning report needs the plain statement - a branch checked out in a
+    /// worktree is exactly the case it wants to report on, and safe-to-delete says false about it for a
+    /// reason that has nothing to do with whether the work is merged.
+    /// </summary>
+    public bool? MergedIntoDefault { get; init; }
+}
+
+/// <summary>
+/// A repository's branch inventory plus the default branch every verdict in it was measured against
+/// (issue #2118). The default branch is carried WITH the branches, rather than resolved a second time by
+/// the caller, because a caller that resolved it independently could disagree with the service that
+/// computed the containment - and a "merged into main" claim measured against a different ref than the
+/// caller believes is exactly the kind of confidently-wrong statement the morning report must not make.
+/// A NULL <see cref="DefaultBranch"/> means it was undetectable, and then every branch's
+/// <see cref="BranchInfo.MergedIntoDefault"/> is null too.
+/// </summary>
+public sealed record BranchInventory
+{
+    /// <summary>The ref every containment verdict was measured against (e.g. "origin/main"), or null.</summary>
+    public string? DefaultBranch { get; init; }
+
+    public IReadOnlyList<BranchInfo> Branches { get; init; } = Array.Empty<BranchInfo>();
 }
 
 /// <summary>
@@ -76,8 +107,15 @@ public sealed class GitBranchService
     }
 
     public async Task<IReadOnlyList<BranchInfo>> ListAsync(string repoPath, CancellationToken ct = default)
+        => (await ListInventoryAsync(repoPath, ct)).Branches;
+
+    /// <summary>
+    /// The branch list AND the default branch it was measured against (issue #2118). <see cref="ListAsync"/>
+    /// is this method's branches; nothing computes a branch verdict twice.
+    /// </summary>
+    public async Task<BranchInventory> ListInventoryAsync(string repoPath, CancellationToken ct = default)
     {
-        FileLog.Write($"[GitBranchService] ListAsync: {repoPath}");
+        FileLog.Write($"[GitBranchService] ListInventoryAsync: {repoPath}");
         var results = new List<BranchInfo>();
 
         var mainRef = await ResolveMainRefAsync(repoPath, ct);
@@ -89,7 +127,7 @@ public sealed class GitBranchService
             "--format=%(HEAD)%09%(refname:short)%09%(committerdate:unix)%09%(objectname)"
         }, ct);
         if (!list.Success)
-            return results;
+            return new BranchInventory { DefaultBranch = mainRef, Branches = results };
 
         // Branches held by linked worktrees (never deletable from under them).
         var worktreeBranches = await BranchesCheckedOutInWorktreesAsync(repoPath, ct);
@@ -109,6 +147,10 @@ public sealed class GitBranchService
             bool inspectionOk = mainRef != null;
             bool originGone = false, containedInMain = false, prMerged = false;
             int ahead = 0, behind = 0;
+            // Null until the containment inspection actually succeeds (issue #2118). With no default branch
+            // there is nothing to be contained in, and a failed `git cherry` proves nothing either way - so
+            // both stay "not determined" rather than collapsing to the false that `containedInMain` holds.
+            bool? mergedIntoDefault = null;
 
             if (mainRef != null)
             {
@@ -125,6 +167,8 @@ public sealed class GitBranchService
                 containedInMain = cherry.Success && !cherry.Output
                     .Split('\n', StringSplitOptions.RemoveEmptyEntries)
                     .Any(l => l.TrimStart().StartsWith('+'));
+                if (cherry.Success)
+                    mergedIntoDefault = containedInMain;
 
                 var counts = await _git.RunAsync(repoPath, new[] { "rev-list", "--left-right", "--count", $"{mainRef}...{name}" }, ct);
                 var nums = counts.Output.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -149,10 +193,11 @@ public sealed class GitBranchService
                 LastCommitUtc = lastCommit,
                 SafeToDelete = safe,
                 Explanation = why,
+                MergedIntoDefault = mergedIntoDefault,
             });
         }
 
-        return results;
+        return new BranchInventory { DefaultBranch = mainRef, Branches = results };
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Git/RepoStateSnapshotCollector.cs
+++ b/src/CcDirector.Core/Git/RepoStateSnapshotCollector.cs
@@ -1,0 +1,139 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Builds the Director's repo-state snapshots (issue #2118) - branches and worktrees per registered
+/// repository - for the periodic push to the Gateway. This is the one hygiene feed the morning report
+/// cannot get from any Gateway-side store: the Gateway knows a repository exists, but only the machine
+/// holding the checkout can enumerate its branches and worktrees.
+///
+/// IT COLLECTS NAMES, PATHS, COUNTS AND DATES, AND NOTHING ELSE. No file contents, no diffs, no commit
+/// messages ever enter a snapshot - see <see cref="RepoStateSnapshotDto"/> for why that is a boundary and
+/// not a preference. Everything here comes from git plumbing already used elsewhere in the Director
+/// (<see cref="GitBranchService"/>, <see cref="WorktreeInventoryService"/>), so there is no second, subtly
+/// different notion of "merged" in the product.
+///
+/// IT NEVER GUESSES. A repository whose default branch cannot be resolved records a null default branch
+/// and null merged-ness on every branch and worktree; a repository whose enumeration fails is OMITTED from
+/// the batch rather than pushed as an empty one. An empty snapshot and a failed one look identical on the
+/// receiving side, and the report would read the failure as "this repository is perfectly clean".
+/// </summary>
+public sealed class RepoStateSnapshotCollector
+{
+    private readonly GitBranchService _branches;
+    private readonly WorktreeInventoryService _worktrees;
+    private readonly Func<DateTime> _utcNow;
+
+    public RepoStateSnapshotCollector(
+        GitBranchService? branches = null,
+        WorktreeInventoryService? worktrees = null,
+        Func<DateTime>? utcNow = null)
+    {
+        _branches = branches ?? new GitBranchService();
+        _worktrees = worktrees ?? new WorktreeInventoryService();
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Collect a snapshot for every repository in <paramref name="repositories"/>. One repository's failure
+    /// is isolated: it is logged and OMITTED, and the rest of the batch is still collected.
+    /// </summary>
+    /// <param name="liveSessions">Sessions running on this machine, so a worktree a session is working in
+    /// is reported as occupied instead of as an abandoned one.</param>
+    public async Task<List<RepoStateSnapshotDto>> CollectAsync(
+        IEnumerable<RepositoryConfig> repositories,
+        IReadOnlyList<LiveSessionRef>? liveSessions = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(repositories);
+
+        var snapshots = new List<RepoStateSnapshotDto>();
+        foreach (var repo in repositories)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(repo.Path) || !Directory.Exists(repo.Path))
+            {
+                FileLog.Write($"[RepoStateSnapshotCollector] skipped a repository whose path is missing: {repo.Path}");
+                continue;
+            }
+
+            try
+            {
+                snapshots.Add(await CollectOneAsync(repo, liveSessions, ct));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Isolated per repository, and OMITTED rather than pushed empty: a pushed empty snapshot
+                // would read downstream as "no branches, no worktrees, nothing to do here" - a clean bill
+                // of health invented out of a failure.
+                FileLog.Write($"[RepoStateSnapshotCollector] CollectOne FAILED for {repo.Path}, omitting it from the batch: {ex.Message}");
+            }
+        }
+
+        FileLog.Write($"[RepoStateSnapshotCollector] CollectAsync: collected {snapshots.Count} repository snapshots");
+        return snapshots;
+    }
+
+    private async Task<RepoStateSnapshotDto> CollectOneAsync(
+        RepositoryConfig repo, IReadOnlyList<LiveSessionRef>? liveSessions, CancellationToken ct)
+    {
+        // ONE branch inventory per repository, and the worktree merged-ness is read back out of it rather
+        // than computed a second way. Two independent notions of "merged" in one snapshot would eventually
+        // disagree, and the report would show a worktree as safe to remove whose branch it also lists as
+        // unmerged - in the same email.
+        var inventory = await _branches.ListInventoryAsync(repo.Path, ct);
+        var byBranch = inventory.Branches.ToDictionary(b => b.Name, StringComparer.Ordinal);
+
+        // fetchPrune: false - the collector runs on a timer in the background and must not mutate the
+        // owner's repositories or spend network time on their behalf. The origin-gone signal it would
+        // refresh is not one this snapshot carries.
+        var worktrees = await _worktrees.GetInventoryAsync(repo.Path, fetchPrune: false, liveSessions, ct);
+        if (!worktrees.Success)
+            throw new InvalidOperationException(
+                $"the worktree enumeration failed: {worktrees.Error ?? "no reason reported"}");
+
+        var primary = worktrees.Worktrees.FirstOrDefault(w => w.IsPrimary);
+        var current = inventory.Branches.FirstOrDefault(b => b.IsCurrent);
+
+        return new RepoStateSnapshotDto
+        {
+            Name = repo.Name,
+            Path = repo.Path,
+            CollectedAtUtc = _utcNow(),
+            DefaultBranch = inventory.DefaultBranch,
+            CurrentBranch = current?.Name,
+            IsDirty = primary is not null && !primary.IsClean,
+            Branches = inventory.Branches.Select(b => new RepoStateBranchDto
+            {
+                Name = b.Name,
+                TipCommitUtc = b.LastCommitUtc,
+                CommitsAheadOfDefault = b.AheadOfMain,
+                MergedIntoDefault = b.MergedIntoDefault,
+                CheckedOut = b.IsCurrent || b.CheckedOutInWorktree,
+            }).ToList(),
+            Worktrees = worktrees.Worktrees
+                .Where(w => !w.IsPrimary)   // the primary checkout is the repository, not one of its worktrees
+                .Select(w => new RepoStateWorktreeDto
+                {
+                    Path = w.Path,
+                    Branch = w.Branch,
+                    TipCommitUtc = w.Branch is not null && byBranch.TryGetValue(w.Branch, out var wb)
+                        ? wb.LastCommitUtc
+                        : null,
+                    LastActivityUtc = w.LastActivityUtc,
+                    IsDirty = !w.IsClean,
+                    BranchMergedIntoDefault = w.Branch is not null && byBranch.TryGetValue(w.Branch, out var mb)
+                        ? mb.MergedIntoDefault
+                        : null,
+                    HasLiveSession = w.OpenSessions.Count > 0,
+                }).ToList(),
+        };
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/RepoStateDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/RepoStateDtos.cs
@@ -1,0 +1,126 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One repository's git-hygiene snapshot as a Director observes it (issue #2118, slice 1 of #2096) - the
+/// one data feed the morning report cannot get from any store the Gateway already has. The Gateway knows a
+/// repository EXISTS; only the machine holding the checkout can say what its branches and worktrees look
+/// like.
+///
+/// NAMES, PATHS, COUNTS AND DATES ONLY - AND THAT IS A HARD BOUNDARY, NOT A STYLE PREFERENCE. There is no
+/// field here for file contents, for a diff, or for a commit MESSAGE, and none may be added: this payload
+/// leaves the owner's machine and lands in a hosted, multi-tenant database, so anything it can carry is
+/// something a private repository can leak. A commit SHA is a name; a commit message is content.
+/// <c>RepoStatePayloadTests</c> asserts the serialized payload against that boundary by inspection of the
+/// contract's own shape, so a well-meaning "just add the subject line" fails the build rather than shipping.
+/// </summary>
+public sealed class RepoStateSnapshotDto
+{
+    /// <summary>The repository's display name as the Director's registry knows it.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>The absolute path of the PRIMARY checkout on the Director's machine.</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>When the Director collected this snapshot.</summary>
+    public DateTime CollectedAtUtc { get; set; }
+
+    /// <summary>
+    /// The repository's default branch (e.g. "main"), or NULL when the Director could not determine it.
+    /// Null is a real answer and is never guessed: without a default branch there is nothing to be merged
+    /// INTO, so every <see cref="RepoStateBranchDto.MergedIntoDefault"/> in this snapshot is also null and
+    /// no hygiene recommendation is made about this repository.
+    /// </summary>
+    public string? DefaultBranch { get; set; }
+
+    /// <summary>The branch checked out in the MAIN working tree, or null when it is on a detached head.</summary>
+    public string? CurrentBranch { get; set; }
+
+    /// <summary>True when the main working tree has any uncommitted change.</summary>
+    public bool IsDirty { get; set; }
+
+    /// <summary>Local branches. Excludes nothing - the report does the excluding, so the feed stays factual.</summary>
+    public List<RepoStateBranchDto> Branches { get; set; } = new();
+
+    /// <summary>Linked worktrees (the primary checkout is not one).</summary>
+    public List<RepoStateWorktreeDto> Worktrees { get; set; } = new();
+}
+
+/// <summary>One local branch: its name, how old its tip is, how far ahead it is, and whether it is merged.</summary>
+public sealed class RepoStateBranchDto
+{
+    public string Name { get; set; } = "";
+
+    /// <summary>The tip commit's author/committer date, or null when git did not report one.</summary>
+    public DateTime? TipCommitUtc { get; set; }
+
+    /// <summary>Commits this branch carries that the default branch does not.</summary>
+    public int CommitsAheadOfDefault { get; set; }
+
+    /// <summary>
+    /// Whether every commit on this branch is already contained in the default branch. NULL means NOT
+    /// DETERMINED - the default branch was undetectable, or the inspection failed - and a null must never
+    /// be read as either true or false: "we could not tell" is the answer, and a recommendation built on
+    /// it would be a guess about the owner's unmerged work.
+    /// </summary>
+    public bool? MergedIntoDefault { get; set; }
+
+    /// <summary>True when this branch is checked out in the main tree or in a linked worktree.</summary>
+    public bool CheckedOut { get; set; }
+}
+
+/// <summary>One linked worktree: where it is, what it holds, and whether its branch is already merged.</summary>
+public sealed class RepoStateWorktreeDto
+{
+    /// <summary>The worktree's absolute path on the Director's machine.</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>The branch it holds, or null on a detached head.</summary>
+    public string? Branch { get; set; }
+
+    /// <summary>The tip commit's date of the branch this worktree holds, or null when it holds no named
+    /// branch (detached head) or git reported no date.</summary>
+    public DateTime? TipCommitUtc { get; set; }
+
+    /// <summary>
+    /// The most recent of the worktree's last commit, its folder's change time, and its HEAD reflog - the
+    /// honest "when was this last touched". Carried ALONGSIDE <see cref="TipCommitUtc"/> and not instead of
+    /// it, because they answer different questions and the report needs this one: a worktree whose last
+    /// commit is three weeks old but whose files were edited this morning is being worked in, and calling
+    /// it stale on the commit date alone would recommend deleting live work.
+    /// </summary>
+    public DateTime? LastActivityUtc { get; set; }
+
+    /// <summary>True when the worktree has any uncommitted change.</summary>
+    public bool IsDirty { get; set; }
+
+    /// <summary>Whether its branch is contained in the default branch. NULL means not determined - see
+    /// <see cref="RepoStateBranchDto.MergedIntoDefault"/>.</summary>
+    public bool? BranchMergedIntoDefault { get; set; }
+
+    /// <summary>True when a live Director session is working in this worktree right now.</summary>
+    public bool HasLiveSession { get; set; }
+}
+
+/// <summary>
+/// A Director's batched repo-state push: every registered repository in one request. The DIRECTOR is
+/// identified by its authenticated device key, never by anything in this body - the tenant and the Director
+/// identity both come from the credential, so a payload cannot claim to be someone else's machine.
+/// </summary>
+public sealed class RepoStatePushRequest
+{
+    /// <summary>The pushing Director's id. Used as the per-repository row key beside the tenant; it is NOT
+    /// an authorization claim (the device key is).</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>The machine's display name, for the report's deep links.</summary>
+    public string MachineName { get; set; } = "";
+
+    public List<RepoStateSnapshotDto> Repositories { get; set; } = new();
+}
+
+/// <summary>What the Gateway tells a pushing Director it durably stored.</summary>
+public sealed class RepoStatePushResponse
+{
+    public int Stored { get; set; }
+    public DateTime ReceivedAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724211742_AddRepoState.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724211742_AddRepoState.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724211742_AddRepoState")]
+    partial class AddRepoState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,84 +57,84 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -137,108 +146,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", (string)null);
+                    b.ToTable("activity_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -247,108 +256,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", (string)null);
+                    b.ToTable("device_credentials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", (string)null);
+                    b.ToTable("device_import_markers", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("TenantId", "Term");
 
@@ -356,99 +369,100 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", (string)null);
+                    b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", (string)null);
+                    b.ToTable("dictation_suggestion_scans", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", (string)null);
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
@@ -456,43 +470,43 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", (string)null);
+                    b.ToTable("dictation_transcripts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
+                    b.Property<Guid>("Subject")
+                        .HasColumnType("uuid")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", null, t =>
+                    b.ToTable("entitlements", "gateway", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -501,38 +515,38 @@ namespace CcDirector.Gateway.Data.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -545,40 +559,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -591,105 +605,107 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.RepoStateEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BranchesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CollectedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CurrentBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefaultBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDirty")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ReceivedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("WorktreesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "DirectorId", "RepoPath");
 
@@ -697,55 +713,56 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "ReceivedAtUtc");
 
-                    b.ToTable("repo_state", (string)null);
+                    b.ToTable("repo_state", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -753,161 +770,165 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", (string)null);
+                    b.ToTable("tenant_settings", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -915,75 +936,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -991,71 +1012,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1065,92 +1086,93 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", (string)null);
+                    b.ToTable("workflow_tenant_overrides", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -1159,7 +1181,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1167,28 +1189,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -1199,18 +1221,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -1230,36 +1252,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -1284,35 +1306,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1323,37 +1345,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -1364,23 +1386,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -1400,26 +1422,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1430,34 +1452,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724211742_AddRepoState.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724211742_AddRepoState.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepoState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "repo_state",
+                schema: "gateway",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "text", nullable: false),
+                    DirectorId = table.Column<string>(type: "text", nullable: false),
+                    RepoPath = table.Column<string>(type: "text", nullable: false),
+                    MachineName = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    DefaultBranch = table.Column<string>(type: "text", nullable: true),
+                    CurrentBranch = table.Column<string>(type: "text", nullable: true),
+                    IsDirty = table.Column<bool>(type: "boolean", nullable: false),
+                    CollectedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReceivedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    BranchesJson = table.Column<string>(type: "text", nullable: false),
+                    WorktreesJson = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_repo_state", x => new { x.tenant_id, x.DirectorId, x.RepoPath });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_repo_state_tenant_id",
+                schema: "gateway",
+                table: "repo_state",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_repo_state_tenant_id_ReceivedAtUtc",
+                schema: "gateway",
+                table: "repo_state",
+                columns: new[] { "tenant_id", "ReceivedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "repo_state",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -661,6 +661,58 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.ToTable("push_subscriptions", "gateway");
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.RepoStateEntity", b =>
+                {
+                    b.Property<string>("TenantId")
+                        .HasColumnType("text")
+                        .HasColumnName("tenant_id");
+
+                    b.Property<string>("DirectorId")
+                        .HasColumnType("text");
+
+                    b.Property<string>("RepoPath")
+                        .HasColumnType("text");
+
+                    b.Property<string>("BranchesJson")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("CollectedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CurrentBranch")
+                        .HasColumnType("text");
+
+                    b.Property<string>("DefaultBranch")
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsDirty")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("MachineName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("ReceivedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("WorktreesJson")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("TenantId", "DirectorId", "RepoPath");
+
+                    b.HasIndex("TenantId");
+
+                    b.HasIndex("TenantId", "ReceivedAtUtc");
+
+                    b.ToTable("repo_state", "gateway");
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")

--- a/src/CcDirector.Gateway.Tests/MorningReportBuilderTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportBuilderTests.cs
@@ -322,6 +322,37 @@ public sealed class MorningReportBuilderTests : IDisposable
     }
 
     [Fact]
+    public void An_open_wait_older_than_the_silence_bar_is_not_reported()
+    {
+        // The defect the first real hosted call exposed: nine rows aged 69-129 hours, every one a true
+        // statement about the ledger and a false statement about the owner's morning. A session that stops
+        // without an exit event leaves its wait open forever, so the age grows without bound and never
+        // resolves. After the bar the Gateway says nothing rather than something plausible.
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "long-gone", GovernanceEventState.WaitingOnHuman,
+            Now - MorningReportBuilder.WaitingReportMaxAge - TimeSpan.FromHours(1));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        Assert.Empty(report.Attention);
+    }
+
+    [Fact]
+    public void A_wait_just_INSIDE_the_silence_bar_is_still_reported()
+    {
+        // The bar has two failure directions. Set it wrong the other way and every genuine multi-day wait
+        // vanishes from the email, which is the same silence dressed as tidiness.
+        var db = DbAs(Alice);
+        SeedSessionEvent(db, Alice, "still-waiting", GovernanceEventState.WaitingOnHuman,
+            Now - MorningReportBuilder.WaitingReportMaxAge + TimeSpan.FromHours(1));
+
+        var report = NewBuilder(db).Build("alice@example.com", Alice, Window());
+
+        var item = Assert.IsType<WaitingSessionAttentionDto>(Assert.Single(report.Attention));
+        Assert.Equal("still-waiting", item.Session);
+    }
+
+    [Fact]
     public void A_session_older_than_the_lookback_horizon_is_not_reported()
     {
         var db = DbAs(Alice);

--- a/src/CcDirector.Gateway.Tests/RepoHygieneFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoHygieneFoldTests.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Reports;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The hygiene fold (issues #2118 + #2119): stored repo-state snapshots into the morning report's
+/// stale-worktree and unmerged-branch rows.
+///
+/// Every rule here is conservative in one direction, because a wrong answer in this email costs the owner
+/// work rather than time. The tests are written as the harms they prevent: never call unmerged work safe to
+/// remove, never call an unknown state a finished one, never suggest deleting a dirty or occupied worktree,
+/// and never report an age that was not measured.
+/// </summary>
+public sealed class RepoHygieneFoldTests
+{
+    private static readonly DateTime Now = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    private static StoredRepoState Repo(
+        string name = "devthrottle",
+        string? defaultBranch = "origin/main",
+        string? currentBranch = "main",
+        IEnumerable<RepoStateWorktreeDto>? worktrees = null,
+        IEnumerable<RepoStateBranchDto>? branches = null) => new()
+    {
+        DirectorId = "dir-1",
+        MachineName = "SOREN",
+        Name = name,
+        Path = "D:/ReposFred/" + name,
+        DefaultBranch = defaultBranch,
+        CurrentBranch = currentBranch,
+        CollectedAtUtc = Now,
+        ReceivedAtUtc = Now,
+        Worktrees = worktrees?.ToList() ?? new List<RepoStateWorktreeDto>(),
+        Branches = branches?.ToList() ?? new List<RepoStateBranchDto>(),
+    };
+
+    private static RepoStateWorktreeDto Worktree(
+        string path, double ageDays, bool? merged = true, bool dirty = false, bool live = false) => new()
+    {
+        Path = path,
+        Branch = "wt/" + path.Split('/').Last(),
+        TipCommitUtc = Now.AddDays(-ageDays),
+        LastActivityUtc = Now.AddDays(-ageDays),
+        IsDirty = dirty,
+        BranchMergedIntoDefault = merged,
+        HasLiveSession = live,
+    };
+
+    private static RepoStateBranchDto Branch(string name, double ageDays, bool? merged = false, int commits = 3) => new()
+    {
+        Name = name,
+        TipCommitUtc = Now.AddDays(-ageDays),
+        CommitsAheadOfDefault = commits,
+        MergedIntoDefault = merged,
+        CheckedOut = false,
+    };
+
+    private static List<T> Of<T>(IEnumerable<MorningAttentionItemDto> items) => items.OfType<T>().Cast<T>().ToList();
+
+    // ---- nothing invented ------------------------------------------------------------------------------
+
+    [Fact]
+    public void No_repositories_yields_no_rows_at_all()
+    {
+        Assert.Empty(RepoHygieneFold.Items(Array.Empty<StoredRepoState>(), Now));
+    }
+
+    [Fact]
+    public void A_tidy_repository_yields_no_rows()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/fresh", ageDays: 1) },
+                 branches: new[] { Branch("feature", ageDays: 0.1) }),
+        }, Now);
+
+        Assert.Empty(items);
+    }
+
+    // ---- safe to remove is the narrow claim ------------------------------------------------------------
+
+    [Fact]
+    public void Old_clean_unoccupied_and_MERGED_is_the_only_thing_called_safe_to_remove()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/done-work", ageDays: 30, merged: true) }),
+        }, Now);
+
+        var item = Assert.Single(Of<StaleWorktreesAttentionDto>(items));
+        Assert.True(item.SafeToRemove);
+        Assert.Equal(1, item.Count);
+        Assert.Equal(new[] { "done-work" }, item.Worktrees);
+        Assert.Equal(30, item.OldestAgeDays);
+        Assert.Equal("devthrottle", item.Repo);
+    }
+
+    [Fact]
+    public void An_old_UNMERGED_worktree_is_listed_but_NEVER_marked_safe()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/unfinished", ageDays: 20, merged: false) }),
+        }, Now);
+
+        var item = Assert.Single(Of<StaleWorktreesAttentionDto>(items));
+        Assert.False(item.SafeToRemove);
+        Assert.Equal(new[] { "unfinished" }, item.Worktrees);
+    }
+
+    [Fact]
+    public void An_UNKNOWN_merged_state_is_never_treated_as_finished()
+    {
+        // Null means the default branch was undetectable or the inspection failed. Saying "this is old" is
+        // honest; saying "this is finished" is not.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(defaultBranch: null, worktrees: new[] { Worktree("D:/wt/unknown", ageDays: 40, merged: null) }),
+        }, Now);
+
+        var item = Assert.Single(Of<StaleWorktreesAttentionDto>(items));
+        Assert.False(item.SafeToRemove);
+    }
+
+    [Fact]
+    public void Safe_and_not_safe_worktrees_become_SEPARATE_rows_never_one_blended_count()
+    {
+        // "Six worktrees, four of them safe to remove" is a sentence a person acts on wrongly.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[]
+            {
+                Worktree("D:/wt/a", ageDays: 10, merged: true),
+                Worktree("D:/wt/b", ageDays: 12, merged: true),
+                Worktree("D:/wt/c", ageDays: 40, merged: false),
+            }),
+        }, Now);
+
+        var rows = Of<StaleWorktreesAttentionDto>(items);
+        Assert.Equal(2, rows.Count);
+
+        var safe = Assert.Single(rows, r => r.SafeToRemove);
+        Assert.Equal(2, safe.Count);
+        Assert.Equal(12, safe.OldestAgeDays);
+
+        var notSafe = Assert.Single(rows, r => !r.SafeToRemove);
+        Assert.Equal(new[] { "c" }, notSafe.Worktrees);
+        Assert.Equal(40, notSafe.OldestAgeDays);
+    }
+
+    // ---- the exclusions --------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_DIRTY_worktree_is_never_reported_however_old_it_is()
+    {
+        // Uncommitted work is the one thing that exists nowhere else.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/dirty", ageDays: 90, merged: true, dirty: true) }),
+        }, Now);
+
+        Assert.Empty(Of<StaleWorktreesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void An_OCCUPIED_worktree_is_never_reported()
+    {
+        // A live session working in it is not stale work - it is someone's desk.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/busy", ageDays: 90, merged: true, live: true) }),
+        }, Now);
+
+        Assert.Empty(Of<StaleWorktreesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void A_worktree_younger_than_the_staleness_bar_is_not_reported()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/wt/recent", ageDays: RepoHygieneFold.StaleWorktreeDays - 0.5, merged: true) }),
+        }, Now);
+
+        Assert.Empty(Of<StaleWorktreesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void A_worktree_with_NO_observed_timestamp_is_skipped_rather_than_aged()
+    {
+        // An unknown age is not a small age and it is not a large one either.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[]
+            {
+                new RepoStateWorktreeDto { Path = "D:/wt/timeless", BranchMergedIntoDefault = true },
+            }),
+        }, Now);
+
+        Assert.Empty(Of<StaleWorktreesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void The_row_carries_BASE_NAMES_never_the_owners_directory_layout()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(worktrees: new[] { Worktree("D:/Personal/Private/Client-Work/secret-client", ageDays: 30, merged: true) }),
+        }, Now);
+
+        var item = Assert.Single(Of<StaleWorktreesAttentionDto>(items));
+        Assert.Equal(new[] { "secret-client" }, item.Worktrees);
+        Assert.DoesNotContain("Personal", string.Join("|", item.Worktrees), StringComparison.Ordinal);
+    }
+
+    // ---- unmerged branches -----------------------------------------------------------------------------
+
+    [Fact]
+    public void Unmerged_branches_are_reported_oldest_first_with_their_commit_counts()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(branches: new[]
+            {
+                Branch("feature/newer", ageDays: 3, commits: 1),
+                Branch("feature/oldest", ageDays: 40, commits: 12),
+                Branch("feature/middle", ageDays: 9, commits: 4),
+            }),
+        }, Now);
+
+        var item = Assert.Single(Of<UnmergedBranchesAttentionDto>(items));
+        Assert.Equal(new[] { "feature/oldest", "feature/middle", "feature/newer" },
+            item.Branches.Select(b => b.Name));
+        Assert.Equal(12, item.Branches[0].Commits);
+        Assert.Equal(40, item.Branches[0].AgeDays);
+    }
+
+    [Fact]
+    public void A_MERGED_branch_and_an_UNKNOWN_one_are_both_left_out()
+    {
+        // Only a definite false is an unmerged branch. A null is "not determined", and reporting it would
+        // tell the owner they have unfinished work on a branch nobody inspected.
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(branches: new[]
+            {
+                Branch("done", ageDays: 30, merged: true),
+                Branch("undetermined", ageDays: 30, merged: null),
+            }),
+        }, Now);
+
+        Assert.Empty(Of<UnmergedBranchesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void The_default_branch_and_the_checked_out_branch_are_excluded()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(defaultBranch: "origin/main", currentBranch: "working-on-this", branches: new[]
+            {
+                Branch("main", ageDays: 30),
+                Branch("working-on-this", ageDays: 30),
+                Branch("genuinely-stale", ageDays: 30),
+            }),
+        }, Now);
+
+        var item = Assert.Single(Of<UnmergedBranchesAttentionDto>(items));
+        Assert.Equal(new[] { "genuinely-stale" }, item.Branches.Select(b => b.Name));
+    }
+
+    [Fact]
+    public void A_branch_touched_within_the_last_day_is_work_in_progress_not_a_recommendation()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(branches: new[] { Branch("today", ageDays: 0.5) }),
+        }, Now);
+
+        Assert.Empty(Of<UnmergedBranchesAttentionDto>(items));
+    }
+
+    [Fact]
+    public void A_branch_with_no_tip_date_is_skipped_rather_than_aged()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo(branches: new[]
+            {
+                new RepoStateBranchDto { Name = "timeless", MergedIntoDefault = false, CommitsAheadOfDefault = 2 },
+            }),
+        }, Now);
+
+        Assert.Empty(Of<UnmergedBranchesAttentionDto>(items));
+    }
+
+    // ---- several repositories --------------------------------------------------------------------------
+
+    [Fact]
+    public void Each_repository_gets_its_own_rows()
+    {
+        var items = RepoHygieneFold.Items(new[]
+        {
+            Repo("alpha", worktrees: new[] { Worktree("D:/wt/a", ageDays: 30, merged: true) }),
+            Repo("beta", branches: new[] { Branch("beta-branch", ageDays: 30) }),
+        }, Now);
+
+        Assert.Equal("alpha", Assert.Single(Of<StaleWorktreesAttentionDto>(items)).Repo);
+        Assert.Equal("beta", Assert.Single(Of<UnmergedBranchesAttentionDto>(items)).Repo);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepoStateEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoStateEndpointsTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The repo-state push endpoint (issue #2118). The claim that matters most is the CROSS-TENANT NEGATIVE: a
+/// device key belonging to account A must not be able to write repo state into account B, whatever the
+/// request body says. The tenant comes from the authenticated credential; <c>directorId</c> in the payload
+/// is a row key inside the caller's own partition and carries no authority at all.
+///
+/// Driven through a real request pipeline (auth middleware + the mapped route) rather than by calling the
+/// handler, because the property under test is exactly the seam between the credential and the store - and
+/// that seam only exists once the middleware has run.
+/// </summary>
+public sealed class RepoStateEndpointsTests : IAsyncLifetime
+{
+    private const string SharedToken = "shared-machine-token";
+
+    private readonly GatewayDbTestHarness _h = new();
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"rs-dev-{Guid.NewGuid():N}.json");
+    private static readonly DateTime T0 = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    private WebApplication _app = null!;
+    private HttpClient _client = null!;
+    private DeviceRegistry _devices = null!;
+    private RepoStateStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        var db = _h.Open(new AsyncLocalTenantContext());
+        _devices = new DeviceRegistry(_devPath);
+        var boundary = new HostedTenantBoundary(new AsyncLocalTenantContext(), _devices);
+        _store = new RepoStateStore(db);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        _app = builder.Build();
+        _app.Urls.Add("http://127.0.0.1:0");
+
+        // The REAL host-wide gate, so an unauthenticated push meets the production wall rather than a
+        // stand-in.
+        var cfg = new AuthMiddleware.RequireToken { Token = SharedToken, Devices = _devices };
+        _app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, cfg, next));
+
+        // The hosted pipeline's tenant middleware: after auth, enter the scope the authenticated device key
+        // resolves to. Present because the property under test is exactly the seam between the credential
+        // and the store, and that seam only exists once this has run.
+        _app.Use(async (ctx, next) =>
+        {
+            if (boundary.ResolveRequestTenant(ctx) is { } resolved)
+            {
+                using (boundary.EnterScope(resolved))
+                    await next();
+            }
+            else
+            {
+                await next();
+            }
+        });
+
+        Api.RepoStateEndpoints.Map(_app, _store, boundary, () => T0);
+        await _app.StartAsync();
+
+        _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_app is not null) await _app.DisposeAsync();
+        _h.Dispose();
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+    }
+
+    /// <summary>Enroll a device and bind it to a tenant, exactly as hosted enrollment does.</summary>
+    private string KeyFor(string deviceId, string tenantId)
+    {
+        var key = _devices.Register(deviceId, deviceId.ToUpperInvariant()).DeviceKey;
+        _devices.SetAccountBinding(deviceId, $"sub-{tenantId}", tenantId);
+        return key;
+    }
+
+    private static RepoStatePushRequest Push(string directorId, string repoPath, string branchName) => new()
+    {
+        DirectorId = directorId,
+        MachineName = "SOREN",
+        Repositories = new List<RepoStateSnapshotDto>
+        {
+            new()
+            {
+                Name = "repo", Path = repoPath, CollectedAtUtc = T0, DefaultBranch = "origin/main",
+                CurrentBranch = "main",
+                Branches = new List<RepoStateBranchDto>
+                {
+                    new() { Name = branchName, CommitsAheadOfDefault = 2, MergedIntoDefault = false },
+                },
+            },
+        },
+    };
+
+    private async Task<HttpResponseMessage> PostAsync(string? key, RepoStatePushRequest body)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, Api.RepoStateEndpoints.Path)
+        {
+            Content = JsonContent.Create(body),
+        };
+        if (key is not null)
+            request.Headers.Add("Authorization", $"Bearer {key}");
+        return await _client.SendAsync(request);
+    }
+
+    [Fact]
+    public async Task A_device_key_from_one_account_cannot_write_repo_state_into_another()
+    {
+        var aliceKey = KeyFor("dev-alice", "tenant-alice");
+        KeyFor("dev-bob", "tenant-bob");
+
+        // Alice pushes, naming a director id and a repository path that Bob also uses. Nothing in the body
+        // names a tenant, and nothing in it could: the tenant comes from the key.
+        var response = await PostAsync(aliceKey, Push("dir-shared", "D:/repos/shared", "alice-branch"));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var alice = Assert.Single(_store.ReadFresh(new TenantId("tenant-alice"), TimeSpan.FromHours(12), T0));
+        Assert.Equal("alice-branch", Assert.Single(alice.Branches).Name);
+
+        // Bob's partition is untouched.
+        Assert.Empty(_store.ReadFresh(new TenantId("tenant-bob"), TimeSpan.FromHours(12), T0));
+    }
+
+    [Fact]
+    public async Task Each_accounts_push_lands_only_in_its_own_partition_even_on_identical_keys()
+    {
+        var aliceKey = KeyFor("dev-alice", "tenant-alice");
+        var bobKey = KeyFor("dev-bob", "tenant-bob");
+
+        Assert.Equal(HttpStatusCode.OK,
+            (await PostAsync(aliceKey, Push("dir-shared", "D:/repos/shared", "alice-branch"))).StatusCode);
+        Assert.Equal(HttpStatusCode.OK,
+            (await PostAsync(bobKey, Push("dir-shared", "D:/repos/shared", "bob-branch"))).StatusCode);
+
+        var alice = Assert.Single(_store.ReadFresh(new TenantId("tenant-alice"), TimeSpan.FromHours(12), T0));
+        var bob = Assert.Single(_store.ReadFresh(new TenantId("tenant-bob"), TimeSpan.FromHours(12), T0));
+
+        Assert.Equal("alice-branch", Assert.Single(alice.Branches).Name);
+        Assert.Equal("bob-branch", Assert.Single(bob.Branches).Name);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_push_is_refused()
+    {
+        var response = await PostAsync(key: null, Push("dir-1", "D:/repos/one", "b"));
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_authenticated_key_with_no_bound_tenant_is_DENIED_never_served_the_local_partition()
+    {
+        // A real, valid device key that was never bound to an account. On hosted this must be a deny - it
+        // must NOT fall through to the Local partition, which is where a self-host install's rows live.
+        var unbound = _devices.Register("dev-unbound", "UNBOUND").DeviceKey;
+
+        var response = await PostAsync(unbound, Push("dir-1", "D:/repos/one", "b"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Empty(_store.ReadFresh(TenantId.Local, TimeSpan.FromHours(12), T0));
+    }
+
+    [Fact]
+    public async Task A_push_with_no_director_id_is_rejected()
+    {
+        var key = KeyFor("dev-alice", "tenant-alice");
+        var body = Push("", "D:/repos/one", "b");
+
+        var response = await PostAsync(key, body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_malformed_repository_rejects_the_push_and_stores_nothing()
+    {
+        var key = KeyFor("dev-alice", "tenant-alice");
+        var body = Push("dir-1", "D:/repos/one", "b");
+        body.Repositories.Add(new RepoStateSnapshotDto { Name = "broken", Path = "", CollectedAtUtc = T0 });
+
+        var response = await PostAsync(key, body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(_store.ReadFresh(new TenantId("tenant-alice"), TimeSpan.FromHours(12), T0));
+    }
+
+    [Fact]
+    public async Task There_is_no_read_route_for_repo_state()
+    {
+        // The only consumer reads the store in-process. A public read would put every repository path and
+        // branch name of every account on an HTTP surface for no caller that exists.
+        var key = KeyFor("dev-alice", "tenant-alice");
+        Assert.Equal(HttpStatusCode.OK, (await PostAsync(key, Push("dir-1", "D:/repos/one", "b"))).StatusCode);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, Api.RepoStateEndpoints.Path);
+        request.Headers.Add("Authorization", $"Bearer {key}");
+        var response = await _client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepoStatePusherTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoStatePusherTests.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Director-side repo-state pusher (issue #2118). The claim under test is the FAIL-SAFE promise, and it
+/// is tested rather than asserted in a comment: this is a background feed for a morning email, and it must
+/// never be able to disturb the sessions a person is working in.
+///
+/// The three failure shapes that matter are all here - the Gateway refusing the push, the Gateway throwing
+/// at the transport, and the repository enumeration itself failing - and in every one the cycle returns
+/// quietly and the NEXT cycle still runs. A pusher that threw, or that stopped trying after a failure,
+/// would look identical on a good day and fail silently on a bad one.
+/// </summary>
+public sealed class RepoStatePusherTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _repo;
+    private readonly string _registryPath;
+
+    public RepoStatePusherTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-pusher-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _repo = Path.Combine(_root, "repo");
+        _registryPath = Path.Combine(_root, "repositories.json");
+
+        RunGit(_root, "-c", "init.defaultBranch=main", "init", _repo);
+        RunGit(_repo, "config", "user.email", "test@cc-director.local");
+        RunGit(_repo, "config", "user.name", "CC Director Test");
+        RunGit(_repo, "config", "commit.gpgsign", "false");
+        File.WriteAllText(Path.Combine(_repo, "a.txt"), "a\n");
+        RunGit(_repo, "add", "-A");
+        RunGit(_repo, "commit", "-m", "initial");
+    }
+
+    public void Dispose()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            try { Directory.Delete(_root, recursive: true); return; }
+            catch { Thread.Sleep(100); }
+        }
+    }
+
+    private RepositoryRegistry Registry(bool withRepo = true)
+    {
+        var registry = new RepositoryRegistry(_registryPath);
+        if (withRepo)
+            registry.SeedFrom(new[] { new RepositoryConfig { Name = "repo", Path = _repo } });
+        return registry;
+    }
+
+    private RepoStatePusher NewPusher(
+        Func<RepoStatePushRequest, CancellationToken, Task<RepoStatePushResponse?>> push,
+        RepositoryRegistry? registry = null)
+        => new(push, registry ?? Registry(), "dir-1", "TEST-MACHINE");
+
+    [Fact]
+    public async Task A_successful_cycle_pushes_the_registered_repository()
+    {
+        RepoStatePushRequest? captured = null;
+        var pusher = NewPusher((req, _) =>
+        {
+            captured = req;
+            return Task.FromResult<RepoStatePushResponse?>(new RepoStatePushResponse { Stored = req.Repositories.Count });
+        });
+
+        var stored = await pusher.PushOnceAsync();
+
+        Assert.Equal(1, stored);
+        Assert.NotNull(captured);
+        Assert.Equal("dir-1", captured!.DirectorId);
+        Assert.Equal("TEST-MACHINE", captured.MachineName);
+        Assert.Equal(_repo, Assert.Single(captured.Repositories).Path);
+    }
+
+    [Fact]
+    public async Task A_Gateway_that_REFUSES_the_push_does_not_throw_and_the_next_cycle_still_runs()
+    {
+        var attempts = 0;
+        var pusher = NewPusher((_, _) =>
+        {
+            attempts++;
+            return Task.FromResult<RepoStatePushResponse?>(null);   // "did not land"
+        });
+
+        Assert.Null(await pusher.PushOnceAsync());
+        Assert.Null(await pusher.PushOnceAsync());
+
+        // Both cycles ran. A pusher that gave up after a refusal would leave the report permanently blind
+        // to this machine after one bad moment.
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task A_Gateway_that_THROWS_is_swallowed_and_the_next_cycle_still_runs()
+    {
+        var attempts = 0;
+        var pusher = NewPusher((_, _) =>
+        {
+            attempts++;
+            throw new HttpRequestException("the Gateway is down");
+        });
+
+        // The exception must not escape into the Director. This is the difference between a hygiene feed
+        // being unavailable and a person's session dying because an email could not be assembled.
+        Assert.Null(await pusher.PushOnceAsync());
+        Assert.Null(await pusher.PushOnceAsync());
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task A_repository_that_cannot_be_enumerated_does_not_stop_the_cycle()
+    {
+        var registry = new RepositoryRegistry(_registryPath);
+        registry.SeedFrom(new[]
+        {
+            new RepositoryConfig { Name = "broken", Path = Path.Combine(_root, "not-a-repo-at-all") },
+            new RepositoryConfig { Name = "repo", Path = _repo },
+        });
+        Directory.CreateDirectory(Path.Combine(_root, "not-a-repo-at-all"));
+
+        RepoStatePushRequest? captured = null;
+        var pusher = NewPusher((req, _) =>
+        {
+            captured = req;
+            return Task.FromResult<RepoStatePushResponse?>(new RepoStatePushResponse { Stored = req.Repositories.Count });
+        }, registry);
+
+        Assert.Equal(1, await pusher.PushOnceAsync());
+        // The healthy repository still went; the broken one was omitted, not pushed as an empty snapshot
+        // that would read downstream as a clean bill of health.
+        Assert.Equal(_repo, Assert.Single(captured!.Repositories).Path);
+    }
+
+    [Fact]
+    public async Task With_no_registered_repositories_nothing_is_pushed_at_all()
+    {
+        var pushed = false;
+        var pusher = NewPusher((_, _) =>
+        {
+            pushed = true;
+            return Task.FromResult<RepoStatePushResponse?>(new RepoStatePushResponse());
+        }, Registry(withRepo: false));
+
+        Assert.Equal(0, await pusher.PushOnceAsync());
+        Assert.False(pushed);
+    }
+
+    [Fact]
+    public async Task An_install_with_no_Gateway_configured_simply_reports_nothing()
+    {
+        // The wiring passes a delegate that answers null when there is no Gateway client. That is not a
+        // failure and must not be logged or retried as one - there is nowhere to report to.
+        var pusher = NewPusher((_, _) => Task.FromResult<RepoStatePushResponse?>(null));
+
+        Assert.Null(await pusher.PushOnceAsync());
+    }
+
+    [Fact]
+    public void Dispose_before_Start_and_double_Dispose_are_both_safe()
+    {
+        var pusher = NewPusher((_, _) => Task.FromResult<RepoStatePushResponse?>(new RepoStatePushResponse()));
+        pusher.Dispose();
+        pusher.Dispose();
+    }
+
+    private static void RunGit(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({p.ExitCode}): {stderr}");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/RepoStateStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepoStateStoreTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Gateway's repo-state store (issue #2118). The claims that matter to the morning report:
+///
+///  - OVERWRITE, NOT APPEND: a re-push replaces the repository's row, so the report reads one moment in
+///    time rather than a pile of snapshots it would have to date-sort itself.
+///  - TENANT ISOLATION IN BOTH DIRECTIONS: one account cannot write into another's partition even when both
+///    register the same repository path on identically-named machines, and cannot read the other's rows.
+///  - WHOLE-BATCH VALIDATION: one malformed repository rejects the entire push, because a half-landed batch
+///    would leave the report mixing this snapshot with the last one and calling it a single moment.
+///  - STALENESS IS EXCLUSION, NOT AGEING: a Director that stopped pushing does not get its week-old picture
+///    served as current - that is how a report comes to recommend deleting a worktree someone is using.
+/// </summary>
+public sealed class RepoStateStoreTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    private static readonly TenantId Alice = new("tenant-alice");
+    private static readonly TenantId Bob = new("tenant-bob");
+    private static readonly DateTime T0 = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    public void Dispose() => _h.Dispose();
+
+    private RepoStateStore NewStore() => new(_h.Open(new AsyncLocalTenantContext()));
+
+    private static RepoStateSnapshotDto Snapshot(
+        string path, string? defaultBranch = "origin/main",
+        IEnumerable<RepoStateBranchDto>? branches = null,
+        IEnumerable<RepoStateWorktreeDto>? worktrees = null,
+        DateTime? collectedAtUtc = null) => new()
+    {
+        Name = System.IO.Path.GetFileName(path),
+        Path = path,
+        CollectedAtUtc = collectedAtUtc ?? T0,
+        DefaultBranch = defaultBranch,
+        CurrentBranch = "main",
+        IsDirty = false,
+        Branches = branches?.ToList() ?? new List<RepoStateBranchDto>(),
+        Worktrees = worktrees?.ToList() ?? new List<RepoStateWorktreeDto>(),
+    };
+
+    private static RepoStateBranchDto Branch(string name, bool? merged = false, int ahead = 1) => new()
+    {
+        Name = name,
+        TipCommitUtc = T0.AddDays(-3),
+        CommitsAheadOfDefault = ahead,
+        MergedIntoDefault = merged,
+        CheckedOut = false,
+    };
+
+    // ---- store and read back ---------------------------------------------------------------------------
+
+    [Fact]
+    public void A_pushed_snapshot_reads_back_whole()
+    {
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN", new[]
+        {
+            Snapshot("D:/repos/one", branches: new[] { Branch("feature-a"), Branch("done", merged: true, ahead: 0) },
+                worktrees: new[]
+                {
+                    new RepoStateWorktreeDto
+                    {
+                        Path = "D:/wt/one-a", Branch = "feature-a", TipCommitUtc = T0.AddDays(-9),
+                        LastActivityUtc = T0.AddDays(-8), IsDirty = true, BranchMergedIntoDefault = false,
+                        HasLiveSession = false,
+                    },
+                }),
+        }, T0);
+
+        var stored = Assert.Single(store.ReadFresh(Alice, TimeSpan.FromHours(12), T0));
+        Assert.Equal("dir-1", stored.DirectorId);
+        Assert.Equal("SOREN", stored.MachineName);
+        Assert.Equal("D:/repos/one", stored.Path);
+        Assert.Equal("origin/main", stored.DefaultBranch);
+        Assert.Equal(T0, stored.ReceivedAtUtc);
+
+        Assert.Equal(2, stored.Branches.Count);
+        Assert.True(Assert.Single(stored.Branches, b => b.Name == "done").MergedIntoDefault);
+        Assert.False(Assert.Single(stored.Branches, b => b.Name == "feature-a").MergedIntoDefault);
+
+        var worktree = Assert.Single(stored.Worktrees);
+        Assert.Equal("D:/wt/one-a", worktree.Path);
+        Assert.True(worktree.IsDirty);
+        Assert.Equal(T0.AddDays(-8), worktree.LastActivityUtc);
+    }
+
+    [Fact]
+    public void A_null_merged_verdict_survives_the_round_trip_as_null()
+    {
+        // The distinction the whole feed rests on: "not determined" must not come back as false, which a
+        // report would read as "this branch definitely has unmerged work".
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN", new[]
+        {
+            Snapshot("D:/repos/lonely", defaultBranch: null, branches: new[] { Branch("whatever", merged: null) }),
+        }, T0);
+
+        var stored = Assert.Single(store.ReadFresh(Alice, TimeSpan.FromHours(12), T0));
+        Assert.Null(stored.DefaultBranch);
+        Assert.Null(Assert.Single(stored.Branches).MergedIntoDefault);
+    }
+
+    [Fact]
+    public void A_re_push_OVERWRITES_the_repositorys_row_rather_than_appending()
+    {
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one", branches: new[] { Branch("old-branch") }) }, T0);
+        store.StoreBatch(Alice, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one", branches: new[] { Branch("new-branch") }) }, T0.AddHours(6));
+
+        var stored = Assert.Single(store.ReadFresh(Alice, TimeSpan.FromDays(1), T0.AddHours(6)));
+        Assert.Equal(T0.AddHours(6), stored.ReceivedAtUtc);
+        Assert.Equal("new-branch", Assert.Single(stored.Branches).Name);
+    }
+
+    [Fact]
+    public void Two_Directors_on_one_account_keep_separate_rows_for_the_same_path()
+    {
+        // Two machines can genuinely hold a checkout at the same path. They are different facts about
+        // different machines, and collapsing them would silently discard one machine's hygiene.
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN", new[] { Snapshot("D:/repos/one") }, T0);
+        store.StoreBatch(Alice, "dir-2", "SOREN-NORTH", new[] { Snapshot("D:/repos/one") }, T0);
+
+        var stored = store.ReadFresh(Alice, TimeSpan.FromHours(12), T0);
+        Assert.Equal(2, stored.Count);
+        Assert.Equal(new[] { "dir-1", "dir-2" }, stored.Select(s => s.DirectorId).OrderBy(x => x));
+    }
+
+    // ---- tenant isolation ------------------------------------------------------------------------------
+
+    [Fact]
+    public void One_accounts_push_never_lands_in_or_overwrites_anothers_row()
+    {
+        // The hardest shape: the SAME director id and the SAME repository path in two accounts.
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one", branches: new[] { Branch("alice-branch") }) }, T0);
+        store.StoreBatch(Bob, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one", branches: new[] { Branch("bob-branch") }) }, T0);
+
+        var alice = Assert.Single(store.ReadFresh(Alice, TimeSpan.FromHours(12), T0));
+        var bob = Assert.Single(store.ReadFresh(Bob, TimeSpan.FromHours(12), T0));
+
+        Assert.Equal("alice-branch", Assert.Single(alice.Branches).Name);
+        Assert.Equal("bob-branch", Assert.Single(bob.Branches).Name);
+    }
+
+    [Fact]
+    public void An_account_with_no_rows_reads_nothing_even_when_another_account_has_plenty()
+    {
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one"), Snapshot("D:/repos/two") }, T0);
+
+        Assert.Empty(store.ReadFresh(Bob, TimeSpan.FromHours(12), T0));
+    }
+
+    // ---- validation ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void One_malformed_repository_rejects_the_WHOLE_batch()
+    {
+        var store = NewStore();
+        var batch = new[] { Snapshot("D:/repos/good"), Snapshot("") };
+
+        Assert.Throws<RepoStateValidationException>(() => store.StoreBatch(Alice, "dir-1", "SOREN", batch, T0));
+        // Nothing landed - not even the good one. A half-landed batch would mix two moments in time.
+        Assert.Empty(store.ReadFresh(Alice, TimeSpan.FromHours(12), T0));
+    }
+
+    [Fact]
+    public void A_push_naming_one_repository_twice_is_rejected()
+    {
+        // Two rows with the same key would make the stored answer depend on iteration order.
+        var store = NewStore();
+        var batch = new[] { Snapshot("D:/repos/one"), Snapshot("D:/repos/one") };
+
+        Assert.Throws<RepoStateValidationException>(() => store.StoreBatch(Alice, "dir-1", "SOREN", batch, T0));
+    }
+
+    [Fact]
+    public void A_push_without_a_director_id_is_rejected()
+    {
+        var store = NewStore();
+        Assert.Throws<RepoStateValidationException>(
+            () => store.StoreBatch(Alice, "  ", "SOREN", new[] { Snapshot("D:/repos/one") }, T0));
+    }
+
+    [Fact]
+    public void A_batch_beyond_the_ceiling_is_rejected_rather_than_truncated()
+    {
+        var store = NewStore();
+        var batch = Enumerable.Range(0, RepoStateStore.MaxRepositoriesPerPush + 1)
+            .Select(i => Snapshot($"D:/repos/{i}")).ToArray();
+
+        // Truncating would store a partial picture and report it as the machine's whole hygiene.
+        Assert.Throws<RepoStateValidationException>(() => store.StoreBatch(Alice, "dir-1", "SOREN", batch, T0));
+    }
+
+    [Fact]
+    public void An_empty_batch_stores_nothing_and_is_not_an_error()
+    {
+        var store = NewStore();
+        Assert.Equal(0, store.StoreBatch(Alice, "dir-1", "SOREN", Array.Empty<RepoStateSnapshotDto>(), T0));
+    }
+
+    [Fact]
+    public void A_collection_time_in_the_future_is_clamped_to_the_receive_time()
+    {
+        // A skewed clock on the pushing machine must not produce a negative age downstream.
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN",
+            new[] { Snapshot("D:/repos/one", collectedAtUtc: T0.AddHours(5)) }, T0);
+
+        var stored = Assert.Single(store.ReadFresh(Alice, TimeSpan.FromHours(12), T0));
+        Assert.Equal(T0, stored.CollectedAtUtc);
+    }
+
+    [Fact]
+    public void An_invalid_tenant_is_refused_rather_than_written_somewhere()
+    {
+        var store = NewStore();
+        Assert.Throws<ArgumentException>(
+            () => store.StoreBatch(default, "dir-1", "SOREN", new[] { Snapshot("D:/repos/one") }, T0));
+        Assert.Throws<ArgumentException>(() => store.ReadFresh(default, TimeSpan.FromHours(12), T0));
+    }
+
+    // ---- staleness -------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_snapshot_older_than_the_freshness_bar_is_EXCLUDED_not_aged()
+    {
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-stale", "OLD", new[] { Snapshot("D:/repos/stale") }, T0.AddDays(-7));
+        store.StoreBatch(Alice, "dir-fresh", "NOW", new[] { Snapshot("D:/repos/fresh") }, T0);
+
+        // A Director that stopped pushing a week ago knows nothing about that repository today; serving its
+        // last picture is how a report comes to recommend deleting a worktree someone has since started in.
+        var stored = store.ReadFresh(Alice, TimeSpan.FromHours(24), T0);
+        Assert.Equal("D:/repos/fresh", Assert.Single(stored).Path);
+
+        // Widen the bar and the older one is there - it was excluded by age, not lost.
+        Assert.Equal(2, store.ReadFresh(Alice, TimeSpan.FromDays(30), T0).Count);
+    }
+
+    [Fact]
+    public void Rows_come_back_newest_first()
+    {
+        var store = NewStore();
+        store.StoreBatch(Alice, "dir-1", "SOREN", new[] { Snapshot("D:/repos/older") }, T0.AddHours(-5));
+        store.StoreBatch(Alice, "dir-2", "SOREN", new[] { Snapshot("D:/repos/newer") }, T0);
+
+        var stored = store.ReadFresh(Alice, TimeSpan.FromDays(1), T0);
+        Assert.Equal(new[] { "D:/repos/newer", "D:/repos/older" }, stored.Select(s => s.Path));
+    }
+}

--- a/src/CcDirector.Gateway/Api/RepoStateEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RepoStateEndpoints.cs
@@ -1,0 +1,70 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Reports;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The repo-state feed's front door (issue #2118):
+///
+///   POST /gateway/repostate - a Director pushes the latest branches and worktrees for its registered
+///   repositories. The Gateway stores the newest snapshot per (tenant, director, repository).
+///
+/// THERE IS NO READ ROUTE, DELIBERATELY. The only consumer is the morning report, which reads the store
+/// IN-PROCESS. A public read would put every repository path and branch name on an HTTP surface for no
+/// caller that exists.
+///
+/// TENANT AND IDENTITY COME FROM THE CREDENTIAL, NOT THE BODY. The route inherits the host-wide token gate
+/// (a Director authenticates with its own device key) and resolves the tenant from that authenticated key -
+/// so a push cannot claim to belong to another account no matter what its payload says. On hosted, a key
+/// with no bound tenant is DENIED (403) and is never served the Local partition. The <c>directorId</c> in
+/// the body is a ROW KEY within the caller's own tenant, never an authorization claim: the worst a
+/// mislabelled id can do is overwrite the caller's own row for the same repository.
+/// </summary>
+internal static class RepoStateEndpoints
+{
+    public const string Path = "/gateway/repostate";
+
+    public static void Map(IEndpointRouteBuilder app, RepoStateStore store,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Func<DateTime>? utcNow = null)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        var now = utcNow ?? (() => DateTime.UtcNow);
+
+        app.MapPost(Path, (HttpContext ctx, RepoStatePushRequest? request) =>
+        {
+            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            if (request is null)
+                return Results.BadRequest(new { error = "a repo-state push body is required" });
+            if (string.IsNullOrWhiteSpace(request.DirectorId))
+                return Results.BadRequest(new { error = "directorId is required" });
+
+            var receivedAtUtc = now();
+            try
+            {
+                var stored = store.StoreBatch(
+                    tenant.Value, request.DirectorId, request.MachineName,
+                    request.Repositories ?? new(), receivedAtUtc);
+
+                FileLog.Write($"[RepoStateEndpoints] POST {Path}: tenant={tenant.Value.ToLogString()} " +
+                              $"director={request.DirectorId} stored={stored}");
+                return Results.Ok(new RepoStatePushResponse { Stored = stored, ReceivedAtUtc = receivedAtUtc });
+            }
+            catch (RepoStateValidationException ex)
+            {
+                FileLog.Write($"[RepoStateEndpoints] rejected a push: {ex.Message}");
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        FileLog.Write($"[RepoStateEndpoints] mapped {Path} (device-authenticated, write-only)");
+    }
+}

--- a/src/CcDirector.Gateway/Data/Entities/RepoStateEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/RepoStateEntity.cs
@@ -1,0 +1,65 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// The LATEST repo-state snapshot a Director pushed for one repository (issue #2118), in the
+/// <c>repo_state</c> table: the branches and worktrees the morning report's hygiene recommendations are
+/// built from. The Gateway knows a repository exists; only the machine holding the checkout can say what
+/// its git hygiene looks like, so this is the one feed the report cannot assemble from Gateway-side stores.
+///
+/// OVERWRITE, NOT APPEND. One row per (tenant, director, repository path); a new push replaces the row.
+/// The report answers "what does this look like NOW", so a history would be storage and retention work
+/// bought for a question nobody asks. <see cref="ReceivedAtUtc"/> is stamped by the Gateway and
+/// <see cref="CollectedAtUtc"/> by the Director, so a stale feed is visible as itself rather than as a
+/// clean repository - a snapshot the report considers too old is dropped, never quietly aged into a
+/// recommendation.
+///
+/// KEY: composite <c>(tenant_id, DirectorId, RepoPath)</c> - a caller-supplied key, which is exactly why
+/// the tenant is part of it: two accounts can register the same repository path on identically-named
+/// machines, and without the tenant in the key one would fail to insert over the other and learn from the
+/// failure that the row exists.
+///
+/// THE PAYLOAD CARRIES NAMES, PATHS, COUNTS AND DATES - NEVER CONTENT. <see cref="BranchesJson"/> and
+/// <see cref="WorktreesJson"/> are serialized <c>RepoStateBranchDto</c> / <c>RepoStateWorktreeDto</c> lists,
+/// whose shape has no room for a file body, a diff, or a commit message. That boundary matters most here,
+/// because this is the row where a private repository's contents would come to rest in a hosted,
+/// multi-tenant database.
+///
+/// <c>tenant_id</c> + the global query filter are inherited from <see cref="TenantScopedEntity"/>.
+/// </summary>
+public sealed class RepoStateEntity : TenantScopedEntity
+{
+    /// <summary>The Director that pushed this snapshot. Part of the composite primary key.</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>The repository's primary checkout path on that machine. Part of the composite primary key.</summary>
+    public string RepoPath { get; set; } = "";
+
+    /// <summary>The pushing machine's display name, for the report's deep links.</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>The repository's display name.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>The default branch, or null when the Director could not determine it - in which case every
+    /// merged-ness in the payload is null too and no hygiene recommendation is made about this repository.</summary>
+    public string? DefaultBranch { get; set; }
+
+    /// <summary>The branch checked out in the main working tree, or null on a detached head.</summary>
+    public string? CurrentBranch { get; set; }
+
+    /// <summary>True when the main working tree has any uncommitted change.</summary>
+    public bool IsDirty { get; set; }
+
+    /// <summary>When the DIRECTOR collected the snapshot.</summary>
+    public DateTime CollectedAtUtc { get; set; }
+
+    /// <summary>When the GATEWAY received it. Both times are kept: a Director whose clock is wrong, or whose
+    /// pushes stopped, is then visible as itself rather than as a repository with nothing to report.</summary>
+    public DateTime ReceivedAtUtc { get; set; }
+
+    /// <summary>The serialized branch list (a JSON array of <c>RepoStateBranchDto</c>).</summary>
+    public string BranchesJson { get; set; } = "[]";
+
+    /// <summary>The serialized worktree list (a JSON array of <c>RepoStateWorktreeDto</c>).</summary>
+    public string WorktreesJson { get; set; } = "[]";
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -95,6 +95,11 @@ public sealed class GatewayDbContext : DbContext
     /// transcript per utterance, per tenant, write-only, for later mistranscription mining (devthrottle #2075).</summary>
     public DbSet<DictationTranscriptEntity> DictationTranscripts => Set<DictationTranscriptEntity>();
 
+    /// <summary>The latest repo-state snapshot per (tenant, director, repository) (<c>repo_state</c>, issue
+    /// #2118) - the branches and worktrees the morning report's hygiene recommendations read. Overwritten on
+    /// each push; never appended.</summary>
+    public DbSet<RepoStateEntity> RepoState => Set<RepoStateEntity>();
+
     /// <summary>Dismissed dictionary suggestions (<c>dictation_suggestion_dismissals</c>, devthrottle #2075) -
     /// one row per term the tenant told us to stop suggesting, with a snapshot of the evidence so the
     /// "Dismissed terms" screen can still explain why it was once offered. Tenant-scoped.</summary>
@@ -374,6 +379,20 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => new { e.TenantId, e.TimestampUtc });
         });
 
+        modelBuilder.Entity<RepoStateEntity>(b =>
+        {
+            b.ToTable("repo_state");
+            // COMPOSITE primary key (tenant_id, DirectorId, RepoPath): both parts of the natural key are
+            // CALLER-SUPPLIED, so the tenant must be in the key. Two accounts can genuinely register the same
+            // repository path on identically-named machines; without tenant_id in the key one account's push
+            // would fail to insert over the other's row and learn from the failure that it exists.
+            b.HasKey(e => new { e.TenantId, e.DirectorId, e.RepoPath });
+            // The report reads one tenant's whole repo-state set at once, ordered by freshness; index the
+            // tenant-leading path so it rides the global query filter's "tenant_id = @t" prefix rather than
+            // forcing a cross-tenant scan.
+            b.HasIndex(e => new { e.TenantId, e.ReceivedAtUtc });
+        });
+
         modelBuilder.Entity<DictationSuggestionDismissalEntity>(b =>
         {
             b.ToTable("dictation_suggestion_dismissals");
@@ -555,6 +574,7 @@ public sealed class GatewayDbContext : DbContext
         ApplyTenantScope<DictationSuggestionVerdictEntity>(modelBuilder);
         ApplyTenantScope<DictationSuggestionScanEntity>(modelBuilder);
         ApplyTenantScope<ActivityEventEntity>(modelBuilder);
+        ApplyTenantScope<RepoStateEntity>(modelBuilder);
 
         ApplyCommonSubsetConventions(modelBuilder);
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260724211735_AddRepoState.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724211735_AddRepoState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724211735_AddRepoState")]
+    partial class AddRepoState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260724211735_AddRepoState.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724211735_AddRepoState.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepoState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "repo_state",
+                columns: table => new
+                {
+                    tenant_id = table.Column<string>(type: "TEXT", nullable: false),
+                    DirectorId = table.Column<string>(type: "TEXT", nullable: false),
+                    RepoPath = table.Column<string>(type: "TEXT", nullable: false),
+                    MachineName = table.Column<string>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    DefaultBranch = table.Column<string>(type: "TEXT", nullable: true),
+                    CurrentBranch = table.Column<string>(type: "TEXT", nullable: true),
+                    IsDirty = table.Column<bool>(type: "INTEGER", nullable: false),
+                    CollectedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ReceivedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    BranchesJson = table.Column<string>(type: "TEXT", nullable: false),
+                    WorktreesJson = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_repo_state", x => new { x.tenant_id, x.DirectorId, x.RepoPath });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_repo_state_tenant_id",
+                table: "repo_state",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_repo_state_tenant_id_ReceivedAtUtc",
+                table: "repo_state",
+                columns: new[] { "tenant_id", "ReceivedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "repo_state");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
 using CcDirector.Core;
@@ -336,6 +336,7 @@ public sealed class GatewayHost : IAsyncDisposable
     // re-snooze), bounded by the live-session prune paths.
     private readonly Snooze.SnoozeRegistry _snoozeRegistry;
     private readonly Activity.ActivityEventStore _activityEvents;
+    private readonly Reports.RepoStateStore _repoState;
     private Activity.ActivityRetentionSweep? _activityRetentionSweep;
     // Fills account_hosted_ai_spend by periodically mirroring the cloud credit-debit ledger (issue #1771).
     private Governance.HostedAiSpendSweep? _hostedAiSpendSweep;
@@ -876,6 +877,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // evidence of why sessions enter/leave Working and why snoozes end, retained 30 days. Constructed
         // before the snooze registry because the registry appends its lifecycle decisions to it.
         _activityEvents = new Activity.ActivityEventStore(_gatewayDb);
+        // The repo-state feed (issue #2118): the latest branches and worktrees each Director reports for
+        // each repository - the one git-hygiene fact the Gateway cannot observe for itself, and the source
+        // of the morning report's stale-worktree and unmerged-branch recommendations.
+        _repoState = new Reports.RepoStateStore(_gatewayDb);
         _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"), _activityEvents);
         // Editable/versioned wingman instructions (issue #537) now persist in the wingman_instructions table
         // of the EF data layer. The path argument is the LEGACY wingman-instructions.json, imported once on
@@ -2493,6 +2498,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // activity/snooze evidence to POST /activity-events/batch (idempotent by producer-minted event id),
         // and diagnosis reads GET /activity-events. Tenant-scoped exactly like the prompt log.
         Activity.ActivityEventEndpoints.Map(_app, _activityEvents, _tenantBoundary);
+
+        // The repo-state feed (issue #2118): POST /gateway/repostate, where a Director pushes its
+        // repositories' branches and worktrees. Device-authenticated and tenant-scoped from the caller's
+        // own key; write-only, because the sole consumer (the morning report) reads the store in-process.
+        Api.RepoStateEndpoints.Map(_app, _repoState, _tenantBoundary);
 
         Mobile.MobileApp.Map(_app, Token);
         // The legacy /m mount: 301 to the canonical /mobile equivalent so installed phone PWAs and

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -866,7 +866,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // the stores above. The pushed-session cache is passed for LABELS ONLY (a waiting row's friendly name
         // and repository path); the waiting fact itself comes from the durable governance ledger, so a
         // Director that happens to be offline at 07:00 costs a row its name, never its place in the email.
-        _morningReport = new Reports.MorningReportBuilder(_gatewayDb, PushedSessions, _streamStaleAfter);
+        // The repo-state feed (issue #2118): the latest branches and worktrees each Director reports for
+        // each repository - the one git-hygiene fact the Gateway cannot observe for itself, and the source
+        // of the morning report's stale-worktree and unmerged-branch recommendations.
+        _repoState = new Reports.RepoStateStore(_gatewayDb);
+        _morningReport = new Reports.MorningReportBuilder(_gatewayDb, PushedSessions, _streamStaleAfter,
+            // The repo-state store (issue #2118) is the hygiene rows' source. Passed here rather than
+            // resolved inside the builder so the report reads the SAME store the push endpoint writes.
+            repoState: _repoState);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the
@@ -877,10 +884,6 @@ public sealed class GatewayHost : IAsyncDisposable
         // evidence of why sessions enter/leave Working and why snoozes end, retained 30 days. Constructed
         // before the snooze registry because the registry appends its lifecycle decisions to it.
         _activityEvents = new Activity.ActivityEventStore(_gatewayDb);
-        // The repo-state feed (issue #2118): the latest branches and worktrees each Director reports for
-        // each repository - the one git-hygiene fact the Gateway cannot observe for itself, and the source
-        // of the morning report's stale-worktree and unmerged-branch recommendations.
-        _repoState = new Reports.RepoStateStore(_gatewayDb);
         _snoozeRegistry = new Snooze.SnoozeRegistry(_gatewayDb, snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"), _activityEvents);
         // Editable/versioned wingman instructions (issue #537) now persist in the wingman_instructions table
         // of the EF data layer. The path argument is the LEGACY wingman-instructions.json, imported once on

--- a/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
@@ -44,6 +44,24 @@ public sealed class MorningReportBuilder
     public const int WaitingLookbackDays = 30;
 
     /// <summary>
+    /// How recently a wait must have BEGUN for the report to say a session is waiting on you.
+    ///
+    /// This exists because of what the first real hosted call returned: nine waiting rows aged 69 to 129
+    /// hours, for sessions that had been gone for days, shown as raw identifiers because no Director was
+    /// connected to name them. Every one was a true statement ABOUT THE LEDGER - the last transition
+    /// recorded really was a wait - and every one was a false statement about the owner's morning.
+    ///
+    /// The ledger only records what it was told. A session that stops without an exit event leaves its
+    /// wait open forever, so "waiting since" ages without bound and never resolves. After two days of
+    /// silence the honest position is that the Gateway does not know what became of that session, and it
+    /// has no business asserting the session is waiting on a person today. So it says nothing about it.
+    ///
+    /// Deliberately a REPORTING bar, not a data change: the ledger keeps every transition, and
+    /// <see cref="WaitingLookbackDays"/> still bounds the scan. This only decides what the email claims.
+    /// </summary>
+    public static readonly TimeSpan WaitingReportMaxAge = TimeSpan.FromHours(48);
+
+    /// <summary>
     /// The hard ceiling on ledger rows the waiting scan materializes. Reaching it is LOGGED (never silent):
     /// a truncated scan can only under-report waiting sessions, and the log says so, so a short list is
     /// never mistaken for a quiet fleet.
@@ -235,6 +253,8 @@ public sealed class MorningReportBuilder
         var live = LiveSessionsById(tenant);
         var items = new List<MorningAttentionItemDto>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        // Counted and logged, never silently dropped: a short waiting list must be explainable.
+        var staleWaits = 0;
 
         foreach (var row in rows)
         {
@@ -245,6 +265,15 @@ public sealed class MorningReportBuilder
             if (row.State != GovernanceEventState.WaitingOnHuman &&
                 row.State != GovernanceEventState.WaitingOnPermission)
                 continue;
+
+            // The silence bar. An open wait older than this is not reported at all - see
+            // WaitingReportMaxAge for why a true statement about the ledger is the wrong thing to put
+            // in a person's inbox.
+            if (now - DateTime.SpecifyKind(row.OccurredUtc, DateTimeKind.Utc) > WaitingReportMaxAge)
+            {
+                staleWaits++;
+                continue;
+            }
 
             // A session the Gateway can currently see is judged on what it can see: one that is HELD
             // (snoozed) was deliberately parked by the owner and is not "waiting on you" this morning, and
@@ -267,6 +296,11 @@ public sealed class MorningReportBuilder
                 AgeHours = Math.Round(Math.Max(0, (now - since).TotalHours), 1),
             });
         }
+
+        if (staleWaits > 0)
+            FileLog.Write($"[MorningReportBuilder] WaitingSessions: {staleWaits} open wait(s) older than " +
+                          $"{WaitingReportMaxAge.TotalHours:0}h were NOT reported for tenant={tenant.ToLogString()} - " +
+                          "the Gateway has not heard about those sessions since, so it does not claim they are waiting.");
 
         // Longest wait first - the row the owner most needs to see is the one at the top of the email.
         items.Sort((a, b) => ((WaitingSessionAttentionDto)b).AgeHours.CompareTo(((WaitingSessionAttentionDto)a).AgeHours));

--- a/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
@@ -32,6 +32,7 @@ public sealed class MorningReportBuilder
 {
     private readonly GatewayDatabase _db;
     private readonly Streaming.PushedSessionStore? _pushedSessions;
+    private readonly RepoStateStore? _repoState;
     private readonly TimeSpan _streamStale;
     private readonly Func<DateTime> _utcNow;
 
@@ -52,6 +53,14 @@ public sealed class MorningReportBuilder
     /// <summary>Micro-dollars per cent - the ceil-rounding divisor for hosted-AI spend.</summary>
     private const long MicrosPerCent = 10_000;
 
+    /// <summary>
+    /// How old a Director's repo-state snapshot may be and still inform a hygiene recommendation. The
+    /// Director pushes every six hours, so this is four missed cycles: long enough that one restart or
+    /// one offline evening does not blank the section, short enough that the report never recommends
+    /// deleting a worktree from a picture of the machine taken last week.
+    /// </summary>
+    public static readonly TimeSpan RepoStateMaxAge = TimeSpan.FromHours(24);
+
     /// <param name="db">The Gateway EF database.</param>
     /// <param name="pushedSessions">The live pushed-session cache, used ONLY to put a friendly name and a
     /// repository path on a waiting row. Null (or a session it has never seen) costs the row nothing but
@@ -62,10 +71,12 @@ public sealed class MorningReportBuilder
         GatewayDatabase db,
         Streaming.PushedSessionStore? pushedSessions = null,
         TimeSpan? streamStale = null,
-        Func<DateTime>? utcNow = null)
+        Func<DateTime>? utcNow = null,
+        RepoStateStore? repoState = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pushedSessions = pushedSessions;
+        _repoState = repoState;
         _streamStale = streamStale ?? TimeSpan.FromMinutes(5);
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
     }
@@ -100,10 +111,40 @@ public sealed class MorningReportBuilder
             Attention = WaitingSessions(ctx, tenant, now),
         };
 
+        // The hygiene rows (issue #2118): stale worktrees and unmerged branches, from the repo-state
+        // snapshots this tenant's Directors pushed. THE HONESTY RULE APPLIES HERE TOO, AND IT IS WHY THE
+        // ENDPOINT COULD SHIP BEFORE THIS FEED EXISTED: no repo-state store, or no fresh snapshot for this
+        // tenant, means NO hygiene rows at all - not empty ones. "We have never been told about your
+        // repositories" and "your repositories are tidy" are different statements, and only one of them
+        // has been measured.
+        report.Attention.AddRange(HygieneItems(tenant, now));
+
         FileLog.Write($"[MorningReportBuilder] Build: tenant={tenant.ToLogString()} window={window.StartUtc:o}..{window.EndUtc:o} " +
                       $"sessionsRan={Describe(report.Stats.SessionsRan)} workDelivered={Describe(report.Stats.WorkDelivered)} " +
                       $"spendUsd={Describe(report.Stats.HostedAiSpendUsd)} attention={report.Attention.Count}");
         return report;
+    }
+
+    /// <summary>
+    /// The stale-worktree and unmerged-branch rows, or NOTHING when this Gateway holds no fresh
+    /// repo-state for the tenant. A stale snapshot is excluded by the store rather than aged into a
+    /// recommendation.
+    /// </summary>
+    private List<MorningAttentionItemDto> HygieneItems(TenantId tenant, DateTime now)
+    {
+        if (_repoState is null)
+            return new List<MorningAttentionItemDto>();
+
+        var repositories = _repoState.ReadFresh(tenant, RepoStateMaxAge, now);
+        if (repositories.Count == 0)
+        {
+            FileLog.Write("[MorningReportBuilder] HygieneItems: no repo-state fresher than " +
+                          $"{RepoStateMaxAge.TotalHours:0}h for tenant={tenant.ToLogString()} - the hygiene " +
+                          "rows are OMITTED, not emptied");
+            return new List<MorningAttentionItemDto>();
+        }
+
+        return RepoHygieneFold.Items(repositories, now);
     }
 
     /// <summary>Distinct sessions with at least one recorded transition in the window, or null when this

--- a/src/CcDirector.Gateway/Reports/RepoHygieneFold.cs
+++ b/src/CcDirector.Gateway/Reports/RepoHygieneFold.cs
@@ -1,0 +1,153 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Reports;
+
+/// <summary>
+/// Turns the stored repo-state snapshots (issue #2118) into the morning report's hygiene rows - the
+/// stale-worktree and unmerged-branch recommendations that are the flagship content of the daily email.
+///
+/// THIS IS WHERE A WRONG ANSWER COSTS THE OWNER WORK, so every rule below is conservative in the same
+/// direction: when the Gateway cannot tell, it says nothing rather than something.
+///
+///  - A worktree is only SAFE TO REMOVE when it is old, clean, unoccupied, AND its branch is provably
+///    merged into the default branch. A worktree whose merged-ness is UNKNOWN (no detectable default
+///    branch, or a failed inspection) is reported in the not-safe item - it is honest to say "this is old"
+///    and dishonest to say "this is finished".
+///  - An age needs an observed timestamp. A worktree with neither a last-activity time nor a tip commit
+///    date is skipped entirely: an unknown age is not a small age.
+///  - A DIRTY worktree is never listed as removable at all. Uncommitted work is the one thing that exists
+///    nowhere else.
+///  - An OCCUPIED worktree (a live session working in it) is never listed. That is not stale, that is
+///    someone's desk.
+///  - A branch counts as unmerged only on a definite <c>false</c>, never on a null.
+/// </summary>
+internal static class RepoHygieneFold
+{
+    /// <summary>How old a worktree's last activity must be before it is worth mentioning at all.</summary>
+    public const double StaleWorktreeDays = 7;
+
+    /// <summary>How old a branch's tip must be before an unmerged branch is worth mentioning. Anything
+    /// younger is simply work in progress, and reporting it would make the email noise.</summary>
+    public const double UnmergedBranchHours = 24;
+
+    /// <summary>The hygiene rows for one tenant's stored repositories, or an EMPTY list when there are
+    /// none. The caller decides what an empty list means: with no snapshots at all the sections are absent
+    /// from the report entirely (the honesty rule), which is not the same as "everything is tidy".</summary>
+    public static List<MorningAttentionItemDto> Items(IReadOnlyList<StoredRepoState> repositories, DateTime nowUtc)
+    {
+        var items = new List<MorningAttentionItemDto>();
+        if (repositories is null || repositories.Count == 0)
+            return items;
+
+        foreach (var repo in repositories)
+        {
+            items.AddRange(WorktreeItems(repo, nowUtc));
+            var branches = UnmergedBranchItem(repo, nowUtc);
+            if (branches is not null)
+                items.Add(branches);
+        }
+
+        FileLog.Write($"[RepoHygieneFold] Items: {repositories.Count} repositories -> {items.Count} hygiene rows");
+        return items;
+    }
+
+    private static IEnumerable<MorningAttentionItemDto> WorktreeItems(StoredRepoState repo, DateTime nowUtc)
+    {
+        var stale = repo.Worktrees
+            .Where(w => !w.HasLiveSession && !w.IsDirty)
+            .Select(w => (Worktree: w, AgeDays: AgeDays(w.LastActivityUtc ?? w.TipCommitUtc, nowUtc)))
+            .Where(x => x.AgeDays is > StaleWorktreeDays)
+            .ToList();
+
+        if (stale.Count == 0)
+            yield break;
+
+        // Two items, never one: "six worktrees, four of them safe to remove" is a sentence a person acts on
+        // wrongly. The safe ones and the not-safe ones are different recommendations and get different rows.
+        var safe = stale.Where(x => x.Worktree.BranchMergedIntoDefault == true).ToList();
+        var notSafe = stale.Where(x => x.Worktree.BranchMergedIntoDefault != true).ToList();
+
+        if (safe.Count > 0)
+            yield return Item(repo, safe, safeToRemove: true);
+        if (notSafe.Count > 0)
+            yield return Item(repo, notSafe, safeToRemove: false);
+    }
+
+    private static StaleWorktreesAttentionDto Item(
+        StoredRepoState repo, List<(RepoStateWorktreeDto Worktree, double? AgeDays)> group, bool safeToRemove)
+        => new()
+        {
+            Repo = string.IsNullOrWhiteSpace(repo.Name) ? repo.Path : repo.Name,
+            Count = group.Count,
+            // BASE NAMES only - the email does not need, and should not carry, the owner's directory layout.
+            Worktrees = group
+                .Select(x => BaseName(x.Worktree.Path))
+                .Where(n => n.Length > 0)
+                .ToList(),
+            OldestAgeDays = Math.Round(group.Max(x => x.AgeDays!.Value), 1),
+            SafeToRemove = safeToRemove,
+        };
+
+    private static UnmergedBranchesAttentionDto? UnmergedBranchItem(StoredRepoState repo, DateTime nowUtc)
+    {
+        // The default branch's own short name, so "main" is not reported as an unmerged branch of itself.
+        var defaultShort = ShortBranchName(repo.DefaultBranch);
+
+        var branches = repo.Branches
+            .Where(b => b.MergedIntoDefault == false)      // a definite false; a null is "not determined"
+            .Where(b => !NameMatches(b.Name, defaultShort))
+            .Where(b => !NameMatches(b.Name, repo.CurrentBranch))
+            .Select(b => (Branch: b, AgeDays: AgeDays(b.TipCommitUtc, nowUtc)))
+            .Where(x => x.AgeDays is not null && x.AgeDays > UnmergedBranchHours / 24.0)
+            .OrderByDescending(x => x.AgeDays)             // oldest first
+            .ToList();
+
+        if (branches.Count == 0)
+            return null;
+
+        return new UnmergedBranchesAttentionDto
+        {
+            Repo = string.IsNullOrWhiteSpace(repo.Name) ? repo.Path : repo.Name,
+            Branches = branches.Select(x => new UnmergedBranchDto
+            {
+                Name = x.Branch.Name,
+                AgeDays = Math.Round(x.AgeDays!.Value, 1),
+                Commits = x.Branch.CommitsAheadOfDefault,
+            }).ToList(),
+        };
+    }
+
+    /// <summary>Days between <paramref name="at"/> and now, or NULL when there is no observed timestamp.
+    /// An unknown age is never treated as zero and never as large - it is simply not reported.</summary>
+    private static double? AgeDays(DateTime? at, DateTime nowUtc)
+    {
+        if (at is not { } when)
+            return null;
+        var days = (nowUtc - DateTime.SpecifyKind(when, DateTimeKind.Utc)).TotalDays;
+        return days < 0 ? 0 : days;
+    }
+
+    /// <summary>"origin/main" -> "main". Null stays null.</summary>
+    private static string? ShortBranchName(string? refName)
+    {
+        if (string.IsNullOrWhiteSpace(refName))
+            return null;
+        var trimmed = refName.Trim();
+        var slash = trimmed.LastIndexOf('/');
+        return slash >= 0 && slash < trimmed.Length - 1 ? trimmed[(slash + 1)..] : trimmed;
+    }
+
+    private static bool NameMatches(string name, string? other)
+        => !string.IsNullOrWhiteSpace(other) && string.Equals(name, other, StringComparison.Ordinal);
+
+    /// <summary>The final path segment, whichever separator the pushing machine used.</summary>
+    private static string BaseName(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "";
+        var trimmed = path.TrimEnd('\\', '/');
+        var cut = trimmed.LastIndexOfAny(new[] { '\\', '/' });
+        return cut >= 0 && cut < trimmed.Length - 1 ? trimmed[(cut + 1)..] : trimmed;
+    }
+}

--- a/src/CcDirector.Gateway/Reports/RepoStateStore.cs
+++ b/src/CcDirector.Gateway/Reports/RepoStateStore.cs
@@ -1,0 +1,260 @@
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Reports;
+
+/// <summary>Thrown when a repo-state push is malformed. The endpoint maps it to a 400 with the message,
+/// so a Director learns what it sent wrong instead of having its snapshot silently dropped.</summary>
+public sealed class RepoStateValidationException : Exception
+{
+    public RepoStateValidationException(string message) : base(message) { }
+}
+
+/// <summary>
+/// The Gateway's repo-state store (issue #2118) over the <c>repo_state</c> table: the LATEST branches and
+/// worktrees each Director reports for each repository, which is the one hygiene feed the morning report
+/// cannot assemble from Gateway-side stores.
+///
+/// OVERWRITE, NOT APPEND: one row per (tenant, director, repository), replaced on every push. The report
+/// asks what a repository looks like NOW, so keeping a history would buy storage and retention work for a
+/// question nobody asks.
+///
+/// EVERY WRITE IS SCOPED BY THE PUSHER'S OWN TENANT, and the tenant comes from the caller's authenticated
+/// device key rather than from anything in the payload - so a body cannot claim to be another account's
+/// machine. The read is scoped the same way: the report reads only the tenant it was asked about.
+///
+/// Threading matches the rest of the data layer: single writer, write lock, fresh pooled context per
+/// operation.
+/// </summary>
+public sealed class RepoStateStore
+{
+    private readonly object _gate = new();
+    private readonly GatewayDatabase _db;
+
+    /// <summary>The hard ceiling on one push, so a single request cannot ask the Gateway to materialize an
+    /// unbounded write set. A machine with more repositories than this pushes the first
+    /// <see cref="MaxRepositoriesPerPush"/> and the overflow is REJECTED loudly rather than truncated.</summary>
+    public const int MaxRepositoriesPerPush = 200;
+
+    /// <summary>Identity fields - ids and paths, bounded because they are names, not prose.</summary>
+    public const int MaxIdChars = 512;
+
+    /// <summary>The hard ceiling on one serialized branch or worktree list. A repository with more branches
+    /// than this serializes to a payload no report needs; the push is rejected rather than truncated.</summary>
+    public const int MaxListJsonChars = 200_000;
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public RepoStateStore(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Store a Director's batch, replacing the row for each (tenant, director, repository) it names.
+    /// Validated as a WHOLE first: one malformed repository rejects the entire push, because a half-landed
+    /// batch would leave the report reading a mixture of this snapshot and the last one and calling it a
+    /// single moment in time. Returns the number of repositories stored.
+    /// </summary>
+    /// <exception cref="RepoStateValidationException">The push or a repository in it is malformed.</exception>
+    public int StoreBatch(TenantId tenant, string directorId, string machineName,
+        IReadOnlyList<RepoStateSnapshotDto> repositories, DateTime receivedAtUtc)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
+        if (repositories is null)
+            throw new RepoStateValidationException("A repositories list is required.");
+
+        var director = Required(directorId, "directorId");
+        if (repositories.Count > MaxRepositoriesPerPush)
+            throw new RepoStateValidationException(
+                $"A push carries at most {MaxRepositoriesPerPush} repositories (got {repositories.Count}).");
+        if (repositories.Count == 0)
+            return 0;
+
+        var received = DateTime.SpecifyKind(receivedAtUtc.ToUniversalTime(), DateTimeKind.Utc);
+        var machine = string.IsNullOrWhiteSpace(machineName) ? "" : machineName.Trim();
+        if (machine.Length > MaxIdChars)
+            throw new RepoStateValidationException($"The machineName is too long (limit {MaxIdChars} characters).");
+
+        // Build (and therefore validate) every row before touching the database.
+        var rows = new List<RepoStateEntity>(repositories.Count);
+        foreach (var repo in repositories)
+        {
+            if (repo is null)
+                throw new RepoStateValidationException("The repositories list contains a null entry.");
+            rows.Add(BuildRow(tenant, director, machine, repo, received));
+        }
+
+        // A duplicate repository path INSIDE one push is a producer bug, not something to silently collapse:
+        // two rows with the same key would make the stored answer depend on iteration order.
+        var duplicate = rows.GroupBy(r => r.RepoPath, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (duplicate is not null)
+            throw new RepoStateValidationException(
+                $"The push names the same repository path more than once ('{duplicate.Key}').");
+
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+
+            var paths = rows.Select(r => r.RepoPath).ToList();
+            // Reads THROUGH the global tenant query filter, so this only ever finds this tenant's own rows -
+            // another account's row for the same path is invisible here and is never overwritten.
+            var existing = ctx.RepoState
+                .Where(e => e.DirectorId == director && paths.Contains(e.RepoPath))
+                .ToDictionary(e => e.RepoPath, StringComparer.Ordinal);
+
+            foreach (var row in rows)
+            {
+                if (existing.TryGetValue(row.RepoPath, out var current))
+                {
+                    current.MachineName = row.MachineName;
+                    current.Name = row.Name;
+                    current.DefaultBranch = row.DefaultBranch;
+                    current.CurrentBranch = row.CurrentBranch;
+                    current.IsDirty = row.IsDirty;
+                    current.CollectedAtUtc = row.CollectedAtUtc;
+                    current.ReceivedAtUtc = row.ReceivedAtUtc;
+                    current.BranchesJson = row.BranchesJson;
+                    current.WorktreesJson = row.WorktreesJson;
+                }
+                else
+                {
+                    ctx.RepoState.Add(row);
+                }
+            }
+
+            ctx.SaveChanges();
+        }
+
+        FileLog.Write($"[RepoStateStore] StoreBatch: tenant={tenant.ToLogString()} director={director} stored {rows.Count} repositories");
+        return rows.Count;
+    }
+
+    /// <summary>
+    /// Every repository snapshot this tenant holds, newest first. Rows whose <c>ReceivedAtUtc</c> is older
+    /// than <paramref name="maxAge"/> are EXCLUDED: a Director that stopped pushing a week ago knows nothing
+    /// about that repository today, and serving its last snapshot would let the report recommend deleting a
+    /// worktree the owner has since started working in.
+    /// </summary>
+    public IReadOnlyList<StoredRepoState> ReadFresh(TenantId tenant, TimeSpan maxAge, DateTime nowUtc)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
+
+        var cutoff = DateTime.SpecifyKind(nowUtc.ToUniversalTime(), DateTimeKind.Utc) - maxAge;
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext(tenant);
+            return ctx.RepoState.AsNoTracking()
+                .Where(e => e.ReceivedAtUtc >= cutoff)
+                .OrderByDescending(e => e.ReceivedAtUtc)
+                .ToList()
+                .Select(ToStored)
+                .ToList();
+        }
+    }
+
+    private static RepoStateEntity BuildRow(
+        TenantId tenant, string director, string machine, RepoStateSnapshotDto repo, DateTime received)
+    {
+        var path = Required(repo.Path, "a repository path");
+        var branchesJson = JsonSerializer.Serialize(repo.Branches ?? new(), Json);
+        var worktreesJson = JsonSerializer.Serialize(repo.Worktrees ?? new(), Json);
+        if (branchesJson.Length > MaxListJsonChars)
+            throw new RepoStateValidationException($"The branch list for '{path}' is too large.");
+        if (worktreesJson.Length > MaxListJsonChars)
+            throw new RepoStateValidationException($"The worktree list for '{path}' is too large.");
+
+        var collected = DateTime.SpecifyKind(repo.CollectedAtUtc.ToUniversalTime(), DateTimeKind.Utc);
+        // A future collection time is a clock error on the pushing machine, not a real observation; clamp it
+        // to the receive time rather than trusting a skewed clock into an age calculation.
+        if (collected > received)
+            collected = received;
+
+        return new RepoStateEntity
+        {
+            TenantId = tenant.Value,
+            DirectorId = director,
+            RepoPath = path,
+            MachineName = machine,
+            Name = string.IsNullOrWhiteSpace(repo.Name) ? path : repo.Name.Trim(),
+            DefaultBranch = string.IsNullOrWhiteSpace(repo.DefaultBranch) ? null : repo.DefaultBranch.Trim(),
+            CurrentBranch = string.IsNullOrWhiteSpace(repo.CurrentBranch) ? null : repo.CurrentBranch.Trim(),
+            IsDirty = repo.IsDirty,
+            CollectedAtUtc = collected,
+            ReceivedAtUtc = received,
+            BranchesJson = branchesJson,
+            WorktreesJson = worktreesJson,
+        };
+    }
+
+    private static StoredRepoState ToStored(RepoStateEntity e) => new()
+    {
+        DirectorId = e.DirectorId,
+        MachineName = e.MachineName,
+        Name = e.Name,
+        Path = e.RepoPath,
+        DefaultBranch = e.DefaultBranch,
+        CurrentBranch = e.CurrentBranch,
+        IsDirty = e.IsDirty,
+        CollectedAtUtc = e.CollectedAtUtc,
+        ReceivedAtUtc = e.ReceivedAtUtc,
+        Branches = Deserialize<RepoStateBranchDto>(e.BranchesJson, e.RepoPath, "branches"),
+        Worktrees = Deserialize<RepoStateWorktreeDto>(e.WorktreesJson, e.RepoPath, "worktrees"),
+    };
+
+    /// <summary>
+    /// Read a stored list back. A row whose JSON will not parse is a FAILURE, not an empty list: returning
+    /// an empty list would tell the report "this repository has no branches and no worktrees", which is a
+    /// clean bill of health invented out of a corrupt row.
+    /// </summary>
+    private static List<T> Deserialize<T>(string json, string repoPath, string what)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<List<T>>(json, Json)
+                   ?? throw new InvalidOperationException("the stored value deserialized to null");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RepoStateStore] stored {what} for '{repoPath}' could not be read: {ex.Message}");
+            throw new InvalidOperationException(
+                $"The stored {what} for '{repoPath}' is unreadable. The Gateway will not report an empty " +
+                "list in its place - that would read as a clean repository.", ex);
+        }
+    }
+
+    private static string Required(string? value, string field)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new RepoStateValidationException($"A repo-state push needs {field}.");
+        var trimmed = value.Trim();
+        if (trimmed.Length > MaxIdChars)
+            throw new RepoStateValidationException($"The value for {field} is too long (limit {MaxIdChars} characters).");
+        return trimmed;
+    }
+}
+
+/// <summary>One stored repository snapshot, read back for the report. In-process only - there is no public
+/// read endpoint for repo state, and the payload never leaves the Gateway except folded into a report row.</summary>
+public sealed class StoredRepoState
+{
+    public string DirectorId { get; init; } = "";
+    public string MachineName { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Path { get; init; } = "";
+    public string? DefaultBranch { get; init; }
+    public string? CurrentBranch { get; init; }
+    public bool IsDirty { get; init; }
+    public DateTime CollectedAtUtc { get; init; }
+    public DateTime ReceivedAtUtc { get; init; }
+    public List<RepoStateBranchDto> Branches { get; init; } = new();
+    public List<RepoStateWorktreeDto> Worktrees { get; init; } = new();
+}


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#2118. First slice of thefrederiksen/devthrottle_internal#925 (the brain / morning report). The report endpoint (#2126, issue thefrederiksen/devthrottle#2119) is already merged and deployed; this is the git-hygiene feed it reads, plus the two report-side pieces that were falling between the two issues.

## What this adds

**1. The Director ships repo-state snapshots** for each registered repository, and the Gateway stores the newest one per (tenant, director, repository). This is the one git-hygiene feed the morning report cannot get from any Gateway-side store: the Gateway knows a repository exists, but only the machine holding the checkout can enumerate its branches and worktrees.

**2. The report's hygiene rows** - stale worktrees and unmerged branches - which thefrederiksen/devthrottle#2118 leaves to "the next slice" and thefrederiksen/devthrottle#2119 omits "until snapshots exist", so neither issue as written actually put them in the email despite their being its flagship content.

**3. A 48-hour reporting bar on waiting rows**, which the first real production call made necessary - see below.

## Director side

`RepoStateSnapshotCollector` builds each snapshot from the git services the Director already uses, so there is no second notion of "merged" anywhere in the product:

- `GitBranchService` gains `ListInventoryAsync`, returning the branches **and** the default branch every containment verdict was measured against. Carried together on purpose - a caller resolving the default branch independently could disagree with the service that computed containment, and "merged into main" measured against a different ref than the caller believes is exactly the confidently-wrong statement this email must not make.
- New `BranchInfo.MergedIntoDefault`, deliberately **narrower** than `SafeToDelete` and not a substitute for it. Safe-to-delete also accepts "origin branch gone" and "pull request merged", and refuses any checked-out branch - which is precisely the case the report wants to talk about.
- Worktree merged-ness is read back out of that one inventory rather than recomputed, so a snapshot cannot show a worktree as safe to remove whose branch it also lists as unmerged, in the same payload.

**It never guesses.** An undetectable default branch records `null`, and every merged-ness in that snapshot is `null` - not `false`, which a reader would legitimately treat as "this definitely has unmerged work". A repository that fails to enumerate is **omitted** rather than pushed empty: an empty snapshot reads downstream as a clean bill of health invented out of a failure.

`RepoStatePusher` runs two minutes after start, then every six hours. Fail-safe is the design, not a `try`/`catch` around it: a refused push, a throwing transport, and a failed enumeration all return quietly and **the next cycle still runs** (asserted, not promised). No outbox, deliberately - this pushes CURRENT state, so a lost push is superseded rather than lost, and replaying one would lay a stale picture over a fresher one.

## Gateway side

`POST /gateway/repostate`, device-authenticated, write-only. The tenant comes from the caller's authenticated key and **never** from the body. **No read route** - the only consumer is the report, which reads in-process; a public read would put every repository path and branch name of every account on an HTTP surface for no caller that exists. `repo_state` is keyed `(tenant_id, DirectorId, RepoPath)` because both natural key parts are caller-supplied; overwritten, never appended. A snapshot older than the freshness bar is **excluded** from a read, never aged into a recommendation.

## The hygiene rows

Every rule is conservative in the same direction, because a wrong answer here costs the owner work rather than time:

- **Safe to remove is the narrow claim.** Old, clean, unoccupied, AND provably merged. Unknown merged-ness goes in the not-safe row: it is honest to say "this is old" and dishonest to say "this is finished".
- **Safe and not-safe are separate rows**, never one blended count. "Six worktrees, four of them safe to remove" is a sentence a person acts on wrongly.
- A **dirty** worktree is never listed (uncommitted work exists nowhere else); nor is an **occupied** one (that is not stale work, that is someone's desk).
- An age needs an **observed timestamp**. No last-activity and no tip date means skipped: an unknown age is not a small one.
- A branch counts as unmerged only on a definite `false`, never a `null`; the default and checked-out branches are excluded; anything touched in the last day is work in progress, not a recommendation.

No repo-state store, or no snapshot fresher than 24 hours (four missed push cycles), means **no hygiene rows at all** rather than empty ones.

## The 48-hour bar, and why production taught us to add it

The first real call to the deployed endpoint returned nine `waiting-session` rows aged **69 to 129 hours**, for sessions long gone, shown as raw identifiers because no Director is connected to the hosted Gateway to name them.

Every one was a true statement *about the ledger* and a false statement about the owner's morning. The ledger records what it is told; a session that stops without an exit event leaves its wait open forever, so "waiting since" ages without bound and never resolves. After two days of silence the Gateway has no business asserting a session is waiting on a person today, so now it says nothing about it - counted and logged, never silently dropped. It is a reporting bar, not a data change: the ledger keeps every transition.

## Two defects the tests caught before they shipped

1. **`repo_state` was missing from the model's tenant-scope list**, so its global query filter was absent: one account's push overwrote another's row for the same repository path, and one account's read returned the other's rows. Both cross-tenant tests went red on the first run. Both migrations were regenerated over the corrected model; both snapshots verify clean with `has-pending-model-changes`.
2. The report builder was being constructed **before** the repo-state store, so it would have silently received `null` and quietly omitted every hygiene row forever. Construction order fixed, with a comment saying why it matters.

## Tests

44 new, and 109 green across the fold, the report, and the repo-state store and endpoint together.

- **Collector (6)**, against REAL git repositories: merged versus unmerged in both directions with ahead-counts; an undetectable default branch recording null everywhere; worktrees reported with the primary checkout excluded; a broken repository omitted rather than pushed empty; a vanished path skipped; and a no-content assertion against a repository whose files **and commit messages** carry a distinctive marker, with a positive control so it cannot pass by testing an empty payload.
- **Store (15)** and **endpoint (7)**, including both cross-tenant negatives and an authenticated key with no bound tenant denied rather than served the Local partition.
- **Hygiene fold (16)**, each written as the harm it prevents.
- **The bar (2)**, in both directions: a wait past it is dropped, a wait just inside it is still reported. A bar set wrong the other way makes every genuine multi-day wait vanish, which is the same silence dressed as tidiness.

## Honest scope note

The hosted tenant is **thin** because the owner's fleet reports to the LOCAL Gateway, not the hosted one. This feed only enriches the hosted morning report once a hosted-enrolled Director registers real repositories - so this ships the mechanism and the correctness, not hygiene content in tomorrow's email.
