### PR TITLE
First-run wizard: Code screen, Morning report promise screen, and the onboarding journey voice

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -110,6 +110,18 @@
             <Setter Property="TextBlock.Foreground" Value="#16181D" />
             <Setter Property="TextBlock.TextDecorations" Value="Underline" />
         </Style>
+
+        <!-- The journey eyebrow: one short beat name above each screen's title, telling the
+             onboarding STORY (your workforce -> what we watch over -> ... -> the payoff) so every
+             ask reads as part of one narrative, not a form. -->
+        <Style Selector="TextBlock.eyebrow">
+            <Setter Property="Foreground" Value="#0066B8" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="LetterSpacing" Value="2" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="Margin" Value="0,0,0,8" />
+        </Style>
     </Window.Styles>
 
     <Grid Margin="44,32,44,24" RowDefinitions="Auto,*,Auto">
@@ -122,12 +134,34 @@
         <Grid Grid.Row="1">
 
             <!-- ===================== WELCOME ===================== -->
-            <StackPanel x:Name="WelcomePanel" IsVisible="False" Spacing="18"
+            <StackPanel x:Name="WelcomePanel" IsVisible="False" Spacing="16"
                         VerticalAlignment="Center">
                 <TextBlock Classes="wtitle" Text="Welcome to DevThrottle" />
                 <TextBlock Classes="wsub"
-                           Text="You are about three minutes from running your first coding agent. We will find your agents, learn where your code lives, and set up your morning report." />
-                <StackPanel Spacing="16" HorizontalAlignment="Center" Margin="0,20,0,0">
+                           Text="You are about three minutes from running your first coding agent. We will find your agents, learn where your code lives, and set up your morning report - the daily email that keeps your week honest." />
+
+                <!-- Founder note: two sentences collapsed, one quiet Read more. It must never
+                     delay the "Set me up" click - short by design. -->
+                <Border Background="#F5F6F8" BorderBrush="#E6E8EC" BorderThickness="1"
+                        CornerRadius="12" Padding="20,16" MaxWidth="540"
+                        HorizontalAlignment="Center" Margin="0,6,0,0">
+                    <StackPanel Spacing="8">
+                        <TextBlock FontSize="13.5" Foreground="#5A616B" TextWrapping="Wrap"
+                                   LineHeight="21"
+                                   Text="I built DevThrottle because running agents was never the hard part. The hard part was getting to Friday and realizing the week went to the wrong things. DevThrottle keeps the books - so that stops happening." />
+                        <TextBlock x:Name="FounderMoreText" FontSize="13.5" Foreground="#5A616B"
+                                   TextWrapping="Wrap" LineHeight="21" IsVisible="False"
+                                   Text="Agents multiply what you can build, and they multiply the bookkeeping with it: branches, worktrees, half-finished work, sessions waiting on you. DevThrottle carries that administration for you and reports back every morning with what happened and what needs your attention. Give it one small task today, then read tomorrow's report. That is the whole loop." />
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" FontSize="12.5" Foreground="#8A909A"
+                                       Text="- Soren, founder" VerticalAlignment="Center" />
+                            <Button Grid.Column="1" x:Name="FounderMoreLink" Classes="quietLink"
+                                    Content="Read more" Click="BtnFounderMore_Click" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <StackPanel Spacing="16" HorizontalAlignment="Center" Margin="0,10,0,0">
                     <Button x:Name="WelcomeSetupButton" Classes="primaryButton"
                             Content="Set me up" HorizontalAlignment="Center"
                             Click="BtnPrimary_Click" />
@@ -137,20 +171,21 @@
                 </StackPanel>
             </StackPanel>
 
-            <!-- ===================== AGENTS (interim: reuses the tool-detection scan) ===================== -->
-            <Grid x:Name="AgentsPanel" IsVisible="False" RowDefinitions="Auto,Auto,*,Auto">
-                <TextBlock Grid.Row="0" x:Name="AgentsTitle" Classes="wtitle"
+            <!-- ===================== AGENTS ===================== -->
+            <Grid x:Name="AgentsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="YOUR WORKFORCE" />
+                <TextBlock Grid.Row="1" x:Name="AgentsTitle" Classes="wtitle"
                            Text="Your agents" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="1" x:Name="AgentsStatusText" Classes="wsub"
+                <TextBlock Grid.Row="2" x:Name="AgentsStatusText" Classes="wsub"
                            Text="Scanning this machine for coding agents..." Margin="0,0,0,20" />
-                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
                     <StackPanel x:Name="AgentsListPanel" Spacing="8" MaxWidth="560"
                                 HorizontalAlignment="Stretch" />
                 </ScrollViewer>
                 <!-- Zero-agents actions: install Claude Code right here, or defer it as a carried
                      to-do. Shown only in the empty state (the step that cannot be skipped). -->
-                <StackPanel Grid.Row="3" x:Name="AgentsEmptyActions" Spacing="12"
+                <StackPanel Grid.Row="4" x:Name="AgentsEmptyActions" Spacing="12"
                             IsVisible="False" Margin="0,16,0,0">
                     <Button x:Name="AgentsInstallButton" Classes="primaryButton"
                             Content="Install Claude Code for me" HorizontalAlignment="Center"
@@ -177,12 +212,52 @@
                 </StackPanel>
             </Grid>
 
+            <!-- ===================== CODE (where your repositories live) ===================== -->
+            <Grid x:Name="CodePanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="WHAT WE WATCH OVER" />
+                <TextBlock Grid.Row="1" Classes="wtitle" Text="Where does your code live?" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,22"
+                           Text="Pick the folder (or folders) where you keep your repositories. This is what DevThrottle keeps the books on - branches, worktrees, unmerged work - and where it offers you repos when you start an agent." />
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                    <StackPanel MaxWidth="600" HorizontalAlignment="Stretch" Spacing="8">
+                        <StackPanel x:Name="CodeSuggestionsPanel" Spacing="8" />
+                        <TextBlock x:Name="CodeScanStatusText" Classes="hint"
+                                   HorizontalAlignment="Center" TextAlignment="Center"
+                                   Text="Checking the usual places for git repositories..." />
+                        <!-- The manual path: always present, works the same on Windows and macOS. -->
+                        <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                                CornerRadius="10" Padding="16,13">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
+                                    <TextBlock Text="Somewhere else" FontSize="14" FontWeight="SemiBold"
+                                               Foreground="#16181D" />
+                                    <TextBlock Text="Add another base folder" FontSize="11"
+                                               Foreground="#8A909A" />
+                                </StackPanel>
+                                <Button Grid.Column="1" Classes="dialogButton" Content="Browse..."
+                                        Click="BtnBrowseCodeFolder_Click" VerticalAlignment="Center" />
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+                <!-- The proof number: how many repositories the added folders will surface. -->
+                <StackPanel Grid.Row="4" x:Name="CodeTotalPanel" IsVisible="False" Margin="0,14,0,0">
+                    <TextBlock x:Name="CodeTotalCount" FontSize="34" FontWeight="Bold"
+                               Foreground="#16181D" HorizontalAlignment="Center"
+                               FontFamily="Segoe UI Variable Display, Segoe UI, Inter" />
+                    <TextBlock Text="repositories will be available when you start an agent"
+                               FontSize="12.5" Foreground="#8A909A" HorizontalAlignment="Center" />
+                </StackPanel>
+            </Grid>
+
             <!-- ===================== SCREENSHOTS ===================== -->
-            <Grid x:Name="ScreenshotsPanel" IsVisible="False" RowDefinitions="Auto,Auto,*">
-                <TextBlock Grid.Row="0" Classes="wtitle" Text="Where do your screenshots go?" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="1" Classes="wsub" Margin="0,0,0,26"
+            <Grid x:Name="ScreenshotsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="SHOW, DON'T TYPE" />
+                <TextBlock Grid.Row="1" Classes="wtitle" Text="Where do your screenshots go?" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,26"
                            Text="Snap a screen, then drag the screenshot straight onto an agent - the fastest way to show it exactly what you mean. DevThrottle watches one folder for new screenshots." />
-                <StackPanel Grid.Row="2" MaxWidth="600" Spacing="14" VerticalAlignment="Top"
+                <StackPanel Grid.Row="3" MaxWidth="600" Spacing="14" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
 
                     <!-- The chosen folder, with a Change (browse) escape hatch. -->
@@ -220,11 +295,12 @@
             </Grid>
 
             <!-- ===================== GATEWAY (native, hosted-first per the mockup) ===================== -->
-            <Grid x:Name="GatewayPanel" IsVisible="False" RowDefinitions="Auto,Auto,*">
-                <TextBlock Grid.Row="0" Classes="wtitle" Text="Connect your gateway" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="1" Classes="wsub" Margin="0,0,0,24"
+            <Grid x:Name="GatewayPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="WITH YOU EVERYWHERE" />
+                <TextBlock Grid.Row="1" Classes="wtitle" Text="Connect your gateway" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,24"
                            Text="The gateway is what lets you check on your agents from your phone, use voice, and get your morning report. Signing in takes seconds." />
-                <Grid Grid.Row="2">
+                <Grid Grid.Row="3">
 
                     <!-- Choice view: one dominant hosted card (pre-selected), two quiet alternatives. -->
                     <StackPanel x:Name="GatewayChoiceView" MaxWidth="600" Spacing="14"
@@ -317,12 +393,54 @@
                 </Grid>
             </Grid>
 
+            <!-- ===================== MORNING REPORT (the promise screen) ===================== -->
+            <Grid x:Name="ReportPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="THE PAYOFF" />
+                <TextBlock Grid.Row="1" Classes="wtitle" Text="Tomorrow morning, we report back" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,24"
+                           Text="Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you." />
+                <StackPanel Grid.Row="3" MaxWidth="520" Spacing="10" VerticalAlignment="Top"
+                            HorizontalAlignment="Stretch">
+                    <Border x:Name="ReportDailyCard" Cursor="Hand"
+                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                            CornerRadius="10" Padding="16,13"
+                            PointerPressed="ReportDailyCard_Pressed">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Daily" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
+                            <TextBlock Text="Every morning at 7:00, your time" FontSize="11" Foreground="#8A909A" />
+                        </StackPanel>
+                    </Border>
+                    <Border x:Name="ReportWeeklyCard" Cursor="Hand"
+                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                            CornerRadius="10" Padding="16,13"
+                            PointerPressed="ReportWeeklyCard_Pressed">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Weekly" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
+                            <TextBlock Text="Monday mornings only" FontSize="11" Foreground="#8A909A" />
+                        </StackPanel>
+                    </Border>
+                    <Border x:Name="ReportOffCard" Cursor="Hand"
+                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                            CornerRadius="10" Padding="16,13"
+                            PointerPressed="ReportOffCard_Pressed">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="No report" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
+                            <TextBlock Text="You can turn it on later in Settings" FontSize="11" Foreground="#8A909A" />
+                        </StackPanel>
+                    </Border>
+                    <TextBlock x:Name="ReportGatewayNote" Classes="hint" IsVisible="False"
+                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="480"
+                               Margin="0,6,0,0"
+                               Text="The report travels through your gateway. Connect one on the previous step - or any time in Settings - and it starts arriving." />
+                </StackPanel>
+            </Grid>
+
             <!-- ===================== DONE ===================== -->
             <StackPanel x:Name="DonePanel" IsVisible="False" Spacing="18"
                         VerticalAlignment="Center">
                 <TextBlock Classes="wtitle" Text="You are ready" />
                 <TextBlock Classes="wsub"
-                           Text="Everything is set. Start an agent on one of your repos - give it a small task and watch the card, not the terminal." />
+                           Text="Start an agent on one of your repos - give it a small task and watch the card, not the terminal. Tomorrow morning, DevThrottle reports back on how it went." />
                 <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
                         CornerRadius="12" Padding="4" MaxWidth="520" HorizontalAlignment="Center"
                         Margin="0,6,0,0">

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -68,6 +68,20 @@ public partial class FirstRunWizardDialog : Window
     private bool _shotsDetectRan;
     private CancellationTokenSource? _shotsWatchCts;
 
+    // Code step: the roots store the board and New Session read, the folders added this run
+    // (path -> repo count, drives the proof number), and the one-shot suggestion scan.
+    private readonly RootDirectoryStore _rootStore = new();
+    private bool _rootStoreLoaded;
+    private readonly Dictionary<string, int> _codeAddedRoots = new(StringComparer.OrdinalIgnoreCase);
+    private bool _codeScanRan;
+    private CancellationTokenSource? _codeScanCts;
+
+    // Morning report step: the chosen cadence. Daily is the default - the report is the payoff the
+    // whole onboarding story builds to, so it arrives unless the user says otherwise.
+    private enum ReportCadence { Daily, Weekly, Off }
+
+    private ReportCadence _reportCadence = ReportCadence.Daily;
+
     // True once the completion marker has been written, so OnClosed does not write it twice.
     private bool _marked;
 
@@ -85,16 +99,10 @@ public partial class FirstRunWizardDialog : Window
         FileLog.Write("[FirstRunWizardDialog] Constructor: initializing");
         _options = options ?? throw new ArgumentNullException(nameof(options));
 
-        // The steps present in THIS release. Code and Morning report are absent until their own
-        // issues land; the model tolerates the shorter list.
-        _model = new FirstRunWizardModel(new[]
-        {
-            WizardStep.Welcome,
-            WizardStep.Agents,
-            WizardStep.Screenshots,
-            WizardStep.Gateway,
-            WizardStep.Done,
-        });
+        // All seven canonical steps are present: the onboarding is one JOURNEY (your workforce ->
+        // what we watch over -> show don't type -> with you everywhere -> the payoff -> done), and
+        // the Morning report screen is the promise the rest of the story builds to.
+        _model = new FirstRunWizardModel(FirstRunWizardModel.CanonicalOrder);
 
         InitializeComponent();
         BuildDots();
@@ -145,8 +153,10 @@ public partial class FirstRunWizardDialog : Window
 
         WelcomePanel.IsVisible = step == WizardStep.Welcome;
         AgentsPanel.IsVisible = step == WizardStep.Agents;
+        CodePanel.IsVisible = step == WizardStep.Code;
         ScreenshotsPanel.IsVisible = step == WizardStep.Screenshots;
         GatewayPanel.IsVisible = step == WizardStep.Gateway;
+        ReportPanel.IsVisible = step == WizardStep.MorningReport;
         DonePanel.IsVisible = step == WizardStep.Done;
 
         // Leaving the Screenshots step ends any take-a-screenshot watch.
@@ -179,6 +189,14 @@ public partial class FirstRunWizardDialog : Window
                     _ = ScanAgentsAsync();
                 break;
 
+            case WizardStep.Code:
+                PrimaryButton.Content = _codeAddedRoots.Count > 0 ? "Looks right" : "Continue";
+                PrimaryButton.IsVisible = true;
+                ConfigureStepSkip();
+                if (!_codeScanRan)
+                    _ = ScanCodeFoldersAsync();
+                break;
+
             case WizardStep.Screenshots:
                 PrimaryButton.Content = "Use this folder";
                 PrimaryButton.IsVisible = true;
@@ -192,6 +210,16 @@ public partial class FirstRunWizardDialog : Window
                 PrimaryButton.IsVisible = true;
                 ConfigureStepSkip();
                 RefreshGatewayChoiceUi();
+                break;
+
+            case WizardStep.MorningReport:
+                PrimaryButton.Content = "Sounds good";
+                PrimaryButton.IsVisible = true;
+                PrimaryButton.IsEnabled = true;
+                ConfigureStepSkip();
+                RefreshReportCards();
+                // The report travels through the gateway; say so plainly when none is connected.
+                ReportGatewayNote.IsVisible = !_gatewayConnected && string.IsNullOrWhiteSpace(GatewayConfig.Load().Url);
                 break;
 
             case WizardStep.Done:
@@ -230,6 +258,11 @@ public partial class FirstRunWizardDialog : Window
 
                 case WizardStep.Screenshots:
                     await SaveScreenshotsFolderAsync();
+                    Advance();
+                    break;
+
+                case WizardStep.MorningReport:
+                    await SaveReportCadenceAsync();
                     Advance();
                     break;
 
@@ -598,6 +631,231 @@ public partial class FirstRunWizardDialog : Window
         Advance();
     }
 
+    // ---- Code step (where your repositories live) --------------------------------------------------
+
+    /// <summary>
+    /// Populate the Code step: show any roots already registered (a re-run wizard tells the truth),
+    /// then stream in verified suggestions from the shallow scout scan - never a full drive walk.
+    /// </summary>
+    private async Task ScanCodeFoldersAsync()
+    {
+        FileLog.Write("[FirstRunWizardDialog] ScanCodeFoldersAsync");
+        _codeScanRan = true;
+        try
+        {
+            await EnsureRootStoreLoadedAsync();
+
+            // Roots that already exist (Settings, a previous run) appear first, marked Added.
+            foreach (var root in _rootStore.Roots)
+            {
+                if (_codeAddedRoots.ContainsKey(root.Path)) continue;
+                var count = await Task.Run(() => CodeFolderScout.CountRepos(root.Path));
+                _codeAddedRoots[root.Path] = count;
+                CodeSuggestionsPanel.Children.Add(CodeRow(root.Path, count, alreadyAdded: true));
+            }
+            UpdateCodeTotal();
+
+            _codeScanCts?.Cancel();
+            _codeScanCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            // Progress<T> posts each suggestion onto the UI thread as the background sweep finds it.
+            var progress = new Progress<CodeFolderSuggestion>(s =>
+            {
+                if (_codeAddedRoots.ContainsKey(s.Path)) return;
+                if (CodeSuggestionsPanel.Children.OfType<Border>().Any(b => Equals(b.Tag as string, s.Path))) return;
+                CodeSuggestionsPanel.Children.Add(CodeRow(s.Path, s.RepoCount, alreadyAdded: false));
+            });
+
+            await CodeFolderScout.ScanAsync(progress, _codeScanCts.Token);
+
+            CodeScanStatusText.Text = CodeSuggestionsPanel.Children.Count > 0
+                ? "That is everywhere we checked - add anything else below."
+                : "No repositories found in the usual places. Browse to where your code lives.";
+        }
+        catch (OperationCanceledException)
+        {
+            FileLog.Write("[FirstRunWizardDialog] ScanCodeFoldersAsync: scan cancelled/timed out");
+            CodeScanStatusText.Text = "That is everywhere we checked - add anything else below.";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] ScanCodeFoldersAsync FAILED: {ex.Message}");
+            CodeScanStatusText.Text = $"Folder scan failed: {ex.Message}";
+        }
+    }
+
+    private async Task EnsureRootStoreLoadedAsync()
+    {
+        if (_rootStoreLoaded) return;
+        await Task.Run(_rootStore.Load);
+        _rootStoreLoaded = true;
+    }
+
+    /// <summary>One suggestion row: the folder, its verified repo count, and Add (or the Added pill).</summary>
+    private Border CodeRow(string path, int repoCount, bool alreadyAdded)
+    {
+        var text = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
+        text.Children.Add(new TextBlock
+        {
+            Text = path,
+            Foreground = Brush("#16181D"),
+            FontSize = 14,
+            FontWeight = FontWeight.SemiBold,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        });
+        text.Children.Add(new TextBlock
+        {
+            Text = repoCount == 1 ? "1 git repository found" : $"{repoCount} git repositories found",
+            Foreground = Brush("#8A909A"),
+            FontSize = 11,
+        });
+
+        var grid = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto") };
+        global::Avalonia.Controls.Grid.SetColumn(text, 0);
+        grid.Children.Add(text);
+
+        Control action;
+        if (alreadyAdded)
+        {
+            action = AddedPill();
+        }
+        else
+        {
+            var addButton = new Button
+            {
+                Content = "Add",
+                Classes = { "dialogButton" },
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            addButton.Click += async (_, _) => await AddCodeRootAsync(path, repoCount, addButton);
+            action = addButton;
+        }
+        global::Avalonia.Controls.Grid.SetColumn(action, 1);
+        grid.Children.Add(action);
+
+        return new Border
+        {
+            Tag = path,
+            Background = Brush("#FFFFFF"),
+            BorderBrush = Brush("#E6E8EC"),
+            BorderThickness = new global::Avalonia.Thickness(1),
+            CornerRadius = new global::Avalonia.CornerRadius(10),
+            Padding = new global::Avalonia.Thickness(16, 13),
+            Child = grid,
+        };
+    }
+
+    private static Border AddedPill() => new()
+    {
+        Background = Brush("#E5F3E9"),
+        CornerRadius = new global::Avalonia.CornerRadius(999),
+        Padding = new global::Avalonia.Thickness(10, 3),
+        VerticalAlignment = VerticalAlignment.Center,
+        Child = new TextBlock
+        {
+            Text = "Added",
+            Foreground = Brush("#1A7F37"),
+            FontSize = 11,
+            FontWeight = FontWeight.SemiBold,
+        },
+    };
+
+    /// <summary>Register a base folder in the same roots store the board and New Session read.</summary>
+    private async Task AddCodeRootAsync(string path, int repoCount, Button addButton)
+    {
+        FileLog.Write($"[FirstRunWizardDialog] AddCodeRootAsync: {path}");
+        try
+        {
+            addButton.IsEnabled = false;
+            await EnsureRootStoreLoadedAsync();
+
+            var duplicate = _rootStore.Roots.Any(r =>
+                string.Equals(System.IO.Path.GetFullPath(r.Path), System.IO.Path.GetFullPath(path), StringComparison.OrdinalIgnoreCase));
+            if (!duplicate)
+            {
+                await Task.Run(() => _rootStore.Add(new RootDirectoryConfig
+                {
+                    Label = System.IO.Path.GetFileName(path.TrimEnd(System.IO.Path.DirectorySeparatorChar)),
+                    Path = path,
+                }));
+            }
+
+            _codeAddedRoots[path] = repoCount;
+            SwapCodeRowActionToAdded(path);
+            UpdateCodeTotal();
+            if (_model.Current == WizardStep.Code)
+                PrimaryButton.Content = "Looks right";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] AddCodeRootAsync FAILED: {ex.Message}");
+            addButton.IsEnabled = true;
+        }
+    }
+
+    /// <summary>Replace a row's Add button with the Added pill after a successful add.</summary>
+    private void SwapCodeRowActionToAdded(string path)
+    {
+        var row = CodeSuggestionsPanel.Children.OfType<Border>().FirstOrDefault(b => Equals(b.Tag as string, path));
+        if (row?.Child is not Grid grid) return;
+        var button = grid.Children.OfType<Button>().FirstOrDefault();
+        if (button is null) return;
+        grid.Children.Remove(button);
+        var pill = AddedPill();
+        global::Avalonia.Controls.Grid.SetColumn(pill, 1);
+        grid.Children.Add(pill);
+    }
+
+    /// <summary>The proof number: repositories across every added folder.</summary>
+    private void UpdateCodeTotal()
+    {
+        var total = _codeAddedRoots.Values.Sum();
+        CodeTotalPanel.IsVisible = total > 0;
+        CodeTotalCount.Text = total.ToString();
+    }
+
+    private async void BtnBrowseCodeFolder_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnBrowseCodeFolder_Click");
+        try
+        {
+            var result = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            {
+                Title = "Select the folder where you keep your repositories",
+                AllowMultiple = false,
+            });
+            if (result.Count == 0) return;
+
+            // A picked SINGLE repository resolves to its parent (the roots list holds base folders;
+            // the monitor lists a root's children).
+            var picked = result[0].Path.LocalPath;
+            var (path, count) = await Task.Run(() =>
+            {
+                var resolved = CodeFolderScout.ResolveBrowsedFolder(picked);
+                return (resolved, CodeFolderScout.CountRepos(resolved));
+            });
+
+            if (_codeAddedRoots.ContainsKey(path)) return;
+
+            var existingRow = CodeSuggestionsPanel.Children.OfType<Border>().FirstOrDefault(b => Equals(b.Tag as string, path));
+            if (existingRow is not null)
+            {
+                // It was already suggested - adding it is what the user meant.
+                var button = (existingRow.Child as Grid)?.Children.OfType<Button>().FirstOrDefault();
+                if (button is not null)
+                    await AddCodeRootAsync(path, count, button);
+                return;
+            }
+
+            CodeSuggestionsPanel.Children.Add(CodeRow(path, count, alreadyAdded: true));
+            await AddCodeRootAsync(path, count, new Button());
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnBrowseCodeFolder_Click FAILED: {ex.Message}");
+        }
+    }
+
     // ---- Screenshots step --------------------------------------------------------------------------
 
     /// <summary>
@@ -748,6 +1006,53 @@ public partial class FirstRunWizardDialog : Window
         {
             ["screenshots"] = new JsonObject { ["source_directory"] = path },
         }));
+    }
+
+    // ---- Morning report step (the promise screen) ---------------------------------------------------
+
+    private void RefreshReportCards()
+    {
+        StyleGatewayCard(ReportDailyCard, _reportCadence == ReportCadence.Daily, emphasized: false);
+        StyleGatewayCard(ReportWeeklyCard, _reportCadence == ReportCadence.Weekly, emphasized: false);
+        StyleGatewayCard(ReportOffCard, _reportCadence == ReportCadence.Off, emphasized: false);
+    }
+
+    private void SelectReportCadence(ReportCadence cadence)
+    {
+        FileLog.Write($"[FirstRunWizardDialog] SelectReportCadence: {cadence}");
+        _reportCadence = cadence;
+        RefreshReportCards();
+    }
+
+    private void ReportDailyCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Daily);
+    private void ReportWeeklyCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Weekly);
+    private void ReportOffCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Off);
+
+    /// <summary>
+    /// Persist the cadence choice to config so the morning-report sender reads the user's answer
+    /// when it ships. Skipping the step writes nothing - only an explicit "Sounds good" commits.
+    /// </summary>
+    private async Task SaveReportCadenceAsync()
+    {
+        var cadence = _reportCadence switch
+        {
+            ReportCadence.Daily => "daily",
+            ReportCadence.Weekly => "weekly",
+            _ => "off",
+        };
+        FileLog.Write($"[FirstRunWizardDialog] SaveReportCadenceAsync: {cadence}");
+        await Task.Run(() => CcDirectorConfigService.MergePatch(new JsonObject
+        {
+            ["morning_report"] = new JsonObject { ["cadence"] = cadence, ["hour"] = 7 },
+        }));
+    }
+
+    // ---- Welcome: founder note ----------------------------------------------------------------------
+
+    private void BtnFounderMore_Click(object? sender, RoutedEventArgs e)
+    {
+        FounderMoreText.IsVisible = !FounderMoreText.IsVisible;
+        FounderMoreLink.Content = FounderMoreText.IsVisible ? "Show less" : "Read more";
     }
 
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
@@ -934,6 +1239,16 @@ public partial class FirstRunWizardDialog : Window
                     : "Add one from Settings > Agents",
                 done: false));
 
+        // Code row.
+        var repoTotal = _codeAddedRoots.Values.Sum();
+        if (repoTotal > 0)
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                repoTotal == 1 ? "1 repository" : $"{repoTotal} repositories",
+                string.Join(", ", _codeAddedRoots.Keys), done: true));
+        else
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                "No code folders yet", "Add them from the Repositories view to get repo suggestions", done: false));
+
         // Screenshots row.
         if (_shotsSelectedPath is not null)
             DoneReceiptPanel.Children.Add(ReceiptRow("Screenshots folder set", _shotsSelectedPath, done: true));
@@ -948,6 +1263,14 @@ public partial class FirstRunWizardDialog : Window
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 "No gateway", "Connect one from Settings for phone access and your morning report", done: false));
+
+        // Morning report row - the promise, restated on the receipt.
+        DoneReceiptPanel.Children.Add(_reportCadence switch
+        {
+            ReportCadence.Daily => ReceiptRow("Morning report", "Every morning at 7:00, your time", done: true),
+            ReportCadence.Weekly => ReceiptRow("Morning report", "Monday mornings", done: true),
+            _ => ReceiptRow("Morning report off", "Turn it on any time in Settings", done: false),
+        });
     }
 
     private static Border ReceiptRow(string name, string sub, bool done)
@@ -1023,6 +1346,7 @@ public partial class FirstRunWizardDialog : Window
         _hostedEnrollCts?.Cancel();
         _claudeInstallCts?.Cancel();
         _shotsWatchCts?.Cancel();
+        _codeScanCts?.Cancel();
         if (!_marked)
         {
             FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (window closed without finishing)");

--- a/src/CcDirector.Core.Tests/Onboarding/CodeFolderScoutTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/CodeFolderScoutTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Onboarding;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Onboarding;
+
+/// <summary>
+/// Tests for <see cref="CodeFolderScout"/> with real temporary directories - the scout's job is
+/// classifying real filesystem shapes, so that is what the tests build.
+/// </summary>
+public sealed class CodeFolderScoutTests : IDisposable
+{
+    private readonly string _root;
+
+    public CodeFolderScoutTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "scout-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string MakeRepo(string parent, string name)
+    {
+        var repo = Path.Combine(parent, name);
+        Directory.CreateDirectory(Path.Combine(repo, ".git"));
+        return repo;
+    }
+
+    [Theory]
+    [InlineData("Repos", true)]
+    [InlineData("repos", true)]
+    [InlineData("ReposFred", true)]
+    [InlineData("repositories", true)]
+    [InlineData("Projects", true)]
+    [InlineData("Project", true)]
+    [InlineData("Code", true)]
+    [InlineData("dev", true)]
+    [InlineData("src", true)]
+    [InlineData("git", true)]
+    [InlineData("source", true)]
+    [InlineData("Windows", false)]
+    [InlineData("Program Files", false)]
+    [InlineData("Users", false)]
+    [InlineData("Games", false)]
+    [InlineData("Decode", false)]
+    public void NameSuggestsCode_ClassifiesFolderNames(string name, bool expected)
+    {
+        Assert.Equal(expected, CodeFolderScout.NameSuggestsCode(name));
+    }
+
+    [Fact]
+    public void CountRepos_CountsImmediateChildrenWithGitDirectories_Only()
+    {
+        MakeRepo(_root, "alpha");
+        MakeRepo(_root, "beta");
+        Directory.CreateDirectory(Path.Combine(_root, "not-a-repo"));
+        // A repo nested two levels down must NOT count - the monitor lists one level only, and the
+        // wizard must promise exactly what the monitor will deliver.
+        MakeRepo(Path.Combine(_root, "not-a-repo"), "nested");
+
+        Assert.Equal(2, CodeFolderScout.CountRepos(_root));
+    }
+
+    [Fact]
+    public void CountRepos_MissingFolder_ReturnsZero()
+    {
+        Assert.Equal(0, CodeFolderScout.CountRepos(Path.Combine(_root, "gone")));
+    }
+
+    [Fact]
+    public void IsItselfARepository_GitDirectoryOrWorktreeFile()
+    {
+        var repo = MakeRepo(_root, "checkout");
+        Assert.True(CodeFolderScout.IsItselfARepository(repo));
+
+        var worktree = Path.Combine(_root, "wt");
+        Directory.CreateDirectory(worktree);
+        File.WriteAllText(Path.Combine(worktree, ".git"), "gitdir: elsewhere");
+        Assert.True(CodeFolderScout.IsItselfARepository(worktree));
+
+        Assert.False(CodeFolderScout.IsItselfARepository(Path.Combine(_root, "not-a-repo-here")));
+        Directory.CreateDirectory(Path.Combine(_root, "plain"));
+        Assert.False(CodeFolderScout.IsItselfARepository(Path.Combine(_root, "plain")));
+    }
+
+    [Fact]
+    public void ResolveBrowsedFolder_BaseFolderWithRepos_IsKeptAsIs()
+    {
+        MakeRepo(_root, "alpha");
+        Assert.Equal(Path.GetFullPath(_root), CodeFolderScout.ResolveBrowsedFolder(_root));
+    }
+
+    [Fact]
+    public void ResolveBrowsedFolder_SingleRepository_ResolvesToItsParent()
+    {
+        // The user browsed INTO one of their repos. The roots list holds base folders and the
+        // monitor lists children, so registering the repo itself would make it invisible - the
+        // parent is the folder they meant.
+        var repo = MakeRepo(_root, "myproject");
+        Assert.Equal(Path.GetFullPath(_root), CodeFolderScout.ResolveBrowsedFolder(repo));
+    }
+
+    [Fact]
+    public void ResolveBrowsedFolder_RepoThatAlsoContainsChildRepos_IsKeptAsIs()
+    {
+        // A monorepo-style folder that is a checkout AND holds child checkouts: the user's pick
+        // wins - it verifiably yields repositories as a base folder.
+        var repo = MakeRepo(_root, "mono");
+        MakeRepo(repo, "sub");
+        Assert.Equal(Path.GetFullPath(repo), CodeFolderScout.ResolveBrowsedFolder(repo));
+    }
+
+    [Fact]
+    public async Task ScanAsync_StreamsOnlyCandidatesThatHoldRepositories()
+    {
+        // CandidateRoots() reads the real machine, so this asserts the CONTRACT of what it streams:
+        // every suggestion must exist and verifiably hold at least one repository by the one-level rule.
+        var seen = new List<CodeFolderSuggestion>();
+        var progress = new SyncProgress(seen);
+
+        await CodeFolderScout.ScanAsync(progress, CancellationToken.None);
+
+        foreach (var s in seen)
+        {
+            Assert.True(Directory.Exists(s.Path));
+            Assert.True(s.RepoCount > 0);
+            Assert.Equal(CodeFolderScout.CountRepos(s.Path), s.RepoCount);
+        }
+    }
+
+    [Fact]
+    public async Task ScanAsync_Cancellation_StopsTheSweep()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => CodeFolderScout.ScanAsync(new SyncProgress(new List<CodeFolderSuggestion>()), cts.Token));
+    }
+
+    /// <summary>Synchronous IProgress - Progress&lt;T&gt; posts to the thread pool, which would race the assertions.</summary>
+    private sealed class SyncProgress : IProgress<CodeFolderSuggestion>
+    {
+        private readonly List<CodeFolderSuggestion> _sink;
+        public SyncProgress(List<CodeFolderSuggestion> sink) => _sink = sink;
+        public void Report(CodeFolderSuggestion value)
+        {
+            lock (_sink) _sink.Add(value);
+        }
+    }
+}

--- a/src/CcDirector.Core/Onboarding/CodeFolderScout.cs
+++ b/src/CcDirector.Core/Onboarding/CodeFolderScout.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Onboarding;
+
+/// <summary>One suggested code base folder: where it is, how many repositories it verifiably holds.</summary>
+public sealed record CodeFolderSuggestion(string Path, int RepoCount);
+
+/// <summary>
+/// Finds the folders where this machine's git repositories plausibly live, for the wizard's
+/// "Where does your code live?" step - WITHOUT ever walking a whole drive. The scan is a fixed
+/// shortlist of shallow probes:
+///
+///   1. Known developer spots under the user profile (source\repos, Projects, Code, repos, git,
+///      dev, src; plus ~/Developer on macOS).
+///   2. One top-level directory listing per fixed drive root (Windows only) keeping folders whose
+///      NAME suggests code (Repos*, Projects, Code, dev, src, git, source) - this is how
+///      D:\Repos<anything> is found by name, never by walking the drive.
+///
+/// Each candidate is then VERIFIED with the same one-level rule the product's repository monitor
+/// uses (immediate children holding a .git directory, via RemoteRepoProvider.ScanLocalRepos), so
+/// the count the wizard promises is exactly what the board and New Session will show. Only
+/// candidates with at least one repository are suggested.
+/// </summary>
+public static class CodeFolderScout
+{
+    /// <summary>Folder names that suggest code when seen at a drive root. Pure - unit-tested.</summary>
+    private static readonly Regex CodeNamePattern = new(
+        "^(repos.*|projects?|code|dev|src|git|source)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>Whether a folder NAME (not path) suggests it holds code. Pure - unit-tested.</summary>
+    public static bool NameSuggestsCode(string folderName) => CodeNamePattern.IsMatch(folderName);
+
+    /// <summary>
+    /// The candidate folders to probe, best-first, existence-filtered and deduplicated. Cheap: a
+    /// handful of existence checks plus one top-level listing per fixed drive (Windows).
+    /// </summary>
+    public static IReadOnlyList<string> CandidateRoots()
+    {
+        var candidates = new List<string>();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        if (!string.IsNullOrEmpty(home))
+        {
+            // Visual Studio's default first on Windows; the common conventions everywhere.
+            if (OperatingSystem.IsWindows())
+                candidates.Add(Path.Combine(home, "source", "repos"));
+            if (OperatingSystem.IsMacOS())
+                candidates.Add(Path.Combine(home, "Developer"));
+            foreach (var name in new[] { "Projects", "Code", "repos", "git", "dev", "src" })
+                candidates.Add(Path.Combine(home, name));
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            foreach (var drive in SafeFixedDriveRoots())
+            {
+                try
+                {
+                    foreach (var dir in Directory.GetDirectories(drive))
+                        if (NameSuggestsCode(Path.GetFileName(dir)))
+                            candidates.Add(dir);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[CodeFolderScout] cannot list {drive}: {ex.Message}");
+                }
+            }
+        }
+
+        var comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var seen = new HashSet<string>(comparer);
+        var result = new List<string>();
+        foreach (var candidate in candidates)
+        {
+            if (!Directory.Exists(candidate)) continue;
+            var full = Path.GetFullPath(candidate);
+            if (seen.Add(full))
+                result.Add(full);
+        }
+        FileLog.Write($"[CodeFolderScout] CandidateRoots -> {result.Count} folder(s)");
+        return result;
+    }
+
+    /// <summary>
+    /// Count the repositories a base folder holds, by the SAME rule the repository monitor uses to
+    /// list them (immediate children with a .git directory). The wizard must promise exactly what
+    /// the product will deliver - one rule for both sides of the number.
+    /// </summary>
+    public static int CountRepos(string root) => RemoteRepoProvider.ScanLocalRepos(root).Count;
+
+    /// <summary>Whether the folder itself is a git checkout (a .git directory or worktree .git file).</summary>
+    public static bool IsItselfARepository(string path)
+        => Directory.Exists(path)
+           && (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")));
+
+    /// <summary>
+    /// Probe every candidate and stream back the ones that verifiably hold repositories, best-first.
+    /// Each probe is one directory listing plus an existence check per child - milliseconds - and the
+    /// token bounds the whole sweep.
+    /// </summary>
+    public static Task ScanAsync(IProgress<CodeFolderSuggestion> progress, CancellationToken ct = default)
+        => Task.Run(() =>
+        {
+            foreach (var candidate in CandidateRoots())
+            {
+                ct.ThrowIfCancellationRequested();
+                var count = CountRepos(candidate);
+                if (count > 0)
+                {
+                    FileLog.Write($"[CodeFolderScout] suggest {candidate}: {count} repo(s)");
+                    progress.Report(new CodeFolderSuggestion(candidate, count));
+                }
+            }
+        }, ct);
+
+    /// <summary>
+    /// Resolve what a user-browsed folder should register as: the folder itself normally, but when
+    /// they picked a single repository (the folder IS a git checkout), its PARENT - the roots list
+    /// holds base folders, and the monitor only lists a root's children.
+    /// </summary>
+    public static string ResolveBrowsedFolder(string picked)
+    {
+        if (IsItselfARepository(picked) && CountRepos(picked) == 0)
+        {
+            var parent = Path.GetDirectoryName(Path.GetFullPath(picked).TrimEnd(Path.DirectorySeparatorChar));
+            if (!string.IsNullOrEmpty(parent))
+            {
+                FileLog.Write($"[CodeFolderScout] browsed folder is itself a repository; using parent {parent}");
+                return parent;
+            }
+        }
+        return Path.GetFullPath(picked);
+    }
+
+    private static IEnumerable<string> SafeFixedDriveRoots()
+    {
+        List<string> roots = new();
+        try
+        {
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                try
+                {
+                    if (drive.DriveType == DriveType.Fixed && drive.IsReady)
+                        roots.Add(drive.RootDirectory.FullName);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[CodeFolderScout] drive probe failed: {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CodeFolderScout] GetDrives failed: {ex.Message}");
+        }
+        return roots;
+    }
+}


### PR DESCRIPTION
Part of the first-run setup wizard epic thefrederiksen/devthrottle_internal#926. This completes all seven screens and reframes the wizard from a configuration form into an onboarding journey.

## The journey

Every screen now carries an eyebrow naming its beat in one story - YOUR WORKFORCE, WHAT WE WATCH OVER, SHOW DON'T TYPE, WITH YOU EVERYWHERE, THE PAYOFF - so each ask explains WHY it matters: DevThrottle is not a multi-agent runner, it is the system that keeps the books on your week (branches, worktrees, unmerged work, sessions waiting on you) and reports back every morning so Friday never surprises you.

- **Welcome:** short founder note (two sentences, quiet Read more) making the promise personal without delaying "Set me up".
- **Code (new):** "Where does your code live?" - shallow scout scan, never a drive walk: profile developer spots plus one top-level listing per fixed drive keeping name-matched folders (Repos*, Projects, Code, dev, src, git, source); each suggestion verified and counted with the SAME one-level rule the repository monitor uses, so the promised count is exactly what the board and New Session will show. Add per suggestion, Browse for anything else (browsing into a single repository resolves to its parent), proof total, persists to the same root-directories store Settings reads. Works on Windows and macOS (~/Developer included; no drive-root scanning on Mac).
- **Morning report (new):** the promise screen - Daily (default) / Weekly / No report cadence cards, persisted to config for the report sender to honor when it ships; plainly notes the report travels through the gateway when none is connected.
- **Done:** the journey's landing - full receipt (repositories, screenshots, gateway, report cadence) and the close: start something small; tomorrow morning DevThrottle reports back.

## Proof

- 88 wizard-related Core tests pass, including 24 new CodeFolderScout tests on real temporary directories (name classification, one-level counting, browsed-repo parent resolution, streaming contract, cancellation).
- Smoke-verified on a fresh profile: all seven steps construct (steps=[Welcome,Agents,Code,Screenshots,Gateway,MorningReport,Done]) and the wizard opens on Welcome.