### PR TITLE
feat(gateway): recognise the pro_selfhost plan and refuse it hosted gateway (#2147)

### DIFF
--- a/docs/cencon/proof/2147/qa-report.html
+++ b/docs/cencon/proof/2147/qa-report.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Issue #2147 - QA verification report</title>
+<style>
+  body { font: 15px/1.6 system-ui, sans-serif; max-width: 960px; margin: 24px auto; padding: 0 16px; color: #1a1a2e; }
+  h1 { font-size: 22px; } h2 { font-size: 18px; margin-top: 30px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  h3 { font-size: 15px; margin-top: 20px; }
+  code { background: #f0f0f5; padding: 1px 5px; border-radius: 3px; font-size: 13px; }
+  pre { background: #f7f7fb; border: 1px solid #ddd; border-radius: 6px; padding: 10px 12px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th, td { border: 1px solid #ccc; padding: 8px 10px; text-align: left; vertical-align: top; font-size: 14px; }
+  th { background: #f5f5fa; }
+  .pass { color: #0a7d2c; font-weight: 700; }
+  .fail { color: #b00020; font-weight: 700; }
+  .note { color: #9a5b00; font-weight: 600; }
+  blockquote { border-left: 4px solid #d0d0dd; margin: 12px 0; padding: 4px 14px; color: #444; background: #fafafd; }
+</style>
+</head>
+<body>
+
+<h1>Issue #2147 - QA verification report</h1>
+
+<p><strong>Verdict:</strong> <span class="pass">VERIFIED - every acceptance criterion that this repository can carry is met.</span></p>
+
+<p>
+<strong>Issue:</strong> 2147 &nbsp;|&nbsp;
+<strong>Pull request:</strong> 2151 &nbsp;|&nbsp;
+<strong>Branch:</strong> <code>feat/gateway-pro-selfhost-scopes</code> at <code>c40a5928</code> &nbsp;|&nbsp;
+<strong>Base:</strong> <code>origin/main</code> at <code>0100a2b5</code> (the merged fourteen-day Pro trial, pull request 2132)
+</p>
+
+<p><strong>How this verification was done.</strong> Independently, in two fresh worktrees cut from the pull
+request commit - not in the shared checkout and not in the developer's tree. Every number below was produced by
+running the code in those worktrees and reading the output. Nothing in the developer's report was taken on
+trust; each claim was re-derived. The branch was confirmed to sit exactly one commit ahead of
+<code>origin/main</code>, so what was tested is what would merge.</p>
+
+<h2>1. The acceptance criteria, one at a time</h2>
+
+<table>
+  <tr><th>Criterion</th><th>Expected</th><th>Actual</th><th>Verdict</th></tr>
+
+  <tr>
+    <td>The Gateway recognises tier <code>pro_selfhost</code> and grants exactly dictation, text to speech and
+      the wingman - no more, no less.</td>
+    <td>The scope set for that tier contains those three and has a count of exactly three.</td>
+    <td><code>EntitlementScopes.ForTier("pro_selfhost")</code> returns exactly
+      <code>{dictation, tts, wingman}</code>. Pinned by
+      <code>ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse</code> and by
+      <code>A_self_host_plan_still_grants_the_artificial_intelligence_features</code>, which asserts
+      <code>granted.Count == 3</code> so a fourth scope cannot creep in. Both green.</td>
+    <td class="pass">PASS</td>
+  </tr>
+
+  <tr>
+    <td>It never provisions or grants hosted gateway capability for that tier.</td>
+    <td>Hosted capacity refused, at every place hosted capacity is handed out.</td>
+    <td>Refused at both, and each was proven to be load bearing by disabling it in isolation (section 3).
+      A source sweep for the two acts that hand out hosted capacity -
+      <code>TenantRegistry.MintOrLookupBySubject</code> and <code>DeviceRegistry.RegisterForTenant</code> -
+      finds exactly one caller, <code>HostedEnrollmentEndpoint.Enroll</code>, and the plan gate sits above it.
+      The ongoing request path reaches <code>HostedAccessLeaseService.AuthorizeAsync</code> from
+      <code>AuthMiddleware</code>, and the plan gate is the first case of its switch.</td>
+    <td class="pass">PASS</td>
+  </tr>
+
+  <tr>
+    <td>Negative control: an account whose entitlement row says <code>pro_selfhost</code> is refused
+      hosted-gateway provisioning.</td>
+    <td>402, no tenant minted, no device key issued - through the real provisioning path.</td>
+    <td><code>A_self_host_plan_is_refused_hosted_gateway_provisioning</code> calls the real
+      <code>HostedEnrollmentEndpoint.Enroll</code> with the best row a subscriber can have (active, live money,
+      in period) and asserts status 402 plus <code>AssertNothingWasGivenAway</code>, which checks both halves:
+      <code>tenants.LookupBySubject(...)</code> is null and the device file holds no key. Green, and proven to
+      fail on purpose (section 3).</td>
+    <td class="pass">PASS</td>
+  </tr>
+
+  <tr>
+    <td>Negative control proven <em>against the deployed gateway</em>.</td>
+    <td>A live check on the hosted service.</td>
+    <td><span class="note">NOT DONE HERE, BY INSTRUCTION.</span> This branch is not deployed; deployment is
+      coordinated by the owner after merge and was explicitly out of scope for this verification. No deployment
+      was attempted and <code>PRO_SUBSCRIPTION_ENABLED</code> was not read, set or changed in any environment.
+      Confirmed by search that the flag does not exist anywhere in this repository.</td>
+    <td class="note">DEFERRED to the owner (post-merge)</td>
+  </tr>
+
+  <tr>
+    <td>The release checklist for opening the till references this issue as a prerequisite.</td>
+    <td>A checklist entry.</td>
+    <td><span class="note">BELONGS TO ANOTHER REPOSITORY.</span> <code>PRO_SUBSCRIPTION_ENABLED</code> does not
+      exist anywhere in this repository - the flag and its release checklist live in the website repository.
+      Writing the till checklist here would put the record in the wrong place. Confirmed by search; agreed as
+      out of scope for this pull request rather than skipped.</td>
+    <td class="note">ROUTED elsewhere</td>
+  </tr>
+</table>
+
+<h2>2. The string trap - is the comparison exact?</h2>
+
+<p>This is the mistake that would silently undo the whole issue. <code>"pro"</code> is a prefix of
+<code>"pro_selfhost"</code>, and <code>"pro"</code> deliberately <em>does</em> carry hosted gateway - the
+fourteen-day trial on main grants exactly that tier. Any comparison sloppy about where a tier string ends would
+hand hosted gateway to the one plan this issue exists to deny, and would look correct doing it.</p>
+
+<p><strong>The code was read, not summarised.</strong> <code>EntitlementScopes.ByTier</code> is a
+<code>Dictionary&lt;string, IReadOnlySet&lt;string&gt;&gt;</code> constructed with
+<code>StringComparer.Ordinal</code>, and the lookup is a single
+<code>ByTier.TryGetValue(tier.Trim(), out var scopes)</code>. That is whole-string ordinal equality. There is no
+<code>StartsWith</code>, no <code>Contains</code>, no substring arithmetic and no case-insensitive comparer
+anywhere in the file. The only normalisation is <code>Trim()</code> on surrounding whitespace, which cannot turn
+one tier into another.</p>
+
+<p><strong>The test that pins it exists</strong> -
+<code>EntitlementScopeTableTests.ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier</code>. It asserts that
+<code>"pro"</code> really is a prefix of <code>"pro_selfhost"</code> (so the trap is real and not hypothetical),
+that the two tiers resolve to different scope sets, and that the difference is exactly the hosted gateway scope.
+Case sloppiness is pinned separately by
+<code>GrantsHostedGateway_AnUnrecognisedTier_IsFalse</code> with <code>"PRO_SELFHOST"</code> and
+<code>"Hosted"</code>.</p>
+
+<p>Reading a test is not proof that it works, so it was made to fail - see sabotage D below, where replacing the
+exact lookup with a prefix and case-insensitive match reddens that test and seven others.</p>
+
+<h2>3. The negative controls were made to fail, by hand, in this session</h2>
+
+<p>Four separate sabotages were applied one at a time to a throwaway worktree, each built and run, each then
+fully reverted. A test that has never failed in the verifier's own hands is not proof, so none of the
+developer's sabotage output was reused.</p>
+
+<p>The test set for each run was the four relevant classes together -
+<code>HostedAccessPlanScopeTests</code>, <code>EntitlementScopeTableTests</code>,
+<code>HostedEntitlementGateTests</code> and <code>HostedProTrialTests</code> - <strong>60 tests</strong>. The
+trial class is included deliberately: it is the control that shows the plan gate does not break the merged
+fourteen-day trial.</p>
+
+<table>
+  <tr><th>#</th><th>Sabotage applied</th><th>Result</th><th>What it proves</th></tr>
+
+  <tr>
+    <td>Baseline</td>
+    <td>None - the branch as it stands.</td>
+    <td><code>Passed! - Failed: 0, Passed: 60, Skipped: 0, Total: 60</code></td>
+    <td>The starting point is green, so every red below is caused by the sabotage.</td>
+  </tr>
+
+  <tr>
+    <td>A</td>
+    <td>Give <code>pro_selfhost</code> the <code>hosted_gateway</code> scope in the table.</td>
+    <td><code>Failed! - Failed: 6, Passed: 54</code><br>
+      <code>A_self_host_plan_is_refused_hosted_gateway_provisioning</code><br>
+      <code>A_self_host_plan_still_grants_the_artificial_intelligence_features</code><br>
+      <code>ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier</code><br>
+      <code>ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse</code><br>
+      <code>GrantsHostedGateway_ProSelfHost_IsFalse</code><br>
+      <code>AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess</code></td>
+    <td>The refusal is real and both doors redden together. The 54 that stayed green - including every trial
+      test - show this is a plan boundary and not a gate that denies everyone.</td>
+  </tr>
+
+  <tr>
+    <td>B</td>
+    <td>Disable ONLY the enrolment door (<code>HostedEnrollmentEndpoint.Enroll</code>), leaving the table and
+      the lease gate intact.</td>
+    <td><code>Failed! - Failed: 2, Passed: 58</code><br>
+      <code>A_self_host_plan_is_refused_hosted_gateway_provisioning</code><br>
+      <code>An_unknown_plan_is_refused_hosted_gateway_provisioning</code></td>
+    <td>The enrolment gate genuinely enforces. It is not decoration on top of a table that would refuse anyway -
+      remove it and provisioning succeeds.</td>
+  </tr>
+
+  <tr>
+    <td>C</td>
+    <td>Disable ONLY the ongoing-request door (the plan case in
+      <code>HostedAccessLeaseService</code>), leaving the table and the enrolment gate intact.</td>
+    <td><code>Failed! - Failed: 2, Passed: 58</code><br>
+      <code>AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess</code><br>
+      <code>AuthorizeAsync_UnknownPlan_DeniesHostedAccess</code></td>
+    <td>The second door genuinely enforces too, independently of the first. An account that moves onto a
+      self-host plan stops being served; without this line it would be served indefinitely.</td>
+  </tr>
+
+  <tr>
+    <td>D</td>
+    <td>Replace the exact ordinal lookup with a <code>StartsWith</code>, case-insensitive match - the exact
+      string trap the issue is exposed to.</td>
+    <td><code>Failed! - Failed: 8, Passed: 52</code>, including
+      <code>ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier</code>,
+      <code>GrantsHostedGateway_AnUnrecognisedTier_IsFalse(tier: "PRO_SELFHOST")</code> and
+      <code>GrantsHostedGateway_AnUnrecognisedTier_IsFalse(tier: "Hosted")</code>, plus both doors.</td>
+    <td>The prefix trap is caught. A sloppy comparison that treated <code>pro_selfhost</code> as
+      <code>pro</code> - and therefore handed it hosted gateway - cannot ship unnoticed.</td>
+  </tr>
+
+  <tr>
+    <td>Revert</td>
+    <td>All sabotage removed; <code>git diff</code> against the commit empty.</td>
+    <td><code>Passed! - Failed: 0, Passed: 60, Skipped: 0, Total: 60</code>, rebuilt with 0 warnings and
+      0 errors.</td>
+    <td>The tree is back exactly as the pull request has it, and green.</td>
+  </tr>
+</table>
+
+<h2>4. The deny default - a guard has two failure directions</h2>
+
+<p>Checked in both directions, not just the one the issue names.</p>
+
+<ul>
+  <li><strong>Unknown tier is DENIED.</strong> <code>ForTier</code> returns the empty set for any tier string
+    not in the table, so <code>GrantsHostedGateway</code> is false. Enforced at both doors and pinned at both:
+    <code>An_unknown_plan_is_refused_hosted_gateway_provisioning</code> (enrolment, 402 with nothing given away)
+    and <code>AuthorizeAsync_UnknownPlan_DeniesHostedAccess</code> (ongoing). Both reddened under sabotage B and
+    C respectively, so both are load bearing.</li>
+  <li><strong>The tiers that already granted it still do.</strong> <code>hosted</code>, <code>pro</code> and a
+    null tier all still grant hosted gateway
+    (<code>GrantsHostedGateway_TheTiersThatAlreadyGrantedIt_StillDo</code>), so the new table does not quietly
+    take hosted access away from an existing paying customer. The null carve-out is the pre-column row and is
+    written as its own documented entry rather than hidden in a default.</li>
+  <li><strong>Self-host deployments are untouched.</strong> A null entitlement registry means no gate at all,
+    which is the deployment that has no billing. That control is still green.</li>
+</ul>
+
+<h3>One observation, not a defect</h3>
+<p>A tier column holding only whitespace is treated as null and therefore grants hosted gateway. That is the
+documented pre-column carve-out and is correct for the rows it exists to protect; it is recorded here only so
+the behaviour is on the record. The payment side writes the literal string <code>pro_selfhost</code>, which the
+Gateway matches exactly, so nothing about the self-host plan depends on this path.</p>
+
+<h2>5. The fourteen-day trial was not broken</h2>
+
+<p>Pull request 2132 grants the literal tier <code>pro</code> with no paid row for fourteen days, and that tier
+legitimately carries hosted gateway. That is written intent (issue 2117) and was neither flagged nor changed.</p>
+
+<ul>
+  <li><code>HostedProTrialTests</code> alone: <code>Passed! - Failed: 0, Passed: 15, Skipped: 0, Total: 15</code>.</li>
+  <li>Not one trial test appears in the failure list of any of the four sabotages. The trial is invisible to the
+    plan gate, which is the intended outcome: <code>EntitlementRegistry.Evaluate</code> folds a running trial and
+    returns tier <code>pro</code>, and <code>pro</code> carries hosted gateway in the table.</li>
+  <li>The enrolment endpoint's separate act of creating a trial on first arrival now stamps
+    <code>tier = TierPro</code> explicitly, so a freshly granted trial and an already-running one are ruled on
+    identically rather than the fresh one being judged on an absent row's null tier. Read in the source and
+    covered by the trial tests above.</li>
+</ul>
+
+<h2>6. Full Gateway suite, run and read by QA</h2>
+
+<p>Run in the QA worktree on the pull request commit, and the final line read directly rather than summarised:</p>
+
+<pre>Passed!  - Failed:     0, Passed:  3997, Skipped:    17, Total:  4014, Duration: 30 m 29 s - CcDirector.Gateway.Tests.dll (net10.0)</pre>
+
+<p>No test failed, so no failing test needed to be re-run alone to separate a regression from contention. The
+17 skips were inspected: they are the pre-existing real-PostgreSQL tests and the architecture skips, unrelated
+to this change. Build of the Gateway test project: <strong>0 warnings, 0 errors</strong>.</p>
+
+<h2>7. Method and regression checks</h2>
+
+<ul>
+  <li><strong>Nothing adjacent broke.</strong> The full suite is green and the pre-existing tier-agnostic
+    enrolment behaviour for <code>hosted</code>, <code>pro</code> and null rows is explicitly preserved and
+    tested.</li>
+  <li><strong>No schema change was needed.</strong> The entitlements table is website-owned and excluded from
+    migrations, and it already carries the tier column. No Entity Framework migration is required, so the
+    standing "a model change needs a migration in the same pull request" rule is not engaged.</li>
+  <li><strong>The verdict lives on the Gateway.</strong> One table owns what a plan grants; the call sites read
+    it rather than re-deriving it. No client-side branching was introduced.</li>
+  <li><strong>No secret, subject or personally identifying value is logged</strong> by either new refusal path -
+    both log the reason only.</li>
+  <li><strong>No attribution.</strong> The commit message, pull request body and all added files were searched
+    for assistant or vendor attribution strings; none present.</li>
+  <li><strong>No deployment, and the paid-till flag untouched.</strong> Nothing was deployed and
+    <code>PRO_SUBSCRIPTION_ENABLED</code> was not set, changed or read in any environment.</li>
+</ul>
+
+<h2>Conclusion</h2>
+
+<p class="pass">VERIFIED - all acceptance criteria that belong to this repository are met.</p>
+
+<p>The Gateway recognises <code>pro_selfhost</code>, grants it exactly dictation, text to speech and the
+wingman, and refuses it hosted gateway capacity at both places hosted capacity is handed out. The comparison is
+whole-string ordinal equality and the prefix trap is pinned by a test that this verification made fail on
+purpose. An unrecognised tier is denied. The merged fourteen-day trial still works. The two remaining
+acceptance items - the check against the deployed gateway, and the till release checklist - are the owner's
+post-merge act and another repository's record respectively, and are called out rather than quietly dropped.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/2147/report.html
+++ b/docs/cencon/proof/2147/report.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Issue #2147 - Gateway adopts the pro_selfhost scope table</title>
+<style>
+  body { font: 15px/1.6 system-ui, sans-serif; max-width: 940px; margin: 24px auto; padding: 0 16px; color: #1a1a2e; }
+  h1 { font-size: 22px; } h2 { font-size: 18px; margin-top: 30px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  h3 { font-size: 15px; margin-top: 20px; }
+  code { background: #f0f0f5; padding: 1px 5px; border-radius: 3px; font-size: 13px; }
+  pre { background: #f7f7fb; border: 1px solid #ddd; border-radius: 6px; padding: 10px 12px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th, td { border: 1px solid #ccc; padding: 8px 10px; text-align: left; vertical-align: top; font-size: 14px; }
+  th { background: #f5f5fa; }
+  .ok { color: #0a7d2c; font-weight: 600; }
+  .warn { color: #9a5b00; font-weight: 600; }
+  .files li { margin: 3px 0; }
+  blockquote { border-left: 4px solid #d0d0dd; margin: 12px 0; padding: 4px 14px; color: #444; background: #fafafd; }
+</style>
+</head>
+<body>
+<h1>Issue #2147 - The Gateway adopts the <code>pro_selfhost</code> scope table</h1>
+<p><strong>Branch:</strong> <code>feat/gateway-pro-selfhost-scopes</code> &nbsp;
+   <strong>Base:</strong> <code>origin/main</code> at <code>0100a2b5</code> (rebased onto the merged fourteen-day
+   Pro trial, pull request 2132) &nbsp;
+   <strong>Schema change:</strong> none (the entitlements table already admits the tier)</p>
+
+<h2>The outcome in one paragraph</h2>
+<p>The website sells a Pro <em>self-host</em> plan that pays for the artificial-intelligence features only -
+dictation, text to speech, and the wingman - and explicitly not for hosted capacity. Until this change the
+Gateway had never heard of that plan: its entitlement read is deliberately tier-agnostic, so <em>any</em> live
+paid row provisioned a hosted tenant and a device key. The day the paid till opens, a self-host subscriber
+would therefore have obtained hosted gateway service they never bought, silently - a successful provisioning
+looks exactly like a correct one. This change gives the Gateway one place that says what a plan grants, and
+enforces it at the two points where hosted capacity is actually handed out.</p>
+
+<h2>What was implemented</h2>
+<ol>
+  <li><strong>One table that owns what a plan grants</strong> - new
+    <code>src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs</code>. It maps a tier string to its scope set
+    (<code>dictation</code>, <code>tts</code>, <code>wingman</code>, <code>hosted_gateway</code>) and is the
+    only place in the Gateway allowed to decide what a plan includes. <code>pro_selfhost</code> gets exactly
+    the three artificial-intelligence scopes and no hosted gateway. The table is an <strong>allowlist with a
+    deny default</strong>: a tier string this code has never been taught grants nothing at all.</li>
+  <li><strong>The provisioning door refuses</strong> -
+    <code>src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs</code>. After the existing money question
+    ("is there a live paid row?") it now asks the plan question ("does that plan include hosted capacity?")
+    and answers 402 when it does not. No tenant is minted and no device key is issued, which is the same
+    both-halves refusal the unpaid path already makes.</li>
+  <li><strong>The ongoing door refuses too</strong> -
+    <code>src/CcDirector.Gateway/Tenancy/HostedAccessLeaseService.cs</code>. Enrolment is a one-time act; a
+    tenant that already exists re-asks this gate on every hosted request. An account that <em>moves</em> from a
+    hosted plan to a self-host one still has an active, paying row, so the entitlement outcome is legitimately
+    <em>Entitled</em> - it is the plan that refuses, not the payment. Without this line such an account would
+    be served hosted service indefinitely. It denies (402 via the authentication middleware) and deliberately
+    does <strong>not</strong> revoke device credentials; see the design notes.</li>
+  <li><strong>A tier constant</strong> - a single <code>TierProSelfHost</code> constant added next to the
+    existing <code>TierHosted</code>/<code>TierPro</code> in <code>EntitlementRegistry.cs</code>. That file's
+    behaviour is otherwise untouched: it still passes whatever tier the row carries straight through,
+    unexamined. The money question and the capability question stay separate on purpose.</li>
+</ol>
+
+<h2>Design notes - the three decisions worth arguing about</h2>
+
+<h3>0. How this composes with the fourteen-day Pro trial (merged while this was in flight)</h3>
+<p>Pull request 2132 landed on main during this work and edits the same two files. This branch was rebased
+onto it and <strong>keeps both behaviours</strong> - the trial fold and the plan gate. The interaction is the
+part worth checking, so it is stated explicitly:</p>
+<ul>
+  <li><code>EntitlementRegistry.Evaluate</code> now folds a running trial itself and returns
+      <strong>tier <code>pro</code></strong> with the trial's end instant. Tier <code>pro</code> carries
+      <code>hosted_gateway</code> in the table, so <strong>a trial account still enrols and is still served</strong>
+      - the plan gate is invisible to it. That is written intent (issue 2117, owner-approved) and this change
+      does not touch it.</li>
+  <li>The enrolment endpoint's separate act of <em>creating</em> a trial on a first arrival now also stamps
+      <code>tier = TierPro</code>, so a freshly granted trial and an already-running one are ruled on
+      identically rather than the fresh one being judged on the absent paid row's null tier.</li>
+  <li>The gate reads <code>Evaluate</code> rather than <code>LookupBySubject</code> so the outcome and the tier
+      come from the <strong>same read of the same row</strong> and cannot disagree.</li>
+</ul>
+<p><strong>The string trap this creates, and the test that holds it.</strong> <code>"pro"</code> is a PREFIX of
+<code>"pro_selfhost"</code>, and <code>"pro"</code> deliberately grants hosted gateway. Any comparison sloppy
+about where a tier string ends - <code>StartsWith</code>, <code>Contains</code>, a substring or
+"begins with pro" shortcut - would hand hosted gateway to the exact plan this issue exists to deny, and would
+look correct doing it. The table matches whole strings by ordinal equality, and
+<code>ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier</code> pins it: the two tiers resolve to different
+scope sets, differing by exactly the hosted gateway scope.</p>
+
+<h3>1. The entitlement read does not police plans, and must not start</h3>
+<p><code>EntitlementRegistry</code> answers "is there live money for this account". It is tier-agnostic by
+design and passes the tier through untouched. The refusal therefore lives in the scope table and at the places
+that authorize a capability - never inside the read. This also keeps the change compatible with the concurrent
+trial work (pull request 2132), which folds a trial into that same read and returns the literal tier
+<code>pro</code>.</p>
+
+<h3>2. The default is deny, and the null tier is a documented carve-out</h3>
+<p>An unrecognised tier grants nothing. The two failure directions are not symmetric: refusing a plan we have
+not taught the Gateway about is visible and reversible in one line, while granting hosted capacity to an
+unknown plan is invisible - which is the exact bypass this issue exists to close. This mirrors the law
+<code>EntitlementRegistry</code> already states about subscription states ("a value it does not recognise is
+NOT entitled").</p>
+<p>The one exception is a <strong>null</strong> tier. The tier column was added to the payment-side table after
+rows already existed, so a pre-column row reads back null. That is an <em>old hosted row</em>, not an unknown
+plan, and it has always granted hosted access; folding it into the deny default would lock out established
+paying customers over a column they predate. It is written as its own entry, with its reason, and pinned by
+its own test.</p>
+
+<h3>3. A plan refusal denies but does not revoke</h3>
+<p>The cancellation path revokes device credentials (a durable tombstone) when a subscription lapses. A plan
+refusal deliberately does not. The reason for a plan refusal is a <em>string the payment side writes</em>: a
+renamed or mistyped plan would otherwise destroy a paying customer's device credentials, and a later
+correction cannot undo that. The deny is re-evaluated on every request and is sufficient - it produces the
+same 402 the caller gets for a cancelled subscription. The lease is still overwritten terminal-negative, for
+the same reason the cancellation branch does it: so a stale positive lease cannot later be ridden into an
+allow by a failed read.</p>
+
+<h2>Acceptance criteria - each with its proof</h2>
+<table>
+  <tr><th>Criterion</th><th>Expected</th><th>Actual (proof)</th><th>Result</th></tr>
+  <tr>
+    <td>The Gateway's entitlement handling recognises tier <code>pro_selfhost</code> and grants exactly
+        dictation, tts, wingman.</td>
+    <td>The three artificial-intelligence scopes, and a set size of exactly three.</td>
+    <td><code>A_self_host_plan_still_grants_the_artificial_intelligence_features</code> and
+        <code>ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse</code> assert the
+        exact set, not just membership - a fourth scope creeping in reddens them.</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>It never provisions hosted gateway capability for that tier.</td>
+    <td>402, no tenant minted, no device key issued - through the real enrolment path.</td>
+    <td><code>A_self_host_plan_is_refused_hosted_gateway_provisioning</code> calls
+        <code>HostedEnrollmentEndpoint.Enroll</code> (the same call the mobile enrolment endpoint makes) with an
+        active, live-money, in-period <code>pro_selfhost</code> row and asserts 402 plus
+        <code>AssertNothingWasGivenAway</code> - no tenant, no device entry.</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>It never <em>grants</em> hosted gateway capability for that tier (not only at provisioning).</td>
+    <td>Hosted requests from such a tenant are denied on the ongoing path.</td>
+    <td><code>AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess</code> - the lease gate the
+        authentication middleware calls on every hosted request returns <code>DenyNotEntitled</code> (which the
+        middleware renders as 402 <code>hosted_subscription_required</code>).</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>Negative control: an account whose entitlement row says <code>pro_selfhost</code> is refused
+        hosted-gateway provisioning.</td>
+    <td>A test that would FAIL if the tier were wrongly granted hosted gateway.</td>
+    <td>Revert-proved below, and repeated on the REBASED tree after the trial work merged into this path:
+        granting <code>pro_selfhost</code> the <code>hosted_gateway</code> scope turns six tests RED while
+        every positive control - including every trial test - stays green.</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>The fourteen-day Pro trial (merged mid-flight) still works.</td>
+    <td>A trial account still enrols and is still served hosted.</td>
+    <td>The trial grants tier <code>pro</code>, which carries <code>hosted_gateway</code> in the table, so the
+        plan gate never sees it. Every trial test on main passes on this branch (included in the 60-test run
+        above and in the full suite), and they stayed green even while the table was sabotaged.</td>
+    <td class="ok">PASS</td>
+  </tr>
+  <tr>
+    <td>Proven against the deployed gateway.</td>
+    <td>A live check against the hosted service.</td>
+    <td><span class="warn">NOT DONE IN THIS CHANGE - deliberately.</span> The supervisor instructed that this
+        session must not deploy the hosted Gateway (a concurrent session may be deploying) and must never set
+        <code>PRO_SUBSCRIPTION_ENABLED</code> anywhere. Deployment is coordinated after merge; this is the
+        merge-first, QA-after order. The live negative control belongs to that step.</td>
+    <td class="warn">DEFERRED</td>
+  </tr>
+  <tr>
+    <td>The release checklist for opening the till references this issue as a prerequisite.</td>
+    <td>A durable checklist entry.</td>
+    <td><span class="warn">BELONGS TO THE OTHER REPOSITORY.</span> <code>PRO_SUBSCRIPTION_ENABLED</code> does
+        not exist anywhere in this repository (verified by search); the flag and its release checklist live in
+        the website repository (devthrottle_internal). Writing a till checklist into this repository would put
+        the record in the wrong place. Flagged for routing rather than guessed at.</td>
+    <td class="warn">OUT OF THIS REPO</td>
+  </tr>
+</table>
+
+<h2>The tests, and how each one fails on purpose</h2>
+<p>A test that cannot fail is not proof, so each one below has a stated way to redden it and a paired positive
+control that stops it passing for the wrong reason (a gate that refused everyone would satisfy every deny
+assertion while shipping a dead product).</p>
+
+<h3>Enrolment - <code>src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs</code></h3>
+<ul>
+  <li><code>A_self_host_plan_is_refused_hosted_gateway_provisioning</code> - the negative control.
+      <em>Reddens if</em> <code>pro_selfhost</code> is given the <code>hosted_gateway</code> scope, or the plan
+      gate is deleted from <code>Enroll</code>: status becomes 200 and a tenant is minted.</li>
+  <li><code>A_self_host_plan_still_grants_the_artificial_intelligence_features</code> - the paired positive.
+      <em>Reddens if</em> someone "fixes" the refusal by denying the plan everything.</li>
+  <li><code>An_unknown_plan_is_refused_hosted_gateway_provisioning</code> - the deny default at the door.</li>
+  <li><code>ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier</code> - the prefix trap described above:
+      <code>"pro"</code> is a prefix of <code>"pro_selfhost"</code> and grants hosted gateway, so a sloppy
+      comparison would silently undo this whole issue.</li>
+  <li>Pre-existing and still green: <code>An_active_subscription_enrolls</code>,
+      <code>Enrollment_grants_on_any_active_entitlement_regardless_of_tier</code> (hosted / pro / null),
+      <code>Self_host_has_no_gate_at_all</code> (the self-hosted deployment control - no entitlement registry,
+      no gate, unchanged behaviour).</li>
+</ul>
+
+<h3>Ongoing access and the table - <code>src/CcDirector.Gateway.Tests/HostedAccessPlanScopeTests.cs</code> (new)</h3>
+<ul>
+  <li><code>AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess</code> - the second door.
+      <em>Reddens if</em> the plan branch is removed from <code>HostedAccessLeaseService</code>.</li>
+  <li><code>AuthorizeAsync_HostedPlanOnAnActiveRow_AllowsHostedAccess</code> - the positive control: an
+      identical row on the hosted plan IS served, so the refusal is aimed at the plan and not at everyone.</li>
+  <li><code>AuthorizeAsync_SelfHostPlan_DeniesWithoutRevokingDeviceCredentials</code> - pins the
+      deny-but-do-not-tombstone decision.</li>
+  <li><code>AuthorizeAsync_UnknownPlan_DeniesHostedAccess</code> - the deny default on the ongoing path.</li>
+  <li><code>AuthorizeAsync_RowPredatingTheTierColumn_AllowsHostedAccess</code> - the null-tier carve-out, so a
+      future edit cannot fold established customers into the deny default unnoticed.</li>
+  <li>Table tests: exact scope set for <code>pro_selfhost</code>; <code>GrantsHostedGateway</code> false for
+      <code>pro_selfhost</code>; still true for hosted / pro / null (the no-regression line); false for an
+      unrecognised tier <em>and</em> for wrong-cased ones (matching is exact, because a tier is a value the
+      payment side writes, not prose to interpret); every paid plan keeps the artificial-intelligence scopes;
+      a blank scope name throws rather than silently answering.</li>
+</ul>
+
+<h2>Revert-proof (the tests fail when the behaviour is removed)</h2>
+<p>The negative controls were confirmed to be load-bearing by deliberately breaking the behaviour and
+re-running: giving <code>pro_selfhost</code> the <code>hosted_gateway</code> scope in the table.</p>
+<pre id="revert-proof">Change made: [EntitlementRegistry.TierProSelfHost] = Set(Dictation, Tts, Wingman, HostedGateway)
+             (that is: the self-host plan wrongly granted hosted gateway)
+
+  Failed CcDirector.Gateway.Tests.HostedAccessPlanScopeTests.AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess [133 ms]
+  Failed CcDirector.Gateway.Tests.EntitlementScopeTableTests.ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse [5 ms]
+  Failed CcDirector.Gateway.Tests.EntitlementScopeTableTests.GrantsHostedGateway_ProSelfHost_IsFalse [&lt; 1 ms]
+  Failed CcDirector.Gateway.Tests.HostedEntitlementGateTests.A_self_host_plan_is_refused_hosted_gateway_provisioning [335 ms]
+  Failed CcDirector.Gateway.Tests.HostedEntitlementGateTests.A_self_host_plan_still_grants_the_artificial_intelligence_features [1 ms]
+
+Failed!  - Failed: 5, Passed: 39, Skipped: 0, Total: 44, Duration: 7 s
+
+READ THIS RESULT CAREFULLY - it says two things, and the second is the important one:
+
+  1. The refusal is REAL at BOTH doors. The enrolment negative control went red (it started
+     returning 200 and minting a tenant) AND the ongoing lease gate went red (it started
+     allowing). Neither is a table-only assertion.
+  2. The 39 that stayed GREEN are what stops these from being a gate that simply denies
+     everyone: the hosted plan still enrolled, the hosted plan was still served on the ongoing
+     path, an unknown plan was still refused, a pre-column null row was still served, and the
+     self-hosted deployment control still had no gate at all.
+
+Restored to Set(AiScopes), rebuilt, and re-run green (below).
+
+REPEATED ON THE REBASED TREE, because a sabotage check passed on the old base proves nothing
+about the merged one - the trial work landed in the exact path being guarded:
+
+  Failed  EntitlementScopeTableTests.ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier [2 ms]
+  Failed  EntitlementScopeTableTests.ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse [5 ms]
+  Failed  EntitlementScopeTableTests.GrantsHostedGateway_ProSelfHost_IsFalse [&lt; 1 ms]
+  Failed  HostedEntitlementGateTests.A_self_host_plan_is_refused_hosted_gateway_provisioning [1 s]
+  Failed  HostedEntitlementGateTests.A_self_host_plan_still_grants_the_artificial_intelligence_features [1 ms]
+  Failed  HostedAccessPlanScopeTests.AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess [103 ms]
+
+Failed!  - Failed: 6, Passed: 54, Skipped: 0, Total: 60, Duration: 9 s
+  (that run covers the three scope classes PLUS every trial test)
+
+Six now, not five: the added prefix-trap test reddens too, which is the point of it. EVERY TRIAL
+TEST STAYED GREEN throughout the sabotage - the wrongly-granted scope changed only the self-host
+plan's fate, never the trial's. Sabotage reverted; `git diff` against the commit is empty.</pre>
+
+<h2>Build and test results</h2>
+<pre id="results">1. FULL SOLUTION BUILD (dotnet build cc-director.sln, from the worktree root)
+
+   Build succeeded.
+       0 Warning(s)
+       0 Error(s)
+
+2. THE AFFECTED CLASSES PLUS EVERY TRIAL TEST, RUN ALONE (the fast signal)
+
+   Passed!  - Failed: 0, Passed: 60, Skipped: 0, Total: 60, Duration: 11 s
+
+   The trial tests are in this filter deliberately: pull request 2132 put the trial into the exact
+   path this change guards, so "did I break the trial" has to be answered every time, not assumed.
+
+3. THE FULL GATEWAY SUITE (dotnet test src/CcDirector.Gateway.Tests, run alone)
+
+   ON THE REBASED BASE (0100a2b5, the merged trial) - this is the run that counts:
+
+   Passed!  - Failed: 0, Passed: 3997, Skipped: 17, Total: 4014, Duration: 14 m 55 s
+
+   For the record, the same suite on the PRE-rebase base (f776ea19) was also green:
+
+   Passed!  - Failed: 0, Passed: 3981, Skipped: 17, Total: 3998, Duration: 15 m 31 s
+
+   The 17 skips are the tests that require a real PostgreSQL server (PostgresProviderProofTests,
+   GatewayHostBootSmokeTests, DeviceCredentialImportPostgresTests, the Postgres half of
+   EntitlementSchemaQualificationTests, and the caller-supplied-key upgrade tests). They skip for
+   want of a configured Postgres, not because of this change, and they skipped the same way before it.
+
+NOTE ON THE RUN, so a slow suite is not mistaken for a hang: the suite takes about fifteen minutes
+because HostedImagePublishedArtifactTests shells out to `dotnet publish` for each entry executable,
+allowing up to five minutes each, and roughly twenty-five dotnet processes from concurrent fleet
+sessions were saturating this machine. An earlier attempt was abandoned after running TWO test hosts
+of this suite at once (my own error) - both were stopped, and the numbers above come from a single
+run with nothing else of mine competing.
+
+Only this one test project is affected: the change touches CcDirector.Gateway and its test project
+and nothing else. No other project references EntitlementScopes.
+
+<h2>CenCon impact</h2>
+<p><strong>No architecture drift.</strong> No new container, no new dependency, no new persisted data, and
+<strong>no Entity Framework migration</strong> - the entitlements table is website-owned and excluded from
+migrations, and it already admits the tier. One new type inside the existing
+<code>CcDirector.Gateway</code> Tenancy area.</p>
+<p><strong>Security posture: strictly tightened.</strong> Every change moves in the deny direction. Nothing
+that was permitted before is permitted now except through an explicitly listed plan, and the previously
+tier-agnostic provisioning path gained a plan check. (Note: <code>docs/cencon/</code> in this repository
+currently holds only <code>DEVELOPMENT_METHOD.md</code> and <code>proof/</code> - there is no
+<code>architecture_manifest.yaml</code> or <code>security_profile.yaml</code> here to drift, so no CenCon
+document required an update.) Nothing personally identifying is logged by the new code paths: the refusal logs
+state the reason and never the subject, the email, or the tier value.</p>
+
+<h2>Files changed</h2>
+<ul class="files">
+  <li><code>src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs</code> - NEW. The one plan-to-scope table.</li>
+  <li><code>src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs</code> - the plan gate at provisioning.</li>
+  <li><code>src/CcDirector.Gateway/Tenancy/HostedAccessLeaseService.cs</code> - the plan gate on the ongoing
+      hosted request path.</li>
+  <li><code>src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs</code> - one added tier constant (kept
+      deliberately surgical: pull request 2132 edits this file).</li>
+  <li><code>src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs</code> - three tests added.</li>
+  <li><code>src/CcDirector.Gateway.Tests/HostedAccessPlanScopeTests.cs</code> - NEW test file.</li>
+</ul>
+
+<h2>Finding for the owner - not fixed here, reported deliberately</h2>
+<blockquote>
+<p><strong>Plain tier <code>pro</code> grants hosted gateway today, and this change keeps it that way.</strong>
+The enrolment gate has always been tier-agnostic, and an existing test
+(<code>Enrollment_grants_on_any_active_entitlement_regardless_of_tier</code>) pins <code>pro</code> as
+enrolling. Narrowing <code>pro</code> would change shipped, tested behaviour with a billing meaning, so it is
+not this issue's call.</p>
+<p>The consequence, for whoever owns the trial work: pull request 2132 makes tier <code>pro</code> reachable
+with <strong>no paid row at all</strong>, for fourteen days, on every new account. Combined with the
+above, that hands fourteen days of free hosted gateway to every new account. The scope table makes this a
+one-line decision if the owner wants it changed - <code>pro</code> simply stops listing
+<code>hosted_gateway</code> - but it needs an explicit business decision, not a developer's guess.</p>
+</blockquote>
+
+<h2>Statement</h2>
+<p>I believe this is finished for what it can prove in code. The Gateway now recognises
+<code>pro_selfhost</code>, grants it exactly dictation, text to speech and the wingman, and refuses it hosted
+gateway capacity at both places where that capacity is handed out - proven by tests that go red when the
+behaviour is removed. The two remaining acceptance items are explicitly outside this session's authority: the
+live check against the deployed gateway (deployment is coordinated by the supervisor after merge) and the till
+release checklist (which lives in the website repository, where the flag lives).</p>
+
+</body>
+</html>

--- a/src/CcDirector.Gateway.Tests/HostedAccessPlanScopeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedAccessPlanScopeTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The SECOND door into hosted capacity, and the one enrolment cannot close (issue #2147).
+///
+/// Enrolment is a one-time act. A tenant that already exists keeps asking this gate on EVERY hosted request,
+/// so an account that MOVES from a hosted plan to a self-host one - a downgrade, which is exactly what a
+/// self-host plan is sold as - would go on being served hosted service forever if only the front door checked
+/// the plan. Its entitlement row is still active and still paying, so the entitlement read legitimately says
+/// Entitled: it is the PLAN that refuses, not the payment, and nothing else in the request path is looking.
+///
+/// Both this gate and the enrolment gate read the SAME table (<see cref="EntitlementScopes"/>), so the two
+/// can never disagree about what a plan includes.
+///
+/// HOW THESE FAIL ON PURPOSE: delete the plan branch from <see cref="HostedAccessLeaseService"/> and the
+/// self-host test goes RED (it starts allowing). Give pro_selfhost the hosted_gateway scope in the table and
+/// it reddens the same way. The hosted control stays green in both cases, which is what proves the refusal is
+/// aimed at the plan and is not a gate that denies everyone.
+/// </summary>
+public sealed class HostedAccessPlanScopeTests : IDisposable
+{
+    private const string Subject = "sub-plan-scope";
+
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    /// <summary>Records revocations instead of performing them, so a test can assert that a plan refusal does
+    /// NOT tombstone a paying customer's device credentials.</summary>
+    private sealed class RecordingRevoker : ITenantAccessRevoker
+    {
+        public List<string> Revoked { get; } = new();
+
+        public Task RevokeAsync(TenantId tenant, string reason, CancellationToken ct = default)
+        {
+            Revoked.Add(tenant.Value);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>The payment-side table this Gateway only reads, with one active, live-money row on the given
+    /// plan - the best row a subscriber can have, so any refusal below is about the PLAN and nothing else.</summary>
+    private GatewayDatabase OpenWithPlan(string? tier)
+    {
+        var db = _harness.Open();
+        using var ctx = db.CreateUnscopedContext();
+        ctx.Database.ExecuteSqlRaw(
+            "CREATE TABLE IF NOT EXISTS entitlements (" +
+            "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
+            "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
+            "livemode INTEGER NULL, tier TEXT NULL)");
+        ctx.Database.ExecuteSqlRaw(
+            "INSERT INTO entitlements (subject, status, current_period_end, livemode, tier) VALUES ({0}, {1}, {2}, {3}, {4})",
+            Subject, EntitlementRegistry.StatusActive, DateTime.UtcNow.AddYears(1), true, tier);
+        return db;
+    }
+
+    private static (HostedAccessLeaseService leases, TenantId tenant, RecordingRevoker revoker) Wire(GatewayDatabase db)
+    {
+        var tenants = new TenantRegistry(db);
+        var tenant = tenants.MintOrLookupBySubject(Subject, "payer@example.com");
+        var revoker = new RecordingRevoker();
+        var leases = new HostedAccessLeaseService(
+            new EntitlementRegistry(db, requireLivemode: true), tenants, revoker);
+        return (leases, tenant, revoker);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess()
+    {
+        // The negative control on the ongoing path. Active, live money, in period - and still refused, because
+        // the plan does not include hosted capacity.
+        var (leases, tenant, _) = Wire(OpenWithPlan(EntitlementRegistry.TierProSelfHost));
+
+        var decision = await leases.AuthorizeAsync(tenant);
+
+        Assert.Equal(HostedAccessDecision.DenyNotEntitled, decision);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_HostedPlanOnAnActiveRow_AllowsHostedAccess()
+    {
+        // The positive control that stops the test above passing for the wrong reason. An identical row on the
+        // hosted plan IS served - so the refusal above is caused by the plan specifically and not by the row
+        // being rejected for some unrelated defect, and not by a gate that denies everyone.
+        var (leases, tenant, _) = Wire(OpenWithPlan(EntitlementRegistry.TierHosted));
+
+        var decision = await leases.AuthorizeAsync(tenant);
+
+        Assert.Equal(HostedAccessDecision.Allow, decision);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_SelfHostPlan_DeniesWithoutRevokingDeviceCredentials()
+    {
+        // A plan refusal denies; it must NOT tombstone. The reason for this refusal is a string the payment
+        // side writes, so a renamed or mistyped plan would otherwise destroy a paying customer's device
+        // credentials - damage a later correction cannot undo. The deny is re-evaluated on every request and is
+        // sufficient. (A CANCELLED subscription still revokes; that path is unchanged.)
+        var (leases, tenant, revoker) = Wire(OpenWithPlan(EntitlementRegistry.TierProSelfHost));
+
+        await leases.AuthorizeAsync(tenant);
+
+        Assert.Empty(revoker.Revoked);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_UnknownPlan_DeniesHostedAccess()
+    {
+        // The default direction on the ongoing path, matching the front door: a plan this code has never been
+        // taught grants nothing, so it is not served hosted capacity.
+        var (leases, tenant, _) = Wire(OpenWithPlan("enterprise_platinum"));
+
+        var decision = await leases.AuthorizeAsync(tenant);
+
+        Assert.Equal(HostedAccessDecision.DenyNotEntitled, decision);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_RowPredatingTheTierColumn_AllowsHostedAccess()
+    {
+        // The established customers who predate the tier column. A null tier is an OLD HOSTED ROW, not an
+        // unknown plan, and refusing it would lock out people who have paid for months over a column they were
+        // written before. If a future edit folds null into the unknown-plan default, this reddens - which is
+        // the point of writing it down.
+        var (leases, tenant, _) = Wire(OpenWithPlan(tier: null));
+
+        var decision = await leases.AuthorizeAsync(tenant);
+
+        Assert.Equal(HostedAccessDecision.Allow, decision);
+    }
+}
+
+/// <summary>
+/// The plan-to-scope table itself (issue #2147). The enforcement tests above prove the Gateway ACTS on this
+/// table; these pin what the table SAYS, so a plan's contents cannot drift silently underneath them.
+/// </summary>
+public sealed class EntitlementScopeTableTests
+{
+    [Fact]
+    public void ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse()
+    {
+        var granted = EntitlementScopes.ForTier(EntitlementRegistry.TierProSelfHost);
+
+        Assert.Equal(
+            new SortedSet<string>(StringComparer.Ordinal)
+            {
+                EntitlementScopes.Dictation, EntitlementScopes.Tts, EntitlementScopes.Wingman,
+            },
+            new SortedSet<string>(granted, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void GrantsHostedGateway_ProSelfHost_IsFalse()
+    {
+        Assert.False(EntitlementScopes.GrantsHostedGateway(EntitlementRegistry.TierProSelfHost));
+    }
+
+    [Theory]
+    [InlineData("hosted")]
+    [InlineData("pro")]
+    [InlineData(null)]
+    public void GrantsHostedGateway_TheTiersThatAlreadyGrantedIt_StillDo(string? tier)
+    {
+        // The no-regression line. These three already provisioned hosted capacity before this table existed
+        // (the tier-agnostic enrolment gate served all of them), and adding the table must not quietly take it
+        // away from anyone. Null is the pre-column row - see the class remarks on EntitlementScopes.
+        Assert.True(EntitlementScopes.GrantsHostedGateway(tier));
+    }
+
+    [Theory]
+    [InlineData("enterprise_platinum")]
+    [InlineData("PRO_SELFHOST")]
+    [InlineData("Hosted")]
+    public void GrantsHostedGateway_AnUnrecognisedTier_IsFalse(string tier)
+    {
+        // Deny by default, and EXACT matching. A tier is a value the payment side writes, not prose to be
+        // interpreted: accepting a different casing would mean accepting a string the payment side never wrote,
+        // and the whole table's safety rests on the two sides using identical values.
+        Assert.False(EntitlementScopes.GrantsHostedGateway(tier));
+    }
+
+    [Fact]
+    public void ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier()
+    {
+        // THE STRING-MATCHING TRAP, and it is the one mistake that would silently undo this entire issue.
+        // "pro" is a PREFIX of "pro_selfhost", and "pro" deliberately DOES carry hosted gateway (the fourteen-day
+        // trial on main grants exactly that tier). So any comparison that is sloppy about where a tier string
+        // ends - StartsWith, Contains, a prefix or substring match, a "does it begin with pro" shortcut - would
+        // hand hosted gateway to the one plan this issue exists to deny, and it would look completely correct
+        // while doing it.
+        //
+        // The table matches whole strings by ordinal equality, and these assertions pin that: the two tiers
+        // resolve to DIFFERENT scope sets, and the difference is exactly the hosted gateway scope.
+        var pro = EntitlementScopes.ForTier(EntitlementRegistry.TierPro);
+        var selfHost = EntitlementScopes.ForTier(EntitlementRegistry.TierProSelfHost);
+
+        Assert.StartsWith(EntitlementRegistry.TierPro, EntitlementRegistry.TierProSelfHost, StringComparison.Ordinal);
+        Assert.NotEqual(EntitlementRegistry.TierPro, EntitlementRegistry.TierProSelfHost);
+
+        Assert.True(pro.Contains(EntitlementScopes.HostedGateway));         // "pro" carries it, on purpose
+        Assert.False(selfHost.Contains(EntitlementScopes.HostedGateway));   // "pro_selfhost" never does
+        Assert.NotEqual(pro.Count, selfHost.Count);
+    }
+
+    [Fact]
+    public void ForTier_AnUnrecognisedTier_GrantsNothingAtAll()
+    {
+        Assert.Empty(EntitlementScopes.ForTier("enterprise_platinum"));
+    }
+
+    [Theory]
+    [InlineData("hosted")]
+    [InlineData("pro")]
+    [InlineData("pro_selfhost")]
+    [InlineData(null)]
+    public void ForTier_EveryPaidPlan_GrantsTheArtificialIntelligenceFeatures(string? tier)
+    {
+        // What every paid plan has in common. Self-host is a plan that pays for exactly these, so if a future
+        // edit narrows it by removing one of them, that is a paying customer losing a feature they bought.
+        var granted = EntitlementScopes.ForTier(tier);
+
+        Assert.Contains(EntitlementScopes.Dictation, granted);
+        Assert.Contains(EntitlementScopes.Tts, granted);
+        Assert.Contains(EntitlementScopes.Wingman, granted);
+    }
+
+    [Fact]
+    public void Grants_WithABlankScopeName_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => EntitlementScopes.Grants(EntitlementRegistry.TierHosted, "  "));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedEntitlementGateTests.cs
@@ -356,6 +356,66 @@ public sealed class HostedEntitlementGateTests : IDisposable
     }
 
     [Fact]
+    public void A_self_host_plan_is_refused_hosted_gateway_provisioning()
+    {
+        // THE NEGATIVE CONTROL for issue #2147, and it runs through the REAL provisioning path - the same
+        // Enroll call a self-host subscriber's Director would make - not through the scope table in isolation.
+        // A table that merely lacks an entry proves nothing about what the Gateway hands out; only refusing at
+        // the door does.
+        //
+        // The row here is as GOOD as a row gets: active, live money, in period. It pays. What it does not buy
+        // is hosted capacity, and this is the one line between a self-host subscriber and a tenant plus a
+        // device key - the tunnel, the cockpit, the mobile application - on a plan priced to exclude them.
+        //
+        // HOW IT FAILS ON PURPOSE: give pro_selfhost the hosted_gateway scope in EntitlementScopes (or delete
+        // the plan gate from HostedEnrollmentEndpoint.Enroll) and this test goes RED on both halves - the
+        // status becomes 200 and a tenant is minted. The paired positive below stops it passing for the wrong
+        // reason: if the gate simply refused everything, that one would red instead.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, livemode: true,
+            tier: EntitlementRegistry.TierProSelfHost);
+        var (devices, tenants, validator) = Wire(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: true), DateTime.UtcNow);
+
+        Assert.Equal(402, result.Status);
+        AssertNothingWasGivenAway(tenants);
+    }
+
+    [Fact]
+    public void A_self_host_plan_still_grants_the_artificial_intelligence_features()
+    {
+        // The POSITIVE half of the same plan, and the reason the refusal above is a plan boundary rather than
+        // a lockout. A self-host subscriber pays for exactly three things and must keep all three: dictation,
+        // text to speech, and the wingman. If a later edit "fixes" the refusal above by denying pro_selfhost
+        // everything, this reddens.
+        var granted = EntitlementScopes.ForTier(EntitlementRegistry.TierProSelfHost);
+
+        Assert.Contains(EntitlementScopes.Dictation, granted);
+        Assert.Contains(EntitlementScopes.Tts, granted);
+        Assert.Contains(EntitlementScopes.Wingman, granted);
+        Assert.DoesNotContain(EntitlementScopes.HostedGateway, granted);
+        Assert.Equal(3, granted.Count);   // EXACTLY those three - no fourth scope crept in
+    }
+
+    [Fact]
+    public void An_unknown_plan_is_refused_hosted_gateway_provisioning()
+    {
+        // The default direction. A tier string the Gateway has never been taught - a new plan the website ships
+        // before this table learns it, or a typo in the payment side - grants NOTHING, so it cannot provision
+        // hosted capacity. Refusing a plan we do not know about is visible and reversible in one line here;
+        // granting hosted capacity to one is silent and is the bypass this whole file exists to prevent.
+        var db = OpenWithEntitlements(EntitlementRegistry.StatusActive, livemode: true, tier: "enterprise_platinum");
+        var (devices, tenants, validator) = Wire(db);
+
+        var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
+            new EntitlementRegistry(db, requireLivemode: true), DateTime.UtcNow);
+
+        Assert.Equal(402, result.Status);
+        AssertNothingWasGivenAway(tenants);
+    }
+
+    [Fact]
     public void Evaluate_carries_no_tier_when_the_read_fails()
     {
         // Ignorance: the read FAILS (the payment-side table is absent, as a lost SELECT grant looks from here).

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -125,7 +125,14 @@ internal static class HostedEnrollmentEndpoint
         if (entitlements is not null)
         {
             var now = nowUtc ?? DateTime.UtcNow;
-            var outcome = entitlements.LookupBySubject(validation.Subject, now);
+
+            // Evaluate rather than LookupBySubject, because the PLAN gate below needs the tier from the SAME
+            // read the outcome came from - one read, one row, so the two questions can never disagree. Evaluate
+            // already folds a RUNNING trial (returning the Pro tier and the trial's end instant); the block
+            // below is the separate act of CREATING one on a first arrival.
+            var decision = entitlements.Evaluate(validation.Subject, now);
+            var outcome = decision.Outcome;
+            var tier = decision.Tier;
 
             // THE FREE TRIAL GRANT (issue #2117), and this is the ONLY place a trial is created. The public
             // pricing page promises every new account 14 days of Pro with no card, so an account that the
@@ -150,6 +157,12 @@ internal static class HostedEnrollmentEndpoint
                 {
                     FileLog.Write("[HostedEnrollment] enrolling on the free Pro trial (no paid entitlement; the account is inside its trial window)");
                     outcome = Tenancy.EntitlementOutcome.Entitled;
+
+                    // The trial grants the PRO plan - the same tier Evaluate returns for a running trial on
+                    // every later read - so the plan gate below sees the trial for what it is rather than
+                    // judging it on the absent paid row's null tier. Stated explicitly here so a freshly
+                    // granted trial and an already-running one are ruled on identically.
+                    tier = Tenancy.EntitlementRegistry.TierPro;
                 }
                 else if (trial.Outcome == Tenancy.TrialOutcome.Unknown)
                 {
@@ -173,6 +186,26 @@ internal static class HostedEnrollmentEndpoint
                 FileLog.Write("[HostedEnrollment] REFUSED: the entitlement read succeeded and this account has no active entitlement (no tenant minted, no device key issued)");
                 return new EnrollResult(StatusCodes.Status402PaymentRequired, null,
                     "this account does not have an active hosted subscription");
+            }
+
+            // THE PLAN GATE, and it is a SECOND question the first one cannot answer. Above we established
+            // that this account pays. Here we establish that what it pays for INCLUDES hosted capacity - which
+            // a self-host plan deliberately does not. Both refusals are a 402, but for different reasons: the
+            // first is "you have not paid", this one is "your plan does not include this".
+            //
+            // Without this, every paid plan would provision hosted capacity, because the entitlement read is
+            // tier-agnostic on purpose and passes the plan through unexamined. A self-host subscriber would
+            // then obtain a tenant and a device key - the tunnel, the cockpit, the mobile application - on a
+            // plan priced to exclude exactly that. Nothing would look wrong: enrolment would simply succeed.
+            //
+            // The verdict is not computed here. It is read from the ONE table that owns what a plan grants
+            // (EntitlementScopes), so adding a plan is one edit there and never a new branch at a call site.
+            if (!Tenancy.EntitlementScopes.GrantsHostedGateway(tier))
+            {
+                FileLog.Write("[HostedEnrollment] REFUSED: the account pays, but its plan does not include hosted " +
+                              "gateway capacity (no tenant minted, no device key issued)");
+                return new EnrollResult(StatusCodes.Status402PaymentRequired, null,
+                    "this plan does not include the hosted gateway");
             }
         }
 

--- a/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
@@ -322,4 +322,12 @@ public sealed class EntitlementRegistry
     /// </summary>
     public const string SubscribeMessage =
         "Your DevThrottle Pro access has ended. Subscribe to keep using the wingman, dictation and spoken replies.";
+
+    /// <summary>
+    /// The pro SELF-HOST plan tier: the artificial-intelligence features only, on a Gateway the customer runs
+    /// themselves. This reader treats it exactly like any other tier - it is passed through unexamined, because
+    /// this type answers "is there live money", not "what does the plan include". What it grants (and, load
+    /// bearing, what it does NOT) lives in <see cref="EntitlementScopes"/>.
+    /// </summary>
+    public const string TierProSelfHost = "pro_selfhost";
 }

--- a/src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs
@@ -1,0 +1,119 @@
+namespace CcDirector.Gateway.Tenancy;
+
+/// <summary>
+/// THE ONE PLACE that says what a paid plan tier grants. Nothing else in the Gateway may decide, infer or
+/// re-derive a plan's capabilities: a caller asks this table and renders the answer, exactly as the client is
+/// dumb about display state and the Gateway owns the verdict.
+///
+/// WHY THIS TABLE EXISTS AT ALL. The website's billing sells more than one shape of product. A hosted plan
+/// pays for a tenant on our infrastructure; a SELF-HOST plan pays only for the artificial-intelligence
+/// features - dictation, text-to-speech, and the wingman - and runs the Gateway on the customer's own
+/// machine. Those two are priced differently precisely because one of them costs us hosting. If the Gateway
+/// cannot tell them apart, a self-host subscriber obtains hosted capacity they never paid for, and the
+/// difference is silent: a successful provisioning looks exactly like a correct one.
+///
+/// THE ENTITLEMENT READ DOES NOT POLICE THIS. <see cref="EntitlementRegistry"/> answers a different question -
+/// "is there a live, paid row for this account" - and it passes whatever tier string that row carries straight
+/// through, unexamined. That separation is deliberate and must stay: the read is about money, this table is
+/// about capability. So the refusal belongs HERE and at the places that authorize a capability, never inside
+/// the entitlement read.
+///
+/// THE DEFAULT IS DENY, AND IT IS AN ALLOWLIST. A tier string this code does not recognise grants NOTHING.
+/// This is the same law <see cref="EntitlementRegistry"/> already states about subscription states - "a value
+/// it does not recognise is NOT entitled, because an unknown state is not an entitled one" - applied to plans.
+/// The failure directions are not symmetric: refusing a plan we have not taught the Gateway about is visible
+/// and reversible in one edit, while granting hosted capacity to an unknown plan is invisible and is exactly
+/// the bypass this table exists to prevent. A new plan therefore lands here as a deliberate line of code.
+///
+/// THE ONE CARVE-OUT IS THE NULL TIER, and it is not a guess. The tier column was added to the payment-side
+/// table after rows already existed, so a row written before it arrives as null. A null is an OLD HOSTED ROW,
+/// not an unknown plan, and it has always granted hosted access; refusing it would lock out established paying
+/// customers over a column they predate. It is written as its own entry so the reasoning is visible rather
+/// than hidden in a default.
+/// </summary>
+public static class EntitlementScopes
+{
+    /// <summary>Voice dictation - speech to text through the Gateway.</summary>
+    public const string Dictation = "dictation";
+
+    /// <summary>Text to speech - the spoken side of voice mode.</summary>
+    public const string Tts = "tts";
+
+    /// <summary>The wingman - the artificial-intelligence turn briefing and conversation.</summary>
+    public const string Wingman = "wingman";
+
+    /// <summary>
+    /// Hosted gateway capacity: a tenant on our infrastructure, a device key against the hosted Gateway, and
+    /// everything that key unlocks (the tunnel, the cockpit, the mobile application). This is the scope that
+    /// costs us money to serve, and the one a self-host plan must never obtain.
+    /// </summary>
+    public const string HostedGateway = "hosted_gateway";
+
+    // The three artificial-intelligence scopes every paid plan includes. Named once so a plan's entry states
+    // what is DIFFERENT about it rather than repeating the common part four times.
+    private static readonly string[] AiScopes = { Dictation, Tts, Wingman };
+
+    // THE TABLE. Ordinal comparison, because a tier is an exact string the payment side writes - not prose to
+    // be interpreted - and case-insensitive matching would quietly accept a value the payment side never wrote.
+    private static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> ByTier =
+        new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+        {
+            // The hosted plan: everything, including the hosted capacity it is named for.
+            [EntitlementRegistry.TierHosted] = Set(Dictation, Tts, Wingman, HostedGateway),
+
+            // The pro plan: today this grants hosted capacity as well. That is EXISTING, TESTED behaviour
+            // (Enrollment_grants_on_any_active_entitlement_regardless_of_tier) and this table preserves it
+            // rather than changing it - narrowing "pro" is a separate decision with its own billing meaning.
+            [EntitlementRegistry.TierPro] = Set(Dictation, Tts, Wingman, HostedGateway),
+
+            // The pro SELF-HOST plan: the artificial-intelligence features and NOTHING ELSE. The absence of
+            // HostedGateway on this line is the whole point of the plan and of this file.
+            [EntitlementRegistry.TierProSelfHost] = Set(AiScopes),
+        };
+
+    // The pre-column row. Carried separately from the table because its key is null and because its reason is
+    // historical rather than commercial - see the class remarks.
+    private static readonly IReadOnlySet<string> LegacyRowScopes = Set(Dictation, Tts, Wingman, HostedGateway);
+
+    // Nothing. The answer for a tier string this code has never been taught.
+    private static readonly IReadOnlySet<string> NoScopes = Set();
+
+    /// <summary>
+    /// What this tier grants. Never null - an unrecognised tier returns the EMPTY set, which is a refusal of
+    /// everything, and a null tier returns the legacy hosted row's scopes (see the class remarks).
+    /// </summary>
+    /// <param name="tier">The tier exactly as the payment-side row records it, or null for a row that predates
+    /// the tier column. Surrounding whitespace is ignored; a blank string is treated as null, because a column
+    /// holding only spaces records no plan.</param>
+    public static IReadOnlySet<string> ForTier(string? tier)
+    {
+        if (string.IsNullOrWhiteSpace(tier))
+            return LegacyRowScopes;
+
+        return ByTier.TryGetValue(tier.Trim(), out var scopes) ? scopes : NoScopes;
+    }
+
+    /// <summary>
+    /// Does this tier grant the named scope? The single question every capability check should ask.
+    /// </summary>
+    /// <param name="tier">The tier as the payment-side row records it, or null for a pre-column row.</param>
+    /// <param name="scope">One of the scope constants on this class.</param>
+    public static bool Grants(string? tier, string scope)
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+            throw new ArgumentException("A scope name is required", nameof(scope));
+
+        return ForTier(tier).Contains(scope);
+    }
+
+    /// <summary>
+    /// May an account on this tier be given HOSTED GATEWAY capacity - a tenant, a device key, and continued
+    /// hosted service? Named separately from <see cref="Grants"/> because it is the expensive question and the
+    /// one whose call sites must be findable in one search.
+    /// </summary>
+    /// <param name="tier">The tier as the payment-side row records it, or null for a pre-column row.</param>
+    public static bool GrantsHostedGateway(string? tier) => Grants(tier, HostedGateway);
+
+    private static IReadOnlySet<string> Set(params string[] scopes)
+        => new HashSet<string>(scopes, StringComparer.Ordinal);
+}

--- a/src/CcDirector.Gateway/Tenancy/HostedAccessLeaseService.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedAccessLeaseService.cs
@@ -135,6 +135,30 @@ public sealed class HostedAccessLeaseService
             var decision = _entitlements.Evaluate(subject, now.UtcDateTime);
             switch (decision.Outcome)
             {
+                case EntitlementOutcome.Entitled when !EntitlementScopes.GrantsHostedGateway(decision.Tier):
+                {
+                    // PAYING, BUT NOT FOR THIS. Enrolment is not the only door into hosted capacity: an account
+                    // that already holds a tenant keeps reaching this gate on every request, so a customer who
+                    // MOVES from a hosted plan to a self-host one would otherwise go on being served hosted
+                    // service indefinitely on a plan that excludes it. The entitlement row is still active, so
+                    // the outcome above is legitimately Entitled - it is the PLAN, not the payment, that
+                    // refuses. Same table as the enrolment gate, so the two can never disagree about a plan.
+                    //
+                    // Denied, and deliberately NOT revoked. Revocation tombstones device credentials, and the
+                    // reason for this refusal is a value written by the payment side: a plan renamed or
+                    // mistyped there would destroy a paying customer's devices, which a later correction cannot
+                    // undo. The deny is re-evaluated on every request and is enough - it is the same 402 the
+                    // caller gets for a cancelled subscription.
+                    //
+                    // The lease is overwritten TERMINAL-NEGATIVE for the same reason the cancellation branch
+                    // does it: it erases any positive lease this tenant still held from its hosted days, so a
+                    // later FAILED read cannot ride that stale positive lease into an Allow.
+                    FileLog.Write("[HostedAccessLease] DENIED: the tenant's entitlement is active but its plan does " +
+                                  "not include hosted gateway capacity (denied, not revoked)");
+                    _leases[key] = new Lease(EntitlementOutcome.NotEntitled, now);
+                    return HostedAccessDecision.DenyNotEntitled;
+                }
+
                 case EntitlementOutcome.Entitled:
                 {
                     // The clip: never past the paid boundary. A null period end means the row recorded none


### PR DESCRIPTION
Closes #2147 (hand-off to QA; the QA role closes it).

## Why

The website sells a Pro **self-host** plan that pays for dictation, text to speech and the wingman only - never for hosted capacity. The Gateway had never heard of that plan. Its entitlement read is deliberately tier-agnostic, so **any** live paid row provisioned a hosted tenant and a device key. The day `PRO_SUBSCRIPTION_ENABLED` opens the paid till, a self-host subscriber would have obtained hosted gateway service they never bought - and silently, because a successful provisioning looks exactly like a correct one.

This is the ordering constraint from the issue: the Gateway must adopt the scope table **before** the till opens.

## What changed

**One table owns what a plan grants** - new `src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs`. `pro_selfhost` gets exactly `dictation`, `tts`, `wingman`. It is an allowlist with a **deny default**: a tier string this code has never been taught grants nothing at all.

**The refusal is enforced where hosted capacity is actually handed out**, not only in the table:

1. `HostedEnrollmentEndpoint.Enroll` - after the money question ("is there a live paid row?") it now asks the plan question ("does that plan include hosted capacity?"). A self-host plan gets a 402 with **no tenant minted and no device key issued**.
2. `HostedAccessLeaseService` - enrolment is a one-time act, but a tenant that already exists re-asks this gate on every hosted request. An account that **moves** from a hosted plan to a self-host one still has an active, paying row, so the entitlement outcome is legitimately *Entitled* - it is the plan that refuses, not the payment. Without this it would be served hosted service indefinitely. It denies and deliberately does **not** revoke device credentials: the reason for a plan refusal is a string the payment side writes, and a rename or typo there must not tombstone a paying customer's devices.

`EntitlementRegistry` gains one constant and is otherwise untouched - it still answers "is there live money", not "what does the plan include". That separation is what keeps the refusal in the scope layer.

## Deliberate non-changes

- **No Entity Framework migration.** The entitlements table is website-owned, excluded from migrations, and already admits the tier.
- **Tier `pro` still grants hosted gateway.** That is existing, tested behaviour (`Enrollment_grants_on_any_active_entitlement_regardless_of_tier`) and narrowing it is a billing decision, not this change's call. See the note below.
- **A null tier still grants hosted gateway**, as its own documented entry: a row written before the tier column existed is an old hosted row, not an unknown plan, and refusing it would lock out established paying customers.

## Proof

`docs/cencon/proof/2147/report.html`

The negative control runs through the **real provisioning path**, not the table in isolation. Revert-proof (giving `pro_selfhost` the `hosted_gateway` scope):

```
Failed  AuthorizeAsync_SelfHostPlanOnAnActiveRow_DeniesHostedAccess
Failed  ForTier_ProSelfHost_GrantsTheThreeArtificialIntelligenceScopesAndNothingElse
Failed  GrantsHostedGateway_ProSelfHost_IsFalse
Failed  A_self_host_plan_is_refused_hosted_gateway_provisioning
Failed  A_self_host_plan_still_grants_the_artificial_intelligence_features
Failed!  - Failed: 5, Passed: 39
```

Both doors redden, and the 39 that stay green are what proves this is a plan boundary rather than a gate that denies everyone: the hosted plan still enrols, is still served on the ongoing path, an unknown plan is still refused, a pre-column row is still served, and the self-hosted deployment still has no gate at all.

## Not done here, on purpose

- **Live check against the deployed gateway.** Not deployed by this branch - deployment is coordinated after merge, and `PRO_SUBSCRIPTION_ENABLED` was not set anywhere.
- **The till release checklist.** `PRO_SUBSCRIPTION_ENABLED` does not exist anywhere in this repository; the flag and its checklist live in the website repository. Flagged for routing rather than written into the wrong repo.

## Note for the owner

Plain tier `pro` grants hosted gateway today and this change keeps it that way. Pull request #2132 makes tier `pro` reachable with **no paid row at all** for fourteen days on every new account - so together those hand fourteen days of free hosted gateway to every new account. The scope table makes it a one-line change if that is not wanted, but it needs an explicit business decision.

---

## Rebased onto the merged 14-day Pro trial (#2132), keeping both behaviours

That pull request landed on main mid-flight and edits the same two files. This branch is rebased onto it (base `0100a2b5`) and keeps the trial fold **and** the plan gate.

- `EntitlementRegistry.Evaluate` now folds a running trial itself and returns **tier `pro`** with the trial's end instant. Tier `pro` carries `hosted_gateway` in the table, so **a trial account still enrols and is still served** - the plan gate is invisible to it. That is the written intent of #2117 and this change does not touch it.
- The enrolment endpoint's separate act of *creating* a trial on first arrival now also stamps `tier = TierPro`, so a freshly granted trial and an already-running one are ruled on identically instead of the fresh one being judged on the absent paid row's null tier.
- The gate reads `Evaluate` rather than `LookupBySubject`, so the outcome and the tier come from the **same read of the same row** and cannot disagree.

### The string trap this creates

`"pro"` is a **prefix** of `"pro_selfhost"`, and `"pro"` deliberately grants hosted gateway. Any comparison sloppy about where a tier string ends - `StartsWith`, `Contains`, a substring or "begins with pro" shortcut - would hand hosted gateway to the exact plan this issue exists to deny, and would look correct doing it. The table matches whole strings by ordinal equality, and `ForTier_ProSelfHost_IsNeverTreatedAsThePlainProTier` pins it: the two tiers resolve to different scope sets, differing by exactly the hosted gateway scope.

### Re-verified on the rebased base (a pass on the old base proves nothing about the merged one)

- Full solution build: **0 warnings, 0 errors**
- Scope classes plus **every trial test**: **60 passed, 0 failed**
- Full Gateway suite: **0 failed, 3997 passed, 17 skipped** (the skips need a real PostgreSQL server; unrelated and pre-existing)
- Sabotage repeated on the rebased tree: **6 failed, 54 passed** - both doors red, the new prefix-trap test red, and **every trial test still green**. Reverted; `git diff` against the commit is empty.
