### PR TITLE
Voice mode: the sweep that keeps new sessions in it now actually sends on hosted

### DIFF
--- a/src/CcDirector.Gateway.Tests/VoiceModeSweepHostedTenantScopeTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeSweepHostedTenantScopeTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The voice-mode sweep must actually SEND on the hosted Gateway (owner report, 2026-07-25).
+///
+/// The sweep is what makes voice mode a standing switch: the fan-out at POST /sessions/voice-mode/all reaches
+/// the sessions alive at that instant, and the sweep carries the same intent to every session that appears
+/// afterwards. On hosted it never switched a single session on. It decided correctly - it named the right
+/// sessions every 15 seconds - and then threw every command away, because the DECIDING half ran inside the
+/// per-tenant scope and the SENDING half ran after that scope had been left. <c>SendCommandAsync</c> resolves
+/// a Director's stream within the tenant of the current unit of work and treats no-scope as a DENY, so each
+/// command was dropped before it reached the tunnel and logged as an unreachable Director - for the whole
+/// lifetime of the process, on a Director that was answering other verbs in the same millisecond.
+///
+/// The existing sweep proofs in <see cref="VoiceModeAllEndpointProofTests"/> could not catch this, and adding
+/// more of them never would: they run SELF-HOST, where the ambient tenant is <c>TenantId.Local</c> whether a
+/// scope was entered or not, so the missing scope has no effect there. Only a HOSTED Gateway can tell the two
+/// apart. Hence this file boots one, with two tenants, and calls the sweep exactly as the timer does - from a
+/// caller holding NO tenant scope of its own.
+///
+/// Revert-prove: move the send loop back outside <c>ITenantPass.ForEachTenantAsync</c> (plan inside a
+/// synchronous <c>ForEachTenant</c>, act after it returns) and both tests below go RED - no voice-mode command
+/// reaches either Director and neither session becomes a voice session.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// reset in DisposeAsync.
+/// </summary>
+public sealed class VoiceModeSweepHostedTenantScopeTests : IAsyncLifetime
+{
+    private const string Token = "test-token-voice-sweep-hosted";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    private HostedTestDevice _deviceA;
+    private HostedTestDevice _deviceB;
+
+    // Every voice-mode command each tenant's Director received. The sweep sends per tenant, so keeping them
+    // apart is what proves each command was sent under the RIGHT tenant's scope rather than one shared one.
+    private readonly ConcurrentBag<string> _voiceModeToA = new();
+    private readonly ConcurrentBag<string> _voiceModeToB = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-vmsweep-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _deviceA = HostedTestEnrollment.Enroll(_gateway, "sub-alice", "alice@example.com", "dev-a", "MACHINE-A");
+        _deviceB = HostedTestEnrollment.Enroll(_gateway, "sub-bob", "bob@example.com", "dev-b", "MACHINE-B");
+
+        // Each Director is registered UNREACHABLE and answers ONLY over the tunnel, so a command that lands
+        // here can only have been routed - which is precisely what the no-scope DENY prevented.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _deviceA.DeviceKey, "dir-a", "MACHINE-A",
+            dispatch: cmd => Record(cmd, _voiceModeToA));
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _deviceB.DeviceKey, "dir-b", "MACHINE-B",
+            dispatch: cmd => Record(cmd, _voiceModeToB));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    private static DirectorCommandResult Record(DirectorCommand cmd, ConcurrentBag<string> sink)
+    {
+        if (cmd.Verb != "voice-mode")
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+        sink.Add(cmd.SessionId ?? "");
+        return FakeTunnelDirector.Ok(new { ok = true });
+    }
+
+    [Fact]
+    public async Task Sweep_switchesOnASessionThatAppearedLater_onTheHOSTEDGateway()
+    {
+        // Tenant A throws the switch while it owns one session. That fan-out is on a request, so it has a
+        // tenant scope and has always worked - it is the arrangement here, not the thing under test.
+        await _dirA.PushSnapshotAsync(Session("a-first"));
+        var toggle = await Post("sessions/voice-mode/all", _deviceA.DeviceKey, new { enabled = true });
+        Assert.Equal(HttpStatusCode.OK, toggle.StatusCode);
+        Assert.Contains("a-first", _voiceModeToA);
+
+        // A new session joins A's fleet a moment later. Nobody has told it anything - this is the session the
+        // owner watched sit outside voice mode while the banner said every session was in it.
+        await _dirA.PushSnapshotAsync(Session("a-first"), Session("a-born-later"));
+
+        // Exactly how the timer calls it: from a caller with NO ambient tenant scope. That is the whole point -
+        // a sweep is not on a request and not on a tunnel connection, so it has no scope of its own.
+        await _gateway.SweepVoiceModeAllAsync();
+
+        // The command actually reached the Director...
+        Assert.Contains("a-born-later", _voiceModeToA);
+        // ...and the Gateway marked it, in TENANT A's voice state, so narration will really be spent on it.
+        Assert.True(_gateway.VoiceService?.IsVoiceSession(_deviceA.Tenant, "a-born-later"));
+
+        // A steady fleet produces no repeat traffic: the session that was already on is not re-sent.
+        Assert.Single(_voiceModeToA, sid => sid == "a-first");
+    }
+
+    [Fact]
+    public async Task Sweep_sendsEachTenantsCommandsUnderItsOwnScope_andLeavesATenantThatNeverAskedAlone()
+    {
+        // Both tenants own a session; only A asks for voice mode.
+        await _dirA.PushSnapshotAsync(Session("a-one"));
+        await _dirB.PushSnapshotAsync(Session("b-one"));
+        (await Post("sessions/voice-mode/all", _deviceA.DeviceKey, new { enabled = true })).EnsureSuccessStatusCode();
+
+        // Each tenant gains a session afterwards.
+        await _dirA.PushSnapshotAsync(Session("a-one"), Session("a-two"));
+        await _dirB.PushSnapshotAsync(Session("b-one"), Session("b-two"));
+
+        await _gateway.SweepVoiceModeAllAsync();
+
+        // A's later session is switched on, under A's own scope - a fix that entered ONE scope for the whole
+        // loop would route A's command into whichever tenant happened to be first and this would go red.
+        Assert.Contains("a-two", _voiceModeToA);
+        Assert.True(_gateway.VoiceService?.IsVoiceSession(_deviceA.Tenant, "a-two"));
+
+        // B never asked for voice mode, so B is untouched. The sweep must never put a fleet on voice that did
+        // not ask for it - merely running the Gateway would otherwise start spending narration on everyone.
+        Assert.Empty(_voiceModeToB);
+        Assert.False(_gateway.VoiceService?.IsVoiceSession(_deviceB.Tenant, "b-two"));
+
+        // And nothing crossed: A's marker lives in A's partition only.
+        Assert.False(_gateway.VoiceService?.IsVoiceSession(_deviceB.Tenant, "a-two"));
+    }
+
+    private Task<HttpResponseMessage> Post(string path, string deviceKey, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, path) { Content = JsonContent.Create(body) };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private static SessionDto Session(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        Status = "WaitingForInput",
+        ActivityState = "WaitingForInput",
+        StatusColor = "red",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1541,11 +1541,14 @@ public sealed class GatewayHost : IAsyncDisposable
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
 
-            // Each tenant is decided and acted on inside its own scope, exactly as the voice pre-build sweep
-            // beside this one does: the flag is read for THAT tenant, the roster is that tenant's partition,
-            // and the marker is written into that tenant's voice state. Self-host runs one Local pass.
-            var passes = new List<(TenantId Tenant, IReadOnlyList<(string DirectorId, string SessionId)> Plan)>();
-            _tenantPass.ForEachTenant(() =>
+            // Each tenant is decided AND ACTED ON inside its own scope - both halves, in one awaited pass.
+            // The deciding half must be scoped because the flag, the roster and the voice marker are all that
+            // tenant's; the ACTING half must be scoped too, because SendCommandAsync resolves the Director's
+            // stream within the tenant of the current unit of work and treats no-scope as a DENY. Planning
+            // here and sending after the pass returned is what broke this sweep on hosted: every command was
+            // dropped before it reached the tunnel and logged as an unreachable Director, forever. Hence
+            // ForEachTenantAsync, which holds the scope ACROSS the await. Self-host runs one Local pass.
+            await _tenantPass.ForEachTenantAsync(async () =>
             {
                 if (_tenantPass.Current is not { } tenant) return;   // deny: no scope in effect -> sweep nothing
                 var on = _tenantSettingsResolver.VoiceModeAll(tenant);
@@ -1555,11 +1558,8 @@ public sealed class GatewayHost : IAsyncDisposable
                     on,
                     PushedSessions.SnapshotFresh(tenant, stale),
                     sid => vs.IsVoiceSession(tenant, sid));
-                if (plan.Count > 0) passes.Add((tenant, plan));
-            });
+                if (plan.Count == 0) return;
 
-            foreach (var (tenant, plan) in passes)
-            {
                 FileLog.Write($"[GatewayHost] voice-mode sweep: {plan.Count} session(s) to switch on for tenant={tenant.ToLogString()}");
                 foreach (var (directorId, sid) in plan)
                 {
@@ -1579,7 +1579,7 @@ public sealed class GatewayHost : IAsyncDisposable
                         FileLog.Write($"[GatewayHost] voice-mode sweep: sid={sid} not reachable on director={directorId} - will retry next pass");
                     }
                 }
-            }
+            }).ConfigureAwait(false);
         }
         catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-mode sweep error: {ex.Message}"); }
         finally { Interlocked.Exchange(ref _voiceModeAllSweepRunning, 0); }

--- a/src/CcDirector.Gateway/Tenancy/ITenantPass.cs
+++ b/src/CcDirector.Gateway/Tenancy/ITenantPass.cs
@@ -34,6 +34,26 @@ public interface ITenantPass
     void ForEachTenant(Action pass);
 
     /// <summary>
+    /// The AWAITABLE per-tenant pass: run <paramref name="pass"/> once per tenant and AWAIT it inside that
+    /// tenant's scope, so work that continues after an await is still scoped to the tenant it belongs to.
+    /// Same tenant set and same self-host behaviour as <see cref="ForEachTenant"/>.
+    ///
+    /// This exists because <see cref="ForEachTenant"/> takes a synchronous <see cref="Action"/>, and a sweep
+    /// that needs to await something cannot express that inside the pass. The one way out is to collect a
+    /// plan inside the pass and act on it after the pass returns - and that hands the caller a trap, because
+    /// the scope is gone by then and every scope-reading call it makes is silently DENIED. That is not
+    /// hypothetical: the voice-mode sweep did exactly this and, on hosted, dropped every command it tried to
+    /// send for its whole lifetime while logging them as an unreachable Director. Self-host never showed it,
+    /// because there the ambient tenant is always Local whether a scope was entered or not.
+    ///
+    /// So: a per-tenant sweep that awaits anything scope-reading MUST use this overload rather than planning
+    /// inside <see cref="ForEachTenant"/> and acting outside it.
+    /// </summary>
+    /// <param name="pass">The per-tenant work, awaited inside that tenant's scope.</param>
+    /// <param name="ct">Checked between tenants so a shutdown does not have to wait out the whole census.</param>
+    Task ForEachTenantAsync(Func<Task> pass, CancellationToken ct = default);
+
+    /// <summary>
     /// The tenant of the unit of work currently running: the pass <see cref="ForEachTenant"/> entered, or
     /// the request / tunnel-connection scope the caller is already inside. Null ONLY on hosted with no scope
     /// in effect, and that null is a DENY - never Local, never System.
@@ -58,6 +78,13 @@ public sealed class SingleTenantPass : ITenantPass
     {
         if (pass is null) throw new ArgumentNullException(nameof(pass));
         pass();
+    }
+
+    /// <inheritdoc />
+    public async Task ForEachTenantAsync(Func<Task> pass, CancellationToken ct = default)
+    {
+        if (pass is null) throw new ArgumentNullException(nameof(pass));
+        await pass().ConfigureAwait(false);
     }
 }
 
@@ -107,6 +134,31 @@ public sealed class TenantPass : ITenantPass
             if (!tenant.IsValid) continue;
             using (_boundary.EnterScope(tenant))
                 pass();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ForEachTenantAsync(Func<Task> pass, CancellationToken ct = default)
+    {
+        if (pass is null) throw new ArgumentNullException(nameof(pass));
+
+        // Self-host: exactly one pass. EnterScope is inert and Current is already Local, so awaiting here is
+        // byte-identical to the single unscoped pass - there is no second tenant for the scope to protect.
+        if (!_boundary.IsHosted)
+        {
+            await pass().ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var tenant in _knownTenants())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!tenant.IsValid) continue;
+            // The scope is held ACROSS the await, not just up to it. The scope is ambient (AsyncLocal), so a
+            // continuation that resumes after an await still resolves this tenant - which is the whole reason
+            // this overload exists.
+            using (_boundary.EnterScope(tenant))
+                await pass().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
## What was wrong

Voice mode is a standing switch. The fan-out at `POST /sessions/voice-mode/all` reaches the sessions alive at that instant; a 15-second sweep is what carries the same intent to every session that appears afterwards.

On the hosted Gateway that sweep never switched a single session on.

It decided correctly - it named the right sessions on every tick - and then threw every command away. The deciding half ran inside the per-tenant scope; the sending half ran after that scope had been left. `SendCommandAsync` resolves a Director's stream within the tenant of the current unit of work and treats no-scope as a deny, so each command was dropped before it reached the tunnel.

From the live hosted Gateway log, three lines apart:

```
voice-mode sweep: 4 session(s) to switch on for tenant=t#3c1f1f15
SendCommandAsync: DENIED (no tenant in scope) director=5edf0787..., verb=voice-mode
DirectorCommandRouter: director not tunnel-connected (unroutable)
voice-mode sweep: sid=91f8d2a6... not reachable - will retry next pass
```

Half a second later the same Director accepts a `history` command. It was never unreachable. 188 denials in one hour, zero successes, and the failure is logged as a network problem rather than the scoping problem it is.

**What this looked like from the outside:** turn voice mode on, and the sessions that already existed join the voice queue while every session created afterwards silently stays out of it - under a banner that says every session on the Gateway narrates its turns.

## The cause, and why it is a seam problem

`ITenantPass.ForEachTenant` takes a synchronous `Action`. A sweep that must await something has nowhere to put that work except after the pass returns - and by then the scope is gone and every scope-reading call it makes is silently denied. The seam handed the caller a trap.

`SweepVoiceModeAllAsync` walked straight into it: build a plan list inside `ForEachTenant`, then `foreach` over the plans and `await` the sends outside it.

## The fix

- `ITenantPass` gains `ForEachTenantAsync`, which holds each tenant's scope **across** the await rather than only up to it.
- The voice-mode sweep decides and sends inside that one pass.

Self-host is unchanged by construction: there the ambient tenant is always `TenantId.Local` whether a scope was entered or not.

## Why no existing test failed

That same self-host property is why. `VoiceModeAllEndpointProofTests` already covers the sweep well - including a test named for exactly this scenario, a session that appeared after the switch was thrown - but it runs self-host, where the missing scope has no effect. No amount of additional self-host tests would ever have gone red. Only a hosted Gateway can tell the two apart.

## Proof

`VoiceModeSweepHostedTenantScopeTests` boots a **hosted** Gateway with two tenants, each with a Director registered unreachable and reachable only over the tunnel, and calls the sweep exactly as the timer does - from a caller holding no tenant scope of its own.

- A session that appears after the switch is switched on, and is marked in its own tenant's voice state.
- Each tenant's commands go under its own scope; a tenant that never asked for voice mode is untouched, and no marker crosses partitions.

Revert-proved. With the send loop moved back outside the pass, both tests fail with the production symptom:

```
Assert.Contains() Failure: Item not found in collection
Collection: ["a-first"]
Not found:  "a-born-later"
```

Full Gateway suite: 3999 passed, 0 failed, 17 skipped (the Postgres-dependent ones).

## Note for a later change

The static gate meant to catch this class of skip - `DT_TEN_3_background_workers_touch_stores_only_through_TenantScopedSweep` - is still skipped/deferred, so review remains the only enforcement for background workers and tenant scope. Worth picking up separately.
