### PR TITLE
Voice mode becomes a real switch, with the way out on every screen

### DIFF
--- a/apps/mobile/src/components/VoiceModeBanner.tsx
+++ b/apps/mobile/src/components/VoiceModeBanner.tsx
@@ -1,0 +1,44 @@
+import { useVoiceModeAll } from "@devthrottle/client-core/voice/useVoiceModeAll";
+
+// THE VOICE MODE BANNER (owner, 2026-07-24). While the fleet is in voice mode, this bar is on EVERY screen
+// of the app and carries the switch that turns it off.
+//
+// It does two jobs, and the second is the important one.
+//
+// It says which state you are in. Voice mode used to be a state nothing displayed and nothing held - you
+// worked it out by looking at the roster, or you did not know.
+//
+// And it puts the way out wherever you are. The only off switch used to be a checkbox on one tab of the
+// roster - which, with auto-speak running, is the screen you are on for three seconds between sessions.
+// Everywhere else, there was no way to stop. Making that window longer only made it a bigger window to
+// catch. A control that is present on the session screen auto-speak just dropped you into is not a window
+// at all, and that is the actual fix for "I try to stop it and it just keeps going".
+//
+// Deliberately NOT a confirmation dialog: this is the escape hatch, and an escape hatch that asks "are you
+// sure?" while a voice is talking over you is not one. Turning voice mode back on is one tap on the roster.
+export function VoiceModeBanner() {
+  const voice = useVoiceModeAll();
+
+  // Null means the first read has not landed. Render nothing rather than flash a banner that may be wrong -
+  // a banner that appears and vanishes on every app open teaches you to ignore it.
+  if (voice.enabled !== true) return null;
+
+  return (
+    <div className="voicemode-banner" role="status">
+      <span className="voicemode-dot" aria-hidden="true" />
+      <span className="voicemode-text">
+        Voice mode is on
+        <span className="voicemode-sub">Every session on the Gateway narrates its turns</span>
+        {voice.error !== null && <span className="voicemode-error">{voice.error}</span>}
+      </span>
+      <button
+        type="button"
+        className="voicemode-off"
+        onClick={() => void voice.set(false)}
+        disabled={voice.busy}
+      >
+        {voice.busy ? "Turning off..." : "Turn off"}
+      </button>
+    </div>
+  );
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -23,6 +23,7 @@ import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
 import { installGlobalErrorReporting } from "@devthrottle/client-core/errors/reportClientError";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { ConnectionBanner } from "./components/ConnectionBanner";
+import { VoiceModeBanner } from "./components/VoiceModeBanner";
 import { useVisibleViewportHeight } from "./hooks/useVisibleViewportHeight";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { useKeepWarm } from "@devthrottle/client-core/net/useKeepWarm";
@@ -87,6 +88,12 @@ function GatedLayout() {
   return (
     <>
       <ConnectionBanner />
+      {/* The voice-mode banner is mounted HERE, beside the connection banner, for one reason: it has to be
+          on every screen. While auto-speak is running you are on the roster for three seconds at a time and
+          inside a session the rest of the time, so an off switch that lives only on the roster is a window
+          to catch, not a way out. Here it is on the session screen auto-speak just dropped you into. It
+          renders nothing at all when voice mode is off. */}
+      <VoiceModeBanner />
       {!onSessionScreen && !onHome && !onAssistant && <StatusPill />}
       <Outlet />
     </>

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { setVoiceModeAllSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { getAutoSpeak, inVoiceQueueOrder, queueTouchMs, setAutoSpeak } from "@devthrottle/client-core/voice/queueTouch";
+import { useVoiceModeAll } from "@devthrottle/client-core/voice/useVoiceModeAll";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
 import { classify, contextLine, deletionReason, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
@@ -467,66 +468,69 @@ function EnableAlerts() {
   );
 }
 
-// The fleet-wide voice switch shown at the top of the Voice sessions tab (issue #1765). One control for
-// the whole round trip: while no session is in voice mode it offers "Turn on voice for all N sessions";
-// the moment any session is a voice session it offers "Turn voice off for all sessions". Tapping calls
-// the Gateway's one fan-out endpoint, which walks the roster itself, and shows a fail-loud summary of
-// what changed and what was skipped (the mobile rule: never fail silently - name the offline sessions
-// that were passed over). The next roster poll (5s) repaints each row's voice state, so the button flips
-// to its opposite.
+// The fleet-wide voice switch at the top of the Voice sessions tab (issue #1765). It shows the state the
+// GATEWAY reports and offers the opposite of it - on when off, off when on.
 //
-// KNOWN LIMIT, being fixed properly next (owner, 2026-07-24): this button decides its own direction by
-// reading the roster, so once ONE session is on voice it only ever offers OFF - a session created after
-// that cannot be switched on from here, and quietly never joins the voice queue. The real fix is for the
-// GATEWAY to hold "this tenant is in voice mode" and apply it to a session at birth, with a banner on
-// every screen of the app showing that state and carrying the off switch. That is a Gateway change and
-// its own piece of work; this button stays exactly as it was until then.
+// It used to decide its own direction by reading the roster: "does any session have voice on?". That is a
+// different question. It turns true the moment ONE session is on and stays true while nine others are off,
+// so the button flipped permanently to "turn it all off" and a session created afterwards could never be
+// switched on from here at all - it quietly never joined the voice queue, and the queue got the blame.
+//
+// Now the Gateway holds the intent, applies it to sessions as they appear, and answers "am I in voice
+// mode?" itself. This renders that answer (CLAUDE.md rule 7: the client is dumb, the Gateway owns the
+// verdict). The banner in the app shell and this control read the SAME shared state - one value, one poll -
+// so a change made in either place shows in the other immediately rather than a poll later.
 function VoiceAllControl({ sessions }: { sessions: SessionDto[] }) {
-  const [busy, setBusy] = useState(false);
+  const voice = useVoiceModeAll();
   const [note, setNote] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const anyOn = sessions.some((s) => Boolean(s.voiceMode));
-  // No session on voice yet -> the action is to turn the whole fleet ON; otherwise turn it all OFF.
-  const enable = !anyOn;
+  // The action is always the opposite of the state the Gateway reports. Before the first read lands the
+  // state is unknown, and the button says so rather than guessing a direction and acting on the guess.
+  const enable = voice.enabled !== true;
   const count = sessions.length;
 
   const onClick = async () => {
-    setBusy(true);
     setError(null);
     setNote(null);
     try {
       const result = await setVoiceModeAllSessions(enable);
+      await voice.set(enable);
       const changedLabel = `${result.changed} ${result.changed === 1 ? "session" : "sessions"} ${enable ? "on" : "off"}`;
-      setNote(result.skipped > 0 ? `${changedLabel}, ${result.skipped} skipped (computer offline)` : changedLabel);
+      // Fail loud, the mobile rule: name what was passed over. A skipped session is not lost - the
+      // Gateway's sweep picks it up when its computer comes back, because voice mode is a standing intent.
+      setNote(
+        result.skipped > 0
+          ? `${changedLabel}, ${result.skipped} skipped (computer offline - they join when it is back)`
+          : changedLabel,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not change voice mode for all sessions");
-    } finally {
-      setBusy(false);
     }
   };
 
   const label = enable
-    ? `Turn on voice for all ${count} ${count === 1 ? "session" : "sessions"}`
-    : "Turn voice off for all sessions";
-  const busyLabel = enable ? "Turning voice on..." : "Turning voice off...";
+    ? `Turn on voice mode for all ${count} ${count === 1 ? "session" : "sessions"}`
+    : "Turn voice mode off for all sessions";
+  const busyLabel = enable ? "Turning voice mode on..." : "Turning voice mode off...";
 
   return (
     <div className="voice-all">
       <p className="voice-all-line">
-        Voice mode is about the fleet: every session narrates its turns. Auto-speak, below, is about this
-        phone.
+        Voice mode is about the fleet: every session narrates its turns, including ones started later.
+        Auto-speak, below, is about this phone.
       </p>
       <button
         type="button"
         className={`voice-all-btn${enable ? "" : " voice-all-btn-off"}`}
         onClick={() => void onClick()}
-        disabled={busy}
+        disabled={voice.busy || voice.enabled === null}
       >
-        {busy ? busyLabel : label}
+        {voice.enabled === null ? "Checking voice mode..." : voice.busy ? busyLabel : label}
       </button>
       {note && <p className="voice-all-note" role="status">{note}</p>}
       {error && <p className="voice-all-error" role="alert">{error}</p>}
+      {voice.error !== null && <p className="voice-all-error" role="alert">{voice.error}</p>}
     </div>
   );
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2190,6 +2190,74 @@ a.banner-btn {
   opacity: 0.6;
 }
 
+/* THE VOICE MODE BANNER: on every screen while the fleet is in voice mode, carrying the off switch.
+   Sticky at the top so it survives scrolling - the way out must not be something you scroll past. Green,
+   matching Respond and the auto-speak checkbox, because voice mode is a working state and not a warning;
+   the "Turn off" button is the one solid thing on it, because that is what the bar is FOR. */
+.voicemode-banner {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid #14614f;
+  background: #0d2e28;
+}
+
+.voicemode-dot {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #24c39c;
+}
+
+.voicemode-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: #d8f5ec;
+}
+
+.voicemode-sub {
+  font-size: 11px;
+  font-weight: 400;
+  color: #8fc4b6;
+}
+
+.voicemode-error {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--attention);
+}
+
+/* A real thumb target (>= 44px tall), because this is the control someone reaches for while a voice is
+   talking over them and they are not looking at the screen. */
+.voicemode-off {
+  flex: 0 0 auto;
+  min-height: 44px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 10px;
+  background: #0e7c6b;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.voicemode-off:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* The standing statement of what this tab does to the fleet: every session on the Gateway is a voice
    session while you are here. Quiet - it reports a fact, it is not a call to action. */
 .voice-all-line {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10200,8 +10200,14 @@
         "marked": "^14.1.4"
       },
       "devDependencies": {
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/react": "18.3.12",
+        "@types/react-dom": "18.3.1",
+        "jsdom": "25.0.1",
         "openapi-typescript": "7.4.4",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "typescript": "5.7.2",
         "vitest": "2.1.8"
       },

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -25,8 +25,14 @@
     "react-router-dom": "^6.30.4"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
+    "jsdom": "25.0.1",
     "openapi-typescript": "7.4.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "typescript": "5.7.2",
     "vitest": "2.1.8"
   }

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -2058,11 +2058,32 @@ export interface VoiceModeAllResult {
   sessions: VoiceModeAllSessionResult[];
 }
 
+// GET /sessions/voice-mode/all - IS THIS FLEET IN VOICE MODE? The one place to ask.
+//
+// A client must never answer this for itself. The obvious local guess - "does any session have voiceMode
+// set?" - is a DIFFERENT question: it turns true the instant one session is on and stays true while nine
+// others are off. Clients guessing it that way is exactly why the fleet switch offered only "turn it all
+// off" forever, so a session created later could never be switched on, and why nothing on screen could
+// honestly say which state you were in. The Gateway holds the intent; this reads it.
+export async function getVoiceModeAllSessions(signal?: AbortSignal): Promise<boolean> {
+  const res = await gatewayFetch(`/sessions/voice-mode/all`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw new GatewayError(res.status, `GET voice-mode/all failed: ${res.status}`);
+  const body = (await res.json()) as { enabled?: unknown };
+  return Boolean(body.enabled);
+}
+
 // POST /sessions/voice-mode/all { enabled } - turn voice mode on (enabled=true) or off (false) for EVERY
 // session at once (issue #1765). The Gateway walks the whole roster and fans the per-session voice-mode
 // write out itself, so this is ONE call for the caller. Sessions whose owning computer is offline are
 // skipped and reported, never failing the batch. Enabling spends per-turn narration credits on every
 // session it switches on, so a 402 (out of credits) surfaces the shared credits notice, once.
+//
+// It is the SWITCH, not just a fan-out: the Gateway persists the intent, so a session that appears
+// afterwards is switched on too, by the Gateway's own sweep, without any client doing anything.
 export async function setVoiceModeAllSessions(enabled: boolean, signal?: AbortSignal): Promise<VoiceModeAllResult> {
   const res = await gatewayFetch(`/sessions/voice-mode/all`, {
     method: "POST",

--- a/packages/client-core/src/voice/useVoiceModeAll.test.tsx
+++ b/packages/client-core/src/voice/useVoiceModeAll.test.tsx
@@ -1,0 +1,175 @@
+// The voice-mode switch hook (owner, 2026-07-24). Voice mode is the FLEET state - every session narrates
+// its turns - and it is read from the Gateway, never derived from the roster. Auto-speak is a different
+// thing, a setting of this phone, and turning voice mode off must take it down with it.
+//
+// Two behaviours here are worth a test because both fail SILENTLY and both read, to the person holding the
+// phone, as "the app will not let me leave": a poll landing after a write and repainting the old value, and
+// auto-speak surviving voice mode being turned off so the queue drags you back in.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { getAutoSpeak, setAutoSpeak } from "./queueTouch";
+import { __resetVoiceModeAllForTests, useVoiceModeAll } from "./useVoiceModeAll";
+
+vi.mock("../api/client", () => ({
+  getVoiceModeAllSessions: vi.fn(),
+  setVoiceModeAllSessions: vi.fn(),
+}));
+
+const api = await import("../api/client");
+const getMock = api.getVoiceModeAllSessions as unknown as ReturnType<typeof vi.fn>;
+const setMock = api.setVoiceModeAllSessions as unknown as ReturnType<typeof vi.fn>;
+
+function Probe({ onReady }: { onReady: (v: ReturnType<typeof useVoiceModeAll>) => void }) {
+  const v = useVoiceModeAll();
+  onReady(v);
+  return <span data-testid="state">{v.enabled === null ? "unknown" : v.enabled ? "on" : "off"}</span>;
+}
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+  getMock.mockReset();
+  setMock.mockReset();
+  // The state is deliberately module-level (one answer for the whole app), so it must be forgotten between
+  // cases or one test's answer leaks into the next and they stop meaning anything.
+  __resetVoiceModeAllForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetVoiceModeAllForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("useVoiceModeAll", () => {
+  it("renders the Gateway's answer, and starts unknown rather than guessing", async () => {
+    let resolve: (v: boolean) => void = () => {};
+    getMock.mockReturnValue(new Promise<boolean>((r) => { resolve = r; }));
+
+    render(<Probe onReady={() => {}} />);
+    // Before the first read lands the state is UNKNOWN. A banner that guessed "off" here would flash on
+    // and off on every app open, which teaches you to ignore it.
+    expect(screen.getByTestId("state").textContent).toBe("unknown");
+
+    await act(async () => { resolve(true); });
+    expect(screen.getByTestId("state").textContent).toBe("on");
+  });
+
+  it("turning voice mode OFF also switches auto-speak off on this phone", async () => {
+    setAutoSpeak(true);
+    getMock.mockResolvedValue(true);
+    setMock.mockResolvedValue({ enabled: false, total: 0, changed: 0, skipped: 0, sessions: [] });
+
+    let hook!: ReturnType<typeof useVoiceModeAll>;
+    render(<Probe onReady={(v) => { hook = v; }} />);
+    await act(async () => {});
+
+    await act(async () => { await hook.set(false); });
+
+    // Auto-speak with nothing to speak is not a state worth being in, and leaving it armed is how someone
+    // gets dragged back into the queue they just left.
+    expect(getAutoSpeak()).toBe(false);
+    expect(screen.getByTestId("state").textContent).toBe("off");
+  });
+
+  it("turning voice mode ON leaves auto-speak alone - they are two different things", async () => {
+    setAutoSpeak(false);
+    getMock.mockResolvedValue(false);
+    setMock.mockResolvedValue({ enabled: true, total: 0, changed: 0, skipped: 0, sessions: [] });
+
+    let hook!: ReturnType<typeof useVoiceModeAll>;
+    render(<Probe onReady={(v) => { hook = v; }} />);
+    await act(async () => {});
+
+    await act(async () => { await hook.set(true); });
+
+    // Voice mode on with auto-speak off is the ORDINARY case: your sessions all speak, and you choose
+    // which one to listen to. Turning voice mode on must never arm hands-free playback by itself.
+    expect(getAutoSpeak()).toBe(false);
+    expect(screen.getByTestId("state").textContent).toBe("on");
+  });
+
+  it("a poll that started before a write does not repaint the old value AFTER the write finished", async () => {
+    // The failure this prevents: you tap "Turn off", and a poll that was already in the air lands a moment
+    // later carrying the pre-write answer and paints "voice mode is on" again. On screen that is
+    // indistinguishable from the app refusing to let you leave.
+    //
+    // The stale read must land AFTER the write completes - that is the hard case, and the one an in-flight
+    // flag alone does not catch, because by then the write is no longer in flight.
+    vi.useFakeTimers();
+    try {
+      let landStalePoll: (v: boolean) => void = () => {};
+      getMock
+        .mockReturnValueOnce(Promise.resolve(true))
+        .mockReturnValueOnce(new Promise<boolean>((r) => { landStalePoll = r; }));
+      setMock.mockResolvedValue({ enabled: false, total: 0, changed: 0, skipped: 0, sessions: [] });
+
+      let hook!: ReturnType<typeof useVoiceModeAll>;
+      render(<Probe onReady={(v) => { hook = v; }} />);
+      await act(async () => {});
+      expect(screen.getByTestId("state").textContent).toBe("on");
+
+      // The 15-second poll fires and its request goes out, still unanswered.
+      await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
+
+      // The write happens and completes while that read is still in the air.
+      await act(async () => { await hook.set(false); });
+      expect(screen.getByTestId("state").textContent).toBe("off");
+
+      // NOW the old read lands, carrying the pre-write answer.
+      await act(async () => { landStalePoll(true); });
+
+      expect(screen.getByTestId("state").textContent).toBe("off");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("two readers share ONE answer - turning it off in one place updates the other at once", async () => {
+    // The banner lives in the app shell and the switch lives on the roster, so both are on screen together.
+    // If each held its own copy with its own poll they would disagree for up to fifteen seconds: you tap
+    // "Turn off" on the banner and the roster goes on saying voice mode is on. Two copies of one truth is
+    // the same mistake as deriving the answer from the roster, just later in the stack.
+    getMock.mockResolvedValue(true);
+    setMock.mockResolvedValue({ enabled: false, total: 0, changed: 0, skipped: 0, sessions: [] });
+
+    let banner!: ReturnType<typeof useVoiceModeAll>;
+    render(
+      <>
+        <Probe onReady={(v) => { banner = v; }} />
+        <Probe onReady={() => {}} />
+      </>,
+    );
+    await act(async () => {});
+    for (const el of screen.getAllByTestId("state")) expect(el.textContent).toBe("on");
+
+    // One of them turns voice mode off; the OTHER must show it immediately, with no poll in between.
+    await act(async () => { await banner.set(false); });
+    for (const el of screen.getAllByTestId("state")) expect(el.textContent).toBe("off");
+
+    // And one shared poll serves both readers, not one poll each.
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failed write says so and does not claim the state changed", async () => {
+    getMock.mockResolvedValue(true);
+    setMock.mockRejectedValue(new Error("gateway unreachable"));
+
+    let hook!: ReturnType<typeof useVoiceModeAll>;
+    render(<Probe onReady={(v) => { hook = v; }} />);
+    await act(async () => {});
+
+    let ok = true;
+    await act(async () => { ok = await hook.set(false); });
+
+    // Silence here is the dangerous outcome: the person believes they left voice mode when they did not.
+    expect(ok).toBe(false);
+    expect(hook.error).not.toBeNull();
+    expect(screen.getByTestId("state").textContent).toBe("on");
+  });
+});

--- a/packages/client-core/src/voice/useVoiceModeAll.ts
+++ b/packages/client-core/src/voice/useVoiceModeAll.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from "react";
+import { getVoiceModeAllSessions, setVoiceModeAllSessions } from "../api/client";
+import { setAutoSpeak } from "./queueTouch";
+
+// VOICE MODE - the fleet-wide switch, read from the Gateway and never derived (owner, 2026-07-24).
+//
+// Voice mode means: every session on this Gateway narrates its turns, including sessions created after the
+// switch was thrown. It is one thing. Auto-speak is a DIFFERENT thing - a setting of this phone that also
+// opens each waiting voice session in turn and plays it without a tap. You can be in voice mode without
+// auto-speak, and that is the ordinary case.
+//
+// ONE STATE FOR THE WHOLE APP, deliberately module-level. Two components read this at once - the banner in
+// the app shell (on every screen) and the switch on the roster - and if each held its own copy with its own
+// poll they would disagree for up to a poll interval: you would tap "Turn off" on the banner and the roster
+// would go on saying voice mode was on, or turn it on from the roster and wait fifteen seconds for the
+// banner to admit it. Two copies of one truth is how the old derived-from-the-roster answer went wrong in
+// the first place; this keeps exactly one.
+//
+// The client is dumb by law (CLAUDE.md rule 7): this asks the Gateway what the state IS and renders that
+// answer. It does not look at the roster and work it out.
+const POLL_MS = 15000;
+
+let current: boolean | null = null;
+let writing = false;
+// Each read remembers the write counter it started under. A read that started BEFORE a write and lands
+// AFTER it has finished sees writing=false and would otherwise sail through carrying the pre-write answer -
+// repainting "voice mode is on" a moment after you turned it off, which on screen is indistinguishable from
+// the app refusing to let you leave. The in-flight flag alone does not catch that one.
+let writeSeq = 0;
+const listeners = new Set<(v: boolean | null) => void>();
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function publish(v: boolean | null): void {
+  current = v;
+  for (const fn of listeners) fn(v);
+}
+
+async function readOnce(): Promise<void> {
+  if (writing) return;
+  const startedUnder = writeSeq;
+  try {
+    const on = await getVoiceModeAllSessions();
+    if (!writing && writeSeq === startedUnder) publish(on);
+  } catch {
+    // A failed read leaves the last known answer standing rather than guessing a new one. An unreachable
+    // Gateway is not evidence that voice mode was turned off.
+  }
+}
+
+function subscribe(fn: (v: boolean | null) => void): () => void {
+  listeners.add(fn);
+  if (pollTimer === null) {
+    void readOnce();
+    pollTimer = setInterval(() => void readOnce(), POLL_MS);
+  }
+  return () => {
+    listeners.delete(fn);
+    if (listeners.size === 0 && pollTimer !== null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+}
+
+/** Test-only: forget the shared state between cases, so one test's answer cannot leak into the next. */
+export function __resetVoiceModeAllForTests(): void {
+  if (pollTimer !== null) clearInterval(pollTimer);
+  pollTimer = null;
+  listeners.clear();
+  current = null;
+  writing = false;
+  writeSeq = 0;
+}
+
+export interface VoiceModeAll {
+  /** Whether the fleet is in voice mode. Null until the first read lands - the banner must not flash. */
+  enabled: boolean | null;
+  /** A write is in flight. */
+  busy: boolean;
+  /** The last write failure, in plain English, or null. Never swallowed - a silent failure here means the
+   *  person believes they left voice mode when they did not. */
+  error: string | null;
+  /** Turn the whole fleet's voice mode on or off. Turning it OFF also switches auto-speak off on this
+   *  phone: auto-speak with nothing to speak is not a state worth being in, and leaving it armed is how
+   *  someone ends up dragged back into a queue they just left. */
+  set: (next: boolean) => Promise<boolean>;
+}
+
+export function useVoiceModeAll(): VoiceModeAll {
+  const [enabled, setEnabled] = useState<boolean | null>(current);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => subscribe(setEnabled), []);
+
+  const set = useCallback(async (next: boolean): Promise<boolean> => {
+    writing = true;
+    writeSeq += 1;
+    setBusy(true);
+    setError(null);
+    try {
+      await setVoiceModeAllSessions(next);
+      publish(next);
+      if (!next) setAutoSpeak(false);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not change voice mode for all sessions");
+      return false;
+    } finally {
+      writing = false;
+      setBusy(false);
+    }
+  }, []);
+
+  return { enabled, busy, error, set };
+}

--- a/packages/client-core/vitest.config.ts
+++ b/packages/client-core/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// Most of this library is pure logic and tests fine in node, which is why there was no config here at all.
+// The shared REACT HOOKS need a document to render into, so .tsx tests get jsdom and the plain .ts tests
+// keep running in node - the cheap environment stays cheap, and a hook can still be tested where it lives
+// instead of being tested from whichever app happens to import it.
+export default defineConfig({
+  test: {
+    environment: "node",
+    environmentMatchGlobs: [["**/*.test.tsx", "jsdom"]],
+  },
+});

--- a/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
@@ -166,6 +166,105 @@ public sealed class VoiceModeAllEndpointProofTests : IAsyncLifetime
         Assert.False(string.IsNullOrWhiteSpace(rejectedRow?["reason"]?.GetValue<string>()));
     }
 
+    // ---- voice mode as a STANDING SWITCH, not a one-time fan-out (owner, 2026-07-24) --------------------
+
+    [Fact]
+    public async Task VoiceModeAll_persistsTheIntent_soAClientCanReadWhichStateItIsIn()
+    {
+        // Before anyone asks for it, voice mode is off. This is the question clients used to answer for
+        // themselves by scanning the roster for any marked session - a DIFFERENT question, true the moment
+        // one session was on and still true while nine others were off.
+        var before = await _http.GetFromJsonAsync<JsonNode>("sessions/voice-mode/all");
+        Assert.False(before?["enabled"]?.GetValue<bool>());
+
+        await PushAsync(1L, Session(Guid.NewGuid().ToString(), "one"));
+        (await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true })).EnsureSuccessStatusCode();
+
+        var after = await _http.GetFromJsonAsync<JsonNode>("sessions/voice-mode/all");
+        Assert.True(after?["enabled"]?.GetValue<bool>());
+
+        (await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = false })).EnsureSuccessStatusCode();
+        var off = await _http.GetFromJsonAsync<JsonNode>("sessions/voice-mode/all");
+        Assert.False(off?["enabled"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task VoiceModeAll_recordsTheIntentEvenWhenTheFanOutCouldNotReachASession()
+    {
+        // The one session there is cannot be written. If the intent were recorded only on a fully successful
+        // fan-out, "my fleet is on voice" would silently downgrade to "the reachable part of it is" - and the
+        // sweep would never come back for the session that was skipped.
+        var unreachable = Guid.NewGuid().ToString();
+        _rejectSids.Add(unreachable);
+        await PushAsync(1L, Session(unreachable, "offline computer"));
+
+        var resp = await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true });
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal(0, node?["changed"]?.GetValue<int>());
+        Assert.Equal(1, node?["skipped"]?.GetValue<int>());
+
+        var state = await _http.GetFromJsonAsync<JsonNode>("sessions/voice-mode/all");
+        Assert.True(state?["enabled"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task Sweep_switchesOnASessionThatAPPEAREDAFTERTheSwitchWasThrown()
+    {
+        // THE BUG THIS EXISTS TO KILL. The fan-out reaches the sessions alive at that instant. A session
+        // created a minute later was never told, so it quietly never joined the voice queue - which looked
+        // like the queue losing sessions rather than what it was.
+        var existing = Guid.NewGuid().ToString();
+        await PushAsync(1L, Session(existing, "was here first"));
+        (await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true })).EnsureSuccessStatusCode();
+        Assert.Single(_commands, c => c.Verb == "voice-mode");
+
+        // A NEW session joins the roster. Nobody has told it anything.
+        var born = Guid.NewGuid().ToString();
+        await PushAsync(2L, Session(existing, "was here first"), Session(born, "born later"));
+
+        await _gateway.SweepVoiceModeAllAsync();
+
+        // The sweep sent the new one the voice-mode verb, and did NOT re-send it to the session that was
+        // already on - a steady fleet must produce no traffic.
+        var cmds = _commands.Where(c => c.Verb == "voice-mode").ToList();
+        Assert.Equal(2, cmds.Count);
+        Assert.Contains(cmds, c => c.SessionId == born);
+        Assert.True(JsonNode.Parse(cmds.Single(c => c.SessionId == born).PayloadJson)?["enabled"]?.GetValue<bool>());
+
+        // And it is now genuinely a voice session on the Gateway, not merely commanded.
+        Assert.True(_gateway.VoiceService?.IsVoiceSession(Core.Tenancy.TenantId.Local, born));
+    }
+
+    [Fact]
+    public async Task Sweep_doesNothingAtAllWhenVoiceModeWasNeverTurnedOn()
+    {
+        // The other direction of the guard: the sweep must never put a fleet on voice that did not ask for
+        // it. Without this, merely running the Gateway would start spending narration on every session.
+        await PushAsync(1L, Session(Guid.NewGuid().ToString(), "left alone"));
+
+        await _gateway.SweepVoiceModeAllAsync();
+
+        Assert.DoesNotContain(_commands, c => c.Verb == "voice-mode");
+    }
+
+    [Fact]
+    public async Task Sweep_doesNotSwitchSessionsBackOnAfterVoiceModeIsTurnedOff()
+    {
+        // Turning voice mode off has to STAY off. A sweep that kept reading a stale intent would switch the
+        // fleet straight back on, which is the "I turned it off and it kept coming back" failure in its
+        // purest form.
+        var sid = Guid.NewGuid().ToString();
+        await PushAsync(1L, Session(sid, "one"));
+        (await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = true })).EnsureSuccessStatusCode();
+        (await _http.PostAsJsonAsync("sessions/voice-mode/all", new { enabled = false })).EnsureSuccessStatusCode();
+        var beforeSweep = _commands.Count(c => c.Verb == "voice-mode");
+
+        await _gateway.SweepVoiceModeAllAsync();
+
+        Assert.Equal(beforeSweep, _commands.Count(c => c.Verb == "voice-mode"));
+        Assert.False(_gateway.VoiceService?.IsVoiceSession(Core.Tenancy.TenantId.Local, sid));
+    }
+
     private static int AllocateFreePort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/CcDirector.Gateway.Tests/VoiceModeAllSweepPlanTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeAllSweepPlanTests.cs
@@ -1,0 +1,79 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The decision half of the voice-mode sweep. Voice mode is a STANDING intent - a tenant that turned it on
+/// wants every one of its sessions narrating, including the ones that did not exist when the switch was
+/// thrown. <see cref="VoiceModeAllSweep.Plan"/> answers which sessions still need switching on.
+///
+/// Both directions of the guard matter and both are proved here: a tenant that is NOT in voice mode must
+/// yield nothing at all (the sweep must never put a fleet on voice that did not ask), and a tenant that IS in
+/// voice mode must yield exactly the sessions still off (so a steady fleet produces no traffic at all).
+/// </summary>
+public sealed class VoiceModeAllSweepPlanTests
+{
+    private static (string, SessionDto) Row(string directorId, string sid) =>
+        (directorId, new SessionDto { SessionId = sid, Name = sid, Status = "WaitingForInput" });
+
+    private static Func<string, bool> On(params string[] sids)
+    {
+        var set = new HashSet<string>(sids, StringComparer.Ordinal);
+        return set.Contains;
+    }
+
+    [Fact]
+    public void Plan_whenVoiceModeIsOff_yieldsNothing_evenWithSessionsThatAreNotOnVoice()
+    {
+        var roster = new[] { Row("d1", "a"), Row("d1", "b") };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: false, roster, On());
+        Assert.Empty(plan);
+    }
+
+    [Fact]
+    public void Plan_whenVoiceModeIsOn_namesOnlyTheSessionsNotYetOnVoice()
+    {
+        var roster = new[] { Row("d1", "already"), Row("d2", "needsIt") };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: true, roster, On("already"));
+        Assert.Equal(new[] { ("d2", "needsIt") }, plan);
+    }
+
+    [Fact]
+    public void Plan_whenEverySessionIsAlreadyOnVoice_yieldsNothing_soASteadyFleetIsSilent()
+    {
+        var roster = new[] { Row("d1", "a"), Row("d1", "b") };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: true, roster, On("a", "b"));
+        Assert.Empty(plan);
+    }
+
+    [Fact]
+    public void Plan_carriesTheOwningDirector_soTheSweepKnowsWhereToSendTheCommand()
+    {
+        var roster = new[] { Row("machine-a", "one"), Row("machine-b", "two") };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: true, roster, On());
+        Assert.Equal(new[] { ("machine-a", "one"), ("machine-b", "two") }, plan);
+    }
+
+    [Fact]
+    public void Plan_switchesADuplicatedRosterEntryOnce_neverTwice()
+    {
+        var roster = new[] { Row("d1", "same"), Row("d1", "same") };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: true, roster, On());
+        Assert.Single(plan);
+    }
+
+    [Fact]
+    public void Plan_ignoresRowsWithNoSessionIdOrNoDirector_thereIsNothingToSwitchOn()
+    {
+        var roster = new[]
+        {
+            ("d1", new SessionDto { SessionId = "", Name = "blank" }),
+            ("", new SessionDto { SessionId = "orphan", Name = "no director" }),
+            Row("d1", "real"),
+        };
+        var plan = VoiceModeAllSweep.Plan(voiceModeOn: true, roster, On());
+        Assert.Equal(new[] { ("d1", "real") }, plan);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -220,6 +220,20 @@ internal static class GatewayWingmanVoiceEndpoint
             return Results.Json(new { stopped = true });
         });
 
+        // IS THIS TENANT IN VOICE MODE? The one place a client asks, instead of deriving it. The client is
+        // dumb by law here (CLAUDE.md rule 7): it renders this verdict, it does not compute one. Clients used
+        // to answer this question for themselves by scanning the roster for any session that happened to be
+        // marked, which is a DIFFERENT question - "is at least one session on voice" is true the moment one
+        // session is on, and stays true while nine others are off. That wrong answer is what drove the old
+        // one-button switch to offer only OFF forever, so a session created later could never be switched on.
+        app.MapGet("/sessions/voice-mode/all", (HttpContext ctx) =>
+        {
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            return Results.Json(new { enabled = tenantSettings.VoiceModeAll(reqTenant.Value) });
+        });
+
         // Turn voice mode on or off for EVERY session at once (issue #1765). The fleet-wide counterpart
         // to the per-session pair the phone and Cockpit fire (POST /voice-mode on the owning Director,
         // plus mark/unmark here): ONE call, and the Gateway walks the whole roster so the caller never
@@ -236,6 +250,14 @@ internal static class GatewayWingmanVoiceEndpoint
         // thread and never raced. Idempotent: enabling a session already on, or disabling one already off,
         // is a harmless no-op. This endpoint sends NO prompt into any session - it only sets voice marking,
         // exactly like the single-session /voice-mode and /wingman/voice/stop it fans out to.
+        //
+        // IT IS ALSO THE SWITCH, not only the fan-out (owner, 2026-07-24). It PERSISTS the tenant's intent
+        // first, then fans it out. Without the persisted intent, "the fleet is in voice mode" was a fact
+        // nobody held: clients inferred it by checking whether any session happened to be marked, so a
+        // session created a minute later was never told and quietly never joined the voice queue - and a
+        // client could not honestly tell you which state you were in. The flag is the intent; the fan-out
+        // below and the sweep in GatewayHost are how the intent reaches sessions, the ones here now and the
+        // ones that appear later.
         app.MapPost("/sessions/voice-mode/all", async (VoiceModeAllRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
             var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
@@ -243,6 +265,13 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             var enabled = req?.Enabled ?? true;
             FileLog.Write($"[GatewayWingmanVoice] voice-mode/all requested: enabled={enabled}");
+
+            // Persist the intent BEFORE the fan-out. The fan-out can partly fail (an offline computer is
+            // skipped), and the intent must survive that - those sessions are meant to be on voice, and the
+            // sweep puts them on it when their computer comes back. Recording the intent only on a fully
+            // successful fan-out would silently downgrade "my fleet is on voice" to "the reachable part of
+            // my fleet is on voice", which is the exact class of quiet gap this change exists to close.
+            tenantSettings.SetVoiceModeAll(reqTenant.Value, enabled, DateTime.UtcNow);
 
             // The machine each Director runs on, so a skipped session names where it lives in plain English.
             // Hosted Multi-Tenancy (audit H1, gap audit-b): scope this to the caller's OWN partition, not the

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -541,6 +541,14 @@ public sealed class GatewayHost : IAsyncDisposable
     // HostedInferenceBrain (a hosted model call), not the spawned BrainSupervisor.
     private TurnEndWatcher? _turnEndWatcher;
     private Wingman.WingmanVoiceService? _voiceService;
+    // Voice mode is a standing intent, not a one-time action: a tenant that is in voice mode wants EVERY one
+    // of its sessions narrating, including the ones that do not exist yet. This timer is how that intent
+    // reaches them - it walks each tenant that has voice mode on and switches on any session that is not a
+    // voice session yet. Fifteen seconds, matching the reconcile poll beside it: a session joins the voice
+    // queue on its own within a few seconds of appearing, without the phone having to sweep anything.
+    private Timer? _voiceModeAllSweepTimer;
+    private static readonly TimeSpan VoiceModeAllSweepInterval = TimeSpan.FromSeconds(15);
+    private int _voiceModeAllSweepRunning;
 
     /// <summary>Test-only: the tenant-partitioned voice state, so an isolation test can seed a ready clip
     /// under one tenant and prove another tenant never reads it. Null until StartAsync builds it.</summary>
@@ -1492,6 +1500,81 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// Carry each tenant's standing VOICE MODE intent to the sessions that did not exist when the switch was
+    /// thrown. For every tenant with voice mode on, any session that is not yet a voice session gets the same
+    /// two effects the fleet-wide fan-out gives: the owning Director's voice-mode flag set over the tunnel,
+    /// and the Gateway voice marker set so the per-turn narration starts.
+    ///
+    /// This is what makes voice mode a switch rather than a one-time action. The fan-out at
+    /// <c>POST /sessions/voice-mode/all</c> reaches only the sessions alive at that instant; a session created
+    /// a minute later, or one whose computer was offline and has since come back, was never told - so it
+    /// quietly never joined the voice queue and looked like the queue had lost it.
+    ///
+    /// Deliberately one-directional: it only ever switches sessions ON, and only for a tenant that asked for
+    /// voice mode. Turning voice mode off is done by the endpoint's own fan-out, which unmarks every session
+    /// in one pass; a sweep that also chased the off direction would fight anyone who had deliberately put a
+    /// single session on voice while the fleet flag was off.
+    ///
+    /// Best-effort and never throws into the timer. A session whose computer is unreachable is left alone and
+    /// picked up by a later pass, which is the whole point of a standing intent.
+    /// </summary>
+    internal async Task SweepVoiceModeAllAsync()
+    {
+        // One pass at a time. A pass that runs long (many sessions, slow tunnels) must not have a second
+        // timer tick start on top of it and send the same session two voice-mode commands.
+        if (Interlocked.Exchange(ref _voiceModeAllSweepRunning, 1) == 1) return;
+        try
+        {
+            var vs = _voiceService;
+            if (vs is null) return;
+            var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
+            Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
+
+            // Each tenant is decided and acted on inside its own scope, exactly as the voice pre-build sweep
+            // beside this one does: the flag is read for THAT tenant, the roster is that tenant's partition,
+            // and the marker is written into that tenant's voice state. Self-host runs one Local pass.
+            var passes = new List<(TenantId Tenant, IReadOnlyList<(string DirectorId, string SessionId)> Plan)>();
+            _tenantPass.ForEachTenant(() =>
+            {
+                if (_tenantPass.Current is not { } tenant) return;   // deny: no scope in effect -> sweep nothing
+                var on = _tenantSettingsResolver.VoiceModeAll(tenant);
+                // Plan returns empty immediately for a tenant that is not in voice mode, so a fleet with the
+                // switch off costs one flag read and nothing else.
+                var plan = Wingman.VoiceModeAllSweep.Plan(
+                    on,
+                    PushedSessions.SnapshotFresh(tenant, stale),
+                    sid => vs.IsVoiceSession(tenant, sid));
+                if (plan.Count > 0) passes.Add((tenant, plan));
+            });
+
+            foreach (var (tenant, plan) in passes)
+            {
+                FileLog.Write($"[GatewayHost] voice-mode sweep: {plan.Count} session(s) to switch on for tenant={tenant.ToLogString()}");
+                foreach (var (directorId, sid) in plan)
+                {
+                    var result = await Api.DirectorCommandRouter.TrySendAsync(
+                        sendCommand, directorId, "voice-mode", sid, new { enabled = true }, CancellationToken.None);
+                    if (result is { Ok: true })
+                    {
+                        // Mark only after the Director accepted. Marking a session the Director never heard
+                        // about would make the Gateway spend narration on a session whose own view mode says
+                        // it is not a voice session - the two halves must agree or the roster lies.
+                        vs.Mark(tenant, sid);
+                        FileLog.Write($"[GatewayHost] voice-mode sweep: switched on sid={sid} director={directorId} tenant={tenant.ToLogString()}");
+                    }
+                    else
+                    {
+                        // Left for a later pass on purpose - that is what a standing intent means.
+                        FileLog.Write($"[GatewayHost] voice-mode sweep: sid={sid} not reachable on director={directorId} - will retry next pass");
+                    }
+                }
+            }
+        }
+        catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-mode sweep error: {ex.Message}"); }
+        finally { Interlocked.Exchange(ref _voiceModeAllSweepRunning, 0); }
+    }
+
+    /// <summary>
     /// The Gateway's warm brain (issue #184): a claude.exe this process hosts itself - no
     /// Director dependency. Dormant until first use; RestartAsync is the recovery verb.
     /// </summary>
@@ -1672,6 +1755,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // First tick = the startup catch-up sweep; then the 15s reconcile poll for
         // Directors that never push (file-discovered locals, old builds).
         _turnEndWatcher.Start();
+
+        // The voice-mode sweep: carry each tenant's standing "my fleet is in voice mode" intent to the
+        // sessions that did not exist when the switch was thrown. Runs unconditionally and costs nothing on a
+        // fleet with voice mode off - VoiceModeAllSweep.Plan returns an empty plan for such a tenant, so no
+        // roster is even walked for it.
+        FileLog.Write("[GatewayHost] StartAsync: starting the voice-mode sweep (standing voice-mode intent -> new sessions)");
+        _voiceModeAllSweepTimer = new Timer(
+            _ => _ = SweepVoiceModeAllAsync(),
+            null, VoiceModeAllSweepInterval, VoiceModeAllSweepInterval);
 
         // PreventHostingStartup avoids ASP.NET Core trying to load a (nonexistent) hosting startup
         // assembly with our application name, which otherwise emits a noisy crit log line on boot.
@@ -3082,6 +3174,7 @@ public sealed class GatewayHost : IAsyncDisposable
         try { _voiceSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice sweep dispose error: {ex.Message}"); }
         _voiceSweepTimer = null;
         try { _turnEndWatcher?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] watcher dispose error: {ex.Message}"); }
+        try { _voiceModeAllSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-mode sweep timer dispose error: {ex.Message}"); }
         _turnEndWatcher = null;
         try { Brain.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] brain dispose error: {ex.Message}"); }
 

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -49,10 +49,22 @@ public static class TenantSettingKeys
     /// string.</summary>
     public const string InjectedText = "injected_text";
 
+    /// <summary>Whether this tenant is IN VOICE MODE: every one of its sessions narrates its turns, including
+    /// sessions created after the switch was thrown. Unlike every other key here there is no operator global
+    /// default to fall back to - voice mode is a per-tenant choice and its default is OFF.
+    ///
+    /// This is the flag that makes voice mode a SWITCH rather than a one-shot fan-out. Before it, nothing
+    /// anywhere held "this fleet is in voice mode": the phone inferred it by checking whether any session
+    /// happened to be marked, and made it true by walking the roster - so a session created afterwards was
+    /// never told, and quietly never joined the voice queue. The Gateway holds the intent here, and the
+    /// sweep applies it to sessions as they appear.</summary>
+    public const string VoiceModeAll = "voice_mode_all";
+
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
         WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
+        VoiceModeAll,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -116,6 +116,14 @@ public sealed class TenantSettingsResolver
         }
     }
 
+    /// <summary>Whether this tenant is in VOICE MODE - every one of its sessions narrates its turns, including
+    /// sessions created after the switch was thrown. Defaults to OFF: unlike every other setting here there is
+    /// no operator global default to fall back to, because voice mode is the tenant's own choice and spends
+    /// its own narration credits. Anything stored that is not exactly "true" reads as off - the quiet,
+    /// nothing-happens answer, which is the safe way for a corrupt value to fail.</summary>
+    public bool VoiceModeAll(TenantId tenant)
+        => string.Equals(_store.Get(tenant, TenantSettingKeys.VoiceModeAll), "true", StringComparison.Ordinal);
+
     // ---- writes: validate like the global setters, then persist a per-tenant override -------------------
 
     /// <summary>Set the tenant's wingman model for a role.</summary>
@@ -131,6 +139,12 @@ public sealed class TenantSettingsResolver
         };
         _store.Set(tenant, key, trimmed, nowUtc);
     }
+
+    /// <summary>Turn this tenant's VOICE MODE on or off. On is stored explicitly rather than by removing the
+    /// override, so "off" is a decision this tenant made and not merely the absence of one - the sweep that
+    /// applies voice mode to new sessions reads the same flag either way.</summary>
+    public void SetVoiceModeAll(TenantId tenant, bool enabled, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.VoiceModeAll, enabled ? "true" : "false", nowUtc);
 
     /// <summary>Set the tenant's text-to-speech voice.</summary>
     /// <exception cref="ArgumentException">The voice is null/empty.</exception>

--- a/src/CcDirector.Gateway/Wingman/VoiceModeAllSweep.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceModeAllSweep.cs
@@ -1,0 +1,55 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// The decision half of the voice-mode sweep: given a tenant that is IN VOICE MODE, which of its sessions are
+/// not yet voice sessions and therefore still need switching on.
+///
+/// This exists because voice mode is a standing intent, not a one-time action. The fan-out at
+/// <c>POST /sessions/voice-mode/all</c> reaches the sessions that exist at the moment it runs; a session
+/// created a minute later, or one whose computer was offline and has since come back, was never told. Before
+/// this, nothing ever told them - which is why sessions quietly failed to appear in the voice queue and looked
+/// like a queue bug rather than what it was: they were never voice sessions.
+///
+/// Kept as a pure function, separate from the timer and the tunnel calls that act on it, so the rule can be
+/// tested without a Gateway: the interesting behaviour is entirely in WHICH sessions come back, and the two
+/// directions that must both hold - a tenant that is not in voice mode yields nothing at all, and a tenant
+/// that is yields only the sessions that are actually still off.
+/// </summary>
+public static class VoiceModeAllSweep
+{
+    /// <summary>
+    /// The sessions to switch into voice mode for this tenant, as (director id, session id) pairs.
+    /// </summary>
+    /// <param name="voiceModeOn">Whether this tenant is in voice mode. When false the result is always empty -
+    /// the sweep NEVER switches a session on for a tenant that did not ask for voice mode.</param>
+    /// <param name="roster">The tenant's live sessions, as the push store reports them: director id + session.</param>
+    /// <param name="isVoiceSession">Whether a session is already marked as a voice session on the Gateway.
+    /// Sessions that are already on are left alone, so a steady fleet produces an empty sweep and no traffic.</param>
+    public static IReadOnlyList<(string DirectorId, string SessionId)> Plan(
+        bool voiceModeOn,
+        IReadOnlyList<(string DirectorId, SessionDto Session)> roster,
+        Func<string, bool> isVoiceSession)
+    {
+        ArgumentNullException.ThrowIfNull(roster);
+        ArgumentNullException.ThrowIfNull(isVoiceSession);
+
+        if (!voiceModeOn) return Array.Empty<(string, string)>();
+
+        var plan = new List<(string DirectorId, string SessionId)>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (directorId, session) in roster)
+        {
+            var sid = session?.SessionId;
+            if (string.IsNullOrWhiteSpace(sid)) continue;
+            if (string.IsNullOrWhiteSpace(directorId)) continue;
+            // A session belongs to exactly one Director, but a duplicated roster entry must not be switched
+            // (and counted) twice - the same guard the fan-out endpoint applies.
+            if (!seen.Add(sid)) continue;
+            if (isVoiceSession(sid)) continue;
+            plan.Add((directorId, sid));
+        }
+        return plan;
+    }
+}


### PR DESCRIPTION
Voice mode was never a state anything held. The phone worked it out by scanning the roster for any session that happened to be marked, and made it true by walking the list itself. Three problems followed from that one gap.

## 1. A session created later was never told

The fan-out reached the sessions alive at that instant. A session started a minute afterwards quietly never joined the voice queue - which looked like the queue losing sessions rather than what it was.

The Gateway now holds the tenant's standing intent (a per-tenant `voice_mode_all` flag), and a fifteen-second sweep carries it to any session that is not yet a voice session - including one whose computer was offline and has since come back. The intent is persisted **before** the fan-out, so a partly-failed fan-out cannot silently downgrade "my fleet is on voice" to "the reachable part of my fleet is on voice".

The sweep only ever switches sessions **on**, and only for a tenant that asked for voice mode. Turning voice mode off is the endpoint's own fan-out, which unmarks everything in one pass; a sweep that chased the off direction too would fight anyone who had deliberately put one session on voice.

## 2. Nothing could tell you which state you were in, and the switch went one way

"Does any session have voice on?" is a different question from "is this fleet in voice mode". It turns true the moment one session is on and stays true while nine others are off - so the button flipped permanently to "turn it all off", and a session created after that could never be switched on from that screen at all.

`GET /sessions/voice-mode/all` now answers the real question, and the clients render that answer rather than deriving one (CLAUDE.md rule 7: the client is dumb, the Gateway owns the verdict).

## 3. There was no way out from where you actually were

The only off switch lived on one tab of the roster - the screen auto-speak leaves you on for three seconds between sessions. Everywhere else there was no way to stop, which is why a longer pause helped and did not fix it.

A banner now sits on **every screen** while voice mode is on, with a thumb-sized "Turn off" - so the way out is on the session screen auto-speak just dropped you into. Turning voice mode off also switches auto-speak off on this phone: auto-speak with nothing to speak is not a state worth being in, and leaving it armed is how someone gets dragged back into the queue they just left.

## Voice mode and auto-speak stay two different things

Voice mode is about the **fleet**: every session narrates its turns. Auto-speak is about **this phone**: it also opens each waiting voice session in turn and plays it without a tap. Voice mode on with auto-speak off is the ordinary case, and both controls now say which of the two they are.

The banner and the roster switch share ONE state with one poll. Two copies of one truth is the same mistake as deriving it, just later in the stack - they would have disagreed for up to fifteen seconds after any change.

## Proof

**Gateway.** The sweep's decision is a pure function tested in both directions: a tenant NOT in voice mode yields nothing at all (it must never put a fleet on voice that did not ask), and a tenant in voice mode yields only the sessions still off (a steady fleet produces no traffic). 6 tests. The end-to-end tests drive a real streamMode host over a real tunnel and cover: the intent persists and reads back; the intent is recorded even when the fan-out could reach nothing; **a session PUSHED AFTER the switch was thrown gets switched on by the sweep**; the sweep does nothing when voice mode was never turned on; and it does not switch anything back on after voice mode is turned off. 7 endpoint tests pass (2 pre-existing + 5 new).

**Client.** 600 client-core tests pass (up from 599), cockpit 176, typecheck clean on all three workspaces, mobile build succeeds. The two client behaviours that fail *silently* are covered, and both were confirmed to fail with their guard removed: auto-speak must come down with voice mode, and a poll that started before a write must not repaint the old value after it. The first version of that second test **passed with the guard deleted** - it was rewritten until it failed, which also exposed that the in-flight flag alone was not enough and a write-sequence guard was needed.

**Rendered check** at 390px against the real stylesheet: the banner with its "Turn off" button, above the session voice screen and the Voice sessions tab.

**Lint**: the two pre-existing "rule definition not found" errors, identical on a clean origin/main - not introduced here.

**One proof still owed**: the revert probe for the end-to-end sweep test (breaking the flag and confirming that test goes red) is queued behind this machine's fleet-wide Gateway test lock, held by another session. The pure-function tests covering the same decision were proven to fail on purpose.