### PR TITLE
mobile: the voice-mode banner moves the pinned screens down instead of painting over them

### DIFF
--- a/apps/mobile/src/components/VoiceModeBanner.tsx
+++ b/apps/mobile/src/components/VoiceModeBanner.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useVoiceModeAll } from "@devthrottle/client-core/voice/useVoiceModeAll";
 
 // THE VOICE MODE BANNER (owner, 2026-07-24). While the fleet is in voice mode, this bar is on EVERY screen
@@ -16,15 +17,49 @@ import { useVoiceModeAll } from "@devthrottle/client-core/voice/useVoiceModeAll"
 //
 // Deliberately NOT a confirmation dialog: this is the escape hatch, and an escape hatch that asks "are you
 // sure?" while a voice is talking over you is not one. Turning voice mode back on is one tap on the roster.
+//
+// IT PUBLISHES ITS OWN HEIGHT AS --voicemode-h, and that is not a detail (owner, 2026-07-25). The session,
+// Car Mode and Assistant screens are PINNED OUT OF THE DOCUMENT FLOW - fixed to the top of the window and
+// sized to the whole visible height - so nothing rendered above them in the markup can push them down.
+// Shipped as a plain sticky bar, this banner simply PAINTED OVER the session screen's own header, taking
+// the back arrow to the roster and the overflow menu with it: you could Respond and Snooze, and you could
+// not leave. Those screens now start below this bar and lose exactly its height, which is why the height
+// has to be a real measured number and not a guess - the message wraps to two lines on a narrow phone.
+//
+// Zero when voice mode is off, so nothing about any screen changes when the banner is not there.
 export function VoiceModeBanner() {
   const voice = useVoiceModeAll();
+  const barRef = useRef<HTMLDivElement | null>(null);
+  const shown = voice.enabled === true;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    // Not rendered -> no strip to give up. Set it explicitly rather than leaving the last value behind:
+    // a stale height would push every screen down by a bar that is no longer on the page.
+    if (!shown) {
+      root.style.setProperty("--voicemode-h", "0px");
+      return;
+    }
+    const el = barRef.current;
+    if (el === null) return;
+    const apply = () => root.style.setProperty("--voicemode-h", `${Math.round(el.getBoundingClientRect().height)}px`);
+    apply();
+    // Measured, not assumed: the sub-line wraps to two lines on a narrow phone and the bar grows, and it
+    // grows again when an error line appears under it. A hard-coded height would be right on one device.
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty("--voicemode-h", "0px");
+    };
+  }, [shown]);
 
   // Null means the first read has not landed. Render nothing rather than flash a banner that may be wrong -
   // a banner that appears and vanishes on every app open teaches you to ignore it.
-  if (voice.enabled !== true) return null;
+  if (!shown) return null;
 
   return (
-    <div className="voicemode-banner" role="status">
+    <div className="voicemode-banner" role="status" ref={barRef}>
       <span className="voicemode-dot" aria-hidden="true" />
       <span className="voicemode-text">
         Voice mode is on

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -37,7 +37,10 @@ body {
 
 .app-bar {
   position: sticky;
-  top: 0;
+  /* Parks BELOW the voice-mode banner, not at the very top. Both are sticky, and the banner has the
+     higher stacking order, so at top: 0 the roster header would slide underneath it as you scroll and
+     take the hamburger menu with it. --voicemode-h is 0px whenever the banner is not on screen. */
+  top: var(--voicemode-h, 0px);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -842,15 +845,20 @@ a.banner-btn {
    plain 100dvh box; that test will fail and tell you why. */
 .terminal-screen {
   position: fixed;
-  top: 0;
+  /* STARTS BELOW THE VOICE-MODE BANNER, and gives up exactly its height (owner, 2026-07-25). This box
+     is pinned out of the document flow, so a bar rendered above it in the markup cannot push it down -
+     it simply painted OVER this screen's own header, hiding the back arrow to the roster and the
+     overflow menu. You could Respond and Snooze, and you could not leave. --voicemode-h is 0px
+     whenever the banner is not on screen, so nothing here changes when voice mode is off. */
+  top: var(--voicemode-h, 0px);
   left: 0;
   right: 0;
   display: flex;
   flex-direction: column;
   height: 100vh;
   height: 100dvh;
-  height: var(--app-vh, 100dvh);
-  max-height: var(--app-vh, 100dvh);
+  height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
+  max-height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
   min-height: 0;
   /* Anything that still overflows the column (a large device font scale, safe-area insets) is
      CLIPPED, never scrolled - the page must not move. */
@@ -3222,7 +3230,10 @@ a.banner-btn {
   /* Anchor top/left/right ONLY - deliberately NOT `inset: 0`. `inset: 0` sets both top:0 AND bottom:0,
      which OVER-CONSTRAINS a fixed box: its height is then derived from top+bottom (the tall, toolbar-
      hidden LAYOUT viewport) and the height below is IGNORED. Anchoring top-only lets the height win. */
-  top: 0;
+  /* Starts below the voice-mode banner and gives up exactly its height, for the same reason
+     .terminal-screen does: this box is pinned out of the flow, so the banner would otherwise paint
+     over Car Mode's own header. 0px when the banner is not on screen. */
+  top: var(--voicemode-h, 0px);
   left: 0;
   right: 0;
   display: flex;
@@ -3239,9 +3250,9 @@ a.banner-btn {
      mechanism, shared with .terminal-screen - see the session-screen shell below. */
   height: 100vh;
   height: 100dvh;
-  height: var(--app-vh, 100dvh);
+  height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
   max-height: 100dvh;
-  max-height: var(--app-vh, 100dvh);
+  max-height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
   overflow: hidden;
 }
 /* The pin only works if the column lays out as: header (natural) -> middle (absorbs + scrolls) -> footer
@@ -4168,8 +4179,12 @@ a.banner-btn {
 .assistant-screen {
   display: flex;
   flex-direction: column;
-  height: var(--app-vh, 100dvh);
-  max-height: var(--app-vh, 100dvh);
+  /* Gives up the voice-mode banner's height. This screen is in the normal flow, so the banner already
+     pushes it down - but without shrinking it too, banner + full visible height is TALLER than the
+     window and the composer at the bottom would be pushed off. No `top` offset here: the flow has
+     already done that half. 0px when the banner is not on screen. */
+  height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
+  max-height: calc(var(--app-vh, 100dvh) - var(--voicemode-h, 0px));
   overflow: hidden;
   padding: 0 12px;
   max-width: 680px;

--- a/src/CcDirector.Core.Tests/MobileViewportContractTests.cs
+++ b/src/CcDirector.Core.Tests/MobileViewportContractTests.cs
@@ -173,6 +173,70 @@ public sealed class MobileViewportContractTests
             + string.Join("\n  ", offenders) + Why);
     }
 
+    /// <summary>
+    /// A full-height bar at the top of the app must MOVE the pinned shells down, not paint over them.
+    ///
+    /// The voice-mode banner shipped as a plain sticky bar and covered the session screen's own header -
+    /// the back arrow to the roster and the overflow menu went under it. You could Respond and Snooze on a
+    /// session, and you could not leave it. The cause is the same property this whole file exists to
+    /// protect: the shells are pinned OUT OF THE DOCUMENT FLOW, so nothing above them in the markup can
+    /// push them down. Rendering order does not move a fixed box; only its own `top` does.
+    ///
+    /// So the contract is: every pinned shell starts at the banner's height and gives up that much height.
+    /// The banner measures itself and publishes --voicemode-h (0px when it is not on screen), because the
+    /// bar wraps to two lines on a narrow phone and a hard-coded height would be right on one device.
+    /// </summary>
+    [Fact]
+    public void PinnedShells_StartBelowTheVoiceModeBanner_AndGiveUpItsHeight()
+    {
+        var root = GetRepoRoot();
+        var css = File.ReadAllText(Path.Combine(root, StylesPath));
+        var offenders = new List<string>();
+
+        foreach (var shell in FullScreenShells)
+        {
+            var block = RuleBlock(css, shell);
+            if (block is null) continue;
+
+            // Pinned to the top of the window: `top` must be the banner offset, not 0.
+            var tops = Regex.Matches(block, @"(?<!-)\btop\s*:\s*([^;]+);").Select(m => m.Groups[1].Value.Trim()).ToList();
+            if (tops.Count == 0 || !tops[^1].Contains("var(--voicemode-h", StringComparison.Ordinal))
+                offenders.Add($"{shell}: its effective `top` is `{(tops.Count == 0 ? "unset" : tops[^1])}`, not var(--voicemode-h, 0px) - the banner will paint over this screen's header, hiding its back button.");
+
+            // And the height must shrink by the same amount, or the bottom of the screen goes off-window.
+            var heights = Regex.Matches(block, @"(?<!max-|min-)\bheight\s*:\s*([^;]+);").Select(m => m.Groups[1].Value.Trim()).ToList();
+            if (heights.Count > 0 && !heights[^1].Contains("var(--voicemode-h", StringComparison.Ordinal))
+                offenders.Add($"{shell}: its effective height `{heights[^1]}` does not subtract var(--voicemode-h, 0px), so the bottom of the screen is pushed off-window while the banner is up.");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A pinned mobile shell does not make room for the top banner:\n  " + string.Join("\n  ", offenders)
+            + "\n\nWHY: these shells are position:fixed and sized to the whole visible height, so a bar rendered "
+            + "ABOVE them in the markup cannot push them down - it paints over their header. That is exactly how "
+            + "the voice-mode banner hid the session screen's back arrow and overflow menu: Respond and Snooze "
+            + "worked, and there was no way back to the roster.");
+    }
+
+    /// <summary>
+    /// The banner must MEASURE itself and publish --voicemode-h. A guard on the shells alone would pass
+    /// happily while the variable was never set - every shell would silently fall back to 0px and the
+    /// banner would be back on top of the back button.
+    /// </summary>
+    [Fact]
+    public void TheVoiceModeBanner_PublishesItsMeasuredHeight()
+    {
+        var path = Path.Combine(GetRepoRoot(), "apps", "mobile", "src", "components", "VoiceModeBanner.tsx");
+        Assert.True(File.Exists(path), "apps/mobile/src/components/VoiceModeBanner.tsx is missing. If the banner was renamed, update this test - do not delete the contract.");
+
+        var src = File.ReadAllText(path);
+        Assert.True(src.Contains("--voicemode-h", StringComparison.Ordinal),
+            "VoiceModeBanner no longer publishes --voicemode-h. Without it every pinned shell falls back to 0px and the banner covers the session screen's back arrow again.");
+        Assert.True(src.Contains("ResizeObserver", StringComparison.Ordinal),
+            "VoiceModeBanner no longer MEASURES itself. The bar wraps to two lines on a narrow phone and grows again when an error line appears - a hard-coded height is right on exactly one device.");
+        Assert.True(Regex.IsMatch(src, @"""--voicemode-h"",\s*""0px"""),
+            "VoiceModeBanner no longer resets --voicemode-h to 0px when it is not shown. A stale height pushes every screen down by a bar that is no longer on the page.");
+    }
+
     /// <summary>Returns the body of the FIRST rule whose selector list contains <paramref name="selector"/> exactly.</summary>
     private static string? RuleBlock(string css, string selector)
     {


### PR DESCRIPTION
The banner covered the session screen's own header. The back arrow to the roster and the overflow menu went underneath it, so on a speaking session you could Respond, you could Snooze, and you could not leave. Reported from the phone with a screenshot.

## Cause

The property the mobile viewport contract exists to protect: the session, Car Mode and Assistant screens are pinned **out of the document flow** - fixed to the top of the window and sized to the whole visible height - so nothing rendered above them in the markup can push them down. Rendering order does not move a fixed box; only its own `top` does. Shipped as a plain sticky bar, the banner painted over their top row.

Raising the header above the banner instead would only swap which one is hidden.

## Fix

The banner measures itself and publishes `--voicemode-h`. The pinned screens start at that offset and give up exactly that much height.

Measured, not assumed: the message wraps to two lines on a narrow phone and grows again when an error line appears, so a hard-coded height would be right on exactly one device.

The Assistant screen is in the normal flow, so it only shrinks - the flow has already moved it down - and without the shrink its composer would be pushed off the bottom.

Zero when voice mode is off, so no screen changes at all when the banner is not there.

## What was NOT broken

The roster header, contrary to my first reading of the report. It and the banner are both sticky in the normal flow, so the banner takes real space and the header lays out below it - the hamburger menu was always fine at rest. It did slide under the banner while scrolling, since both parked at the very top and the banner has the higher stacking order; it now parks below it.

## Proof

Guarded in `MobileViewportContractTests` - the same architecture fitness function that already documents five recurrences of this exact class of bug. Two new guards: pinned shells must offset by the banner height in both `top` and `height`, and the banner must actually measure and publish it (a guard on the shells alone would pass happily while the variable was never set and every shell fell back to 0px). **Both were confirmed to fail with the fix undone.**

A rendered check at 390px against the real stylesheet hit-tests the centre of the back button and gets the back button back. **The same probe with the offset forced to zero gets the banner text instead** - the reported bug reproduced, so the check is known to be capable of failing rather than merely passing.

6 contract tests pass, client-core 600, cockpit 180, typecheck clean on all three workspaces, mobile build succeeds. Lint: the two pre-existing "rule definition not found" errors, identical on a clean origin/main.