### PR TITLE
First-run wizard: Tools screen - the toolbelt, maintained automatically

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -212,6 +212,26 @@
                 </StackPanel>
             </Grid>
 
+            <!-- ===================== TOOLS (the toolbelt, maintained automatically) ===================== -->
+            <Grid x:Name="ToolsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="YOUR TOOLBELT" />
+                <TextBlock Grid.Row="1" x:Name="ToolsTitle" Classes="wtitle"
+                           Text="Tools, maintained for you" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,10"
+                           Text="DevThrottle ships command tools you and your agents use every day - and it installs and updates them itself. You never run an updater." />
+                <TextBlock Grid.Row="3" x:Name="ToolsStatusText" FontSize="13" FontWeight="SemiBold"
+                           Foreground="#1A7F37" HorizontalAlignment="Center" TextAlignment="Center"
+                           Margin="0,0,0,14" Text="" />
+                <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                    <StackPanel x:Name="ToolsListPanel" Spacing="6" MaxWidth="600"
+                                HorizontalAlignment="Stretch" />
+                </ScrollViewer>
+                <Button Grid.Row="5" Classes="quietLink" Content="What these tools can do"
+                        HorizontalAlignment="Center" Margin="0,10,0,0"
+                        Click="BtnToolsDocs_Click" />
+            </Grid>
+
             <!-- ===================== CODE (where your repositories live) ===================== -->
             <Grid x:Name="CodePanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="WHAT WE WATCH OVER" />

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -17,6 +17,7 @@ using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
 using CcDirector.Core.Onboarding;
 using CcDirector.Core.Settings;
+using CcDirector.Core.Tools;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Setup.Engine;
@@ -67,6 +68,13 @@ public partial class FirstRunWizardDialog : Window
     private string? _shotsSelectedPath;
     private bool _shotsDetectRan;
     private CancellationTokenSource? _shotsWatchCts;
+
+    // Tools step: the shipped cc-* toolbelt, read from the embedded manifest catalog. The screen
+    // explains that DevThrottle maintains these itself; while any are still installing it polls so
+    // rows flip to Ready live - the same state the main window's corner indicator tracks.
+    private global::Avalonia.Threading.DispatcherTimer? _toolsPollTimer;
+    private int _toolsReadyCount;
+    private int _toolsTotalCount;
 
     // Code step: the roots store the board and New Session read, the folders added this run
     // (path -> repo count, drives the proof number), and the one-shot suggestion scan.
@@ -153,15 +161,19 @@ public partial class FirstRunWizardDialog : Window
 
         WelcomePanel.IsVisible = step == WizardStep.Welcome;
         AgentsPanel.IsVisible = step == WizardStep.Agents;
+        ToolsPanel.IsVisible = step == WizardStep.Tools;
         CodePanel.IsVisible = step == WizardStep.Code;
         ScreenshotsPanel.IsVisible = step == WizardStep.Screenshots;
         GatewayPanel.IsVisible = step == WizardStep.Gateway;
         ReportPanel.IsVisible = step == WizardStep.MorningReport;
         DonePanel.IsVisible = step == WizardStep.Done;
 
-        // Leaving the Screenshots step ends any take-a-screenshot watch.
+        // Leaving the Screenshots step ends any take-a-screenshot watch; leaving Tools stops the
+        // install-progress poll.
         if (step != WizardStep.Screenshots)
             CancelScreenshotWatch();
+        if (step != WizardStep.Tools)
+            StopToolsPoll();
 
         RefreshDots();
 
@@ -187,6 +199,14 @@ public partial class FirstRunWizardDialog : Window
                 ConfigureStepSkip();
                 if (!_agentScanRan)
                     _ = ScanAgentsAsync();
+                break;
+
+            case WizardStep.Tools:
+                PrimaryButton.Content = "Continue";
+                PrimaryButton.IsVisible = true;
+                PrimaryButton.IsEnabled = true;
+                ConfigureStepSkip();
+                _ = RefreshToolsScreenAsync();
                 break;
 
             case WizardStep.Code:
@@ -629,6 +649,90 @@ public partial class FirstRunWizardDialog : Window
         FileLog.Write("[FirstRunWizardDialog] BtnDeferAgents_Click");
         _model.DeferAgents();
         Advance();
+    }
+
+    // ---- Tools step (the toolbelt, maintained automatically) ---------------------------------------
+
+    /// <summary>
+    /// Render the toolbelt from the embedded manifest catalog: every shipped tool with its one-line
+    /// description and a Ready / Installing pill. All ready ends the story in one glance; anything
+    /// still installing starts a light poll so the rows flip to Ready live while the user watches -
+    /// the promise ("maintenance is our job now") demonstrated, not described.
+    /// </summary>
+    private async Task RefreshToolsScreenAsync()
+    {
+        try
+        {
+            var catalog = await Task.Run(() => new ToolCatalogService().GetCatalog());
+            _toolsTotalCount = catalog.Count;
+            _toolsReadyCount = catalog.Count(t => t.IsAvailable);
+
+            ToolsTitle.Text = $"{_toolsTotalCount} tools, maintained for you";
+
+            ToolsListPanel.Children.Clear();
+            foreach (var tool in catalog)
+            {
+                ToolsListPanel.Children.Add(AgentRow(
+                    tool.Name,
+                    tool.Description,
+                    tool.IsAvailable ? "Ready" : "Installing...",
+                    ready: tool.IsAvailable));
+            }
+
+            if (_toolsReadyCount == _toolsTotalCount)
+            {
+                ToolsStatusText.Text = $"All {_toolsTotalCount} tools are installed and up to date.";
+                ToolsStatusText.Foreground = Brush("#1A7F37");
+                StopToolsPoll();
+            }
+            else
+            {
+                ToolsStatusText.Text =
+                    $"{_toolsReadyCount} of {_toolsTotalCount} ready - DevThrottle is installing the rest now. It finishes on its own; you don't have to wait.";
+                ToolsStatusText.Foreground = Brush("#0066B8");
+                StartToolsPoll();
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] RefreshToolsScreenAsync FAILED: {ex.Message}");
+            ToolsStatusText.Text = $"Could not read the tool catalog: {ex.Message}";
+            ToolsStatusText.Foreground = Brush("#DC2626");
+        }
+    }
+
+    private void StartToolsPoll()
+    {
+        if (_toolsPollTimer is not null) return;
+        FileLog.Write("[FirstRunWizardDialog] StartToolsPoll");
+        _toolsPollTimer = new global::Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(2),
+        };
+        _toolsPollTimer.Tick += (_, _) => _ = RefreshToolsScreenAsync();
+        _toolsPollTimer.Start();
+    }
+
+    private void StopToolsPoll()
+    {
+        if (_toolsPollTimer is null) return;
+        FileLog.Write("[FirstRunWizardDialog] StopToolsPoll");
+        _toolsPollTimer.Stop();
+        _toolsPollTimer = null;
+    }
+
+    private void BtnToolsDocs_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnToolsDocs_Click");
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://devthrottle.com/docs/tools") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnToolsDocs_Click FAILED: {ex.Message}");
+            ToolsStatusText.Text = "Could not open the browser. Visit devthrottle.com/docs/tools manually.";
+        }
     }
 
     // ---- Code step (where your repositories live) --------------------------------------------------
@@ -1264,6 +1368,14 @@ public partial class FirstRunWizardDialog : Window
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 "No gateway", "Connect one from Settings for phone access and your morning report", done: false));
 
+        // Tools row (only when the Tools screen was seen, so the numbers are real).
+        if (_toolsTotalCount > 0)
+        {
+            DoneReceiptPanel.Children.Add(_toolsReadyCount == _toolsTotalCount
+                ? ReceiptRow($"{_toolsTotalCount} tools ready", "Installed and kept current automatically", done: true)
+                : ReceiptRow("Tools installing", "Finishes on its own in the background", done: false));
+        }
+
         // Morning report row - the promise, restated on the receipt.
         DoneReceiptPanel.Children.Add(_reportCadence switch
         {
@@ -1347,6 +1459,7 @@ public partial class FirstRunWizardDialog : Window
         _claudeInstallCts?.Cancel();
         _shotsWatchCts?.Cancel();
         _codeScanCts?.Cancel();
+        StopToolsPoll();
         if (!_marked)
         {
             FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (window closed without finishing)");

--- a/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
@@ -123,11 +123,14 @@ public class FirstRunWizardModelTests
     }
 
     [Fact]
-    public void CreateFull_HasAllSevenStepsInCanonicalOrder()
+    public void CreateFull_HasAllEightStepsInCanonicalOrder()
     {
         var model = FirstRunWizardModel.CreateFull();
         Assert.Equal(FirstRunWizardModel.CanonicalOrder, model.Steps);
-        Assert.Equal(7, model.Count);
+        Assert.Equal(8, model.Count);
+
+        // Tools sits right after Agents: workforce first, then their toolbelt.
+        Assert.Equal(WizardStep.Tools, model.Steps[2]);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
+++ b/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
@@ -13,6 +13,7 @@ public enum WizardStep
 {
     Welcome,
     Agents,
+    Tools,
     Code,
     Screenshots,
     Gateway,
@@ -55,6 +56,7 @@ public sealed class FirstRunWizardModel
     {
         WizardStep.Welcome,
         WizardStep.Agents,
+        WizardStep.Tools,
         WizardStep.Code,
         WizardStep.Screenshots,
         WizardStep.Gateway,


### PR DESCRIPTION
Part of the first-run setup wizard epic thefrederiksen/devthrottle_internal#926. Adds the eighth journey screen, between Agents and Code.

## What changed

- **New Tools screen (eyebrow: YOUR TOOLBELT):** lists the nine shipped cc-* tools (cc-pdf, cc-html, cc-word, cc-vault, cc-image, cc-gmail, cc-outlook, cc-playwright, cc-devthrottle) with the one-line description each carries in the embedded manifest catalog, plus a Ready / Installing pill per tool. One message, kept short: DevThrottle installs and updates these itself - you never run an updater. No off switch mentioned (none exists yet, deliberately).
- **Live proof, not prose:** all current -> one green "All 9 tools are installed and up to date" and the screen costs two seconds. Anything still installing -> "N of M ready - it finishes on its own, you don't have to wait", with a two-second poll flipping rows to Ready live while the user watches.
- **No new machinery:** the list and availability come from ToolCatalogService - the same catalog the Tools dashboard and the corner sync indicator trust - so the screen cannot drift from what actually ships.
- Quiet "What these tools can do" link to devthrottle.com/docs/tools (verified live, returns 200).
- Done receipt gains a tools row; WizardStep.Tools joins the canonical order (eight steps); model tests updated and extended.

## Proof

- 88 wizard-related Core tests pass (canonical-order test now pins Tools right after Agents).
- Smoke-verified on a fresh profile: steps=[Welcome,Agents,Tools,Code,Screenshots,Gateway,MorningReport,Done], opens on Welcome.