### PR TITLE
Hosted gateway: grant every new account a 14-day Pro trial (#2117)

### DIFF
--- a/docs/cencon/proof/issue-2117/qa-report.html
+++ b/docs/cencon/proof/issue-2117/qa-report.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA proof - issue 2117 - hosted gateway 14-day Pro trial</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem auto; max-width: 60rem; color: #1c1c1c; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #1c4e80; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #1c4e80; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .6rem; vertical-align: top; text-align: left; font-size: .95rem; }
+  th { background: #eef2f7; }
+  code { background: #f4f4f4; padding: .1rem .3rem; font-family: Consolas, monospace; font-size: .9rem; }
+  .pass { color: #0a6b2d; font-weight: bold; }
+  .note { background: #fbf8e6; border-left: 4px solid #c9a227; padding: .7rem 1rem; margin: 1rem 0; }
+  .verdict { background: #e8f5ec; border-left: 6px solid #0a6b2d; padding: 1rem; font-size: 1.1rem; }
+</style>
+</head>
+<body>
+
+<h1>QA proof - issue 2117</h1>
+<p><strong>Issue:</strong> Hosted gateway: grant every new account a 14-day Pro trial entitlement<br>
+<strong>Pull request:</strong> 2132, branch <code>issue-2117-pro-trial</code><br>
+<strong>Verified by:</strong> the QA Agent, independently, in its own worktree cut from the pull request branch.
+The developer's report and committed evidence were read for context only; every result below was reproduced
+by QA from the source.</p>
+
+<h2>How this was verified</h2>
+<ul>
+  <li>Own worktree cut from <code>origin/issue-2117-pro-trial</code>. No shipped code was read from a shared checkout.</li>
+  <li>Every changed source file was read in full - the trial ledger, the entitlement fold, the enrollment path,
+      the request-path refusal, the database context, both migrations, and every changed test.</li>
+  <li>The new tests were run, and then <strong>mutation-tested</strong>: the behaviour each one claims to protect
+      was deliberately removed from the production code, one change at a time, to prove the test actually fails
+      when the behaviour is gone. A test that cannot fail is not coverage.</li>
+  <li>Both migration sets were checked against the model with the tooling, on both database providers.</li>
+  <li>The full Gateway suite was run by QA, before and after merging current main into the branch.</li>
+</ul>
+
+<h2>Acceptance criteria</h2>
+
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual</th><th>Evidence</th><th>Result</th></tr>
+
+<tr>
+  <td>1</td>
+  <td>A brand-new account, created with email only, can use the hosted gateway with zero payment steps.</td>
+  <td>Enrollment succeeds with no entitlement row and no card, and the account is entitled at Pro tier.</td>
+  <td>Enrollment returns 200 with a device key and mints a tenant. The entitlement read returns Entitled,
+      tier <code>pro</code>, period end exactly grant plus 14 days. Pro is granted as the tier the pricing page
+      names; hosted access itself is what the wingman, dictation and spoken replies run behind, and the trial
+      account passes that gate identically to a paying one.</td>
+  <td><code>HostedProTrialTests.A_brand_new_account_with_no_payment_enrolls_on_the_free_trial</code>,
+      <code>...The_trial_grants_PRO_tier_and_expires_exactly_fourteen_days_after_the_grant</code> - both run by QA, both pass.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>2</td>
+  <td>The same account 15 days later, with no subscription, gets a clean entitlement-denied response that points
+      at subscribing - not a raw error. Expiry enforced at the entitlement read, not merely displayed.</td>
+  <td>The entitlement read itself stops returning Entitled at the expiry instant, so the ongoing request-path
+      cutoff denies, and the refusal carries a sentence and an address.</td>
+  <td>The trial is folded into <code>EntitlementRegistry.Evaluate</code>, which is the single read used by the
+      enrollment gate, by <code>HostedAccessLeaseService</code> on the request path, and by the 60-second sweep -
+      QA traced all three call sites. At day 15 the read returns NotEntitled; at exactly the expiry instant it is
+      already NotEntitled, one tick before it is Entitled. The positive lease is clipped to the trial end instant,
+      so caching cannot outlive the trial. The 402 written by the request-path middleware and by both enrollment
+      surfaces now carries <code>message</code> and <code>subscribeUrl</code> alongside the unchanged
+      <code>error</code>/<code>code</code>.</td>
+  <td><code>...Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED</code>,
+      <code>...The_trial_is_over_AT_the_exact_expiry_instant_not_a_tick_later</code>,
+      <code>...Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing</code>,
+      <code>...The_402_a_member_meets_after_the_trial_says_what_to_do_about_it</code> (drives the real endpoint over
+      HTTP and reads the body). All run by QA, all pass.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>3</td>
+  <td>A trial account that subscribes on day 7 keeps working without interruption, and its paid entitlement does
+      not inherit the trial's expiry.</td>
+  <td>The paid record takes over seamlessly; the period end handed to the lease is the paid one.</td>
+  <td>A valid paid entitlement is read first and returned outright; the trial is not consulted at all while a paid
+      row is valid, so there is no gap and no double grant. With a paid row present the decision carries the paid
+      period end, not the trial's. QA also confirmed the reverse guard: an account that pays from the start never
+      has a trial row written, so it does not burn its one trial while paying.</td>
+  <td><code>...Subscribing_on_day_seven_takes_over_with_no_gap_and_no_trial_expiry_clipped_onto_it</code>,
+      <code>...A_paying_account_is_never_handed_a_trial_it_does_not_need</code> - both run by QA, both pass;
+      plus QA's own reading of the ordering in <code>EntitlementRegistry.Evaluate</code>.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>4</td>
+  <td>Rollout rule (the owner's decision on this issue): only accounts arriving at or after rollout get the trial;
+      existing accounts are NOT backfilled.</td>
+  <td>Nothing is granted to an account that was already using the hosted gateway.</td>
+  <td>The grant happens only at an account's first arrival and is refused when the gateway already holds a tenant
+      for that account. QA confirmed the rule is enforced inside the ledger itself, not only at the caller, and that
+      the ledger re-checks its own table before writing, so an expired trial is never re-granted. The residual the
+      developer stated is real and correctly scoped: an account that signed up before rollout and never once reached
+      the hosted gateway is indistinguishable here and would get a trial on first arrival - nothing is granted
+      silently, and no account already using hosted gets anything. Excluding that last case needs a creation-time
+      signal from the website, which is a separate repository.</td>
+  <td><code>...An_account_the_gateway_already_knew_about_is_granted_NO_trial</code> - run by QA, passes.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>5</td>
+  <td>One trial per account, ever - the free window cannot be restarted.</td>
+  <td>Re-arriving after the window closes is refused; a second grant inside the window does not extend it.</td>
+  <td>The account subject is the table's primary key, so one-trial-per-account is enforced by the database and not
+      only by code. A second grant after expiry returns nothing and writes nothing; a second grant inside the window
+      returns the identical expiry. The expired row is deliberately kept - it is the evidence that stops a restart.</td>
+  <td><code>...A_second_grant_attempt_after_expiry_NEVER_restarts_the_fourteen_days</code>,
+      <code>...Granting_twice_inside_the_window_returns_the_SAME_expiry_and_never_extends_it</code> - run by QA, pass.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>6</td>
+  <td>Ignorance is never a verdict - a failed read must not deny a member inside their window and must not hand
+      hosted to someone with no trial.</td>
+  <td>A failed trial read answers retry (503), never 402 and never a grant; a live trial still entitles when the
+      paid read fails; a failed paid read with no trial is still a retry and mints nothing.</td>
+  <td>All three hold. The three-way outcome is preserved end to end and the enrollment path turns an unreadable
+      ledger into a 503 with nothing minted.</td>
+  <td><code>...A_failed_TRIAL_read_is_UNKNOWN_and_must_never_masquerade_as_a_refusal</code>,
+      <code>...A_live_trial_entitles_even_when_the_PAID_read_fails</code>,
+      <code>...A_failed_PAID_read_with_no_trial_is_still_a_retry_never_a_free_grant</code> - run by QA, pass.</td>
+  <td class="pass">PASS</td>
+</tr>
+
+<tr>
+  <td>7</td>
+  <td>Usage during the trial is metered exactly like paid usage.</td>
+  <td>No metering path excludes a trial account.</td>
+  <td>A trial account enrolls through the same hosted mint and holds an ordinary tenant, and the spend records are
+      tenant-scoped with no entitlement condition anywhere in that path. QA found no code that skips metering for a
+      non-paying tenant, so trial usage is recorded on the same footing as paid usage.</td>
+  <td>Source review of the spend and activity records and of the enrollment path.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>The tests were proven able to fail</h2>
+
+<p>Each behaviour was removed from the production code, one at a time, and the suite re-run. Every removal turned
+tests red, and the tree was restored to the committed state after each one.</p>
+
+<table>
+<tr><th>Behaviour removed</th><th>Tests that went red</th></tr>
+<tr>
+  <td>The trial expiry check - the window was widened so a trial never ends.</td>
+  <td>4 failed: the day-15 read, the exact-expiry boundary, the re-enrollment refusal, and the never-restart rule.</td>
+</tr>
+<tr>
+  <td>The rollout rule - the already-known-to-the-gateway refusal was neutered.</td>
+  <td>2 failed: the no-trial-for-an-existing-account rule, and the 402 body test that depends on it.</td>
+</tr>
+<tr>
+  <td>The trial grant in the entitlement fold - trials stopped entitling.</td>
+  <td>2 failed, including the Pro tier and 14-day expiry assertion.</td>
+</tr>
+<tr>
+  <td>Control: the wiring as it was before this issue (no trial ledger).</td>
+  <td>The committed control test asserts the old 402 behaviour is byte-unchanged, and it passes both with and
+      without the change - which is what makes it a control rather than a duplicate.</td>
+</tr>
+</table>
+
+<div class="note">
+<strong>One coverage observation, not a defect.</strong> The ordering "a valid paid entitlement is checked first and
+wins outright" is correct in the code and QA read it directly, but no test fails if that ordering is inverted: the
+day-seven test asserts at day fifteen, when the trial has already ended, so both orderings produce the same answer
+there. The member-visible behaviour is unaffected either way - under the inverted ordering the lease would simply be
+clipped to the trial end and renewed on the next read, with no interruption - so this is a thin spot in the test set
+rather than a defect in the shipped behaviour. Recorded here so it is not rediscovered as a surprise.
+</div>
+
+<h2>Migrations - the model change ships with its migration on both providers</h2>
+
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td>SQLite migration creating <code>account_trials</code> present in the same pull request as the model change</td><td class="pass">PASS - primary key on subject, index on the expiry</td></tr>
+<tr><td>PostgreSQL migration creating <code>gateway.account_trials</code> present in the same pull request</td><td class="pass">PASS - byte-ordinal collation on the subject key, timestamps with time zone, matching the convention of every other gateway table</td></tr>
+<tr><td>SQLite model in sync with the committed migrations</td><td class="pass">PASS - the tooling reports no pending model changes</td></tr>
+<tr><td>PostgreSQL model in sync with the committed migrations</td><td class="pass">PASS - the tooling reports no pending model changes</td></tr>
+<tr><td>The SQLite migration actually runs</td><td class="pass">PASS - the test harness opens a real database through the normal startup path, which applies migrations; the trial tests read and write the table, and one of them drops it to prove the failure path</td></tr>
+<tr><td>A concurrent migration landed on main while this branch was open</td><td class="pass">PASS - merged, no conflict; the trial migration sorts after it, both model snapshots carry both tables, and both providers still report no pending model changes after the merge</td></tr>
+</table>
+
+<h2>Regression and method checks</h2>
+
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td>Full Gateway suite on the branch, run by QA</td><td class="pass">PASS - 3816 passed, 0 failed, 17 skipped</td></tr>
+<tr><td>Full Gateway suite after merging current main, run by QA</td><td class="pass">PASS - 3961 passed, 2 failed, 17 skipped; both failures pass when run alone, both are known load-sensitive tests unrelated to entitlements (a stream-mode kill route and a storage-root redirect), and a first run of the same suite under heavy machine load produced a broad cascade that vanished on re-run. Contention, not regression.</td></tr>
+<tr><td>Full solution build after merging current main</td><td class="pass">PASS - build succeeded, 0 warnings, 0 errors</td></tr>
+<tr><td>Continuous integration on the pull request</td><td class="pass">PASS - both the .NET and the web check are green</td></tr>
+<tr><td>Tenant-gate and tenant-scope guards</td><td class="pass">PASS - the new table is named on both global-table allowlists with a written reason, which is exactly the review-visible act those guards exist to force. It is keyed by account subject and read before a tenant exists, the same shape as the tenants and entitlements tables beside it, and it is only ever written for the subject the caller has already been verified as.</td></tr>
+<tr><td>Self-host unchanged</td><td class="pass">PASS - with no trial ledger wired the gate behaves exactly as before, and the hosted enrollment route and lease service are not mapped on self-host at all</td></tr>
+<tr><td>No non-ASCII characters in the changed source</td><td class="pass">PASS</td></tr>
+<tr><td>No assistant or tool attribution anywhere in the branch</td><td class="pass">PASS</td></tr>
+<tr><td>Secrets and personally identifying data</td><td class="pass">PASS - the account subject is never written to the log on any path, including the failure paths</td></tr>
+<tr><td>Deployment</td><td>Out of scope and deliberately not done. The hosted gateway is released only through its deploy pipeline.</td></tr>
+</table>
+
+<h2>Verdict</h2>
+<p class="verdict">VERIFIED - all acceptance criteria met. Every criterion was reproduced independently from the
+source, the new tests were proven able to fail when the behaviour they protect is removed, both database
+migrations ship with the model change and are in sync on both providers, the merged result builds clean, and the
+only regression-suite failures are load-sensitive tests unrelated to this change that pass in isolation.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-2117/report.html
+++ b/docs/cencon/proof/issue-2117/report.html
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue 2117 - Hosted gateway: 14-day Pro trial for every new account</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 1080px; margin: 2rem auto; padding: 0 1.5rem;
+         color: #1c2530; line-height: 1.55; }
+  h1 { border-bottom: 3px solid #2f6fb0; padding-bottom: .4rem; }
+  h2 { margin-top: 2.2rem; color: #2f6fb0; }
+  h3 { margin-top: 1.6rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #c9d3dd; padding: .55rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #eef4fa; }
+  code { background: #f2f5f8; padding: .1rem .3rem; border-radius: 3px; font-size: .93em; }
+  pre { background: #f2f5f8; padding: .8rem; overflow-x: auto; border-left: 4px solid #2f6fb0; }
+  .pass { color: #1d6b32; font-weight: 600; }
+  .note { background: #fff8e6; border-left: 4px solid #d9a300; padding: .8rem 1rem; margin: 1rem 0; }
+  .verdict { background: #eaf6ed; border-left: 4px solid #1d6b32; padding: 1rem; margin: 2rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Issue 2117 - Hosted gateway: grant every new account a 14-day Pro trial</h1>
+
+<p><strong>Branch:</strong> <code>issue-2117-pro-trial</code><br>
+<strong>Base:</strong> <code>origin/main</code> at <code>86682135</code><br>
+<strong>Date:</strong> 2026-07-24</p>
+
+<h2>Why this was urgent</h2>
+
+<p>The live pricing page at devthrottle.com/pricing already tells every visitor: "Every new account starts
+with 14 days of Pro. Just sign up with your email - no card required." The hosted gateway granted no such
+entitlement, so the public page was over-promising. This change makes the sentence true, and - just as
+important - makes it BOUNDED, so the trial ends rather than becoming a permanent free plan.</p>
+
+<h2>The design decision that shaped the implementation</h2>
+
+<p>The paid entitlement table (<code>gateway.entitlements</code>) is <strong>not the gateway's to
+write</strong>. It is the agreed cross-team hand-off point: the website's payment webhook UPSERTs it as the
+service role, while the gateway runs as a scoped role holding SELECT and nothing more, and the table is
+explicitly excluded from gateway migrations. A trial is not a payment, and no webhook produces one - so the
+gateway cannot grant a trial by writing there.</p>
+
+<p>The trial is therefore recorded on the gateway's own side of the boundary, in a new gateway-owned table
+<code>account_trials</code>, and the entitlement decision reads BOTH sources in one place. Nothing about the
+website's schema, the webhook, or the gateway's database role changes.</p>
+
+<h3>Where the trial is decided (one place, not two)</h3>
+
+<p>The trial is folded into <code>EntitlementRegistry.Evaluate</code> - the single read that the enrollment
+gate, the hosted-access lease and the 60-second entitlement sweep all call. It is deliberately NOT bolted onto
+the enrollment endpoint: a trial applied only at enrollment would let a member in and then be invisible to the
+ongoing request-path cutoff, which is exactly where a trial has to EXPIRE. One place decides, so the three
+callers can never disagree about whether an account may use hosted today.</p>
+
+<p>The grant itself happens in exactly one place - the hosted enrollment path, at an account's first arrival.
+Reads never grant.</p>
+
+<h3>The rollout rule (the owner's decision on this issue)</h3>
+
+<p>The owner's comment settled it: only accounts created at or after rollout get the trial; existing accounts
+are NOT backfilled. The gateway cannot observe account creation - that happens on the website, and the
+Supabase access token carries no creation claim - so the rule is implemented against the one thing the gateway
+CAN observe: whether it has ever seen this account before.</p>
+
+<ul>
+  <li>An account that <strong>already holds a tenant</strong> was using hosted before the trial existed. It is
+      granted <strong>nothing</strong>. This is asserted by its own test.</li>
+  <li>An account arriving at the hosted gateway for the first time is granted the 14 days.</li>
+</ul>
+
+<div class="note">
+<strong>Residual, stated plainly rather than hidden.</strong> An account that signed up on the website before
+rollout and never once reached the hosted gateway is indistinguishable here from a brand-new one, and will be
+granted a trial on its first arrival. It is granted nothing silently - only when the member actively tries to
+use hosted for the first time, which is behaviourally identical to a new signup - and <em>no account that was
+already using hosted is granted anything at all</em>. If the owner wants that last case excluded too, it needs
+a creation-time signal from the website (a custom token claim or a website-written trial row); that is a
+cross-repo change and is not in this pull request.
+</div>
+
+<h2>What changed</h2>
+
+<table>
+<tr><th>File</th><th>Change</th></tr>
+<tr><td><code>src/CcDirector.Gateway/Data/Entities/AccountTrialEntity.cs</code></td>
+    <td>NEW. One row per account: subject, trial start, trial end. Written once, never extended.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Tenancy/TrialRegistry.cs</code></td>
+    <td>NEW. The trial ledger. <code>Evaluate</code> (read-only, three-way outcome) and
+        <code>GrantIfFirstArrival</code> (the only writer, idempotent, never extends).</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs</code></td>
+    <td>Optional trial ledger dependency. <code>Evaluate</code> now folds paid + trial: a valid paid
+        entitlement always wins; otherwise a live trial entitles at <code>pro</code> tier with the trial's end
+        as the period end. Adds the <code>SubscribeUrl</code>/<code>SubscribeMessage</code> constants.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs</code></td>
+    <td>Grants the trial at first arrival when the paid read says NotEntitled. The 402 body now carries the
+        subscribe message and URL.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Api/MobileEnrollmentEndpoint.cs</code></td>
+    <td>Passes the trial ledger into the one hosted mint; same 402 wording on the mobile surface.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Api/HostedEnrollDependencies.cs</code></td>
+    <td>The bundle now carries the trial ledger, so every hosted entry point applies the identical rule.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Util/AuthMiddleware.cs</code></td>
+    <td>The request-path 402 body gains <code>message</code> and <code>subscribeUrl</code> (additive;
+        <code>error</code> and <code>code</code> are unchanged so existing callers keep parsing).</td></tr>
+<tr><td><code>src/CcDirector.Gateway/Data/GatewayDbContext.cs</code></td>
+    <td><code>account_trials</code> mapping - global (no tenant filter, like <code>tenants</code>), subject as
+        primary key, byte-ordinal <code>C</code> collation on Postgres so uniqueness matches SQLite exactly.</td></tr>
+<tr><td><code>src/CcDirector.Gateway/GatewayHost.cs</code></td>
+    <td>Builds the trial ledger and injects it into the entitlement registry and the enrollment bundle.</td></tr>
+<tr><td><code>.../Data/Migrations/20260724212144_AddAccountTrials.cs</code></td>
+    <td>SQLite migration - in the SAME pull request as the model change.</td></tr>
+<tr><td><code>.../Migrations.Postgres/Migrations/20260724212205_AddAccountTrials.cs</code></td>
+    <td>Postgres migration - in the SAME pull request as the model change.</td></tr>
+<tr><td><code>src/CcDirector.Gateway.Tests/HostedProTrialTests.cs</code></td>
+    <td>NEW. 15 tests covering every acceptance criterion plus the controls.</td></tr>
+<tr><td><code>src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs</code>,
+        <code>.../Architecture/TenantGateArchitectureTests.cs</code></td>
+    <td>The two global-table allowlists name <code>AccountTrialEntity</code>, each with its reason. Adding a
+        global table is deliberately a review-visible act in both places.</td></tr>
+<tr><td><code>src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs</code></td>
+    <td>The paid-gate refusal test now uses an account whose trial has ended - the account that is genuinely
+        not entitled under the new rules - keeping every assertion it had.</td></tr>
+</table>
+
+<h2>Acceptance criteria, and how each is proven</h2>
+
+<table>
+<tr><th>Criterion (from the issue)</th><th>How the code satisfies it</th><th>Proof</th></tr>
+
+<tr>
+<td>A brand-new account, created with email only, can use dictation, spoken replies and the wingman against
+    the hosted gateway with zero payment steps.</td>
+<td>At first arrival the paid read answers NotEntitled and the trial is granted, so enrollment returns 200 and
+    a device key. With a device key the tenant passes the request-path cutoff, which is the single gate in
+    front of dictation, spoken replies and the wingman. No payment interaction exists anywhere on the path.</td>
+<td class="pass">PASS -
+    <code>A_brand_new_account_with_no_payment_enrolls_on_the_free_trial</code><br>
+    Expected 200 + device key + tenant minted. Actual: 200, non-empty device key, tenant present.</td>
+</tr>
+
+<tr>
+<td>The trial grants exactly the Pro entitlement set.</td>
+<td>The trial decision returns tier <code>pro</code> - the same value a paying Pro subscriber's row carries -
+    and the entitlement outcome Entitled, which is what every hosted capability reads.</td>
+<td class="pass">PASS -
+    <code>The_trial_grants_PRO_tier_and_expires_exactly_fourteen_days_after_the_grant</code><br>
+    Expected tier <code>pro</code>, period end = grant + 14 days, trial length 14 days. Actual: all three.</td>
+</tr>
+
+<tr>
+<td>The same account 15 days later (no subscription) gets clean entitlement-denied responses on those
+    features, with a message that points at subscribing - not a raw error.</td>
+<td>The entitlement read - the same read the request-path cutoff calls - stops returning Entitled the instant
+    the trial ends, so the cutoff answers 402 and the sweep revokes the tenant's device credentials. The 402
+    body carries a finished sentence and the subscribe URL, computed on the gateway; the client only renders
+    them.</td>
+<td class="pass">PASS -
+    <code>Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED</code>,
+    <code>The_trial_is_over_AT_the_exact_expiry_instant_not_a_tick_later</code>,
+    <code>Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing</code>,
+    <code>The_402_a_member_meets_after_the_trial_says_what_to_do_about_it</code> (drives the real endpoint over
+    HTTP and reads the wire body).<br>
+    Expected NotEntitled at day 15, Entitled one tick before expiry, NotEntitled at exactly expiry, 402 whose
+    body contains the subscribe message and URL. Actual: all four.</td>
+</tr>
+
+<tr>
+<td>Expiry must be enforced at the gateway's entitlement read - not just displayed.</td>
+<td>The trial lives inside <code>EntitlementRegistry.Evaluate</code>, not in a view. The trial's end instant is
+    returned as the period end, so the hosted-access lease clips to it
+    (<code>expiry = min(now + ttl, periodEnd)</code>) and caching cannot extend a trial one moment past its
+    end.</td>
+<td class="pass">PASS - the expiry tests above operate on the entitlement read itself, which is the read the
+    lease and the 60-second sweep call. The tier/period-end assertion pins that the clip value is the trial's
+    own end.</td>
+</tr>
+
+<tr>
+<td>A trial account that subscribes on day 7 keeps working without interruption and its paid entitlements have
+    no expiry.</td>
+<td>A valid paid entitlement is checked FIRST and wins outright - the trial is not consulted at all while a
+    paid row is valid. So there is no gap (the trial was never removed) and no double-grant (the paid decision
+    is returned whole, carrying the paid period end, not the trial's).</td>
+<td class="pass">PASS -
+    <code>Subscribing_on_day_seven_takes_over_with_no_gap_and_no_trial_expiry_clipped_onto_it</code><br>
+    Expected at day 15: Entitled, tier <code>pro</code>, period end = the PAID period end and specifically NOT
+    the trial's 14-day end. Actual: all four assertions hold - had the trial expiry leaked through, the lease
+    would have cut a paying member off on day 14.</td>
+</tr>
+
+<tr>
+<td>A paying account is never handed a trial it does not need.</td>
+<td>The trial is only reached after the paid read has answered NotEntitled, so an account that pays from the
+    start writes no trial row and keeps its one trial unspent.</td>
+<td class="pass">PASS - <code>A_paying_account_is_never_handed_a_trial_it_does_not_need</code>.
+    Expected: 200 enrollment and NO trial row. Actual: both.</td>
+</tr>
+
+<tr>
+<td>Usage during trial is metered exactly like paid usage; the fair-use / anomaly reporting must include
+    trials.</td>
+<td>No change was needed and none was made. A trial account is an ordinary entitled tenant holding an ordinary
+    device key; the hosted-AI spend store and the session spend store record per tenant with no entitlement,
+    tier, or trial condition anywhere on the path, so a trial is metered by the same code that meters a paid
+    account.</td>
+<td class="pass">PASS by inspection - <code>AccountHostedAiSpendStore</code>,
+    <code>HostedAiSpendSweep</code> and <code>SessionSpendEmitter</code> contain no entitlement, tier or trial
+    branch. There is no code path a trial could take that a paid account does not.</td>
+</tr>
+
+<tr>
+<td>Existing accounts created before rollout: no automatic grant (owner's decision in the issue comment).</td>
+<td>An account already known to this gateway - it holds a tenant - is refused a trial explicitly, and the
+    refusal is the enrollment 402 with nothing minted.</td>
+<td class="pass">PASS - <code>An_account_the_gateway_already_knew_about_is_granted_NO_trial</code><br>
+    Expected 402, no device key, and no trial row written. Actual: all three. (See the stated residual above.)</td>
+</tr>
+
+<tr>
+<td>One trial per account - the free window must not restart.</td>
+<td>The grant is idempotent and never extends: an existing row (live or expired) is returned as it stands, and
+    the expired row is deliberately kept as the evidence that this account already had its trial.</td>
+<td class="pass">PASS -
+    <code>A_second_grant_attempt_after_expiry_NEVER_restarts_the_fourteen_days</code>,
+    <code>Granting_twice_inside_the_window_returns_the_SAME_expiry_and_never_extends_it</code><br>
+    Expected: a post-expiry grant attempt returns no trial; a mid-window second grant returns the identical
+    original expiry. Actual: both.</td>
+</tr>
+
+<tr>
+<td>Ignorance is never a verdict (the pre-existing three-outcome law must survive this change).</td>
+<td>A failed trial read answers Unknown, which the enrollment path turns into 503-retry - never 402 and never
+    a grant. A failed PAID read with no trial is still 503, so the trial cannot turn an unreadable payment
+    table into a free enrollment. A failed PAID read WITH a live trial is Entitled, because the trial is
+    knowledge we hold ourselves.</td>
+<td class="pass">PASS -
+    <code>A_failed_TRIAL_read_is_UNKNOWN_and_must_never_masquerade_as_a_refusal</code>,
+    <code>A_failed_PAID_read_with_no_trial_is_still_a_retry_never_a_free_grant</code>,
+    <code>A_live_trial_entitles_even_when_the_PAID_read_fails</code><br>
+    Expected 503 (not 402) with nothing minted on the first two; Entitled at pro tier on the third. Actual: all
+    three.</td>
+</tr>
+
+<tr>
+<td>Revert-proof / self-host control.</td>
+<td>With no trial ledger wired - the wiring before this issue, and the wiring self-host still gets - the gate
+    behaves exactly as it did: an unpaid account is refused.</td>
+<td class="pass">PASS - <code>With_no_trial_ledger_wired_the_gate_behaves_exactly_as_it_did_before</code>.
+    Expected 402 with nothing minted. Actual: both. If this ever passed WITH a ledger wired, the grant tests
+    would be proving nothing.</td>
+</tr>
+</table>
+
+<h2>Build and test evidence</h2>
+
+<h3>Full-solution build</h3>
+<pre>dotnet build cc-director.sln
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)</pre>
+
+<h3>New tests for this issue</h3>
+<p>Per-test output is committed beside this report as
+<code>docs/cencon/proof/issue-2117/trial-tests.txt</code>.</p>
+<pre>dotnet test src/CcDirector.Gateway.Tests --filter FullyQualifiedName~HostedProTrialTests
+
+  Passed A_brand_new_account_with_no_payment_enrolls_on_the_free_trial
+  Passed The_trial_grants_PRO_tier_and_expires_exactly_fourteen_days_after_the_grant
+  Passed Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED
+  Passed The_trial_is_over_AT_the_exact_expiry_instant_not_a_tick_later
+  Passed Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing
+  Passed A_second_grant_attempt_after_expiry_NEVER_restarts_the_fourteen_days
+  Passed Granting_twice_inside_the_window_returns_the_SAME_expiry_and_never_extends_it
+  Passed An_account_the_gateway_already_knew_about_is_granted_NO_trial
+  Passed Subscribing_on_day_seven_takes_over_with_no_gap_and_no_trial_expiry_clipped_onto_it
+  Passed A_paying_account_is_never_handed_a_trial_it_does_not_need
+  Passed A_live_trial_entitles_even_when_the_PAID_read_fails
+  Passed A_failed_TRIAL_read_is_UNKNOWN_and_must_never_masquerade_as_a_refusal
+  Passed A_failed_PAID_read_with_no_trial_is_still_a_retry_never_a_free_grant
+  Passed The_402_a_member_meets_after_the_trial_says_what_to_do_about_it
+  Passed With_no_trial_ledger_wired_the_gate_behaves_exactly_as_it_did_before
+
+Passed!  - Failed: 0, Passed: 15, Skipped: 0, Total: 15</pre>
+
+<h3>Full Gateway suite (regression)</h3>
+<pre>dotnet test src/CcDirector.Gateway.Tests
+Passed!  - Failed: 0, Passed: 3816, Skipped: 17, Total: 3833, Duration: 18 m 58 s</pre>
+
+<h3>What the first full-suite run caught, and what it cost</h3>
+
+<p>The first run of the full suite was NOT green, and the three failures were all real consequences of this
+change rather than flakes. They are recorded here because "the tests passed" is only meaningful if the run
+that failed is shown too.</p>
+
+<table>
+<tr><th>Failure</th><th>What it meant</th><th>Fix</th></tr>
+<tr>
+  <td><code>TenantScopeGuardTests.EveryMappedTable_IsTenantScopedOrAnExplicitlyAllowlistedGlobalTable</code></td>
+  <td>The data-layer guard refused a new mapped table that is neither tenant-scoped nor allowlisted. Correct
+      behaviour: it forces a written reason for every global table.</td>
+  <td>Allowlisted <code>AccountTrialEntity</code> with the reason - keyed by account subject and read before a
+      tenant is minted, exactly like the entitlements table beside it.</td>
+</tr>
+<tr>
+  <td><code>TenantGateArchitectureTests.DT_TEN_2_every_mapped_entity_is_tenant_scoped_or_named_on_the_global_allowlist</code></td>
+  <td>The CenCon structural tenant gate keeps its OWN allowlist, deliberately separate, so adding a global
+      table is a review-visible act in two places rather than one.</td>
+  <td>Named on <code>GlobalUnscopedTables</code> with the same reason.</td>
+</tr>
+<tr>
+  <td><code>HostedMobileAccountEnrollTests.NotEntitled_402_NoCookie_RegistryUnchanged</code></td>
+  <td>Expected 402, got 200. This is the change working: an unpaid account arriving for the first time on the
+      mobile surface now gets the trial and enrolls. The test's premise - "unpaid means refused" - was true
+      before this issue and is no longer the whole truth.</td>
+  <td>The account that is genuinely not entitled now is one whose trial has ENDED, so the test grants a trial
+      thirty days in the past and keeps every assertion it had (402, no cookie, no tenant, registry byte-for-byte
+      unchanged). The paid gate is still proven; it is proven against the account that can actually reach it.</td>
+</tr>
+</table>
+
+<p>Note that the mobile failure is the useful one: it is the surface I did not write a test for, and the
+existing suite caught that the trial reaches it too - which is the intended behaviour, since both surfaces run
+through the one hosted mint.</p>
+
+<h3>Migration pair is in sync with the model</h3>
+<p>The model change and BOTH migrations are in this one pull request, and each provider's migration set is
+verified in sync with the model:</p>
+<pre>dotnet ef migrations has-pending-model-changes --project src/CcDirector.Gateway
+  -> No changes have been made to the model since the last migration.
+
+CC_GATEWAY_EF_PROVIDER=postgres dotnet ef migrations has-pending-model-changes \
+  --project src/CcDirector.Gateway.Migrations.Postgres
+  -> No changes have been made to the model since the last migration.</pre>
+
+<p>The generated Postgres table (the one that will be applied on the hosted deploy):</p>
+<pre>CREATE TABLE gateway.account_trials (
+    subject         text COLLATE "C" NOT NULL,
+    started_at_utc  timestamp with time zone NOT NULL,
+    expires_at_utc  timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_account_trials" PRIMARY KEY (subject)
+);
+CREATE INDEX "IX_account_trials_expires_at_utc" ON gateway.account_trials (expires_at_utc);</pre>
+
+<h2>CenCon impact</h2>
+
+<p><strong>Architecture:</strong> one new gateway-owned table and one new registry inside the existing
+Gateway container. No new container, no new cross-boundary call, no change to the website/gateway data
+contract - the website-owned <code>entitlements</code> table is still read-only to the gateway and still
+excluded from migrations. No drift in <code>architecture_manifest.yaml</code>.</p>
+
+<p><strong>Security:</strong> no blocking rule is touched. The account subject is personally identifying and is
+never logged on any new path (only the grant/refusal decision is). The new table holds no payment data and no
+personally-identifying data beyond the subject that the neighbouring <code>tenants</code> table already holds.
+The change can only make the gate MORE permissive for accounts arriving for the first time, and every deny
+path was re-proven, including that ignorance still never grants. No drift in
+<code>security_profile.yaml</code>.</p>
+
+<h2>Not in this pull request (deliberately)</h2>
+<ul>
+  <li><strong>No deployment.</strong> The hosted gateway deploys only through the GitHub deploy pipeline, and
+      a separate session is coordinating today's deploy. This work ends at a merged pull request.</li>
+  <li><strong>No user-interface surface.</strong> Nothing in this change draws anything, so there is no screen
+      to screenshot; the proof is the executed behaviour of the real code paths, including one test that
+      drives the real endpoint over HTTP and asserts the response body a client would render.</li>
+  <li><strong>No goodwill backfill</strong> for pre-rollout accounts. The owner asked for the conservative
+      default. Because the expiry is stored per account, a later one-time backfill needs no schema change -
+      exactly as the owner's comment anticipated.</li>
+</ul>
+
+<div class="verdict">
+<h2 style="margin-top:0">I believe this is finished.</h2>
+<p>Every acceptance criterion in the issue is implemented and proven by an executed test, including the two
+that are easy to fake - that the trial actually ENDS at the entitlement read, and that a paid subscription
+taken during the trial does not inherit the trial's expiry. The build is clean, the migration pair is in the
+same pull request as the model change and verified in sync on both providers, and the pre-existing paid gate
+is unchanged with its own control asserting so.</p>
+</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-2117/report.html
+++ b/docs/cencon/proof/issue-2117/report.html
@@ -323,6 +323,20 @@ that failed is shown too.</p>
 existing suite caught that the trial reaches it too - which is the intended behaviour, since both surfaces run
 through the one hosted mint.</p>
 
+<h3>Continuous integration on the pull request</h3>
+<pre>Build &amp; Test (.NET)   pass   31m26s
+Build &amp; Test (web)    pass    1m07s</pre>
+
+<p>The first .NET run on this branch failed on ONE test, and it is worth naming rather than hiding:
+<code>CcDirector.Core.Tests.Tenancy.TenantSessionMapTests.Contend_GetOrAddOnOneKey_HasExactlyOneWinnerPerRound</code>,
+with the message "no round ever ran the value factory more than once, so the callers never actually contended
+for the same key and this test proved nothing". That is the test's own self-check reporting that a loaded
+runner never produced real thread contention - a timing-dependent condition, not an assertion about behaviour.
+It is unrelated to this change on the evidence rather than by assertion: this branch touches no file under
+<code>src/CcDirector.Core</code> at all (<code>git diff origin/main...HEAD -- src/CcDirector.Core/</code> is
+empty), the whole class passes locally on this branch (19 of 19), and the re-run of the same commit passed.
+The Gateway suite passed in that first run too - 3910 tests, 3893 passed, 17 skipped, 0 failed.</p>
+
 <h3>Migration pair is in sync with the model</h3>
 <p>The model change and BOTH migrations are in this one pull request, and each provider's migration set is
 verified in sync with the model:</p>

--- a/docs/cencon/proof/issue-2117/trial-tests.txt
+++ b/docs/cencon/proof/issue-2117/trial-tests.txt
@@ -1,0 +1,24 @@
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing [1 s]
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_failed_PAID_read_with_no_trial_is_still_a_retry_never_a_free_grant 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.The_trial_grants_PRO_tier_and_expires_exactly_fourteen_days_after_the_grant 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.Subscribing_on_day_seven_takes_over_with_no_gap_and_no_trial_expiry_clipped_onto_it 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.With_no_trial_ledger_wired_the_gate_behaves_exactly_as_it_did_before 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_second_grant_attempt_after_expiry_NEVER_restarts_the_fourteen_days 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.Granting_twice_inside_the_window_returns_the_SAME_expiry_and_never_extends_it 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_paying_account_is_never_handed_a_trial_it_does_not_need 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_failed_TRIAL_read_is_UNKNOWN_and_must_never_masquerade_as_a_refusal 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_brand_new_account_with_no_payment_enrolls_on_the_free_trial 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.A_live_trial_entitles_even_when_the_PAID_read_fails 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.The_402_a_member_meets_after_the_trial_says_what_to_do_about_it 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.The_trial_is_over_AT_the_exact_expiry_instant_not_a_tick_later 
+  Passed CcDirector.Gateway.Tests.HostedProTrialTests.An_account_the_gateway_already_knew_about_is_granted_NO_trial 
+
+Passed!  - Failed: 0, Passed: 15, Skipped: 0, Total: 15 - HostedProTrialTests
+
+Full Gateway suite (regression, same build):
+Passed!  - Failed: 0, Passed: 3816, Skipped: 17, Total: 3833, Duration: 18 m 58 s
+
+Full-solution build: Build succeeded. 0 Warning(s) 0 Error(s)
+Migration model sync (SQLite):   No changes have been made to the model since the last migration.
+Migration model sync (Postgres): No changes have been made to the model since the last migration.

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724212205_AddAccountTrials.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724212205_AddAccountTrials.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724212205_AddAccountTrials")]
+    partial class AddAccountTrials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,105 +57,106 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountTrialEntity", b =>
                 {
                     b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("subject");
+                        .HasColumnType("text")
+                        .HasColumnName("subject")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ExpiresAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("expires_at_utc");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("started_at_utc");
 
                     b.HasKey("Subject");
 
                     b.HasIndex("ExpiresAtUtc");
 
-                    b.ToTable("account_trials", (string)null);
+                    b.ToTable("account_trials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -158,108 +168,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", (string)null);
+                    b.ToTable("activity_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -268,108 +278,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", (string)null);
+                    b.ToTable("device_credentials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", (string)null);
+                    b.ToTable("device_import_markers", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("TenantId", "Term");
 
@@ -377,99 +391,100 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", (string)null);
+                    b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", (string)null);
+                    b.ToTable("dictation_suggestion_scans", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", (string)null);
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
@@ -477,43 +492,43 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", (string)null);
+                    b.ToTable("dictation_transcripts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
+                    b.Property<Guid>("Subject")
+                        .HasColumnType("uuid")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", null, t =>
+                    b.ToTable("entitlements", "gateway", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -522,38 +537,38 @@ namespace CcDirector.Gateway.Data.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -566,40 +581,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -612,109 +627,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -722,161 +740,165 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", (string)null);
+                    b.ToTable("tenant_settings", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -884,75 +906,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -960,71 +982,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1034,92 +1056,93 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", (string)null);
+                    b.ToTable("workflow_tenant_overrides", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -1128,7 +1151,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1136,28 +1159,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -1168,18 +1191,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -1199,36 +1222,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -1253,35 +1276,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1292,37 +1315,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -1333,23 +1356,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -1369,26 +1392,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1399,34 +1422,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724212205_AddAccountTrials.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260724212205_AddAccountTrials.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccountTrials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "account_trials",
+                schema: "gateway",
+                columns: table => new
+                {
+                    subject = table.Column<string>(type: "text", nullable: false, collation: "C"),
+                    started_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    expires_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_account_trials", x => x.subject);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_trials_expires_at_utc",
+                schema: "gateway",
+                table: "account_trials",
+                column: "expires_at_utc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "account_trials",
+                schema: "gateway");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -57,6 +57,28 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
+            modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountTrialEntity", b =>
+                {
+                    b.Property<string>("Subject")
+                        .HasColumnType("text")
+                        .HasColumnName("subject")
+                        .UseCollation("C");
+
+                    b.Property<DateTime>("ExpiresAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("expires_at_utc");
+
+                    b.Property<DateTime>("StartedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("started_at_utc");
+
+                    b.HasKey("Subject");
+
+                    b.HasIndex("ExpiresAtUtc");
+
+                    b.ToTable("account_trials", "gateway");
+                });
+
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")

--- a/src/CcDirector.Gateway.Tests/Architecture/TenantGateArchitectureTests.cs
+++ b/src/CcDirector.Gateway.Tests/Architecture/TenantGateArchitectureTests.cs
@@ -59,6 +59,7 @@ public sealed class TenantGateArchitectureTests
     {
         nameof(TenantEntity),             // the account-subject -> tenant mapping (the tenant census itself)
         nameof(EntitlementEntity),        // paid entitlements owned/written by the payment side; Gateway only READs
+        nameof(AccountTrialEntity),       // free-trial ledger, keyed by account subject and read pre-tenant (#2117)
         nameof(DeviceCredentialEntity),   // per-device key records; a presented key is resolved by hash pre-tenant
         nameof(DeviceImportMarkerEntity), // one-time devices.json import idempotency markers (global, like above)
     };

--- a/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/TenantScopeGuardTests.cs
@@ -122,10 +122,18 @@ public sealed class TenantScopeGuardTests : IDisposable
         //  - DeviceImportMarkerEntity is the one-time devices.json -> device_credentials import marker (MTR-14A).
         //    It guards a migration that spans every tenant's devices at once and runs before any tenant is
         //    resolved, so it is global for the same reason its table is.
+        //
+        //  - AccountTrialEntity is the free-trial ledger (issue #2117), the exact counterpart of
+        //    EntitlementEntity: keyed by account subject, read at enrollment BEFORE a tenant is minted, and
+        //    specifically in order to decide whether a tenant may be minted at all - so scoping it to a tenant
+        //    would be circular in the same way. It carries no tenant content: one subject, one start, one end.
+        //    Unlike EntitlementEntity this one IS written here, but only ever for the subject the caller has
+        //    already been verified as, so a tenant cannot reach another tenant's row through it.
         var allowedGlobalTables = new HashSet<Type>
         {
             typeof(TenantEntity),
             typeof(EntitlementEntity),
+            typeof(AccountTrialEntity),
             typeof(DeviceCredentialEntity),
             typeof(DeviceImportMarkerEntity),
         };

--- a/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
@@ -125,7 +125,11 @@ public sealed class HostedMobileAccountEnrollTests : IDisposable
         var validator = new JwtAccessTokenValidator(
             "test-signing-secret", timeProvider: null, publicKeySetJson: _key.PublicKeySetJson(),
             expectedAudience: Audience, expectedIssuer: Issuer, allowSymmetricHs256: false);
-        var hosted = new HostedEnrollDependencies(devices, tenants, validator, new EntitlementRegistry(db, requireLivemode: false));
+        // The free-trial ledger (issue #2117) rides in the bundle. These tests seed a PAID entitlement, which
+        // wins outright, so the trial is never consulted and this wiring changes none of their outcomes - it
+        // just keeps the bundle complete, the way the host builds it.
+        var hosted = new HostedEnrollDependencies(devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false), new TrialRegistry(db));
         return (devices, tenants, hosted);
     }
 

--- a/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedMobileAccountEnrollTests.cs
@@ -382,6 +382,13 @@ public sealed class HostedMobileAccountEnrollTests : IDisposable
         var (app, http) = await StartHostedAsync(hosted);
         try
         {
+            // Since issue #2117 an account with no paid entitlement that is ARRIVING FOR THE FIRST TIME is
+            // granted the free Pro trial and enrolls - that is the promise on the pricing page, and it is
+            // proven in HostedProTrialTests. So the account that is genuinely NOT entitled, and the one this
+            // test is about, is one whose trial has already ended: granted thirty days ago, so its fourteen
+            // days are long gone and the trial is never re-granted.
+            hosted.Trials.GrantIfFirstArrival(SubjectAlice, alreadyKnownToGateway: false, DateTime.UtcNow.AddDays(-30));
+
             var before = RegistrySnapshot(devices);
             var resp = await PostBearerAsync(http, Token(SubjectAlice), "dev-a");
             Assert.Equal(HttpStatusCode.PaymentRequired, resp.StatusCode);

--- a/src/CcDirector.Gateway.Tests/HostedProTrialTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedProTrialTests.cs
@@ -1,0 +1,463 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The 14-day Pro trial (issue #2117). The public pricing page tells every visitor "Every new account starts
+/// with 14 days of Pro. Just sign up with your email - no card required." These tests are what keeps that
+/// sentence true, and what keeps it BOUNDED.
+///
+/// THE FOUR THINGS THAT MUST HOLD, and each has its own independent control below:
+///
+///   1. A brand-new account with NO payment of any kind enrolls and is entitled, at Pro tier. If this breaks,
+///      the live page is lying to every visitor.
+///   2. The trial ENDS. Not "is displayed as ended" - the entitlement read itself stops returning Entitled at
+///      the expiry instant, so the request-path cutoff denies. A trial that only expires in the user interface
+///      is a free product with a countdown on it.
+///   3. ONE trial per account, ever. Re-arriving after the window has closed is refused, never re-granted -
+///      otherwise the fourteen days renew forever and there is no paywall at all.
+///   4. A paid subscription taken DURING the trial takes over with no gap and no double-grant.
+///
+/// AND THE ROLLOUT RULE (the owner's decision on this issue): an account this Gateway already knew about -
+/// one that already holds a tenant - is granted NOTHING. The trial is for accounts arriving for the first
+/// time. Granting silently to accounts that were already using hosted is the thing the owner explicitly
+/// refused, so it is asserted here rather than trusted.
+///
+/// Every deny path asserts BOTH halves of the refusal - the status AND that no tenant was minted and no
+/// device key issued - because a 402 that still minted a tenant would satisfy a status-only assertion while
+/// having given away the thing the gate protects.
+///
+/// Revert-prove: pass <c>trials: null</c> (the wiring before this issue) and the grant tests go RED while the
+/// paid tests in HostedEntitlementGateTests stay green - that null case is the explicit control at the bottom.
+/// </summary>
+public sealed class HostedProTrialTests : IDisposable
+{
+    private const string Audience = "authenticated";
+    private const string Issuer = "https://test.example.supabase.co/auth/v1";
+    private const string Subject = "sub-brand-new-account";
+
+    /// <summary>A fixed instant so the fourteen-day window is judged exactly, not in whichever direction the
+    /// clock happens to be pointing when the suite runs.</summary>
+    private static readonly DateTime SignupMoment = new(2026, 7, 24, 9, 0, 0, DateTimeKind.Utc);
+
+    private readonly GatewayDbTestHarness _harness = new();
+    private readonly string _devPath = Path.Combine(Path.GetTempPath(), $"trial-dev-{Guid.NewGuid():N}.json");
+    private readonly TestEs256Key _key = new();
+
+    public void Dispose()
+    {
+        _harness.Dispose();
+        _key.Dispose();
+        if (File.Exists(_devPath)) File.Delete(_devPath);
+    }
+
+    private static EnrollSignedInRequest Req() => new()
+    {
+        DeviceId = "device-1",
+        MachineName = "M",
+        Platform = "linux",
+        DeviceType = "workstation",
+    };
+
+    /// <summary>Creates the payment-side table this Gateway only reads, and optionally seeds one row. Without
+    /// a seeded row the paid read succeeds and finds nothing - which is exactly a brand-new account that has
+    /// never paid.</summary>
+    private GatewayDatabase OpenWithEntitlements(string? status = null, DateTime? periodEnd = null,
+        bool? livemode = true, string? tier = null)
+    {
+        var db = _harness.Open();
+        using var ctx = db.CreateUnscopedContext();
+        ctx.Database.ExecuteSqlRaw(
+            "CREATE TABLE IF NOT EXISTS entitlements (" +
+            "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
+            "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
+            "livemode INTEGER NULL, tier TEXT NULL)");
+
+        if (status is not null)
+        {
+            ctx.Database.ExecuteSqlRaw(
+                "INSERT INTO entitlements (subject, status, current_period_end, livemode, tier) VALUES ({0}, {1}, {2}, {3}, {4})",
+                Subject, status, periodEnd, livemode, tier);
+        }
+        return db;
+    }
+
+    private (DeviceRegistry devices, TenantRegistry tenants, JwtAccessTokenValidator validator) Wire(GatewayDatabase db)
+    {
+        var devices = new DeviceRegistry(_devPath);
+        var tenants = new TenantRegistry(db);
+        var validator = new JwtAccessTokenValidator(
+            "test-signing-secret", timeProvider: null, publicKeySetJson: _key.PublicKeySetJson(),
+            expectedAudience: Audience, expectedIssuer: Issuer, allowSymmetricHs256: false);
+        return (devices, tenants, validator);
+    }
+
+    private string Token() => _key.Token(Subject, "newcomer@example.com", Audience, Issuer);
+
+    /// <summary>Did anything get given away? Both halves of what a refusal must withhold.</summary>
+    private void AssertNothingWasGivenAway(TenantRegistry tenants)
+    {
+        Assert.Null(tenants.LookupBySubject(Subject));
+        Assert.False(File.Exists(_devPath) && File.ReadAllText(_devPath).Contains("device-1", StringComparison.Ordinal));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // 1. The promise on the page: a brand-new account, email only, no card.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_brand_new_account_with_no_payment_enrolls_on_the_free_trial()
+    {
+        // The acceptance criterion the live pricing page depends on. The paid read SUCCEEDS and finds nothing
+        // (no row for this subject) - the account has never paid and presented no card - and it enrolls anyway.
+        var db = OpenWithEntitlements();
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
+
+        Assert.Equal(200, result.Status);
+        Assert.NotNull(result.Response);
+        Assert.False(string.IsNullOrWhiteSpace(result.Response!.DeviceKey));
+        Assert.NotNull(tenants.LookupBySubject(Subject));
+    }
+
+    [Fact]
+    public void The_trial_grants_PRO_tier_and_expires_exactly_fourteen_days_after_the_grant()
+    {
+        // "14 days of Pro" - both halves of that phrase, asserted. The tier must be pro (the trial grants the
+        // same entitlement set a paying Pro member gets), and the period end must be the trial's own end, which
+        // is what the hosted access lease clips to so caching cannot outlive the trial.
+        var db = OpenWithEntitlements();
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var decision = entitlements.Evaluate(Subject, SignupMoment.AddDays(7));
+
+        Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+        Assert.Equal(EntitlementRegistry.TierPro, decision.Tier);
+        Assert.Equal(SignupMoment.AddDays(14), decision.CurrentPeriodEnd);
+        Assert.Equal(TimeSpan.FromDays(14), TrialRegistry.TrialLength);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // 2. The trial ENDS - at the entitlement read, not in the user interface.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED()
+    {
+        // The acceptance criterion for expiry. This is the read the request-path cutoff calls on every hosted
+        // request, so a NotEntitled here IS the 402 on dictation, spoken replies and the wingman. If this
+        // returned Entitled, the trial would be a permanent free plan.
+        var db = OpenWithEntitlements();
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var decision = entitlements.Evaluate(Subject, SignupMoment.AddDays(15));
+
+        Assert.Equal(EntitlementOutcome.NotEntitled, decision.Outcome);
+        Assert.NotEqual(EntitlementOutcome.Unknown, decision.Outcome);   // a refusal, not a retry
+    }
+
+    [Fact]
+    public void The_trial_is_over_AT_the_exact_expiry_instant_not_a_tick_later()
+    {
+        // Boundaries are where a policy is decided, so this one is pinned by its own test. At exactly the
+        // expiry the trial HAS ended - an inclusive comparison would grant on an expired trial, which is one
+        // tick of access in the give-it-away direction.
+        var db = OpenWithEntitlements();
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var oneTickBefore = entitlements.Evaluate(Subject, SignupMoment.AddDays(14).AddTicks(-1));
+        var atExpiry = entitlements.Evaluate(Subject, SignupMoment.AddDays(14));
+
+        Assert.Equal(EntitlementOutcome.Entitled, oneTickBefore.Outcome);
+        Assert.Equal(EntitlementOutcome.NotEntitled, atExpiry.Outcome);
+    }
+
+    [Fact]
+    public void Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing()
+    {
+        // The expiry proven end to end, through the enrollment path rather than the registry: a member whose
+        // fourteen days are up meets a 402 and gets no key. The tenant they minted during the trial still
+        // exists - the account is not deleted, self-host remains available - so this asserts the DEVICE KEY
+        // was withheld, which is what actually gates hosted use.
+        var db = OpenWithEntitlements();
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        var during = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            entitlements, SignupMoment, trials);
+        Assert.Equal(200, during.Status);
+
+        var after = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            entitlements, SignupMoment.AddDays(15), trials);
+
+        Assert.Equal(402, after.Status);
+        Assert.Null(after.Response);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // 3. One trial per account, ever.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_second_grant_attempt_after_expiry_NEVER_restarts_the_fourteen_days()
+    {
+        // Without this, a member could restart the free window forever by re-enrolling, and the paywall would
+        // exist only on paper. The expired row is the evidence that stops it - which is why the row is kept
+        // rather than deleted when the trial ends.
+        var db = OpenWithEntitlements();
+        var trials = new TrialRegistry(db);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var retry = trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment.AddDays(30));
+
+        Assert.Equal(TrialOutcome.None, retry.Outcome);
+        Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment.AddDays(30)).Outcome);
+    }
+
+    [Fact]
+    public void Granting_twice_inside_the_window_returns_the_SAME_expiry_and_never_extends_it()
+    {
+        // Idempotence stated as the property that matters: a second arrival during the trial (a second device,
+        // a re-enroll) must not push the end date out. An extending grant would be a rolling free plan.
+        var db = OpenWithEntitlements();
+        var trials = new TrialRegistry(db);
+
+        var first = trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+        var second = trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment.AddDays(7));
+
+        Assert.Equal(TrialOutcome.Active, second.Outcome);
+        Assert.Equal(first.ExpiresAtUtc, second.ExpiresAtUtc);
+        Assert.Equal(SignupMoment.AddDays(14), second.ExpiresAtUtc);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The rollout rule: accounts this Gateway already knew about get nothing.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void An_account_the_gateway_already_knew_about_is_granted_NO_trial()
+    {
+        // The owner's conservative rollout decision on this issue, asserted rather than trusted. An account
+        // that already holds a tenant was using hosted before the trial existed; handing it fourteen free days
+        // the next time it comes back is exactly the silent grant that was refused.
+        var db = OpenWithEntitlements();
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+
+        // The account already exists on this Gateway - it holds a tenant from before the trial shipped.
+        tenants.MintOrLookupBySubject(Subject, "returning@example.com");
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
+
+        Assert.Equal(402, result.Status);
+        Assert.Null(result.Response);
+        Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment).Outcome);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // 4. Subscribing during the trial.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Subscribing_on_day_seven_takes_over_with_no_gap_and_no_trial_expiry_clipped_onto_it()
+    {
+        // The paid row wins outright, so the member's access does not pause at the fourteen-day mark and does
+        // not carry the trial's end date as its period end. Asserting the period end is the point: if the
+        // trial's expiry leaked through, the hosted access lease would cut a PAYING member off on day fourteen.
+        var paidPeriodEnd = SignupMoment.AddDays(37);
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, paidPeriodEnd,
+            livemode: true, tier: EntitlementRegistry.TierPro);
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var onDayFifteen = entitlements.Evaluate(Subject, SignupMoment.AddDays(15));
+
+        Assert.Equal(EntitlementOutcome.Entitled, onDayFifteen.Outcome);
+        Assert.Equal(EntitlementRegistry.TierPro, onDayFifteen.Tier);
+        Assert.Equal(paidPeriodEnd, onDayFifteen.CurrentPeriodEnd);
+        Assert.NotEqual(SignupMoment.AddDays(14), onDayFifteen.CurrentPeriodEnd);
+    }
+
+    [Fact]
+    public void A_paying_account_is_never_handed_a_trial_it_does_not_need()
+    {
+        // The trial is only ever reached after the paid read has already answered NotEntitled, so an account
+        // that pays from the start writes no trial row at all. If it did, the account would be burning its one
+        // trial while paying - and would have none left if it later cancelled and came back.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, tier: EntitlementRegistry.TierPro);
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
+
+        Assert.Equal(200, result.Status);
+        Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment).Outcome);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Ignorance is still never a verdict - in EITHER direction, for EITHER read.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_live_trial_entitles_even_when_the_PAID_read_fails()
+    {
+        // The paid table is unreadable (no table at all - a lost SELECT grant, or an un-migrated database).
+        // That is ignorance about the SUBSCRIPTION, but the trial we granted ourselves is knowledge, and it
+        // entitles on its own. Denying here would lock a member out of their free window over a database fault
+        // that has nothing to do with them.
+        var db = _harness.Open();          // no entitlements table
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, SignupMoment);
+
+        var decision = entitlements.Evaluate(Subject, SignupMoment.AddDays(3));
+
+        Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+        Assert.Equal(EntitlementRegistry.TierPro, decision.Tier);
+    }
+
+    [Fact]
+    public void A_failed_TRIAL_read_is_UNKNOWN_and_must_never_masquerade_as_a_refusal()
+    {
+        // The mirror of the entitlement gate's ignorance control, for the ledger this issue added. With the
+        // trial table gone we cannot tell whether a trial covers this account - so this must answer retry, not
+        // 402. A 402 here would refuse a member inside their free window because a table was unreadable, and a
+        // grant would hand hosted to someone with no trial at all.
+        var db = OpenWithEntitlements();
+        using (var ctx = db.CreateUnscopedContext())
+            ctx.Database.ExecuteSqlRaw("DROP TABLE account_trials");
+
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+
+        Assert.Equal(TrialOutcome.Unknown, trials.Evaluate(Subject, SignupMoment).Outcome);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
+
+        Assert.Equal(503, result.Status);
+        Assert.NotEqual(402, result.Status);
+        AssertNothingWasGivenAway(tenants);
+    }
+
+    [Fact]
+    public void A_failed_PAID_read_with_no_trial_is_still_a_retry_never_a_free_grant()
+    {
+        // The trial must not weaken the original gate. The paid table is unreadable and this account has no
+        // trial: the answer is still 503-retry, and above all NOT a mint. A trial feature that turned an
+        // unreadable payment table into a free enrollment would be the silent give-away the gate exists to stop.
+        var db = _harness.Open();          // no entitlements table
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
+
+        Assert.Equal(503, result.Status);
+        AssertNothingWasGivenAway(tenants);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The refusal a member actually reads.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task The_402_a_member_meets_after_the_trial_says_what_to_do_about_it()
+    {
+        // The acceptance criterion is not just "denied" - it is "a message that points at subscribing, not a
+        // raw error". So this drives the REAL endpoint over HTTP and reads the body the client renders. The
+        // Gateway owns the wording; the client only shows it. Asserted on the wire because a constant that is
+        // never written into a response is not a message anybody sees.
+        var db = OpenWithEntitlements();
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
+
+        // Already known to this Gateway, so the trial is refused and the refusal is the one under test.
+        tenants.MintOrLookupBySubject(Subject, "returning@example.com");
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+        HostedEnrollmentEndpoint.Map(app, devices, tenants, validator, entitlements, trials);
+        await app.StartAsync();
+
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+            var msg = new HttpRequestMessage(HttpMethod.Post, HostedEnrollmentEndpoint.Path)
+            {
+                Content = JsonContent.Create(new { deviceId = "device-1", machineName = "M", platform = "linux", deviceType = "workstation" }),
+            };
+            msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token());
+
+            var resp = await http.SendAsync(msg);
+            var body = await resp.Content.ReadAsStringAsync();
+
+            Assert.Equal(402, (int)resp.StatusCode);
+            Assert.Contains(EntitlementRegistry.SubscribeMessage, body, StringComparison.Ordinal);
+            Assert.Contains(EntitlementRegistry.SubscribeUrl, body, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The control: the wiring as it was before this issue.
+    // ---------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void With_no_trial_ledger_wired_the_gate_behaves_exactly_as_it_did_before()
+    {
+        // The revert-proof and the self-host control in one. With trials null - the wiring before this issue,
+        // and the wiring self-host still gets - an account with no paid entitlement is refused, unchanged. If
+        // this ever passed WITH a trial ledger, the tests above would be proving nothing about the new code.
+        var db = OpenWithEntitlements();
+        var (devices, tenants, validator) = Wire(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: false), SignupMoment, trials: null);
+
+        Assert.Equal(402, result.Status);
+        AssertNothingWasGivenAway(tenants);
+    }
+}

--- a/src/CcDirector.Gateway/Api/HostedEnrollDependencies.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollDependencies.cs
@@ -5,7 +5,7 @@ using CcDirector.Gateway.Tenancy;
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
-/// The four dependencies the ONE hosted mint - <see cref="HostedEnrollmentEndpoint.Enroll"/> - needs, bundled
+/// The five dependencies the ONE hosted mint - <see cref="HostedEnrollmentEndpoint.Enroll"/> - needs, bundled
 /// so every hosted entry point that mints a tenant-scoped device key passes the identical set. Presence of this
 /// object (non-null) is exactly what puts an entry point into hosted mode; a null bundle is the self-host case,
 /// where the entry point's existing single-owner behaviour is byte-unchanged.
@@ -20,8 +20,12 @@ namespace CcDirector.Gateway.Api;
 /// <param name="Tenants">The tenant registry that mint-or-looks-up the account's tenant.</param>
 /// <param name="AccountTokenValidator">The account access-token validator (signature, expiry, audience, issuer).</param>
 /// <param name="Entitlements">The paid-entitlement gate that sits between subject verification and tenant mint.</param>
+/// <param name="Trials">The free-trial ledger (issue #2117) - the one place a 14-day Pro trial is granted, at
+/// an account's first arrival. It rides in this bundle for the same reason the entitlement gate does: every
+/// hosted entry point that mints a device key must apply the identical grant rule, never its own.</param>
 internal sealed record HostedEnrollDependencies(
     DeviceRegistry Devices,
     TenantRegistry Tenants,
     JwtAccessTokenValidator AccountTokenValidator,
-    EntitlementRegistry Entitlements);
+    EntitlementRegistry Entitlements,
+    TrialRegistry Trials);

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -43,9 +43,14 @@ internal static class HostedEnrollmentEndpoint
     /// and no boundary, and enrollment behaves exactly as it always has. On hosted this is REQUIRED, and the
     /// gate is what makes hosted a paid product rather than a free one.
     /// </param>
+    /// <param name="trials">
+    /// The free-trial ledger (issue #2117). NULL means no trial concept - the behaviour before trials existed.
+    /// When supplied, an account with no paid entitlement that this Gateway has never seen before is GRANTED
+    /// the 14-day Pro trial here, at its first arrival, and enrolls on it.
+    /// </param>
     public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices,
         Tenancy.TenantRegistry tenants, JwtAccessTokenValidator accountTokenValidator,
-        Tenancy.EntitlementRegistry? entitlements = null)
+        Tenancy.EntitlementRegistry? entitlements = null, Tenancy.TrialRegistry? trials = null)
     {
         if (devices is null) throw new ArgumentNullException(nameof(devices));
         if (tenants is null) throw new ArgumentNullException(nameof(tenants));
@@ -53,10 +58,24 @@ internal static class HostedEnrollmentEndpoint
 
         app.MapPost(Path, (EnrollSignedInRequest req, HttpContext ctx) =>
         {
-            var result = Enroll(BearerToken.Read(ctx), req, devices, tenants, accountTokenValidator, entitlements, DateTime.UtcNow);
-            return result.Status == StatusCodes.Status200OK
-                ? Results.Json(result.Response, statusCode: StatusCodes.Status200OK)
-                : Results.Json(new { error = result.Error }, statusCode: result.Status);
+            var result = Enroll(BearerToken.Read(ctx), req, devices, tenants, accountTokenValidator, entitlements, DateTime.UtcNow, trials);
+            if (result.Status == StatusCodes.Status200OK)
+                return Results.Json(result.Response, statusCode: StatusCodes.Status200OK);
+
+            // A payment refusal has to say what to do about it, not just that it happened (issue #2117): the
+            // member is told, in one finished sentence the Gateway owns, that access has ended and where to
+            // subscribe. Every other status keeps its plain error shape.
+            if (result.Status == StatusCodes.Status402PaymentRequired)
+            {
+                return Results.Json(new
+                {
+                    error = result.Error,
+                    message = Tenancy.EntitlementRegistry.SubscribeMessage,
+                    subscribeUrl = Tenancy.EntitlementRegistry.SubscribeUrl,
+                }, statusCode: result.Status);
+            }
+
+            return Results.Json(new { error = result.Error }, statusCode: result.Status);
         });
     }
 
@@ -70,7 +89,8 @@ internal static class HostedEnrollmentEndpoint
     /// </summary>
     public static EnrollResult Enroll(string? bearer, EnrollSignedInRequest? req, DeviceRegistry devices,
         Tenancy.TenantRegistry tenants, JwtAccessTokenValidator accountTokenValidator,
-        Tenancy.EntitlementRegistry? entitlements = null, DateTime? nowUtc = null)
+        Tenancy.EntitlementRegistry? entitlements = null, DateTime? nowUtc = null,
+        Tenancy.TrialRegistry? trials = null)
     {
         if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
             return new EnrollResult(StatusCodes.Status400BadRequest, null, "deviceId is required");
@@ -104,7 +124,42 @@ internal static class HostedEnrollmentEndpoint
         // Null entitlements is the SELF-HOST case - no gate at all, unchanged behaviour. That is the control.
         if (entitlements is not null)
         {
-            var outcome = entitlements.LookupBySubject(validation.Subject, nowUtc ?? DateTime.UtcNow);
+            var now = nowUtc ?? DateTime.UtcNow;
+            var outcome = entitlements.LookupBySubject(validation.Subject, now);
+
+            // THE FREE TRIAL GRANT (issue #2117), and this is the ONLY place a trial is created. The public
+            // pricing page promises every new account 14 days of Pro with no card, so an account that the
+            // entitlement read just refused gets one more question asked of it: is this its FIRST arrival at
+            // the hosted Gateway? If it is, the trial is granted here and the account enrolls on it.
+            //
+            // It sits AFTER the paid read, so a paying account never reaches it and can never be handed a
+            // trial it does not need. It reads NotEntitled only - an Unknown falls through to the 503 below
+            // untouched, because granting a trial on a failed paid read would hand a free window to an account
+            // whose subscription we simply could not see.
+            //
+            // "Never seen before" is the tenant mapping: an account that already holds a tenant was using
+            // hosted before the trial existed, and the owner's rollout rule grants it nothing (issue #2117).
+            // TrialRegistry re-checks its own ledger, so an account whose trial has already ended is refused
+            // here rather than being handed a second one.
+            if (outcome == Tenancy.EntitlementOutcome.NotEntitled && trials is not null)
+            {
+                var alreadyKnown = tenants.LookupBySubject(validation.Subject) is not null;
+                var trial = trials.GrantIfFirstArrival(validation.Subject, alreadyKnown, now);
+
+                if (trial.Outcome == Tenancy.TrialOutcome.Active)
+                {
+                    FileLog.Write("[HostedEnrollment] enrolling on the free Pro trial (no paid entitlement; the account is inside its trial window)");
+                    outcome = Tenancy.EntitlementOutcome.Entitled;
+                }
+                else if (trial.Outcome == Tenancy.TrialOutcome.Unknown)
+                {
+                    // The trial ledger could not be read or written. We do not know what covers this account,
+                    // so this is the SAME temporary condition as an unreadable entitlement table: retry, never
+                    // refuse, never grant.
+                    outcome = Tenancy.EntitlementOutcome.Unknown;
+                }
+            }
+
             if (outcome == Tenancy.EntitlementOutcome.Unknown)
             {
                 FileLog.Write("[HostedEnrollment] RETRY: the entitlement read failed, so entitlement is UNKNOWN - " +

--- a/src/CcDirector.Gateway/Api/MobileEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MobileEnrollmentEndpoint.cs
@@ -131,11 +131,24 @@ internal static class MobileEnrollmentEndpoint
         };
 
         var result = HostedEnrollmentEndpoint.Enroll(BearerToken.Read(ctx), enrollReq, hosted.Devices,
-            hosted.Tenants, hosted.AccountTokenValidator, hosted.Entitlements, DateTime.UtcNow);
+            hosted.Tenants, hosted.AccountTokenValidator, hosted.Entitlements, DateTime.UtcNow, hosted.Trials);
 
         if (result.Status != StatusCodes.Status200OK || result.Response is null)
         {
             FileLog.Write($"[MobileEnrollment] POST /mobile/enroll (hosted): the hosted mint did not enroll -> {result.Status} (no cookie set)");
+
+            // A payment refusal says what to do about it (issue #2117), with the SAME sentence and address the
+            // Director enrollment route returns - one wording, owned by the Gateway, on every surface.
+            if (result.Status == StatusCodes.Status402PaymentRequired)
+            {
+                return Results.Json(new
+                {
+                    error = result.Error,
+                    message = Tenancy.EntitlementRegistry.SubscribeMessage,
+                    subscribeUrl = Tenancy.EntitlementRegistry.SubscribeUrl,
+                }, statusCode: result.Status);
+            }
+
             return Results.Json(new { error = result.Error }, statusCode: result.Status);
         }
 

--- a/src/CcDirector.Gateway/Data/Entities/AccountTrialEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/AccountTrialEntity.cs
@@ -1,0 +1,39 @@
+namespace CcDirector.Gateway.Data.Entities;
+
+/// <summary>
+/// One free-trial grant for a hosted account - the row that records that this account was given the 14-day
+/// Pro trial the public pricing page promises ("Every new account starts with 14 days of Pro"), and exactly
+/// when that trial ends.
+///
+/// THIS TABLE IS OURS, and that is the whole reason it exists. The paid record
+/// (<see cref="EntitlementEntity"/>) belongs to the payment side: the website's webhook writes it as the
+/// service role and this Gateway holds SELECT and nothing more, so the Gateway cannot grant anything by
+/// writing there. A trial is not a payment and no webhook produces one, so the grant has to be recorded on
+/// the Gateway's own side of the boundary - here.
+///
+/// Keyed by the STABLE account subject, the same identity the tenant mapping and the entitlement read use,
+/// never the email (which can change over an account's life).
+///
+/// ONE ROW PER ACCOUNT, WRITTEN ONCE. The expiry is stamped at grant time and is never extended or
+/// re-stamped: an account gets one trial, ever. That is what stops a member from restarting the free window
+/// by re-enrolling, and it is why the row is kept even after the trial has ended - an expired row is the
+/// evidence that this account already had its trial.
+///
+/// Nothing on this row is ever logged: the subject is personally identifying.
+/// </summary>
+public sealed class AccountTrialEntity
+{
+    /// <summary>The verified account subject this trial belongs to. Primary key. Never logged.</summary>
+    public string Subject { get; set; } = "";
+
+    /// <summary>When the trial was granted (UTC) - the moment the account first arrived at the hosted Gateway.</summary>
+    public DateTime StartedAtUtc { get; set; }
+
+    /// <summary>
+    /// When the trial ends (UTC), stamped once at grant time as start + the trial length. Stored rather than
+    /// derived so the window is a fact on the row: a later change to the trial length does not silently move
+    /// the end date of a trial already running, and a one-time goodwill grant can be written with any expiry
+    /// without a schema change.
+    /// </summary>
+    public DateTime ExpiresAtUtc { get; set; }
+}

--- a/src/CcDirector.Gateway/Data/GatewayDbContext.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDbContext.cs
@@ -143,6 +143,15 @@ public sealed class GatewayDbContext : DbContext
     /// </summary>
     public DbSet<EntitlementEntity> Entitlements => Set<EntitlementEntity>();
 
+    /// <summary>
+    /// The free-trial ledger (<c>account_trials</c>, issue #2117) - the Gateway's OWN record of which accounts
+    /// were granted the 14-day Pro trial the public pricing page promises, and when each trial ends. GLOBAL
+    /// like <see cref="Tenants"/>: keyed by the verified account subject and read before any tenant exists, so
+    /// it carries no <c>tenant_id</c> and no query filter. This one IS ours to create and write, unlike
+    /// <see cref="Entitlements"/> - a trial is not a payment, so no payment webhook produces it.
+    /// </summary>
+    public DbSet<AccountTrialEntity> AccountTrials => Set<AccountTrialEntity>();
+
     /// <summary>The durable per-device-key credential records (<c>device_credentials</c>, MTR-14) - the per-row
     /// replacement for the shared <c>devices.json</c> file. A GLOBAL table (no <c>tenant_id</c> query filter):
     /// a presented key is resolved by its hash before any tenant is known, and the tenant is read off the
@@ -505,6 +514,22 @@ public sealed class GatewayDbContext : DbContext
             b.HasIndex(e => e.AccountSubject).IsUnique();
         });
 
+        modelBuilder.Entity<AccountTrialEntity>(b =>
+        {
+            b.ToTable("account_trials");
+            // The account subject is the natural primary key - one trial per account, enforced at the
+            // DATABASE rather than only in code, so two racing grants can never write an account two trials
+            // (and therefore can never restart a free window). This table is GLOBAL, like tenants: it is
+            // deliberately NOT passed to ApplyTenantScope, because it is keyed by subject and read before any
+            // tenant is resolved.
+            b.HasKey(e => e.Subject);
+            b.Property(e => e.Subject).HasColumnName("subject").IsRequired();
+            b.Property(e => e.StartedAtUtc).HasColumnName("started_at_utc").IsRequired();
+            b.Property(e => e.ExpiresAtUtc).HasColumnName("expires_at_utc").IsRequired();
+            // The expiry sweep and the "who is still in trial" read both order by the end instant.
+            b.HasIndex(e => e.ExpiresAtUtc);
+        });
+
         modelBuilder.Entity<DeviceCredentialEntity>(b =>
         {
             b.ToTable("device_credentials");
@@ -603,6 +628,15 @@ public sealed class GatewayDbContext : DbContext
             // so pin them to "C" too - the account subject in particular must match EXACTLY on both providers.
             modelBuilder.Entity<TenantEntity>().Property(e => e.Id).UseCollation("C");
             modelBuilder.Entity<TenantEntity>().Property(e => e.AccountSubject).UseCollation("C");
+
+            // account_trials.subject is the same verified account subject as tenants.account_subject, and it
+            // is this table's PRIMARY KEY - the thing that enforces one trial per account. Its equality and
+            // uniqueness must match SQLite's byte-ordinal BINARY collation exactly, or the same subject could
+            // be treated as two different accounts on Postgres and be granted a second trial. Pin it to "C"
+            // for the same reason as the keys above. It stays TEXT here (unlike entitlements.subject, which is
+            // uuid because the website's schema owns that column) - this table is ours, and its column type
+            // matches tenants.account_subject, the other subject-keyed table the Gateway itself creates.
+            modelBuilder.Entity<AccountTrialEntity>().Property(e => e.Subject).UseCollation("C");
 
             // The device_credentials natural-key columns (MTR-14): the DeviceId primary key and the
             // DeviceKeyHash lookup index both rely on byte-ordinal equality/ordering, same as the keys above -

--- a/src/CcDirector.Gateway/Data/Migrations/20260724212144_AddAccountTrials.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724212144_AddAccountTrials.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724212144_AddAccountTrials")]
+    partial class AddAccountTrials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260724212144_AddAccountTrials.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260724212144_AddAccountTrials.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccountTrials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "account_trials",
+                columns: table => new
+                {
+                    subject = table.Column<string>(type: "TEXT", nullable: false),
+                    started_at_utc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    expires_at_utc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_account_trials", x => x.subject);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_trials_expires_at_utc",
+                table: "account_trials",
+                column: "expires_at_utc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "account_trials");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -393,6 +393,11 @@ public sealed class GatewayHost : IAsyncDisposable
     /// where the hosted enrollment route is mapped, which is hosted only.</summary>
     public Tenancy.EntitlementRegistry EntitlementRegistry { get; }
 
+    /// <summary>The free-trial ledger (issue #2117) - the 14-day Pro trial granted at an account's first
+    /// arrival at the hosted Gateway. Read through <see cref="EntitlementRegistry"/> everywhere; exposed here
+    /// because the hosted enrollment route is the one place that GRANTS a trial.</summary>
+    public Tenancy.TrialRegistry TrialRegistry { get; }
+
     // The persisted workflow catalog (Workflows mission, phase 1): built-ins seeded at startup,
     // user-defined workflows beside them, served by Api.WorkflowEndpoints.
     private readonly Workflows.WorkflowStore _workflows;
@@ -794,7 +799,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // the hosted enrollment boundary (which validates the account token and stamps the resolved tenant on
         // the device) in the follow-up increment. Unused on the single-tenant local install.
         TenantRegistry = new Tenancy.TenantRegistry(_gatewayDb);
-        EntitlementRegistry = new Tenancy.EntitlementRegistry(_gatewayDb);
+        // The free-trial ledger (issue #2117): the Gateway's OWN record of the 14-day Pro trial the public
+        // pricing page promises every new account. It is passed INTO the entitlement registry rather than
+        // consulted beside it, so the enrollment gate, the request-path lease and the 60s sweep all read one
+        // decision and can never disagree about whether an account may use hosted today - which is also what
+        // makes the trial EXPIRE on the request path instead of only at enrollment.
+        TrialRegistry = new Tenancy.TrialRegistry(_gatewayDb);
+        EntitlementRegistry = new Tenancy.EntitlementRegistry(_gatewayDb, trials: TrialRegistry);
         // MTR-15 cancellation cutoff, hosted-only. Reuses the SAME EntitlementRegistry as the enrollment gate
         // so the enrollment check and the ongoing check cannot drift. The revoker calls MTR-14B's tenant-wide
         // device tombstone; the lease is the O(1) hot-path check; the monitor is the 60s sweep.
@@ -2150,7 +2161,7 @@ public sealed class GatewayHost : IAsyncDisposable
             ? new Api.HostedEnrollDependencies(
                 Devices, TenantRegistry,
                 CcDirector.Gateway.Account.GatewayAccountFactory.BuildAuthorizationValidator(),
-                EntitlementRegistry)
+                EntitlementRegistry, TrialRegistry)
             : null;
 
         // POST /devices/enroll-hosted (Hosted Multi-Tenancy increment 1): the HOSTED counterpart - a REMOTE
@@ -2163,7 +2174,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // the entitlement registry means the gate is active wherever enrollment is possible - self-host
             // never maps this route at all and therefore cannot be gated by accident.
             Api.HostedEnrollmentEndpoint.Map(_app, hostedEnrollDeps.Devices, hostedEnrollDeps.Tenants,
-                hostedEnrollDeps.AccountTokenValidator, entitlements: hostedEnrollDeps.Entitlements);
+                hostedEnrollDeps.AccountTokenValidator, entitlements: hostedEnrollDeps.Entitlements,
+                trials: hostedEnrollDeps.Trials);
         }
 
         // Wingman-voice surface for the Cockpit's Voice tab (issue #531): drive one turn of a

--- a/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
@@ -76,11 +76,20 @@ public sealed record EntitlementDecision(EntitlementOutcome Outcome, string? Tie
 /// into a denial. The failure is logged LOUD, because a persistent inability to read this table means
 /// nobody can enroll and that must not be silent.
 ///
+/// THE FREE TRIAL IS FOLDED IN HERE, AND ONLY HERE (issue #2117). The public pricing page promises every new
+/// account 14 days of Pro, and that promise has to be kept at the same read every other entitlement question
+/// is answered at - not bolted onto the enrollment endpoint - or the trial would let a member IN at
+/// enrollment and then be invisible to the ongoing request-path cutoff, which is where a trial has to EXPIRE.
+/// One place decides, so the enrollment gate, the hosted access lease and the 60-second sweep can never
+/// disagree about whether an account may use hosted today. See <see cref="TrialRegistry"/> for who is granted
+/// a trial; this type only READS the ledger and never grants.
+///
 /// Nothing personally identifying is logged here - not the subject, not the subscription reference.
 /// </summary>
 public sealed class EntitlementRegistry
 {
     private readonly GatewayDatabase _db;
+    private readonly TrialRegistry? _trials;
 
     /// <param name="db">The Gateway database. The entitlement table is read through the UNSCOPED context:
     /// it is keyed by account subject and is read BEFORE any tenant exists, so scoping it to a tenant would
@@ -90,10 +99,17 @@ public sealed class EntitlementRegistry
     /// hosted demands real money and nothing else has to remember to. A test may pass false to exercise the
     /// rest of the policy without a live row.
     /// </param>
-    public EntitlementRegistry(GatewayDatabase db, bool? requireLivemode = null)
+    /// <param name="trials">
+    /// The free-trial ledger (issue #2117). NULL means no trial concept at all - the behaviour before trials
+    /// existed, byte-for-byte, which is what self-host and the existing tests get. When supplied, an account
+    /// with no valid PAID entitlement is entitled while its trial is running, at Pro tier and expiring at the
+    /// trial's end instant.
+    /// </param>
+    public EntitlementRegistry(GatewayDatabase db, bool? requireLivemode = null, TrialRegistry? trials = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _requireLivemode = requireLivemode ?? GatewayHostedMode.IsHosted;
+        _trials = trials;
     }
 
     private readonly bool _requireLivemode;
@@ -130,6 +146,59 @@ public sealed class EntitlementRegistry
     /// this came from; this method does not re-verify it.</param>
     /// <param name="nowUtc">The moment to judge the paid period against, injected for exact-boundary tests.</param>
     public EntitlementDecision Evaluate(string accountSubject, DateTime nowUtc)
+    {
+        var paid = EvaluatePaid(accountSubject, nowUtc);
+
+        // No trial ledger wired means trials do not exist here at all - the paid answer IS the answer, exactly
+        // as it was before trials. That is the self-host case and the control the trial tests revert against.
+        if (_trials is null)
+            return paid;
+
+        // A VALID PAID ENTITLEMENT ALWAYS WINS, and it is checked first. That is what makes "subscribes on day
+        // seven" seamless: the moment the payment side writes an active row, this returns the PAID decision -
+        // paid tier, paid period end, no trial expiry clipped onto it - and the member's access simply carries
+        // on. There is no gap because the trial was never removed, and no double-grant because the trial is
+        // not consulted at all while a paid row is valid.
+        if (paid.Outcome == EntitlementOutcome.Entitled)
+            return paid;
+
+        // The paid answer is NotEntitled (no row, cancelled, elapsed, test-mode) or Unknown (the read failed).
+        // Either way a running trial entitles this account on its own, so the trial is read in BOTH cases: a
+        // failed PAID read is not a reason to deny a member who is inside their free window.
+        var trial = _trials.Evaluate(accountSubject, nowUtc);
+
+        if (trial.Outcome == TrialOutcome.Active)
+        {
+            // THE TRIAL GRANT. Pro tier - the trial grants exactly the Pro entitlement set the pricing page
+            // promises - and the period end is the trial's own end instant, so the hosted access lease clips
+            // to it and caching can never extend a trial one moment past its end. This is where "expiry is
+            // enforced at the entitlement read, not just displayed" actually happens: the instant the trial
+            // ends this stops returning Entitled, and the same read that lets a member in is the one that
+            // stops letting them in.
+            FileLog.Write("[EntitlementRegistry] Evaluate: ENTITLED by the free Pro trial (no paid entitlement; the trial has not ended)");
+            return new EntitlementDecision(EntitlementOutcome.Entitled, TierPro, trial.ExpiresAtUtc);
+        }
+
+        if (trial.Outcome == TrialOutcome.Unknown)
+        {
+            // The trial read FAILED. We cannot say whether a trial covers this account, so we may not deny -
+            // that would lock out a member inside their free window because the database hiccuped - and we may
+            // not grant. Ignorance about EITHER source is ignorance about the answer.
+            FileLog.Write("[EntitlementRegistry] Evaluate: UNKNOWN - the trial read failed, so no verdict can be given (must be retried, never treated as unpaid or as paid)");
+            return new EntitlementDecision(EntitlementOutcome.Unknown, null);
+        }
+
+        // The trial read succeeded and no trial covers this account. The paid answer stands, whatever it was -
+        // a NotEntitled refusal, or an Unknown that must still be retried rather than refused.
+        return paid;
+    }
+
+    /// <summary>
+    /// The PAID half of the decision: the payment side's row and nothing else. Split out from
+    /// <see cref="Evaluate"/> so the paid policy - active, the past-due grace window, live-money-only, and the
+    /// three outcomes - is one unbroken piece of reasoning that the free trial sits beside rather than inside.
+    /// </summary>
+    private EntitlementDecision EvaluatePaid(string accountSubject, DateTime nowUtc)
     {
         // A blank subject is not a failed read - it is a caller error, and answering Unknown would invite a
         // retry loop that can never succeed. There is no entitlement for nobody, and no tier.
@@ -237,4 +306,20 @@ public sealed class EntitlementRegistry
 
     /// <summary>The pro plan tier.</summary>
     public const string TierPro = "pro";
+
+    /// <summary>
+    /// Where a member goes to subscribe. Stated ONCE so every refusal the Gateway writes points at the same
+    /// place: an entitlement denial has to tell the member what to do about it, and a refusal that only says
+    /// "not entitled" is a raw error, not an answer (issue #2117). The client is dumb - the Gateway hands it
+    /// the finished message and this address, and the client only renders them.
+    /// </summary>
+    public const string SubscribeUrl = "https://devthrottle.com/pricing";
+
+    /// <summary>
+    /// The human sentence that accompanies every hosted entitlement refusal, paired with
+    /// <see cref="SubscribeUrl"/>. One string, so the wording cannot drift between the enrollment refusal and
+    /// the request-path cutoff.
+    /// </summary>
+    public const string SubscribeMessage =
+        "Your DevThrottle Pro access has ended. Subscribe to keep using the wingman, dictation and spoken replies.";
 }

--- a/src/CcDirector.Gateway/Tenancy/TrialRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TrialRegistry.cs
@@ -1,0 +1,237 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// What a trial read established. THREE outcomes, for exactly the reason
+/// <see cref="EntitlementOutcome"/> has three: "I looked and there is no live trial" and "I could not look"
+/// demand opposite answers, and folding them together either denies a member who is inside their free window
+/// or grants the product to someone who is not.
+/// </summary>
+public enum TrialOutcome
+{
+    /// <summary>The read succeeded and a trial is running right now.</summary>
+    Active,
+
+    /// <summary>
+    /// The read SUCCEEDED and no trial covers this account now - either no trial was ever granted, or the one
+    /// that was has ended. This is knowledge, and it justifies falling back to the paid answer.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The read FAILED - connection, timeout, permission, anything. We do not KNOW whether a trial covers this
+    /// account, so this must never be answered as a grant and never as a refusal.
+    /// </summary>
+    Unknown,
+}
+
+/// <summary>The result of one trial read: the three-way outcome and, on <see cref="TrialOutcome.Active"/>,
+/// the exact instant the trial ends.</summary>
+/// <param name="Outcome">The three-way outcome. Never fold the three into two.</param>
+/// <param name="ExpiresAtUtc">The trial's end instant, present only on <see cref="TrialOutcome.Active"/>.
+/// The entitlement decision carries it forward as the period end, so the hosted access lease clips to it and
+/// caching can never extend a trial one moment past its end.</param>
+public sealed record TrialDecision(TrialOutcome Outcome, DateTime? ExpiresAtUtc = null);
+
+/// <summary>
+/// The free-trial ledger: the Gateway's own record of which accounts were granted the 14-day Pro trial the
+/// public pricing page promises, and when each trial ends.
+///
+/// WHY THE GATEWAY OWNS THIS AND NOT THE PAYMENT SIDE. The paid entitlement table belongs to the website's
+/// payment webhook, which writes it as the service role while this Gateway holds SELECT and nothing more. A
+/// trial is not a payment - no webhook produces one - so the Gateway cannot grant it by writing there. It
+/// records the grant on its own side of the boundary, in <c>account_trials</c>, and the entitlement decision
+/// reads BOTH.
+///
+/// WHO GETS A TRIAL, stated rather than implied. A trial is granted at an account's FIRST ARRIVAL at the
+/// hosted Gateway and nowhere else: the account presents a verified token, holds no paid entitlement, has
+/// never been granted a trial, and has no tenant - meaning this Gateway has never seen it before. An account
+/// that already holds a tenant was already using hosted before this feature existed and is NOT granted a
+/// trial; that is the owner's conservative rollout rule (issue #2117) expressed as something the Gateway can
+/// actually observe, since account creation happens on the website and the Gateway never sees it. The
+/// residual is stated plainly rather than hidden: an account that signed up before rollout and never once
+/// reached the hosted Gateway is indistinguishable here from a brand-new one, and will be granted a trial on
+/// its first arrival. It is granted nothing silently - only when the member actively tries to use hosted for
+/// the first time - and no account that was already using hosted is granted anything at all.
+///
+/// ONE TRIAL PER ACCOUNT, EVER. <see cref="GrantIfFirstArrival"/> is idempotent: an existing row is returned
+/// as it stands and is NEVER extended or re-stamped, so an expired trial row is what stops a member from
+/// restarting the free window by re-enrolling.
+///
+/// THE READ IS NEVER A VERDICT WHEN IT FAILS. Every failure path returns <see cref="TrialOutcome.Unknown"/>,
+/// and the caller turns that into a retry rather than a refusal or a grant. This type deliberately does not
+/// throw. Failures are logged LOUD, because an unreadable trial ledger stops every new member from starting.
+///
+/// Nothing personally identifying is logged here - the subject never reaches the log.
+/// </summary>
+public sealed class TrialRegistry
+{
+    /// <summary>
+    /// The length of the free trial: 14 days, the number the public pricing page states. It is a constant
+    /// rather than a setting because the page says fourteen days and the two must not be able to disagree.
+    /// </summary>
+    public static readonly TimeSpan TrialLength = TimeSpan.FromDays(14);
+
+    private readonly GatewayDatabase _db;
+    private readonly object _writeLock = new();
+
+    /// <param name="db">The Gateway database. The trial ledger is read and written through the UNSCOPED
+    /// context: it is keyed by account subject and is read BEFORE any tenant exists, so scoping it to a
+    /// tenant would be circular - the same reason the tenant mapping and entitlement tables are unscoped.</param>
+    public TrialRegistry(GatewayDatabase db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <summary>
+    /// Read whether a trial covers this account at <paramref name="nowUtc"/>. READ-ONLY - it never grants,
+    /// so the hot paths (the hosted access lease and its sweep) can call it on every check without the read
+    /// itself creating an entitlement.
+    /// </summary>
+    /// <param name="accountSubject">The verified account subject. The caller must have validated the token
+    /// this came from; this method does not re-verify it.</param>
+    /// <param name="nowUtc">The moment to judge the trial window against. Injected so the expiry boundary is
+    /// testable at an exact instant.</param>
+    public TrialDecision Evaluate(string accountSubject, DateTime nowUtc)
+    {
+        // A blank subject is a caller error, not a failed read. Answering Unknown would invite a retry loop
+        // that can never succeed. There is no trial for nobody.
+        if (string.IsNullOrWhiteSpace(accountSubject))
+        {
+            FileLog.Write("[TrialRegistry] Evaluate: NO TRIAL - no account subject was supplied");
+            return new TrialDecision(TrialOutcome.None);
+        }
+
+        var subject = accountSubject.Trim();
+
+        Data.Entities.AccountTrialEntity? row;
+        try
+        {
+            using var ctx = _db.CreateUnscopedContext();
+            row = ctx.AccountTrials.AsNoTracking().FirstOrDefault(t => t.Subject == subject);
+        }
+        catch (Exception ex)
+        {
+            // IGNORANCE, NOT ABSENCE. A failed read does not tell us the account has no trial, so it may not
+            // deny and it may not grant. Logged loud and by type: a persistent failure here stops every new
+            // member from starting a trial and must not be quiet.
+            FileLog.Write($"[TrialRegistry] Evaluate: READ FAILED ({ex.GetType().Name}) - answering UNKNOWN, " +
+                          "which must be retried and must NEVER be treated as no-trial or as a live trial");
+            return new TrialDecision(TrialOutcome.Unknown);
+        }
+
+        if (row is null)
+            return new TrialDecision(TrialOutcome.None);
+
+        // STRICTLY LESS THAN, so the expiry instant itself is already outside the window - at exactly
+        // ExpiresAtUtc the trial HAS ended, which is what the field means. An inclusive comparison would grant
+        // on an expired trial: one tick, but a tick in the give-it-away direction, and boundaries are where a
+        // policy is decided, so this one is pinned by its own test.
+        if (nowUtc < row.ExpiresAtUtc)
+            return new TrialDecision(TrialOutcome.Active, row.ExpiresAtUtc);
+
+        FileLog.Write("[TrialRegistry] Evaluate: NO TRIAL - this account's trial has ended (it is never extended or re-granted)");
+        return new TrialDecision(TrialOutcome.None);
+    }
+
+    /// <summary>
+    /// Grant the 14-day Pro trial to an account arriving at the hosted Gateway for the FIRST time, and return
+    /// what now covers it.
+    ///
+    /// This is the ONLY place a trial is created. It is called from the hosted enrollment path after the paid
+    /// entitlement read has already answered NotEntitled, so a paying account never reaches it and can never
+    /// be given a trial it does not need.
+    ///
+    /// IDEMPOTENT AND NEVER EXTENDING. An account that already has a trial row gets that row back exactly as
+    /// it stands - live or expired - and nothing is written. That is what makes one trial per account a
+    /// property of the code rather than a hope: re-enrolling after the window has closed re-reads the same
+    /// expired row and is refused.
+    /// </summary>
+    /// <param name="accountSubject">The verified account subject. The caller must have validated the token
+    /// this came from; this method does not re-verify it.</param>
+    /// <param name="alreadyKnownToGateway">True when this Gateway has seen this account before (it already
+    /// holds a tenant). Such an account was using hosted before the trial existed and is granted NOTHING -
+    /// the owner's conservative rollout rule. The caller supplies this because the tenant mapping is the
+    /// tenant registry's table, not this one's.</param>
+    /// <param name="nowUtc">The grant instant; the trial ends at this plus <see cref="TrialLength"/>.</param>
+    public TrialDecision GrantIfFirstArrival(string accountSubject, bool alreadyKnownToGateway, DateTime nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(accountSubject))
+        {
+            FileLog.Write("[TrialRegistry] GrantIfFirstArrival: NO TRIAL - no account subject was supplied");
+            return new TrialDecision(TrialOutcome.None);
+        }
+
+        // An existing trial - live or expired - always wins over a new grant, and it is checked FIRST so the
+        // never-extend rule holds no matter what the caller believes about the account.
+        var existing = Evaluate(accountSubject, nowUtc);
+        if (existing.Outcome != TrialOutcome.None)
+            return existing;
+
+        // Evaluate answered None. That is either "no row at all" or "the row has expired", and only the first
+        // may be granted. Re-read the row itself rather than inferring, so an expired trial is never re-granted.
+        var subject = accountSubject.Trim();
+
+        lock (_writeLock)
+        {
+            try
+            {
+                using var ctx = _db.CreateUnscopedContext();
+
+                if (ctx.AccountTrials.AsNoTracking().Any(t => t.Subject == subject))
+                {
+                    FileLog.Write("[TrialRegistry] GrantIfFirstArrival: NO TRIAL - this account already had its trial and it has ended (never re-granted)");
+                    return new TrialDecision(TrialOutcome.None);
+                }
+
+                if (alreadyKnownToGateway)
+                {
+                    // The conservative rollout rule (issue #2117): an account that already holds a tenant was
+                    // using hosted before the trial existed, so it is granted nothing. A goodwill window for
+                    // those accounts is a later, deliberate, one-time write - never something that happens by
+                    // itself the first time they come back.
+                    FileLog.Write("[TrialRegistry] GrantIfFirstArrival: NO TRIAL - this account was already known to the hosted Gateway before the trial existed");
+                    return new TrialDecision(TrialOutcome.None);
+                }
+
+                var expires = nowUtc + TrialLength;
+                ctx.AccountTrials.Add(new Data.Entities.AccountTrialEntity
+                {
+                    Subject = subject,
+                    StartedAtUtc = nowUtc,
+                    ExpiresAtUtc = expires,
+                });
+                ctx.SaveChanges();
+
+                FileLog.Write($"[TrialRegistry] GrantIfFirstArrival: GRANTED a {TrialLength.TotalDays:0}-day Pro trial to a first-seen account (no subject logged), ending {expires:O}");
+                return new TrialDecision(TrialOutcome.Active, expires);
+            }
+            catch (DbUpdateException)
+            {
+                // A competing grant for the SAME subject won the primary key (a second instance, or a future
+                // non-single-writer deployment - the in-process lock above does not cover those). One trial per
+                // account is the rule, so the loser adopts the winner's row: re-read what the key enforced.
+                // This is not a fallback that hides a problem - the primary key is the source of truth and we
+                // are reading back the value it enforced. A still-absent row would be a genuine failure, so it
+                // re-throws rather than granting again.
+                var winner = Evaluate(subject, nowUtc);
+                if (winner.Outcome != TrialOutcome.None)
+                {
+                    FileLog.Write("[TrialRegistry] GrantIfFirstArrival: lost a grant race, adopting the trial the winner wrote");
+                    return winner;
+                }
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // The write failed for anything else. We did not grant, and we do not know what covers this
+                // account - answering None here would refuse a brand-new member because the database hiccuped.
+                FileLog.Write($"[TrialRegistry] GrantIfFirstArrival: WRITE FAILED ({ex.GetType().Name}) - answering UNKNOWN, which must be retried");
+                return new TrialDecision(TrialOutcome.Unknown);
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -226,7 +226,16 @@ internal static class AuthMiddleware
                     {
                         ctx.Response.StatusCode = StatusCodes.Status402PaymentRequired;
                         ctx.Response.ContentType = "application/json; charset=utf-8";
-                        await ctx.Response.WriteAsync("{\"error\":\"hosted subscription required\",\"code\":\"hosted_subscription_required\"}");
+                        // The refusal carries the FINISHED sentence and the address to act on, not just a
+                        // code (issue #2117). A member whose free trial has just ended meets this response,
+                        // and "hosted subscription required" alone is a raw error - it tells them nothing
+                        // about what to do. error/code are unchanged so existing callers keep parsing; the
+                        // message and subscribeUrl are additive, and the Gateway - not the client - owns
+                        // their wording.
+                        await ctx.Response.WriteAsync(
+                            "{\"error\":\"hosted subscription required\",\"code\":\"hosted_subscription_required\"," +
+                            "\"message\":\"" + CcDirector.Gateway.Tenancy.EntitlementRegistry.SubscribeMessage + "\"," +
+                            "\"subscribeUrl\":\"" + CcDirector.Gateway.Tenancy.EntitlementRegistry.SubscribeUrl + "\"}");
                         return;
                     }
                     if (access == CcDirector.Gateway.Tenancy.HostedAccessDecision.RetryUnknown)


### PR DESCRIPTION
Closes #2117.

## Why

The live pricing page at devthrottle.com/pricing already tells every visitor: "Every new account starts with 14 days of Pro. Just sign up with your email - no card required." The hosted gateway granted no such entitlement, so the public page was over-promising. This makes the sentence true, and makes it bounded.

## The design decision that shaped this

The paid entitlement table (`gateway.entitlements`) is not the gateway's to write. It is the agreed cross-team hand-off point: the website's payment webhook upserts it as the service role, the gateway holds SELECT and nothing more, and the table is explicitly excluded from gateway migrations. A trial is not a payment and no webhook produces one, so the gateway cannot grant a trial by writing there.

The trial is therefore recorded on the gateway's own side of the boundary, in a new gateway-owned `account_trials` table, and one entitlement read folds both sources. Nothing about the website schema, the webhook, or the gateway's database role changes.

**One place decides.** The trial is folded into `EntitlementRegistry.Evaluate` - the single read that the enrollment gate, the hosted-access lease and the 60-second entitlement sweep all call. It is deliberately not bolted onto the enrollment endpoint: a trial applied only at enrollment would let a member in and then be invisible to the ongoing request-path cutoff, which is exactly where a trial has to expire. The grant itself happens in exactly one place - the hosted enrollment path, at an account's first arrival. Reads never grant.

## Rollout rule (the owner's decision on the issue)

Only accounts created at or after rollout get the trial; existing accounts are not backfilled. The gateway cannot observe account creation - that happens on the website, and the Supabase access token carries no creation claim - so the rule is implemented against the one thing the gateway can observe: whether it has ever seen this account before. An account that already holds a tenant was using hosted before the trial existed and is granted nothing (asserted by its own test).

Residual, stated rather than hidden: an account that signed up before rollout and never once reached the hosted gateway is indistinguishable here from a brand-new one and will be granted a trial on its first arrival. It is granted nothing silently - only when the member actively tries to use hosted for the first time - and no account that was already using hosted is granted anything. Excluding that last case needs a creation-time signal from the website, which is a cross-repo change and is not in this pull request.

## Changes

- `AccountTrialEntity` + `account_trials` table (gateway-owned, global, subject as primary key).
- `TrialRegistry` - `Evaluate` (read-only, three-way outcome) and `GrantIfFirstArrival` (the only writer, idempotent, never extends).
- `EntitlementRegistry.Evaluate` folds paid + trial. A valid paid entitlement always wins outright, so subscribing during the trial takes over with no gap and does not inherit the trial's expiry as its period end. A live trial entitles at `pro` tier with the trial's end as the period end, so the hosted-access lease clips to it.
- The hosted enrollment path grants the trial at first arrival; both enrollment surfaces and the request-path cutoff now return a finished sentence and the subscribe address instead of a bare code (`error`/`code` unchanged, the new fields are additive).
- Both migrations (SQLite and Postgres) ship here, in the same change as the model, and each provider reports no pending model changes.

## Metering

No change was needed and none was made. A trial account is an ordinary entitled tenant with an ordinary device key; the hosted-AI spend store, the spend sweep and the session spend emitter carry no entitlement, tier or trial branch, so a trial is metered by the same code that meters a paid account.

## How to test

`dotnet test src/CcDirector.Gateway.Tests --filter FullyQualifiedName~HostedProTrialTests`

15 tests covering: a brand-new account enrolling with no payment; pro tier and a 14-day window; the expiry at the exact instant and at day 15; re-enrolling after expiry refused; one trial per account with no restart and no extension; an already-known account granted nothing; subscribing on day 7 taking over with the paid period end; a paying account never handed a trial; a failed trial read answering retry rather than refusal; a failed paid read with no trial still never granting; a live trial entitling when the paid read fails; the real endpoint over HTTP returning a 402 whose body says what to do about it; and the revert-proof control with no trial ledger wired.

## Expected result

A brand-new account, email only, enrolls and is entitled at Pro tier for 14 days. Fifteen days later, with no subscription, the entitlement read itself says not entitled - so the request-path cutoff denies with a message that points at subscribing. A subscription taken on day 7 carries on without interruption.

## Proof

`docs/cencon/proof/issue-2117/report.html`