### PR TITLE
First-run wizard: real Agents screen with in-place Claude Code install and honest deferral

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -148,18 +148,32 @@
                     <StackPanel x:Name="AgentsListPanel" Spacing="8" MaxWidth="560"
                                 HorizontalAlignment="Stretch" />
                 </ScrollViewer>
-                <!-- Install guidance, shown only when zero agents are found (the unskippable case). -->
-                <StackPanel Grid.Row="3" x:Name="AgentsInstallGuidance" Spacing="10"
-                            IsVisible="False" Margin="0,14,0,0">
-                    <TextBlock Classes="hint" HorizontalAlignment="Center" TextAlignment="Center"
-                               MaxWidth="520"
-                               Text="DevThrottle runs command-line coding agents. We did not find one on this machine - install one, then re-check. This step cannot be skipped: nothing works without an agent." />
-                    <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-                        <Button x:Name="AgentsInstallButton" Classes="dialogButton"
-                                Content="Open install guide" Click="BtnInstallAgent_Click" />
-                        <Button x:Name="AgentsRecheckButton" Classes="dialogButton"
-                                Content="Re-check" Click="BtnRecheckAgents_Click" />
+                <!-- Zero-agents actions: install Claude Code right here, or defer it as a carried
+                     to-do. Shown only in the empty state (the step that cannot be skipped). -->
+                <StackPanel Grid.Row="3" x:Name="AgentsEmptyActions" Spacing="12"
+                            IsVisible="False" Margin="0,16,0,0">
+                    <Button x:Name="AgentsInstallButton" Classes="primaryButton"
+                            Content="Install Claude Code for me" HorizontalAlignment="Center"
+                            Click="BtnInstallClaude_Click" />
+                    <TextBlock x:Name="AgentsInstallProgressText" Classes="hint" IsVisible="False"
+                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540"
+                               FontFamily="Consolas, Cascadia Mono, monospace" />
+                    <StackPanel x:Name="AgentsInstallErrorPanel" Spacing="6" IsVisible="False">
+                        <TextBlock x:Name="AgentsInstallErrorText" FontSize="13" Foreground="#DC2626"
+                                   TextWrapping="Wrap" TextAlignment="Center" MaxWidth="540"
+                                   HorizontalAlignment="Center" />
+                        <Button Classes="quietLink" Content="Open the install guide instead"
+                                HorizontalAlignment="Center" Click="BtnInstallAgent_Click" />
                     </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="22" HorizontalAlignment="Center">
+                        <Button x:Name="AgentsRecheckButton" Classes="quietLink"
+                                Content="Re-check" Click="BtnRecheckAgents_Click" />
+                        <Button x:Name="AgentsDeferButton" Classes="quietLink"
+                                Content="I'll do this later" Click="BtnDeferAgents_Click" />
+                    </StackPanel>
+                    <TextBlock Classes="hint" HorizontalAlignment="Center" TextAlignment="Center"
+                               MaxWidth="480"
+                               Text="Takes about a minute. You sign in to Claude the first time an agent starts." />
                 </StackPanel>
             </Grid>
 

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -38,6 +38,8 @@ public partial class FirstRunWizardDialog : Window
 {
     private readonly AgentOptions _options;
     private readonly ToolDetectionWizardModel _toolModel = new(new ToolDetectionService());
+    private readonly ToolDetectionService _detectionService = new();
+    private CancellationTokenSource? _claudeInstallCts;
     private readonly FirstRunWizardModel _model;
     private readonly List<Ellipse> _dots = new();
 
@@ -170,7 +172,10 @@ public partial class FirstRunWizardDialog : Window
                 break;
 
             case WizardStep.Done:
-                // Primary ("Start my first agent") and the board link live in the content panel.
+                // Primary and the board link live in the content panel. With no agent on the machine
+                // the carried to-do leads: the button routes back to the Agents step and its installer
+                // instead of promising a session that cannot start.
+                DoneStartButton.Content = _model.AgentsFound ? "Start my first agent" : "Install an agent";
                 FooterNote.Text = "Everything here can be changed in Settings.";
                 FooterNote.IsVisible = true;
                 BuildDoneReceipt();
@@ -270,9 +275,17 @@ public partial class FirstRunWizardDialog : Window
 
     private async void BtnStartFirstAgent_Click(object? sender, RoutedEventArgs e)
     {
-        FileLog.Write("[FirstRunWizardDialog] BtnStartFirstAgent_Click");
+        FileLog.Write($"[FirstRunWizardDialog] BtnStartFirstAgent_Click: agentsFound={_model.AgentsFound}");
         try
         {
+            if (!_model.AgentsFound)
+            {
+                // "Install an agent": jump back to the Agents step, whose empty state carries the
+                // in-place installer. Nothing is finished yet - the wizard stays open.
+                _model.GoTo(WizardStep.Agents);
+                ShowStep(_model.Current);
+                return;
+            }
             await FinishAsync(wantsNewSession: true);
         }
         catch (Exception ex)
@@ -281,13 +294,14 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
-    // ---- Agents step (interim: reuses the tool-detection scan) -------------------------------------
+    // ---- Agents step -------------------------------------------------------------------------------
 
     private async Task ScanAgentsAsync()
     {
         FileLog.Write("[FirstRunWizardDialog] ScanAgentsAsync");
+        AgentsTitle.Text = "Your agents";
         AgentsStatusText.Text = "Scanning this machine for coding agents...";
-        AgentsInstallGuidance.IsVisible = false;
+        AgentsEmptyActions.IsVisible = false;
         try
         {
             var (suggestions, existing) = await Task.Run(() =>
@@ -304,16 +318,27 @@ public partial class FirstRunWizardDialog : Window
             var anyFound = suggestions.Any(s => s.Found) || existing.Count > 0;
             _model.SetAgentsFound(anyFound);
 
-            BuildAgentRows(suggestions, existing);
+            // Probe each found agent's version so the rows read "v2.1.4 - path": the version is the
+            // proof the detection is real, not a guess. Best-effort - a probe that fails or times
+            // out just leaves the row without a version.
+            var versions = await ProbeVersionsAsync(suggestions);
+            BuildAgentRows(suggestions, existing, versions);
 
             var foundCount = suggestions.Count(s => s.Found);
-            AgentsStatusText.Text = anyFound
-                ? $"We found {foundCount} coding {(foundCount == 1 ? "agent" : "agents")}. These are ready to use - you can add more or change paths later in Settings."
-                : "You need a coding agent. DevThrottle runs and supervises command-line coding agents, and we did not find one on this machine.";
+            if (anyFound)
+            {
+                AgentsTitle.Text = $"We found {foundCount} coding {(foundCount == 1 ? "agent" : "agents")}";
+                AgentsStatusText.Text = "These are ready to use. You can add more or change paths later in Settings.";
+            }
+            else
+            {
+                AgentsTitle.Text = "You need a coding agent";
+                AgentsStatusText.Text = "DevThrottle runs and supervises command-line coding agents, and we did not find any on this machine - so let's install one now.";
+            }
 
             // Zero agents: the one step the user cannot skip. Hide the skip link, block Continue, and
-            // show install guidance; otherwise allow both and hide the guidance.
-            AgentsInstallGuidance.IsVisible = !anyFound;
+            // offer the in-place install (or the deferral); otherwise allow both and hide the actions.
+            AgentsEmptyActions.IsVisible = !anyFound;
             PrimaryButton.IsEnabled = anyFound;
             ConfigureStepSkip();
 
@@ -326,7 +351,30 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
-    private void BuildAgentRows(IReadOnlyList<ToolDetectionSuggestion> suggestions, ISet<AgentKind> existing)
+    /// <summary>Version-probe every found agent (bounded per-tool by the plugin's validation timeout).</summary>
+    private async Task<Dictionary<AgentKind, string>> ProbeVersionsAsync(IReadOnlyList<ToolDetectionSuggestion> suggestions)
+    {
+        var versions = new Dictionary<AgentKind, string>();
+        foreach (var s in suggestions.Where(s => s.Found))
+        {
+            try
+            {
+                var test = await _detectionService.TestToolAsync(s.Tool, s.ResolvedPath);
+                if (test.Ok && !string.IsNullOrWhiteSpace(test.Version))
+                    versions[s.Tool] = test.Version!;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[FirstRunWizardDialog] ProbeVersionsAsync: {s.Tool} probe failed: {ex.Message}");
+            }
+        }
+        return versions;
+    }
+
+    private void BuildAgentRows(
+        IReadOnlyList<ToolDetectionSuggestion> suggestions,
+        ISet<AgentKind> existing,
+        IReadOnlyDictionary<AgentKind, string> versions)
     {
         AgentsListPanel.Children.Clear();
 
@@ -335,9 +383,12 @@ public partial class FirstRunWizardDialog : Window
         foreach (var s in suggestions.Where(s => s.Found))
         {
             var alreadyAdded = existing.Contains(s.Tool);
+            var detail = versions.TryGetValue(s.Tool, out var v)
+                ? $"{(v.StartsWith('v') || v.StartsWith('V') ? v : "v" + v)} - {s.ResolvedPath}"
+                : s.ResolvedPath;
             AgentsListPanel.Children.Add(AgentRow(
                 s.DisplayName,
-                alreadyAdded ? $"Already in your Agents list - {s.ResolvedPath}" : s.ResolvedPath,
+                alreadyAdded ? $"Already in your Agents list - {detail}" : detail,
                 alreadyAdded ? "In list" : "Ready",
                 ready: true));
         }
@@ -443,6 +494,80 @@ public partial class FirstRunWizardDialog : Window
         FileLog.Write("[FirstRunWizardDialog] BtnRecheckAgents_Click");
         _agentScanRan = false;
         _ = ScanAgentsAsync();
+    }
+
+    /// <summary>
+    /// The zero-agents primary action: run the official Claude Code installer right here, stream its
+    /// progress into the screen, and re-scan when it finishes - the user never leaves the wizard.
+    /// </summary>
+    private async void BtnInstallClaude_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnInstallClaude_Click");
+        try
+        {
+            AgentsInstallButton.IsEnabled = false;
+            AgentsRecheckButton.IsEnabled = false;
+            AgentsDeferButton.IsEnabled = false;
+            AgentsInstallErrorPanel.IsVisible = false;
+            AgentsInstallProgressText.IsVisible = true;
+            AgentsInstallProgressText.Text = "Starting the official Claude Code installer...";
+
+            _claudeInstallCts?.Cancel();
+            _claudeInstallCts = new CancellationTokenSource();
+
+            // Progress<T> posts to the UI context it was created on, so the report lands on the UI thread.
+            var progress = new Progress<string>(line => AgentsInstallProgressText.Text = line);
+            var result = await new ClaudeCodeInstaller().InstallAsync(progress, _claudeInstallCts.Token);
+
+            if (result.Success)
+            {
+                AgentsInstallProgressText.Text = "Installed. Checking this machine again...";
+                _agentScanRan = false;
+                await ScanAgentsAsync();
+
+                if (!_model.AgentsFound)
+                {
+                    // The script said success but the re-scan still sees nothing - never leave the
+                    // user with a silent no-op. Name the state and hand them the guide.
+                    AgentsInstallErrorText.Text =
+                        "The installer finished, but Claude Code was not found afterwards. Restart the Director and re-check, or use the install guide.";
+                    AgentsInstallErrorPanel.IsVisible = true;
+                }
+            }
+            else
+            {
+                AgentsInstallErrorText.Text = result.Message;
+                AgentsInstallErrorPanel.IsVisible = true;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            FileLog.Write("[FirstRunWizardDialog] BtnInstallClaude_Click: cancelled");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnInstallClaude_Click FAILED: {ex.Message}");
+            AgentsInstallErrorText.Text = $"Could not run the installer: {ex.Message}";
+            AgentsInstallErrorPanel.IsVisible = true;
+        }
+        finally
+        {
+            AgentsInstallProgressText.IsVisible = false;
+            AgentsInstallButton.IsEnabled = true;
+            AgentsRecheckButton.IsEnabled = true;
+            AgentsDeferButton.IsEnabled = true;
+        }
+    }
+
+    /// <summary>
+    /// "I'll do this later": the honest deferral on the zero-agents state. The wizard proceeds, and
+    /// the missing agent stays a carried to-do - the Done screen leads with installing an agent.
+    /// </summary>
+    private void BtnDeferAgents_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnDeferAgents_Click");
+        _model.DeferAgents();
+        Advance();
     }
 
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
@@ -623,7 +748,11 @@ public partial class FirstRunWizardDialog : Window
                 string.Join(", ", addedNames), done: true));
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
-                "No agent yet", "Add one from Settings > Agents", done: false));
+                "No agent yet",
+                _model.AgentsDeferred
+                    ? "You chose to do this later - the button below installs one now"
+                    : "Add one from Settings > Agents",
+                done: false));
 
         // Gateway row.
         var gatewayUrl = GatewayConfig.Load().Url;
@@ -705,6 +834,7 @@ public partial class FirstRunWizardDialog : Window
     protected override void OnClosed(EventArgs e)
     {
         _hostedEnrollCts?.Cancel();
+        _claudeInstallCts?.Cancel();
         if (!_marked)
         {
             FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (window closed without finishing)");

--- a/src/CcDirector.Core.Tests/Onboarding/ClaudeCodeInstallerTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/ClaudeCodeInstallerTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Onboarding;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Onboarding;
+
+/// <summary>
+/// Tests for <see cref="ClaudeCodeInstaller"/>. The real installer runs the official claude.ai
+/// script; these pin the invocation shape and the exit-code contract through the process seam,
+/// with no network and no process.
+/// </summary>
+public sealed class ClaudeCodeInstallerTests
+{
+    [Fact]
+    public void BuildStartInfo_RunsTheOfficialInstaller_ForThisPlatform()
+    {
+        var psi = ClaudeCodeInstaller.BuildStartInfo();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("powershell.exe", psi.FileName);
+            Assert.Contains(ClaudeCodeInstaller.WindowsInstallCommand, psi.Arguments);
+        }
+        else
+        {
+            Assert.Equal("/bin/bash", psi.FileName);
+            Assert.Contains(ClaudeCodeInstaller.UnixInstallCommand, psi.Arguments);
+        }
+
+        // The wizard must be able to stream the script's own words as progress.
+        Assert.True(psi.RedirectStandardOutput);
+        Assert.True(psi.RedirectStandardError);
+        Assert.False(psi.UseShellExecute);
+    }
+
+    /// <summary>Synchronous IProgress so the test observes reports deterministically -
+    /// Progress&lt;T&gt; posts to the thread pool, which would make this assertion a race.</summary>
+    private sealed class ImmediateProgress : IProgress<string>
+    {
+        public List<string> Lines { get; } = new();
+        public void Report(string value) => Lines.Add(value);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ExitZero_IsSuccess_AndStreamsProgress()
+    {
+        var progress = new ImmediateProgress();
+        var installer = new ClaudeCodeInstaller
+        {
+            RunProcessSeam = (_, p, _) =>
+            {
+                p.Report("Downloading Claude Code...");
+                p.Report("Installed to ~/.local/bin");
+                return Task.FromResult(0);
+            },
+        };
+
+        var result = await installer.InstallAsync(progress);
+
+        Assert.True(result.Success);
+        Assert.Equal(new[] { "Downloading Claude Code...", "Installed to ~/.local/bin" }, progress.Lines);
+    }
+
+    [Fact]
+    public async Task InstallAsync_NonZeroExit_IsFailure_NamingTheCode()
+    {
+        var installer = new ClaudeCodeInstaller { RunProcessSeam = (_, _, _) => Task.FromResult(7) };
+
+        var result = await installer.InstallAsync(new Progress<string>(_ => { }));
+
+        Assert.False(result.Success);
+        Assert.Contains("7", result.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ProcessLaunchFailure_IsFailure_WithTheReason()
+    {
+        var installer = new ClaudeCodeInstaller
+        {
+            RunProcessSeam = (_, _, _) => throw new InvalidOperationException("powershell not found"),
+        };
+
+        var result = await installer.InstallAsync(new Progress<string>(_ => { }));
+
+        Assert.False(result.Success);
+        Assert.Contains("powershell not found", result.Message);
+    }
+
+    [Fact]
+    public async Task InstallAsync_Cancellation_Propagates()
+    {
+        var installer = new ClaudeCodeInstaller
+        {
+            RunProcessSeam = (_, _, ct) => Task.FromCanceled<int>(ct),
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => installer.InstallAsync(new Progress<string>(_ => { }), cts.Token));
+    }
+}

--- a/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
@@ -276,4 +276,41 @@ public class FirstRunWizardModelTests
         model.GoTo(WizardStep.Agents);
         Assert.False(model.CanSkipCurrent);
     }
+
+    [Fact]
+    public void DeferAgents_RecordsTheCarriedToDo_WithoutMakingTheStepSkippable()
+    {
+        var model = new FirstRunWizardModel(ShellSteps());
+        model.SetAgentsFound(false);
+
+        Assert.False(model.AgentsDeferred);
+        model.DeferAgents();
+
+        // The deferral is a carried to-do, not a skip: the step's skip rule is unchanged.
+        Assert.True(model.AgentsDeferred);
+        Assert.False(model.CanSkipStep(WizardStep.Agents));
+    }
+
+    [Fact]
+    public void DeferAgents_IsCleared_WhenAnAgentIsFoundLater()
+    {
+        var model = new FirstRunWizardModel(ShellSteps());
+        model.SetAgentsFound(false);
+        model.DeferAgents();
+        Assert.True(model.AgentsDeferred);
+
+        // A later successful scan (e.g. after an install) resolves the to-do.
+        model.SetAgentsFound(true);
+        Assert.False(model.AgentsDeferred);
+    }
+
+    [Fact]
+    public void DeferAgents_WithAgentsAlreadyFound_ReportsNoPendingToDo()
+    {
+        var model = new FirstRunWizardModel(ShellSteps());
+        model.SetAgentsFound(true);
+
+        model.DeferAgents();
+        Assert.False(model.AgentsDeferred);
+    }
 }

--- a/src/CcDirector.Core/AgentPlugins/ClaudeAgentPlugin.cs
+++ b/src/CcDirector.Core/AgentPlugins/ClaudeAgentPlugin.cs
@@ -26,6 +26,10 @@ public sealed class ClaudeAgentPlugin : IAgentPlugin
         [
             new AgentPluginDetectionCandidate("claude"),
             new AgentPluginDetectionCandidate(DefaultNpmCliPath("claude")),
+            // The official claude.ai installer scripts place the binary in ~/.local/bin. A Director
+            // launched before that install ran has a stale PATH, so probe the location directly -
+            // this is what lets the wizard's re-scan find Claude Code right after installing it.
+            new AgentPluginDetectionCandidate(LocalBinCliPath("claude")),
         ],
         "Install Claude Code and make the claude command available on PATH.");
 
@@ -82,5 +86,14 @@ public sealed class ClaudeAgentPlugin : IAgentPlugin
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         return string.IsNullOrWhiteSpace(appData) ? binName : Path.Combine(appData, "npm", binName + ".cmd");
+    }
+
+    /// <summary>The official installer's target: ~/.local/bin/claude (claude.exe on Windows).</summary>
+    private static string LocalBinCliPath(string binName)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home)) return binName;
+        var fileName = OperatingSystem.IsWindows() ? binName + ".exe" : binName;
+        return Path.Combine(home, ".local", "bin", fileName);
     }
 }

--- a/src/CcDirector.Core/Onboarding/ClaudeCodeInstaller.cs
+++ b/src/CcDirector.Core/Onboarding/ClaudeCodeInstaller.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Onboarding;
+
+/// <summary>Outcome of an in-wizard Claude Code install attempt.</summary>
+public sealed record ClaudeInstallResult(bool Success, string Message);
+
+/// <summary>
+/// Installs Claude Code from inside the first-run wizard by running the OFFICIAL claude.ai
+/// installer script for the current platform - the same one the docs tell a user to paste into a
+/// terminal. Windows runs the PowerShell script, macOS and Linux run the shell script. Output
+/// lines stream to the caller so the wizard can show live progress, and the exit code decides
+/// success. Nothing is guessed: a non-zero exit is a failure with the script's own words.
+///
+/// The installer script places the binary in ~/.local/bin, which agent detection probes directly
+/// (see ClaudeAgentPlugin), so a re-scan straight after a successful install finds it even though
+/// this process' PATH predates the install.
+/// </summary>
+public sealed class ClaudeCodeInstaller
+{
+    /// <summary>Windows: official PowerShell installer.</summary>
+    internal const string WindowsInstallCommand = "irm https://claude.ai/install.ps1 | iex";
+
+    /// <summary>macOS / Linux: official shell installer.</summary>
+    internal const string UnixInstallCommand = "curl -fsSL https://claude.ai/install.sh | bash";
+
+    // Test seam: replaces the real process run. Receives the start info, streams progress lines,
+    // returns the exit code. Null -> run the real process.
+    internal Func<ProcessStartInfo, IProgress<string>, CancellationToken, Task<int>>? RunProcessSeam;
+
+    /// <summary>Build the platform's installer invocation. Internal so tests can pin its shape.</summary>
+    internal static ProcessStartInfo BuildStartInfo()
+    {
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("powershell.exe", $"-NoProfile -ExecutionPolicy Bypass -Command \"{WindowsInstallCommand}\"")
+            : new ProcessStartInfo("/bin/bash", $"-c \"{UnixInstallCommand}\"");
+        psi.UseShellExecute = false;
+        psi.CreateNoWindow = true;
+        psi.RedirectStandardOutput = true;
+        psi.RedirectStandardError = true;
+        return psi;
+    }
+
+    /// <summary>
+    /// Run the official installer, streaming its output lines to <paramref name="progress"/>.
+    /// Success is the script exiting 0; failure carries the exit code so the wizard can show it.
+    /// </summary>
+    public async Task<ClaudeInstallResult> InstallAsync(IProgress<string> progress, CancellationToken ct = default)
+    {
+        FileLog.Write("[ClaudeCodeInstaller] InstallAsync: starting official installer");
+        var psi = BuildStartInfo();
+
+        var run = RunProcessSeam ?? RunRealProcessAsync;
+        int exitCode;
+        try
+        {
+            exitCode = await run(psi, progress, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            FileLog.Write("[ClaudeCodeInstaller] InstallAsync: cancelled");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ClaudeCodeInstaller] InstallAsync FAILED to run installer: {ex.Message}");
+            return new ClaudeInstallResult(false, $"Could not run the installer: {ex.Message}");
+        }
+
+        if (exitCode == 0)
+        {
+            FileLog.Write("[ClaudeCodeInstaller] InstallAsync: installer exited 0");
+            return new ClaudeInstallResult(true, "Claude Code installed.");
+        }
+
+        FileLog.Write($"[ClaudeCodeInstaller] InstallAsync: installer exited {exitCode}");
+        return new ClaudeInstallResult(false, $"The installer exited with code {exitCode}. See the output above for the reason.");
+    }
+
+    private static async Task<int> RunRealProcessAsync(ProcessStartInfo psi, IProgress<string> progress, CancellationToken ct)
+    {
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += (_, e) => { if (!string.IsNullOrWhiteSpace(e.Data)) progress.Report(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (!string.IsNullOrWhiteSpace(e.Data)) progress.Report(e.Data); };
+
+        if (!process.Start())
+            throw new InvalidOperationException("The installer process did not start.");
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.WaitForExitAsync(ct);
+        return process.ExitCode;
+    }
+}

--- a/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
+++ b/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
@@ -68,6 +68,7 @@ public sealed class FirstRunWizardModel
     // Until an agent scan says otherwise, assume at least one agent exists so the Agents step does
     // not block skipping before it has been evaluated. The shell calls SetAgentsFound after its scan.
     private bool _agentsFound = true;
+    private bool _agentsDeferred;
 
     /// <summary>
     /// Build a wizard over the given present steps. The list is normalised to
@@ -163,6 +164,21 @@ public sealed class FirstRunWizardModel
 
     /// <summary>Whether the last agent scan reported at least one agent (defaults true pre-scan).</summary>
     public bool AgentsFound => _agentsFound;
+
+    /// <summary>
+    /// Record that the user chose "I'll do this later" on the zero-agents state. Deferral is the
+    /// honest alternative to a skip the rule forbids: the wizard may proceed, but the missing agent
+    /// stays a carried to-do - the Done screen leads with "install an agent" instead of "start my
+    /// first agent". Finding an agent later (a re-scan after an install) clears the deferral.
+    /// </summary>
+    public void DeferAgents()
+    {
+        _agentsDeferred = true;
+        FileLog.Write("[FirstRunWizardModel] DeferAgents");
+    }
+
+    /// <summary>True while the user has parked the zero-agents state for later and no agent has been found since.</summary>
+    public bool AgentsDeferred => _agentsDeferred && !_agentsFound;
 
     /// <summary>
     /// Whether the given step may be individually skipped. Every step is skippable EXCEPT the Agents


### PR DESCRIPTION
Part of the first-run setup wizard epic thefrederiksen/devthrottle_internal#926. Second increment after the shell + light design.

## What changed

- **Found state leads with proof:** headline "We found N coding agents"; each found agent shows its probed version and path with a green Ready pill; not-installed tools collapse into one quiet row.
- **Zero agents is no longer a wall:** the primary action is "Install Claude Code for me" - the wizard runs the official claude.ai installer script for the platform, streams its output as live progress, and re-scans automatically on success. Failure names the exit code with a retry and the install guide.
- **Honest deferral instead of a forbidden skip:** "I'll do this later" lets the wizard proceed while carrying the to-do - the Done screen's receipt says so and its primary button becomes "Install an agent", routing back to the Agents step and its installer.
- **Detection fix:** Claude Code detection now probes ~/.local/bin (the official installer's target), so the post-install re-scan finds the fresh binary even though the running Director's PATH predates the install.

## Proof

- 44 related Core tests pass (three consecutive runs): wizard model incl. three new deferral tests, five ClaudeCodeInstaller tests through a process seam (no network), and tool detection.
- Found state verified in a running build on a fresh profile (versions + Ready pills render).