### PR TITLE
mobile: one banner offset per screen - a header inside a pinned shell must not take it twice

### DIFF
--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -50,6 +50,21 @@ body {
   z-index: 5;
 }
 
+/* ...but NOT when the header is inside a screen that has ALREADY been offset. The pinned shells set
+   their own `top` to the banner height, so their header starts below the banner by virtue of being in
+   that box. A sticky `top: var(--voicemode-h)` there means "never come closer than the banner height
+   to the TOP OF THIS BOX", which pushes the header down a SECOND time and leaves an empty strip of
+   page background exactly one banner tall. Shipped that way on 2026-07-25 and reported from the
+   phone: "there's a black space at the top... it's like it bumped it down too far".
+   Scoped by ancestor rather than by the session-header class because that is the actual rule: one
+   offset per screen, applied by whichever box owns the offsetting. The file viewer's own header is
+   inside .terminal-screen too, and is covered by the same line. */
+.terminal-screen .app-bar,
+.car-screen .app-bar,
+.assistant-screen .app-bar {
+  top: 0;
+}
+
 .app-bar h1 {
   margin: 0;
   font-size: 20px;

--- a/src/CcDirector.Core.Tests/MobileViewportContractTests.cs
+++ b/src/CcDirector.Core.Tests/MobileViewportContractTests.cs
@@ -218,6 +218,43 @@ public sealed class MobileViewportContractTests
     }
 
     /// <summary>
+    /// ONE offset per screen. A header INSIDE a pinned shell must not take the banner offset a second time.
+    ///
+    /// The pinned shells set their own `top` to the banner height, so a header inside one is already below
+    /// the banner by virtue of being in that box. The roster's header, which shares the page with the
+    /// banner, does need the offset - and it is the SAME `.app-bar` class. Giving the class the offset
+    /// gave it to both, and a sticky `top: var(--voicemode-h)` inside an already-offset box means "never
+    /// come closer than the banner height to the top of THIS box", which pushed the session header down a
+    /// second time. Shipped 2026-07-25 and reported from the phone: "there's a black space at the top...
+    /// it's like it bumped it down too far". The strip was exactly one banner tall.
+    /// </summary>
+    [Fact]
+    public void HeadersInsideAPinnedShell_DoNotTakeTheBannerOffsetASecondTime()
+    {
+        var css = File.ReadAllText(Path.Combine(GetRepoRoot(), StylesPath));
+        var offenders = new List<string>();
+
+        foreach (var shell in FullScreenShells)
+        {
+            var block = RuleBlock(css, $"{shell} .app-bar");
+            if (block is null)
+            {
+                offenders.Add($"{shell} .app-bar: no rule resets this header's sticky `top`. It inherits the roster header's banner offset and is pushed down a SECOND time, leaving an empty strip one banner tall.");
+                continue;
+            }
+            var tops = Regex.Matches(block, @"(?<!-)\btop\s*:\s*([^;]+);").Select(m => m.Groups[1].Value.Trim()).ToList();
+            if (tops.Count == 0 || tops[^1] != "0")
+                offenders.Add($"{shell} .app-bar: its effective `top` is `{(tops.Count == 0 ? "unset" : tops[^1])}`, not 0. Inside an already-offset shell the offset must not be applied again.");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A header inside a pinned shell takes the banner offset twice:\n  " + string.Join("\n  ", offenders)
+            + "\n\nWHY: the shell has ALREADY moved itself below the banner. The roster's header needs the offset "
+            + "because it shares the page with the banner; a session header does not, and they are the same class. "
+            + "One offset per screen, applied by whichever box owns the offsetting.");
+    }
+
+    /// <summary>
     /// The banner must MEASURE itself and publish --voicemode-h. A guard on the shells alone would pass
     /// happily while the variable was never set - every shell would silently fall back to 0px and the
     /// banner would be back on top of the back button.


### PR DESCRIPTION
The voice screen showed an empty strip of page background at the top, exactly one banner tall. Reported from the phone: *"there's a black space at the top... it's like it bumped it down too far"*.

## Cause

The pinned shells already move themselves below the banner, so a header **inside** one is already below it. But the roster's header - which shares the page with the banner and genuinely does need the offset - is the same `.app-bar` class. Giving the class the offset gave it to both.

A sticky `top: var(--voicemode-h)` inside an already-offset box means "never come closer than the banner height to the top of **this** box", so the session header was pushed down a second time.

Scoped by ancestor rather than by the session-header class, because that states the actual rule: **one offset per screen, applied by whichever box owns the offsetting.** The file viewer's header is inside `.terminal-screen` too and is covered by the same line.

## How it was found

By running the **real built app** against a local stub Gateway, not hand-written markup. The earlier harness that verified the first fix did not contain the session header at all, so it could not have shown this - which is exactly why it passed while the shipped app was wrong.

Measured in that rig, before the fix:

| | |
|---|---|
| banner | 0 → 63 |
| screen top | 63 (correct) |
| **session header top** | **126** (should be 63) |

After the fix: header at 63, gap 0, screen still reaches the bottom of the window, and the back button hit-tests as reachable.

Also checked in the same rig, in the real app:
- **Roster with the banner up**: header at 63, gap 0, hamburger menu reachable.
- **Voice mode off**: no banner, offset `0px`, screen fills 0 → 800, nothing moved.

## Proof

New guard in `MobileViewportContractTests` - a header inside a pinned shell must reset its sticky `top` to 0 - **confirmed to fail with the reset removed**. 7 contract tests pass, client-core 600, cockpit 180, typecheck clean, mobile build succeeds.