### PR TITLE
feat(gateway+web): client error channel - every on-screen browser error also lands in the Gateway log

### DIFF
--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -7,6 +7,7 @@ import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { configureEnrollment, COCKPIT_ENROLLMENT_PROFILE } from "@devthrottle/client-core/auth/enrollRequest";
 import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
+import { installGlobalErrorReporting } from "@devthrottle/client-core/errors/reportClientError";
 import { registerCockpitServiceWorker } from "./push/registerSw";
 import { AppShell } from "./AppShell";
 import { NotFound } from "./panes/NotFound";
@@ -65,6 +66,11 @@ ensureGatewayCookie();
 // instead of the retired /login token wall (issue #1088: a revoke returns the browser to the shared
 // sign-in flow, never to login.html).
 configureUnauthorizedRedirect(cockpitSignInRedirect);
+
+// The client error channel: uncaught browser errors and un-awaited promise failures are reported to
+// the Gateway (POST /client-errors) so they land in the server log - no error exists only in a user's
+// devtools console. Pages that handle and render errors report those explicitly at their call sites.
+installGlobalErrorReporting("cockpit");
 
 // Browser notifications (issue #1257): register the Cockpit's push service worker, then - only if the
 // user already granted notification permission on a previous visit - silently refresh this browser's

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -55,6 +55,8 @@ const devProxy = proxyTarget
       // keep-warm ping reuses Car Mode's POST /carmode/warmup.
       "/assistant": { target: proxyTarget, changeOrigin: true },
       "/carmode": { target: proxyTarget, changeOrigin: true },
+      // The client error channel: on-screen and uncaught errors report to the Gateway log.
+      "/client-errors": { target: proxyTarget, changeOrigin: true },
       "/lists": { target: proxyTarget, changeOrigin: true },
       "/account": { target: proxyTarget, changeOrigin: true },
       "/gateway": { target: proxyTarget, changeOrigin: true },

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -20,6 +20,7 @@ import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { ensureGatewayCookie, configureUnauthorizedRedirect, mobileSignInRedirect } from "@devthrottle/client-core/api/client";
 import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
+import { installGlobalErrorReporting } from "@devthrottle/client-core/errors/reportClientError";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { ConnectionBanner } from "./components/ConnectionBanner";
 import { useVisibleViewportHeight } from "./hooks/useVisibleViewportHeight";
@@ -99,6 +100,11 @@ ensureGatewayCookie();
 // so the desktop Cockpit can install its own /signin flow instead (issues #1024/#1088); installing it
 // here explicitly keeps the mobile shell self-documenting about its own re-gate entry.
 configureUnauthorizedRedirect(mobileSignInRedirect);
+
+// The client error channel: uncaught browser errors and un-awaited promise failures are reported to
+// the Gateway (POST /client-errors) so they land in the server log - no error exists only on the
+// phone's screen. Pages that handle and render errors report those explicitly at their call sites.
+installGlobalErrorReporting("mobile");
 
 // If the user already granted notification permission on a previous visit, silently refresh the push
 // subscription so the Gateway's record stays current (subscriptions can rotate). Never prompts here -

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -31,6 +31,8 @@ const devProxy = proxyTarget
       "/carmode": { target: proxyTarget, changeOrigin: true },
       // The Assistant screen: its turn calls POST /assistant/turn (keep-warm reuses /carmode/warmup above).
       "/assistant": { target: proxyTarget, changeOrigin: true },
+      // The client error channel: on-screen and uncaught errors report to the Gateway log.
+      "/client-errors": { target: proxyTarget, changeOrigin: true },
       "/stats": { target: proxyTarget, changeOrigin: true },
       "/healthz": { target: proxyTarget, changeOrigin: true },
       "/diag": { target: proxyTarget, changeOrigin: true },

--- a/packages/client-core/src/assistant/useAssistant.ts
+++ b/packages/client-core/src/assistant/useAssistant.ts
@@ -16,6 +16,7 @@ import { blobToWav16kMono } from "../dictation/wav";
 import { playClip } from "../carmode/audioPlayback";
 import { postCarModeWarmup, speakCarModeText, transcribeCarModeAudio } from "../carmode/carModeApi";
 import { gatewayErrorMessage } from "../api/client";
+import { reportClientError } from "../errors/reportClientError";
 import { assistantTurn } from "./assistantApi";
 import { appendEntry, awaitingConfirmation, type AssistantEntry } from "./transcript";
 
@@ -99,6 +100,11 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
   }, [abandonCapture]);
 
   const push = useCallback((entry: AssistantEntry) => {
+    // Enterprise logging rule: every error this screen SHOWS is also REPORTED - the on-screen text and
+    // the Gateway log can never disagree about what the user saw, and no one has to read a screen back.
+    if (entry.role === "error") {
+      reportClientError("assistant", typeof window !== "undefined" ? window.location.pathname : "", entry.text);
+    }
     setEntries((cur) => appendEntry(cur, entry));
   }, []);
 

--- a/packages/client-core/src/errors/reportClientError.test.ts
+++ b/packages/client-core/src/errors/reportClientError.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { admitReport, resetReportWindow } from "./reportClientError";
+
+describe("client error report rate cap", () => {
+  beforeEach(() => resetReportWindow());
+
+  it("admits up to the cap within one minute, then drops", () => {
+    const t0 = 1_000_000;
+    let admitted = 0;
+    for (let i = 0; i < 60; i++) {
+      if (admitReport(t0 + i * 10)) admitted++;
+    }
+    expect(admitted).toBe(20);
+  });
+
+  it("a new minute opens a fresh window", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < 30; i++) admitReport(t0);
+    expect(admitReport(t0 + 60_000)).toBe(true);
+  });
+
+  it("a render-loop burst cannot exceed the cap even across repeated calls", () => {
+    const t0 = 5_000_000;
+    let admitted = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (admitReport(t0 + i)) admitted++;
+    }
+    expect(admitted).toBe(20);
+  });
+});

--- a/packages/client-core/src/errors/reportClientError.ts
+++ b/packages/client-core/src/errors/reportClientError.ts
@@ -1,0 +1,97 @@
+// The browser side of the client error channel (client error logging build): every error a shell shows
+// the user - and every uncaught browser error - is ALSO reported to the Gateway (POST /client-errors),
+// where it lands in the server log and the tenant's queryable recent ring. Before this, a browser error
+// existed only on the user's screen and in devtools, and an agent had to ask the user to read it back.
+//
+// Design constraints, all deliberate:
+// - FIRE-AND-FORGET and swallow-everything: reporting an error must never throw, never block the UI,
+//   and never itself become an error the user sees. A raw fetch with keepalive (NOT gatewayFetch: a
+//   report during a bad connection must not feed the connection-health store or retry machinery).
+// - CLIENT-SIDE rate cap in addition to the server's: an error thrown in a render loop would otherwise
+//   fire hundreds of identical reports a second before the server ever saw the first.
+// - The report carries what a debugging agent needs (surface, page, message, detail, stack) and nothing
+//   personal beyond it.
+
+import { authHeaders } from "../api/client";
+
+/** Client-side cap: at most this many reports per minute; the rest are counted and dropped. The server
+ *  enforces its own cap too - this one exists so a render-loop error does not even leave the browser. */
+const MAX_REPORTS_PER_MINUTE = 20;
+
+let windowStartMs = 0;
+let reportsInWindow = 0;
+let droppedInWindow = 0;
+
+/** Decide whether one more report may leave the browser this minute. Exported for unit tests. */
+export function admitReport(nowMs: number): boolean {
+  if (nowMs - windowStartMs >= 60_000) {
+    windowStartMs = nowMs;
+    reportsInWindow = 0;
+    droppedInWindow = 0;
+  }
+  if (reportsInWindow < MAX_REPORTS_PER_MINUTE) {
+    reportsInWindow++;
+    return true;
+  }
+  droppedInWindow++;
+  if (droppedInWindow === 1) {
+    console.warn("[client-errors] rate cap reached; further reports this minute stay local");
+  }
+  return false;
+}
+
+/** Reset the rate window (unit tests only). */
+export function resetReportWindow(): void {
+  windowStartMs = 0;
+  reportsInWindow = 0;
+  droppedInWindow = 0;
+}
+
+/**
+ * Report one error the user was shown (or an uncaught one) to the Gateway. Never throws; never blocks.
+ * `surface` is the app plus area ("cockpit-assistant", "mobile-global"); `page` is the current route.
+ */
+export function reportClientError(surface: string, page: string, message: string, err?: unknown): void {
+  try {
+    if (!admitReport(Date.now())) return;
+    const detail = err instanceof Error ? `${err.name}: ${err.message}` : err !== undefined ? String(err) : "";
+    const stack = err instanceof Error && typeof err.stack === "string" ? err.stack : "";
+    void fetch("/client-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ surface, page, message, detail, stack }),
+      keepalive: true,
+    }).catch(() => {
+      // Unreachable Gateway: nothing to do - the error is already on screen, and reporting must not
+      // create follow-on noise. The server-side record simply does not exist for this one.
+    });
+  } catch {
+    // Reporting is best-effort by definition; swallowing here is the contract, not a shortcut.
+  }
+}
+
+let globalInstalled = false;
+
+/**
+ * Install the app-wide catchers for errors NOBODY handled: window "error" (uncaught throw) and
+ * "unhandledrejection" (un-awaited promise failure). Call once from the shell's entry point. Errors a
+ * page handles and renders keep their own explicit reportClientError call sites - the global hook is
+ * the net under everything else, not a replacement for them.
+ */
+export function installGlobalErrorReporting(surface: string): void {
+  if (globalInstalled || typeof window === "undefined") return;
+  globalInstalled = true;
+  window.addEventListener("error", (event) => {
+    reportClientError(
+      `${surface}-global`,
+      window.location.pathname,
+      event.message || "Uncaught error",
+      event.error ?? undefined,
+    );
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason: unknown = event.reason;
+    const message = reason instanceof Error ? reason.message : String(reason ?? "Unhandled promise rejection");
+    reportClientError(`${surface}-global`, window.location.pathname, message, reason);
+  });
+}

--- a/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
@@ -1,0 +1,32 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The client error channel's per-device rate gate (client error logging build): a browser error loop
+/// must not flood the Gateway log, and one device's flood must never gag another device's reports.
+/// </summary>
+public sealed class ClientErrorEndpointsTests
+{
+    [Fact]
+    public void AdmitWithinRate_CapsOneDevice_PerMinute()
+    {
+        var device = "device-" + Guid.NewGuid().ToString("N");
+        var admitted = 0;
+        for (var i = 0; i < 100; i++)
+        {
+            if (ClientErrorEndpoints.AdmitWithinRate(device)) admitted++;
+        }
+        Assert.Equal(30, admitted);
+    }
+
+    [Fact]
+    public void AdmitWithinRate_DistinctDevices_AreIndependent()
+    {
+        var deviceA = "device-" + Guid.NewGuid().ToString("N");
+        var deviceB = "device-" + Guid.NewGuid().ToString("N");
+        for (var i = 0; i < 100; i++) ClientErrorEndpoints.AdmitWithinRate(deviceA);
+        Assert.True(ClientErrorEndpoints.AdmitWithinRate(deviceB));
+    }
+}

--- a/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
@@ -1,0 +1,187 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The browser error channel (client error logging build): every error a browser app shows the user is
+/// ALSO reported here, so no on-screen error ever exists only on the user's screen. Before this, a
+/// browser exception died in the devtools console and the owner had to read error text back to an agent
+/// by hand - the opposite of the enterprise logging rule (log every error, always).
+///
+///   POST /client-errors          - a browser reports one error it just showed (or caught globally).
+///   GET  /client-errors/recent   - the CALLER'S TENANT's recent reports, newest first, so an agent can
+///                                  ask the Gateway what the owner actually saw instead of asking the owner.
+///
+/// Two records per report, on purpose:
+///  - ONE greppable FileLog line ("[ClientError] ..."), the durable record - on self-host in the local
+///    Gateway log, on hosted on the persistent Azure Files share, exactly where every other Gateway
+///    error already goes.
+///  - An in-memory per-tenant ring (the queryable convenience for GET; process-lifetime, capped). The
+///    ring is NOT the durable record and says so - the log line is.
+///
+/// Tenancy: reports and reads are partitioned by the caller's resolved tenant (403 unresolved), so one
+/// tenant's errors are never disclosed to another. The reporting device is recorded as a one-way hash of
+/// the authenticated credential - enough to tell two devices apart, never the credential itself.
+///
+/// Abuse bounds: every field is length-capped server-side, and each device is capped to a fixed number
+/// of reports per minute (a client-side error loop must not flood the log; the drop is itself logged
+/// once per window).
+/// </summary>
+internal static class ClientErrorEndpoints
+{
+    /// <summary>How many reports one tenant's ring retains (newest win). Process-lifetime only.</summary>
+    private const int RingCapacity = 300;
+
+    /// <summary>Per-device reports accepted per minute; beyond it reports are dropped (and the drop
+    ///  logged once), so a render-loop error cannot flood the Gateway log.</summary>
+    private const int MaxReportsPerDevicePerMinute = 30;
+
+    private sealed record ClientErrorRecord(
+        DateTime AtUtc, string DeviceHash, string Surface, string Page, string Message, string Detail, string Stack);
+
+    private sealed class TenantRing
+    {
+        public readonly object Lock = new();
+        public readonly Queue<ClientErrorRecord> Records = new();
+    }
+
+    private static readonly ConcurrentDictionary<TenantId, TenantRing> Rings = new();
+
+    // The per-device rate window: device hash -> (window start, count in window). Pruned lazily.
+    private static readonly ConcurrentDictionary<string, (DateTime WindowStartUtc, int Count)> RateWindows = new();
+
+    /// <summary>Body of POST /client-errors. Every field is a plain string the server caps; nothing here
+    ///  is trusted beyond being text to record.</summary>
+    public sealed class ClientErrorPost
+    {
+        public string Surface { get; set; } = "";
+        public string Page { get; set; } = "";
+        public string Message { get; set; } = "";
+        public string? Detail { get; set; }
+        public string? Stack { get; set; }
+    }
+
+    public static void Map(IEndpointRouteBuilder app, HostedTenantBoundary tenantBoundary)
+    {
+        app.MapPost("/client-errors", (HttpContext ctx, ClientErrorPost? req) =>
+        {
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (req is null || string.IsNullOrWhiteSpace(req.Message))
+                return Results.Json(new { error = "message is required" }, statusCode: StatusCodes.Status400BadRequest);
+
+            var deviceHash = CarMode.CarModeDeviceHash.Of(AuthenticatedCredential(ctx));
+            if (!AdmitWithinRate(deviceHash))
+                return Results.Json(new { recorded = false, reason = "rate limited" },
+                    statusCode: StatusCodes.Status429TooManyRequests);
+
+            var record = new ClientErrorRecord(
+                AtUtc: DateTime.UtcNow,
+                DeviceHash: deviceHash,
+                Surface: Cap(req.Surface, 40),
+                Page: Cap(req.Page, 200),
+                Message: Cap(req.Message, 500),
+                Detail: Cap(req.Detail ?? "", 2000),
+                Stack: Cap(req.Stack ?? "", 4000));
+
+            // The durable record: one greppable line in the same log every Gateway error goes to. The
+            // stack is deliberately excluded from the line (it is multi-line noise in a line-oriented
+            // log) - it stays readable on the ring.
+            FileLog.Write($"[ClientError] tenant={tenant.Value} device={record.DeviceHash} surface={record.Surface} "
+                + $"page={record.Page} message={record.Message}"
+                + (record.Detail.Length > 0 ? $" detail={record.Detail}" : ""));
+
+            var ring = Rings.GetOrAdd(tenant.Value, static _ => new TenantRing());
+            lock (ring.Lock)
+            {
+                ring.Records.Enqueue(record);
+                while (ring.Records.Count > RingCapacity) ring.Records.Dequeue();
+            }
+            return Results.Json(new { recorded = true });
+        });
+
+        app.MapGet("/client-errors/recent", (HttpContext ctx) =>
+        {
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var limit = 50;
+            if (int.TryParse(ctx.Request.Query["limit"], out var q) && q > 0) limit = Math.Min(q, RingCapacity);
+
+            ClientErrorRecord[] snapshot;
+            if (Rings.TryGetValue(tenant.Value, out var ring))
+            {
+                lock (ring.Lock) { snapshot = ring.Records.ToArray(); }
+            }
+            else
+            {
+                snapshot = Array.Empty<ClientErrorRecord>();
+            }
+            return Results.Json(new
+            {
+                // The ring is process-lifetime: an empty list means "none since the Gateway started",
+                // never "none ever". The durable record is the [ClientError] lines in the Gateway log.
+                sinceProcessStart = true,
+                errors = snapshot.Reverse().Take(limit).Select(r => new
+                {
+                    atUtc = r.AtUtc,
+                    device = r.DeviceHash,
+                    surface = r.Surface,
+                    page = r.Page,
+                    message = r.Message,
+                    detail = r.Detail.Length > 0 ? r.Detail : null,
+                    stack = r.Stack.Length > 0 ? r.Stack : null,
+                }),
+            });
+        });
+
+        FileLog.Write("[ClientErrorEndpoints] mapped /client-errors (report) + /client-errors/recent (read)");
+    }
+
+    /// <summary>Admit a report within the per-device rate window; the first drop of a window is logged so
+    ///  a flooding client is visible without the flood itself reaching the log.</summary>
+    internal static bool AdmitWithinRate(string deviceHash)
+    {
+        var now = DateTime.UtcNow;
+        var admitted = false;
+        RateWindows.AddOrUpdate(
+            deviceHash,
+            _ => { admitted = true; return (now, 1); },
+            (_, cur) =>
+            {
+                if (now - cur.WindowStartUtc >= TimeSpan.FromMinutes(1)) { admitted = true; return (now, 1); }
+                if (cur.Count < MaxReportsPerDevicePerMinute) { admitted = true; return (cur.WindowStartUtc, cur.Count + 1); }
+                if (cur.Count == MaxReportsPerDevicePerMinute)
+                {
+                    FileLog.Write($"[ClientError] device={deviceHash} exceeded {MaxReportsPerDevicePerMinute} reports/minute; dropping until the window resets");
+                    return (cur.WindowStartUtc, cur.Count + 1);
+                }
+                return cur;
+            });
+        return admitted;
+    }
+
+    private static string Cap(string value, int max)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length <= max ? trimmed : trimmed[..max];
+    }
+
+    /// <summary>The exact credential the auth gate accepted (resolved once by the gate; see
+    ///  CarModeEndpoint.AuthenticatedCredential for why this is never re-read from headers). Absent (auth
+    ///  gate off in local debug) maps to the one shared anonymous bucket.</summary>
+    private static string AuthenticatedCredential(HttpContext ctx)
+        => ctx.Items.TryGetValue(Util.AuthMiddleware.AuthenticatedCredentialItemKey, out var credential)
+            ? credential as string ?? ""
+            : "";
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2232,6 +2232,11 @@ public sealed class GatewayHost : IAsyncDisposable
                 return (tts.BaseUrl, _tenantSettingsResolver.TtsVoice(tenant, mode), _tenantSettingsResolver.TtsModel(tenant, mode), key);
             });
         Api.CarModeEndpoint.Map(_app, carModeBrain, assistantBrain, _carModeTurnCache, _carModeDiagnostics, carModeWarmup, _tenantBoundary);
+
+        // The browser error channel (client error logging build): every error a browser app shows the
+        // user is also reported here and lands in the Gateway log, tenant-partitioned, with a queryable
+        // recent ring - no on-screen error exists only on the user's screen.
+        Api.ClientErrorEndpoints.Map(_app, _tenantBoundary);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, WingmanBrainAsync);


### PR DESCRIPTION
Closes the gap where a browser error existed only on the user's screen: no client-to-Gateway error reporting existed anywhere. Adds POST /client-errors (tenant-resolved, device-attributed, length- and rate-capped, one greppable [ClientError] log line per report) and GET /client-errors/recent (the caller's tenant's recent reports, so an agent queries what the user saw instead of asking them). Client side is one implementation in client-core used by both shells: a fire-and-forget reporter with its own rate cap, global window error and unhandled-rejection catchers installed by the cockpit and mobile entry points, and the Assistant reporting every error entry it renders. Verification: Gateway groups 138/138, client-core 594/594, cockpit 176/176, all workspaces typecheck.