### PR TITLE
fix(gateway): Assistant and Car Mode fleet tools run AS the calling device (#2129)

### DIFF
--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -155,7 +155,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             Speak("One session needs you: Local Files Manager, in the devthrottle repo."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how many need me over", CancellationToken.None);
 
@@ -176,7 +176,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "who needs me over", CancellationToken.None);
 
@@ -196,7 +196,7 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"I can run your fleet by voice.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what can you help me with over", CancellationToken.None);
 
@@ -216,7 +216,7 @@ public sealed class CarModeBrainTests
         // terminal (like speak_answer) and reads no fleet, so it is fast.
         var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
         var chat = new ScriptedChat(new CarModeAssistantTurn(null, new[] { Call("get_help") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what can you do over", CancellationToken.None);
 
@@ -242,7 +242,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"Car Mode Demo\",\"message\":\"delete session five\"}") }),
             Speak("Told the Car Mode Demo session to delete session five."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "tell the devthrottle session to delete session five over", CancellationToken.None);
 
@@ -269,7 +269,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_session_activity", "{\"session\":\"car mode\"}") }),
             Speak("Car Mode Manager, in the devthrottle repo, is building the fleet brain."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what is the car mode session doing", CancellationToken.None);
 
@@ -284,12 +284,12 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
         var chat1 = new ScriptedChat(Speak("Nothing needs you right now."));
-        var brain1 = new CarModeBrain(chat1, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain1 = new CarModeBrain(chat1, _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brain1.RunTurnAsync(TenantId.Local, "device-a", "who needs me", CancellationToken.None);
 
         // The next turn on the SAME device must carry the prior exchange into the model's messages.
         var chat2 = new ScriptedChat(Speak("Still nothing."));
-        var brain2 = new CarModeBrain(chat2, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain2 = new CarModeBrain(chat2, _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brain2.RunTurnAsync(TenantId.Local, "device-a", "and now", CancellationToken.None);
 
         Assert.Contains("who needs me", chat2.SeenMessages[0]);
@@ -301,11 +301,11 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
-        var brainA = new CarModeBrain(new ScriptedChat(Speak("A reply")), fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brainA = new CarModeBrain(new ScriptedChat(Speak("A reply")), _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brainA.RunTurnAsync(TenantId.Local, "device-a", "secret A question", CancellationToken.None);
 
         var chatB = new ScriptedChat(Speak("B reply"));
-        var brainB = new CarModeBrain(chatB, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brainB = new CarModeBrain(chatB, _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brainB.RunTurnAsync(TenantId.Local, "device-b", "question B", CancellationToken.None);
 
         Assert.DoesNotContain("secret A question", chatB.SeenMessages[0]);
@@ -314,7 +314,7 @@ public sealed class CarModeBrainTests
     [Fact]
     public async Task RunTurn_EmptyText_Throws()
     {
-        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(), _ => new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<ArgumentException>(() => brain.RunTurnAsync(TenantId.Local, "device-a", "   ", CancellationToken.None));
     }
 
@@ -324,7 +324,7 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
         // Every round asks for a tool and never answers - the loop must stop and speak a failure.
         var turns = Enumerable.Range(0, 10).Select(_ => new CarModeAssistantTurn(null, new[] { Call("list_sessions") })).ToArray();
-        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(turns), _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "who needs me", CancellationToken.None);
 
@@ -336,7 +336,7 @@ public sealed class CarModeBrainTests
     {
         var brain = new CarModeBrain(
             new ScriptedChat(Speak("   ")),
-            new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+            _ => new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.RunTurnAsync(TenantId.Local, "device-a", "hi", CancellationToken.None));
     }
 
@@ -361,7 +361,7 @@ public sealed class CarModeBrainTests
         // A pure conversational turn under tool_choice=required: the model calls only speak_answer.
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Nothing needs you right now.\"}") }));
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "anything for me", CancellationToken.None);
 
@@ -377,7 +377,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you: Local Files Manager.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "who needs me", CancellationToken.None);
 
@@ -393,7 +393,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Deleting Old Worker is permanent. Say confirm to proceed.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "delete old worker", CancellationToken.None);
 
@@ -411,7 +411,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"  \"}") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"All set.\"}") }));
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "hi", CancellationToken.None);
 
@@ -427,7 +427,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
             Speak("Started a session in the devthrottle repo."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "start a session in devthrottle", CancellationToken.None);
 
@@ -444,7 +444,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"car mode worker\",\"message\":\"run the tests\"}") }),
             Speak("Told Car Mode Worker to run the tests."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "message the worker", CancellationToken.None);
 
@@ -461,7 +461,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"ghost\",\"message\":\"hi\"}") }),
             Speak("I couldn't find a session called ghost."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "message ghost", CancellationToken.None);
 
@@ -478,7 +478,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
             Speak("Deleting Old Worker is permanent. Say confirm to proceed, or cancel."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "delete the old worker", CancellationToken.None);
 
@@ -500,13 +500,13 @@ public sealed class CarModeBrainTests
             new ScriptedChat(
                 new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
                 Speak("Say confirm to delete Old Worker.")),
-            fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
+            _ => fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
         await brain1.RunTurnAsync(TenantId.Local, "device-a", "delete old worker", CancellationToken.None);
         Assert.Empty(fleet.Deleted);
 
         // Turn 2: the owner confirms. The model is NOT consulted - the gate executes deterministically.
         var chat2 = new ScriptedChat(); // must not be called
-        var brain2 = new CarModeBrain(chat2, fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
+        var brain2 = new CarModeBrain(chat2, _ => fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
         var result = await brain2.RunTurnAsync(TenantId.Local, "device-a", "confirm", CancellationToken.None);
 
         Assert.Single(fleet.Deleted);
@@ -525,7 +525,7 @@ public sealed class CarModeBrainTests
         pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
 
         var chat = new ScriptedChat(); // must not be called
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => new FakeFleet(), new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "no cancel that", CancellationToken.None);
 
         Assert.Empty(fleet.Deleted);
@@ -540,7 +540,7 @@ public sealed class CarModeBrainTests
         pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
         var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
         var chat = new ScriptedChat(Speak("Nothing needs you."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "who needs me", CancellationToken.None);
 
@@ -574,7 +574,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("read_wingman", "{\"session\":\"car mode demo\"}") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Car Mode Demo needs you to pick option two.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what does the car mode demo need over", CancellationToken.None);
 
@@ -592,7 +592,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("switch_to_voice_mode", "{\"session\":\"car mode demo\"}") }),
             Speak("Switched Car Mode Demo to voice mode."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "put the car mode demo in voice mode over", CancellationToken.None);
 
@@ -608,7 +608,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{\"session\":\"car mode demo\"}") }),
             Speak("Snoozed Car Mode Demo."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "snooze the car mode demo over", CancellationToken.None);
 
@@ -628,7 +628,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("focus_next_needs_me") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Longest Waiting has been waiting forty minutes.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "who needs me next over", CancellationToken.None);
 
@@ -651,7 +651,7 @@ public sealed class CarModeBrainTests
             new ScriptedChat(
                 new CarModeAssistantTurn(null, new[] { Call("focus_next_needs_me") }),
                 Speak("Car Mode Demo has been waiting twelve minutes.")),
-            fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
+            _ => fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
         await brain1.RunTurnAsync(TenantId.Local, "device-a", "read me the next one over", CancellationToken.None);
 
         // Turn 2: "answer it and say yes" - message_session with NO session argument -> the current subject.
@@ -659,7 +659,7 @@ public sealed class CarModeBrainTests
             new ScriptedChat(
                 new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"message\":\"yes\"}") }),
                 Speak("Answered Car Mode Demo.")),
-            fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
+            _ => fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
         await brain2.RunTurnAsync(TenantId.Local, "device-a", "answer it and say yes over", CancellationToken.None);
 
         Assert.Single(fleet.Messaged);
@@ -676,7 +676,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{}") }),
             Speak("Which session should I snooze?"));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "snooze it over", CancellationToken.None);
 
@@ -697,7 +697,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("delete_session", "{}") }),
             Speak("Deleting Car Mode Demo in the devthrottle repo. Say confirm."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, subjects, _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), pending, subjects, _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "remove it over", CancellationToken.None);
 
@@ -722,7 +722,7 @@ public sealed class CarModeBrainTests
             new CarModeAssistantTurn("Okay, I've snoozed it for you.", Array.Empty<CarModeToolCall>()), // hallucinated claim, no tool
             new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{}") }),                      // re-prompted -> real call
             Speak("Snoozed the Car Mode Demo."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), subjects, _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), subjects, _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "snooze it", CancellationToken.None);
 
@@ -739,7 +739,7 @@ public sealed class CarModeBrainTests
         // never have its unbacked plain-text claim spoken as the answer.
         var turns = Enumerable.Range(0, 10)
             .Select(_ => new CarModeAssistantTurn("I did it.", Array.Empty<CarModeToolCall>())).ToArray();
-        var brain = new CarModeBrain(new ScriptedChat(turns), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(turns), _ => new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "snooze it", CancellationToken.None);
 
@@ -941,7 +941,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
             Speak("Started a session in the devthrottle repo."));
-        var brain = new CarModeBrain(chat, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         var cache = new CarModeTurnCache(_ => { });
 
         var r1 = await cache.GetOrRunAsync("dev", "turn-1", () => brain.RunTurnAsync(TenantId.Local, "dev", "start a session in devthrottle", CancellationToken.None));
@@ -964,7 +964,7 @@ public sealed class CarModeBrainTests
             Speak("Started one."),
             new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
             Speak("Started two."));
-        var brain = new CarModeBrain(chat, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         var cache = new CarModeTurnCache(_ => { });
 
         await cache.GetOrRunAsync("dev", "key-A", () => brain.RunTurnAsync(TenantId.Local, "dev", "start a session", CancellationToken.None));
@@ -1022,7 +1022,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
             Speak("You have about twelve dollars and thirty four cents left."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how are we doing on credits", CancellationToken.None);
 
@@ -1039,7 +1039,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
             Speak("The Gateway is not signed in, so there is no balance to read."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None);
 
@@ -1061,7 +1061,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_machines") }),
             Speak("Two machines are online."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "which machines are online", CancellationToken.None);
 
@@ -1087,7 +1087,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_schedules") }),
             Speak("One schedule: Nightly hygiene at three in the morning."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "what runs automatically", CancellationToken.None);
 
@@ -1103,7 +1103,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_spend") }),
             Speak("About two and a half dollars this week."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "what have we spent", CancellationToken.None);
 
@@ -1121,7 +1121,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"three weeks\"}") }),
             Speak("How many days did you mean?"));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for three weeks", CancellationToken.None);
 
@@ -1138,7 +1138,7 @@ public sealed class CarModeBrainTests
         // plausible fabricated number and must be impossible to produce.
         var fleet = new FakeFleet { CreditsResult = new CarModeCredits(true, null, null) };
         var chat = new ScriptedChat(new CarModeAssistantTurn(null, new[] { Call("get_credits") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None));
@@ -1151,7 +1151,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"30\"}") }),
             Speak("Nothing in the last thirty days."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for the month", CancellationToken.None);
 
@@ -1165,7 +1165,7 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var chat = new ScriptedChat(Speak("Hello."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { }, CarModeSurface.Desk);
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { }, CarModeSurface.Desk);
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "hello", CancellationToken.None);
 
@@ -1177,7 +1177,7 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var chat = new ScriptedChat(Speak("Hello."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "hello", CancellationToken.None);
 
@@ -1192,7 +1192,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             Speak("Old Timer has been open thirty one hours."));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync(TenantId.Local, "device-a", "anything open too long", CancellationToken.None);
 
@@ -1200,5 +1200,81 @@ public sealed class CarModeBrainTests
         // default encoder writes an embedded double-quote as the u0022 escape - match that exact form.
         Assert.Contains("\\u0022AgeHours\\u0022:31", chat.SeenMessages[1]);
         Assert.Contains("\\u0022IdleMinutes\\u0022:95", chat.SeenMessages[1]);
+    }
+
+    // ---- Tenant-aware fleet resolution (issue #2129) ----
+
+    [Fact]
+    public async Task RunTurn_ResolvesTheFleetForTheCallingDevice()
+    {
+        // The fleet factory must receive the SAME authenticated credential that keys the conversation,
+        // so on hosted every loopback call runs as the caller and lands in the caller's tenant.
+        var fleet = new FakeFleet { Sessions = new[] { Session("Solo", false) } };
+        string? seenCredential = null;
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
+            Speak("One session."));
+        var brain = new CarModeBrain(chat, credential =>
+        {
+            seenCredential = credential;
+            return fleet;
+        }, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync(TenantId.Local, "device-key-alpha", "how many sessions", CancellationToken.None);
+
+        Assert.Equal("device-key-alpha", seenCredential);
+        Assert.Equal(1, fleet.ListCalls);
+    }
+
+    [Fact]
+    public async Task RunTurn_UnavailableTool_IsRelayedAsAToolError_NotATurnFailure()
+    {
+        // A knowingly-unavailable tool (per-tenant credits on hosted, issue #2129) must reach the model
+        // as a tool error it can say in plain words - the turn succeeds, and the message carries the fact.
+        var fleet = new UnavailableCreditsFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
+            Speak("Credits are not available on the hosted Gateway yet."));
+        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how are my credits", CancellationToken.None);
+
+        Assert.Contains("not available", result.Spoken);
+        Assert.Contains("not available per account on the hosted Gateway yet", chat.SeenMessages[1]);
+    }
+
+    /// <summary>A fleet whose credits read is knowingly unavailable (the hosted refusal shape).</summary>
+    private sealed class UnavailableCreditsFleet : FakeFleet2
+    {
+        public override Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
+            => throw new CarModeToolUnavailableException(
+                "The credit balance is not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
+    }
+
+    /// <summary>An overridable fake fleet for one-off shapes (FakeFleet's members are not virtual).</summary>
+    private class FakeFleet2 : ICarModeFleet
+    {
+        public Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<CarModeSessionInfo>>(new List<CarModeSessionInfo>());
+        public Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct)
+            => Task.FromResult<CarModeActivity?>(null);
+        public Task<CarModeSessionInfo?> ResolveSessionAsync(string sessionReference, CancellationToken ct)
+            => Task.FromResult<CarModeSessionInfo?>(null);
+        public Task<string> StartSessionAsync(string repo, CancellationToken ct) => Task.FromResult("");
+        public Task MessageSessionAsync(string sessionId, string message, CancellationToken ct) => Task.CompletedTask;
+        public Task ApproveSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+        public Task DeleteSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+        public Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct)
+            => Task.FromResult(new CarModeExplain("", false));
+        public Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct) => Task.CompletedTask;
+        public Task SnoozeSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+        public virtual Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
+            => Task.FromResult(new CarModeCredits(false, null, null));
+        public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<CarModeMachineInfo>>(new List<CarModeMachineInfo>());
+        public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<CarModeScheduleInfo>>(new List<CarModeScheduleInfo>());
+        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
+            => Task.FromResult(new CarModeSpendSummary(0, 0, DateTime.UtcNow, DateTime.UtcNow));
     }
 }

--- a/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
@@ -58,7 +58,7 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
         var diagnostics = new CarModeDiagnosticsStore(_storePath, _ => { });
         var brain = new CarModeBrain(
             new UnusedChat(),
-            new UnusedFleet(),
+            _ => new UnusedFleet(),
             new CarModeConversationStore(_ => { }),
             new CarModePendingStore(_ => { }),
             new CarModeSubjectStore(_ => { }),

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -25,20 +25,25 @@ public sealed class CarModeBrain
     private static readonly JsonSerializerOptions ToolResultJson = new() { WriteIndented = false };
 
     private readonly ICarModeChat _chat;
-    private readonly ICarModeFleet _fleet;
+    private readonly Func<string, ICarModeFleet> _fleetForCaller;
     private readonly CarModeConversationStore _conversations;
     private readonly CarModePendingStore _pending;
     private readonly CarModeSubjectStore _subjects;
     private readonly Action<string> _log;
     private readonly string _systemPrompt;
 
+    /// <param name="fleetForCaller">Resolves the fleet view for one authenticated caller credential
+    ///  (issue #2129, hosted tenant isolation): every fleet tool call must run AS the calling device, so
+    ///  the Gateway's own endpoints resolve the caller's tenant exactly as they do for any client. The
+    ///  factory is invoked once per turn with the same authenticated credential that keys the conversation;
+    ///  tests pass a constant fake fleet.</param>
     /// <param name="surface">Which surface this brain instance speaks to. Car (the default) keeps the
     ///  hands-free one-or-two-sentence style; Desk (the cockpit Assistant screen) appends the desk-surface
     ///  overrides. Everything else - loop, tools, stores, model - is identical.</param>
-    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null, CarModeSurface surface = CarModeSurface.Car)
+    public CarModeBrain(ICarModeChat chat, Func<string, ICarModeFleet> fleetForCaller, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null, CarModeSurface surface = CarModeSurface.Car)
     {
         _chat = chat ?? throw new ArgumentNullException(nameof(chat));
-        _fleet = fleet ?? throw new ArgumentNullException(nameof(fleet));
+        _fleetForCaller = fleetForCaller ?? throw new ArgumentNullException(nameof(fleetForCaller));
         _conversations = conversations ?? throw new ArgumentNullException(nameof(conversations));
         _pending = pending ?? throw new ArgumentNullException(nameof(pending));
         _subjects = subjects ?? throw new ArgumentNullException(nameof(subjects));
@@ -122,6 +127,10 @@ public sealed class CarModeBrain
 
         _log($"[CarModeBrain] turn: len={userText.Length}");
 
+        // The fleet view for THIS caller: every tool call this turn runs as the calling device, so on the
+        // hosted Gateway the loopback requests resolve to the caller's own tenant (issue #2129).
+        var fleet = _fleetForCaller(deviceKey);
+
         // The confirmation gate (decision 3): if a destructive action is armed for this device, THIS turn
         // is the spoken confirmation. A clear affirmative executes it; a cancel drops it; anything else
         // disarms it (safe default - the delete never runs) and is processed as a fresh command. This is
@@ -133,7 +142,7 @@ public sealed class CarModeBrain
             _pending.Clear(deviceKey);
             if (CarModeConfirm.IsAffirmative(userText))
             {
-                var (spokenDone, action) = await ExecuteConfirmedAsync(armed, timer, ct);
+                var (spokenDone, action) = await ExecuteConfirmedAsync(fleet, armed, timer, ct);
                 _conversations.Append(deviceKey, userText, spokenDone);
                 _log($"[CarModeBrain] confirmed {armed.Tool} for {armed.TargetName}");
                 return new CarModeTurnResponse { Spoken = spokenDone, Actions = new[] { action } };
@@ -237,7 +246,7 @@ public sealed class CarModeBrain
                     messages.Add(new { role = "tool", tool_call_id = call.Id, content = "{\"status\":\"spoken\"}" });
                     continue;
                 }
-                var outcome = await ExecuteToolAsync(deviceKey, call, timer, ct);
+                var outcome = await ExecuteToolAsync(fleet, deviceKey, call, timer, ct);
                 if (outcome.Action is not null) actions.Add(outcome.Action);
                 if (outcome.ArmedConfirmation) armedThisTurn = true;
                 messages.Add(new { role = "tool", tool_call_id = call.Id, content = outcome.ResultJson });
@@ -270,16 +279,32 @@ public sealed class CarModeBrain
     ///  a tool error (the model can recover next round); a genuine fleet failure throws (a loud, specific,
     ///  spoken failure). Ordinary acts (start / message / approve) run immediately; the destructive act
     ///  (delete) is NOT run - it arms a confirmation the owner must speak next turn (decision 3).</summary>
-    private async Task<ToolOutcome> ExecuteToolAsync(string deviceKey, CarModeToolCall call, TurnTimer timer, CancellationToken ct)
+    private async Task<ToolOutcome> ExecuteToolAsync(ICarModeFleet fleet, string deviceKey, CarModeToolCall call, TurnTimer timer, CancellationToken ct)
     {
         // Log the raw arguments too: model tool arguments are the boundary where a mis-resolve (the wrong
         // session) originates, so the exact reference the model produced must be visible when diagnosing.
         _log($"[CarModeBrain] tool: {call.Name} args={call.ArgumentsJson}");
+        try
+        {
+            return await ExecuteToolCoreAsync(fleet, deviceKey, call, timer, ct);
+        }
+        catch (CarModeToolUnavailableException ex)
+        {
+            // A tool that is KNOWINGLY unavailable on this deployment (issue #2129) is a fact for the model
+            // to relay in plain words, not a turn-killing failure - the owner hears the truth, and the rest
+            // of the conversation keeps working.
+            _log($"[CarModeBrain] tool {call.Name} unavailable: {ex.Message}");
+            return Result(new { error = ex.Message });
+        }
+    }
+
+    private async Task<ToolOutcome> ExecuteToolCoreAsync(ICarModeFleet fleet, string deviceKey, CarModeToolCall call, TurnTimer timer, CancellationToken ct)
+    {
         switch (call.Name)
         {
             case "list_sessions":
             {
-                var sessions = await timer.TimeFleetAsync(() => _fleet.ListSessionsAsync(ct));
+                var sessions = await timer.TimeFleetAsync(() => fleet.ListSessionsAsync(ct));
                 return Result(new
                 {
                     needsYouCount = sessions.Count(s => s.NeedsYou),
@@ -296,7 +321,7 @@ public sealed class CarModeBrain
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 if (string.IsNullOrWhiteSpace(reference))
                     return Result(new { error = "Provide a session name, repo, or number." });
-                var activity = await timer.TimeFleetAsync(() => _fleet.GetSessionActivityAsync(reference, ct));
+                var activity = await timer.TimeFleetAsync(() => fleet.GetSessionActivityAsync(reference, ct));
                 if (activity is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
                 // Reading a session makes it the current subject, so a follow-up "read the wingman" / "answer
@@ -308,7 +333,7 @@ public sealed class CarModeBrain
             {
                 // "The next one that needs me": focus the OLDEST-waiting needs-you session (longest wait first)
                 // as the current subject, so follow-ups ("read the wingman", "answer it", "snooze it") resolve.
-                var sessions = await timer.TimeFleetAsync(() => _fleet.ListSessionsAsync(ct));
+                var sessions = await timer.TimeFleetAsync(() => fleet.ListSessionsAsync(ct));
                 var next = sessions.Where(s => s.NeedsYou).OrderByDescending(s => s.WaitingMinutes).FirstOrDefault();
                 if (next is null)
                     return Result(new { status = "none", message = "No session is waiting on the owner right now." });
@@ -318,9 +343,9 @@ public sealed class CarModeBrain
             case "read_wingman":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "read the wingman for", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "read the wingman for", timer, ct);
                 if (target is null) return Result(new { error });
-                var explain = await timer.TimeFleetAsync(() => _fleet.ExplainSessionAsync(target.SessionId, ct));
+                var explain = await timer.TimeFleetAsync(() => fleet.ExplainSessionAsync(target.SessionId, ct));
                 // The REAL, current narration - the brain reads this aloud, never a canned "it is waiting".
                 return Result(new { session = target.Name, repo = target.Repo, narration = explain.Spoken, explain.NothingYet });
             }
@@ -329,7 +354,7 @@ public sealed class CarModeBrain
                 var repo = ReadStringArg(call.ArgumentsJson, "repo");
                 if (string.IsNullOrWhiteSpace(repo))
                     return Result(new { error = "Provide the repository name to start a session in." });
-                var summary = await timer.TimeFleetAsync(() => _fleet.StartSessionAsync(repo, ct));
+                var summary = await timer.TimeFleetAsync(() => fleet.StartSessionAsync(repo, ct));
                 return Acted(new { status = "started", summary }, new CarModeActionRecord("start_session", summary));
             }
             case "message_session":
@@ -338,43 +363,43 @@ public sealed class CarModeBrain
                 var message = ReadStringArg(call.ArgumentsJson, "message");
                 if (string.IsNullOrWhiteSpace(message))
                     return Result(new { error = "Provide the message to send into the session." });
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "send that to", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "send that to", timer, ct);
                 if (target is null) return Result(new { error });
-                await timer.TimeFleetAsync(() => _fleet.MessageSessionAsync(target.SessionId, message, ct));
+                await timer.TimeFleetAsync(() => fleet.MessageSessionAsync(target.SessionId, message, ct));
                 var summary = $"Messaged {target.Name}.";
                 return Acted(new { status = "sent", session = target.Name }, new CarModeActionRecord("message_session", summary));
             }
             case "approve_session":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "approve", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "approve", timer, ct);
                 if (target is null) return Result(new { error });
-                await timer.TimeFleetAsync(() => _fleet.ApproveSessionAsync(target.SessionId, ct));
+                await timer.TimeFleetAsync(() => fleet.ApproveSessionAsync(target.SessionId, ct));
                 var summary = $"Approved {target.Name}.";
                 return Acted(new { status = "approved", session = target.Name }, new CarModeActionRecord("approve_session", summary));
             }
             case "switch_to_voice_mode":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "switch to voice mode", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "switch to voice mode", timer, ct);
                 if (target is null) return Result(new { error });
-                await timer.TimeFleetAsync(() => _fleet.SwitchVoiceModeAsync(target.SessionId, true, ct));
+                await timer.TimeFleetAsync(() => fleet.SwitchVoiceModeAsync(target.SessionId, true, ct));
                 var summary = $"Switched {target.Name} to voice mode.";
                 return Acted(new { status = "voice_on", session = target.Name }, new CarModeActionRecord("switch_to_voice_mode", summary));
             }
             case "snooze_session":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "snooze", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "snooze", timer, ct);
                 if (target is null) return Result(new { error });
-                await timer.TimeFleetAsync(() => _fleet.SnoozeSessionAsync(target.SessionId, ct));
+                await timer.TimeFleetAsync(() => fleet.SnoozeSessionAsync(target.SessionId, ct));
                 var summary = $"Snoozed {target.Name}.";
                 return Acted(new { status = "snoozed", session = target.Name }, new CarModeActionRecord("snooze_session", summary));
             }
             case "delete_session":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "delete", timer, ct);
+                var (target, error) = await ResolveActTargetAsync(fleet, deviceKey, reference, "delete", timer, ct);
                 if (target is null) return Result(new { error });
                 // Destructive: do NOT delete. Arm a confirmation the owner must speak next turn. The
                 // confirmation ALWAYS names the resolved session and repo out loud, so even a stale current
@@ -393,7 +418,7 @@ public sealed class CarModeBrain
             }
             case "get_credits":
             {
-                var credits = await timer.TimeFleetAsync(() => _fleet.GetCreditsAsync(ct));
+                var credits = await timer.TimeFleetAsync(() => fleet.GetCreditsAsync(ct));
                 if (!credits.SignedIn)
                     return Result(new { signedIn = false, message = "The Gateway is not signed in to a DevThrottle account, so there is no balance to read." });
                 // The fleet guarantees a signed-in read carries a balance (it throws on a malformed
@@ -410,7 +435,7 @@ public sealed class CarModeBrain
             }
             case "list_machines":
             {
-                var machines = await timer.TimeFleetAsync(() => _fleet.ListMachinesAsync(ct));
+                var machines = await timer.TimeFleetAsync(() => fleet.ListMachinesAsync(ct));
                 return Result(new
                 {
                     count = machines.Count,
@@ -422,7 +447,7 @@ public sealed class CarModeBrain
             }
             case "list_schedules":
             {
-                var schedules = await timer.TimeFleetAsync(() => _fleet.ListSchedulesAsync(ct));
+                var schedules = await timer.TimeFleetAsync(() => fleet.ListSchedulesAsync(ct));
                 return Result(new
                 {
                     count = schedules.Count,
@@ -444,7 +469,7 @@ public sealed class CarModeBrain
                     days = 7;
                 else if (!int.TryParse(daysText, out days) || days < 1 || days > 90)
                     return Result(new { error = "days must be a whole number from 1 to 90, or omitted for the default 7." });
-                var spend = await timer.TimeFleetAsync(() => _fleet.GetSpendAsync(days, ct));
+                var spend = await timer.TimeFleetAsync(() => fleet.GetSpendAsync(days, ct));
                 return Result(new
                 {
                     days,
@@ -468,11 +493,11 @@ public sealed class CarModeBrain
     /// confirmation still names the resolved session and repo out loud.
     /// </summary>
     private async Task<(CarModeSubject? Target, string? Error)> ResolveActTargetAsync(
-        string deviceKey, string? reference, string actionPhrase, TurnTimer timer, CancellationToken ct)
+        ICarModeFleet fleet, string deviceKey, string? reference, string actionPhrase, TurnTimer timer, CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(reference))
         {
-            var resolved = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
+            var resolved = await timer.TimeFleetAsync(() => fleet.ResolveSessionAsync(reference, ct));
             if (resolved is null)
                 return (null, $"No session matched \"{reference}\".");
             var subject = new CarModeSubject(resolved.SessionId, resolved.Name, resolved.Repo);
@@ -487,12 +512,12 @@ public sealed class CarModeBrain
 
     /// <summary>Execute a destructive action the owner has just confirmed out loud, returning the spoken
     ///  acknowledgement and the action record. A fleet failure throws (a loud, specific, spoken failure).</summary>
-    private async Task<(string Spoken, CarModeActionRecord Action)> ExecuteConfirmedAsync(CarModePendingAction pending, TurnTimer timer, CancellationToken ct)
+    private async Task<(string Spoken, CarModeActionRecord Action)> ExecuteConfirmedAsync(ICarModeFleet fleet, CarModePendingAction pending, TurnTimer timer, CancellationToken ct)
     {
         switch (pending.Tool)
         {
             case "delete":
-                await timer.TimeFleetAsync(() => _fleet.DeleteSessionAsync(pending.SessionId, ct));
+                await timer.TimeFleetAsync(() => fleet.DeleteSessionAsync(pending.SessionId, ct));
                 return ($"Done. I deleted {pending.TargetName}.", new CarModeActionRecord("delete_session", $"Deleted {pending.TargetName}."));
             default:
                 throw new InvalidOperationException($"Unknown pending action \"{pending.Tool}\".");

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -85,6 +85,17 @@ public sealed record CarModeScheduleInfo
 /// GET /gateway/governance/hosted-ai-spend/summary.</summary>
 public sealed record CarModeSpendSummary(long TotalMicros, int DebitCount, DateTime SinceUtc, DateTime UntilUtc);
 
+/// <summary>
+/// A fleet tool that is KNOWINGLY unavailable on this deployment (issue #2129: per-tenant credits and
+/// spend are not served on the hosted Gateway yet). Distinct from a genuine failure on purpose: the brain
+/// converts this into a tool-error result the model RELAYS in plain words ("credits are not available
+/// here yet"), instead of failing the whole turn - the owner hears the truth, not an error page.
+/// </summary>
+public sealed class CarModeToolUnavailableException : Exception
+{
+    public CarModeToolUnavailableException(string message) : base(message) { }
+}
+
 /// <summary>What one session is doing, for the "read me that one" / "what is X doing" read tool. For v1
 /// this is the roster's own summary fields (name + repo + short line), which already answer the mission's
 /// Phase 2 proof; a richer transcript read can be layered on later without changing the tool contract.</summary>

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -37,14 +37,22 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
     private IReadOnlyList<SessionDto>? _rosterCache;
     private DateTime _rosterCachedAtUtc = DateTime.MinValue;
 
+    /// <summary>The one loopback client every fleet instance shares. Instances are now created per turn
+    ///  (one per caller credential - issue #2129), so each newing up its own HttpClient would leak
+    ///  sockets; the client is stateless, so sharing is safe.</summary>
+    private static readonly HttpClient SharedLoopbackClient = new() { Timeout = TimeSpan.FromSeconds(20) };
+
     /// <param name="port">This Gateway's own listening port (loopback).</param>
-    /// <param name="token">The per-machine Gateway token, attached as the Bearer so the call works
-    ///  whether or not the host-wide auth gate is on.</param>
-    /// <param name="http">HTTP client; a short-timeout loopback client when null.</param>
+    /// <param name="token">The credential the loopback calls authenticate WITH - normally the CALLING
+    ///  device's own authenticated credential (issue #2129), so on the hosted Gateway every read and act
+    ///  resolves to the caller's own tenant exactly as it would for any client. Self-host with the auth
+    ///  gate off has no caller credential; the factory in GatewayHost passes the machine token for that
+    ///  one case (self-host is single-tenant Local, so no isolation is at stake).</param>
+    /// <param name="http">HTTP client; the shared loopback client when null.</param>
     /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
     public LoopbackCarModeFleet(int port, string token, HttpClient? http = null, Action<string>? log = null)
     {
-        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        _http = http ?? SharedLoopbackClient;
         _baseUrl = $"http://127.0.0.1:{port}";
         _token = token ?? "";
         _log = log ?? FileLog.Write;
@@ -195,6 +203,12 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
 
     public async Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
     {
+        // Issue #2129: /account/credits reads the MACHINE's one stored account credential, which has no
+        // per-tenant meaning on the hosted Gateway (absent by design there; were it present, every tenant
+        // would be shown the same account's balance). Refuse with a relayable fact instead of either lie.
+        if (GatewayHostedMode.IsHosted)
+            throw new CarModeToolUnavailableException(
+                "The credit balance is not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
         // The SAME token-free proxy the Settings account section reads (GET /account/credits). A signed-out
         // Gateway answers signedIn=false explicitly; a cloud failure is a non-success status and throws loud.
         var root = await GetJsonObjectAsync("/account/credits", ct);
@@ -283,6 +297,12 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
 
     public async Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
     {
+        // Issue #2129: the governance spend store is process-wide, so on the hosted Gateway its total would
+        // AGGREGATE every tenant's spending - an aggregate no single tenant may see (partition when
+        // attributable, deny when aggregate). Refuse with a relayable fact until a per-tenant read exists.
+        if (GatewayHostedMode.IsHosted)
+            throw new CarModeToolUnavailableException(
+                "Spending totals are not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
         if (days <= 0) throw new ArgumentOutOfRangeException(nameof(days), "The spend window must be at least one day.");
         var until = DateTime.UtcNow;
         var since = until.AddDays(-days);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2199,12 +2199,19 @@ public sealed class GatewayHost : IAsyncDisposable
         // conversation context is kept server-side per device. Inherits the host-wide auth gate (the
         // caller's per-device key), like every other data route.
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get, _tenantSettingsResolver));
-        var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
-        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending, _carModeSubjects);
+        // The fleet view is created PER TURN, as the CALLING DEVICE (issue #2129): the loopback calls
+        // authenticate with the caller's own credential, so on hosted every read and act resolves to the
+        // caller's tenant exactly as it would for any client - the machine token (which hosted rejects,
+        // and which carries no tenant) never authenticates a tenant's fleet read. The empty-credential arm
+        // exists ONLY for self-host with the auth gate off (single-tenant Local): there is no caller
+        // credential on the request at all, and the machine token is the same identity every client uses.
+        Func<string, CarMode.ICarModeFleet> carModeFleetForCaller = callerCredential =>
+            new CarMode.LoopbackCarModeFleet(Port, string.IsNullOrEmpty(callerCredential) ? Token : callerCredential);
+        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects);
         // The cockpit Assistant (POST /assistant/turn): the SAME loop, tools, stores, model, and turn cache
         // as Car Mode, with only the desk-surface speech style. Sharing the stores means a device that uses
         // both surfaces keeps one conversation and one armed-confirmation state - no split-brain.
-        var assistantBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending, _carModeSubjects, surface: CarMode.CarModeSurface.Desk);
+        var assistantBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects, surface: CarMode.CarModeSurface.Desk);
         // Keep-warm (Car Mode performance round): warm the SAME hosted model the brain uses and the SAME
         // text-to-speech target /wingman/tts uses, resolved fresh each warmup so a settings change applies.
         var carModeWarmup = new CarMode.CarModeWarmup(


### PR DESCRIPTION
On hosted, the brain's loopback fleet calls used the shared machine token, which hosted auth rejects - every Assistant and Car Mode turn failed with 502. Now the brain resolves a per-turn fleet view authenticated with the CALLER's own credential, so the Gateway's endpoints resolve the caller's tenant exactly as for any client; the roster cache is per turn so it can never cross tenants. get_credits and get_spend refuse on hosted with a plain-words relayable fact (machine-account read and cross-tenant aggregate respectively - the rest of thefrederiksen/devthrottle_internal#935) instead of lying; both keep working on self-host, and everything else works on hosted. Two new brain tests; Car Mode group 136/136. Self-host behavior is unchanged.