### PR TITLE
fix(assistant): shared dictation control, centred mode toggle, big chooser when blank

### DIFF
--- a/apps/cockpit/src/assistant/AssistantView.test.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within, cleanup } from "@testing-library/react";
+
+// Regression tests for the three Assistant screen complaints (owner report, this branch):
+//
+//   1. The recording button did not use the shared dictation control. Speaking a question was a bare
+//      round microphone button that turned red: no level bars, no elapsed timer, no Pause to check the
+//      words, and no way out of a recording except sending it. It now opens the SHARED
+//      DictationDialog - the same control the session composer's Speak button opens - and hands that
+//      dialog's Send text to the turn machine.
+//   2. The Chat / Voice toggle sat in the top-right corner, where (on the phone) the fixed network
+//      status pill landed on top of it. The toggle is no longer cornered: the blank screen shows it
+//      big in the MIDDLE, and once a conversation exists it is the header's compact control.
+//   3. On the blank screen the toggle was a 13px pill in the chrome. Blank is exactly when choosing
+//      how to ask is the only decision on the screen, so it renders large and centred there.
+//
+// Revert-proof: put the mic button back on an inline recorder (the old startTalk path) and test 2
+// finds no "Dictate" dialog; drop the large empty-state chooser and test 1 finds no large tablist.
+
+const { assistantTurn, postCarModeWarmup, transcribeUtterance } = vi.hoisted(() => ({
+  assistantTurn: vi.fn(async () => ({ spoken: "Four sessions are open.", actions: [], pendingConfirmation: false })),
+  postCarModeWarmup: vi.fn(async () => {}),
+  transcribeUtterance: vi.fn(async () => "how many sessions are open"),
+}));
+
+// The brain (POST /assistant/turn) and the keep-warm ping.
+vi.mock("@devthrottle/client-core/assistant/assistantApi", () => ({ assistantTurn }));
+vi.mock("@devthrottle/client-core/carmode/carModeApi", () => ({
+  postCarModeWarmup,
+  speakCarModeText: vi.fn(async () => new Blob(["audio"])),
+}));
+
+// The Gateway client boundary. transcribeUtterance is the dictation dialog's tenant-aware
+// transcription; authHeaders is what the client error channel reads.
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  transcribeUtterance,
+  authHeaders: () => ({}),
+  gatewayErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+// Mic + audio-decode boundaries jsdom cannot provide (same fakes as the composer Speak test). The
+// recorder fires onCaptureLive on start so the dialog reaches RECORDING without a real microphone, and
+// a 1000 ms clip that decodes to 1.0 s means zero capture deficit, so Send commits instead of parking
+// on a dropped-audio warning.
+vi.mock("@devthrottle/client-core/dictation/recorder", () => {
+  class MicRecorder {
+    onCaptureLive: (() => void) | null = null;
+    lastRecordedMs = 1000;
+    async start() {
+      this.onCaptureLive?.();
+    }
+    async stop() {
+      return new Blob(["clip"], { type: "audio/webm" });
+    }
+    level() {
+      return 0;
+    }
+    dispose() {}
+  }
+  return { MicRecorder, rmsLevel: () => 0 };
+});
+vi.mock("@devthrottle/client-core/dictation/wav", () => ({
+  blobToWav16kMono: async () => ({ wav: new Blob(["wav"]), decodedSeconds: 1, sourceBytes: 1000 }),
+}));
+vi.mock("@devthrottle/client-core/dictation/readyCue", () => ({
+  playReadyCue: () => {},
+  primeCueAudio: () => {},
+  releaseCueAudio: () => {},
+  startThinkingCue: () => () => {},
+  playYourTurnCue: () => {},
+}));
+
+import { AssistantView } from "./AssistantView";
+
+describe("Assistant screen", () => {
+  // This project does not run vitest with globals, so testing-library's auto-cleanup is off: without
+  // this every render stacks in the same document and the queries find two of everything.
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom has no requestAnimationFrame; the dictation dialog's display-only equalizer loop uses it.
+    globalThis.requestAnimationFrame = (() => 0) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+    // The turn id. jsdom's crypto has getRandomValues but not always randomUUID.
+    if (typeof globalThis.crypto?.randomUUID !== "function") {
+      Object.defineProperty(globalThis.crypto, "randomUUID", { value: () => "11111111-1111-4111-8111-111111111111", configurable: true });
+    }
+  });
+
+  it("offers ONE Chat / Voice control on the blank screen, big and in the middle - not a small pill in a corner", () => {
+    render(<AssistantView />);
+
+    const toggle = screen.getByRole("tablist", { name: "Assistant mode" });
+    // The large variant: a wide, centred target in the empty state (52px-tall halves), not the 13px
+    // header pill the owner could barely hit.
+    expect(toggle.classList.contains("asst-mode-large")).toBe(true);
+    // Exactly one such control - the header's compact copy stands down while the screen is blank, so
+    // there are never two live Chat / Voice controls to choose between.
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+    expect(screen.getByRole("tab", { name: "Chat" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Voice" })).toBeTruthy();
+  });
+
+  it("switching to Voice keeps the choice reachable and changes what the screen offers", () => {
+    render(<AssistantView />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Voice" }));
+
+    expect(screen.getByRole("tab", { name: "Voice" }).getAttribute("aria-selected")).toBe("true");
+    // Voice mode replaces the typing composer with the press-to-speak dock.
+    expect(screen.queryByPlaceholderText(/Ask about your fleet/i)).toBeNull();
+    expect(screen.getByText(/Press to speak/i)).toBeTruthy();
+  });
+
+  it("the microphone opens the SHARED dictation control - level bars, timer, Cancel and Send - and its Send asks the fleet", async () => {
+    render(<AssistantView />);
+
+    fireEvent.click(screen.getByTitle("Dictate your question"));
+
+    // The shared control, not a button that merely turns red: the dictation dialog, in RECORDING, with
+    // its equalizer bars, its elapsed timer, and a way OUT of the recording (Cancel).
+    const dialog = await screen.findByRole("dialog", { name: "Dictate" });
+    await within(dialog).findByText("RECORDING");
+    expect(dialog.querySelectorAll(".dictate-eq-bar")).toHaveLength(9);
+    expect(dialog.querySelector(".dictate-timer")?.textContent).toBe("0:00");
+    expect(within(dialog).getByText("Cancel")).toBeTruthy();
+    expect(within(dialog).getByText("Insert")).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByText("Send"));
+
+    // The dictated words are transcribed through the one Gateway transcription path and asked as a turn.
+    await waitFor(() => expect(assistantTurn).toHaveBeenCalledWith("how many sessions are open", expect.any(String)));
+    expect(transcribeUtterance).toHaveBeenCalledTimes(1);
+
+    // The dialog closes, the answer lands, and the mode control is still there - now the header's
+    // compact copy, since the screen is no longer blank.
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Dictate" })).toBeNull());
+    await screen.findByText("Four sessions are open.");
+    const toggle = screen.getByRole("tablist", { name: "Assistant mode" });
+    expect(toggle.classList.contains("asst-mode-large")).toBe(false);
+  });
+
+  it("voice mode dictation offers no Insert - there is no box to drop the words into, Send asks straight away", async () => {
+    render(<AssistantView />);
+    fireEvent.click(screen.getByRole("tab", { name: "Voice" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Dictate your question" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Dictate" });
+    await within(dialog).findByText("RECORDING");
+    expect(within(dialog).queryByText("Insert")).toBeNull();
+    expect(within(dialog).getByText("Send")).toBeTruthy();
+  });
+});

--- a/apps/cockpit/src/assistant/AssistantView.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.tsx
@@ -1,24 +1,29 @@
 import { useCallback, useLayoutEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useAssistant, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+import { useAssistant, type AssistantMode, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
+import { joinText } from "@devthrottle/client-core/dictation/transcript";
 import { PageHeader } from "../components";
 
 // The Assistant (fleet assistant build): a fleet-level chat + voice screen that is NOT tied to any
 // session. It drives the Gateway brain at POST /assistant/turn - the desk surface of the same brain
 // Car Mode uses - so every fact on screen came from a real Gateway tool call, never from the page.
 //
-// Two modes, one conversation: Chat types, Voice talks with a BUTTON (tap to talk, tap again to
-// send - no silence detection, no end phrase) and reads every reply aloud. The transcript, the turn
-// machine, and all Gateway calls live in client-core/assistant/useAssistant; this file is layout.
+// Two modes, one conversation: Chat types, Voice talks. Speaking is the SHARED DICTATION DIALOG
+// (DictationDialog in client-core) - the same recorder the session composer's Speak button opens,
+// with equalizer bars, an elapsed timer, a Pause checkpoint, an editable transcript, and Cancel /
+// Send. It replaced a bare round microphone button that just turned red: no level meter, no timer,
+// and no way to back out once it was recording. Voice mode also reads every reply aloud.
+//
+// The transcript, the turn machine, and all Gateway calls live in client-core/assistant/useAssistant;
+// this file is layout.
 
 const PHASE_LINE: Record<AssistantPhase, string> = {
   idle: "",
-  listening: "Listening... tap again when you are done.",
-  transcribing: "Transcribing...",
   thinking: "Checking the fleet...",
   speaking: "Reading the answer aloud...",
 };
 
-/** The tap-to-talk microphone glyph, drawn on the shared 24x24 / 2px-stroke grid the rail icons use. */
+/** The dictate microphone glyph, drawn on the shared 24x24 / 2px-stroke grid the rail icons use. */
 function MicGlyph() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"
@@ -30,6 +35,27 @@ function MicGlyph() {
   );
 }
 
+/** The one Chat / Voice control, rendered small in the page header and BIG in the middle of the empty
+ *  state - where nothing has been asked yet, so picking how to ask is the only thing to do on the
+ *  screen and it is worth a real target instead of a 13px pill up in the chrome. */
+function ModeToggle({ mode, setMode, large = false }: {
+  mode: AssistantMode;
+  setMode: (mode: AssistantMode) => void;
+  large?: boolean;
+}) {
+  return (
+    <div className={large ? "asst-mode asst-mode-large" : "asst-mode"} role="tablist"
+      aria-label="Assistant mode">
+      <button type="button" role="tab" aria-selected={mode === "chat"}
+        className={mode === "chat" ? "asst-mode-btn active" : "asst-mode-btn"}
+        onClick={() => setMode("chat")}>Chat</button>
+      <button type="button" role="tab" aria-selected={mode === "voice"}
+        className={mode === "voice" ? "asst-mode-btn active" : "asst-mode-btn"}
+        onClick={() => setMode("voice")}>Voice</button>
+    </div>
+  );
+}
+
 export function AssistantView() {
   // The permanently-mounted, hidden audio element read-aloud plays on (the mobile Voice pattern:
   // never unmounted, so a mode switch or re-render cannot orphan live audio).
@@ -38,6 +64,8 @@ export function AssistantView() {
   const { entries, phase, mode, setMode, busy, confirmOffered } = assistant;
 
   const [draft, setDraft] = useState("");
+  // Whether the shared dictation dialog is open. It owns the microphone the whole time it is up.
+  const [dictating, setDictating] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const atBottomRef = useRef(true);
 
@@ -67,31 +95,34 @@ export function AssistantView() {
     }
   }, [send]);
 
-  const toggleTalk = useCallback(() => {
-    if (phase === "listening") assistant.endTalk();
-    else assistant.startTalk();
-  }, [assistant, phase]);
+  // Insert (chat mode only): the dictated words land in the composer to edit instead of being asked
+  // straight away. joinText is the one transformation allowed on dictated words.
+  const onDictateInsert = useCallback((text: string) => {
+    setDraft((cur) => joinText(cur, text));
+  }, []);
 
   return (
     <div className="asst-page">
       <PageHeader
         title="Assistant"
         subtitle="Ask about your whole fleet - sessions, machines, credits, schedules. Not tied to any session."
-        actions={
-          <div className="asst-mode" role="tablist" aria-label="Assistant mode">
-            <button type="button" role="tab" aria-selected={mode === "chat"}
-              className={mode === "chat" ? "asst-mode-btn active" : "asst-mode-btn"}
-              onClick={() => setMode("chat")}>Chat</button>
-            <button type="button" role="tab" aria-selected={mode === "voice"}
-              className={mode === "voice" ? "asst-mode-btn active" : "asst-mode-btn"}
-              onClick={() => setMode("voice")}>Voice</button>
-          </div>
-        }
+        actions={entries.length > 0 ? <ModeToggle mode={mode} setMode={setMode} /> : undefined}
       />
 
       <div className="asst-stage">
         {entries.length === 0 ? (
           <div className="asst-empty">
+            {/* Nothing asked yet: the mode choice is the screen's one decision, so it sits big and
+                centred above the examples instead of as a small pill in the header. */}
+            <div className="asst-modepick">
+              <p className="asst-modepick-label">How do you want to ask?</p>
+              <ModeToggle mode={mode} setMode={setMode} large />
+              <p className="asst-modepick-hint">
+                {mode === "chat"
+                  ? "Type it, or press the microphone to dictate. Replies stay quiet."
+                  : "Press the microphone, speak, then Send. Replies are read aloud."}
+              </p>
+            </div>
             <p>Ask anything about your development fleet:</p>
             <ul>
               <li>"How many sessions do I have open, and is anything stuck?"</li>
@@ -151,10 +182,11 @@ export function AssistantView() {
           />
           <button
             type="button"
-            className={phase === "listening" ? "asst-round listening" : "asst-round"}
-            title={phase === "listening" ? "Tap to send what you said" : "Tap to talk"}
-            disabled={busy && phase !== "listening"}
-            onClick={toggleTalk}
+            className="asst-round"
+            title="Dictate your question"
+            aria-label="Dictate your question"
+            disabled={busy}
+            onClick={() => setDictating(true)}
           >
             <MicGlyph />
           </button>
@@ -176,18 +208,32 @@ export function AssistantView() {
           )}
           <button
             type="button"
-            className={phase === "listening" ? "asst-talkbtn listening" : "asst-talkbtn"}
-            disabled={busy && phase !== "listening"}
-            onClick={toggleTalk}
+            className="asst-talkbtn"
+            title="Dictate your question"
+            aria-label="Dictate your question"
+            disabled={busy}
+            onClick={() => setDictating(true)}
           >
             <MicGlyph />
           </button>
           <div className="asst-talkhint">
-            {phase === "listening"
-              ? "Tap again when you are done."
-              : "Tap to talk - tap again when done. Replies are read aloud."}
+            Press to speak - Pause to check the words, Send to ask. Replies are read aloud.
           </div>
         </div>
+      )}
+
+      {/* The shared dictation dialog owns the microphone while it is open. Send hands the finished
+          text to the turn machine; Insert (chat mode only) drops it in the composer to edit first.
+          onSendAudio is deliberately NOT wired - the answer appears on THIS screen, so there is
+          nothing to release the screen for (the session composer leaves it unwired for the same
+          reason, issue #1210's fix). */}
+      {dictating && (
+        <DictationDialog
+          showInsert={mode === "chat"}
+          onInsert={onDictateInsert}
+          onSend={(text) => assistant.sendText(text)}
+          onClose={() => setDictating(false)}
+        />
       )}
 
       {/* Read-aloud plays here; never unmounted (see useAssistant). */}

--- a/apps/cockpit/src/assistant/assistant.css
+++ b/apps/cockpit/src/assistant/assistant.css
@@ -32,6 +32,47 @@
   font-weight: 600;
 }
 
+/* The empty-state size: nothing has been asked yet, so picking how to ask is the screen's one
+   decision and it gets a real target in the middle instead of a 13px pill in the header. */
+.asst-mode-large {
+  width: 100%;
+  max-width: 320px;
+}
+
+.asst-mode-large .asst-mode-btn {
+  flex: 1 1 0;
+  min-height: 52px;
+  font-size: 17px;
+  font-weight: 600;
+  padding: 12px 24px;
+}
+
+/* The empty state's centred "how do you want to ask" block: the big toggle, what it means, then the
+   examples below. Centred within the empty column, which itself is left-aligned prose. */
+.asst-modepick {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0 26px;
+  text-align: center;
+}
+
+.asst-modepick-label {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.asst-modepick-hint {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 340px;
+}
+
 .asst-stage {
   flex: 1 1 auto;
   min-height: 0;
@@ -50,12 +91,17 @@
   padding: 12px 4px 12px 0;
 }
 
+/* The empty state scrolls in its own right: it now carries the big mode picker above the examples, so
+   in a short window the two together are taller than the stage. */
 .asst-empty {
   color: var(--text-dim);
   font-size: 14px;
   line-height: 1.6;
   max-width: 560px;
   padding: 24px 0;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .asst-empty ul {
@@ -218,11 +264,8 @@
   cursor: default;
 }
 
-.asst-round.listening {
-  background: var(--attention);
-  border-color: var(--attention);
-  color: #fff;
-}
+/* No "listening" state on these buttons: they OPEN the dictation dialog, which shows the recording
+   state itself (RECORDING, the timer, the bars). The button is never the recorder. */
 
 .asst-talkdock {
   flex: 0 0 auto;
@@ -253,11 +296,6 @@
   height: 32px;
 }
 
-.asst-talkbtn.listening {
-  background: var(--attention);
-  box-shadow: 0 0 0 10px rgba(241, 76, 76, 0.14), 0 0 0 22px rgba(241, 76, 76, 0.06);
-}
-
 .asst-talkbtn:disabled {
   opacity: 0.5;
   cursor: default;
@@ -266,6 +304,9 @@
 .asst-talkhint {
   color: var(--text-dim);
   font-size: 12px;
+  text-align: center;
+  max-width: 360px;
+  line-height: 1.45;
 }
 
 .asst-stopread {

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -77,13 +77,17 @@ function GatedLayout() {
   // The roster (Home, "/") also gives the pill a real home on its header row now - an inline item in the
   // middle of the bar, the same as the session screens - so the fixed overlay stands down there too. It
   // used to sit fixed in the top-right corner and land on top of the roster's filter button.
+  // The Assistant ("/assistant") is the third such screen, for the same reason: the fixed pill landed
+  // directly on its Chat / Voice toggle - a green pill over the control that decides how the whole
+  // screen behaves. It renders <StatusPill inline /> in its own bar and its toggle now owns the middle.
   const pathname = useLocation().pathname;
   const onSessionScreen = pathname.startsWith("/session/");
   const onHome = pathname === "/";
+  const onAssistant = pathname === "/assistant";
   return (
     <>
       <ConnectionBanner />
-      {!onSessionScreen && !onHome && <StatusPill />}
+      {!onSessionScreen && !onHome && !onAssistant && <StatusPill />}
       <Outlet />
     </>
   );

--- a/apps/mobile/src/pages/Assistant.tsx
+++ b/apps/mobile/src/pages/Assistant.tsx
@@ -1,23 +1,37 @@
 import { useCallback, useLayoutEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Link } from "react-router-dom";
-import { useAssistant, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+import { useAssistant, type AssistantMode, type AssistantPhase } from "@devthrottle/client-core/assistant/useAssistant";
+import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
+import { joinText } from "@devthrottle/client-core/dictation/transcript";
+import { StatusPill } from "../components/StatusPill";
 
 // The Assistant on the phone (fleet assistant build): the SAME fleet-level chat + voice screen the
 // cockpit has, as a thin phone view over the shared client-core turn machine (useAssistant). Not tied
 // to any session; every answer comes from the Gateway brain's tool calls at POST /assistant/turn.
 //
 // Distinct from Car Mode on purpose: Car Mode is hands-free driving (auto turn taking, end phrases,
-// wake lock, full-screen chrome-less). The Assistant is hands-ON: a BUTTON is the turn - tap to talk,
-// tap again to send - and chat mode types. No silence detection, no end phrase, ever.
+// wake lock, full-screen chrome-less). The Assistant is hands-ON: you press to speak and press Send
+// when you are done, and chat mode types. No silence detection, no end phrase, ever.
+//
+// Speaking a question is the SHARED DICTATION DIALOG (DictationDialog in client-core) - the same
+// recorder the Terminal, Chat and Voice-mode Respond flows open, with equalizer bars, an elapsed
+// timer, a Pause checkpoint, an editable transcript, and Cancel / Send. It replaced a bare round
+// microphone button that just turned red: no level meter, no timer, and no way to back out of a
+// recording once it had started. Its Send text goes straight into sendText().
 //
 // The screen is pinned to the ACTUALLY-VISIBLE viewport via --app-vh (the app-wide fit, published by
 // useVisibleViewportHeight in main.tsx), so the composer and the talk button are always on-screen -
 // the law every mobile session screen follows.
+//
+// The mode toggle is CENTRED, never in the top-right corner. That corner is not this screen's to
+// spend: the fixed network status pill (.net-pill) is pinned there on every screen that does not give
+// it a home of its own, and it sat directly on top of the toggle - a green pill over the one control
+// that decides how the whole screen behaves. This screen now gives the pill a real home inline in its
+// own bar (the Home and session-screen pattern; the fixed one stands down for /assistant in
+// main.tsx), and the toggle owns the middle.
 
 const PHASE_LINE: Record<AssistantPhase, string> = {
   idle: "",
-  listening: "Listening... tap again when you are done.",
-  transcribing: "Transcribing...",
   thinking: "Checking the fleet...",
   speaking: "Reading the answer aloud...",
 };
@@ -33,12 +47,35 @@ function MicGlyph() {
   );
 }
 
+/** The one Chat / Voice control, rendered small on its own centred row and BIG in the empty state -
+ *  where the screen has nothing else to say and picking how to ask is the only thing to do, so it is
+ *  worth a wide tap target in the middle instead of a 13px pill up in the chrome. */
+function ModeToggle({ mode, setMode, large = false }: {
+  mode: AssistantMode;
+  setMode: (mode: AssistantMode) => void;
+  large?: boolean;
+}) {
+  return (
+    <div className={large ? "assistant-mode assistant-mode-large" : "assistant-mode"} role="tablist"
+      aria-label="Assistant mode">
+      <button type="button" role="tab" aria-selected={mode === "chat"}
+        className={mode === "chat" ? "assistant-mode-btn active" : "assistant-mode-btn"}
+        onClick={() => setMode("chat")}>Chat</button>
+      <button type="button" role="tab" aria-selected={mode === "voice"}
+        className={mode === "voice" ? "assistant-mode-btn active" : "assistant-mode-btn"}
+        onClick={() => setMode("voice")}>Voice</button>
+    </div>
+  );
+}
+
 export function Assistant() {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const assistant = useAssistant(audioRef);
   const { entries, phase, mode, setMode, busy, confirmOffered } = assistant;
 
   const [draft, setDraft] = useState("");
+  // Whether the shared dictation dialog is open. It owns the microphone the whole time it is up.
+  const [dictating, setDictating] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const atBottomRef = useRef(true);
 
@@ -66,10 +103,11 @@ export function Assistant() {
     }
   }, [send]);
 
-  const toggleTalk = useCallback(() => {
-    if (phase === "listening") assistant.endTalk();
-    else assistant.startTalk();
-  }, [assistant, phase]);
+  // Insert (chat mode only): the dictated words land in the composer to edit instead of being asked
+  // straight away. joinText is the one transformation allowed on dictated words.
+  const onDictateInsert = useCallback((text: string) => {
+    setDraft((cur) => joinText(cur, text));
+  }, []);
 
   return (
     <div className="assistant-screen">
@@ -77,19 +115,31 @@ export function Assistant() {
         <Link className="back-link" to="/">Back</Link>
         <h1>Assistant</h1>
         <div className="assistant-bar-spacer" />
-        <div className="assistant-mode" role="tablist" aria-label="Assistant mode">
-          <button type="button" role="tab" aria-selected={mode === "chat"}
-            className={mode === "chat" ? "assistant-mode-btn active" : "assistant-mode-btn"}
-            onClick={() => setMode("chat")}>Chat</button>
-          <button type="button" role="tab" aria-selected={mode === "voice"}
-            className={mode === "voice" ? "assistant-mode-btn active" : "assistant-mode-btn"}
-            onClick={() => setMode("voice")}>Voice</button>
-        </div>
+        {/* The network pill's home on this screen - inline, so the fixed overlay stands down and
+            nothing lands on top of the mode toggle. */}
+        <StatusPill inline />
       </div>
+
+      {/* Once a conversation exists the toggle is chrome: small, centred, clear of both corners. In
+          the empty state it is the main event and renders big in the middle of the stage instead. */}
+      {entries.length > 0 && (
+        <div className="assistant-moderow">
+          <ModeToggle mode={mode} setMode={setMode} />
+        </div>
+      )}
 
       <div className="assistant-stage">
         {entries.length === 0 ? (
           <div className="assistant-empty">
+            <div className="assistant-modepick">
+              <p className="assistant-modepick-label">How do you want to ask?</p>
+              <ModeToggle mode={mode} setMode={setMode} large />
+              <p className="assistant-modepick-hint">
+                {mode === "chat"
+                  ? "Type it, or press the microphone to dictate. Replies stay quiet."
+                  : "Press the microphone, speak, then Send. Replies are read aloud."}
+              </p>
+            </div>
             <p>Ask anything about your fleet - no session needed:</p>
             <ul>
               <li>"How many sessions do I have open?"</li>
@@ -147,10 +197,11 @@ export function Assistant() {
           />
           <button
             type="button"
-            className={phase === "listening" ? "assistant-round listening" : "assistant-round"}
-            title={phase === "listening" ? "Tap to send what you said" : "Tap to talk"}
-            disabled={busy && phase !== "listening"}
-            onClick={toggleTalk}
+            className="assistant-round"
+            title="Dictate your question"
+            aria-label="Dictate your question"
+            disabled={busy}
+            onClick={() => setDictating(true)}
           >
             <MicGlyph />
           </button>
@@ -172,18 +223,31 @@ export function Assistant() {
           )}
           <button
             type="button"
-            className={phase === "listening" ? "assistant-talkbtn listening" : "assistant-talkbtn"}
-            disabled={busy && phase !== "listening"}
-            onClick={toggleTalk}
+            className="assistant-talkbtn"
+            title="Dictate your question"
+            aria-label="Dictate your question"
+            disabled={busy}
+            onClick={() => setDictating(true)}
           >
             <MicGlyph />
           </button>
           <div className="assistant-talkhint">
-            {phase === "listening"
-              ? "Tap again when you are done."
-              : "Tap to talk - tap again when done. Replies are read aloud."}
+            Press to speak - Pause to check the words, Send to ask. Replies are read aloud.
           </div>
         </div>
+      )}
+
+      {/* The shared dictation dialog owns the microphone while it is open. Send hands the finished
+          text to the turn machine; Insert (chat mode only) drops it in the composer to edit first.
+          onSendAudio is deliberately NOT wired: the answer appears on THIS screen, so there is
+          nothing to release the screen for - the same reason the Cockpit composer leaves it unwired. */}
+      {dictating && (
+        <DictationDialog
+          showInsert={mode === "chat"}
+          onInsert={onDictateInsert}
+          onSend={(text) => assistant.sendText(text)}
+          onClose={() => setDictating(false)}
+        />
       )}
 
       <audio ref={audioRef} className="assistant-audio" />

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -4128,6 +4128,18 @@ a.banner-btn {
   min-width: 0;
 }
 
+/* The Chat / Voice toggle lives in the MIDDLE, on a row of its own beneath the bar. It used to sit at
+   the right end of the bar, where the fixed network pill (.net-pill, top-right on any screen that does
+   not give it a home) landed straight on top of it - a green pill over the one control that decides how
+   this whole screen behaves. The bar now hosts the pill inline instead, and this row centres the toggle
+   clear of both corners. */
+.assistant-moderow {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 2px;
+}
+
 .assistant-mode {
   display: flex;
   border: 1px solid var(--border);
@@ -4143,12 +4155,56 @@ a.banner-btn {
   font-size: 13px;
   padding: 6px 14px;
   cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .assistant-mode-btn.active {
   background: var(--accent);
   color: #fff;
   font-weight: 600;
+}
+
+/* The empty-state size: nothing has been asked yet, so picking how to ask is the only thing to do on
+   the screen and it gets a real target instead of a 13px pill in the chrome. Each half is a full
+   44px-plus tap target (issue #1004's floor) and reads at a glance from arm's length. */
+.assistant-mode-large {
+  width: 100%;
+  max-width: 300px;
+}
+
+.assistant-mode-large .assistant-mode-btn {
+  flex: 1 1 0;
+  min-height: 52px;
+  font-size: 17px;
+  font-weight: 600;
+  padding: 12px 20px;
+}
+
+/* The empty state's centred "how do you want to ask" block: the big toggle, what it means, and then
+   the examples below it. */
+.assistant-modepick {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0 22px;
+  text-align: center;
+}
+
+.assistant-modepick-label {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.assistant-modepick-hint {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 320px;
 }
 
 .assistant-stage {
@@ -4169,11 +4225,17 @@ a.banner-btn {
   padding: 12px 2px 12px 0;
 }
 
+/* The empty state scrolls in its own right: it now carries the big mode picker above the examples, and
+   on a short phone screen the two together are taller than the stage. The screen itself is
+   overflow: hidden by law (the composer must stay on-screen), so the overflow has to be absorbed here. */
 .assistant-empty {
   color: var(--text-dim);
   font-size: 14px;
   line-height: 1.6;
   padding: 20px 4px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .assistant-empty ul {
@@ -4327,11 +4389,8 @@ a.banner-btn {
   opacity: 0.5;
 }
 
-.assistant-round.listening {
-  background: var(--attention);
-  border-color: var(--attention);
-  color: #fff;
-}
+/* No "listening" state on these buttons: they OPEN the dictation dialog, which shows the recording
+   state itself (RECORDING, the timer, the bars). The button is never the recorder. */
 
 .assistant-talkdock {
   flex: 0 0 auto;
@@ -4362,11 +4421,6 @@ a.banner-btn {
   height: 32px;
 }
 
-.assistant-talkbtn.listening {
-  background: var(--attention);
-  box-shadow: 0 0 0 10px rgba(241, 76, 76, 0.14), 0 0 0 22px rgba(241, 76, 76, 0.06);
-}
-
 .assistant-talkbtn:disabled {
   opacity: 0.5;
 }
@@ -4374,6 +4428,9 @@ a.banner-btn {
 .assistant-talkhint {
   color: var(--text-dim);
   font-size: 12px;
+  text-align: center;
+  max-width: 320px;
+  line-height: 1.45;
 }
 
 .assistant-stopread {

--- a/packages/client-core/src/assistant/useAssistant.ts
+++ b/packages/client-core/src/assistant/useAssistant.ts
@@ -1,38 +1,36 @@
 // The Assistant turn machine (fleet assistant build), shared by any shell that mounts the screen
-// (the cockpit today, the phone later - issue #1213 pattern: logic in client-core, thin JSX views).
+// (the cockpit and the phone - issue #1213 pattern: logic in client-core, thin JSX views).
 //
-// Turn-taking is A BUTTON, deliberately: tap to talk, tap again to send. No silence detection, no
-// end-phrase keyword - both were tried in Car Mode and the owner rejected them for the desk. The
-// phases are linear and visible: listening -> transcribing -> thinking -> (voice mode) speaking.
+// Turn-taking is A BUTTON, deliberately: you press to speak and press Send when you are done. No
+// silence detection, no end-phrase keyword - both were tried in Car Mode and the owner rejected them
+// for the desk. The phases this machine owns are linear and visible: thinking -> (voice) speaking.
 //
-// Reuse, do not rebuild: mic capture is the shared MicRecorder, transcode is the shared
-// blobToWav16kMono, speech-to-text is POST /wingman/transcribe, the brain is POST /assistant/turn,
-// and read-aloud is POST /wingman/tts played through the shared playClip discipline (one src
-// assignment per element, never a clobber).
+// SPEAKING A QUESTION IS THE SHARED DICTATION DIALOG, NOT A PATH IN HERE. This machine used to open
+// its own microphone (startTalk / endTalk) behind a plain round button: no level meter, no timer, no
+// pause, and no way out once it was listening except sending. That is a second, poorer microphone
+// owner sitting beside the one the rest of the product uses. The screens now mount the shared
+// DictationDialog (packages/client-core/dictation/DictationDialog) - equalizer bars, elapsed timer,
+// Pause checkpoint, editable transcript, Cancel and Send - and hand its finished text to sendText().
+// One microphone owner, one dictation look, everywhere.
+//
+// Reuse, do not rebuild: the brain is POST /assistant/turn, and read-aloud is POST /wingman/tts
+// played through the shared playClip discipline (one src assignment per element, never a clobber).
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import { MicRecorder } from "../dictation/recorder";
-import { blobToWav16kMono } from "../dictation/wav";
 import { playClip } from "../carmode/audioPlayback";
-import { postCarModeWarmup, speakCarModeText, transcribeCarModeAudio } from "../carmode/carModeApi";
+import { postCarModeWarmup, speakCarModeText } from "../carmode/carModeApi";
 import { gatewayErrorMessage } from "../api/client";
 import { reportClientError } from "../errors/reportClientError";
 import { assistantTurn } from "./assistantApi";
 import { appendEntry, awaitingConfirmation, type AssistantEntry } from "./transcript";
 
-/** Where the machine is in one turn. Idle between turns; the rest are the visible stages. */
-export type AssistantPhase = "idle" | "listening" | "transcribing" | "thinking" | "speaking";
+/** Where the machine is in one turn. Idle between turns; the rest are the visible stages. The mic
+ *  stages (listening, transcribing) are NOT here - the dictation dialog owns capture and shows its
+ *  own status, and it only reaches this machine once it has text. */
+export type AssistantPhase = "idle" | "thinking" | "speaking";
 
 /** Chat mode types (replies stay silent); voice mode talks and reads every reply aloud. */
 export type AssistantMode = "chat" | "voice";
-
-/** The one in-flight microphone capture: its recorder, its generation (stale-settle detection),
- *  and the start() promise every teardown path must let settle before disposing. */
-interface TalkCapture {
-  recorder: MicRecorder;
-  generation: number;
-  started: Promise<void>;
-}
 
 export interface UseAssistant {
   entries: AssistantEntry[];
@@ -43,15 +41,9 @@ export interface UseAssistant {
   busy: boolean;
   /** True when the brain is holding a destructive action; the screen offers Yes / Cancel. */
   confirmOffered: boolean;
-  /** Send a typed question (chat mode's Send button / Enter). No-op on blank or while busy. */
+  /** Run a turn on this text - chat mode's Send button / Enter, and the dictation dialog's Send.
+   *  No-op on blank or while busy. */
   sendText: (text: string) => void;
-  /** Start capturing a spoken question (the talk button). Throws never - a mic failure lands in
-   *  the transcript as an error entry. */
-  startTalk: () => void;
-  /** Stop capturing and run the turn (the talk button again). */
-  endTalk: () => void;
-  /** Abandon the capture without sending (Escape / leaving the screen). */
-  cancelTalk: () => void;
   /** Stop the read-aloud playback immediately ("Stop reading"). */
   stopSpeaking: () => void;
 }
@@ -66,38 +58,22 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
   const [phase, setPhase] = useState<AssistantPhase>("idle");
   const [mode, setMode] = useState<AssistantMode>("chat");
 
-  // One capture in flight, identified by its generation number (Codex review finding 3). The
-  // microphone permission prompt makes MicRecorder.start() genuinely asynchronous: a cancel, a
-  // quick second tap, or an unmount can all arrive while getUserMedia is still pending, and a
-  // recorder disposed at that moment would come alive afterwards as an invisible open microphone.
-  // Every settle path therefore checks its generation against the current one and disposes the
-  // recorder AFTER its start() promise settles - never before.
-  const talkRef = useRef<TalkCapture | null>(null);
-  const generationRef = useRef(0);
-
   const stopPlaybackRef = useRef<() => void>(() => {});
   // The mode at the moment a turn RUNS decides whether its reply is read aloud; a ref avoids the
   // stale-closure trap when the owner flips the toggle mid-turn.
   const modeRef = useRef<AssistantMode>("chat");
   modeRef.current = mode;
 
-  /** Abandon the in-flight capture, disposing the recorder only after its start() settles. */
-  const abandonCapture = useCallback(() => {
-    const talk = talkRef.current;
-    if (talk === null) return;
-    talkRef.current = null;
-    void talk.started.catch(() => {}).then(() => talk.recorder.dispose());
-  }, []);
-
   // Warm the hosted model + text-to-speech the moment the screen opens, so the first question does
   // not pay the cold start (the same keep-warm door Car Mode uses; best-effort, never throws).
+  // Leaving the screen silences any read-aloud in flight; the microphone belongs to the dictation
+  // dialog, which disposes its own recorder on unmount.
   useEffect(() => {
     void postCarModeWarmup();
     return () => {
-      abandonCapture();
       stopPlaybackRef.current();
     };
-  }, [abandonCapture]);
+  }, []);
 
   const push = useCallback((entry: AssistantEntry) => {
     // Enterprise logging rule: every error this screen SHOWS is also REPORTED - the on-screen text and
@@ -163,62 +139,6 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
     void runTurn(trimmed);
   }, [phase, runTurn]);
 
-  const startTalk = useCallback(() => {
-    if (phase !== "idle" || talkRef.current !== null) return;
-    const generation = ++generationRef.current;
-    const recorder = new MicRecorder();
-    const started = recorder.start();
-    talkRef.current = { recorder, generation, started };
-    setPhase("listening");
-    started.catch((err: unknown) => {
-      // Settle path for a start that failed (permission denied, no device). Act only if THIS capture
-      // is still the current one - endTalk/cancelTalk may have claimed it already, and their own
-      // settle handling owns the outcome then. A stale failure only disposes its own recorder.
-      if (talkRef.current?.generation !== generation) {
-        recorder.dispose();
-        return;
-      }
-      talkRef.current = null;
-      setPhase("idle");
-      push({ role: "error", text: err instanceof Error ? err.message : "The microphone could not be opened." });
-    });
-  }, [phase, push]);
-
-  const endTalk = useCallback(() => {
-    const talk = talkRef.current;
-    if (talk === null || phase !== "listening") return;
-    // Claim the capture: from here the start-failure handler above sees a stale generation and
-    // stands down, so this path owns every outcome exactly once.
-    talkRef.current = null;
-    setPhase("transcribing");
-    void (async () => {
-      try {
-        // Let start() finish before stopping - stop() on a recorder whose getUserMedia is still
-        // pending would throw AND leave the microphone to open later, unowned (finding 3).
-        await talk.started;
-        const captured = await talk.recorder.stop();
-        const { wav } = await blobToWav16kMono(captured);
-        const transcript = await transcribeCarModeAudio(wav);
-        if (transcript.length === 0) {
-          setPhase("idle");
-          push({ role: "error", text: "Nothing was heard. Tap to talk and try again." });
-          return;
-        }
-        await runTurn(transcript);
-      } catch (err) {
-        talk.recorder.dispose();
-        setPhase("idle");
-        push({ role: "error", text: gatewayErrorMessage(err) });
-      }
-    })();
-  }, [phase, push, runTurn]);
-
-  const cancelTalk = useCallback(() => {
-    if (phase !== "listening") return;
-    abandonCapture();
-    setPhase("idle");
-  }, [abandonCapture, phase]);
-
   const stopSpeaking = useCallback(() => {
     stopPlaybackRef.current();
   }, []);
@@ -238,9 +158,6 @@ export function useAssistant(audioRef: RefObject<HTMLAudioElement | null>): UseA
     busy: phase !== "idle",
     confirmOffered: awaitingConfirmation(entries) && phase === "idle",
     sendText,
-    startTalk,
-    endTalk,
-    cancelTalk,
     stopSpeaking,
   };
 }


### PR DESCRIPTION
Three things the owner reported on the Assistant screen, fixed on both surfaces (the phone screen and the cockpit screen are deliberate twins).

## 1. The recording button did not use the shared dictation control

Speaking a question was a bare round microphone button that turned red: no level meter, no elapsed timer, no way to check the words before sending, and no way out of a recording except sending it.

Both screens now open the **shared `DictationDialog`** - the same control the Terminal, the session composer and Voice mode's Respond flow open - with equalizer bars, an elapsed timer, a Pause checkpoint, an editable transcript, and Cancel / Send. Send hands the finished text to the turn machine; in chat mode Insert drops the words into the composer to edit first.

The turn machine's own microphone path (`startTalk` / `endTalk` / `cancelTalk`, and the `listening` / `transcribing` phases) is deleted. One owner holds the microphone on this screen now instead of two, and dictation looks the same here as everywhere else.

`onSendAudio` is deliberately left unwired: the answer appears on this screen, so there is nothing to release the screen for - the same reason the session composer leaves it unwired.

## 2. The mode toggle was overlaid by the green network pill

The Chat / Voice toggle sat at the right end of the phone's bar. That is exactly where the fixed network status pill (`.net-pill`, green when the connection is good) is pinned on every screen that does not give it a home of its own - so a green pill landed on top of the one control that decides how the whole screen behaves.

The Assistant now gives the pill a real home **inline in its own bar** (the same pattern Home and the session screens already use), and the fixed overlay stands down for `/assistant` in `main.tsx`. The toggle moved to the **middle**. Measured on a 390px viewport: dead centre (offset 0px), computed pill position `static`, zero overlap - blank state and conversation state both.

Adding a screen to that suppression list means the screen owns its own pill; this one renders `<StatusPill inline />` in its bar.

## 3. The toggle was tiny on the blank screen

Blank is exactly when choosing how to ask is the only decision on the screen, so the same control now renders **big and centred** there (300x54, 52px-tall halves at 17px - well over the 44px tap floor) with a line saying what each mode does. Once a conversation exists it shrinks back to a small centred row on the phone and to the page header in the cockpit, so there are never two live copies.

## Proof

Four new cockpit tests (`AssistantView.test.tsx`):

- the blank screen offers exactly one Chat / Voice control, in its large variant
- switching to Voice replaces the typing composer with the press-to-speak dock
- the microphone opens the Dictate dialog in RECORDING with nine equalizer bars, a `0:00` timer, Cancel and Insert - and its Send transcribes through the one Gateway path and reaches `POST /assistant/turn`, after which the toggle is the compact variant
- voice-mode dictation offers no Insert; Send asks straight away

Fail-on-purpose checked: removing the big empty-state chooser reddens three of them, unmounting the dictation dialog reddens two.

- cockpit: 180 passed (was 176)
- client-core: 594 passed
- typecheck clean on all three workspaces; mobile production build succeeds
- the real phone screen rendered and measured at 390x780 in three states (blank chat, blank voice, conversation)

Lint has two pre-existing errors in untouched files (`apps/cockpit/src/push/sw.test.ts`, `apps/mobile/src/pages/VoiceMode.tsx` - `eslint-disable` comments naming rules that are not installed).

Stated gap: the mobile workspace has no test harness at all (no vitest, jsdom or testing-library), so the pill-stands-down guard in `main.tsx` is covered by the measured live render rather than by an automated test. Standing up a mobile test harness is its own piece of work.
