### PR TITLE
feat(voice): test your microphone and test transcription, on Cockpit and mobile

### DIFF
--- a/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
+++ b/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
+import { MicTestPanel } from "@devthrottle/client-core/dictation/MicTestPanel";
+import { TranscriptionTestPanel } from "@devthrottle/client-core/dictation/TranscriptionTestPanel";
 import {
   clearTranscriptionHistory,
   countFailedTurns,
@@ -235,6 +237,17 @@ export function TranscriptionHealthView() {
           </p>
         </>
       )}
+
+      {/* Outside the stats conditional on purpose: the microphone check is most useful exactly when
+          there are no stats to show - a Gateway that cannot be reached, or a first run with no
+          history - because that is when the user is asking "is my microphone even working?". It
+          needs nothing from the Gateway, so a load failure above must not take it down with it. */}
+      <div className="txh-section">
+        <MicTestPanel />
+      </div>
+      <div className="txh-section">
+        <TranscriptionTestPanel />
+      </div>
     </div>
   );
 }

--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -48,6 +48,12 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings
             </Link>
+            <Link className="drawer-item" to="/mic-test" onClick={close}>
+              Test microphone
+            </Link>
+            <Link className="drawer-item" to="/transcription-test" onClick={close}>
+              Test transcription
+            </Link>
             <Link className="drawer-item" to="/diagnostics" onClick={close}>
               Diagnostics
             </Link>

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -11,6 +11,8 @@ import { CarMode } from "./pages/CarMode";
 import { Assistant } from "./pages/Assistant";
 import { EndWordTest } from "./pages/EndWordTest";
 import { AiSettings } from "./pages/AiSettings";
+import { MicTest } from "./pages/MicTest";
+import { TranscriptionTest } from "./pages/TranscriptionTest";
 import { About } from "./pages/About";
 import { Diagnostics } from "./pages/Diagnostics";
 import { YourThrottle } from "./pages/YourThrottle";
@@ -172,6 +174,8 @@ const router = createBrowserRouter(
             // settings tab once the approach is proven.
             { path: "/endword", element: <EndWordTest /> },
             { path: "/settings", element: <AiSettings /> },
+            { path: "/mic-test", element: <MicTest /> },
+            { path: "/transcription-test", element: <TranscriptionTest /> },
             { path: "/about", element: <About /> },
             // Diagnostics (auto-network-switching mission): a phone-side connection tester - route
             // (direct LAN vs Tailscale relay), latency, and download/upload throughput, with a verdict.

--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -266,6 +266,20 @@ export function AiSettings() {
         Transcription: <span className="mono">{snap.transcriptionModel}</span>
       </div>
 
+      {/* Discovery: someone who came here because dictation is poor is looking at the transcription
+          model, when the cause is far more often the microphone. Point them at the check. */}
+      <div className="setting-block">
+        <div className="setting-label">Dictation coming out wrong?</div>
+        <div className="setting-actions">
+          <Link className="setting-btn" to="/mic-test">
+            Test microphone
+          </Link>
+          <Link className="setting-btn" to="/transcription-test">
+            Test transcription
+          </Link>
+        </div>
+      </div>
+
       {msg !== "" && <div className="setting-msg setting-msg-foot">{msg}</div>}
     </Frame>
   );

--- a/apps/mobile/src/pages/MicTest.tsx
+++ b/apps/mobile/src/pages/MicTest.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { MicTestPanel } from "@devthrottle/client-core/dictation/MicTestPanel";
+
+// "Test microphone" on the phone. The whole screen is the shared MicTestPanel, which is the same
+// component and the same measurements the Cockpit dictation health page mounts - a phone and a
+// desktop must not disagree about whether a headset is any good.
+//
+// Its own route rather than a block inside AI settings: the check needs real vertical room once the
+// playback player, the advice and the measurements are on screen, and a headset problem is worth
+// reaching directly from the menu rather than hunting for inside another page.
+export function MicTest() {
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Test microphone</h1>
+      </header>
+      <MicTestPanel />
+    </div>
+  );
+}

--- a/apps/mobile/src/pages/TranscriptionTest.tsx
+++ b/apps/mobile/src/pages/TranscriptionTest.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { TranscriptionTestPanel } from "@devthrottle/client-core/dictation/TranscriptionTestPanel";
+
+// "Test transcription" on the phone: read a passage in one of eight languages and see how much of it
+// came back. The whole screen is the shared panel, the same component and the same scoring the Cockpit
+// mounts, so a phone and a desktop can never report different accuracy for the same recording.
+//
+// Its own route, beside Test microphone, because they answer different questions: one is about the
+// audio going in, the other about the text coming out. Someone whose dictation is poor needs to know
+// which of the two is at fault.
+export function TranscriptionTest() {
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Test transcription</h1>
+      </header>
+      <TranscriptionTestPanel />
+    </div>
+  );
+}

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -8,6 +8,8 @@
     "./auth/SignIn": "./src/auth/SignIn.tsx",
     "./auth/DeviceCallback": "./src/auth/DeviceCallback.tsx",
     "./dictation/DictationDialog": "./src/dictation/DictationDialog.tsx",
+    "./dictation/MicTestPanel": "./src/dictation/MicTestPanel.tsx",
+    "./dictation/TranscriptionTestPanel": "./src/dictation/TranscriptionTestPanel.tsx",
     "./*": "./src/*.ts"
   },
   "scripts": {

--- a/packages/client-core/src/dictation/MicTestPanel.tsx
+++ b/packages/client-core/src/dictation/MicTestPanel.tsx
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MicRecorder, startRecorderWithTimeout } from "./recorder";
+import { blobToWav16kMono, decodeToMono } from "./wav";
+import { checkMicQuality, formatDb, type MicQualityVerdict } from "./micQuality";
+import { uploadVoiceTestClip } from "./voiceTestClient";
+import "./mictest.css";
+
+// The "Test microphone" check, shared verbatim by the Cockpit dictation health page and the mobile
+// app so both surfaces give identical readings and identical advice (one fold, two renderers).
+//
+// It answers the question a user actually has when dictation keeps coming out as nonsense: "is it me,
+// the software, or my headset?" It records a short clip through THE SAME capture path dictation uses,
+// plays it straight back so the user can hear what the transcriber hears, and measures the three
+// defects that break transcription (micQuality.ts).
+//
+// The measurement and the verdict are computed entirely in the browser, so the check works and reports
+// even when the Gateway cannot be reached. The clip and its measurements are then sent to the Gateway
+// and kept per tenant, so microphone problems can be studied across real hardware rather than one
+// person's anecdote - see VoiceTestClipStore for what is kept and for how long. That send happens
+// after the verdict is already on screen and never blocks it.
+
+// Bars in the live level meter, matching the dictation dialog's equalizer so the two feel like the
+// same microphone.
+const BAR_COUNT = 9;
+
+// Below this there is not enough speech to measure honestly - too few frames for a stable noise floor
+// or a stable spectrum. We ask for more rather than reporting a shaky verdict.
+const MIN_USEFUL_SECONDS = 1.5;
+
+// Hard stop, so a forgotten test cannot record forever.
+const MAX_SECONDS = 30;
+
+// The sentence we ask people to read. Not decorative: it is loaded with /s/ and /sh/ sounds, whose
+// energy sits in the 4.5-8 kHz band the narrowband check reads. A sentence without them would leave
+// that band empty for an honest reason and make a perfectly good microphone look band-limited.
+const PROMPT_SENTENCE = "The six sisters shared fresh fish and crisp chips at sunset.";
+
+type Stage = "idle" | "recording" | "analyzing" | "done" | "error";
+
+export interface MicTestPanelProps {
+  /** Extra class on the root, so a host page can scope its own layout around the panel. */
+  className?: string;
+}
+
+export function MicTestPanel({ className }: MicTestPanelProps) {
+  const [stage, setStage] = useState<Stage>("idle");
+  const [level, setLevel] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+  const [verdict, setVerdict] = useState<MicQualityVerdict | null>(null);
+  const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
+  const [errorText, setErrorText] = useState("");
+  const [tooShort, setTooShort] = useState(false);
+
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const capRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedAtRef = useRef(0);
+  // Held in a ref as well as state so cleanup can revoke the URL without re-running on every render.
+  const playbackUrlRef = useRef<string | null>(null);
+
+  const releasePlayback = useCallback(() => {
+    if (playbackUrlRef.current !== null) {
+      URL.revokeObjectURL(playbackUrlRef.current);
+      playbackUrlRef.current = null;
+    }
+    setPlaybackUrl(null);
+  }, []);
+
+  const stopMeter = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  const clearCap = useCallback(() => {
+    if (capRef.current !== null) {
+      clearTimeout(capRef.current);
+      capRef.current = null;
+    }
+  }, []);
+
+  // Release the microphone and the playback URL if the panel goes away mid-test - a page change must
+  // never leave the microphone light on.
+  useEffect(() => {
+    return () => {
+      stopMeter();
+      if (capRef.current !== null) clearTimeout(capRef.current);
+      recorderRef.current?.dispose();
+      recorderRef.current = null;
+      if (playbackUrlRef.current !== null) URL.revokeObjectURL(playbackUrlRef.current);
+    };
+  }, [stopMeter]);
+
+  const finish = useCallback(async () => {
+    const recorder = recorderRef.current;
+    if (recorder === null) return;
+    stopMeter();
+    clearCap();
+    setStage("analyzing");
+    setLevel(0);
+
+    try {
+      const captured = await recorder.stop();
+      recorderRef.current = null;
+
+      // Measure at the microphone's native rate (the resampled 16 kHz clip cannot answer the
+      // bandwidth question), but play back the 16 kHz WAV, because that is literally the audio the
+      // transcription model receives. Hearing the real thing is the point of the playback.
+      const clip = await decodeToMono(captured);
+      if (clip.samples.length / clip.sampleRate < MIN_USEFUL_SECONDS) {
+        setTooShort(true);
+        setStage("idle");
+        return;
+      }
+
+      const result = checkMicQuality(clip.samples, clip.sampleRate);
+      const { wav } = await blobToWav16kMono(captured);
+
+      releasePlayback();
+      const url = URL.createObjectURL(wav);
+      playbackUrlRef.current = url;
+      setPlaybackUrl(url);
+      setVerdict(result);
+      setStage("done");
+
+      // Keep the clip and its measurements on the Gateway so microphone problems can be studied
+      // across real hardware. Deliberately AFTER the verdict is on screen and deliberately not
+      // awaited into the result: this is our analysis, not the user's answer, and a Gateway that is
+      // unreachable must not turn a perfectly good microphone check into an error.
+      void uploadVoiceTestClip({ kind: "microphone", audio: wav, quality: result.report }).catch((err: unknown) => {
+        console.warn(`[MicTestPanel] could not store the test clip: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    } catch (err) {
+      setErrorText(err instanceof Error ? err.message : String(err));
+      setStage("error");
+    }
+  }, [clearCap, releasePlayback, stopMeter]);
+
+  // finish() is recreated on each render; the meter loop needs the latest one without restarting.
+  const finishRef = useRef(finish);
+  finishRef.current = finish;
+
+  const start = useCallback(async () => {
+    setTooShort(false);
+    setErrorText("");
+    setVerdict(null);
+    releasePlayback();
+    // Never leave a previous run's cap armed - it would cut this recording short.
+    stopMeter();
+    clearCap();
+
+    const recorder = new MicRecorder();
+    recorderRef.current = recorder;
+    try {
+      await startRecorderWithTimeout(recorder);
+    } catch (err) {
+      recorderRef.current = null;
+      // No silent fallback: say exactly what failed and what to check.
+      const reason = err instanceof Error ? err.message : String(err);
+      setErrorText(
+        `The microphone could not be opened: ${reason} Check that a microphone is connected, that it ` +
+          "is not muted, and that this site is allowed to use it.",
+      );
+      setStage("error");
+      return;
+    }
+
+    startedAtRef.current = performance.now();
+    setElapsed(0);
+    setStage("recording");
+
+    // The hard stop runs on a TIMER, not on the animation frame below. A browser suspends animation
+    // frames entirely in a hidden tab - which is exactly what happens when someone starts the test on
+    // their phone and switches app - and a cap that rode on them would simply never fire, leaving the
+    // microphone open indefinitely. Timers are throttled in the background but they still arrive.
+    capRef.current = setTimeout(() => void finishRef.current(), MAX_SECONDS * 1000);
+
+    // The meter and timer are display only, so animation frames are the right vehicle: they stop when
+    // nobody is looking and resume when the user comes back.
+    const tick = () => {
+      const active = recorderRef.current;
+      if (active === null) return;
+      setLevel(active.level());
+      setElapsed((performance.now() - startedAtRef.current) / 1000);
+      frameRef.current = requestAnimationFrame(tick);
+    };
+    frameRef.current = requestAnimationFrame(tick);
+  }, [clearCap, releasePlayback, stopMeter]);
+
+  const cancel = useCallback(() => {
+    stopMeter();
+    clearCap();
+    recorderRef.current?.dispose();
+    recorderRef.current = null;
+    setLevel(0);
+    setStage("idle");
+  }, [clearCap, stopMeter]);
+
+  return (
+    <div className={className ? `mictest ${className}` : "mictest"}>
+      <div className="mictest-head">
+        <h2>Test your microphone</h2>
+      </div>
+      <p className="mictest-lede">
+        Poor dictation is usually a poor microphone, not a poor model. Record yourself for a few
+        seconds, listen back to exactly what the transcriber hears, and see what we measure. The
+        recording is kept on your Gateway so microphone problems can be improved.
+      </p>
+
+      {stage === "idle" && (
+        <div className="mictest-idle">
+          <p className="mictest-prompt-label">When you start, read this out loud at your normal volume:</p>
+          <p className="mictest-prompt">&ldquo;{PROMPT_SENTENCE}&rdquo;</p>
+          {tooShort && (
+            <p className="mictest-warn">
+              That was too short to measure. Record for at least a couple of seconds and read the whole
+              sentence.
+            </p>
+          )}
+          <button type="button" className="mictest-primary" onClick={() => void start()}>
+            Start recording
+          </button>
+        </div>
+      )}
+
+      {stage === "recording" && (
+        <div className="mictest-recording">
+          <p className="mictest-prompt">&ldquo;{PROMPT_SENTENCE}&rdquo;</p>
+          <div className="mictest-meter" role="img" aria-label="Microphone input level">
+            {Array.from({ length: BAR_COUNT }, (_, i) => (
+              <span
+                key={i}
+                className={level * BAR_COUNT > i ? "mictest-bar mictest-bar-on" : "mictest-bar"}
+              />
+            ))}
+          </div>
+          <div className="mictest-timer">{elapsed.toFixed(1)}s</div>
+          <div className="mictest-actions">
+            <button type="button" className="mictest-primary" onClick={() => void finish()}>
+              I&apos;m finished
+            </button>
+            <button type="button" className="mictest-secondary" onClick={cancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {stage === "analyzing" && <div className="mictest-loading">Listening to your recording...</div>}
+
+      {stage === "error" && (
+        <div className="mictest-error">
+          <p>{errorText}</p>
+          <button type="button" className="mictest-primary" onClick={() => void start()}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {stage === "done" && verdict !== null && (
+        <div className="mictest-result">
+          <div className={`mictest-banner mictest-${verdict.rating}`}>{verdict.headline}</div>
+
+          {playbackUrl !== null && (
+            <div className="mictest-playback">
+              <div className="mictest-playback-label">This is exactly what the transcriber hears:</div>
+              <audio className="mictest-audio" src={playbackUrl} controls preload="auto" />
+            </div>
+          )}
+
+          {verdict.issues.length > 0 && (
+            <ul className="mictest-issues">
+              {verdict.issues.map((issue) => (
+                <li key={issue.id} className={`mictest-issue mictest-issue-${issue.severity}`}>
+                  <div className="mictest-issue-title">{issue.title}</div>
+                  <div className="mictest-issue-advice">{issue.advice}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <MicMeasurements verdict={verdict} />
+
+          <div className="mictest-actions">
+            <button type="button" className="mictest-primary" onClick={() => void start()}>
+              Record again
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The raw numbers behind the verdict. Shown so the reading can be checked rather than trusted. */
+function MicMeasurements({ verdict }: { verdict: MicQualityVerdict }) {
+  const r = verdict.report;
+  if (!r.heardSpeech) return null;
+
+  return (
+    <details className="mictest-details">
+      <summary>What we measured</summary>
+      <dl className="mictest-measurements">
+        <div>
+          <dt>Your voice</dt>
+          <dd>{formatDb(r.speechLevelDb)}</dd>
+        </div>
+        <div>
+          <dt>Background noise</dt>
+          <dd>{formatDb(r.noiseFloorDb)}</dd>
+        </div>
+        <div>
+          <dt>Voice above noise</dt>
+          <dd>{r.signalToNoiseDb.toFixed(0)} dB</dd>
+        </div>
+        <div>
+          <dt>Distorted audio</dt>
+          <dd>{(r.clippedFraction * 100).toFixed(2)}%</dd>
+        </div>
+        <div>
+          <dt>Audio bandwidth</dt>
+          <dd>{r.narrowband ? "Telephone quality" : "Full bandwidth"}</dd>
+        </div>
+        <div>
+          <dt>Sample rate</dt>
+          <dd>{(r.sampleRate / 1000).toFixed(1)} kHz</dd>
+        </div>
+      </dl>
+    </details>
+  );
+}

--- a/packages/client-core/src/dictation/TranscriptionTestPanel.tsx
+++ b/packages/client-core/src/dictation/TranscriptionTestPanel.tsx
@@ -1,0 +1,369 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MicRecorder, startRecorderWithTimeout } from "./recorder";
+import { blobToWav16kMono } from "./wav";
+import { judgeAccuracy, scoreTranscription, type AccuracyVerdict, type DiffStep } from "./transcriptionAccuracy";
+import { preferredLanguage, TEST_LANGUAGES, type TestLanguage } from "./languages";
+import { uploadVoiceTestClip } from "./voiceTestClient";
+import "./mictest.css";
+
+// The "Test transcription" check, shared verbatim by the Cockpit dictation health page and the mobile
+// app.
+//
+// The microphone check answers "is my audio any good". This answers the question that actually sends
+// people looking: "how much of what I say does it get right?" It puts a passage on screen, records the
+// user reading it, transcribes it through the real Gateway path, and scores the result against the
+// passage - so the answer is a percentage and a list of the exact words that were missed, rather than
+// an impression.
+//
+// It runs in eight languages because the answer is not the same in all of them, and we cannot know
+// where it is weak without measuring. The clip, the passage and the transcript are stored on the
+// Gateway, per tenant, so those comparisons can be made later across headsets, languages and releases.
+
+const BAR_COUNT = 9;
+const MAX_SECONDS = 90;
+
+// The passages take 15-25 seconds to read, so a recording this short cannot contain one. Scoring it
+// anyway would report "none of the passage came back correctly" and send the reader off to check
+// their headset, when all they did was stop early - the confident wrong diagnosis this whole feature
+// exists to avoid. Ask again instead.
+const MIN_USEFUL_MS = 3000;
+
+type Stage = "idle" | "recording" | "transcribing" | "done" | "error";
+
+export interface TranscriptionTestPanelProps {
+  className?: string;
+}
+
+export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProps) {
+  const [language, setLanguage] = useState<TestLanguage>(() =>
+    preferredLanguage(typeof navigator === "undefined" ? [] : navigator.languages ?? [navigator.language]),
+  );
+  const [stage, setStage] = useState<Stage>("idle");
+  const [level, setLevel] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+  const [verdict, setVerdict] = useState<AccuracyVerdict | null>(null);
+  const [transcript, setTranscript] = useState("");
+  const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
+  const [errorText, setErrorText] = useState("");
+  const [tooShort, setTooShort] = useState(false);
+
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const capRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedAtRef = useRef(0);
+  const playbackUrlRef = useRef<string | null>(null);
+  // The language at the moment recording started. Read in finish() so switching the picker mid-record
+  // cannot score a Danish reading against the Spanish passage.
+  const recordingLanguageRef = useRef(language);
+
+  const stopMeter = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  const clearCap = useCallback(() => {
+    if (capRef.current !== null) {
+      clearTimeout(capRef.current);
+      capRef.current = null;
+    }
+  }, []);
+
+  const releasePlayback = useCallback(() => {
+    if (playbackUrlRef.current !== null) {
+      URL.revokeObjectURL(playbackUrlRef.current);
+      playbackUrlRef.current = null;
+    }
+    setPlaybackUrl(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stopMeter();
+      if (capRef.current !== null) clearTimeout(capRef.current);
+      recorderRef.current?.dispose();
+      recorderRef.current = null;
+      if (playbackUrlRef.current !== null) URL.revokeObjectURL(playbackUrlRef.current);
+    };
+  }, [stopMeter]);
+
+  const finish = useCallback(async () => {
+    const recorder = recorderRef.current;
+    if (recorder === null) return;
+    stopMeter();
+    clearCap();
+    setStage("transcribing");
+    setLevel(0);
+
+    const spoken = recordingLanguageRef.current;
+    try {
+      const captured = await recorder.stop();
+      recorderRef.current = null;
+
+      if (recorder.lastRecordedMs > 0 && recorder.lastRecordedMs < MIN_USEFUL_MS) {
+        setTooShort(true);
+        setStage("idle");
+        return;
+      }
+
+      const { wav } = await blobToWav16kMono(captured);
+
+      // Play back the same WAV that was sent, so "what it heard" is not a claim.
+      releasePlayback();
+      const url = URL.createObjectURL(wav);
+      playbackUrlRef.current = url;
+      setPlaybackUrl(url);
+
+      const result = await uploadVoiceTestClip({
+        kind: "transcription",
+        audio: wav,
+        language: spoken.code,
+        expected: spoken.passage,
+      });
+
+      setTranscript(result.transcript);
+      setVerdict(judgeAccuracy(scoreTranscription(spoken.passage, result.transcript, spoken.tokenMode), spoken.name));
+      setStage("done");
+    } catch (err) {
+      setErrorText(err instanceof Error ? err.message : String(err));
+      setStage("error");
+    }
+  }, [clearCap, releasePlayback, stopMeter]);
+
+  const finishRef = useRef(finish);
+  finishRef.current = finish;
+
+  const start = useCallback(async () => {
+    setErrorText("");
+    setTooShort(false);
+    setVerdict(null);
+    setTranscript("");
+    releasePlayback();
+    stopMeter();
+    clearCap();
+    recordingLanguageRef.current = language;
+
+    const recorder = new MicRecorder();
+    recorderRef.current = recorder;
+    try {
+      await startRecorderWithTimeout(recorder);
+    } catch (err) {
+      recorderRef.current = null;
+      const reason = err instanceof Error ? err.message : String(err);
+      setErrorText(
+        `The microphone could not be opened: ${reason} Check that a microphone is connected, that it ` +
+          "is not muted, and that this site is allowed to use it.",
+      );
+      setStage("error");
+      return;
+    }
+
+    startedAtRef.current = performance.now();
+    setElapsed(0);
+    setStage("recording");
+    // On a timer, not an animation frame: a hidden tab suspends frames entirely and the cap would
+    // never fire, leaving the microphone open.
+    capRef.current = setTimeout(() => void finishRef.current(), MAX_SECONDS * 1000);
+
+    const tick = () => {
+      const active = recorderRef.current;
+      if (active === null) return;
+      setLevel(active.level());
+      setElapsed((performance.now() - startedAtRef.current) / 1000);
+      frameRef.current = requestAnimationFrame(tick);
+    };
+    frameRef.current = requestAnimationFrame(tick);
+  }, [clearCap, language, releasePlayback, stopMeter]);
+
+  const cancel = useCallback(() => {
+    stopMeter();
+    clearCap();
+    recorderRef.current?.dispose();
+    recorderRef.current = null;
+    setLevel(0);
+    setStage("idle");
+  }, [clearCap, stopMeter]);
+
+  const passageDir = language.rightToLeft ? "rtl" : "ltr";
+  const busy = stage === "recording" || stage === "transcribing";
+
+  return (
+    <div className={className ? `mictest ${className}` : "mictest"}>
+      <div className="mictest-head">
+        <h2>Test transcription</h2>
+      </div>
+      <p className="mictest-lede">
+        Read a passage out loud and see how much of it comes back correctly. This runs through the same
+        transcription your dictation uses, so the score is the real one. The recording and the result
+        are kept on your Gateway so transcription can be improved.
+      </p>
+
+      <div className="mictest-langrow">
+        <label className="mictest-langlabel" htmlFor="mictest-language">
+          Language
+        </label>
+        <select
+          id="mictest-language"
+          className="mictest-langselect"
+          value={language.code}
+          disabled={busy}
+          onChange={(e) => setLanguage(TEST_LANGUAGES.find((l) => l.code === e.target.value) ?? TEST_LANGUAGES[0])}
+        >
+          {TEST_LANGUAGES.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.nativeName} ({l.name})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {(stage === "idle" || stage === "recording") && (
+        <>
+          <p className="mictest-prompt-label">
+            {stage === "idle" ? "When you start, read this out loud at your normal pace:" : "Read this out loud:"}
+          </p>
+          <p className="mictest-prompt mictest-passage" dir={passageDir} lang={language.code}>
+            {language.passage}
+          </p>
+        </>
+      )}
+
+      {stage === "idle" && (
+        <>
+          {tooShort && (
+            <p className="mictest-warn">
+              That was too short to score. Record again and read the whole passage out loud.
+            </p>
+          )}
+          <button type="button" className="mictest-primary" onClick={() => void start()}>
+            Start recording
+          </button>
+        </>
+      )}
+
+      {stage === "recording" && (
+        <>
+          <div className="mictest-meter" role="img" aria-label="Microphone input level">
+            {Array.from({ length: BAR_COUNT }, (_, i) => (
+              <span key={i} className={level * BAR_COUNT > i ? "mictest-bar mictest-bar-on" : "mictest-bar"} />
+            ))}
+          </div>
+          <div className="mictest-timer">{elapsed.toFixed(1)}s</div>
+          <div className="mictest-actions">
+            <button type="button" className="mictest-primary" onClick={() => void finish()}>
+              I&apos;m finished
+            </button>
+            <button type="button" className="mictest-secondary" onClick={cancel}>
+              Cancel
+            </button>
+          </div>
+        </>
+      )}
+
+      {stage === "transcribing" && <div className="mictest-loading">Transcribing what you said...</div>}
+
+      {stage === "error" && (
+        <div className="mictest-error">
+          <p>{errorText}</p>
+          <button type="button" className="mictest-primary" onClick={() => void start()}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {stage === "done" && verdict !== null && (
+        <div className="mictest-result">
+          <div className={`mictest-banner mictest-acc-${verdict.rating}`}>{verdict.headline}</div>
+          <p className="mictest-lede">{verdict.detail}</p>
+
+          {playbackUrl !== null && (
+            <div className="mictest-playback">
+              <div className="mictest-playback-label">What the transcriber heard:</div>
+              <audio className="mictest-audio" src={playbackUrl} controls preload="auto" />
+            </div>
+          )}
+
+          <div className="mictest-diffblock">
+            <div className="mictest-playback-label">
+              What came back, with the differences marked:
+            </div>
+            <DiffView diff={verdict.result.diff} rtl={language.rightToLeft === true} lang={language.code} />
+            <dl className="mictest-measurements">
+              <div>
+                <dt>Correct</dt>
+                <dd>{verdict.result.correct}</dd>
+              </div>
+              <div>
+                <dt>Misheard</dt>
+                <dd>{verdict.result.substitutions}</dd>
+              </div>
+              <div>
+                <dt>Missed</dt>
+                <dd>{verdict.result.deletions}</dd>
+              </div>
+              <div>
+                <dt>Added</dt>
+                <dd>{verdict.result.insertions}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <details className="mictest-details">
+            <summary>The raw transcript</summary>
+            <p className="mictest-rawtranscript" dir={passageDir} lang={language.code}>
+              {transcript === "" ? "(nothing came back)" : transcript}
+            </p>
+          </details>
+
+          <div className="mictest-actions">
+            <button type="button" className="mictest-primary" onClick={() => void start()}>
+              Record again
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The aligned passage, with each token marked by what happened to it. This is the part people actually
+ * act on: a percentage says how bad it is, but only the specific misheard words tell you whether the
+ * problem is your microphone, your accent, or a term that belongs in your dictionary.
+ */
+function DiffView({ diff, rtl, lang }: { diff: DiffStep[]; rtl: boolean; lang: string }) {
+  if (diff.length === 0) return <p className="mictest-diff">(nothing to compare)</p>;
+  return (
+    <p className="mictest-diff" dir={rtl ? "rtl" : "ltr"} lang={lang}>
+      {diff.map((step, i) => {
+        if (step.op === "equal") {
+          return (
+            <span key={i} className="mictest-tok mictest-tok-ok">
+              {step.expected}
+            </span>
+          );
+        }
+        if (step.op === "substitute") {
+          return (
+            <span key={i} className="mictest-tok mictest-tok-sub" title={`You said "${step.expected}"`}>
+              {step.actual}
+            </span>
+          );
+        }
+        if (step.op === "delete") {
+          return (
+            <span key={i} className="mictest-tok mictest-tok-del" title="This word was missed">
+              {step.expected}
+            </span>
+          );
+        }
+        return (
+          <span key={i} className="mictest-tok mictest-tok-ins" title="This word was not in the passage">
+            {step.actual}
+          </span>
+        );
+      })}
+    </p>
+  );
+}

--- a/packages/client-core/src/dictation/languages.ts
+++ b/packages/client-core/src/dictation/languages.ts
@@ -1,0 +1,140 @@
+import type { TokenMode } from "./transcriptionAccuracy";
+
+// The reading passages for the "Test transcription" check, one per language.
+//
+// WHY THESE LANGUAGES: English, then the six most widely spoken languages in the world, plus Danish.
+// The six are the most-spoken reading of "top six" - the aim is to find out how DevThrottle behaves
+// for people all over the world, not to mirror any one country's developer population. Adding or
+// swapping a language is one entry in this list and nothing else: the panel, the scoring and the
+// storage are all driven from it.
+//
+// WHY EACH PASSAGE IS THE SAME STORY: every language says roughly the same thing, so a score in one
+// language can be compared against a score in another. If the Danish passage were a tongue-twister
+// and the Spanish one were a nursery rhyme, the two numbers would not mean the same thing and the
+// whole point of testing many languages would be lost.
+//
+// WHAT MAKES A GOOD PASSAGE: 30-40 words, so it takes 15-25 seconds to read - long enough for a
+// stable score, short enough that people finish it. Ordinary prose rather than a pangram, because
+// people read familiar sentence shapes at a natural pace and it is natural speech we want to measure.
+// No proper nouns, numbers written as words, no jargon: those are dictionary problems, not
+// transcription problems, and they would blame the transcriber for the wrong thing.
+//
+// NON-ASCII TEXT IS DELIBERATE HERE. These passages cannot be written in ASCII; that is the feature.
+// Console output, identifiers and comments elsewhere stay ASCII.
+
+export interface TestLanguage {
+  /** BCP 47 tag, sent to the transcriber as the language hint and stored with the clip. */
+  code: string;
+  /** Name in English, for our own screens and reports. */
+  name: string;
+  /** Name as a speaker of the language would write it, for the picker. */
+  nativeName: string;
+  /** The passage to read aloud. */
+  passage: string;
+  /** How this language is split for scoring. */
+  tokenMode: TokenMode;
+  /** True for right-to-left scripts, so the passage is laid out correctly. */
+  rightToLeft?: boolean;
+}
+
+export const TEST_LANGUAGES: readonly TestLanguage[] = [
+  {
+    code: "en",
+    name: "English",
+    nativeName: "English",
+    tokenMode: "words",
+    passage:
+      "Yesterday I finished six small tasks before lunch, then walked through the park to clear my " +
+      "head. The weather was cold but bright, and the streets were surprisingly quiet for a " +
+      "Thursday afternoon.",
+  },
+  {
+    code: "zh",
+    name: "Chinese (Mandarin)",
+    nativeName: "中文",
+    tokenMode: "characters",
+    passage:
+      "昨天午饭前我完成了六项小任务，然后去公园散步透透气。天气很冷，但是天空很晴朗，街道在星期四的下午安静得出奇。",
+  },
+  {
+    code: "hi",
+    name: "Hindi",
+    nativeName: "हिन्दी",
+    tokenMode: "words",
+    passage:
+      "कल मैंने दोपहर के भोजन से पहले छह छोटे काम पूरे किए, फिर ताज़ी हवा के लिए पार्क में टहलने गया। मौसम ठंडा लेकिन साफ़ था, " +
+      "और गुरुवार की दोपहर सड़कें बेहद शांत थीं।",
+  },
+  {
+    code: "es",
+    name: "Spanish",
+    nativeName: "Español",
+    tokenMode: "words",
+    passage:
+      "Ayer terminé seis tareas pequeñas antes del almuerzo y luego caminé por el parque para " +
+      "despejarme. Hacía frío pero el cielo estaba despejado, y las calles estaban sorprendentemente " +
+      "tranquilas para ser un jueves por la tarde.",
+  },
+  {
+    code: "fr",
+    name: "French",
+    nativeName: "Français",
+    tokenMode: "words",
+    passage:
+      "Hier, j'ai terminé six petites tâches avant le déjeuner, puis j'ai marché dans le parc pour me " +
+      "changer les idées. Il faisait froid mais lumineux, et les rues étaient étonnamment calmes pour " +
+      "un jeudi après-midi.",
+  },
+  {
+    code: "ar",
+    name: "Arabic",
+    nativeName: "العربية",
+    tokenMode: "words",
+    rightToLeft: true,
+    passage:
+      "أنهيت أمس ست مهام صغيرة قبل الغداء، ثم مشيت في الحديقة لأستنشق بعض الهواء. كان الطقس باردا لكنه " +
+      "صافيا، وكانت الشوارع هادئة بشكل مدهش في عصر يوم الخميس.",
+  },
+  {
+    code: "pt",
+    name: "Portuguese",
+    nativeName: "Português",
+    tokenMode: "words",
+    passage:
+      "Ontem terminei seis pequenas tarefas antes do almoço e depois caminhei pelo parque para clarear " +
+      "as ideias. Estava frio mas o céu estava limpo, e as ruas estavam surpreendentemente tranquilas " +
+      "para uma quinta-feira à tarde.",
+  },
+  {
+    code: "da",
+    name: "Danish",
+    nativeName: "Dansk",
+    tokenMode: "words",
+    passage:
+      "I går afsluttede jeg seks små opgaver før frokost og gik derefter en tur i parken for at få " +
+      "luft. Vejret var koldt, men klart, og gaderne var overraskende stille en torsdag eftermiddag.",
+  },
+];
+
+/** The language a first-time visitor is offered, matched to the browser when we support it. */
+export const DEFAULT_LANGUAGE_CODE = "en";
+
+/** Look a language up by code, falling back to English rather than returning nothing. */
+export function languageByCode(code: string): TestLanguage {
+  const found = TEST_LANGUAGES.find((l) => l.code === code);
+  return found ?? TEST_LANGUAGES[0];
+}
+
+/**
+ * The best supported language for a browser's stated preferences. Matches on the PRIMARY subtag, so
+ * a browser set to Brazilian Portuguese or Swiss French still lands on Portuguese or French rather
+ * than falling back to English.
+ */
+export function preferredLanguage(browserLanguages: readonly string[]): TestLanguage {
+  for (const tag of browserLanguages) {
+    const primary = tag.toLowerCase().split("-")[0];
+    const match = TEST_LANGUAGES.find((l) => l.code === primary);
+    if (match) return match;
+  }
+  return languageByCode(DEFAULT_LANGUAGE_CODE);
+}

--- a/packages/client-core/src/dictation/micQuality.test.ts
+++ b/packages/client-core/src/dictation/micQuality.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeMicQuality,
+  averageSpectrum,
+  checkMicQuality,
+  fft,
+  formatDb,
+  judgeMicQuality,
+  percentile,
+} from "./micQuality";
+
+// These tests are the evidence that the microphone check is worth shipping at all. The whole feature
+// rests on one claim: that we can tell a genuinely bad capture from a good one WITHOUT guessing. So
+// each defect is synthesized from its physical cause - a telephone-band link really is band-limited,
+// a clipped signal really is flat-topped, a noisy room really does raise the floor between words -
+// and the check must name that defect and, just as importantly, must stay silent on a good
+// microphone. A check that cried wolf would be worse than no check, because the advice it gives
+// ("replace your headset") costs the user real money.
+
+// --- Signal synthesis ---------------------------------------------------------------------------
+
+/** Deterministic PRNG so a threshold that sits too close to the edge fails every run, not one in ten. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** One RBJ-cookbook lowpass biquad pass (Q = 0.707). Cascaded to model a codec's steep band limit. */
+function lowpassOnce(input: Float32Array, sampleRate: number, cutoffHz: number): Float32Array {
+  const w0 = (2 * Math.PI * cutoffHz) / sampleRate;
+  const alpha = Math.sin(w0) / (2 * 0.7071);
+  const cosW0 = Math.cos(w0);
+  const b0 = (1 - cosW0) / 2;
+  const b1 = 1 - cosW0;
+  const b2 = (1 - cosW0) / 2;
+  const a0 = 1 + alpha;
+  const a1 = -2 * cosW0;
+  const a2 = 1 - alpha;
+
+  const out = new Float32Array(input.length);
+  let x1 = 0;
+  let x2 = 0;
+  let y1 = 0;
+  let y2 = 0;
+  for (let i = 0; i < input.length; i++) {
+    const x0 = input[i];
+    const y0 = (b0 / a0) * x0 + (b1 / a0) * x1 + (b2 / a0) * x2 - (a1 / a0) * y1 - (a2 / a0) * y2;
+    out[i] = y0;
+    x2 = x1;
+    x1 = x0;
+    y2 = y1;
+    y1 = y0;
+  }
+  return out;
+}
+
+function lowpass(input: Float32Array, sampleRate: number, cutoffHz: number, passes: number): Float32Array {
+  let out = input;
+  for (let i = 0; i < passes; i++) out = lowpassOnce(out, sampleRate, cutoffHz);
+  return out;
+}
+
+function highpass(input: Float32Array, sampleRate: number, cutoffHz: number): Float32Array {
+  // Subtracting the lowpass leaves the high band - enough to place sibilant energy up top.
+  const low = lowpass(input, sampleRate, cutoffHz, 2);
+  const out = new Float32Array(input.length);
+  for (let i = 0; i < input.length; i++) out[i] = input[i] - low[i];
+  return out;
+}
+
+interface SpeechOptions {
+  sampleRate: number;
+  seconds: number;
+  /** Peak amplitude of the voiced syllables, 0..1. */
+  level: number;
+  /** True for a real wideband microphone (sibilants present above 4.5 kHz). */
+  wideband: boolean;
+  /** Amplitude of the steady background noise. */
+  noiseLevel?: number;
+  /** Clip the finished signal at this absolute value (models an over-hot input). */
+  clipAt?: number;
+  seed?: number;
+  /** Loudness of the fricatives relative to the voiced syllables. Lower models a duller microphone
+   *  with weak sibilance - the hardest honest case for the narrowband check not to false-positive on. */
+  sibilantGain?: number;
+  /** Roll the whole signal off above this frequency (a muffled but genuinely wideband microphone). */
+  dullAboveHz?: number;
+}
+
+/**
+ * A speech-like signal: voiced syllables (a 120 Hz harmonic stack shaped by formants) separated by
+ * quiet gaps, with fricative bursts every fourth syllable. Envelopes are raised-cosine because hard
+ * gating would splatter broadband energy across the spectrum and fake the very high-frequency
+ * content the narrowband check looks for.
+ */
+function synthSpeech(opts: SpeechOptions): Float32Array {
+  const { sampleRate, seconds, level, wideband } = opts;
+  const rand = mulberry32(opts.seed ?? 1);
+  const n = Math.round(sampleRate * seconds);
+  const out = new Float32Array(n);
+
+  const syllableMs = 220;
+  const gapMs = 90;
+  const syllableLen = Math.round((syllableMs / 1000) * sampleRate);
+  const gapLen = Math.round((gapMs / 1000) * sampleRate);
+  const strideLen = syllableLen + gapLen;
+
+  // Fricative source: broadband noise, high-passed so its energy sits where /s/ lives (4-9 kHz).
+  const rawNoise = new Float32Array(n);
+  for (let i = 0; i < n; i++) rawNoise[i] = rand() * 2 - 1;
+  const sibilant = highpass(rawNoise, sampleRate, 4500);
+
+  let syllable = 0;
+  for (let start = 0; start + syllableLen < n; start += strideLen, syllable++) {
+    const isFricative = syllable % 4 === 3;
+    for (let i = 0; i < syllableLen; i++) {
+      // Raised-cosine envelope: no hard edges, so no spectral splatter.
+      const env = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (syllableLen - 1)));
+      const t = (start + i) / sampleRate;
+      let sample: number;
+      if (isFricative && wideband) {
+        sample = sibilant[start + i] * (opts.sibilantGain ?? 1);
+      } else if (isFricative) {
+        // A telephone link turns /s/ into a dull low-frequency thud - no high content at all.
+        sample = Math.sin(2 * Math.PI * 900 * t) * 0.5 + Math.sin(2 * Math.PI * 1500 * t) * 0.3;
+      } else {
+        // Voiced: harmonics of 120 Hz with a 1/n rolloff, all inside the speech band on both
+        // wideband and narrowband captures (real voiced speech has little energy above 3.4 kHz).
+        sample = 0;
+        for (let h = 1; h * 120 < 3400; h++) {
+          sample += Math.sin(2 * Math.PI * h * 120 * t) / h;
+        }
+        sample /= 2.5;
+      }
+      out[start + i] += sample * env * level;
+    }
+  }
+
+  if (opts.noiseLevel && opts.noiseLevel > 0) {
+    // The background comes through the SAME link as the voice, so a narrowband capture has
+    // band-limited noise too. Modelling it any other way would hand the check a free high-band clue.
+    const bg = new Float32Array(n);
+    for (let i = 0; i < n; i++) bg[i] = rand() * 2 - 1;
+    const shaped = wideband ? bg : lowpass(bg, sampleRate, 3400, 8);
+    for (let i = 0; i < n; i++) out[i] += shaped[i] * opts.noiseLevel;
+  }
+
+  // A narrowband link band-limits EVERYTHING it carries. Eight cascaded poles at 3.6 kHz is the
+  // steep cliff a real 8 kHz codec leaves behind. A merely DULL microphone gets a gentle rolloff
+  // instead - it still carries high content, just less of it.
+  const banded = wideband
+    ? opts.dullAboveHz
+      ? lowpass(out, sampleRate, opts.dullAboveHz, 2)
+      : out
+    : lowpass(out, sampleRate, 3600, 8);
+
+  if (opts.clipAt !== undefined) {
+    for (let i = 0; i < banded.length; i++) {
+      banded[i] = Math.max(-opts.clipAt, Math.min(opts.clipAt, banded[i]));
+    }
+    // A real clip pins samples AT the rail; normalise so the flat tops land at full scale.
+    for (let i = 0; i < banded.length; i++) banded[i] /= opts.clipAt;
+  }
+  return banded;
+}
+
+const RATE = 48000;
+
+// --- The building blocks ------------------------------------------------------------------------
+
+describe("fft", () => {
+  it("puts a pure tone in the bin that matches its frequency", () => {
+    const size = 1024;
+    const rate = 48000;
+    const toneHz = 3000;
+    const re = new Float64Array(size);
+    const im = new Float64Array(size);
+    for (let i = 0; i < size; i++) re[i] = Math.sin((2 * Math.PI * toneHz * i) / rate);
+    fft(re, im);
+
+    let peakBin = 0;
+    let peak = 0;
+    for (let bin = 1; bin < size / 2; bin++) {
+      const power = re[bin] * re[bin] + im[bin] * im[bin];
+      if (power > peak) {
+        peak = power;
+        peakBin = bin;
+      }
+    }
+    expect(peakBin * (rate / size)).toBeCloseTo(toneHz, -2);
+  });
+});
+
+describe("percentile", () => {
+  it("reads the value at the requested point of a sorted list", () => {
+    const sorted = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    expect(percentile(sorted, 0)).toBe(0);
+    expect(percentile(sorted, 1)).toBe(9);
+    expect(percentile(sorted, 0.5)).toBeGreaterThanOrEqual(4);
+    expect(percentile(sorted, 0.5)).toBeLessThanOrEqual(5);
+  });
+
+  it("is 0 for an empty list rather than throwing", () => {
+    expect(percentile([], 0.5)).toBe(0);
+  });
+});
+
+describe("averageSpectrum", () => {
+  it("returns an all-zero spectrum when there are no usable frames", () => {
+    const power = averageSpectrum(new Float32Array(100), []);
+    expect(power.every((p) => p === 0)).toBe(true);
+  });
+});
+
+// --- The measurement ----------------------------------------------------------------------------
+
+describe("analyzeMicQuality", () => {
+  it("measures a healthy wideband microphone as good, with no issues raised", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: true, noiseLevel: 0.002 });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.narrowband).toBe(false);
+    expect(report.clippedFraction).toBeLessThan(0.001);
+    expect(report.signalToNoiseDb).toBeGreaterThan(18);
+    expect(report.speechLevelDb).toBeGreaterThan(-32);
+  });
+
+  it("detects a telephone-band capture (the Bluetooth hands-free headset)", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: false, noiseLevel: 0.002 });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.narrowband).toBe(true);
+  });
+
+  it("does NOT flag a dull microphone with weak sibilance as narrowband", () => {
+    // The false positive that would matter most: telling someone with a perfectly usable microphone
+    // to go and buy a new headset. A dull capture still carries real high-frequency content, just
+    // less of it, and the check must see the difference between "quiet up there" and "nothing there".
+    const samples = synthSpeech({
+      sampleRate: RATE,
+      seconds: 4,
+      level: 0.3,
+      wideband: true,
+      noiseLevel: 0.002,
+      sibilantGain: 0.1,
+    });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.narrowband).toBe(false);
+    // And with real margin, not by a hair - the decision must not be knife-edge.
+    expect(report.highBandRatioDb).toBeGreaterThan(-40);
+  });
+
+  it("does NOT flag a muffled but genuinely wideband microphone as narrowband", () => {
+    const samples = synthSpeech({
+      sampleRate: RATE,
+      seconds: 4,
+      level: 0.3,
+      wideband: true,
+      noiseLevel: 0.002,
+      sibilantGain: 0.3,
+      dullAboveHz: 5500,
+    });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.narrowband).toBe(false);
+  });
+
+  it("separates wideband from narrowband by a wide margin, not a hair", () => {
+    // The evidence that the narrowband threshold is safe: the two populations are not adjacent, they
+    // are tens of decibels apart, and -45 dB sits in the empty gap between them.
+    const wide = analyzeMicQuality(
+      synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: true, noiseLevel: 0.002, sibilantGain: 0.1 }),
+      RATE,
+    );
+    const narrow = analyzeMicQuality(
+      synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: false, noiseLevel: 0.002 }),
+      RATE,
+    );
+    expect(wide.highBandRatioDb - narrow.highBandRatioDb).toBeGreaterThan(40);
+  });
+
+  it("calls a device that cannot even deliver the band narrowband outright", () => {
+    // An 8 kHz stream has a 4 kHz Nyquist - there is no high band to inspect, it IS the defect.
+    const samples = synthSpeech({ sampleRate: 8000, seconds: 4, level: 0.3, wideband: false, noiseLevel: 0.002 });
+    const report = analyzeMicQuality(samples, 8000);
+    expect(report.narrowband).toBe(true);
+  });
+
+  it("measures clipping on an over-hot input", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.9, wideband: true, noiseLevel: 0.002, clipAt: 0.35 });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.clippedFraction).toBeGreaterThan(0.01);
+  });
+
+  it("measures a quiet microphone as quiet without inventing other faults", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.004, wideband: true, noiseLevel: 0.00002 });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.speechLevelDb).toBeLessThan(-42);
+    expect(report.clippedFraction).toBe(0);
+  });
+
+  it("measures a poor signal-to-noise ratio when the room is loud", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.25, wideband: true, noiseLevel: 0.1 });
+    const report = analyzeMicQuality(samples, RATE);
+
+    expect(report.heardSpeech).toBe(true);
+    expect(report.signalToNoiseDb).toBeLessThan(18);
+  });
+
+  it("reports no speech for digital silence", () => {
+    const report = analyzeMicQuality(new Float32Array(RATE * 3), RATE);
+    expect(report.heardSpeech).toBe(false);
+  });
+
+  it("reports no speech for a clip that is nothing but steady hiss", () => {
+    const rand = mulberry32(7);
+    const samples = new Float32Array(RATE * 3);
+    for (let i = 0; i < samples.length; i++) samples[i] = (rand() * 2 - 1) * 0.05;
+    const report = analyzeMicQuality(samples, RATE);
+    // Steady noise has no loud end standing above its quiet end - there is no voice here.
+    expect(report.heardSpeech).toBe(false);
+  });
+
+  it("does not throw on a clip too short to hold a single frame", () => {
+    const report = analyzeMicQuality(new Float32Array(4), RATE);
+    expect(report.heardSpeech).toBe(false);
+    expect(report.durationSeconds).toBeGreaterThan(0);
+  });
+});
+
+// --- The verdict --------------------------------------------------------------------------------
+
+describe("judgeMicQuality", () => {
+  it("passes a good wideband microphone silently - no advice, nothing to fix", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: true, noiseLevel: 0.002 });
+    const verdict = checkMicQuality(samples, RATE);
+
+    expect(verdict.rating).toBe("good");
+    expect(verdict.issues).toEqual([]);
+    expect(verdict.headline).toContain("sounds good");
+  });
+
+  it("names the Bluetooth hands-free link as the problem and says how to fix it", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.3, wideband: false, noiseLevel: 0.002 });
+    const verdict = checkMicQuality(samples, RATE);
+
+    expect(verdict.rating).toBe("poor");
+    const narrow = verdict.issues.find((i) => i.id === "narrowband");
+    expect(narrow).toBeDefined();
+    expect(narrow?.advice).toContain("Bluetooth");
+  });
+
+  it("reports clipping with the measured percentage in the title", () => {
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.9, wideband: true, noiseLevel: 0.002, clipAt: 0.35 });
+    const verdict = checkMicQuality(samples, RATE);
+
+    const clipping = verdict.issues.find((i) => i.id === "clipping");
+    expect(clipping).toBeDefined();
+    expect(clipping?.severity).toBe("poor");
+    expect(clipping?.title).toMatch(/%/);
+  });
+
+  it("tells the user we heard nothing rather than scoring an empty clip", () => {
+    const verdict = checkMicQuality(new Float32Array(RATE * 3), RATE);
+
+    expect(verdict.rating).toBe("poor");
+    expect(verdict.issues).toHaveLength(1);
+    expect(verdict.issues[0].id).toBe("no-speech");
+    // It must NOT claim the microphone is narrowband or clipping on the strength of silence.
+    expect(verdict.issues.some((i) => i.id === "narrowband")).toBe(false);
+  });
+
+  it("puts the most damaging problem first", () => {
+    // Quiet AND telephone-band: the band limit is what actually breaks transcription.
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.005, wideband: false, noiseLevel: 0.00002 });
+    const verdict = checkMicQuality(samples, RATE);
+
+    expect(verdict.issues.length).toBeGreaterThan(1);
+    expect(verdict.issues[0].severity).toBe("poor");
+  });
+
+  it("grades a merely imperfect microphone fair, not poor - a good mic is never nagged", () => {
+    // Wideband and undistorted, just a little hissy: worth a note, not an alarm.
+    const samples = synthSpeech({ sampleRate: RATE, seconds: 4, level: 0.25, wideband: true, noiseLevel: 0.05 });
+    const verdict = checkMicQuality(samples, RATE);
+
+    expect(verdict.report.narrowband).toBe(false);
+    expect(verdict.rating).toBe("fair");
+    expect(verdict.issues.every((i) => i.severity === "fair")).toBe(true);
+  });
+});
+
+describe("judgeMicQuality thresholds", () => {
+  // The fold pinned directly against hand-built measurements, independent of the synthesizer: these
+  // fix WHERE each threshold sits, so a later tweak to the analysis cannot quietly move the point at
+  // which a user starts being told their microphone is bad.
+  const healthy = {
+    heardSpeech: true,
+    durationSeconds: 4,
+    sampleRate: 48000,
+    speechLevelDb: -20,
+    noiseFloorDb: -55,
+    signalToNoiseDb: 35,
+    clippedFraction: 0,
+    highBandRatioDb: -25,
+    narrowband: false,
+  };
+
+  it("passes a healthy report with no issues", () => {
+    expect(judgeMicQuality(healthy).rating).toBe("good");
+  });
+
+  it("stays silent just inside every threshold and speaks up just outside", () => {
+    expect(judgeMicQuality({ ...healthy, signalToNoiseDb: 18 }).issues).toEqual([]);
+    expect(judgeMicQuality({ ...healthy, signalToNoiseDb: 17 }).issues[0].id).toBe("noisy");
+
+    expect(judgeMicQuality({ ...healthy, speechLevelDb: -32 }).issues).toEqual([]);
+    expect(judgeMicQuality({ ...healthy, speechLevelDb: -33 }).issues[0].id).toBe("too-quiet");
+
+    expect(judgeMicQuality({ ...healthy, clippedFraction: 0.0009 }).issues).toEqual([]);
+    expect(judgeMicQuality({ ...healthy, clippedFraction: 0.0011 }).issues[0].id).toBe("clipping");
+  });
+
+  it("escalates from fair to poor at the severe end of each threshold", () => {
+    expect(judgeMicQuality({ ...healthy, signalToNoiseDb: 12 }).rating).toBe("fair");
+    expect(judgeMicQuality({ ...healthy, signalToNoiseDb: 9 }).rating).toBe("poor");
+
+    expect(judgeMicQuality({ ...healthy, speechLevelDb: -38 }).rating).toBe("fair");
+    expect(judgeMicQuality({ ...healthy, speechLevelDb: -45 }).rating).toBe("poor");
+  });
+
+  it("treats a narrowband link as poor on its own, however clean the rest is", () => {
+    const verdict = judgeMicQuality({ ...healthy, narrowband: true, highBandRatioDb: -110 });
+    expect(verdict.rating).toBe("poor");
+    expect(verdict.issues).toHaveLength(1);
+    expect(verdict.issues[0].id).toBe("narrowband");
+  });
+});
+
+describe("formatDb", () => {
+  it("renders a level and guards the silent case", () => {
+    expect(formatDb(-20.4)).toBe("-20 dB");
+    expect(formatDb(-Infinity)).toBe("--");
+  });
+});

--- a/packages/client-core/src/dictation/micQuality.ts
+++ b/packages/client-core/src/dictation/micQuality.ts
@@ -1,0 +1,425 @@
+// Microphone quality measurement for the "Test microphone" check on the Cockpit dictation health
+// screen and the mobile app.
+//
+// WHY THIS EXISTS: bad transcription is usually a bad MICROPHONE, not a bad model. A headset on a
+// Bluetooth hands-free link delivers 8 kHz phone-quality audio; a gain-staged-too-hot mic clips; a
+// laptop mic across the room buries the voice in room noise. All three produce a transcript full of
+// nonsense and none of them are visible to the user, who only knows "dictation is rubbish". This
+// module turns a recorded clip into MEASUREMENTS of those three specific defects.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO: it does not score "audio quality" as a single opinion, and it
+// does not guess. Every number below is a physical measurement of the samples with an unambiguous
+// meaning, and each one maps to a defect the user can actually act on. Anything we could not measure
+// honestly (is the speaker mumbling? is the accent hard? is the room reverberant?) is absent rather
+// than estimated, because a confident wrong diagnosis is worse than no diagnosis - it sends the user
+// to replace a microphone that was fine.
+//
+// ON THE "CLIENT IS DUMB" RULE (CLAUDE.md #7): that rule puts every SESSION display verdict on the
+// Gateway so two clients cannot invent different meanings for the same pushed state. This check is
+// local-only by design - the audio never leaves the device, and shipping it to the Gateway just to
+// be ruled on would be a privacy regression for zero benefit. The rule's actual principle - ONE
+// place folds the verdict, clients render it verbatim - is honoured here: the fold is this shared
+// module, and both the Cockpit and the mobile app render the strings it returns without re-deciding
+// anything. Adding a new defect is one edit here, not a branch in each client.
+
+// Analysis frame. 20 ms is the standard short-time window for speech: long enough for a stable
+// energy reading, short enough that a frame is either speech or gap rather than a blur of both.
+const FRAME_MS = 20;
+
+// A frame this far above the measured noise floor is counted as speech. 6 dB is 2x the noise
+// amplitude - comfortably above floor wobble, low enough to keep quiet syllables.
+const SPEECH_OVER_FLOOR_DB = 6;
+
+// |sample| at or above this is treated as pinned to the rail. Not exactly 1.0: integer-encoded audio
+// that has been resampled lands a hair under full scale, and a true clip is flat-topped regardless.
+const CLIP_CEILING = 0.98;
+
+// Speech band used for every relative-energy comparison: the range that actually carries
+// intelligibility, and the band a telephone link preserves.
+const SPEECH_BAND_LOW_HZ = 300;
+const SPEECH_BAND_HIGH_HZ = 3400;
+
+// The band that only a genuinely wideband capture can contain. A narrowband (8 kHz) source upsampled
+// to 48 kHz has essentially NOTHING here - the resampler's stopband, tens of dB below anything real.
+const HIGH_BAND_LOW_HZ = 4500;
+const HIGH_BAND_HIGH_HZ = 8000;
+
+// --- Thresholds -------------------------------------------------------------------------------
+// Each is a cliff in how the audio BEHAVES, not a taste preference, and each is set where the
+// evidence is unambiguous so a good microphone is never nagged.
+
+// Real speech through a wideband microphone always puts SOME energy at 4.5-8 kHz (sibilants, breath,
+// room air) - typically 20-35 dB below the speech band. A narrowband link upsampled to 48 kHz leaves
+// the resampler's stopband there instead, 50+ dB down. -45 dB sits in the empty gap between those two
+// populations, so this fires on a genuine cliff and not on a merely dull-sounding microphone.
+const NARROWBAND_RATIO_DB = -45;
+
+// Clipping is flat-topped distortion; the transcriber hears a buzz over the vowels. A stray sample or
+// two at the rail is normal, a percent of them is not.
+const CLIP_POOR = 0.01;
+const CLIP_FAIR = 0.001;
+
+// Whisper degrades sharply once the voice stops standing clear of the background.
+const SNR_POOR_DB = 10;
+const SNR_FAIR_DB = 18;
+
+// Below this the voice is so far down that the encoder spends its bits on noise.
+const LEVEL_POOR_DB = -42;
+const LEVEL_FAIR_DB = -32;
+
+// 16-bit audio quantises at about -96 dBFS, so a "noise floor" below this is digital silence rather
+// than a measurement of a room. Clamping here keeps the signal-to-noise ratio a finite number: an
+// unclamped floor of zero makes it Infinity, which is not a reading anyone can act on and which
+// would propagate through the verdict and out to the screen.
+const MIN_MEASURABLE_DB = -100;
+
+export type QualityRating = "good" | "fair" | "poor";
+
+export interface MicQualityReport {
+  /** Whether the clip contained any speech at all. Everything below is meaningless when false. */
+  heardSpeech: boolean;
+  /** Duration of the analysed audio. */
+  durationSeconds: number;
+  /** Sample rate the microphone actually delivered. */
+  sampleRate: number;
+  /** Typical loudness of the speech itself, in dBFS (0 = full scale). Around -20 is healthy. */
+  speechLevelDb: number;
+  /** Loudness of the quiet gaps between words, in dBFS. The room + the microphone's own hiss. */
+  noiseFloorDb: number;
+  /** How far the voice stands above the background, in dB. The single best predictor of whether
+   *  transcription will work. */
+  signalToNoiseDb: number;
+  /** Fraction of samples pinned to full scale (0..1). Anything above a trace is audible distortion. */
+  clippedFraction: number;
+  /** Energy in the 4.5-8 kHz band relative to the speech band, in dB. A hard cliff here is the
+   *  signature of a Bluetooth hands-free / telephone-grade link. -Infinity when nothing is there. */
+  highBandRatioDb: number;
+  /** True when the capture carries no real content above the telephone band. */
+  narrowband: boolean;
+}
+
+/** One named thing that is wrong with the capture, in the user's words, with what to do about it. */
+export interface MicQualityIssue {
+  /** Stable identifier, for tests and telemetry. Never shown to the user. */
+  id: "no-speech" | "narrowband" | "clipping" | "too-quiet" | "noisy";
+  severity: "poor" | "fair";
+  /** What was measured, in plain English. */
+  title: string;
+  /** What the user should change. */
+  advice: string;
+}
+
+/** The finished verdict both clients render verbatim. */
+export interface MicQualityVerdict {
+  rating: QualityRating;
+  /** One-line headline for the result banner. */
+  headline: string;
+  /** Ordered worst-first. Empty when the microphone is good. */
+  issues: MicQualityIssue[];
+  report: MicQualityReport;
+}
+
+function toDb(amplitude: number): number {
+  if (amplitude <= 0) return -Infinity;
+  return 20 * Math.log10(amplitude);
+}
+
+/** Value at a percentile (0..1) of a numeric list. Used to read the noise floor and the speech level
+ *  off the distribution of frame energies rather than off the min/max, which single clicks and pops
+ *  would otherwise dominate. */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.round(p * (sorted.length - 1))));
+  return sorted[index];
+}
+
+/** Root-mean-square amplitude of a slice of samples. */
+function rms(samples: Float32Array, from: number, to: number): number {
+  let sum = 0;
+  for (let i = from; i < to; i++) sum += samples[i] * samples[i];
+  const n = to - from;
+  return n > 0 ? Math.sqrt(sum / n) : 0;
+}
+
+// --- Fast Fourier transform (iterative radix-2, in place) ------------------------------------
+// A compact FFT so the bandwidth check needs no dependency. re/im are power-of-two length.
+export function fft(re: Float64Array, im: Float64Array): void {
+  const n = re.length;
+  if (n <= 1) return;
+
+  // Bit-reversal permutation.
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1;
+    for (; j & bit; bit >>= 1) j ^= bit;
+    j ^= bit;
+    if (i < j) {
+      [re[i], re[j]] = [re[j], re[i]];
+      [im[i], im[j]] = [im[j], im[i]];
+    }
+  }
+
+  for (let len = 2; len <= n; len <<= 1) {
+    const angle = (-2 * Math.PI) / len;
+    const wRe = Math.cos(angle);
+    const wIm = Math.sin(angle);
+    for (let i = 0; i < n; i += len) {
+      let curRe = 1;
+      let curIm = 0;
+      for (let k = 0; k < len / 2; k++) {
+        const aRe = re[i + k];
+        const aIm = im[i + k];
+        const bRe = re[i + k + len / 2] * curRe - im[i + k + len / 2] * curIm;
+        const bIm = re[i + k + len / 2] * curIm + im[i + k + len / 2] * curRe;
+        re[i + k] = aRe + bRe;
+        im[i + k] = aIm + bIm;
+        re[i + k + len / 2] = aRe - bRe;
+        im[i + k + len / 2] = aIm - bIm;
+        const nextRe = curRe * wRe - curIm * wIm;
+        curIm = curRe * wIm + curIm * wRe;
+        curRe = nextRe;
+      }
+    }
+  }
+}
+
+// Spectrum window for the bandwidth check. 1024 bins at 48 kHz is ~47 Hz resolution over a 21 ms
+// window - fine enough to place the telephone cliff at 3.4-4 kHz precisely.
+const SPECTRUM_SIZE = 1024;
+
+/**
+ * Average power spectrum across the given frame start offsets, Hann-windowed. Returns power per bin
+ * for bins 0..SPECTRUM_SIZE/2 (the real half of the spectrum).
+ */
+export function averageSpectrum(samples: Float32Array, frameStarts: number[]): Float64Array {
+  const half = SPECTRUM_SIZE / 2;
+  const power = new Float64Array(half + 1);
+  if (frameStarts.length === 0) return power;
+
+  // Hann window, precomputed once.
+  const window = new Float64Array(SPECTRUM_SIZE);
+  for (let i = 0; i < SPECTRUM_SIZE; i++) {
+    window[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (SPECTRUM_SIZE - 1)));
+  }
+
+  const re = new Float64Array(SPECTRUM_SIZE);
+  const im = new Float64Array(SPECTRUM_SIZE);
+  let used = 0;
+
+  for (const start of frameStarts) {
+    if (start + SPECTRUM_SIZE > samples.length) continue;
+    for (let i = 0; i < SPECTRUM_SIZE; i++) {
+      re[i] = samples[start + i] * window[i];
+      im[i] = 0;
+    }
+    fft(re, im);
+    for (let bin = 0; bin <= half; bin++) {
+      power[bin] += re[bin] * re[bin] + im[bin] * im[bin];
+    }
+    used++;
+  }
+
+  if (used > 0) {
+    for (let bin = 0; bin <= half; bin++) power[bin] /= used;
+  }
+  return power;
+}
+
+/** Sum the power spectrum over a frequency range. */
+function bandEnergy(power: Float64Array, sampleRate: number, lowHz: number, highHz: number): number {
+  const binHz = sampleRate / SPECTRUM_SIZE;
+  const from = Math.max(1, Math.floor(lowHz / binHz));
+  const to = Math.min(power.length - 1, Math.ceil(highHz / binHz));
+  let sum = 0;
+  for (let bin = from; bin <= to; bin++) sum += power[bin];
+  return sum;
+}
+
+/**
+ * Measure a recorded clip. `samples` must be mono at the microphone's NATIVE sample rate - measuring
+ * a clip that has already been resampled to 16 kHz would destroy the very high-frequency evidence
+ * the narrowband check reads.
+ */
+export function analyzeMicQuality(samples: Float32Array, sampleRate: number): MicQualityReport {
+  const frameSize = Math.max(1, Math.round((FRAME_MS / 1000) * sampleRate));
+  const durationSeconds = samples.length / sampleRate;
+
+  // Per-frame energy, which everything else is read off.
+  const frameLevels: number[] = [];
+  const frameStarts: number[] = [];
+  for (let start = 0; start + frameSize <= samples.length; start += frameSize) {
+    frameLevels.push(rms(samples, start, start + frameSize));
+    frameStarts.push(start);
+  }
+
+  const empty: MicQualityReport = {
+    heardSpeech: false,
+    durationSeconds,
+    sampleRate,
+    speechLevelDb: -Infinity,
+    noiseFloorDb: -Infinity,
+    signalToNoiseDb: 0,
+    clippedFraction: 0,
+    highBandRatioDb: -Infinity,
+    narrowband: false,
+  };
+  if (frameLevels.length === 0) return empty;
+
+  const sortedLevels = [...frameLevels].sort((a, b) => a - b);
+  // The noise floor is the quiet end of the distribution (the gaps between words); the speech level
+  // is the loud end (the vowels). Percentiles, not min/max, so one door slam cannot define either.
+  const noiseFloor = percentile(sortedLevels, 0.1);
+  const speechLevel = percentile(sortedLevels, 0.9);
+  // Clamped so a digitally-silent gap yields a large-but-finite ratio rather than Infinity.
+  const noiseFloorDb = Math.max(MIN_MEASURABLE_DB, toDb(noiseFloor));
+  const speechLevelDb = toDb(speechLevel);
+  const signalToNoiseDb = Number.isFinite(speechLevelDb) ? speechLevelDb - noiseFloorDb : 0;
+
+  // Did anything actually get said? A clip of pure silence or pure steady hiss has no loud end
+  // standing above its quiet end, and every measurement below would be noise about noise.
+  const speechThreshold = noiseFloor * Math.pow(10, SPEECH_OVER_FLOOR_DB / 20);
+  const speechFrameStarts = frameStarts.filter((_, i) => frameLevels[i] > speechThreshold);
+  // An audible clip needs both a real dynamic gap AND a speech level above the floor of hearing.
+  const heardSpeech = speechFrameStarts.length >= 3 && signalToNoiseDb >= 3 && speechLevelDb > -60;
+  if (!heardSpeech) return { ...empty, durationSeconds, sampleRate, speechLevelDb, noiseFloorDb, signalToNoiseDb };
+
+  let clipped = 0;
+  for (let i = 0; i < samples.length; i++) {
+    if (Math.abs(samples[i]) >= CLIP_CEILING) clipped++;
+  }
+  const clippedFraction = samples.length > 0 ? clipped / samples.length : 0;
+
+  // Bandwidth: compare the band only a wideband capture can fill against the speech band. Measured
+  // on SPEECH frames only - the gaps carry no high-frequency content in any capture and would make
+  // every microphone look narrowband.
+  const nyquist = sampleRate / 2;
+  let highBandRatioDb = -Infinity;
+  let narrowband: boolean;
+  if (nyquist <= HIGH_BAND_LOW_HZ) {
+    // The device did not even deliver enough bandwidth to ask the question - it IS narrowband.
+    narrowband = true;
+  } else {
+    const power = averageSpectrum(samples, speechFrameStarts);
+    const speechBand = bandEnergy(power, sampleRate, SPEECH_BAND_LOW_HZ, SPEECH_BAND_HIGH_HZ);
+    const highBand = bandEnergy(power, sampleRate, HIGH_BAND_LOW_HZ, Math.min(HIGH_BAND_HIGH_HZ, nyquist));
+    highBandRatioDb = speechBand > 0 ? 10 * Math.log10(highBand / speechBand) : -Infinity;
+    narrowband = highBandRatioDb < NARROWBAND_RATIO_DB;
+  }
+
+  return {
+    heardSpeech: true,
+    durationSeconds,
+    sampleRate,
+    speechLevelDb,
+    noiseFloorDb,
+    signalToNoiseDb,
+    clippedFraction,
+    highBandRatioDb,
+    narrowband,
+  };
+}
+
+/**
+ * Fold the measurements into the verdict both clients render. Ordered worst-first so the first issue
+ * shown is the one most worth fixing.
+ */
+export function judgeMicQuality(report: MicQualityReport): MicQualityVerdict {
+  if (!report.heardSpeech) {
+    return {
+      rating: "poor",
+      headline: "We did not hear any speech in that recording.",
+      issues: [
+        {
+          id: "no-speech",
+          severity: "poor",
+          title: "No speech was detected.",
+          advice:
+            "Check that the right microphone is selected and that it is not muted, then record again " +
+            "and speak a full sentence at your normal volume.",
+        },
+      ],
+      report,
+    };
+  }
+
+  const issues: MicQualityIssue[] = [];
+
+  // Narrowband first: it is the single most destructive defect for transcription and the one users
+  // never suspect, because the audio sounds "fine, just a bit muffled" to a human ear.
+  if (report.narrowband) {
+    issues.push({
+      id: "narrowband",
+      severity: "poor",
+      title: "Your microphone is sending telephone-quality audio.",
+      advice:
+        "This is almost always a Bluetooth headset running in hands-free mode, which drops the audio " +
+        "to 8 kHz and strips out the consonants. Switch the headset to its headphones profile and use " +
+        "a different microphone, use the headset's dongle instead of Bluetooth, or use a wired " +
+        "microphone. This alone is usually the difference between dictation working and not.",
+    });
+  }
+
+  if (report.clippedFraction >= CLIP_FAIR) {
+    const poor = report.clippedFraction >= CLIP_POOR;
+    issues.push({
+      id: "clipping",
+      severity: poor ? "poor" : "fair",
+      title: `Your audio is distorting (${(report.clippedFraction * 100).toFixed(1)}% of it is clipped).`,
+      advice:
+        "The microphone is too loud and the peaks are being cut flat. Move it further from your mouth, " +
+        "or turn the input level down in your operating system's sound settings.",
+    });
+  }
+
+  if (report.speechLevelDb < LEVEL_FAIR_DB) {
+    const poor = report.speechLevelDb < LEVEL_POOR_DB;
+    issues.push({
+      id: "too-quiet",
+      severity: poor ? "poor" : "fair",
+      title: "Your voice is very quiet in the recording.",
+      advice:
+        "Move the microphone closer to your mouth, or raise the input level in your operating system's " +
+        "sound settings.",
+    });
+  }
+
+  if (report.signalToNoiseDb < SNR_FAIR_DB) {
+    const poor = report.signalToNoiseDb < SNR_POOR_DB;
+    issues.push({
+      id: "noisy",
+      severity: poor ? "poor" : "fair",
+      title: "There is a lot of background noise behind your voice.",
+      advice:
+        "Your voice is only just louder than the room. Move the microphone closer to your mouth, or " +
+        "record somewhere quieter - a fan, air conditioning or an open office all show up like this.",
+    });
+  }
+
+  // Worst first, so the top card is the one worth acting on.
+  issues.sort((a, b) => (a.severity === b.severity ? 0 : a.severity === "poor" ? -1 : 1));
+
+  const rating: QualityRating = issues.some((i) => i.severity === "poor")
+    ? "poor"
+    : issues.length > 0
+      ? "fair"
+      : "good";
+
+  const headline =
+    rating === "good"
+      ? "Your microphone sounds good. Dictation should work well."
+      : rating === "fair"
+        ? "Your microphone works, but it could be better."
+        : "Your microphone is likely to give you poor dictation.";
+
+  return { rating, headline, issues, report };
+}
+
+/** Convenience: measure and judge in one call. */
+export function checkMicQuality(samples: Float32Array, sampleRate: number): MicQualityVerdict {
+  return judgeMicQuality(analyzeMicQuality(samples, sampleRate));
+}
+
+/** Format a dBFS reading for display, guarding the silent case. */
+export function formatDb(db: number): string {
+  if (!Number.isFinite(db)) return "--";
+  return `${db.toFixed(0)} dB`;
+}

--- a/packages/client-core/src/dictation/mictest.css
+++ b/packages/client-core/src/dictation/mictest.css
@@ -1,0 +1,355 @@
+/* ===== Test your microphone =====
+   Styling for MicTestPanel, the shared microphone check mounted by the Cockpit dictation health
+   page and the mobile app. Lives next to the component and is imported BY the component, so every
+   shell that mounts the panel gets its styling automatically from one copy (the same arrangement as
+   dictation.css).
+
+   Only the theme tokens BOTH shells define are used (--surface, --surface-2, --border, --text,
+   --text-dim, --accent, --attention). The two verdict colours the shells do not share are declared
+   locally below, so mounting this panel never requires a host to add a token. */
+.mictest {
+  --mictest-ok: #22c55e;
+  --mictest-warn: #f59e0b;
+
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.mictest-head h2 {
+  margin: 0;
+  font-size: 17px;
+  color: var(--text);
+}
+
+.mictest-lede {
+  margin: 8px 0 16px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.mictest-prompt-label {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.mictest-prompt {
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  font-size: 16px;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+/* --- Live capture --- */
+.mictest-meter {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 44px;
+  margin-bottom: 8px;
+}
+
+.mictest-bar {
+  flex: 1;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--surface-2);
+  transition: background 60ms linear;
+}
+
+.mictest-bar-on {
+  background: var(--attention);
+}
+
+.mictest-timer {
+  font-family: "Cascadia Mono", Consolas, "Courier New", monospace;
+  font-size: 15px;
+  color: var(--text-dim);
+  margin-bottom: 14px;
+}
+
+/* --- Actions --- */
+.mictest-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mictest-primary,
+.mictest-secondary {
+  appearance: none;
+  border-radius: 8px;
+  padding: 11px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  /* Comfortably above the 44px touch target minimum on the phone. */
+  min-height: 44px;
+}
+
+.mictest-primary {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: #fff;
+}
+
+.mictest-secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+.mictest-primary:hover,
+.mictest-secondary:hover {
+  filter: brightness(1.12);
+}
+
+/* --- Transient states --- */
+.mictest-loading {
+  color: var(--text-dim);
+  font-size: 14px;
+  padding: 12px 0;
+}
+
+.mictest-error {
+  color: var(--attention);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.mictest-warn {
+  color: var(--mictest-warn);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+/* --- Result --- */
+.mictest-banner {
+  padding: 12px 14px;
+  border-radius: 8px;
+  border-left: 4px solid var(--border);
+  background: var(--surface-2);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 14px;
+}
+
+.mictest-good {
+  border-left-color: var(--mictest-ok);
+}
+
+.mictest-fair {
+  border-left-color: var(--mictest-warn);
+}
+
+.mictest-poor {
+  border-left-color: var(--attention);
+}
+
+.mictest-playback {
+  margin-bottom: 14px;
+}
+
+.mictest-playback-label {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+}
+
+.mictest-audio {
+  width: 100%;
+  /* The stock player is light-on-light in some browsers; the filter keeps it legible on the dark
+     theme without replacing the whole transport with custom controls. */
+  filter: invert(0.9) hue-rotate(180deg);
+}
+
+.mictest-issues {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mictest-issue {
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--surface-2);
+  border-left: 3px solid var(--border);
+}
+
+.mictest-issue-poor {
+  border-left-color: var(--attention);
+}
+
+.mictest-issue-fair {
+  border-left-color: var(--mictest-warn);
+}
+
+.mictest-issue-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.mictest-issue-advice {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+/* --- The raw numbers --- */
+.mictest-details {
+  margin-bottom: 14px;
+}
+
+.mictest-details summary {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-dim);
+  padding: 6px 0;
+}
+
+.mictest-measurements {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 10px 0 0;
+}
+
+.mictest-measurements > div {
+  background: var(--surface-2);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.mictest-measurements dt {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 3px;
+}
+
+.mictest-measurements dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Test transcription --- */
+.mictest-langrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.mictest-langlabel {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.mictest-langselect {
+  flex: 1;
+  min-width: 180px;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 15px;
+  min-height: 44px;
+}
+
+/* The passage is read aloud, so it is set larger and looser than body copy - someone reading from a
+   phone at arm's length must not have to squint or lose their place. */
+.mictest-passage {
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.mictest-acc-excellent {
+  border-left-color: var(--mictest-ok);
+}
+
+.mictest-acc-good {
+  border-left-color: var(--mictest-warn);
+}
+
+.mictest-acc-poor {
+  border-left-color: var(--attention);
+}
+
+.mictest-diffblock {
+  margin-bottom: 14px;
+}
+
+.mictest-diff {
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border-radius: 8px;
+  font-size: 16px;
+  line-height: 1.9;
+}
+
+/* Each token carries its own outcome. Colour is never the only signal - a substitution is also
+   underlined and a miss is struck through - so the marking still reads without colour vision. */
+.mictest-tok {
+  padding: 1px 3px;
+  border-radius: 3px;
+}
+
+.mictest-tok::after {
+  content: " ";
+}
+
+/* Chinese and Japanese are scored per character, so the tokens must sit flush rather than being
+   separated by the space that follows every other language's word. */
+.mictest-diff[lang="zh"] .mictest-tok::after,
+.mictest-diff[lang="ja"] .mictest-tok::after {
+  content: "";
+}
+
+.mictest-tok-ok {
+  color: var(--text);
+}
+
+.mictest-tok-sub {
+  color: var(--attention);
+  text-decoration: underline wavy;
+  background: rgba(241, 76, 76, 0.12);
+}
+
+.mictest-tok-del {
+  color: var(--text-dim);
+  text-decoration: line-through;
+}
+
+.mictest-tok-ins {
+  color: var(--mictest-warn);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.mictest-rawtranscript {
+  margin: 10px 0 0;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border-radius: 8px;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-dim);
+}

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -52,6 +52,43 @@ export function rmsLevel(timeDomain: Uint8Array): number {
   return Math.min(1, rms * 3.2);
 }
 
+// How long to wait for the microphone to open before giving up on it. getUserMedia is specified to
+// resolve or reject, but in practice it can do NEITHER - a contended or wedged capture device leaves
+// the promise pending forever. Without a backstop the caller sits in its "starting" state with no
+// error and no recording, which reads to the user as a dead button. The dictation dialog has carried
+// its own version of this backstop since issue #817; this is the same guard for the voice checks.
+export const MIC_OPEN_TIMEOUT_MS = 8000;
+
+/**
+ * Open the microphone, but fail LOUDLY if it does not open within the timeout instead of hanging.
+ * The recorder is disposed on timeout so a stream that arrives late cannot leave the microphone live
+ * behind a screen that has already given up on it.
+ */
+export async function startRecorderWithTimeout(recorder: MicRecorder, timeoutMs = MIC_OPEN_TIMEOUT_MS): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `The microphone did not open within ${Math.round(timeoutMs / 1000)} seconds. It may be in use by ` +
+              "another application, or disconnected.",
+          ),
+        ),
+      timeoutMs,
+    );
+  });
+
+  try {
+    await Promise.race([recorder.start(), timeout]);
+  } catch (err) {
+    recorder.dispose();
+    throw err;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export class MicRecorder {
   private stream: MediaStream | null = null;
   private recorder: MediaRecorder | null = null;

--- a/packages/client-core/src/dictation/recorderTimeout.test.ts
+++ b/packages/client-core/src/dictation/recorderTimeout.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { MIC_OPEN_TIMEOUT_MS, startRecorderWithTimeout, type MicRecorder } from "./recorder";
+
+// The backstop for a microphone that never opens.
+//
+// getUserMedia is specified to resolve or reject, and in practice it can do NEITHER: a contended or
+// wedged capture device leaves the promise pending forever. This was not theoretical - it happened
+// while testing the voice checks in a real browser, and the symptom was a Start button that did
+// nothing at all, with no error, for as long as you cared to wait. A check whose failure looks
+// exactly like a dead button is worse than no check.
+
+/** A stand-in recorder whose start() resolves, rejects, or hangs on demand. */
+function fakeRecorder(behaviour: "resolves" | "rejects" | "hangs") {
+  const disposed = { count: 0 };
+  const recorder = {
+    start: () => {
+      if (behaviour === "resolves") return Promise.resolve();
+      if (behaviour === "rejects") return Promise.reject(new Error("Permission denied"));
+      return new Promise<void>(() => {
+        /* never settles - the real wedged-device case */
+      });
+    },
+    dispose: () => {
+      disposed.count++;
+    },
+  } as unknown as MicRecorder;
+  return { recorder, disposed };
+}
+
+describe("startRecorderWithTimeout", () => {
+  it("returns normally when the microphone opens", async () => {
+    const { recorder, disposed } = fakeRecorder("resolves");
+    await expect(startRecorderWithTimeout(recorder, 50)).resolves.toBeUndefined();
+    // A successful open must NOT dispose the recorder - the caller is about to record with it.
+    expect(disposed.count).toBe(0);
+  });
+
+  it("passes a real rejection through unchanged, so the reason still reaches the user", async () => {
+    const { recorder } = fakeRecorder("rejects");
+    await expect(startRecorderWithTimeout(recorder, 50)).rejects.toThrow("Permission denied");
+  });
+
+  it("gives up on a microphone that never opens, instead of hanging forever", async () => {
+    const { recorder } = fakeRecorder("hangs");
+    await expect(startRecorderWithTimeout(recorder, 30)).rejects.toThrow(/did not open within/);
+  });
+
+  it("releases the microphone when it times out, so a late stream cannot leak", async () => {
+    const { recorder, disposed } = fakeRecorder("hangs");
+    await expect(startRecorderWithTimeout(recorder, 30)).rejects.toThrow();
+    expect(disposed.count).toBe(1);
+  });
+
+  it("says how long it waited, in seconds, so the message is actionable", async () => {
+    const { recorder } = fakeRecorder("hangs");
+    await expect(startRecorderWithTimeout(recorder, 2000)).rejects.toThrow(/2 seconds/);
+  });
+
+  it("clears its timer on success, so a resolved open leaves nothing pending", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { recorder } = fakeRecorder("resolves");
+    await startRecorderWithTimeout(recorder, 5000);
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it("defaults to a wait short enough to be noticed but long enough for a slow device", () => {
+    expect(MIC_OPEN_TIMEOUT_MS).toBeGreaterThanOrEqual(3000);
+    expect(MIC_OPEN_TIMEOUT_MS).toBeLessThanOrEqual(15000);
+  });
+});

--- a/packages/client-core/src/dictation/transcriptionAccuracy.test.ts
+++ b/packages/client-core/src/dictation/transcriptionAccuracy.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { alignTokens, judgeAccuracy, scoreTranscription, tokenize } from "./transcriptionAccuracy";
+import { languageByCode, preferredLanguage, TEST_LANGUAGES } from "./languages";
+
+// The transcription check reports a NUMBER to the user and, on a bad score, tells them their setup is
+// at fault. So the number has to be right, and it has to be right in every language we offer - a
+// scorer that silently mis-handles Chinese, or that marks a perfect transcript down for punctuation,
+// would send people chasing microphone problems they do not have.
+
+describe("tokenize", () => {
+  it("folds case and drops punctuation, which are not transcription errors", () => {
+    expect(tokenize("Yesterday, I finished six tasks.", "words")).toEqual([
+      "yesterday",
+      "i",
+      "finished",
+      "six",
+      "tasks",
+    ]);
+  });
+
+  it("drops the punctuation of other writing systems too, not just the Latin comma", () => {
+    // Arabic comma, Devanagari danda, Chinese full stop: one rule has to cover all of them.
+    expect(tokenize("bonjour، le monde", "words")).toEqual(["bonjour", "le", "monde"]);
+    expect(tokenize("नमस्ते दुनिया।", "words")).toEqual(["नमस्ते", "दुनिया"]);
+  });
+
+  it("splits Chinese into characters, because it is not written with spaces between words", () => {
+    // A whitespace split would make this ONE token and score the whole sentence right or wrong.
+    const tokens = tokenize("天气很冷。", "characters");
+    expect(tokens).toEqual(["天", "气", "很", "冷"]);
+  });
+
+  it("ignores spacing differences in a character language", () => {
+    expect(tokenize("天气 很冷", "characters")).toEqual(tokenize("天气很冷", "characters"));
+  });
+
+  it("returns nothing for empty or punctuation-only text", () => {
+    expect(tokenize("", "words")).toEqual([]);
+    expect(tokenize("  ...  ", "words")).toEqual([]);
+  });
+});
+
+describe("alignTokens", () => {
+  it("marks a perfect match as all equal", () => {
+    const diff = alignTokens(["a", "b", "c"], ["a", "b", "c"]);
+    expect(diff.every((d) => d.op === "equal")).toBe(true);
+  });
+
+  it("identifies a substituted word and keeps both sides for display", () => {
+    const diff = alignTokens(["the", "cat", "sat"], ["the", "hat", "sat"]);
+    const sub = diff.find((d) => d.op === "substitute");
+    expect(sub).toEqual({ op: "substitute", expected: "cat", actual: "hat" });
+  });
+
+  it("identifies a dropped word as a deletion", () => {
+    const diff = alignTokens(["the", "cat", "sat"], ["the", "sat"]);
+    expect(diff.find((d) => d.op === "delete")?.expected).toBe("cat");
+  });
+
+  it("identifies an invented word as an insertion", () => {
+    const diff = alignTokens(["the", "sat"], ["the", "cat", "sat"]);
+    expect(diff.find((d) => d.op === "insert")?.actual).toBe("cat");
+  });
+
+  it("handles either side being empty", () => {
+    expect(alignTokens([], ["a", "b"]).every((d) => d.op === "insert")).toBe(true);
+    expect(alignTokens(["a", "b"], []).every((d) => d.op === "delete")).toBe(true);
+    expect(alignTokens([], [])).toEqual([]);
+  });
+
+  it("reads the alignment in order, so the screen can render the passage left to right", () => {
+    const diff = alignTokens(["one", "two", "three"], ["one", "too", "three"]);
+    expect(diff.map((d) => d.expected)).toEqual(["one", "two", "three"]);
+  });
+});
+
+describe("scoreTranscription", () => {
+  it("scores a perfect transcript as 100% however it was punctuated and capitalised", () => {
+    const passage = "Yesterday I finished six small tasks before lunch.";
+    const result = scoreTranscription(passage, "yesterday i finished six small tasks before lunch", "words");
+    expect(result.accuracy).toBe(1);
+    expect(result.errorRate).toBe(0);
+    expect(result.substitutions + result.deletions + result.insertions).toBe(0);
+  });
+
+  it("computes the standard word error rate", () => {
+    // Eight expected words, one misheard: one error in eight.
+    const result = scoreTranscription("one two three four five six seven eight", "one two free four five six seven eight", "words");
+    expect(result.substitutions).toBe(1);
+    expect(result.errorRate).toBeCloseTo(1 / 8);
+    expect(result.accuracy).toBeCloseTo(7 / 8);
+  });
+
+  it("counts dropped words and invented words separately", () => {
+    const dropped = scoreTranscription("one two three four", "one three four", "words");
+    expect(dropped.deletions).toBe(1);
+
+    const invented = scoreTranscription("one two three", "one two extra three", "words");
+    expect(invented.insertions).toBe(1);
+  });
+
+  it("never reports negative accuracy when the transcriber invents more than it heard", () => {
+    const result = scoreTranscription("one two", "completely different words all over the place", "words");
+    expect(result.errorRate).toBeGreaterThan(1);
+    expect(result.accuracy).toBe(0);
+  });
+
+  it("scores an empty transcript as zero rather than throwing", () => {
+    const result = scoreTranscription("one two three", "", "words");
+    expect(result.accuracy).toBe(0);
+    expect(result.deletions).toBe(3);
+  });
+
+  it("scores Chinese by character", () => {
+    const perfect = scoreTranscription("天气很冷", "天气很冷", "characters");
+    expect(perfect.accuracy).toBe(1);
+
+    // One character in four misheard.
+    const oneWrong = scoreTranscription("天气很冷", "天气很热", "characters");
+    expect(oneWrong.accuracy).toBeCloseTo(0.75);
+  });
+});
+
+describe("judgeAccuracy", () => {
+  const score = (expected: string, actual: string) => scoreTranscription(expected, actual, "words");
+
+  it("calls a near-perfect transcript excellent", () => {
+    const verdict = judgeAccuracy(score("one two three four five six seven eight nine ten", "one two three four five six seven eight nine ten"), "English");
+    expect(verdict.rating).toBe("excellent");
+    expect(verdict.headline).toContain("100%");
+  });
+
+  it("calls a mostly-right transcript good and points at the microphone test", () => {
+    // Eight of ten right.
+    const verdict = judgeAccuracy(score("one two three four five six seven eight nine ten", "one two three four five six seven eight wrong words"), "English");
+    expect(verdict.rating).toBe("good");
+    expect(verdict.detail).toContain("microphone");
+  });
+
+  it("calls a poor transcript poor and names the usual cause", () => {
+    const verdict = judgeAccuracy(score("one two three four five six seven eight nine ten", "one two wrong wrong wrong wrong wrong wrong wrong wrong"), "English");
+    expect(verdict.rating).toBe("poor");
+    expect(verdict.detail).toContain("Bluetooth");
+  });
+
+  it("handles a transcript with nothing in common without claiming a percentage is meaningful", () => {
+    const verdict = judgeAccuracy(score("one two three", "completely unrelated text"), "Danish");
+    expect(verdict.rating).toBe("poor");
+    expect(verdict.headline).toContain("None of the passage");
+    expect(verdict.detail).toContain("Danish");
+  });
+
+  it("names the language it is talking about, so a multi-language run is readable", () => {
+    const verdict = judgeAccuracy(score("one two three", "one two three"), "Danish");
+    expect(verdict.detail).toContain("Danish");
+  });
+});
+
+describe("the language pack", () => {
+  it("offers English, the six most-spoken languages, and Danish", () => {
+    expect(TEST_LANGUAGES).toHaveLength(8);
+    const codes = TEST_LANGUAGES.map((l) => l.code);
+    expect(codes).toContain("en");
+    expect(codes).toContain("da");
+    for (const code of ["zh", "hi", "es", "fr", "ar", "pt"]) {
+      expect(codes).toContain(code);
+    }
+  });
+
+  it("gives every language a real passage, a native name and a token mode", () => {
+    for (const lang of TEST_LANGUAGES) {
+      expect(lang.passage.trim().length).toBeGreaterThan(40);
+      expect(lang.nativeName.trim()).not.toBe("");
+      expect(lang.name.trim()).not.toBe("");
+      expect(["words", "characters"]).toContain(lang.tokenMode);
+    }
+  });
+
+  it("uses character scoring for Chinese and word scoring for the rest", () => {
+    expect(languageByCode("zh").tokenMode).toBe("characters");
+    expect(languageByCode("da").tokenMode).toBe("words");
+    expect(languageByCode("en").tokenMode).toBe("words");
+  });
+
+  it("marks Arabic right to left so its passage is laid out correctly", () => {
+    expect(languageByCode("ar").rightToLeft).toBe(true);
+    expect(languageByCode("en").rightToLeft).toBeUndefined();
+  });
+
+  it("gives every passage enough tokens for a stable score", () => {
+    // A passage too short makes one misheard word swing the percentage wildly.
+    for (const lang of TEST_LANGUAGES) {
+      expect(tokenize(lang.passage, lang.tokenMode).length).toBeGreaterThanOrEqual(25);
+    }
+  });
+
+  it("scores each language's own passage as perfect against itself", () => {
+    // Guards the tokenizer against a script it mishandles: if a language's punctuation or spacing
+    // defeated the tokenizer, a perfect transcript would not score 100% and every user of that
+    // language would be told their setup is broken.
+    for (const lang of TEST_LANGUAGES) {
+      const result = scoreTranscription(lang.passage, lang.passage, lang.tokenMode);
+      expect(`${lang.code}:${result.accuracy}`).toBe(`${lang.code}:1`);
+    }
+  });
+
+  it("falls back to English for an unknown code instead of returning nothing", () => {
+    expect(languageByCode("xx").code).toBe("en");
+  });
+
+  it("matches a browser language on its primary subtag, so regional variants still match", () => {
+    expect(preferredLanguage(["pt-BR"]).code).toBe("pt");
+    expect(preferredLanguage(["fr-CH", "en"]).code).toBe("fr");
+    expect(preferredLanguage(["da-DK"]).code).toBe("da");
+    expect(preferredLanguage(["nl-NL"]).code).toBe("en");
+    expect(preferredLanguage([]).code).toBe("en");
+  });
+});

--- a/packages/client-core/src/dictation/transcriptionAccuracy.ts
+++ b/packages/client-core/src/dictation/transcriptionAccuracy.ts
@@ -1,0 +1,223 @@
+// Scoring for the "Test transcription" check: how much of a KNOWN passage the transcriber actually
+// got right.
+//
+// The microphone check (micQuality.ts) measures the audio going in. This measures the text coming
+// out, against a passage we chose, so the answer is a number rather than an impression. That matters
+// for the same reason as the microphone check: "dictation is rubbish" is not actionable, but "we got
+// 82% of the words, and here are the ones we missed" is.
+//
+// The measure is the standard one for speech recognition - word error rate, computed by aligning the
+// transcript against the expected text and counting substitutions, deletions and insertions. It is
+// reported as accuracy (1 - error rate) because that is the direction people read, and the alignment
+// is kept so the screen can SHOW which words were missed rather than only scoring them.
+//
+// NOTE ON NON-ASCII TEXT: this file and languages.ts necessarily carry non-ASCII characters, because
+// the passages are in Chinese, Hindi, Arabic, Danish and so on. That is the feature. Every console
+// line, identifier and comment stays ASCII.
+
+/** How a language's text is split for comparison. */
+export type TokenMode =
+  /** Words separated by whitespace - every language written with spaces. */
+  | "words"
+  /** Individual characters - Chinese and Japanese do not put spaces between words, so a
+   *  whitespace split would score a whole sentence as one enormous token. */
+  | "characters";
+
+/** One aligned step between the expected passage and what came back. */
+export interface DiffStep {
+  op: "equal" | "substitute" | "delete" | "insert";
+  /** The expected token. Empty for an insertion (the transcriber invented a word). */
+  expected: string;
+  /** The transcribed token. Empty for a deletion (the transcriber dropped a word). */
+  actual: string;
+}
+
+export interface AccuracyResult {
+  /** 0..1, the share of the passage transcribed correctly. */
+  accuracy: number;
+  /** 0..1, the standard word error rate. Can exceed 1 when the transcriber invents more than it hears. */
+  errorRate: number;
+  correct: number;
+  substitutions: number;
+  deletions: number;
+  insertions: number;
+  /** Tokens in the expected passage. */
+  expectedCount: number;
+  /** The full alignment, for rendering the passage with its mistakes marked. */
+  diff: DiffStep[];
+}
+
+export type AccuracyRating = "excellent" | "good" | "poor";
+
+export interface AccuracyVerdict {
+  rating: AccuracyRating;
+  headline: string;
+  /** Plain-English reading of the number, including what to try next. */
+  detail: string;
+  result: AccuracyResult;
+}
+
+/**
+ * Reduce text to comparable tokens: case-folded, stripped of punctuation and of the marks that only
+ * exist in writing. Without this a transcriber would be marked wrong for writing "Yesterday," with a
+ * comma, or for capitalising a sentence - neither of which is a transcription error.
+ */
+export function tokenize(text: string, mode: TokenMode): string[] {
+  const cleaned = text
+    .toLowerCase()
+    // Unicode punctuation and symbols, which covers the Latin comma, the Arabic comma, the Devanagari
+    // danda and the Chinese full stop in one rule rather than a list that would always be incomplete.
+    .replace(/[\p{P}\p{S}]/gu, " ")
+    .trim();
+
+  if (mode === "characters") {
+    // Drop whitespace entirely: whether a transcriber puts spaces between Chinese words is a
+    // formatting choice, not a transcription error.
+    return Array.from(cleaned.replace(/\s+/gu, ""));
+  }
+  if (cleaned === "") return [];
+  return cleaned.split(/\s+/u);
+}
+
+/**
+ * Align two token sequences with Levenshtein and return the edit path. Standard dynamic programming:
+ * the table holds the cost of turning the first i expected tokens into the first j actual ones, and
+ * the backtrace turns that into the list of operations the screen renders.
+ */
+export function alignTokens(expected: string[], actual: string[]): DiffStep[] {
+  const n = expected.length;
+  const m = actual.length;
+
+  // cost[i][j] = edits needed to turn expected[0..i) into actual[0..j).
+  const cost: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = 0; i <= n; i++) cost[i][0] = i;
+  for (let j = 0; j <= m; j++) cost[0][j] = j;
+
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const same = expected[i - 1] === actual[j - 1];
+      cost[i][j] = Math.min(
+        cost[i - 1][j - 1] + (same ? 0 : 1), // match or substitute
+        cost[i - 1][j] + 1, // delete (the transcriber missed this word)
+        cost[i][j - 1] + 1, // insert (the transcriber added a word)
+      );
+    }
+  }
+
+  const steps: DiffStep[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0) {
+      const same = expected[i - 1] === actual[j - 1];
+      if (cost[i][j] === cost[i - 1][j - 1] + (same ? 0 : 1)) {
+        steps.push({
+          op: same ? "equal" : "substitute",
+          expected: expected[i - 1],
+          actual: actual[j - 1],
+        });
+        i--;
+        j--;
+        continue;
+      }
+    }
+    if (i > 0 && cost[i][j] === cost[i - 1][j] + 1) {
+      steps.push({ op: "delete", expected: expected[i - 1], actual: "" });
+      i--;
+      continue;
+    }
+    steps.push({ op: "insert", expected: "", actual: actual[j - 1] });
+    j--;
+  }
+
+  steps.reverse();
+  return steps;
+}
+
+/** Score a transcript against the passage the user was asked to read. */
+export function scoreTranscription(expectedText: string, actualText: string, mode: TokenMode): AccuracyResult {
+  const expected = tokenize(expectedText, mode);
+  const actual = tokenize(actualText, mode);
+  const diff = alignTokens(expected, actual);
+
+  let correct = 0;
+  let substitutions = 0;
+  let deletions = 0;
+  let insertions = 0;
+  for (const step of diff) {
+    if (step.op === "equal") correct++;
+    else if (step.op === "substitute") substitutions++;
+    else if (step.op === "delete") deletions++;
+    else insertions++;
+  }
+
+  const expectedCount = expected.length;
+  // The standard definition divides every error by the length of the REFERENCE, so inventing words is
+  // penalised as heavily as dropping them.
+  const errorRate = expectedCount === 0 ? 0 : (substitutions + deletions + insertions) / expectedCount;
+  const accuracy = expectedCount === 0 ? 0 : Math.max(0, 1 - errorRate);
+
+  return { accuracy, errorRate, correct, substitutions, deletions, insertions, expectedCount, diff };
+}
+
+// Where the reading changes meaning. Speech recognition research treats a word error rate under about
+// 10% as a transcript you can use as-is, and above about 25% as one you spend longer fixing than you
+// would have spent typing.
+const EXCELLENT_ACCURACY = 0.9;
+const GOOD_ACCURACY = 0.75;
+
+/** Fold the score into the verdict both clients render, worded for someone who is not an engineer. */
+export function judgeAccuracy(result: AccuracyResult, languageName: string): AccuracyVerdict {
+  const percent = Math.round(result.accuracy * 100);
+
+  if (result.expectedCount === 0) {
+    return {
+      rating: "poor",
+      headline: "There was nothing to compare against.",
+      detail: "The passage was empty, so no score could be worked out.",
+      result,
+    };
+  }
+
+  if (result.correct === 0) {
+    return {
+      rating: "poor",
+      headline: "None of the passage came back correctly.",
+      detail:
+        `Nothing matched the ${languageName} passage. Check that the transcription language matches ` +
+        "what you actually spoke, and run the microphone test - this is what a badly band-limited " +
+        "headset looks like from the text side.",
+      result,
+    };
+  }
+
+  if (result.accuracy >= EXCELLENT_ACCURACY) {
+    return {
+      rating: "excellent",
+      headline: `${percent}% of the passage came back correctly.`,
+      detail: `Transcription is working well in ${languageName}. You can dictate and trust what you get.`,
+      result,
+    };
+  }
+
+  if (result.accuracy >= GOOD_ACCURACY) {
+    return {
+      rating: "good",
+      headline: `${percent}% of the passage came back correctly.`,
+      detail:
+        `Transcription mostly works in ${languageName}, but you will be correcting the odd word. If ` +
+        "the microphone test also flagged a problem, fix that first - it is the usual cause.",
+      result,
+    };
+  }
+
+  return {
+    rating: "poor",
+    headline: `Only ${percent}% of the passage came back correctly.`,
+    detail:
+      `Transcription is struggling with ${languageName}. Run the microphone test first: a Bluetooth ` +
+      "hands-free headset or a noisy room will produce exactly this. If the microphone is good, the " +
+      "words below show what is being misheard, and those are worth adding to your dictionary.",
+    result,
+  };
+}

--- a/packages/client-core/src/dictation/voiceTestClient.ts
+++ b/packages/client-core/src/dictation/voiceTestClient.ts
@@ -1,0 +1,63 @@
+import { authHeaders, creditsErrorFrom, gatewayFetch, GatewayError } from "../api/client";
+import type { MicQualityReport } from "./micQuality";
+
+// Gateway calls for the Test microphone and Test transcription checks (POST /voice-test/clip).
+//
+// Both checks send their clip here. The microphone check sends the audio and its measurements and asks
+// for nothing back; the transcription check additionally sends the passage the user was reading and
+// gets the transcript. One endpoint for both, because the point of storing them is to compare them,
+// and two endpoints would be two schemas to reconcile at analysis time.
+//
+// Routed through gatewayFetch (never a raw fetch) so these calls feed the app-wide connection-health
+// signal like every other Gateway contact.
+
+export type VoiceTestKind = "microphone" | "transcription";
+
+export interface VoiceTestUpload {
+  kind: VoiceTestKind;
+  /** The clip. The WAV the transcriber would receive, so what is stored is what was heard. */
+  audio: Blob;
+  /** BCP 47 primary subtag. Sent to the transcriber as a language hint and stored with the clip. */
+  language?: string;
+  /** The passage the user was asked to read. Transcription check only. */
+  expected?: string;
+  /** The microphone measurements, stored verbatim for later analysis. */
+  quality?: MicQualityReport;
+}
+
+export interface VoiceTestResult {
+  /** Identifier of the stored clip, or null when the Gateway could not store it. */
+  clipId: string | null;
+  /** What the transcriber returned. Empty for a microphone check. */
+  transcript: string;
+}
+
+/**
+ * Send a test clip to the Gateway. For a transcription check the response carries the transcript.
+ *
+ * A 402 becomes the shared credits error so the caller shows the standard add-credits message; any
+ * other non-2xx throws a specific GatewayError. Nothing here fails silently: a check that cannot
+ * reach the Gateway must say so, because a blank result would read as "your microphone is broken".
+ */
+export async function uploadVoiceTestClip(upload: VoiceTestUpload, signal?: AbortSignal): Promise<VoiceTestResult> {
+  const form = new FormData();
+  form.append("audio", upload.audio, `voice-test-${upload.kind}.wav`);
+  form.append("kind", upload.kind);
+  if (upload.language) form.append("language", upload.language);
+  if (upload.expected) form.append("expected", upload.expected);
+  if (upload.quality) form.append("quality", JSON.stringify(upload.quality));
+
+  const res = await gatewayFetch("/voice-test/clip", {
+    method: "POST",
+    headers: { ...authHeaders() },
+    body: form,
+    signal,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 402) throw creditsErrorFrom(body);
+    throw new GatewayError(res.status, body.error ?? `The voice test failed: ${res.status}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as { clipId?: string; transcript?: string };
+  return { clipId: body.clipId ?? null, transcript: (body.transcript ?? "").trim() };
+}

--- a/packages/client-core/src/dictation/wav.ts
+++ b/packages/client-core/src/dictation/wav.ts
@@ -74,6 +74,49 @@ export async function blobToWav16kMono(blob: Blob): Promise<TranscodeResult> {
   };
 }
 
+/** A captured clip decoded at the rate the MICROPHONE actually delivered, downmixed to mono. */
+export interface DecodedClip {
+  samples: Float32Array;
+  sampleRate: number;
+}
+
+/**
+ * Decode a captured blob to mono at its NATIVE sample rate, for the microphone check (micQuality.ts).
+ *
+ * Deliberately separate from blobToWav16kMono: that function resamples to 16 kHz for transcription,
+ * which throws away everything above 8 kHz - and the presence or absence of energy up there is
+ * exactly the evidence that distinguishes a wideband microphone from a Bluetooth hands-free link.
+ * Measuring the resampled clip would make every microphone look identical. This decodes once at the
+ * native rate and changes nothing on the live dictation path.
+ */
+export async function decodeToMono(blob: Blob): Promise<DecodedClip> {
+  const arrayBuffer = await blob.arrayBuffer();
+  if (arrayBuffer.byteLength === 0) throw new Error("No audio was captured.");
+
+  const AudioCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+  const decodeCtx = new AudioCtor();
+  let decoded: AudioBuffer;
+  try {
+    decoded = await decodeCtx.decodeAudioData(arrayBuffer.slice(0));
+  } finally {
+    void decodeCtx.close();
+  }
+
+  if (decoded.numberOfChannels === 1) {
+    return { samples: decoded.getChannelData(0), sampleRate: decoded.sampleRate };
+  }
+  // Average the channels rather than taking the first: a headset that feeds only one side would
+  // otherwise measure as silence on the channel we happened to pick.
+  const frames = decoded.length;
+  const mixed = new Float32Array(frames);
+  for (let ch = 0; ch < decoded.numberOfChannels; ch++) {
+    const data = decoded.getChannelData(ch);
+    for (let i = 0; i < frames; i++) mixed[i] += data[i];
+  }
+  for (let i = 0; i < frames; i++) mixed[i] /= decoded.numberOfChannels;
+  return { samples: mixed, sampleRate: decoded.sampleRate };
+}
+
 // Build a canonical 16-bit PCM WAV (RIFF) blob from mono float samples in -1..1.
 function encodeWav(samples: Float32Array, sampleRate: number): Blob {
   const bytesPerSample = 2;

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -258,6 +258,13 @@ public static class CcStorage
     /// so a suspicious transcript line leads straight to the clip that produced it.</summary>
     public static string TranscriptionAudio() => Path.Combine(Base(), "transcription-audio");
 
+    /// <summary>Clips from the Test microphone / Test transcription checks, kept per tenant for later
+    /// analysis: base/voice-test-clips/. Deliberately NOT the same directory as TranscriptionAudio():
+    /// that one is a 24-hour troubleshooting buffer for ordinary dictation, whereas these are
+    /// deliberate, user-initiated recordings of a passage WE supplied, kept longer on purpose so
+    /// transcription quality can be compared across languages, headsets and releases.</summary>
+    public static string VoiceTestClips() => Path.Combine(Base(), "voice-test-clips");
+
     /// <summary>Terminal screen captures: base/terminal-captures/.</summary>
     public static string TerminalCaptures() => Path.Combine(Base(), "terminal-captures");
 

--- a/src/CcDirector.Gateway.Tests/TranscriptionLanguageHintTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionLanguageHintTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the spoken-language hint actually reaches the provider.
+///
+/// This is the property the whole multi-language transcription check rests on, and it is exactly the
+/// kind that is easy to plumb and never verify: the field can be added to a record, threaded through
+/// five methods, and silently dropped at the wire, and every screen above would still look right while
+/// every non-English result quietly came back worse. So the assertion is made where it matters - on
+/// the outgoing HTTP request - not on the intermediate types.
+///
+/// Auto-detection is the default and must stay the default: every ordinary dictation path passes no
+/// language, and sending an empty or guessed one would be worse than sending none.
+/// </summary>
+public sealed class TranscriptionLanguageHintTests
+{
+    /// <summary>Captures the outgoing request body so the multipart parts can be inspected.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string LastBody { get; private set; } = "";
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastBody = request.Content is null ? "" : await request.Content.ReadAsStringAsync(ct);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"text":"hello"}"""),
+            };
+        }
+    }
+
+    private static ResolvedTranscription Routing(string? language) => new()
+    {
+        BaseUrl = "https://example.invalid/api/v1",
+        ApiKey = "dt_test",
+        Transport = TranscriptionTransport.Batch,
+        Model = "gpt-4o-transcribe",
+        Mode = TranscriptionMode.DevThrottle,
+        Language = language,
+    };
+
+    private static async Task<string> PostAndCaptureAsync(string? language)
+    {
+        var handler = new CapturingHandler();
+        using var http = new HttpClient(handler);
+        using var pipeline = new BatchTranscriptionPipeline(httpClient: http);
+
+        await pipeline.TranscribeRawAsync(new byte[] { 1, 2, 3, 4 }, "voice-test.wav", Routing(language), CancellationToken.None);
+        return handler.LastBody;
+    }
+
+    [Fact]
+    public async Task TheLanguageHintIsSentToTheProvider()
+    {
+        var body = await PostAndCaptureAsync("da");
+
+        Assert.Contains("name=language", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("da", body, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("zh")]
+    [InlineData("hi")]
+    [InlineData("es")]
+    [InlineData("fr")]
+    [InlineData("ar")]
+    [InlineData("pt")]
+    [InlineData("da")]
+    public async Task EveryLanguageTheCheckOffersIsCarriedThrough(string code)
+    {
+        // One per offered language, so adding a language to the picker without plumbing it is caught
+        // here rather than by a user in that language wondering why their results are poor.
+        var body = await PostAndCaptureAsync(code);
+
+        Assert.Contains("name=language", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"\r\n\r\n{code}\r\n", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithNoHint_NoLanguageFieldIsSent_SoTheProviderStillDetects()
+    {
+        // The behaviour every existing dictation caller depends on. A "language" part carrying an
+        // empty value would tell the provider to detect nothing rather than to detect for itself.
+        var body = await PostAndCaptureAsync(null);
+
+        Assert.DoesNotContain("name=language", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AWhitespaceHintIsTreatedAsNoHint()
+    {
+        var body = await PostAndCaptureAsync("   ");
+
+        Assert.DoesNotContain("name=language", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TheModelAndResponseFormatAreStillSent()
+    {
+        // Guards against a change to the form construction that adds the hint and drops something the
+        // provider requires - the test would otherwise pass on a request that no longer works at all.
+        var body = await PostAndCaptureAsync("da");
+
+        Assert.Contains("name=model", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("name=response_format", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("name=file", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToResolved_NormalizesTheHint_SoBlankNeverReachesTheWire()
+    {
+        var endpoint = TranscriptionEndpointResolver.Resolve(TranscriptionMode.DevThrottle);
+        var routing = new GatewayTranscriptionRouting { Endpoint = endpoint, Key = "dt_test" };
+
+        Assert.Equal("da", routing.ToResolved("  da  ").Language);
+        Assert.Null(routing.ToResolved("   ").Language);
+        Assert.Null(routing.ToResolved(null).Language);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceTestClipStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTestClipStoreTests.cs
@@ -1,0 +1,233 @@
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the voice-test clip store keeps recorded speech inside the tenant that produced it, and
+/// keeps it BOUNDED.
+///
+/// These are the two properties that decide whether this store may run on a hosted Gateway at all. The
+/// older <see cref="TranscriptionAudioArchive"/> is switched off on hosted precisely because it has one
+/// process-wide directory and a global prune, which would mix accounts' speech at rest and let a busy
+/// tenant evict a quiet one's clips. This store exists to close that gap, so the gap is what these
+/// tests aim at: a partition that is real, and a prune that cannot reach across it.
+/// </summary>
+public sealed class VoiceTestClipStoreTests : IDisposable
+{
+    private readonly string _root;
+
+    public VoiceTestClipStoreTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cc-voice-test-clips-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private VoiceTestClipStore StoreIn(string name) => new(Path.Combine(_root, name));
+
+    private static VoiceTestClip Clip(string kind = VoiceTestKind.Transcription, string? language = "en",
+        string? expected = "the passage", string? transcript = "the passage")
+        => new()
+        {
+            ClipId = Guid.NewGuid().ToString("N"),
+            Kind = kind,
+            RecordedAtUtc = DateTime.UtcNow,
+            Language = language,
+            ExpectedText = expected,
+            Transcript = transcript,
+        };
+
+    private static byte[] Audio(int bytes = 64) => Enumerable.Range(0, bytes).Select(i => (byte)i).ToArray();
+
+    [Fact]
+    public void TrySave_StoresTheAudioAndASidecarBesideIt()
+    {
+        var store = StoreIn("a");
+        var clip = Clip();
+
+        var id = store.TrySave(clip, Audio(), "audio/wav");
+
+        Assert.Equal(clip.ClipId, id);
+        Assert.True(File.Exists(Path.Combine(store.Directory, $"clip-{clip.ClipId}.wav")));
+        Assert.True(File.Exists(Path.Combine(store.Directory, $"clip-{clip.ClipId}.json")));
+    }
+
+    [Fact]
+    public void TrySave_KeepsThePassageAndTheTranscript_SoAScoreCanBeRecomputedLater()
+    {
+        // The sidecar deliberately holds the EVIDENCE, not a score. A future question - a different
+        // scoring rule, a per-word breakdown - must still be answerable from what was stored.
+        var store = StoreIn("a");
+        var clip = Clip(language: "da", expected: "I gaar afsluttede jeg seks", transcript: "i gaar afsluttede jeg six");
+        store.TrySave(clip, Audio(), "audio/wav");
+
+        var stored = Assert.Single(store.List());
+        Assert.Equal("da", stored.Language);
+        Assert.Equal("I gaar afsluttede jeg seks", stored.ExpectedText);
+        Assert.Equal("i gaar afsluttede jeg six", stored.Transcript);
+    }
+
+    [Fact]
+    public void TrySave_RecordsTheMeasurementsVerbatim()
+    {
+        var store = StoreIn("a");
+        var quality = JsonDocument.Parse("""{"narrowband":true,"signalToNoiseDb":41.5}""").RootElement.Clone();
+        var clip = Clip(kind: VoiceTestKind.Microphone, expected: null, transcript: null) with { Quality = quality };
+
+        store.TrySave(clip, Audio(), "audio/wav");
+
+        var stored = Assert.Single(store.List());
+        Assert.NotNull(stored.Quality);
+        Assert.True(stored.Quality!.Value.GetProperty("narrowband").GetBoolean());
+    }
+
+    [Fact]
+    public void OneTenantsClipsAreInvisibleToAnother()
+    {
+        // The property the hosted deployment turns on. Two stores, two partitions, no leakage.
+        var alice = VoiceTestClipStore.ForTenant(new TenantId("alice"));
+        var bob = VoiceTestClipStore.ForTenant(new TenantId("bob"));
+        Assert.NotEqual(alice.Directory, bob.Directory);
+    }
+
+    [Fact]
+    public void ATenantIdCannotEscapeItsOwnDirectory()
+    {
+        // A tenant id is attacker-influenced in principle, so path separators and traversal segments
+        // must not survive into the path. Without this a tenant called "../other" would write into a
+        // sibling's partition.
+        var nasty = VoiceTestClipStore.ForTenant(new TenantId("../../etc/passwd"));
+        var root = VoiceTestClipStore.DefaultDirectory();
+
+        Assert.StartsWith(root, nasty.Directory, StringComparison.Ordinal);
+        Assert.DoesNotContain("..", Path.GetFileName(nasty.Directory));
+    }
+
+    [Fact]
+    public void PruneKeepsOnlyTheNewestClipsWithinOneTenant()
+    {
+        var store = StoreIn("a");
+        for (var i = 0; i < VoiceTestClipStore.MaxClipsPerTenant + 12; i++)
+            store.TrySave(Clip(), Audio(), "audio/wav");
+
+        Assert.Equal(VoiceTestClipStore.MaxClipsPerTenant, store.List().Count);
+    }
+
+    [Fact]
+    public void PruneDeletesTheAudioWithItsSidecar_SoAListingNeverPointsAtAMissingClip()
+    {
+        var store = StoreIn("a");
+        for (var i = 0; i < VoiceTestClipStore.MaxClipsPerTenant + 5; i++)
+            store.TrySave(Clip(), Audio(), "audio/wav");
+
+        var sidecars = Directory.GetFiles(store.Directory, "clip-*.json").Length;
+        var audio = Directory.GetFiles(store.Directory, "clip-*.wav").Length;
+        Assert.Equal(sidecars, audio);
+    }
+
+    [Fact]
+    public void PruneNeverReachesIntoAnotherTenantsPartition()
+    {
+        // The exact failure that disabled the older archive on hosted: one tenant's traffic evicting
+        // another's clips. Fill one partition past its cap and prove the neighbour is untouched.
+        var busy = StoreIn("busy");
+        var quiet = StoreIn("quiet");
+        quiet.TrySave(Clip(), Audio(), "audio/wav");
+
+        for (var i = 0; i < VoiceTestClipStore.MaxClipsPerTenant + 20; i++)
+            busy.TrySave(Clip(), Audio(), "audio/wav");
+
+        Assert.Single(quiet.List());
+        Assert.Equal(VoiceTestClipStore.MaxClipsPerTenant, busy.List().Count);
+    }
+
+    [Fact]
+    public void PruneRemovesClipsOlderThanTheRetentionWindow()
+    {
+        var store = StoreIn("a");
+        var old = Clip();
+        store.TrySave(old, Audio(), "audio/wav");
+
+        // Age the stored pair past the window; the prune keys on the file timestamp.
+        var stale = DateTime.UtcNow - VoiceTestClipStore.MaxAge - TimeSpan.FromDays(1);
+        foreach (var f in Directory.GetFiles(store.Directory, $"clip-{old.ClipId}.*"))
+            File.SetLastWriteTimeUtc(f, stale);
+
+        // Any save runs the prune.
+        store.TrySave(Clip(), Audio(), "audio/wav");
+
+        Assert.DoesNotContain(store.List(), c => c.ClipId == old.ClipId);
+        Assert.False(File.Exists(Path.Combine(store.Directory, $"clip-{old.ClipId}.wav")));
+    }
+
+    [Fact]
+    public void ListIsNewestFirst()
+    {
+        var store = StoreIn("a");
+        var older = Clip() with { RecordedAtUtc = DateTime.UtcNow.AddMinutes(-10) };
+        var newer = Clip() with { RecordedAtUtc = DateTime.UtcNow };
+        store.TrySave(older, Audio(), "audio/wav");
+        store.TrySave(newer, Audio(), "audio/wav");
+
+        Assert.Equal(newer.ClipId, store.List()[0].ClipId);
+    }
+
+    [Fact]
+    public void ListSurvivesAnUnreadableSidecar()
+    {
+        // One corrupt file must not hide every other clip from an analysis run.
+        var store = StoreIn("a");
+        store.TrySave(Clip(), Audio(), "audio/wav");
+        File.WriteAllText(Path.Combine(store.Directory, "clip-corrupt.json"), "{ not json", Encoding.UTF8);
+
+        Assert.Single(store.List());
+    }
+
+    [Fact]
+    public void ListIsEmptyBeforeAnythingIsStored()
+    {
+        Assert.Empty(StoreIn("never-used").List());
+    }
+
+    [Fact]
+    public void ClearRemovesEveryClipForThisTenantOnly()
+    {
+        var mine = StoreIn("mine");
+        var theirs = StoreIn("theirs");
+        mine.TrySave(Clip(), Audio(), "audio/wav");
+        mine.TrySave(Clip(), Audio(), "audio/wav");
+        theirs.TrySave(Clip(), Audio(), "audio/wav");
+
+        var removed = mine.Clear();
+
+        Assert.Equal(2, removed);
+        Assert.Empty(mine.List());
+        Assert.Single(theirs.List());
+    }
+
+    [Fact]
+    public void TrySave_ReportsRatherThanThrows_WhenThereIsNoAudio()
+    {
+        // Storing a diagnostic must never fail the check the user is running.
+        Assert.Null(StoreIn("a").TrySave(Clip(), Array.Empty<byte>(), "audio/wav"));
+    }
+
+    [Fact]
+    public void TrySave_DerivesTheAudioExtensionFromTheContentType()
+    {
+        var store = StoreIn("a");
+        var clip = Clip();
+        store.TrySave(clip, Audio(), "audio/webm;codecs=opus");
+
+        // The MIME parameter must not leak into the filename, or the clip will not open in a player.
+        Assert.True(File.Exists(Path.Combine(store.Directory, $"clip-{clip.ClipId}.webm")));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceTestEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTestEndpointTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Core;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Transcription;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Drives the REAL /voice-test endpoint over real HTTP.
+///
+/// The behaviour worth pinning is not the happy path - it is what happens when transcription is not
+/// available. The clip must still be stored, because a clip that could not be transcribed is the most
+/// interesting one there is, and the caller must still be told plainly rather than shown an empty
+/// result that reads as "your microphone is broken".
+///
+/// Storage is redirected to a temp root through CC_DIRECTOR_ROOT so the suite never writes into the
+/// developer's own clip store.
+/// </summary>
+[Collection("VoiceTestEndpoint")] // serial: mutates the CC_DIRECTOR_ROOT process env var
+public sealed class VoiceTestEndpointTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+
+    public VoiceTestEndpointTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-voice-test-ep-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Boot the real endpoint against a real clip store in a temp directory. The transcription service
+    /// is real but has no key, which is exactly the state a self-host install starts in.
+    /// </summary>
+    private async Task<(WebApplication App, HttpClient Http, VoiceTestClipStore Store)> StartAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var vault = new KeyVault(Path.Combine(_root, "test.vault"));
+        var store = new VoiceTestClipStore(Path.Combine(_root, "clips"));
+        VoiceTestEndpoint.Map(app, new GatewayTranscriptionService(vault), tenantBoundary: null, storeOverride: store);
+
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, store);
+    }
+
+    private static MultipartFormDataContent Clip(
+        string kind, byte[]? audio = null, string? language = null, string? expected = null, string? quality = null)
+    {
+        var form = new MultipartFormDataContent();
+        if (audio is not null)
+        {
+            var file = new ByteArrayContent(audio);
+            file.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
+            form.Add(file, "audio", "voice-test.wav");
+        }
+        form.Add(new StringContent(kind), "kind");
+        if (language is not null) form.Add(new StringContent(language), "language");
+        if (expected is not null) form.Add(new StringContent(expected), "expected");
+        if (quality is not null) form.Add(new StringContent(quality), "quality");
+        return form;
+    }
+
+    private static byte[] Audio(int bytes = 2048) => Enumerable.Range(0, bytes).Select(i => (byte)i).ToArray();
+
+    [Fact]
+    public async Task MicrophoneClip_IsStoredWithItsMeasurements_AndNeedsNoTranscription()
+    {
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        var res = await http.PostAsync("/voice-test/clip",
+            Clip(VoiceTestKind.Microphone, Audio(), quality: """{"narrowband":true}"""));
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        var stored = Assert.Single(store.List());
+        Assert.Equal(VoiceTestKind.Microphone, stored.Kind);
+        Assert.NotNull(stored.Quality);
+        Assert.True(stored.Quality!.Value.GetProperty("narrowband").GetBoolean());
+        // A microphone check asks nothing of the transcriber, so it must not be blocked by a missing key.
+        Assert.Null(stored.Transcript);
+    }
+
+    [Fact]
+    public async Task TranscriptionClip_WithNoKey_SaysSoPlainly_AndSTILLStoresTheClip()
+    {
+        // The case that matters: the check cannot run, but the evidence must not be thrown away, and
+        // the user must be told why rather than shown a blank score.
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        var res = await http.PostAsync("/voice-test/clip",
+            Clip(VoiceTestKind.Transcription, Audio(), language: "da", expected: "I gaar afsluttede jeg seks"));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, res.StatusCode);
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.Contains("no key configured", body, StringComparison.OrdinalIgnoreCase);
+
+        var stored = Assert.Single(store.List());
+        Assert.Equal("da", stored.Language);
+        Assert.Equal("I gaar afsluttede jeg seks", stored.ExpectedText);
+        Assert.Equal("no_key", stored.Outcome);
+    }
+
+    [Fact]
+    public async Task TheStoredClipKeepsTheAudioOnDisk_NotJustTheMetadata()
+    {
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        await http.PostAsync("/voice-test/clip", Clip(VoiceTestKind.Microphone, Audio(1234)));
+
+        var stored = Assert.Single(store.List());
+        var audioPath = Path.Combine(store.Directory, $"clip-{stored.ClipId}.wav");
+        Assert.True(File.Exists(audioPath));
+        Assert.Equal(1234, new FileInfo(audioPath).Length);
+        Assert.Equal(1234, stored.AudioBytes);
+    }
+
+    [Fact]
+    public async Task NoAudio_Is400()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var __ = app;
+
+        var res = await http.PostAsync("/voice-test/clip", Clip(VoiceTestKind.Microphone, audio: null));
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnUnknownKind_Is400_RatherThanBeingStoredAsSomethingUnreadable()
+    {
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        var res = await http.PostAsync("/voice-test/clip", Clip("something-else", Audio()));
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+        Assert.Empty(store.List());
+    }
+
+    [Fact]
+    public async Task AClipOverTheLimit_IsRefused()
+    {
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        var tooBig = new byte[CcDirector.Gateway.Voice.VoiceUploadLimits.MaxOneShotFileBytes + 1024];
+        var res = await http.PostAsync("/voice-test/clip", Clip(VoiceTestKind.Microphone, tooBig));
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+        Assert.Empty(store.List());
+    }
+
+    [Fact]
+    public async Task UnparseableMeasurements_AreDropped_NotFatal()
+    {
+        // The measurements are a bonus for later analysis. Losing them must never cost the user the
+        // clip they were actually asking about.
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        var res = await http.PostAsync("/voice-test/clip",
+            Clip(VoiceTestKind.Microphone, Audio(), quality: "{ not json"));
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        var stored = Assert.Single(store.List());
+        Assert.Null(stored.Quality);
+    }
+
+    [Fact]
+    public async Task AnOverlongPassage_IsTrimmedRatherThanStoredWhole()
+    {
+        var (app, http, store) = await StartAsync();
+        await using var _ = app;
+
+        await http.PostAsync("/voice-test/clip",
+            Clip(VoiceTestKind.Microphone, Audio(), expected: new string('x', 20_000)));
+
+        var stored = Assert.Single(store.List());
+        Assert.NotNull(stored.ExpectedText);
+        Assert.True(stored.ExpectedText!.Length <= 4000);
+    }
+
+    [Fact]
+    public async Task ListReturnsWhatWasStored_AndDeleteRemovesIt()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var __ = app;
+
+        await http.PostAsync("/voice-test/clip", Clip(VoiceTestKind.Microphone, Audio()));
+        await http.PostAsync("/voice-test/clip", Clip(VoiceTestKind.Microphone, Audio()));
+
+        var listed = await http.GetStringAsync("/voice-test/clips");
+        using (var doc = JsonDocument.Parse(listed))
+        {
+            Assert.Equal(2, doc.RootElement.GetProperty("clips").GetArrayLength());
+        }
+
+        var deleted = await http.DeleteAsync("/voice-test/clips");
+        Assert.Equal(HttpStatusCode.OK, deleted.StatusCode);
+
+        var afterwards = await http.GetStringAsync("/voice-test/clips");
+        using (var doc = JsonDocument.Parse(afterwards))
+        {
+            Assert.Equal(0, doc.RootElement.GetProperty("clips").GetArrayLength());
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/VoiceTestEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/VoiceTestEndpoint.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The Test microphone / Test transcription checks.
+///
+///   POST   /voice-test/clip     multipart: audio, kind, language?, expected?, quality?
+///          -&gt; 200 { clipId, transcript? }   stored; transcript present for a transcription check
+///          -&gt; 400 { error }                 no audio, unknown kind, or clip too large
+///          -&gt; 403 { error }                 no tenant is bound to this request
+///          -&gt; 402 { error, code }           the account is out of credits
+///          -&gt; 502 { error }                 the provider rejected the request
+///   GET    /voice-test/clips    -&gt; { clips: [...] }   this tenant's stored clips, newest first
+///   DELETE /voice-test/clips    -&gt; { removed }        delete every clip this tenant stored
+///
+/// WHY THE CLIPS ARE KEPT. The microphone check tells one user about one headset. The point of
+/// keeping the clips is the question no single run can answer: how well does transcription actually
+/// work, per language, across real headsets and real rooms. That needs the audio, the passage the
+/// user was reading and the text that came back, held together and compared later. See
+/// <see cref="VoiceTestClipStore"/> for why keeping THIS audio is a different proposition from
+/// keeping dictation, and for the retention that still applies.
+///
+/// WHY THE DICTIONARY CORRECTOR IS OFF for the transcription check: it would swap known terms after
+/// the fact and mask the very thing being measured. The Settings "Test it" button already leaves it
+/// off for exactly this reason - a test of transcription must test transcription.
+///
+/// TENANCY. This route stores speech at rest, so it uses
+/// <see cref="GatewayDictationEndpoint.ResolveTenant"/>, which returns null - a refusal - when a
+/// hosted request carries no bound tenant. It deliberately does NOT use the read-side helper, which
+/// falls back to Local when no boundary was passed and would therefore write one account's audio into
+/// the self-host partition.
+/// </summary>
+internal static class VoiceTestEndpoint
+{
+    private const string Prefix = "/voice-test";
+
+    /// <summary>Largest metadata field accepted. The passages are a few hundred characters; a
+    /// megabyte of "expected text" is not a passage, and storing it would be someone else's idea.</summary>
+    private const int MaxTextFieldChars = 4000;
+
+    public static void Map(
+        IEndpointRouteBuilder app,
+        GatewayTranscriptionService transcription,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        VoiceTestClipStore? storeOverride = null)
+    {
+        var group = app.MapGroup(Prefix);
+
+        group.MapPost("/clip", async (HttpContext ctx, CancellationToken ct) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+
+            if (!ctx.Request.HasFormContentType)
+                return BadRequest("send the clip as multipart form-data with an 'audio' file");
+
+            var form = await ctx.Request.ReadFormAsync(ct);
+            var file = form.Files.GetFile("audio") ?? form.Files.FirstOrDefault();
+            if (file is null || file.Length == 0)
+                return BadRequest("no audio in the upload");
+
+            if (file.Length > VoiceUploadLimits.MaxOneShotFileBytes)
+            {
+                FileLog.Write($"[VoiceTest] clip rejected: {file.Length} bytes > {VoiceUploadLimits.MaxOneShotFileBytes} cap");
+                return BadRequest($"audio is {file.Length} bytes; the limit for this endpoint is {VoiceUploadLimits.MaxOneShotFileBytes}");
+            }
+
+            var kind = Field(form, "kind");
+            if (!VoiceTestKind.IsValid(kind))
+                return BadRequest($"kind must be '{VoiceTestKind.Microphone}' or '{VoiceTestKind.Transcription}'");
+
+            var language = Trim(Field(form, "language"), 32);
+            var expected = Trim(Field(form, "expected"), MaxTextFieldChars);
+
+            byte[] bytes;
+            using (var ms = new MemoryStream())
+            {
+                await file.CopyToAsync(ms, ct);
+                bytes = ms.ToArray();
+            }
+            var fileName = string.IsNullOrWhiteSpace(file.FileName) ? "voice-test.wav" : file.FileName;
+            var contentType = string.IsNullOrWhiteSpace(file.ContentType) ? "audio/wav" : file.ContentType;
+
+            string? transcript = null;
+            string? outcome = null;
+            IResult? failure = null;
+
+            if (kind == VoiceTestKind.Transcription)
+            {
+                var routing = transcription.Resolve();
+                if (routing.Key is null)
+                {
+                    outcome = "no_key";
+                    failure = Results.Json(
+                        new { error = $"no key configured for transcription mode {routing.Mode.ToConfigString()}" },
+                        statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+                else
+                {
+                    // Correction OFF on purpose - see the class remarks. The language hint is what makes
+                    // a non-English run meaningful: auto-detection on a short clip is exactly where it
+                    // goes wrong, and a wrong detection returns confident nonsense rather than an error.
+                    var result = await transcription.TranscribeAsync(
+                        bytes, fileName, contentType, applyCorrection: false, ct,
+                        tenant: tenant, source: "voice-test", language: language);
+
+                    outcome = result.Outcome.ToString();
+                    if (result.Outcome == TranscriptionOutcome.Ok)
+                    {
+                        transcript = result.Text;
+                    }
+                    else if (result.Outcome == TranscriptionOutcome.OutOfCredits)
+                    {
+                        failure = HostedAiHttp.PaymentRequiredResult(HostedAiErrorMapper.MapCode(result.Code));
+                    }
+                    else
+                    {
+                        failure = Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status502BadGateway);
+                    }
+                }
+            }
+
+            // Store whatever happened, INCLUDING a failure. A clip that could not be transcribed is the
+            // most interesting clip there is - it is the one carrying the defect worth studying - so a
+            // provider error must not also throw the evidence away.
+            var clip = new VoiceTestClip
+            {
+                ClipId = Guid.NewGuid().ToString("N"),
+                Kind = kind!,
+                RecordedAtUtc = DateTime.UtcNow,
+                Language = language,
+                ExpectedText = expected,
+                Transcript = transcript,
+                Outcome = outcome,
+                Quality = ParseQuality(Field(form, "quality")),
+                AudioBytes = bytes.LongLength,
+                ContentType = contentType,
+            };
+            var store = storeOverride ?? VoiceTestClipStore.ForTenant(tenant);
+            var clipId = store.TrySave(clip, bytes, contentType);
+
+            if (failure is not null) return failure;
+            return Results.Json(new { clipId, transcript });
+        });
+
+        group.MapGet("/clips", (HttpContext ctx) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+            var store = storeOverride ?? VoiceTestClipStore.ForTenant(tenant);
+            return Results.Json(new { clips = store.List() });
+        });
+
+        group.MapDelete("/clips", (HttpContext ctx) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+            var store = storeOverride ?? VoiceTestClipStore.ForTenant(tenant);
+            return Results.Json(new { removed = store.Clear() });
+        });
+    }
+
+    private static IResult BadRequest(string error)
+        => Results.Json(new { error }, statusCode: StatusCodes.Status400BadRequest);
+
+    private static string? Field(IFormCollection form, string name)
+        => form.TryGetValue(name, out var value) ? value.ToString() : null;
+
+    private static string? Trim(string? value, int maxChars)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxChars ? trimmed : trimmed[..maxChars];
+    }
+
+    /// <summary>
+    /// Parse the client's measurements, which are stored verbatim. Unparseable input is dropped rather
+    /// than rejected: the measurements are a bonus for later analysis, and losing them must never cost
+    /// the user the clip or the transcript they were actually asking for.
+    /// </summary>
+    private static JsonElement? ParseQuality(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            FileLog.Write($"[VoiceTest] ignoring unparseable quality payload: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2512,6 +2512,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // see how fast and how good transcription is - all from data on this machine, never a server.
         Api.TranscriptionAnalysisEndpoint.Map(_app, _tenantBoundary);
 
+        // The Test microphone / Test transcription checks: a user records a passage we put on screen,
+        // hears it back, and sees how much of it came back correctly. The clips are kept per tenant so
+        // transcription quality can be compared across languages, headsets and releases - the question
+        // no single run can answer.
+        Api.VoiceTestEndpoint.Map(
+            _app,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(
+                _keyVault, history: _transcriptionHistory, audioArchive: _transcriptionAudioArchive, transcripts: _transcripts),
+            _tenantBoundary);
+
         // Text-in / text-out cleanup: run ONLY the deterministic dictionary correction over supplied
         // text + a supplied term list (no audio). The engine the multilingual eval harness drives, and
         // a way for any agent to test cleanup on arbitrary text/terms.

--- a/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
@@ -374,6 +374,12 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         form.Add(audioContent, "file", string.IsNullOrEmpty(fileName) ? "audio.webm" : fileName);
         form.Add(new StringContent(routing.Model), "model");
         form.Add(new StringContent("json"), "response_format");
+        // Spoken-language hint, when the caller knows it. Only sent when set, so the provider keeps
+        // auto-detecting for every existing caller. Detection is what fails hardest on the cases this
+        // matters for - a short clip, an accent, or a language that shares vocabulary with English -
+        // and a wrong detection produces confident nonsense rather than an error.
+        if (!string.IsNullOrWhiteSpace(routing.Language))
+            form.Add(new StringContent(routing.Language), "language");
         request.Content = form;
 
         using var resp = await _http.SendAsync(request, ct);

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -113,9 +113,11 @@ public sealed class GatewayTranscriptionService
     /// <param name="ct">Cancellation token.</param>
     /// <param name="source">The surface that produced the utterance (e.g. "dictation", "voice", "batch"),
     /// stamped on the stored transcript (issue #509) for later mining. Defaults to "gateway" when blank.</param>
+    /// <param name="language">Optional spoken-language hint (BCP 47 primary subtag, e.g. "da"). Null
+    /// leaves the provider to detect the language, which is what every ordinary dictation path does.</param>
     public async Task<GatewayTranscriptionResult> TranscribeAsync(
         byte[] audio, string fileName, string contentType, bool applyCorrection, CancellationToken ct,
-        CcDirector.Core.Tenancy.TenantId? tenant = null, string? source = null)
+        CcDirector.Core.Tenancy.TenantId? tenant = null, string? source = null, string? language = null)
     {
         if (audio is null) throw new ArgumentNullException(nameof(audio));
 
@@ -141,7 +143,7 @@ public sealed class GatewayTranscriptionService
         string raw;
         try
         {
-            raw = await TranscribeRawCoreAsync(routing, audio, fileName, contentType, ct);
+            raw = await TranscribeRawCoreAsync(routing, audio, fileName, contentType, ct, language);
             swTranscribe.Stop();
         }
         catch (OperationCanceledException)
@@ -298,12 +300,13 @@ public sealed class GatewayTranscriptionService
     /// real failure the caller must surface).
     /// </summary>
     private async Task<string> TranscribeRawCoreAsync(
-        GatewayTranscriptionRouting routing, byte[] audio, string fileName, string contentType, CancellationToken ct)
+        GatewayTranscriptionRouting routing, byte[] audio, string fileName, string contentType, CancellationToken ct,
+        string? language = null)
     {
         var name = string.IsNullOrWhiteSpace(fileName) ? "audio." + ExtensionFor(contentType) : fileName;
         using var pipeline = new BatchTranscriptionPipeline(httpClient: _http, cleanupModel: _cleanupModel);
-        FileLog.Write($"[GatewayTranscriptionService] transcribe remote: bytes={audio.Length}, mode={routing.Mode.ToConfigString()}, model={routing.Endpoint.Model}");
-        return await pipeline.TranscribeRawAsync(audio, name, routing.ToResolved(), ct);
+        FileLog.Write($"[GatewayTranscriptionService] transcribe remote: bytes={audio.Length}, mode={routing.Mode.ToConfigString()}, model={routing.Endpoint.Model}, language={language ?? "auto"}");
+        return await pipeline.TranscribeRawAsync(audio, name, routing.ToResolved(language), ct);
     }
 
     /// <summary>
@@ -374,7 +377,7 @@ public sealed record GatewayTranscriptionRouting
     /// Compose the <see cref="ResolvedTranscription"/> the Gateway-local batch transport consumes.
     /// Throws when no key is set - call only after checking <see cref="Key"/> is non-null.
     /// </summary>
-    public ResolvedTranscription ToResolved()
+    public ResolvedTranscription ToResolved(string? language = null)
     {
         if (string.IsNullOrWhiteSpace(Key))
             throw new InvalidOperationException($"no key set for transcription mode {Mode.ToConfigString()}");
@@ -385,6 +388,7 @@ public sealed record GatewayTranscriptionRouting
             Transport = Endpoint.Transport,
             Model = Endpoint.Model,
             Mode = Mode,
+            Language = string.IsNullOrWhiteSpace(language) ? null : language.Trim(),
         };
     }
 }
@@ -463,4 +467,13 @@ public sealed record ResolvedTranscription
 
     /// <summary>The mode this target was resolved for.</summary>
     public required TranscriptionMode Mode { get; init; }
+
+    /// <summary>
+    /// Optional spoken-language hint (a BCP 47 primary subtag such as "da" or "zh") passed to the
+    /// provider. Null means "let the provider detect it", which is the behaviour every existing caller
+    /// keeps. It lives on this record rather than on the pipeline's method signatures because a long
+    /// clip is split into several independent POSTs, and every one of them must carry the same hint -
+    /// threading it here makes that automatic instead of a parameter each chunking method could drop.
+    /// </summary>
+    public string? Language { get; init; }
 }

--- a/src/CcDirector.Gateway/Transcription/VoiceTestClipStore.cs
+++ b/src/CcDirector.Gateway/Transcription/VoiceTestClipStore.cs
@@ -1,0 +1,258 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Utilities;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// Stores the clips produced by the Test microphone and Test transcription checks, per tenant, with a
+/// metadata sidecar, so transcription quality can be studied after the fact.
+///
+/// WHY A NEW STORE RATHER THAN <see cref="TranscriptionAudioArchive"/>. That archive is a 24-hour
+/// troubleshooting buffer for ORDINARY dictation, and it refuses to write at all on a hosted Gateway
+/// because it has one process-wide directory with a global prune - which would mix every account's
+/// speech at rest and let a busy tenant evict a quiet one's clips (MTR-10 Gap A). Both properties are
+/// wrong for this feature: these clips exist to be compared over weeks, and they must work on hosted,
+/// which is where the interesting variety of languages and headsets actually is. So this store carries
+/// the tenant in its path from the very first write and prunes strictly WITHIN one tenant, which is
+/// exactly the gap that disabled the other one.
+///
+/// WHY KEEPING THIS AUDIO IS DIFFERENT FROM KEEPING DICTATION. The repository's standing position is
+/// that recorded speech is bounded everywhere ("there is no deployment where keeping it forever is
+/// right"), and that is not weakened here. What changes is the CONTENT: a test clip is the user
+/// deliberately reading a passage THIS PRODUCT PUT ON THEIR SCREEN. It contains no private message, no
+/// customer name and no dictated work - only known words the user chose to record for the purpose of
+/// being analysed. That is a materially different category from an intercepted utterance, and it is
+/// why a longer window is defensible here and nowhere else. The window still exists.
+///
+/// RETENTION: 30 days and 200 clips per tenant, whichever bites first. The 30 days matches the window
+/// <see cref="TranscriptStore"/> already applies to transcript text, so the product keeps one answer to
+/// "how long do you hold on to my voice work" rather than two. The 200 is a per-tenant cap, so one
+/// tenant running the check repeatedly can never prune another tenant's clips.
+/// </summary>
+public sealed class VoiceTestClipStore
+{
+    /// <summary>How long a stored clip is kept. Matches the transcript-text window deliberately.</summary>
+    public static readonly TimeSpan MaxAge = TimeSpan.FromDays(30);
+
+    /// <summary>Most clips kept for ONE tenant. Per tenant, never global - that distinction is the
+    /// whole reason this store may run on hosted when the older archive may not.</summary>
+    public const int MaxClipsPerTenant = 200;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly object _gate = new();
+    private readonly string _directory;
+
+    /// <summary>Root directory holding every tenant's partition.</summary>
+    public static string DefaultDirectory() => CcStorage.VoiceTestClips();
+
+    /// <summary>
+    /// This tenant's partition. The tenant is in the PATH, not merely in a field, so there is no code
+    /// path that can write a clip outside its own tenant's folder - a store instance simply cannot
+    /// address another tenant's directory.
+    /// </summary>
+    public static string DirectoryFor(TenantId tenant)
+    {
+        var chars = tenant.Value.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray();
+        return Path.Combine(DefaultDirectory(), new string(chars));
+    }
+
+    /// <summary>A store bound to one tenant's partition.</summary>
+    public static VoiceTestClipStore ForTenant(TenantId tenant) => new(DirectoryFor(tenant));
+
+    public VoiceTestClipStore(string? directory = null)
+    {
+        _directory = directory ?? DefaultDirectory();
+    }
+
+    /// <summary>The directory this instance writes to.</summary>
+    public string Directory => _directory;
+
+    /// <summary>
+    /// Save one clip and its sidecar. Returns the clip id, or null when nothing could be written -
+    /// storing a diagnostic must never fail the check the user is running, so this reports rather than
+    /// throws, and the caller still returns the transcript it already has.
+    /// </summary>
+    public string? TrySave(VoiceTestClip clip, byte[] audio, string contentType)
+    {
+        if (clip is null) throw new ArgumentNullException(nameof(clip));
+        if (audio is null || audio.Length == 0) return null;
+
+        try
+        {
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(_directory);
+                var extension = GatewayTranscriptionService.ExtensionFor(contentType);
+                var audioPath = Path.Combine(_directory, $"clip-{SafeName(clip.ClipId)}.{extension}");
+                File.WriteAllBytes(audioPath, audio);
+
+                // The sidecar carries everything needed to interpret the clip later: which check it
+                // came from, which language, the passage the user was asked to read, and what came
+                // back. Stored beside the audio rather than in a table so an analyst can copy one
+                // folder and have the complete picture, audio included.
+                var sidecarPath = Path.Combine(_directory, $"clip-{SafeName(clip.ClipId)}.json");
+                File.WriteAllText(sidecarPath, JsonSerializer.Serialize(clip, JsonOptions));
+
+                Prune();
+                FileLog.Write(
+                    $"[VoiceTestClipStore] saved clip={clip.ClipId} kind={clip.Kind} language={clip.Language} " +
+                    $"bytes={audio.Length} dir={_directory}");
+                return clip.ClipId;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceTestClipStore] TrySave FAILED (swallowed): {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Every stored clip's metadata for this tenant, newest first. The analysis read.</summary>
+    public IReadOnlyList<VoiceTestClip> List()
+    {
+        lock (_gate)
+        {
+            if (!System.IO.Directory.Exists(_directory)) return Array.Empty<VoiceTestClip>();
+            var clips = new List<VoiceTestClip>();
+            foreach (var file in new DirectoryInfo(_directory).GetFiles("clip-*.json"))
+            {
+                try
+                {
+                    var clip = JsonSerializer.Deserialize<VoiceTestClip>(File.ReadAllText(file.FullName), JsonOptions);
+                    if (clip is not null) clips.Add(clip);
+                }
+                catch (Exception ex)
+                {
+                    // One unreadable sidecar must not hide every other clip.
+                    FileLog.Write($"[VoiceTestClipStore] skipping unreadable sidecar {file.Name}: {ex.Message}");
+                }
+            }
+            return clips.OrderByDescending(c => c.RecordedAtUtc).ToList();
+        }
+    }
+
+    /// <summary>Delete every clip in this tenant's partition. Returns how many clips were removed.</summary>
+    public int Clear()
+    {
+        lock (_gate)
+        {
+            if (!System.IO.Directory.Exists(_directory)) return 0;
+            var removed = 0;
+            foreach (var file in new DirectoryInfo(_directory).GetFiles("clip-*"))
+            {
+                try
+                {
+                    file.Delete();
+                    if (file.Extension == ".json") removed++;
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[VoiceTestClipStore] could not delete {file.Name}: {ex.Message}");
+                }
+            }
+            return removed;
+        }
+    }
+
+    /// <summary>
+    /// Enforce both bounds inside THIS tenant's directory. Called under the lock on every save. A clip
+    /// and its sidecar are deleted together, so a listing can never show metadata whose audio is gone.
+    /// </summary>
+    private void Prune()
+    {
+        if (!System.IO.Directory.Exists(_directory)) return;
+
+        var sidecars = new DirectoryInfo(_directory)
+            .GetFiles("clip-*.json")
+            .OrderByDescending(f => f.LastWriteTimeUtc)
+            .ToList();
+
+        var cutoff = DateTime.UtcNow - MaxAge;
+        var doomed = sidecars.Where((f, index) => index >= MaxClipsPerTenant || f.LastWriteTimeUtc < cutoff).ToList();
+
+        foreach (var sidecar in doomed)
+        {
+            var stem = Path.GetFileNameWithoutExtension(sidecar.Name);
+            foreach (var companion in new DirectoryInfo(_directory).GetFiles(stem + ".*"))
+            {
+                try
+                {
+                    companion.Delete();
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[VoiceTestClipStore] prune could not delete {companion.Name}: {ex.Message}");
+                }
+            }
+        }
+    }
+
+    private static string SafeName(string name)
+    {
+        var chars = name.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray();
+        return new string(chars);
+    }
+}
+
+/// <summary>Which check produced a stored clip.</summary>
+public static class VoiceTestKind
+{
+    /// <summary>The microphone check: no transcription, only the recorded audio and its measurements.</summary>
+    public const string Microphone = "microphone";
+
+    /// <summary>The transcription check: a known passage read aloud, transcribed and compared.</summary>
+    public const string Transcription = "transcription";
+
+    public static bool IsValid(string? kind) => kind is Microphone or Transcription;
+}
+
+/// <summary>
+/// The metadata sidecar stored beside a test clip.
+///
+/// It deliberately holds the EXPECTED passage and the RAW transcript rather than a score. A score is
+/// one interpretation, computed by one version of one scorer; the passage and the transcript are the
+/// evidence, and any future question - a different scoring rule, a per-word breakdown, a comparison
+/// across releases - can still be answered from them. Storing only a number would foreclose all of it.
+/// </summary>
+public sealed record VoiceTestClip
+{
+    /// <summary>Identifier shared by the audio file and this sidecar.</summary>
+    public required string ClipId { get; init; }
+
+    /// <summary>"microphone" or "transcription" (see <see cref="VoiceTestKind"/>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>When the clip was received.</summary>
+    public required DateTime RecordedAtUtc { get; init; }
+
+    /// <summary>BCP 47 primary subtag the user selected, and the hint sent to the transcriber.</summary>
+    public string? Language { get; init; }
+
+    /// <summary>The passage the user was asked to read. Null for a microphone check.</summary>
+    public string? ExpectedText { get; init; }
+
+    /// <summary>What the transcriber returned. Null for a microphone check, or when it failed.</summary>
+    public string? Transcript { get; init; }
+
+    /// <summary>Why transcription did not produce text, when it did not.</summary>
+    public string? Outcome { get; init; }
+
+    /// <summary>The client's own audio measurements, verbatim, so a clip can be studied without
+    /// re-deriving them. Free-form on purpose: the microphone check owns their shape, and this store
+    /// must not become a second place that has to be edited when a measurement is added.</summary>
+    public JsonElement? Quality { get; init; }
+
+    /// <summary>Size of the stored audio in bytes.</summary>
+    public long AudioBytes { get; init; }
+
+    /// <summary>The clip's MIME type.</summary>
+    public string? ContentType { get; init; }
+}


### PR DESCRIPTION
Two checks a user can run when dictation keeps coming out wrong, so the answer is a
measurement rather than an impression. Both appear on the Cockpit dictation health page
and as their own screens on the phone, and both render one shared component from
`client-core`, so a phone and a desktop can never disagree about the same recording.

## Test microphone

Records a short clip through the same capture path dictation uses, plays back the exact
16 kHz audio the transcriber receives, and measures the three defects that actually break
transcription: a band-limited link, a clipped input, and a voice that does not stand clear
of the room.

The band-limit reading is the valuable one. A Bluetooth headset in hands-free mode delivers
8 kHz telephone audio, which sounds merely dull to a person but strips out the consonants
the model needs - and it is invisible in every other reading. Driven through a real browser
with an injected clip, the telephone-grade recording measured **68 dB signal-to-noise, louder
and cleaner than the good one**, and only the bandwidth check caught it.

The threshold sits in a wide empty gap rather than on a knife edge: wideband capture measures
about -8 to -25 dB in the 4.5-8 kHz band, a telephone link about -110 dB. Tests cover the
false positive that would matter most - a dull microphone with weak sibilance must never be
told to go and buy a new headset.

## Test transcription

Puts a passage on screen in one of eight languages, records the user reading it, and scores
what came back by word error rate - showing the individual words that were misheard, missed
or invented, because a percentage says how bad it is but only the specific words say whether
the cause is the microphone, the accent, or a term that belongs in the dictionary.

Chinese is scored per character, since a whitespace split would make a whole sentence a
single token. The eight languages are English, the six most widely spoken, and Danish;
adding or swapping one is a single entry in `languages.ts` and nothing else.

## Storing the clips

Both checks keep their clip on the Gateway, per tenant, so transcription quality can be
compared later across languages, headsets and releases - the question no single run can
answer.

This needed a new store rather than `TranscriptionAudioArchive`, which prunes at 24 hours and
refuses to write at all on hosted, because it has one process-wide directory and a global
prune that would mix every account's speech at rest and let a busy tenant evict a quiet one's
clips (MTR-10 Gap A). `VoiceTestClipStore` carries the tenant in its path from the first write
and prunes strictly within one tenant, which is that gap closed - a test fills one partition
past its cap and proves the neighbour is untouched, and another proves a tenant id cannot
escape its own directory.

Retention is 30 days or 200 clips per tenant, matching the window already applied to
transcript text, so the product keeps one answer to how long it holds recorded speech. The
sidecar stores the passage and the raw transcript rather than a score: a score is one
interpretation by one version of one scorer, while the passage and the transcript are the
evidence any later question can still be answered from.

Keeping this audio is a different proposition from keeping dictation, and the standing
position that recorded speech stays bounded is not weakened. What differs is the content: a
test clip is the user deliberately reading a passage this product put on their screen,
carrying no private message and no dictated work. The window still exists. The microphone
panel's copy changed accordingly - it previously said the recording was never uploaded, which
would now have been untrue.

## Language hint

Transcription gains an optional spoken-language hint, which nothing carried before. Every call
left the provider to detect the language, which is exactly where a short non-English clip goes
wrong, and a wrong detection returns confident nonsense rather than an error. It rides on the
resolved routing record so every chunk of a split recording carries it automatically.

Auto-detection remains the default for every existing caller; only these checks send a hint. A
test asserts the field on the outgoing HTTP request for all eight languages, and asserts its
absence when no hint is set - the property is easy to plumb and never verify, and a field
dropped at the wire would leave every screen looking right while non-English results quietly
got worse.

The dictionary corrector is off for the transcription check, following the existing "Test it"
button: a term swap after the fact would mask the very thing being measured.

## A hang found while testing

`getUserMedia` can neither resolve nor reject when the capture device is wedged. This was not
theoretical - it happened in a real browser, and the symptom was a Start button that did
nothing at all, with no error, for as long as you cared to wait. Both checks now give up after
eight seconds and say why.

The recording cap also moved from an animation frame to a timer, because a browser suspends
frames entirely in a hidden tab: a phone user who started a check and switched app would have
left the microphone open indefinitely. Verified by killing animation frames outright and
watching the recording still stop.

## Verification

- 673 client-core tests, 180 Cockpit tests, 3661 Core tests, 24 new Gateway tests for the clip
  store and endpoint, 13 for the language hint
- Release build of the full solution, both web apps build, root typecheck clean
- Driven end to end in a real browser with injected audio: wideband clip rated good, telephone
  clip correctly identified with the Bluetooth advice, 88% scored on an English passage with the
  four misheard words individually marked, 47 of 49 characters on Chinese, all eight passages
  rendering with Arabic right-to-left

## Note

The passages are necessarily non-ASCII - Chinese, Hindi, Arabic, and the Danish letters. That
is the feature. Console output, identifiers, log lines and comments remain ASCII throughout.
