### PR TITLE
feat(mobile): the Assistant on the phone - fleet chat + voice, not tied to a session

### DIFF
--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -32,6 +32,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/new" onClick={close}>
               New session
             </Link>
+            <Link className="drawer-item" to="/assistant" onClick={close}>
+              Assistant
+            </Link>
             <Link className="drawer-item" to="/car" onClick={close}>
               Car Mode
             </Link>

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -8,6 +8,7 @@ import { Chat } from "./pages/Chat";
 import { FileView } from "./pages/FileView";
 import { VoiceMode } from "./pages/VoiceMode";
 import { CarMode } from "./pages/CarMode";
+import { Assistant } from "./pages/Assistant";
 import { EndWordTest } from "./pages/EndWordTest";
 import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
@@ -145,6 +146,10 @@ const router = createBrowserRouter(
             // Car Mode (Car Mode mission): its own chrome-less, full-screen route, NOT nested in any
             // tabbed session view. Hands-free voice control of the whole fleet with a screen wake-lock.
             { path: "/car", element: <CarMode /> },
+            // The Assistant (fleet assistant build): fleet-level chat + voice, not tied to any
+            // session - the phone view of the same client-core turn machine the cockpit mounts.
+            // Distinct from Car Mode: button turns (tap to talk), no auto turn taking, hands-on.
+            { path: "/assistant", element: <Assistant /> },
             // Car Mode End Word Test (harness for the spoken end-of-turn phrase): set a configurable
             // phrase and test detecting it live. Standalone for now; folds into the Cockpit Car Mode
             // settings tab once the approach is proven.

--- a/apps/mobile/src/pages/Assistant.tsx
+++ b/apps/mobile/src/pages/Assistant.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useLayoutEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Link } from "react-router-dom";
+import { useAssistant, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+
+// The Assistant on the phone (fleet assistant build): the SAME fleet-level chat + voice screen the
+// cockpit has, as a thin phone view over the shared client-core turn machine (useAssistant). Not tied
+// to any session; every answer comes from the Gateway brain's tool calls at POST /assistant/turn.
+//
+// Distinct from Car Mode on purpose: Car Mode is hands-free driving (auto turn taking, end phrases,
+// wake lock, full-screen chrome-less). The Assistant is hands-ON: a BUTTON is the turn - tap to talk,
+// tap again to send - and chat mode types. No silence detection, no end phrase, ever.
+//
+// The screen is pinned to the ACTUALLY-VISIBLE viewport via --app-vh (the app-wide fit, published by
+// useVisibleViewportHeight in main.tsx), so the composer and the talk button are always on-screen -
+// the law every mobile session screen follows.
+
+const PHASE_LINE: Record<AssistantPhase, string> = {
+  idle: "",
+  listening: "Listening... tap again when you are done.",
+  transcribing: "Transcribing...",
+  thinking: "Checking the fleet...",
+  speaking: "Reading the answer aloud...",
+};
+
+function MicGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+      strokeLinejoin="round" aria-hidden="true" focusable="false">
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <path d="M12 19v3" />
+    </svg>
+  );
+}
+
+export function Assistant() {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const assistant = useAssistant(audioRef);
+  const { entries, phase, mode, setMode, busy, confirmOffered } = assistant;
+
+  const [draft, setDraft] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const atBottomRef = useRef(true);
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [entries, phase]);
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  const send = useCallback(() => {
+    if (draft.trim().length === 0) return;
+    assistant.sendText(draft);
+    setDraft("");
+  }, [assistant, draft]);
+
+  const onComposerKeyDown = useCallback((e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }, [send]);
+
+  const toggleTalk = useCallback(() => {
+    if (phase === "listening") assistant.endTalk();
+    else assistant.startTalk();
+  }, [assistant, phase]);
+
+  return (
+    <div className="assistant-screen">
+      <div className="assistant-bar">
+        <Link className="back-link" to="/">Back</Link>
+        <h1>Assistant</h1>
+        <div className="assistant-bar-spacer" />
+        <div className="assistant-mode" role="tablist" aria-label="Assistant mode">
+          <button type="button" role="tab" aria-selected={mode === "chat"}
+            className={mode === "chat" ? "assistant-mode-btn active" : "assistant-mode-btn"}
+            onClick={() => setMode("chat")}>Chat</button>
+          <button type="button" role="tab" aria-selected={mode === "voice"}
+            className={mode === "voice" ? "assistant-mode-btn active" : "assistant-mode-btn"}
+            onClick={() => setMode("voice")}>Voice</button>
+        </div>
+      </div>
+
+      <div className="assistant-stage">
+        {entries.length === 0 ? (
+          <div className="assistant-empty">
+            <p>Ask anything about your fleet - no session needed:</p>
+            <ul>
+              <li>"How many sessions do I have open?"</li>
+              <li>"Which have been open too long?"</li>
+              <li>"How are we doing on credits?"</li>
+              <li>"Which machines are online?"</li>
+            </ul>
+            <p>It can also message, snooze, start, or close sessions - closing always asks first.</p>
+          </div>
+        ) : (
+          <div className="assistant-scroll" ref={scrollRef} onScroll={onScroll}>
+            {entries.map((entry, i) => (
+              entry.role === "user" ? (
+                <div className="assistant-user" key={i}>{entry.text}</div>
+              ) : entry.role === "error" ? (
+                <div className="assistant-error" role="alert" key={i}>{entry.text}</div>
+              ) : (
+                <div className="assistant-turn" key={i}>
+                  {(entry.actions ?? []).map((action, j) => (
+                    <div className="assistant-action" key={j}>
+                      <span className="assistant-dot" aria-hidden="true" />
+                      <span>{action.summary}</span>
+                    </div>
+                  ))}
+                  <div className="assistant-reply">{entry.text}</div>
+                </div>
+              )
+            ))}
+            {phase !== "idle" && <div className="assistant-phase">{PHASE_LINE[phase]}</div>}
+          </div>
+        )}
+      </div>
+
+      {confirmOffered && (
+        <div className="assistant-confirm">
+          <button type="button" className="assistant-confirm-yes" onClick={() => assistant.sendText("confirm")}>
+            Yes, do it
+          </button>
+          <button type="button" className="assistant-confirm-no" onClick={() => assistant.sendText("cancel")}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {mode === "chat" ? (
+        <div className="assistant-composer">
+          <textarea
+            className="assistant-input"
+            placeholder="Ask about your fleet..."
+            rows={1}
+            value={draft}
+            disabled={busy}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onComposerKeyDown}
+          />
+          <button
+            type="button"
+            className={phase === "listening" ? "assistant-round listening" : "assistant-round"}
+            title={phase === "listening" ? "Tap to send what you said" : "Tap to talk"}
+            disabled={busy && phase !== "listening"}
+            onClick={toggleTalk}
+          >
+            <MicGlyph />
+          </button>
+          <button type="button" className="assistant-round send" title="Send"
+            disabled={busy || draft.trim().length === 0} onClick={send}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+              strokeLinejoin="round" aria-hidden="true" focusable="false">
+              <path d="M22 2L11 13" />
+              <path d="M22 2l-7 20-4-9-9-4 20-7z" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <div className="assistant-talkdock">
+          {phase === "speaking" && (
+            <button type="button" className="assistant-stopread" onClick={assistant.stopSpeaking}>
+              Stop reading
+            </button>
+          )}
+          <button
+            type="button"
+            className={phase === "listening" ? "assistant-talkbtn listening" : "assistant-talkbtn"}
+            disabled={busy && phase !== "listening"}
+            onClick={toggleTalk}
+          >
+            <MicGlyph />
+          </button>
+          <div className="assistant-talkhint">
+            {phase === "listening"
+              ? "Tap again when you are done."
+              : "Tap to talk - tap again when done. Replies are read aloud."}
+          </div>
+        </div>
+      )}
+
+      <audio ref={audioRef} className="assistant-audio" />
+    </div>
+  );
+}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -4063,3 +4063,303 @@ a.banner-btn {
   margin: 4px 2px 0;
   text-align: center;
 }
+
+/* ============================================================================================
+   The Assistant screen (fleet assistant build): fleet-level chat + voice, not tied to a session.
+   Pinned to the ACTUALLY-VISIBLE viewport via --app-vh (the app-wide fit) so the composer and the
+   talk button are always on-screen. Same tokens as everything else; no new colors.
+   ============================================================================================ */
+
+.assistant-screen {
+  display: flex;
+  flex-direction: column;
+  height: var(--app-vh, 100dvh);
+  max-height: var(--app-vh, 100dvh);
+  overflow: hidden;
+  padding: 0 12px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.assistant-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.assistant-bar h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.assistant-bar-spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.assistant-mode {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.assistant-mode-btn {
+  border: none;
+  background: var(--surface);
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.assistant-mode-btn.active {
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.assistant-stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.assistant-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 2px 12px 0;
+}
+
+.assistant-empty {
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1.6;
+  padding: 20px 4px;
+}
+
+.assistant-empty ul {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+.assistant-user {
+  align-self: flex-end;
+  max-width: 82%;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px 14px 4px 14px;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.assistant-turn {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.assistant-action {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: Consolas, "Cascadia Mono", ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.assistant-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #22c55e;
+  flex: 0 0 auto;
+  position: relative;
+  top: -1px;
+}
+
+.assistant-reply {
+  font-size: 14px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.assistant-error {
+  align-self: stretch;
+  color: var(--attention);
+  border: 1px solid rgba(241, 76, 76, 0.4);
+  background: rgba(241, 76, 76, 0.08);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.assistant-phase {
+  color: var(--text-dim);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.assistant-confirm {
+  display: flex;
+  gap: 10px;
+  padding: 8px 0;
+  flex: 0 0 auto;
+}
+
+.assistant-confirm-yes,
+.assistant-confirm-no {
+  font: inherit;
+  font-size: 14px;
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.assistant-confirm-yes {
+  border: 1px solid rgba(241, 76, 76, 0.5);
+  background: rgba(241, 76, 76, 0.12);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.assistant-confirm-no {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.assistant-composer {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 0 12px;
+  border-top: 1px solid var(--border);
+}
+
+.assistant-input {
+  flex: 1 1 auto;
+  resize: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 11px 14px;
+  font: inherit;
+  font-size: 16px; /* 16px so iOS does not zoom the page on focus */
+  color: var(--text);
+  line-height: 1.4;
+  min-height: 44px;
+  max-height: 120px;
+}
+
+.assistant-round {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.assistant-round svg {
+  width: 19px;
+  height: 19px;
+}
+
+.assistant-round.send {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.assistant-round:disabled {
+  opacity: 0.5;
+}
+
+.assistant-round.listening {
+  background: var(--attention);
+  border-color: var(--attention);
+  color: #fff;
+}
+
+.assistant-talkdock {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0 18px;
+  border-top: 1px solid var(--border);
+}
+
+.assistant-talkbtn {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 0 0 10px rgba(59, 130, 246, 0.12), 0 0 0 22px rgba(59, 130, 246, 0.05);
+}
+
+.assistant-talkbtn svg {
+  width: 32px;
+  height: 32px;
+}
+
+.assistant-talkbtn.listening {
+  background: var(--attention);
+  box-shadow: 0 0 0 10px rgba(241, 76, 76, 0.14), 0 0 0 22px rgba(241, 76, 76, 0.06);
+}
+
+.assistant-talkbtn:disabled {
+  opacity: 0.5;
+}
+
+.assistant-talkhint {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.assistant-stopread {
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.assistant-audio {
+  display: none;
+}

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -29,6 +29,8 @@ const devProxy = proxyTarget
       "/vault": { target: proxyTarget, changeOrigin: true },
       "/push": { target: proxyTarget, changeOrigin: true },
       "/carmode": { target: proxyTarget, changeOrigin: true },
+      // The Assistant screen: its turn calls POST /assistant/turn (keep-warm reuses /carmode/warmup above).
+      "/assistant": { target: proxyTarget, changeOrigin: true },
       "/stats": { target: proxyTarget, changeOrigin: true },
       "/healthz": { target: proxyTarget, changeOrigin: true },
       "/diag": { target: proxyTarget, changeOrigin: true },


### PR DESCRIPTION
The phone view of the fleet Assistant (#2125, #2130): a thin page over the shared client-core turn machine, so both shells share one transcript model, one microphone lifecycle, and one turn contract. New /assistant route plus an Assistant entry in the navigation menu above Car Mode. Button turns only (tap to talk, tap again to send) - deliberately distinct from Car Mode's hands-free auto turn taking. Screen pinned to the visible viewport via --app-vh per the mobile screen law; 16px composer font so iOS does not zoom; 44px tap targets. Voice mode reads replies aloud with Stop reading; destructive holds get explicit confirm buttons. Verification: all three workspaces typecheck, the mobile app builds, client-core and cockpit suites pass.