### PR TITLE
First-run wizard: Screenshots step with platform-aware detection and the take-a-screenshot trick

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -177,6 +177,48 @@
                 </StackPanel>
             </Grid>
 
+            <!-- ===================== SCREENSHOTS ===================== -->
+            <Grid x:Name="ScreenshotsPanel" IsVisible="False" RowDefinitions="Auto,Auto,*">
+                <TextBlock Grid.Row="0" Classes="wtitle" Text="Where do your screenshots go?" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="1" Classes="wsub" Margin="0,0,0,26"
+                           Text="Snap a screen, then drag the screenshot straight onto an agent - the fastest way to show it exactly what you mean. DevThrottle watches one folder for new screenshots." />
+                <StackPanel Grid.Row="2" MaxWidth="600" Spacing="14" VerticalAlignment="Top"
+                            HorizontalAlignment="Stretch">
+
+                    <!-- The chosen folder, with a Change (browse) escape hatch. -->
+                    <Border Background="#F5F6F8" BorderBrush="#E6E8EC" BorderThickness="1"
+                            CornerRadius="12" Padding="16,13">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" x:Name="ShotsPathText"
+                                       FontFamily="Consolas, Cascadia Mono, monospace" FontSize="13.5"
+                                       Foreground="#16181D" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"
+                                       Text="Looking for your screenshots folder..." />
+                            <Button Grid.Column="1" Classes="dialogButton" Content="Change..."
+                                    Click="BtnBrowseScreenshots_Click" Margin="12,0,0,0" />
+                        </Grid>
+                    </Border>
+
+                    <!-- Provenance + proof line: WHERE this answer came from and how many images live there. -->
+                    <TextBlock x:Name="ShotsProvenanceText" Classes="hint"
+                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540" />
+
+                    <!-- The certainty trick: press the normal screenshot shortcut; we watch where it lands. -->
+                    <StackPanel x:Name="ShotsWatchIdle" HorizontalAlignment="Center">
+                        <Button Classes="quietLink" Content="Not sure? Take a screenshot and we'll find it"
+                                Click="BtnWatchScreenshot_Click" />
+                    </StackPanel>
+                    <StackPanel x:Name="ShotsWatchActive" IsVisible="False" Spacing="8"
+                                HorizontalAlignment="Center">
+                        <TextBlock x:Name="ShotsWatchText" FontSize="13.5" Foreground="#0066B8"
+                                   FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap"
+                                   MaxWidth="480" />
+                        <Button Classes="quietLink" Content="Stop watching" HorizontalAlignment="Center"
+                                Click="BtnCancelWatchScreenshot_Click" />
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+
             <!-- ===================== GATEWAY (native, hosted-first per the mockup) ===================== -->
             <Grid x:Name="GatewayPanel" IsVisible="False" RowDefinitions="Auto,Auto,*">
                 <TextBlock Grid.Row="0" Classes="wtitle" Text="Connect your gateway" Margin="0,0,0,10" />

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -13,8 +13,11 @@ using Avalonia.Media;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.GatewayConnection;
+using System.Text.Json.Nodes;
+using Avalonia.Platform.Storage;
 using CcDirector.Core.Onboarding;
 using CcDirector.Core.Settings;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Setup.Engine;
 
@@ -59,6 +62,12 @@ public partial class FirstRunWizardDialog : Window
     // The existing join-an-existing-gateway flow, embedded only behind the self-hosted advanced path.
     private Controls.GatewayConnectionPanel? _gatewayPanel;
 
+    // Screenshots step: the folder the user is about to confirm, its plain-English provenance, and
+    // the live take-a-screenshot watch.
+    private string? _shotsSelectedPath;
+    private bool _shotsDetectRan;
+    private CancellationTokenSource? _shotsWatchCts;
+
     // True once the completion marker has been written, so OnClosed does not write it twice.
     private bool _marked;
 
@@ -76,13 +85,13 @@ public partial class FirstRunWizardDialog : Window
         FileLog.Write("[FirstRunWizardDialog] Constructor: initializing");
         _options = options ?? throw new ArgumentNullException(nameof(options));
 
-        // The steps present in THIS release: the two bookends the shell ships, plus the interim
-        // Agents and Gateway steps that reuse existing controls. Code, Screenshots and Morning report
-        // are absent until their own issues land; the model tolerates the shorter list.
+        // The steps present in THIS release. Code and Morning report are absent until their own
+        // issues land; the model tolerates the shorter list.
         _model = new FirstRunWizardModel(new[]
         {
             WizardStep.Welcome,
             WizardStep.Agents,
+            WizardStep.Screenshots,
             WizardStep.Gateway,
             WizardStep.Done,
         });
@@ -136,8 +145,13 @@ public partial class FirstRunWizardDialog : Window
 
         WelcomePanel.IsVisible = step == WizardStep.Welcome;
         AgentsPanel.IsVisible = step == WizardStep.Agents;
+        ScreenshotsPanel.IsVisible = step == WizardStep.Screenshots;
         GatewayPanel.IsVisible = step == WizardStep.Gateway;
         DonePanel.IsVisible = step == WizardStep.Done;
+
+        // Leaving the Screenshots step ends any take-a-screenshot watch.
+        if (step != WizardStep.Screenshots)
+            CancelScreenshotWatch();
 
         RefreshDots();
 
@@ -163,6 +177,15 @@ public partial class FirstRunWizardDialog : Window
                 ConfigureStepSkip();
                 if (!_agentScanRan)
                     _ = ScanAgentsAsync();
+                break;
+
+            case WizardStep.Screenshots:
+                PrimaryButton.Content = "Use this folder";
+                PrimaryButton.IsVisible = true;
+                PrimaryButton.IsEnabled = _shotsSelectedPath is not null;
+                ConfigureStepSkip();
+                if (!_shotsDetectRan)
+                    _ = DetectScreenshotsForWizardAsync();
                 break;
 
             case WizardStep.Gateway:
@@ -202,6 +225,11 @@ public partial class FirstRunWizardDialog : Window
             {
                 case WizardStep.Agents:
                     await AcceptAgentsAsync();
+                    Advance();
+                    break;
+
+                case WizardStep.Screenshots:
+                    await SaveScreenshotsFolderAsync();
                     Advance();
                     break;
 
@@ -570,6 +598,158 @@ public partial class FirstRunWizardDialog : Window
         Advance();
     }
 
+    // ---- Screenshots step --------------------------------------------------------------------------
+
+    /// <summary>
+    /// Detect where this machine's screenshots land (Windows known folder / OneDrive / Pictures on
+    /// Windows 10 and 11; the screencapture setting or Desktop on macOS) and present the best
+    /// answer with its provenance and image count as proof.
+    /// </summary>
+    private async Task DetectScreenshotsForWizardAsync()
+    {
+        FileLog.Write("[FirstRunWizardDialog] DetectScreenshotsForWizardAsync");
+        _shotsDetectRan = true;
+        try
+        {
+            var best = await Task.Run(() => ScreenshotLocator.DetectCandidates().FirstOrDefault());
+            if (best is not null)
+            {
+                var count = await Task.Run(() => ScreenshotLocator.CountImages(best.Path));
+                SetScreenshotsFolder(best.Path, best.Provenance, count);
+            }
+            else
+            {
+                ShotsPathText.Text = "No screenshots folder found";
+                ShotsProvenanceText.Text =
+                    "We could not detect where your screenshots go. Browse to the folder, or take a screenshot and we'll find where it lands.";
+                if (_model.Current == WizardStep.Screenshots)
+                    PrimaryButton.IsEnabled = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] DetectScreenshotsForWizardAsync FAILED: {ex.Message}");
+            ShotsPathText.Text = "No screenshots folder found";
+            ShotsProvenanceText.Text = $"Detection failed: {ex.Message}";
+        }
+    }
+
+    /// <summary>Adopt a folder as the screenshots choice and render its provenance + proof line.</summary>
+    private void SetScreenshotsFolder(string path, string provenance, int imageCount)
+    {
+        _shotsSelectedPath = path;
+        ShotsPathText.Text = path;
+        var proof = imageCount switch
+        {
+            0 => "no images in it yet",
+            1 => "1 image in it",
+            _ => $"{imageCount} images in it",
+        };
+        ShotsProvenanceText.Text = $"{provenance} - {proof}.";
+        if (_model.Current == WizardStep.Screenshots)
+            PrimaryButton.IsEnabled = true;
+    }
+
+    private async void BtnBrowseScreenshots_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnBrowseScreenshots_Click");
+        try
+        {
+            var result = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            {
+                Title = "Select your screenshots folder",
+                AllowMultiple = false,
+            });
+            if (result.Count > 0)
+            {
+                CancelScreenshotWatch();
+                var path = result[0].Path.LocalPath;
+                var count = await Task.Run(() => ScreenshotLocator.CountImages(path));
+                SetScreenshotsFolder(path, "Chosen by you", count);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnBrowseScreenshots_Click FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The certainty trick: watch every plausible screenshot location, ask the user to press their
+    /// normal shortcut, and adopt whichever folder the new image lands in. Works the same on
+    /// Windows 10, Windows 11, and macOS because it observes the OS instead of guessing.
+    /// </summary>
+    private async void BtnWatchScreenshot_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnWatchScreenshot_Click");
+        try
+        {
+            ShotsWatchIdle.IsVisible = false;
+            ShotsWatchActive.IsVisible = true;
+            ShotsWatchText.Text = OperatingSystem.IsMacOS()
+                ? "Press Shift+Cmd+3 (or your usual screenshot shortcut) now - we are watching for the new file..."
+                : "Press Win+PrtScn (or your usual screenshot shortcut) now - we are watching for the new file...";
+
+            _shotsWatchCts?.Cancel();
+            _shotsWatchCts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+            var roots = await Task.Run(() => ScreenshotCaptureWatcher.WatchRoots());
+            if (roots.Count == 0)
+            {
+                ShotsWatchText.Text = "No folders to watch on this machine - browse to the folder instead.";
+                return;
+            }
+
+            var landed = await new ScreenshotCaptureWatcher().WaitForNewScreenshotAsync(roots, _shotsWatchCts.Token);
+            if (landed is not null)
+            {
+                var count = await Task.Run(() => ScreenshotLocator.CountImages(landed));
+                SetScreenshotsFolder(landed, "Detected from the screenshot you just took", count);
+            }
+            CancelScreenshotWatch();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnWatchScreenshot_Click FAILED: {ex.Message}");
+            CancelScreenshotWatch();
+        }
+    }
+
+    private void BtnCancelWatchScreenshot_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnCancelWatchScreenshot_Click");
+        CancelScreenshotWatch();
+    }
+
+    /// <summary>End any live watch and restore the idle affordance.</summary>
+    private void CancelScreenshotWatch()
+    {
+        _shotsWatchCts?.Cancel();
+        _shotsWatchCts = null;
+        if (ShotsWatchActive.IsVisible)
+        {
+            ShotsWatchActive.IsVisible = false;
+            ShotsWatchIdle.IsVisible = true;
+        }
+    }
+
+    /// <summary>Persist the confirmed folder as the screenshots source (same key Settings writes).</summary>
+    private async Task SaveScreenshotsFolderAsync()
+    {
+        if (_shotsSelectedPath is null)
+        {
+            FileLog.Write("[FirstRunWizardDialog] SaveScreenshotsFolderAsync: nothing selected");
+            return;
+        }
+
+        var path = _shotsSelectedPath;
+        FileLog.Write($"[FirstRunWizardDialog] SaveScreenshotsFolderAsync: {path}");
+        await Task.Run(() => CcDirectorConfigService.MergePatch(new JsonObject
+        {
+            ["screenshots"] = new JsonObject { ["source_directory"] = path },
+        }));
+    }
+
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
 
     /// <summary>Paint the three choice cards and the primary CTA from the current selection.</summary>
@@ -754,6 +934,13 @@ public partial class FirstRunWizardDialog : Window
                     : "Add one from Settings > Agents",
                 done: false));
 
+        // Screenshots row.
+        if (_shotsSelectedPath is not null)
+            DoneReceiptPanel.Children.Add(ReceiptRow("Screenshots folder set", _shotsSelectedPath, done: true));
+        else
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                "Screenshots folder", "Set it any time in Settings to drag screenshots straight to agents", done: false));
+
         // Gateway row.
         var gatewayUrl = GatewayConfig.Load().Url;
         if (!string.IsNullOrWhiteSpace(gatewayUrl))
@@ -835,6 +1022,7 @@ public partial class FirstRunWizardDialog : Window
     {
         _hostedEnrollCts?.Cancel();
         _claudeInstallCts?.Cancel();
+        _shotsWatchCts?.Cancel();
         if (!_marked)
         {
             FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (window closed without finishing)");

--- a/src/CcDirector.Core.Tests/ScreenshotLocatorTests.cs
+++ b/src/CcDirector.Core.Tests/ScreenshotLocatorTests.cs
@@ -53,4 +53,71 @@ public class ScreenshotLocatorTests
 
         Assert.Null(ex);
     }
+
+    [Fact]
+    public void DetectCandidates_ReturnsOnlyExistingFolders_WithProvenance_NoDuplicates()
+    {
+        var candidates = ScreenshotLocator.DetectCandidates();
+
+        foreach (var c in candidates)
+        {
+            Assert.True(Directory.Exists(c.Path), $"candidate does not exist: {c.Path}");
+            Assert.False(string.IsNullOrWhiteSpace(c.Provenance));
+        }
+
+        var distinct = candidates.Select(c => c.Path.ToLowerInvariant()).Distinct().Count();
+        Assert.Equal(candidates.Count, distinct);
+    }
+
+    [Fact]
+    public void Detect_AgreesWithTheFirstCandidate()
+    {
+        // Detect() is the Settings-page entry point; it must be the wizard's best candidate, not a
+        // separately-derived answer that could drift.
+        var candidates = ScreenshotLocator.DetectCandidates();
+        Assert.Equal(candidates.FirstOrDefault()?.Path, ScreenshotLocator.Detect());
+    }
+
+    [Theory]
+    [InlineData("shot.png", true)]
+    [InlineData("shot.PNG", true)]
+    [InlineData("photo.jpg", true)]
+    [InlineData("photo.jpeg", true)]
+    [InlineData("anim.gif", true)]
+    [InlineData("old.bmp", true)]
+    [InlineData("modern.webp", true)]
+    [InlineData("clip.mp4", false)]
+    [InlineData("notes.txt", false)]
+    [InlineData("noext", false)]
+    public void IsImageFile_ClassifiesByExtension(string name, bool expected)
+    {
+        Assert.Equal(expected, ScreenshotLocator.IsImageFile(name));
+    }
+
+    [Fact]
+    public void CountImages_CountsOnlyImageFiles_TopLevel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "shots-count-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "a.png"), "x");
+            File.WriteAllText(Path.Combine(dir, "b.jpg"), "x");
+            File.WriteAllText(Path.Combine(dir, "c.txt"), "x");
+            Directory.CreateDirectory(Path.Combine(dir, "nested"));
+            File.WriteAllText(Path.Combine(dir, "nested", "d.png"), "x");
+
+            Assert.Equal(2, ScreenshotLocator.CountImages(dir));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CountImages_MissingFolder_ReturnsZero_NeverThrows()
+    {
+        Assert.Equal(0, ScreenshotLocator.CountImages(Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N"))));
+    }
 }

--- a/src/CcDirector.Core.Tests/Storage/ScreenshotCaptureWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ScreenshotCaptureWatcherTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for <see cref="ScreenshotCaptureWatcher"/> against real temporary directories - the
+/// watcher's whole job is observing the filesystem, so a seam would test nothing.
+/// </summary>
+public sealed class ScreenshotCaptureWatcherTests : IDisposable
+{
+    private readonly string _root;
+
+    public ScreenshotCaptureWatcherTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "shots-watch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task NewImageInWatchedRoot_ReturnsItsDirectory()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var watcher = new ScreenshotCaptureWatcher();
+
+        var wait = watcher.WaitForNewScreenshotAsync(new[] { _root }, cts.Token);
+        await Task.Delay(200); // let the watcher arm before the file appears
+        await File.WriteAllTextAsync(Path.Combine(_root, "capture.png"), "x");
+
+        var result = await wait;
+        Assert.Equal(Path.GetFullPath(_root), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public async Task NewImageInSubdirectory_ReturnsTheSubdirectory()
+    {
+        // A OneDrive-redirected Screenshots folder lives UNDER the watched Pictures root - the
+        // watcher must report the folder the file actually landed in, not the watch root.
+        var sub = Path.Combine(_root, "Screenshots");
+        Directory.CreateDirectory(sub);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var watcher = new ScreenshotCaptureWatcher();
+
+        var wait = watcher.WaitForNewScreenshotAsync(new[] { _root }, cts.Token);
+        await Task.Delay(200);
+        await File.WriteAllTextAsync(Path.Combine(sub, "capture.png"), "x");
+
+        var result = await wait;
+        Assert.Equal(Path.GetFullPath(sub), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public async Task NonImageFile_IsIgnored_UntilAnImageArrives()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var watcher = new ScreenshotCaptureWatcher();
+
+        var wait = watcher.WaitForNewScreenshotAsync(new[] { _root }, cts.Token);
+        await Task.Delay(200);
+        await File.WriteAllTextAsync(Path.Combine(_root, "notes.txt"), "x");
+        await Task.Delay(200);
+        Assert.False(wait.IsCompleted, "a text file must not complete the screenshot wait");
+
+        await File.WriteAllTextAsync(Path.Combine(_root, "real.png"), "x");
+        var result = await wait;
+        Assert.Equal(Path.GetFullPath(_root), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public async Task Cancellation_ReturnsNull()
+    {
+        using var cts = new CancellationTokenSource();
+        var watcher = new ScreenshotCaptureWatcher();
+
+        var wait = watcher.WaitForNewScreenshotAsync(new[] { _root }, cts.Token);
+        cts.Cancel();
+
+        Assert.Null(await wait);
+    }
+
+    [Fact]
+    public async Task NoWatchableRoots_ReturnsNull()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var watcher = new ScreenshotCaptureWatcher();
+
+        var missing = Path.Combine(Path.GetTempPath(), "gone-" + Guid.NewGuid().ToString("N"));
+        Assert.Null(await watcher.WaitForNewScreenshotAsync(new[] { missing }, cts.Token));
+    }
+
+    [Fact]
+    public void WatchRoots_OnThisPlatform_ExistAndAreNotNested()
+    {
+        var roots = ScreenshotCaptureWatcher.WatchRoots();
+
+        foreach (var root in roots)
+            Assert.True(Directory.Exists(root), $"watch root does not exist: {root}");
+
+        // No root may be inside another - the parent's recursive watch already covers it, and
+        // double-watching doubles the event storm.
+        for (var i = 0; i < roots.Count; i++)
+            for (var j = 0; j < roots.Count; j++)
+            {
+                if (i == j) continue;
+                Assert.False(
+                    roots[i].StartsWith(roots[j].TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase),
+                    $"nested watch roots: {roots[i]} inside {roots[j]}");
+            }
+    }
+}

--- a/src/CcDirector.Core/Storage/ScreenshotCaptureWatcher.cs
+++ b/src/CcDirector.Core/Storage/ScreenshotCaptureWatcher.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Storage;
+
+/// <summary>
+/// The "take a screenshot and we'll find it" detection: watch every folder the OS could plausibly
+/// drop a screenshot into, and when a new image file appears anywhere in them, report the folder it
+/// landed in. This works identically on Windows 10, Windows 11, and macOS because it observes what
+/// the OS actually DOES instead of guessing from settings - the user presses their normal
+/// screenshot shortcut and the landing folder is the proof.
+///
+/// Watches subdirectories too (a OneDrive-redirected Screenshots folder lives under the watched
+/// Pictures root), and listens for both Created and Renamed events (macOS writes a temporary
+/// .screencapture file first and renames it to the final .png).
+/// </summary>
+public sealed class ScreenshotCaptureWatcher
+{
+    /// <summary>
+    /// The platform's plausible screenshot roots that exist right now: every detection candidate
+    /// plus the broad OS locations (Pictures, Desktop, OneDrive Pictures) so a capture is caught
+    /// even when the exact target was not predictable. Deduplicated; nested roots are removed
+    /// (watching the parent recursively already covers them).
+    /// </summary>
+    public static IReadOnlyList<string> WatchRoots()
+    {
+        var roots = new List<string>();
+
+        foreach (var candidate in ScreenshotLocator.DetectCandidates())
+            roots.Add(candidate.Path);
+
+        void AddIfExists(string? dir)
+        {
+            if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+                roots.Add(Path.GetFullPath(dir));
+        }
+
+        AddIfExists(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures));
+        AddIfExists(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory));
+        foreach (var oneDrive in new[] { Environment.GetEnvironmentVariable("OneDrive"), Environment.GetEnvironmentVariable("OneDriveConsumer"), Environment.GetEnvironmentVariable("OneDriveCommercial") })
+        {
+            if (!string.IsNullOrWhiteSpace(oneDrive))
+                AddIfExists(Path.Combine(oneDrive, "Pictures"));
+        }
+
+        var comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var distinct = roots.Distinct(comparer).ToList();
+
+        // Drop any root nested inside another - the recursive watch on the parent covers it.
+        var result = distinct
+            .Where(dir => !distinct.Any(other =>
+                !comparer.Equals(other, dir)
+                && dir.StartsWith(other.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)))
+            .ToList();
+
+        FileLog.Write($"[ScreenshotCaptureWatcher] WatchRoots -> {result.Count} root(s)");
+        return result;
+    }
+
+    /// <summary>
+    /// Wait until a new image file appears under any of <paramref name="roots"/> and return the
+    /// directory it landed in, or null when cancelled. The caller owns the timeout via the token.
+    /// </summary>
+    public async Task<string?> WaitForNewScreenshotAsync(IReadOnlyList<string> roots, CancellationToken ct)
+    {
+        FileLog.Write($"[ScreenshotCaptureWatcher] WaitForNewScreenshotAsync: watching {roots.Count} root(s)");
+        var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var watchers = new List<FileSystemWatcher>();
+
+        void OnHit(string fullPath)
+        {
+            if (!ScreenshotLocator.IsImageFile(fullPath)) return;
+            var dir = Path.GetDirectoryName(fullPath);
+            if (string.IsNullOrEmpty(dir)) return;
+            FileLog.Write($"[ScreenshotCaptureWatcher] new image: {fullPath}");
+            tcs.TrySetResult(dir);
+        }
+
+        try
+        {
+            foreach (var root in roots)
+            {
+                try
+                {
+                    var watcher = new FileSystemWatcher(root)
+                    {
+                        IncludeSubdirectories = true,
+                        NotifyFilter = NotifyFilters.FileName,
+                    };
+                    watcher.Created += (_, e) => OnHit(e.FullPath);
+                    watcher.Renamed += (_, e) => OnHit(e.FullPath);
+                    watcher.EnableRaisingEvents = true;
+                    watchers.Add(watcher);
+                }
+                catch (Exception ex)
+                {
+                    // One unwatchable root (permissions, a vanished folder) must not kill the probe.
+                    FileLog.Write($"[ScreenshotCaptureWatcher] cannot watch {root}: {ex.Message}");
+                }
+            }
+
+            if (watchers.Count == 0)
+            {
+                FileLog.Write("[ScreenshotCaptureWatcher] no watchable roots");
+                return null;
+            }
+
+            using var registration = ct.Register(() => tcs.TrySetResult(null));
+            return await tcs.Task;
+        }
+        finally
+        {
+            foreach (var watcher in watchers)
+            {
+                try { watcher.Dispose(); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/ScreenshotLocator.cs
+++ b/src/CcDirector.Core/Storage/ScreenshotLocator.cs
@@ -1,7 +1,11 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Storage;
+
+/// <summary>One place the OS might be saving screenshots: the folder plus a plain-English reason.</summary>
+public sealed record ScreenshotFolderCandidate(string Path, string Provenance);
 
 /// <summary>
 /// Detects where the operating system saves screenshots, cross-platform, so the Settings page
@@ -24,41 +28,142 @@ public static class ScreenshotLocator
     /// <summary>Detect the OS screenshots folder for the current platform, or null if none found.</summary>
     public static string? Detect()
     {
-        var result = OperatingSystem.IsWindows() ? DetectWindows()
-                   : OperatingSystem.IsMacOS() ? DetectMac()
-                   : DetectUnix();
+        var result = DetectCandidates().FirstOrDefault()?.Path;
         FileLog.Write($"[ScreenshotLocator] Detect -> {result ?? "(none)"}");
         return result;
     }
 
-    private static string? DetectWindows()
+    /// <summary>
+    /// Every folder the OS might be saving screenshots to, best-first, each with a plain-English
+    /// provenance the wizard can show. Only folders that actually exist are returned, deduplicated.
+    ///
+    ///   - Windows 10/11: the Screenshots KNOWN FOLDER first (via SHGetKnownFolderPath) - it is its
+    ///     own known folder, movable independently of Pictures, and it is where Win+PrtScn and the
+    ///     Windows 11 Snipping Tool auto-save land, including when OneDrive has redirected it. Then
+    ///     the OneDrive Pictures\Screenshots copy (OneDrive's "save screenshots" setting writes there
+    ///     even without a folder redirect), then the classic Pictures\Screenshots.
+    ///   - macOS: the user's screencapture location setting, else the Desktop (the macOS default).
+    ///   - Linux: Pictures/Screenshots.
+    /// </summary>
+    public static IReadOnlyList<ScreenshotFolderCandidate> DetectCandidates()
     {
-        var pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
-        if (string.IsNullOrEmpty(pictures)) return null;
-        var dir = Path.Combine(pictures, "Screenshots");
-        return Directory.Exists(dir) ? dir : null;
+        var raw = OperatingSystem.IsWindows() ? WindowsCandidates()
+                : OperatingSystem.IsMacOS() ? MacCandidates()
+                : UnixCandidates();
+
+        var result = new List<ScreenshotFolderCandidate>();
+        var seen = new HashSet<string>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        foreach (var c in raw)
+        {
+            if (string.IsNullOrWhiteSpace(c.Path) || !Directory.Exists(c.Path)) continue;
+            var full = Path.GetFullPath(c.Path);
+            if (seen.Add(full))
+                result.Add(c with { Path = full });
+        }
+        FileLog.Write($"[ScreenshotLocator] DetectCandidates -> {result.Count} folder(s)");
+        return result;
     }
 
-    private static string? DetectMac()
+    /// <summary>Count the images directly in a folder - the proof line ("312 images"). Never throws.</summary>
+    public static int CountImages(string directory)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(directory)
+                .Count(f => IsImageFile(f));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ScreenshotLocator] CountImages failed for {directory}: {ex.Message}");
+            return 0;
+        }
+    }
+
+    /// <summary>Whether the file name looks like a screenshot image. Pure - unit-tested.</summary>
+    public static bool IsImageFile(string path)
+    {
+        var ext = Path.GetExtension(path);
+        return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".gif", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".webp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<ScreenshotFolderCandidate> WindowsCandidates()
+    {
+        // The authoritative answer on Windows 10 AND 11: the Screenshots known folder itself.
+        // Covers a user-moved folder and OneDrive's known-folder redirect.
+        var known = TryGetWindowsScreenshotsKnownFolder();
+        if (known is not null)
+            yield return new ScreenshotFolderCandidate(known, "Where Windows saves Win+PrtScn and Snipping Tool captures");
+
+        // OneDrive's "save screenshots to OneDrive" writes here even when the known folder was
+        // never redirected. Both consumer and business env variables are probed.
+        foreach (var oneDrive in new[] { Environment.GetEnvironmentVariable("OneDrive"), Environment.GetEnvironmentVariable("OneDriveConsumer"), Environment.GetEnvironmentVariable("OneDriveCommercial") })
+        {
+            if (!string.IsNullOrWhiteSpace(oneDrive))
+                yield return new ScreenshotFolderCandidate(Path.Combine(oneDrive, "Pictures", "Screenshots"), "Your OneDrive screenshot backup");
+        }
+
+        var pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+        if (!string.IsNullOrEmpty(pictures))
+            yield return new ScreenshotFolderCandidate(Path.Combine(pictures, "Screenshots"), "The default Windows screenshots folder");
+    }
+
+    private static IEnumerable<ScreenshotFolderCandidate> MacCandidates()
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-        // macOS lets the user move the screenshot location; read it from the defaults system.
         var configured = ParseMacScreencaptureLocation(RunDefaultsScreencaptureLocation(), home);
-        if (configured is not null && Directory.Exists(configured))
-            return configured;
+        if (configured is not null)
+            yield return new ScreenshotFolderCandidate(configured, "Your macOS screenshot location setting");
 
-        // Default location is the Desktop.
         var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-        return Directory.Exists(desktop) ? desktop : null;
+        if (!string.IsNullOrEmpty(desktop))
+            yield return new ScreenshotFolderCandidate(desktop, "The macOS default - screenshots land on the Desktop");
     }
 
-    private static string? DetectUnix()
+    private static IEnumerable<ScreenshotFolderCandidate> UnixCandidates()
     {
         var pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
-        if (string.IsNullOrEmpty(pictures)) return null;
-        var dir = Path.Combine(pictures, "Screenshots");
-        return Directory.Exists(dir) ? dir : null;
+        if (!string.IsNullOrEmpty(pictures))
+            yield return new ScreenshotFolderCandidate(Path.Combine(pictures, "Screenshots"), "The Pictures/Screenshots folder");
+    }
+
+    // ---- Windows Screenshots known folder (FOLDERID_Screenshots) -----------------------------------
+
+    private static readonly Guid FolderIdScreenshots = new("b7bede81-df94-4682-a7d8-57a52620b86f");
+
+    [DllImport("shell32.dll")]
+    private static extern int SHGetKnownFolderPath(
+        [MarshalAs(UnmanagedType.LPStruct)] Guid rfid, uint dwFlags, IntPtr hToken, out IntPtr ppszPath);
+
+    /// <summary>
+    /// Resolve the Screenshots known folder via the shell - the same answer Explorer gives. Returns
+    /// null when the folder is not registered (it is created lazily on first Win+PrtScn) or on any
+    /// error; callers fall through to the conventional locations.
+    /// </summary>
+    private static string? TryGetWindowsScreenshotsKnownFolder()
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+        var ptr = IntPtr.Zero;
+        try
+        {
+            // KF_FLAG_DONT_VERIFY (0x4000): return the configured path even if the shell has not
+            // touched it lately; existence is checked by the caller like every other candidate.
+            var hr = SHGetKnownFolderPath(FolderIdScreenshots, 0x4000, IntPtr.Zero, out ptr);
+            return hr == 0 ? Marshal.PtrToStringUni(ptr) : null;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ScreenshotLocator] SHGetKnownFolderPath failed: {ex.Message}");
+            return null;
+        }
+        finally
+        {
+            if (ptr != IntPtr.Zero) Marshal.FreeCoTaskMem(ptr);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Part of the first-run setup wizard epic thefrederiksen/devthrottle_internal#926. Third increment: the Screenshots step, between Agents and Gateway (five dots now).

## What changed

- **The why leads:** the screen opens with the point - drag a screenshot straight onto an agent to show it exactly what you mean; DevThrottle watches one folder for new screenshots.
- **Platform-honest detection:**
  - Windows 10/11: the Screenshots KNOWN FOLDER first (SHGetKnownFolderPath) - its own known folder, movable independently of Pictures, where Win+PrtScn and the Windows 11 Snipping Tool save, including under OneDrive redirection. Then OneDrive's Pictures\Screenshots copy, then the classic Pictures\Screenshots.
  - macOS: the screencapture location setting, else the Desktop.
  - Every answer shows plain-English provenance plus the folder's image count as proof.
- **The certainty trick:** "Not sure? Take a screenshot and we'll find it" watches every plausible root (recursive, Created + Renamed - macOS renames a temp file into place) while the user presses their normal shortcut; whichever folder the image lands in is adopted. Works identically on Windows 10, Windows 11, and macOS because it observes what the OS does instead of guessing.
- Browse as manual fallback; step skippable; persists to the same screenshots.source_directory key Settings writes; Done receipt gains a Screenshots row.
- Settings' Detect button improves for free: ScreenshotLocator.Detect() is now known-folder-aware.

## Proof

- 59 related Core tests pass, including 15 new ones: candidate detection, image classification/counting, and real filesystem watcher tests (subfolder landing, non-image ignored, cancellation, no-watchable-roots).
- Verified in a running build on a fresh profile: detection shows the real folder with provenance and count; the take-a-screenshot watch adopts the landing folder.