### PR TITLE
docs(proof): live negative control for issue #2147 against the deployed hosted Gateway

### DIFF
--- a/docs/cencon/proof/2147/live-control.html
+++ b/docs/cencon/proof/2147/live-control.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue 2147 - deploy and live negative control against the deployed hosted Gateway</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+         max-width: 1080px; margin: 0 auto; padding: 24px; line-height: 1.55; }
+  h1 { font-size: 1.7rem; margin-bottom: 0.2em; }
+  h2 { font-size: 1.25rem; margin-top: 2em; border-bottom: 1px solid #8884; padding-bottom: 0.25em; }
+  h3 { font-size: 1.02rem; margin-top: 1.6em; }
+  .sub { color: #6b7280; margin-top: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+  th, td { border: 1px solid #8884; padding: 7px 9px; vertical-align: top; text-align: left; font-size: 0.92rem; }
+  th { background: #8881; }
+  code, pre { font-family: Consolas, "Courier New", monospace; font-size: 0.86rem; }
+  pre { background: #8881; padding: 11px 13px; overflow-x: auto; border-radius: 5px; }
+  .pass { color: #15803d; font-weight: 700; }
+  .fail { color: #b91c1c; font-weight: 700; }
+  .blocked { color: #b45309; font-weight: 700; }
+  .note { background: #8881; border-left: 4px solid #6b7280; padding: 10px 14px; margin: 1em 0; border-radius: 0 4px 4px 0; }
+  .scroll { overflow-x: auto; }
+</style>
+</head>
+<body>
+
+<h1>Issue 2147 - deploy and live negative control</h1>
+<p class="sub">The hosted Gateway at <code>devthrottle-gw.azurewebsites.net</code>, deployed from
+<code>dc5f8b99</code> and then made to refuse a self-host plan on the wire.
+Run on 2026-07-25, 06:07Z to 06:25Z.</p>
+
+<div class="note">
+<strong>What this report is for.</strong> The change adds <code>EntitlementScopes</code> and refuses the
+<code>pro_selfhost</code> plan hosted-gateway capacity at two doors. That was proven in the test suite before
+merge. This report answers a different question, and the only one the issue actually exists for: does the
+<em>deployed service</em>, reachable on the public internet right now, refuse it? Every status code and body
+below came off the live service over HTTPS.
+</div>
+
+<h2>1. The deploy</h2>
+
+<table>
+<tr><th>Item</th><th>Value</th></tr>
+<tr><td>Deployed commit</td><td><code>dc5f8b99</code> - "feat(gateway): recognise the pro_selfhost plan and refuse it hosted gateway (#2147) (#2151)"</td></tr>
+<tr><td>Previous live commit</td><td><code>0100a2b5</code> - the 14-day Pro trial, deployed 2026-07-25T04:10Z</td></tr>
+<tr><td>Delta shipped</td><td>Exactly one commit. This deploy carries the #2147 change and nothing else.</td></tr>
+<tr><td>Workflow run</td><td><code>deploy-hosted-gateway.yml</code> run 30146954636, warmed slot swap, 9m48s, conclusion <span class="pass">success</span></td></tr>
+<tr><td>Health after deploy</td><td><code>HTTP 200</code> on <code>/healthz</code>, three consecutive reads</td></tr>
+</table>
+
+<h3>The running commit, read from the live service - not from the workflow</h3>
+
+<p>A green workflow says a deploy finished, not that the new code is answering requests. The live service
+reports its own build on <code>/healthz</code>. Before the deploy it named the old commit; after, the new one:</p>
+
+<div class="scroll"><pre>BEFORE (06:10:06Z)
+$ curl -s https://devthrottle-gw.azurewebsites.net/healthz
+{"status":"ok","version":"1.7.4","commit":"0100a2b","serverTime":"2026-07-25T06:10:06.6747959Z",
+ "directorId":null,"machineName":null}
+
+AFTER (06:17:38Z, 06:17:42Z, 06:17:45Z - three reads)
+$ curl -s https://devthrottle-gw.azurewebsites.net/healthz
+{"status":"ok","version":"1.7.4","commit":"dc5f8b9","serverTime":"2026-07-25T06:17:38.799228Z",
+ "directorId":null,"machineName":null}
+HTTP 200</pre></div>
+
+<p>The self-report is corroborated behaviourally: the <code>402</code> in section 3 carries the string
+<code>"this plan does not include the hosted gateway"</code>, which exists only in <code>dc5f8b99</code>.
+A service running <code>0100a2b5</code> cannot emit it. That is the stronger proof of the two, because
+it is the new code path executing rather than a build label being echoed.</p>
+
+<h2>2. How the live control was set up</h2>
+
+<p>The plan gate reads the <code>tier</code> column of <code>gateway.entitlements</code>, the table the
+website's payment webhook owns. To exercise it live, three throwaway accounts were created in the production
+authentication project and given entitlement rows naming their plan. Every row was marked
+<code>stripe_subscription_id = 'sub_qa_test_2147_*'</code> so it could be identified and removed, and every
+account used the address prefix <code>qa-test-2147-</code>. No existing row was read into the test, altered,
+or deleted. Section 6 shows the database back in its exact prior state.</p>
+
+<table>
+<tr><th>Arm</th><th>Test account</th><th>Entitlement row written</th><th>What it is testing</th></tr>
+<tr><td>Negative control</td><td><code>qa-test-2147-selfhost@duksrevo.com</code></td>
+    <td><code>active</code>, <code>livemode=true</code>, <code>tier='pro_selfhost'</code>, period end +30 days</td>
+    <td>A paying self-host subscriber must be refused hosted capacity</td></tr>
+<tr><td>Control arm A</td><td><code>qa-test-2147-hosted@duksrevo.com</code></td>
+    <td><code>active</code>, <code>livemode=true</code>, <code>tier='hosted'</code>, period end +30 days</td>
+    <td>A hosted subscriber must still be granted it</td></tr>
+<tr><td>Control arm B</td><td><code>qa-test-2147-unknown@duksrevo.com</code></td>
+    <td><code>active</code>, <code>livemode=true</code>, <code>tier='pro'</code>, period end +30 days</td>
+    <td>Pro keeps granting hosted gateway - the behaviour the change deliberately did not narrow</td></tr>
+</table>
+
+<div class="note">
+<strong>Why the control arms are not optional.</strong> A refusal on its own proves nothing: a Gateway that
+was simply broken, or that refused every caller, would pass a refusal-only test with full marks. The two
+control arms ran against the same deployed service, in the same minute, through the same endpoint, and were
+granted. That is what makes the refusal a plan decision rather than an outage.
+</div>
+
+<h3>A finding from the production table: <code>pro_selfhost</code> is already writable</h3>
+
+<p>The first insert attempt used a made-up tier to test deny-by-default, and the database refused it:</p>
+
+<div class="scroll"><pre>ERROR:  23514: new row for relation "entitlements" violates check constraint "entitlements_tier_known"
+DETAIL:  Failing row contains (4f6c0da4-..., active, 2026-08-24 06:19:43.507559+00,
+         sub_qa_test_2147_unknown, 2026-07-25 06:19:43.507559+00, t, team_unknown_plan).
+
+-- the constraint, read from the production catalogue:
+entitlements_tier_known  CHECK (((tier IS NULL) OR (tier = ANY (ARRAY['hosted','pro','pro_selfhost']))))</pre></div>
+
+<p>Two things follow, and both matter.</p>
+<ul>
+  <li><strong>The plan this change refuses is a real, writable production value.</strong> The payment side can
+      already stamp <code>pro_selfhost</code> on a row today. The Gateway was not being hardened against a
+      hypothetical string; it was closing a gap that a single webhook write could have walked through.</li>
+  <li><strong>The deny-by-default arm cannot be exercised through the production table.</strong> An
+      unrecognised tier is rejected by the database before the Gateway ever sees it, so the allowlist's
+      "unknown tier grants nothing" branch has no live reachable path today. It is covered by the merged unit
+      tests, and it is a second line of defence rather than the first - worth stating plainly rather than
+      claiming a live proof that was not run. Control arm B was therefore run on <code>pro</code>, which is
+      both a permitted value and the behaviour the change explicitly preserved.</li>
+</ul>
+
+<h2>3. Door one - enrolment. The negative control</h2>
+
+<p>All three arms posted the same request shape to the same deployed endpoint, each carrying its own valid
+Supabase access token. The tokens themselves are not reproduced here.</p>
+
+<div class="scroll"><pre>POST https://devthrottle-gw.azurewebsites.net/devices/enroll-hosted
+Authorization: Bearer &lt;valid Supabase ES256 access token for the arm's account&gt;
+Content-Type: application/json
+
+{"deviceId":"qa-test-2147-&lt;arm&gt;","machineName":"QA-TEST-2147","platform":"windows","deviceType":"director"}</pre></div>
+
+<h3>The self-host plan - REFUSED</h3>
+<div class="scroll"><pre>HTTP 402
+{"error":"this plan does not include the hosted gateway",
+ "message":"Your DevThrottle Pro access has ended. Subscribe to keep using the wingman, dictation and spoken replies.",
+ "subscribeUrl":"https://devthrottle.com/pricing"}</pre></div>
+
+<p>The body is the discriminator. The Gateway has two distinct <code>402</code> refusals at this door, and
+this is the plan one, not the payment one:</p>
+
+<table>
+<tr><th>Refusal</th><th>Body <code>error</code></th><th>Meaning</th></tr>
+<tr><td>Payment gate</td><td><code>this account does not have an active hosted subscription</code></td><td>You have not paid</td></tr>
+<tr><td>Plan gate (this test)</td><td><code>this plan does not include the hosted gateway</code></td><td>You pay, but not for this</td></tr>
+</table>
+
+<p>The account held an <code>active</code>, <code>livemode</code> row with an unexpired period, so it passed
+the payment gate. The refusal came from the line this issue added.</p>
+
+<h3>The hosted plan - GRANTED</h3>
+<div class="scroll"><pre>HTTP 200
+{"deviceKey":"hvyYeBtfxg5Ot6bsmY0ffc2NHryuZYdWeTeISS8sH34",
+ "deviceId":"7f10f15637eb845f1e7a2bd09746c794022466808a8502ca74dab69445b62dc8|qa-test-2147-hosted",
+ "machineName":"QA-TEST-2147","status":"active","deviceCount":1}</pre></div>
+
+<h3>The pro plan - GRANTED</h3>
+<div class="scroll"><pre>HTTP 200
+{"deviceKey":"dWAb4xIbtqVkHXRykONOWVCC3pXKbm1aU1ehV52Jkz8",
+ "deviceId":"48513cbb95f19f81fa7609e923fa9d6d064a5c22bf3eb46d90db7b595702e0c4|qa-test-2147-pro",
+ "machineName":"QA-TEST-2147","status":"active","deviceCount":1}</pre></div>
+
+<h3>The refusal minted nothing - checked in the database, not inferred from the status code</h3>
+
+<p>A <code>402</code> body proves what the caller was told. It does not prove what the service kept. The
+promise in the issue is that a refused enrolment leaves no tenant and no device key, so the state was read
+directly out of the production database immediately after the three calls:</p>
+
+<table>
+<tr><th>Arm</th><th><code>gateway.tenants</code></th><th><code>gateway.device_credentials</code></th><th><code>gateway.account_trials</code></th></tr>
+<tr><td>pro_selfhost (refused)</td><td class="pass">0</td><td class="pass">0</td><td class="pass">0</td></tr>
+<tr><td>hosted (granted)</td><td>1</td><td>1 (active)</td><td>0</td></tr>
+<tr><td>pro (granted)</td><td>1</td><td>1 (active)</td><td>0</td></tr>
+</table>
+
+<p>The zero in the trial column is worth its own sentence. A brand-new account with no paid row is handed the
+14-day Pro trial at first arrival and enrols on it. The refused account did not get one, because it never
+reached that branch: it held a valid paid row, so the trial grant was skipped and the plan gate ruled. The
+refusal did not accidentally consume the account's free trial either.</p>
+
+<h2>4. Door two - ongoing hosted requests. The customer who moves plan</h2>
+
+<p>Enrolment happens once. An account that already holds a tenant never passes through that gate again, so a
+customer who moves from a hosted plan to a self-host one would keep being served indefinitely if the only
+check were at enrolment. The second door is in the authentication middleware, on every hosted request.</p>
+
+<p>To exercise it live, the <em>already enrolled</em> hosted test account - holding a real tenant and a
+working device key from section 3 - had its entitlement row moved to the self-host plan, exactly as a plan
+change would write it. The pro account was left untouched as a simultaneous control.</p>
+
+<div class="scroll"><pre>update gateway.entitlements
+set tier = 'pro_selfhost', updated_at = now()
+where stripe_subscription_id = 'sub_qa_test_2147_hosted';</pre></div>
+
+<p>Both device keys were then polled against the same authenticated endpoint every 20 seconds:</p>
+
+<div class="scroll"><pre>GET https://devthrottle-gw.azurewebsites.net/account/status
+Authorization: Bearer &lt;the device key issued at enrolment&gt;
+
+06:22:20Z   the entitlement row is moved to pro_selfhost
+06:22:41Z   moved account HTTP 200   control (pro) HTTP 200
+            {"signedIn":true,"email":"qa-test-2147-hosted@duksrevo.com"}
+06:23:01Z   moved account HTTP 402   control (pro) HTTP 200
+            {"error":"hosted subscription required","code":"hosted_subscription_required",
+             "message":"Your DevThrottle Pro access has ended. Subscribe to keep using the wingman,
+                        dictation and spoken replies.",
+             "subscribeUrl":"https://devthrottle.com/pricing"}</pre></div>
+
+<p>The account was served on the plan it had, and cut off roughly 40 seconds after its plan changed - the
+per-tenant positive lease being re-read by the 60-second sweep rather than waiting out its 5-minute lifetime.
+The control arm answered <code>200</code> in the same poll, in the same second, through the same endpoint,
+which is what rules out "the Gateway stopped serving anyone".</p>
+
+<h3>Denied, and deliberately not revoked - confirmed on the live row</h3>
+
+<p>The merged code says a plan refusal must deny without tombstoning device credentials, because the reason
+for it is a string the payment side writes and a rename there must not destroy a paying customer's devices.
+Read from the production table while the account was being denied:</p>
+
+<table>
+<tr><th>Account</th><th>Live request outcome</th><th><code>device_credentials.Status</code></th><th><code>RevokedAtUtc</code></th></tr>
+<tr><td>moved to pro_selfhost</td><td class="fail">402 denied</td><td class="pass">active</td><td>null</td></tr>
+<tr><td>control, pro</td><td class="pass">200 served</td><td>active</td><td>null</td></tr>
+</table>
+
+<p>Denied on every request, credential intact. If the payment side corrects a mistyped plan, the customer's
+devices come straight back with no re-enrolment.</p>
+
+<h2>5. The three artificial-intelligence scopes - not provable at this boundary</h2>
+
+<p><span class="blocked">BLOCKED, and stated rather than papered over.</span> The other half of the plan's
+definition is that <code>pro_selfhost</code> still grants <code>dictation</code>, <code>tts</code> and
+<code>wingman</code> - the features the customer actually pays for. That could not be exercised as a live
+control against the deployed service, for a structural reason rather than a testing shortfall.</p>
+
+<p><code>EntitlementScopes</code> has exactly two call sites in the shipped Gateway, and both ask the same
+question:</p>
+
+<div class="scroll"><pre>$ git grep -n "EntitlementScopes\." origin/main -- src   (excluding tests)
+src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs:203:   if (!Tenancy.EntitlementScopes.GrantsHostedGateway(tier))
+src/CcDirector.Gateway/Tenancy/HostedAccessLeaseService.cs:138: case EntitlementOutcome.Entitled when !EntitlementScopes.GrantsHostedGateway(decision.Tier):</pre></div>
+
+<p>No deployed route asks <code>Grants(tier, "dictation")</code>, <code>"tts"</code> or <code>"wingman"</code>.
+The three constants are declared in the table and carried by the plan, but nothing in the request path
+consults them yet, so there is no live surface where granting or withholding them would produce an observable
+difference. At the wire, a <code>pro_selfhost</code> account and a hypothetical unknown-plan account look
+identical: both are refused hosted capacity and neither is asked about anything else.</p>
+
+<p>What can be said from the live evidence, and no more than this: the change did not take the paid features
+away, because it added no gate in front of them. On hosted, all three run behind a device key, which a
+self-host plan is not meant to hold - a self-host subscriber runs those features through their own Gateway,
+where there is no entitlement gate at all. The claim that the paid plan keeps working is therefore true by
+construction here and covered by the merged unit tests, but it is <strong>not</strong> demonstrated by a live
+request in this report, and should not be read as if it were. The moment an artificial-intelligence route
+starts consulting the scope table, that arm becomes testable and should be added.</p>
+
+<h2>6. Everything the test created was removed</h2>
+
+<p>The test wrote to a production table. Its footprint was measured before and after so the removal could be
+proven rather than asserted.</p>
+
+<table>
+<tr><th>Measurement</th><th>Before the test (06:19Z)</th><th>After cleanup (06:25Z)</th></tr>
+<tr><td><code>gateway.entitlements</code>, tier null / active / livemode</td><td>3</td><td class="pass">3</td></tr>
+<tr><td><code>gateway.entitlements</code>, tier hosted / canceled / not livemode</td><td>1</td><td class="pass">1</td></tr>
+<tr><td><code>gateway.entitlements</code>, total rows</td><td>4</td><td class="pass">4</td></tr>
+<tr><td>Rows matching <code>sub_qa_test_2147%</code></td><td>0</td><td class="pass">0</td></tr>
+<tr><td>Tenants named <code>qa-test-2147-%</code></td><td>0</td><td class="pass">0</td></tr>
+<tr><td>Device credentials on machine <code>QA-TEST-2147</code></td><td>0</td><td class="pass">0</td></tr>
+<tr><td>Authentication accounts <code>qa-test-2147-%</code></td><td>0</td><td class="pass">0</td></tr>
+</table>
+
+<p>The two device keys the control arms were issued are dead - both now answer <code>HTTP 401</code> - and
+the live service still answers <code>/healthz</code> with <code>200</code> on commit <code>dc5f8b9</code>.
+No pre-existing row was read into the test, modified, or removed at any point; the four rows that were there
+at the start are the four that are there now, unchanged.</p>
+
+<h2>7. Verdict</h2>
+
+<table>
+<tr><th>Claim</th><th>Verdict</th><th>Evidence on the deployed service</th></tr>
+<tr><td>Deploy landed and the service is healthy</td><td class="pass">PASS</td>
+    <td>Run 30146954636 success; <code>/healthz</code> 200</td></tr>
+<tr><td>The running commit is <code>dc5f8b99</code></td><td class="pass">PASS</td>
+    <td><code>/healthz</code> reports <code>dc5f8b9</code>; corroborated by a response string that exists only in that commit</td></tr>
+<tr><td>A self-host plan is refused hosted provisioning</td><td class="pass">PASS</td>
+    <td><code>402</code> "this plan does not include the hosted gateway"</td></tr>
+<tr><td>The refusal mints no tenant and issues no device key</td><td class="pass">PASS</td>
+    <td>0 tenants, 0 device credentials, 0 trials in the live database</td></tr>
+<tr><td>An account that moves to a self-host plan stops being served</td><td class="pass">PASS</td>
+    <td><code>200</code> then <code>402</code> "hosted subscription required", about 40 seconds after the plan changed</td></tr>
+<tr><td>That denial does not tombstone the customer's devices</td><td class="pass">PASS</td>
+    <td>Credential still <code>active</code>, <code>RevokedAtUtc</code> null, while requests are denied</td></tr>
+<tr><td>Hosted and pro plans are still granted (control arm)</td><td class="pass">PASS</td>
+    <td>Both <code>200</code> with a device key, same endpoint, same minute</td></tr>
+<tr><td>The self-host plan still grants dictation, text to speech and the wingman</td><td class="blocked">BLOCKED</td>
+    <td>No deployed route consults those scopes; see section 5</td></tr>
+<tr><td>An unknown plan grants nothing (deny by default)</td><td class="blocked">BLOCKED</td>
+    <td>The production check constraint rejects an unknown tier before the Gateway sees it; see section 2</td></tr>
+</table>
+
+<h2>Constraints observed during this run</h2>
+<ul>
+  <li><code>PRO_SUBSCRIPTION_ENABLED</code> was not set, changed, enabled or read in any environment. It does
+      not exist in this repository's source at all - it belongs to the website - and nothing in this test
+      required it.</li>
+  <li>No production configuration was altered. The only change to the live deployment was the deploy itself.</li>
+  <li>No real customer row was created, modified or deleted. The three entitlement rows written were
+      throwaway test accounts, and section 6 shows the table restored exactly.</li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Deployed `dc5f8b99` to the hosted Gateway (workflow run 30146954636, warmed slot swap, success) and then ran the live control the issue exists for, against the deployed service.

**The running commit was read off the live service, not taken from the workflow.** `/healthz` reported `0100a2b` before and `dc5f8b9` after. That is corroborated behaviourally: the 402 body below contains a string that exists only in `dc5f8b99`.

**Door one, enrolment.** Three throwaway accounts, each given a clearly-marked entitlement row, all posting the same request to `POST /devices/enroll-hosted` on the live service:

| Plan | Status | Body |
|---|---|---|
| `pro_selfhost` | **402** | `this plan does not include the hosted gateway` |
| `hosted` | 200 | device key issued |
| `pro` | 200 | device key issued |

The refusal body is the plan refusal, not the payment one (`this account does not have an active hosted subscription`) - the account held an active live-mode row, so it passed the payment gate and was stopped by the line this issue added. The live database confirms the refused account got 0 tenants, 0 device credentials and 0 trials.

**Door two, ongoing requests.** The already-enrolled hosted account was moved to `pro_selfhost`, as a plan change would write it. It went 200 -> 402 `hosted subscription required` about forty seconds later, while the untouched `pro` control answered 200 in the same poll. Its device credential stayed `active` with a null revocation - denied, not tombstoned, exactly as the code says it should be.

**Two things are recorded as blocked rather than claimed.** The three artificial-intelligence scopes have no live consumer - `EntitlementScopes` has exactly two call sites and both ask `GrantsHostedGateway` - so nothing on the wire can demonstrate them being granted. And the deny-by-default arm is unreachable in production: `gateway.entitlements` carries `entitlements_tier_known`, limiting tier to null, `hosted`, `pro`, `pro_selfhost`, so an unknown tier is rejected by the database before the Gateway sees it.

That constraint is also the useful finding in the other direction: `pro_selfhost` is already a writable production value, so this was a reachable gap rather than a hypothetical one.

**Cleanup.** Every test row, tenant, device credential and authentication account was removed. The four pre-existing entitlement rows are unchanged and the two issued device keys now answer 401. `PRO_SUBSCRIPTION_ENABLED` was not set, changed or read in any environment, and no production configuration was altered beyond the deploy itself.