### PR TITLE
Compact a session's context from outside, and continue it (#2150)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -928,6 +928,47 @@ internal static class ControlEndpoints
             }
         });
 
+        // POST /fleet/compact - compact a session's context, and continue it (issue #2150). The rescue for a
+        // session whose window is full: it can no longer read anything sent to it, so no message, no
+        // interrupt and no amount of waiting reaches it - only compaction does. The call BLOCKS until the
+        // tool reports the compaction finished (bounded by Session.CompactionWaitTimeout) so the answer is
+        // what happened, not what was attempted; the optional continuation is submitted at that moment.
+        app.MapPost("/fleet/compact", async (FleetCompactRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            if (sessionManager.GetSession(toGuid) is not null)
+            {
+                var command = new DirectorCommand
+                {
+                    Verb = "compact-context",
+                    SessionId = req.ToSessionId,
+                    PayloadJson = JsonSerializer.Serialize(new CompactContextRequest { ContinuePrompt = req.ContinuePrompt }),
+                };
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ct);
+                return CommandResultToHttp(result);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                    statusCode: StatusCodes.Status404NotFound);
+            try
+            {
+                var compacted = await gw.CompactFleetAsync(req.ToSessionId, req.ContinuePrompt, ct);
+                return Results.Json(compacted);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/compact relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot compact the target via the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
         // POST /fleet/hold - park a session, or release it (the old POST /sessions/{sid}/hold). A hold asked
         // for mid-turn is DEFERRED and applies when the turn settles (see HoldState) - the response's pending
         // flag says so, which is why it is surfaced rather than swallowed.

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -533,6 +533,44 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Compact a session anywhere in the fleet, through the Gateway's POST /sessions/{sid}/compact-context,
+    /// which routes it to the owning Director over the tunnel. Used by the local POST /fleet/compact for a
+    /// target this Director does not host (issue #2150).
+    ///
+    /// Uses a DEDICATED HttpClient: the shared <c>_http</c> gives up after 10 seconds, but a compaction
+    /// legitimately runs for minutes, and this call deliberately waits for the FINISH rather than the
+    /// submission. Its timeout sits outside the Gateway's own wait for the verb, which sits outside the
+    /// Director's compaction wait - so the innermost bound always fires first and names what failed.
+    /// </summary>
+    public async Task<CompactContextResponse> CompactFleetAsync(string toSessionId, string? continuePrompt, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] CompactFleetAsync: POST /sessions/{toSessionId}/compact-context " +
+                      $"continue={(string.IsNullOrWhiteSpace(continuePrompt) ? "no" : "yes")}");
+        using var http = new HttpClient(GatewayHttp.Handler())
+        {
+            BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/"),
+            Timeout = TimeSpan.FromMinutes(4),
+        };
+        if (!string.IsNullOrEmpty(_config.Token))
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.Token);
+
+        var body = new CompactContextRequest { ContinuePrompt = continuePrompt };
+        using var resp = await http.PostAsJsonAsync($"sessions/{toSessionId}/compact-context", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw await RelayFailureAsync(resp, $"compaction of {toSessionId}", ct);
+
+        var parsed = await resp.Content.ReadFromJsonAsync<CompactContextResponse>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway compaction returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
     /// Read a session's terminal buffer anywhere in the fleet, through the Gateway's GET
     /// /sessions/{sid}/buffer, which routes it to the owning Director over the tunnel. Used by the local
     /// GET /fleet/buffer for a target this Director does not host.

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -33,7 +33,7 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
         // Worker W1: the remaining Director session STATE writes, moved onto the tunnel dispatch. Each core
         // below reproduces its old REST lambda's guards and effect verbatim, so the REST path and the tunnel
         // verb share one core and cannot drift.
-        "clear-context", "history-picker", "mobile-mode", "voice-mode", "wingman-enabled",
+        "clear-context", "compact-context", "history-picker", "mobile-mode", "voice-mode", "wingman-enabled",
         "relink", "request-deletion", "cancel-deletion", "execute-action",
         // Gateway Cleanup Phase 0 (wave 3): the final deferred write verbs. handover-generate is
         // director-level (creates/targets a session from a source); wingman-ask and recap-generate are
@@ -74,6 +74,7 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             "resize" => Resize(sessionManager, command),
             "terminal-input" => TerminalInput(sessionManager, command),
             "clear-context" => await ClearContextAsync(sessionManager, command, cancellationToken),
+            "compact-context" => await CompactContextAsync(sessionManager, command, cancellationToken),
             "history-picker" => await HistoryPickerAsync(sessionManager, command),
             "mobile-mode" => MobileMode(sessionManager, command, context.Services),
             "voice-mode" => VoiceMode(sessionManager, command, context.Services),
@@ -194,6 +195,55 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             accepted = true,
             oldAgentSessionId = oldId,
             newAgentSessionId = newId,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>compact-context</c> verb (issue #2150): summarize a session's conversation IN PLACE and,
+    /// when the payload carries one, send a follow-up prompt the moment the compaction finishes. This is
+    /// the only way a full session gets moving again without a person at its keyboard.
+    ///
+    /// Unlike <see cref="ClearContextAsync"/> there is no re-link: compaction keeps the agent session id.
+    /// Invalid id -&gt; BadRequest; missing session -&gt; NotFound; a driver that declares no compaction, or
+    /// that cannot time a continuation (NotSupportedException) -&gt; Conflict; a compaction that never
+    /// reports finishing (TimeoutException) -&gt; Timeout, naming what did not happen rather than letting
+    /// the Gateway's outer wait mask it with "the Director did not answer".
+    /// </summary>
+    internal static async Task<DirectorCommandResult> CompactContextAsync(SessionManager sessionManager, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var request = SessionCommandExecutor.Deserialize<CompactContextRequest>(command.PayloadJson);
+        CompactContextOutcome outcome;
+        try
+        {
+            outcome = await session.CompactContextAsync(request?.ContinuePrompt, cancellationToken);
+        }
+        catch (NotSupportedException ex)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, ex.Message);
+        }
+        catch (TimeoutException ex)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Timeout, ex.Message);
+        }
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new CompactContextResponse
+        {
+            Submitted = outcome.Submitted,
+            CompactionObserved = outcome.CompactionObserved,
+            WaitedSeconds = Math.Round(outcome.WaitedSeconds, 1),
+            Continued = outcome.Continued,
+            Detail = outcome.Detail,
         }));
     }
 

--- a/src/CcDirector.Core.Tests/AutoDismissVerdictWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/AutoDismissVerdictWatcherTests.cs
@@ -93,6 +93,7 @@ public sealed class AutoDismissVerdictWatcherTests
         public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => _widgets;
         public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => null;
         public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+        public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) => null;
     }
 
     private sealed class NullBackend : ISessionBackend

--- a/src/CcDirector.Core.Tests/Claude/CompactionMarkerTests.cs
+++ b/src/CcDirector.Core.Tests/Claude/CompactionMarkerTests.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using CcDirector.Core.Claude;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Claude;
+
+/// <summary>
+/// Issue #2150 - reading the COMPACTION mark out of a claude transcript, the signal compact-and-continue
+/// waits on.
+///
+/// The sample lines here are the real shape claude writes (verified against live transcripts written by
+/// claude 2.1.195 through 2.1.218). Two properties matter and are each tested: the mark carries its own
+/// timestamp, and it is appended to the SAME file under the SAME session id - which is why compaction,
+/// unlike clearing, needs no transcript re-link.
+/// </summary>
+public sealed class CompactionMarkerTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-compaction-" + Guid.NewGuid().ToString("N"));
+
+    public CompactionMarkerTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* a leftover temp directory is not a test failure */ }
+    }
+
+    private string WriteTranscript(params string[] lines)
+    {
+        var path = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".jsonl");
+        File.WriteAllText(path, string.Join("\n", lines) + "\n", Encoding.UTF8);
+        return path;
+    }
+
+    private static string PlainLine(string timestamp, string sessionId = "s-1") =>
+        $$"""{"type":"user","message":{"role":"user","content":"do the thing"},"timestamp":"{{timestamp}}","sessionId":"{{sessionId}}"}""";
+
+    private static string CompactionLine(string timestamp, string sessionId = "s-1") =>
+        $$"""{"type":"user","isVisibleInTranscriptOnly":true,"isCompactSummary":true,"message":{"role":"user","content":"This session is being continued from a previous conversation that ran out of context."},"timestamp":"{{timestamp}}","sessionId":"{{sessionId}}","version":"2.1.218"}""";
+
+    [Fact]
+    public void ReadLastCompactionUtc_ReturnsTheMarkTimestamp()
+    {
+        var path = WriteTranscript(
+            PlainLine("2026-07-25T09:00:00.000Z"),
+            CompactionLine("2026-07-25T09:14:22.500Z"),
+            PlainLine("2026-07-25T09:15:00.000Z"));
+
+        var stamp = CompactionMarker.ReadLastCompactionUtc(path);
+
+        Assert.NotNull(stamp);
+        Assert.Equal(new DateTime(2026, 7, 25, 9, 14, 22, 500, DateTimeKind.Utc), stamp!.Value);
+        Assert.Equal(DateTimeKind.Utc, stamp.Value.Kind);
+    }
+
+    /// <summary>
+    /// A long-lived session compacts repeatedly. The NEWEST mark is the one that answers "has it
+    /// compacted since I asked" - reporting the first would make every later request look instantly done.
+    /// </summary>
+    [Fact]
+    public void ReadLastCompactionUtc_ReturnsTheNewestMarkWhenTheSessionCompactedMoreThanOnce()
+    {
+        var path = WriteTranscript(
+            CompactionLine("2026-07-25T08:00:00.000Z"),
+            PlainLine("2026-07-25T08:30:00.000Z"),
+            CompactionLine("2026-07-25T11:45:00.000Z"),
+            PlainLine("2026-07-25T11:46:00.000Z"));
+
+        var stamp = CompactionMarker.ReadLastCompactionUtc(path);
+
+        Assert.Equal(new DateTime(2026, 7, 25, 11, 45, 0, DateTimeKind.Utc), stamp);
+    }
+
+    [Fact]
+    public void ReadLastCompactionUtc_NullWhenTheSessionHasNeverCompacted()
+    {
+        var path = WriteTranscript(
+            PlainLine("2026-07-25T09:00:00.000Z"),
+            PlainLine("2026-07-25T09:05:00.000Z"));
+
+        Assert.Null(CompactionMarker.ReadLastCompactionUtc(path));
+    }
+
+    [Fact]
+    public void ReadLastCompactionUtc_NullWhenTheTranscriptDoesNotExist()
+    {
+        Assert.Null(CompactionMarker.ReadLastCompactionUtc(Path.Combine(_dir, "not-written-yet.jsonl")));
+    }
+
+    /// <summary>
+    /// The words appear inside ordinary message text all the time - this very repository discusses
+    /// isCompactSummary in prose. Only a top-level boolean true is a mark; a mention is not.
+    /// </summary>
+    [Fact]
+    public void ReadLastCompactionUtc_IgnoresTheFieldNameMentionedInsideMessageText()
+    {
+        var path = WriteTranscript(
+            """{"type":"user","message":{"role":"user","content":"explain what isCompactSummary means"},"timestamp":"2026-07-25T09:00:00.000Z","sessionId":"s-1"}""",
+            """{"type":"assistant","message":{"role":"assistant","content":"isCompactSummary marks a compaction"},"timestamp":"2026-07-25T09:00:30.000Z","sessionId":"s-1"}""");
+
+        Assert.Null(CompactionMarker.ReadLastCompactionUtc(path));
+    }
+
+    /// <summary>A mark written as the string "true" rather than the boolean is not a mark either.</summary>
+    [Fact]
+    public void ReadLastCompactionUtc_IgnoresANonBooleanMarkerValue()
+    {
+        var path = WriteTranscript(
+            """{"type":"user","isCompactSummary":"true","timestamp":"2026-07-25T09:00:00.000Z","sessionId":"s-1"}""");
+
+        Assert.Null(CompactionMarker.ReadLastCompactionUtc(path));
+    }
+
+    /// <summary>
+    /// We read the file WHILE claude is appending to it, so the last line is regularly half-written.
+    /// A torn line must be skipped and the next poll must still find the mark - a parse crash here would
+    /// take down the rescue.
+    /// </summary>
+    [Fact]
+    public void ReadLastCompactionUtc_SurvivesAHalfWrittenTrailingLine()
+    {
+        var path = WriteTranscript(
+            CompactionLine("2026-07-25T09:14:00.000Z"),
+            """{"type":"assistant","isCompactSummary":tr""");
+
+        Assert.Equal(new DateTime(2026, 7, 25, 9, 14, 0, DateTimeKind.Utc), CompactionMarker.ReadLastCompactionUtc(path));
+    }
+
+    /// <summary>
+    /// The transcript is open and being written by claude when we read it. Opening it exclusively would
+    /// throw the moment a compaction actually landed - the one moment this must work.
+    /// </summary>
+    [Fact]
+    public void ReadLastCompactionUtc_ReadsAFileThatIsStillOpenForWriting()
+    {
+        var path = WriteTranscript(CompactionLine("2026-07-25T09:14:00.000Z"));
+
+        using var writer = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+
+        Assert.NotNull(CompactionMarker.ReadLastCompactionUtc(path));
+    }
+}

--- a/src/CcDirector.Core.Tests/Drivers/CompactContextDriverTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/CompactContextDriverTests.cs
@@ -1,0 +1,200 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Drivers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Drivers;
+
+/// <summary>
+/// Issue #2150 - the driver half of compaction: WHICH command each tool compacts with, which tools
+/// declare they cannot, and how claude decides a compaction has finished.
+///
+/// The point of these tests is that the answer differs per tool and is never guessed. Gemini compacts
+/// with a different word than everyone else, and Copilot cannot compact at all - a driver layer that
+/// quietly typed "/compact" at Copilot, or "/compact" at gemini, would be typing nonsense into a live
+/// session. And a driver must never substitute a CLEAR for a compaction: that would destroy exactly
+/// the work compaction exists to preserve.
+/// </summary>
+public sealed class CompactContextDriverTests
+{
+    private static ClaudeDriver NewClaudeDriver(ITranscriptReader? transcripts = null) =>
+        new(transcripts ?? new EmptyTranscriptReader(), TimeSpan.Zero, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ClaudeDriver_CompactContextAsync_SubmitsSlashCompact()
+    {
+        var backend = new RecordingSessionBackend();
+
+        await NewClaudeDriver().CompactContextAsync(backend);
+
+        Assert.Equal("/compact", Assert.Single(backend.SentTexts));
+    }
+
+    /// <summary>
+    /// The command must be /compact and NOT /clear. They differ by one word and by everything that
+    /// matters: one summarizes the conversation, the other throws it away.
+    /// </summary>
+    [Fact]
+    public async Task ClaudeDriver_CompactContextAsync_DoesNotClear()
+    {
+        var backend = new RecordingSessionBackend();
+
+        await NewClaudeDriver().CompactContextAsync(backend);
+
+        Assert.DoesNotContain("/clear", backend.SentTexts);
+    }
+
+    [Fact]
+    public async Task CodexDriver_CompactContextAsync_SubmitsSlashCompact()
+    {
+        var backend = new RecordingSessionBackend();
+
+        await new CodexDriver().CompactContextAsync(backend);
+
+        Assert.Equal("/compact", Assert.Single(backend.SentTexts));
+    }
+
+    [Fact]
+    public async Task PiDriver_CompactContextAsync_SubmitsSlashCompact()
+    {
+        var backend = new RecordingSessionBackend();
+
+        await new PiDriver().CompactContextAsync(backend);
+
+        Assert.Equal("/compact", Assert.Single(backend.SentTexts));
+    }
+
+    /// <summary>Gemini's own catalog spells compaction /compress. This is the whole reason the command
+    /// belongs to the driver rather than to one shared string at the call site.</summary>
+    [Fact]
+    public async Task GeminiDriver_CompactContextAsync_SubmitsSlashCompress()
+    {
+        var backend = new RecordingSessionBackend();
+
+        await AgentDrivers.For(AgentKind.Gemini).CompactContextAsync(backend);
+
+        Assert.Equal("/compress", Assert.Single(backend.SentTexts));
+    }
+
+    [Theory]
+    [InlineData(AgentKind.Grok, "/compact")]
+    [InlineData(AgentKind.OpenCode, "/compact")]
+    public async Task RegisteredGenericDrivers_CompactContextAsync_SubmitTheirOwnCommand(AgentKind kind, string expected)
+    {
+        var backend = new RecordingSessionBackend();
+
+        await AgentDrivers.For(kind).CompactContextAsync(backend);
+
+        Assert.Equal(expected, Assert.Single(backend.SentTexts));
+    }
+
+    [Theory]
+    [InlineData(AgentKind.ClaudeCode)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Gemini)]
+    [InlineData(AgentKind.Grok)]
+    [InlineData(AgentKind.OpenCode)]
+    public void CompactingDrivers_DeclareTheCapability(AgentKind kind)
+    {
+        Assert.True(AgentDrivers.For(kind).Capabilities.HasFlag(DriverCapabilities.CompactContext));
+    }
+
+    /// <summary>
+    /// Copilot's command catalog has /clear and no compaction of any kind. The absence must be DECLARED
+    /// and the call must throw - a driver that fell back to /clear here would silently destroy the
+    /// conversation the caller was trying to preserve.
+    /// </summary>
+    [Fact]
+    public async Task CopilotDriver_DeclaresNoCompaction_AndThrows()
+    {
+        IAgentDriver driver = new CopilotDriver();
+        var backend = new RecordingSessionBackend();
+
+        Assert.False(driver.Capabilities.HasFlag(DriverCapabilities.CompactContext));
+        await Assert.ThrowsAsync<NotSupportedException>(() => driver.CompactContextAsync(backend));
+        Assert.Empty(backend.SentTexts);
+    }
+
+    /// <summary>Cursor's compaction is not live-verified, exactly as its context clear is not. An
+    /// unverified verb stays absent rather than being typed hopefully at a real session.</summary>
+    [Fact]
+    public async Task CursorDriver_DeclaresNoCompaction_AndThrows()
+    {
+        IAgentDriver driver = new CursorDriver();
+        var backend = new RecordingSessionBackend();
+
+        Assert.False(driver.Capabilities.HasFlag(DriverCapabilities.CompactContext));
+        await Assert.ThrowsAsync<NotSupportedException>(() => driver.CompactContextAsync(backend));
+        Assert.Empty(backend.SentTexts);
+    }
+
+    /// <summary>A generic driver built with no compaction command has none, and says so.</summary>
+    [Fact]
+    public async Task GenericDriver_WithoutACompactCommand_DeclaresNothingAndThrows()
+    {
+        var driver = new GenericDriver(AgentKind.RawCli);
+        var backend = new RecordingSessionBackend();
+
+        Assert.False(driver.Capabilities.HasFlag(DriverCapabilities.CompactContext));
+        await Assert.ThrowsAsync<NotSupportedException>(() => driver.CompactContextAsync(backend));
+        Assert.Empty(backend.SentTexts);
+    }
+
+    // ===== The completion signal =====
+
+    [Fact]
+    public void ClaudeDriver_HasCompactedSince_TrueWhenTheMarkIsNewerThanTheRequest()
+    {
+        var submittedAt = new DateTime(2026, 7, 25, 10, 0, 0, DateTimeKind.Utc);
+        var driver = NewClaudeDriver(new StubTranscriptReader(submittedAt.AddSeconds(30)));
+
+        Assert.True(driver.HasCompactedSince("agent-1", @"C:\repo", submittedAt));
+    }
+
+    /// <summary>
+    /// The session being rescued has almost always compacted BEFORE - that is how it filled up again.
+    /// An older mark must not be read as the compaction we just asked for, or the follow-up prompt
+    /// would fire immediately, into a composer still busy summarizing.
+    /// </summary>
+    [Fact]
+    public void ClaudeDriver_HasCompactedSince_FalseForAnEarlierCompaction()
+    {
+        var submittedAt = new DateTime(2026, 7, 25, 10, 0, 0, DateTimeKind.Utc);
+        var driver = NewClaudeDriver(new StubTranscriptReader(submittedAt.AddHours(-3)));
+
+        Assert.False(driver.HasCompactedSince("agent-1", @"C:\repo", submittedAt));
+    }
+
+    [Fact]
+    public void ClaudeDriver_HasCompactedSince_FalseWhenTheTranscriptHasNeverBeenCompacted()
+    {
+        var driver = NewClaudeDriver(new StubTranscriptReader(compactionUtc: null));
+
+        Assert.False(driver.HasCompactedSince("agent-1", @"C:\repo", DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void ClaudeDriver_DeclaresItCanReportCompletion()
+    {
+        Assert.True(NewClaudeDriver().Capabilities.HasFlag(DriverCapabilities.CompactCompletionReport));
+    }
+
+    /// <summary>
+    /// Typing a command is not the same competence as knowing when it finished. These tools can be told
+    /// to compact but their records are not read here, so they must NOT claim a completion report -
+    /// that claim is what compact-and-continue times the follow-up on.
+    /// </summary>
+    [Theory]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Gemini)]
+    [InlineData(AgentKind.Grok)]
+    [InlineData(AgentKind.OpenCode)]
+    public void DriversWithoutRecordsWeRead_DoNotClaimACompletionReport(AgentKind kind)
+    {
+        var driver = AgentDrivers.For(kind);
+
+        Assert.False(driver.Capabilities.HasFlag(DriverCapabilities.CompactCompletionReport));
+        Assert.Throws<NotSupportedException>(() => driver.HasCompactedSince("agent-1", @"C:\repo", DateTime.UtcNow));
+    }
+}

--- a/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
@@ -296,5 +296,6 @@ public sealed class ContextUsageTests
         public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => new();
         public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => _usage;
         public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+        public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) => null;
     }
 }

--- a/src/CcDirector.Core.Tests/Drivers/EmptyTranscriptReader.cs
+++ b/src/CcDirector.Core.Tests/Drivers/EmptyTranscriptReader.cs
@@ -10,4 +10,40 @@ internal sealed class EmptyTranscriptReader : ITranscriptReader
     public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => null;
 
     public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+
+    /// <summary>Never compacted. Tests that care about compaction use <see cref="StubTranscriptReader"/>.</summary>
+    public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) => null;
+}
+
+/// <summary>
+/// A transcript store whose compaction mark the test sets - including "the mark appears only after N
+/// reads", which is what a compaction that takes a while actually looks like from outside.
+/// </summary>
+internal sealed class StubTranscriptReader : ITranscriptReader
+{
+    private readonly int _readsBeforeMark;
+
+    public StubTranscriptReader(DateTime? compactionUtc = null, int readsBeforeMark = 0)
+    {
+        CompactionUtc = compactionUtc;
+        _readsBeforeMark = readsBeforeMark;
+    }
+
+    /// <summary>The mark the store reports once <see cref="Reads"/> passes readsBeforeMark.</summary>
+    public DateTime? CompactionUtc { get; set; }
+
+    /// <summary>How many times the mark has been read - the proof that waiting actually polls.</summary>
+    public int Reads { get; private set; }
+
+    public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => new();
+
+    public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => null;
+
+    public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+
+    public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath)
+    {
+        Reads++;
+        return Reads > _readsBeforeMark ? CompactionUtc : null;
+    }
 }

--- a/src/CcDirector.Core.Tests/Drivers/ModelReportTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ModelReportTests.cs
@@ -344,5 +344,6 @@ public sealed class ModelReportTests
         public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => new();
         public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => _usage;
         public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+        public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) => null;
     }
 }

--- a/src/CcDirector.Core.Tests/Drivers/SessionAskRunnerTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/SessionAskRunnerTests.cs
@@ -534,4 +534,6 @@ internal sealed class FakeAskTranscriptReader : ITranscriptReader
 
     public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) =>
         _widgets.Keys.Select(k => (k, DateTime.UtcNow)).ToList();
+
+    public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) => null;
 }

--- a/src/CcDirector.Core.Tests/Sessions/SessionCompactContextTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionCompactContextTests.cs
@@ -1,0 +1,341 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// Issue #2150 - compact AND CONTINUE, the part that actually rescues a stuck session.
+///
+/// The failure this prevents is specific. A session whose context window is full swallows everything
+/// sent to it, so the follow-up prompt is only worth anything AFTER the compaction has finished. Timing
+/// it on a sleep would fire it into a composer mid-summary and it would vanish exactly like every
+/// message before it. So the follow-up is gated on the tool's own completion signal, a tool that cannot
+/// give that signal is refused rather than guessed at, and a compaction that never reports finishing
+/// fails loudly instead of quietly reporting success.
+/// </summary>
+public sealed class SessionCompactContextTests
+{
+    private static readonly TimeSpan ShortWait = TimeSpan.FromMilliseconds(600);
+    private static readonly TimeSpan FastPoll = TimeSpan.FromMilliseconds(10);
+
+    private static Session NewSession(StubDriver driver, string? agentSessionId = "agent-1")
+    {
+        var session = new Session(
+            Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new RecordingBackend(), claudeSessionId: agentSessionId,
+            activityState: ActivityState.WaitingForInput, createdAt: DateTimeOffset.UtcNow,
+            customName: null, customColor: null);
+        session.DriverOverride = driver;
+        return session;
+    }
+
+    private static RecordingBackend BackendOf(Session session) => (RecordingBackend)session.Backend;
+
+    [Fact]
+    public async Task CompactContextAsync_SubmitsTheCompactionCommand()
+    {
+        var driver = new StubDriver { CompactedAt = DateTime.UtcNow.AddSeconds(1) };
+        using var session = NewSession(driver);
+
+        await session.CompactContextAsync(continuePrompt: null, default, ShortWait, FastPoll);
+
+        Assert.Equal(1, driver.CompactCalls);
+    }
+
+    /// <summary>The whole feature in one test: wait for the finish, THEN send the follow-up.</summary>
+    [Fact]
+    public async Task CompactContextAsync_WithAContinuation_WaitsForTheFinishThenSendsIt()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 3 };
+        using var session = NewSession(driver);
+
+        var outcome = await session.CompactContextAsync("continue", default, ShortWait, FastPoll);
+
+        Assert.True(outcome.Submitted);
+        Assert.True(outcome.CompactionObserved);
+        Assert.True(outcome.Continued);
+        Assert.Equal("continue", Assert.Single(BackendOf(session).SentTexts));
+        Assert.True(driver.Probes >= 3, $"expected the wait to poll for the finish; probes={driver.Probes}");
+    }
+
+    /// <summary>
+    /// The follow-up must not go out while the tool is still summarizing - that is the exact way the
+    /// original message was lost. Nothing is sent on any probe before the completion signal appears.
+    /// </summary>
+    [Fact]
+    public async Task CompactContextAsync_SendsNothingBeforeTheCompactionFinishes()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 4 };
+        using var session = NewSession(driver);
+        var backend = BackendOf(session);
+        driver.OnProbe = () => Assert.Empty(backend.SentTexts);
+
+        await session.CompactContextAsync("continue", default, ShortWait, FastPoll);
+
+        Assert.Equal("continue", Assert.Single(backend.SentTexts));
+    }
+
+    [Fact]
+    public async Task CompactContextAsync_WithoutAContinuation_SendsNothingAfterwards()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 1 };
+        using var session = NewSession(driver);
+
+        var outcome = await session.CompactContextAsync(continuePrompt: null, default, ShortWait, FastPoll);
+
+        Assert.True(outcome.CompactionObserved);
+        Assert.False(outcome.Continued);
+        Assert.Empty(BackendOf(session).SentTexts);
+    }
+
+    /// <summary>Blank is not a follow-up. A caller passing whitespace gets a compaction, not an empty turn.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CompactContextAsync_TreatsBlankContinuationAsNoContinuation(string blank)
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 1 };
+        using var session = NewSession(driver);
+
+        var outcome = await session.CompactContextAsync(blank, default, ShortWait, FastPoll);
+
+        Assert.False(outcome.Continued);
+        Assert.Empty(BackendOf(session).SentTexts);
+    }
+
+    /// <summary>
+    /// A compaction that never reports finishing must FAIL, and say so. Returning a success outcome here
+    /// would tell a rescuing agent the session is moving again when it is still wedged.
+    /// </summary>
+    [Fact]
+    public async Task CompactContextAsync_ThrowsWhenTheCompactionNeverReportsFinishing()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = int.MaxValue };
+        using var session = NewSession(driver);
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => session.CompactContextAsync("continue", default, ShortWait, FastPoll));
+
+        Assert.Contains("did not report a finished compaction", ex.Message);
+        Assert.Empty(BackendOf(session).SentTexts);
+    }
+
+    /// <summary>
+    /// A tool that can be told to compact but cannot report finishing is refused the CONTINUATION - and
+    /// refused before anything is typed at it, so the caller can choose to compact plainly instead.
+    /// </summary>
+    [Fact]
+    public async Task CompactContextAsync_RefusesAContinuationWhenTheDriverCannotReportCompletion()
+    {
+        var driver = new StubDriver { CanReportCompletion = false };
+        using var session = NewSession(driver);
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => session.CompactContextAsync("continue", default, ShortWait, FastPoll));
+
+        Assert.Contains("cannot report when a compaction finished", ex.Message);
+        Assert.Equal(0, driver.CompactCalls);
+        Assert.Empty(BackendOf(session).SentTexts);
+    }
+
+    /// <summary>Without a continuation, that same tool still compacts - and the outcome says plainly that
+    /// the finish was not watched rather than implying it was.</summary>
+    [Fact]
+    public async Task CompactContextAsync_CompactsWithoutWatchingWhenTheDriverCannotReportCompletion()
+    {
+        var driver = new StubDriver { CanReportCompletion = false };
+        using var session = NewSession(driver);
+
+        var outcome = await session.CompactContextAsync(continuePrompt: null, default, ShortWait, FastPoll);
+
+        Assert.True(outcome.Submitted);
+        Assert.False(outcome.CompactionObserved);
+        Assert.False(outcome.Continued);
+        Assert.Contains("cannot report when it finishes", outcome.Detail);
+        Assert.Equal(1, driver.CompactCalls);
+    }
+
+    [Fact]
+    public async Task CompactContextAsync_RefusesWhenTheDriverDeclaresNoCompaction()
+    {
+        var driver = new StubDriver { CanCompact = false };
+        using var session = NewSession(driver);
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => session.CompactContextAsync(continuePrompt: null, default, ShortWait, FastPoll));
+
+        Assert.Contains("declares no compaction", ex.Message);
+        Assert.Equal(0, driver.CompactCalls);
+    }
+
+    /// <summary>Before the first turn there is no conversation to watch, so a continuation cannot be timed.</summary>
+    [Fact]
+    public async Task CompactContextAsync_RefusesAContinuationBeforeTheSessionHasAnAgentSessionId()
+    {
+        var driver = new StubDriver();
+        using var session = NewSession(driver, agentSessionId: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => session.CompactContextAsync("continue", default, ShortWait, FastPoll));
+
+        Assert.Equal(0, driver.CompactCalls);
+    }
+
+    /// <summary>
+    /// Compaction continues under the SAME agent session id. Re-pointing the session at a new transcript
+    /// - which is right for a CLEAR - would here detach it from the conversation it just preserved.
+    /// </summary>
+    [Fact]
+    public async Task CompactContextAsync_LeavesTheAgentSessionIdAlone()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 1 };
+        using var session = NewSession(driver);
+
+        await session.CompactContextAsync("continue", default, ShortWait, FastPoll);
+
+        Assert.Equal("agent-1", session.ClaudeSessionId);
+    }
+
+    /// <summary>
+    /// The follow-up is the product's own text, not the owner coming back. Counting it as an owner turn
+    /// would silently end a hold the owner had set on the session being rescued.
+    /// </summary>
+    [Fact]
+    public async Task CompactContextAsync_ContinuationDoesNotCountAsAnOwnerTurn()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 1 };
+        using var session = NewSession(driver);
+        var before = session.LastOwnerTurnAtUtc;
+
+        await session.CompactContextAsync("continue", default, ShortWait, FastPoll);
+
+        Assert.Equal(before, session.LastOwnerTurnAtUtc);
+    }
+
+    /// <summary>A driver that declares compaction is called for it - and never for a CLEAR instead.</summary>
+    [Fact]
+    public async Task CompactContextAsync_NeverClearsTheContext()
+    {
+        var driver = new StubDriver { CompletesAfterProbes = 1 };
+        using var session = NewSession(driver);
+
+        await session.CompactContextAsync("continue", default, ShortWait, FastPoll);
+
+        Assert.Equal(0, driver.ClearCalls);
+    }
+
+    /// <summary>
+    /// The Director's own wait must expire BEFORE the Gateway stops waiting for the Director, or the
+    /// specific message ("the tool never reported a finished compaction") is masked by the generic one
+    /// ("the Director did not answer"). The Gateway side asserts the other half of this ordering.
+    /// </summary>
+    [Fact]
+    public void CompactionWaitTimeout_IsShorterThanThreeMinutes()
+    {
+        Assert.True(Session.CompactionWaitTimeout < TimeSpan.FromMinutes(3),
+            "the Director's compaction wait must fire before the Gateway's wait for the Director");
+    }
+
+    // ===== Stubs =====
+
+    /// <summary>A driver whose capabilities and completion signal the test dictates.</summary>
+    private sealed class StubDriver : IAgentDriver
+    {
+        public bool CanCompact { get; init; } = true;
+        public bool CanReportCompletion { get; init; } = true;
+
+        /// <summary>Report the compaction finished once this many probes have been answered.</summary>
+        public int CompletesAfterProbes { get; init; } = 1;
+
+        /// <summary>A completion time to report immediately, bypassing the probe count.</summary>
+        public DateTime? CompactedAt { get; init; }
+
+        public Action? OnProbe { get; set; }
+
+        public int CompactCalls { get; private set; }
+        public int ClearCalls { get; private set; }
+        public int Probes { get; private set; }
+
+        public AgentKind Kind => AgentKind.ClaudeCode;
+
+        public DriverCapabilities Capabilities =>
+            (CanCompact ? DriverCapabilities.CompactContext : DriverCapabilities.None)
+            | (CanReportCompletion ? DriverCapabilities.CompactCompletionReport : DriverCapabilities.None);
+
+        public IReadOnlyList<AgentSlashCommand> SlashCommands => [];
+        public string ModelFlag => "";
+        public IReadOnlyList<AgentModelOption> KnownModels => [];
+        public string? ReadConfiguredDefaultModel() => null;
+
+        public string ResolveExecutable(string? configuredPath) => throw new NotSupportedException();
+        public AgentLaunchSpec BuildLaunchSpec(string? baseArgs, string? resumeSessionId) => throw new NotSupportedException();
+        public Task SubmitAsync(ISessionBackend backend, string text) => backend.SendTextAsync(text);
+        public Task CancelAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task InterruptAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task ShowHistoryAsync(ISessionBackend backend) => Task.CompletedTask;
+
+        public Task ClearContextAsync(ISessionBackend backend)
+        {
+            ClearCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task CompactContextAsync(ISessionBackend backend)
+        {
+            if (!CanCompact)
+                throw new NotSupportedException("stub declares no compaction");
+            CompactCalls++;
+            return Task.CompletedTask;
+        }
+
+        public bool HasCompactedSince(string agentSessionId, string workingDirectory, DateTime sinceUtc)
+        {
+            if (!CanReportCompletion)
+                throw new NotSupportedException("stub cannot report completion");
+            OnProbe?.Invoke();
+            Probes++;
+            if (CompactedAt is not null)
+                return CompactedAt.Value >= sinceUtc;
+            return Probes >= CompletesAfterProbes;
+        }
+
+        public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) => new();
+        public SessionUsageDto? ReadUsage(string agentSessionId, string workingDirectory) => null;
+        public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) => new();
+    }
+
+    private sealed class RecordingBackend : ISessionBackend
+    {
+        public List<string> SentTexts { get; } = new();
+
+        public int ProcessId => 1;
+        public string Status => "Running";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface, never raised here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+
+        public Task SendTextAsync(string text)
+        {
+            SentTexts.Add(text);
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Core/Claude/CompactionMarker.cs
+++ b/src/CcDirector.Core/Claude/CompactionMarker.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Claude;
+
+/// <summary>
+/// Reads the COMPACTION mark out of a claude transcript (issue #2150).
+///
+/// When claude compacts a conversation - whether a person typed <c>/compact</c>, the Director
+/// commanded it, or the tool auto-compacted on its own - it appends one entry carrying
+/// <c>isCompactSummary: true</c>: the summary the next turn is continued from. Crucially it appends
+/// that entry to the SAME transcript file under the SAME session id, so compaction is observable
+/// without re-linking anything. Verified against live transcripts written by claude 2.1.195 through
+/// 2.1.218 (the summary line, the file's first line and its last line all carry one session id).
+///
+/// This is the completion signal for compact-and-continue: the Director submits the compaction
+/// command, then watches here for a mark stamped after the moment it submitted, and only then sends
+/// the follow-up prompt. Terminal quiet would be a guess; this is the tool's own record.
+/// </summary>
+public static class CompactionMarker
+{
+    /// <summary>The transcript field that marks a compaction summary entry.</summary>
+    private const string MarkerField = "isCompactSummary";
+
+    /// <summary>
+    /// The timestamp of the NEWEST compaction mark in this transcript, or null when the file does not
+    /// exist, has no compaction mark, or carries a mark with no readable timestamp. Reads the file line
+    /// by line with a cheap substring pre-filter, so an unrelated multi-megabyte transcript costs a scan
+    /// and no JSON parsing.
+    /// </summary>
+    public static DateTime? ReadLastCompactionUtc(string jsonlPath)
+    {
+        if (string.IsNullOrWhiteSpace(jsonlPath) || !File.Exists(jsonlPath))
+            return null;
+
+        DateTime? newest = null;
+        using var stream = new FileStream(jsonlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        while (reader.ReadLine() is { } line)
+        {
+            if (line.Length == 0 || !line.Contains(MarkerField, StringComparison.Ordinal))
+                continue;
+
+            var stamp = ReadMarkedTimestamp(line);
+            if (stamp is not null && (newest is null || stamp > newest))
+                newest = stamp;
+        }
+
+        return newest;
+    }
+
+    /// <summary>
+    /// The entry's timestamp when the line IS a compaction mark, else null. A line mentioning the field
+    /// inside message text is not a mark: the value must be the boolean true at the top level.
+    /// </summary>
+    private static DateTime? ReadMarkedTimestamp(string line)
+    {
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(line);
+        }
+        catch (JsonException)
+        {
+            // A partially-written last line while claude is mid-append. The next poll reads it whole.
+            return null;
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+            if (!root.TryGetProperty(MarkerField, out var marker) || marker.ValueKind != JsonValueKind.True)
+                return null;
+            if (!root.TryGetProperty("timestamp", out var timestamp) || timestamp.ValueKind != JsonValueKind.String)
+            {
+                FileLog.Write("[CompactionMarker] compaction mark carries no readable timestamp; ignoring it");
+                return null;
+            }
+            return timestamp.TryGetDateTime(out var parsed) ? parsed.ToUniversalTime() : null;
+        }
+    }
+}

--- a/src/CcDirector.Core/Drivers/AgentDrivers.cs
+++ b/src/CcDirector.Core/Drivers/AgentDrivers.cs
@@ -23,11 +23,14 @@ public static class AgentDrivers
         AgentKind.Codex => new CodexDriver(),
         // Gemini wires NO current-model reader: the installed binary (0.1.11) records no model
         // anywhere readable (issue #1637) - re-probe after it is upgraded.
-        AgentKind.Gemini => new GenericDriver(k, GeminiSlashCommands.All),
+        // The compaction command each tool documents in its OWN catalog (issue #2150) - gemini alone
+        // spells it /compress, which is exactly why the command belongs to the driver and not to one
+        // shared string at the call site.
+        AgentKind.Gemini => new GenericDriver(k, GeminiSlashCommands.All, compactCommand: "/compress"),
         AgentKind.OpenCode => new GenericDriver(k, OpenCodeSlashCommands.All,
-            currentModelReader: OpenCode.OpenCodeCurrentModel.ReadForRepo),
+            currentModelReader: OpenCode.OpenCodeCurrentModel.ReadForRepo, compactCommand: "/compact"),
         AgentKind.Grok => new GenericDriver(k, GrokSlashCommands.All, emitsContinuousIdleOutput: true,
-            currentModelReader: Grok.GrokCurrentModel.ReadForRepo),
+            currentModelReader: Grok.GrokCurrentModel.ReadForRepo, compactCommand: "/compact"),
         _ => new GenericDriver(k),
     });
 }

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -50,7 +50,9 @@ public sealed class ClaudeDriver : IAgentDriver
         | DriverCapabilities.ModelSelection
         | DriverCapabilities.ContextUsage
         | DriverCapabilities.ModelReport
-        | DriverCapabilities.TokenUsage;
+        | DriverCapabilities.TokenUsage
+        | DriverCapabilities.CompactContext
+        | DriverCapabilities.CompactCompletionReport;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => BuiltInSlashCommands.All
         .Select(command => new AgentSlashCommand(
@@ -200,6 +202,32 @@ public sealed class ClaudeDriver : IAgentDriver
         ArgumentNullException.ThrowIfNull(backend);
         FileLog.Write("[ClaudeDriver] ClearContextAsync: submitting /clear");
         return backend.SendTextAsync("/clear");
+    }
+
+    /// <summary>
+    /// Claude's <c>/compact</c>: it summarizes the conversation so far and continues from the summary,
+    /// in the SAME agent session. Submitted the same way a person would type it - through the shared
+    /// composer submit, so a composer that is not accepting input fails loud rather than dropping the
+    /// command into the void.
+    /// </summary>
+    public Task CompactContextAsync(ISessionBackend backend)
+    {
+        ArgumentNullException.ThrowIfNull(backend);
+        FileLog.Write("[ClaudeDriver] CompactContextAsync: submitting /compact");
+        return backend.SendTextAsync("/compact");
+    }
+
+    /// <summary>
+    /// Has claude finished a compaction since <paramref name="sinceUtc"/>? Read from its own transcript:
+    /// a completed compaction appends an entry carrying <c>isCompactSummary</c>, stamped with the moment
+    /// it landed. The mark must be NEWER than the moment we submitted the command, so an older compaction
+    /// in the same conversation - and this session has usually compacted before - can never be mistaken
+    /// for the one we just asked for.
+    /// </summary>
+    public bool HasCompactedSince(string agentSessionId, string workingDirectory, DateTime sinceUtc)
+    {
+        var last = _transcripts.LastCompactionUtc(agentSessionId, workingDirectory);
+        return last is not null && last.Value >= sinceUtc;
     }
 
     public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory)

--- a/src/CcDirector.Core/Drivers/CodexDriver.cs
+++ b/src/CcDirector.Core/Drivers/CodexDriver.cs
@@ -22,7 +22,12 @@ public sealed class CodexDriver : IAgentDriver
         | DriverCapabilities.Interrupt
         | DriverCapabilities.ClearContext
         | DriverCapabilities.ContextUsage
-        | DriverCapabilities.ModelReport;
+        | DriverCapabilities.ModelReport
+        // Codex compacts with /compact, the same command its own catalog documents. It gets
+        // CompactContext but NOT CompactCompletionReport: the Director cannot read codex's records to
+        // learn when a compaction finished, so compact-and-continue refuses for codex rather than
+        // timing the follow-up on a guess (issue #2150).
+        | DriverCapabilities.CompactContext;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => CodexSlashCommands.All;
 
@@ -93,6 +98,14 @@ public sealed class CodexDriver : IAgentDriver
         ArgumentNullException.ThrowIfNull(backend);
         FileLog.Write("[CodexDriver] ClearContextAsync: submitting /clear");
         return backend.SendTextAsync("/clear");
+    }
+
+    /// <summary>Codex's in-place summarize: the /compact command its own catalog documents.</summary>
+    public Task CompactContextAsync(ISessionBackend backend)
+    {
+        ArgumentNullException.ThrowIfNull(backend);
+        FileLog.Write("[CodexDriver] CompactContextAsync: submitting /compact");
+        return backend.SendTextAsync("/compact");
     }
 
     public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) =>

--- a/src/CcDirector.Core/Drivers/GenericDriver.cs
+++ b/src/CcDirector.Core/Drivers/GenericDriver.cs
@@ -23,17 +23,28 @@ public sealed class GenericDriver : IAgentDriver
 
     private readonly IReadOnlyList<AgentSlashCommand> _slashCommands;
     private readonly Func<string, string?>? _currentModelReader;
+    private readonly string? _compactCommand;
 
+    /// <param name="compactCommand">
+    /// The command THIS tool compacts with, when it has one and we have read it from the tool's own
+    /// catalog - "/compact" for grok and opencode, "/compress" for gemini (issue #2150). Supplying it
+    /// declares <see cref="DriverCapabilities.CompactContext"/>; leaving it null keeps compaction
+    /// honestly absent, which is the right answer for a tool with no such command. It never declares
+    /// <see cref="DriverCapabilities.CompactCompletionReport"/>: typing a command is not the same as
+    /// being able to observe it finish, and these tools' records are not read here.
+    /// </param>
     public GenericDriver(
         AgentKind kind,
         IReadOnlyList<AgentSlashCommand>? slashCommands = null,
         bool emitsContinuousIdleOutput = false,
-        Func<string, string?>? currentModelReader = null)
+        Func<string, string?>? currentModelReader = null,
+        string? compactCommand = null)
     {
         Kind = kind;
         _slashCommands = slashCommands ?? [];
         EmitsContinuousIdleOutput = emitsContinuousIdleOutput;
         _currentModelReader = currentModelReader;
+        _compactCommand = string.IsNullOrWhiteSpace(compactCommand) ? null : compactCommand.Trim();
     }
 
     public AgentKind Kind { get; }
@@ -41,7 +52,8 @@ public sealed class GenericDriver : IAgentDriver
     public DriverCapabilities Capabilities =>
         DriverCapabilities.Cancel
         | DriverCapabilities.Interrupt
-        | (_currentModelReader is not null ? DriverCapabilities.ModelReport : DriverCapabilities.None);
+        | (_currentModelReader is not null ? DriverCapabilities.ModelReport : DriverCapabilities.None)
+        | (_compactCommand is not null ? DriverCapabilities.CompactContext : DriverCapabilities.None);
 
     /// <summary>
     /// Set true for Grok: its idle terminal keeps repainting an animated footer (spinner +
@@ -92,6 +104,19 @@ public sealed class GenericDriver : IAgentDriver
 
     public Task ClearContextAsync(ISessionBackend backend) =>
         throw new NotSupportedException($"[GenericDriver] {Kind} has no verified context-clear command.");
+
+    /// <summary>
+    /// Submit the compaction command this tool was constructed with. A tool constructed WITHOUT one has
+    /// no compaction we have read, and says so rather than typing a plausible guess at its composer.
+    /// </summary>
+    public Task CompactContextAsync(ISessionBackend backend)
+    {
+        ArgumentNullException.ThrowIfNull(backend);
+        if (_compactCommand is null)
+            throw new NotSupportedException($"[GenericDriver] {Kind} has no known compaction command.");
+        FileLog.Write($"[GenericDriver:{Kind}] CompactContextAsync: submitting {_compactCommand}");
+        return backend.SendTextAsync(_compactCommand);
+    }
 
     public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) =>
         throw new NotSupportedException($"[GenericDriver] {Kind} has no verified transcript format.");

--- a/src/CcDirector.Core/Drivers/IAgentDriver.cs
+++ b/src/CcDirector.Core/Drivers/IAgentDriver.cs
@@ -67,6 +67,25 @@ public enum DriverCapabilities
     /// drivers implement <see cref="IAgentDriver.ReadUsage"/> as a throw, so calling it ungated would
     /// use an exception as control flow at every turn-end.</summary>
     TokenUsage = 512,
+
+    /// <summary>The tool can SUMMARIZE its own conversation in place, freeing context window while
+    /// keeping what it has learned (claude's <c>/compact</c>, gemini's <c>/compress</c>). Distinct
+    /// from <see cref="ClearContext"/>, which throws the conversation away: a compacted session
+    /// remembers what it was doing, a cleared one does not. Also distinct in a way that matters to
+    /// the host - clearing starts a NEW agent conversation and forces a transcript re-link, while
+    /// compaction continues under the SAME agent session id, so nothing is re-linked (issue #2150).
+    /// A tool with no compaction command at all (Copilot) declares this absent and throws.</summary>
+    CompactContext = 1024,
+
+    /// <summary>The driver can tell when a compaction it started has FINISHED
+    /// (<see cref="IAgentDriver.HasCompactedSince"/>), by reading the tool's own records rather than
+    /// guessing from terminal quiet. Separate from <see cref="CompactContext"/> because submitting
+    /// the command and knowing when it is done are different competences: claude has both (its
+    /// transcript gains a compaction-summary entry), while a tool we can only type at has the first
+    /// without the second. Compact-AND-CONTINUE requires this flag - without it there is no honest
+    /// moment at which to send the follow-up prompt, so the Director refuses rather than guessing a
+    /// delay and firing the prompt into a busy composer.</summary>
+    CompactCompletionReport = 2048,
 }
 
 /// <summary>
@@ -145,6 +164,30 @@ public interface IAgentDriver
     /// re-discovering the tool's new transcript id afterwards via
     /// <see cref="ListTranscripts"/>.</summary>
     Task ClearContextAsync(ISessionBackend backend);
+
+    /// <summary>
+    /// Summarize the conversation in place (capability <see cref="DriverCapabilities.CompactContext"/>):
+    /// the tool rewrites its own history down to a summary and carries on. Unlike
+    /// <see cref="ClearContextAsync"/> this keeps the tool's conversation identity, so the host must NOT
+    /// re-link a transcript afterwards. The default throws <see cref="NotSupportedException"/> so a tool
+    /// with no compaction command is honestly absent - never emulated with a clear, which would silently
+    /// destroy the very work compaction exists to preserve.
+    /// </summary>
+    Task CompactContextAsync(ISessionBackend backend) =>
+        throw new NotSupportedException(
+            $"[{GetType().Name}] {Kind} does not declare DriverCapabilities.CompactContext.");
+
+    /// <summary>
+    /// Has a compaction finished since <paramref name="sinceUtc"/> (capability
+    /// <see cref="DriverCapabilities.CompactCompletionReport"/>)? Read from the tool's own records - for
+    /// claude, a compaction-summary entry in the transcript. This is the completion signal that lets the
+    /// host wait for a compaction and only then send a follow-up prompt. The default throws
+    /// <see cref="NotSupportedException"/>: a driver that cannot observe completion says so, rather than
+    /// returning false forever (a silent never-finishes) or true immediately (a lie).
+    /// </summary>
+    bool HasCompactedSince(string agentSessionId, string workingDirectory, DateTime sinceUtc) =>
+        throw new NotSupportedException(
+            $"[{GetType().Name}] {Kind} does not declare DriverCapabilities.CompactCompletionReport.");
 
     /// <summary>Parsed conversation widgets of one transcript, chronological; empty
     /// when the transcript does not exist yet (capability TranscriptRead).</summary>

--- a/src/CcDirector.Core/Drivers/ITranscriptReader.cs
+++ b/src/CcDirector.Core/Drivers/ITranscriptReader.cs
@@ -19,6 +19,11 @@ public interface ITranscriptReader
 
     /// <summary>The repo's transcript files, newest first.</summary>
     List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath);
+
+    /// <summary>The timestamp of the newest COMPACTION mark in this transcript, or null when the file
+    /// does not exist or has never been compacted. The completion signal for compact-and-continue
+    /// (issue #2150).</summary>
+    DateTime? LastCompactionUtc(string claudeSessionId, string repoPath);
 }
 
 /// <summary>Disk-backed implementation over the same Core readers the Director uses.</summary>
@@ -43,4 +48,7 @@ public sealed class ClaudeTranscriptReader : ITranscriptReader
 
     public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath)
         => ClaudeSessionReader.ListTranscripts(repoPath);
+
+    public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath)
+        => CompactionMarker.ReadLastCompactionUtc(ClaudeSessionReader.GetJsonlPath(claudeSessionId, repoPath));
 }

--- a/src/CcDirector.Core/Drivers/PiDriver.cs
+++ b/src/CcDirector.Core/Drivers/PiDriver.cs
@@ -33,7 +33,11 @@ public sealed class PiDriver : IAgentDriver
         DriverCapabilities.Cancel
         | DriverCapabilities.ClearContext
         | DriverCapabilities.ContextUsage
-        | DriverCapabilities.ModelReport;
+        | DriverCapabilities.ModelReport
+        // pi compacts with /compact (its own catalog: "Manually compact context"). No completion
+        // report: pi transcript parsing is not implemented, so there is nothing to read a finish from,
+        // and compact-and-continue refuses for pi rather than guessing (issue #2150).
+        | DriverCapabilities.CompactContext;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => PiSlashCommands.All;
 
@@ -84,6 +88,14 @@ public sealed class PiDriver : IAgentDriver
         ArgumentNullException.ThrowIfNull(backend);
         FileLog.Write("[PiDriver] ClearContextAsync: submitting /new");
         return backend.SendTextAsync("/new");
+    }
+
+    /// <summary>pi's in-place summarize: /compact, distinct from /new which starts over.</summary>
+    public Task CompactContextAsync(ISessionBackend backend)
+    {
+        ArgumentNullException.ThrowIfNull(backend);
+        FileLog.Write("[PiDriver] CompactContextAsync: submitting /compact");
+        return backend.SendTextAsync("/compact");
     }
 
     public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) =>

--- a/src/CcDirector.Core/Sessions/CompactContextOutcome.cs
+++ b/src/CcDirector.Core/Sessions/CompactContextOutcome.cs
@@ -1,0 +1,21 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// What actually happened when a session was told to compact (issue #2150). Every field is a fact the
+/// caller would otherwise have to assume: whether the command reached the tool, whether the tool was
+/// seen to FINISH, how long that took, and whether the follow-up prompt went out. A caller reading
+/// only "accepted" would call a compaction that never completed a success.
+/// </summary>
+/// <param name="Submitted">The compaction command reached the tool's composer.</param>
+/// <param name="CompactionObserved">The tool's own records confirm a compaction finished after we asked
+/// for one. False when the driver cannot report completion - which is a stated limit, not a failure.</param>
+/// <param name="WaitedSeconds">Seconds between submitting the command and observing it finish; 0 when
+/// completion was not watched.</param>
+/// <param name="Continued">The follow-up prompt was submitted after the compaction finished.</param>
+/// <param name="Detail">One plain-English sentence for a person or an agent reading the result.</param>
+public sealed record CompactContextOutcome(
+    bool Submitted,
+    bool CompactionObserved,
+    double WaitedSeconds,
+    bool Continued,
+    string Detail);

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -2280,10 +2280,19 @@ public sealed class Session : IDisposable
     // GenericDriver (the pre-driver bytes, minimal declared capabilities). UIs and
     // endpoints read Driver.Capabilities to know which verbs this session supports.
 
+    /// <summary>
+    /// Test seam: a driver supplied directly instead of resolved from <see cref="AgentKind"/>. Null in
+    /// every real session - drivers are resolved from the kind, never assigned - and settable only from
+    /// this assembly's tests, so the verbs below can be exercised against a stub driver without a live
+    /// agent process and without reading the developer's own transcript store.
+    /// </summary>
+    internal Drivers.IAgentDriver? DriverOverride { get; set; }
+
     /// <summary>The interaction driver for this session's CLI. Stateless singleton.</summary>
-    public Drivers.IAgentDriver Driver => AgentPlugins.AgentPluginRegistry.Contains(AgentKind)
-        ? AgentPlugins.AgentPluginRegistry.Get(AgentKind).Driver
-        : Drivers.AgentDrivers.For(AgentKind);
+    public Drivers.IAgentDriver Driver => DriverOverride
+        ?? (AgentPlugins.AgentPluginRegistry.Contains(AgentKind)
+            ? AgentPlugins.AgentPluginRegistry.Get(AgentKind).Driver
+            : Drivers.AgentDrivers.For(AgentKind));
 
     /// <summary>Soft-stop the current turn (Esc for Claude and pi).</summary>
     public async Task CancelTurnAsync()
@@ -2356,6 +2365,119 @@ public sealed class Session : IDisposable
         }
         throw new InvalidOperationException(
             $"ClearContextAsync: no new transcript appeared within 60s (session={Id}, oldId={oldId})");
+    }
+
+    /// <summary>
+    /// How long a compaction is allowed to take before the Director stops waiting for it. This is the
+    /// INNER bound of the compact-and-continue call and must stay strictly shorter than the Gateway's
+    /// outer wait for the verb (DirectorCommandRouter.LanguageModelCommandTimeout, 3 minutes), so the
+    /// inner one always fires first and reports WHAT failed - "the tool never reported a finished
+    /// compaction" - instead of the outer one masking it with "the Director did not answer".
+    /// </summary>
+    public static readonly TimeSpan CompactionWaitTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>How often the completion mark is re-read while waiting. The tool writes it once; there is
+    /// nothing to gain from a tighter loop over a file that only grows.</summary>
+    private static readonly TimeSpan CompactionPollInterval = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Compact the conversation in place and, when asked, CONTINUE it (issue #2150).
+    ///
+    /// A session whose context window is full cannot read anything sent to it - every prompt is swallowed
+    /// and the tool prints its context-limit line again - so nothing but compaction gets it moving, and
+    /// until now nothing but a person at that keyboard could compact it. This is that verb.
+    ///
+    /// Unlike <see cref="ClearContextAsync"/> there is NO transcript re-link: compaction continues under
+    /// the same agent session id (verified against live claude transcripts), so re-linking would wait for
+    /// a new transcript that is never coming.
+    ///
+    /// The continuation is timed on the tool's OWN completion signal, never on a delay: with
+    /// <paramref name="continuePrompt"/> set, the follow-up is submitted only once the driver reports the
+    /// compaction finished. A driver that cannot report completion refuses the continuation outright
+    /// rather than firing a prompt into a composer that is still summarizing.
+    /// </summary>
+    /// <param name="continuePrompt">The text to send once compaction finishes, or null/blank to compact only.</param>
+    /// <param name="ct">Cancels the wait promptly; the compaction itself is already submitted by then.</param>
+    /// <param name="waitTimeout">Overrides <see cref="CompactionWaitTimeout"/>. Tests pass a short one so the
+    /// give-up path can be proven in milliseconds instead of minutes; callers pass null.</param>
+    /// <param name="pollInterval">Overrides <see cref="CompactionPollInterval"/>, same reason.</param>
+    public async Task<CompactContextOutcome> CompactContextAsync(
+        string? continuePrompt = null,
+        CancellationToken ct = default,
+        TimeSpan? waitTimeout = null,
+        TimeSpan? pollInterval = null)
+    {
+        if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed)
+            throw new InvalidOperationException($"CompactContextAsync: session {Id} is not running (status={Status})");
+
+        var driver = Driver;
+        if (!driver.Capabilities.HasFlag(Drivers.DriverCapabilities.CompactContext))
+            throw new NotSupportedException($"CompactContextAsync: the {driver.Kind} driver declares no compaction.");
+
+        var wantsContinue = !string.IsNullOrWhiteSpace(continuePrompt);
+        var agentSessionId = ClaudeSessionId;
+        var canObserve = driver.Capabilities.HasFlag(Drivers.DriverCapabilities.CompactCompletionReport)
+                         && !string.IsNullOrEmpty(agentSessionId);
+
+        if (wantsContinue && !driver.Capabilities.HasFlag(Drivers.DriverCapabilities.CompactCompletionReport))
+            throw new NotSupportedException(
+                $"CompactContextAsync: the {driver.Kind} driver cannot report when a compaction finished, " +
+                "so a follow-up prompt cannot be timed. Compact without a continuation, then send the " +
+                "prompt yourself once the session is idle.");
+        if (wantsContinue && string.IsNullOrEmpty(agentSessionId))
+            throw new InvalidOperationException(
+                $"CompactContextAsync: session {Id} has no agent session id yet, so the compaction cannot be " +
+                "watched and a follow-up prompt cannot be timed.");
+
+        FileLog.Write($"[Session] CompactContextAsync: session={Id}, driver={driver.Kind}, " +
+                      $"agentSessionId={agentSessionId ?? "(none)"}, continue={(wantsContinue ? "yes" : "no")}");
+
+        var t0 = DateTime.UtcNow;
+        await driver.CompactContextAsync(_backend);
+        SetActivityState(ActivityState.Working);
+
+        if (!canObserve)
+        {
+            FileLog.Write($"[Session] CompactContextAsync: {driver.Kind} reports no completion signal; " +
+                          "compaction submitted, not watched");
+            return new CompactContextOutcome(
+                Submitted: true,
+                CompactionObserved: false,
+                WaitedSeconds: 0,
+                Continued: false,
+                Detail: $"Compaction submitted. {driver.Kind} cannot report when it finishes, so this was not watched.");
+        }
+
+        var allowed = waitTimeout ?? CompactionWaitTimeout;
+        var poll = pollInterval ?? CompactionPollInterval;
+        var deadline = t0 + allowed;
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (driver.HasCompactedSince(agentSessionId!, WorkingDirectory, t0))
+            {
+                var waited = (DateTime.UtcNow - t0).TotalSeconds;
+                FileLog.Write($"[Session] CompactContextAsync: compaction finished after {waited:F1}s (session={Id})");
+
+                if (!wantsContinue)
+                    return new CompactContextOutcome(true, true, waited, false,
+                        $"Compacted in {waited:F0} seconds.");
+
+                // Framework, not Agent or UserInput: this text is the product's own follow-up to a
+                // compaction it ran. It must not clear the owner's hold and must not be counted as
+                // anybody's turn.
+                await SendTextAsync(continuePrompt!, SendSource.Framework);
+                FileLog.Write($"[Session] CompactContextAsync: continuation submitted (session={Id})");
+                return new CompactContextOutcome(true, true, waited, true,
+                    $"Compacted in {waited:F0} seconds, then sent the follow-up.");
+            }
+            await Task.Delay(poll, ct);
+        }
+
+        throw new TimeoutException(
+            $"CompactContextAsync: {driver.Kind} did not report a finished compaction within " +
+            $"{allowed.TotalSeconds:F0} seconds (session={Id}). The compaction command was " +
+            "submitted; no follow-up was sent.");
     }
 
     private void SetActivityState(ActivityState newState)

--- a/src/CcDirector.Gateway.Contracts/CompactContextRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/CompactContextRequest.cs
@@ -1,0 +1,38 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The payload for the <c>compact-context</c> verb (POST /sessions/{sid}/compact-context), issue #2150:
+/// summarize a session's conversation in place and, when a continuation is given, send it once the
+/// compaction has actually finished.
+/// </summary>
+public sealed class CompactContextRequest
+{
+    /// <summary>
+    /// The text to submit once the compaction has finished, or blank/absent to compact only. The wait is
+    /// on the tool's own completion signal, so a driver that cannot report completion refuses this
+    /// outright rather than firing the prompt at a guessed moment.
+    /// </summary>
+    public string? ContinuePrompt { get; set; }
+}
+
+/// <summary>
+/// What the <c>compact-context</c> verb answers. It reports the FINISH, not just the submission: a caller
+/// that only knew "accepted" could not tell a completed compaction from one that never landed.
+/// </summary>
+public sealed class CompactContextResponse
+{
+    /// <summary>The compaction command reached the tool.</summary>
+    public bool Submitted { get; set; }
+
+    /// <summary>The tool's own records confirm the compaction finished.</summary>
+    public bool CompactionObserved { get; set; }
+
+    /// <summary>Seconds between submitting the command and seeing it finish; 0 when not watched.</summary>
+    public double WaitedSeconds { get; set; }
+
+    /// <summary>The follow-up prompt was submitted after the compaction finished.</summary>
+    public bool Continued { get; set; }
+
+    /// <summary>One plain-English sentence describing what happened.</summary>
+    public string Detail { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -171,6 +171,19 @@ public sealed class FleetTargetRequest
 }
 
 /// <summary>
+/// Body of POST /fleet/compact on the Director (issue #2150): compact a session's context anywhere in
+/// the fleet and, when a continuation is given, send it once the compaction has finished.
+/// </summary>
+public sealed class FleetCompactRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>The text to send once compaction finishes, or blank to compact only.</summary>
+    public string? ContinuePrompt { get; set; }
+}
+
+/// <summary>
 /// Body of POST /fleet/hold on the Director: park a session, or release it. Restores the old POST
 /// /sessions/{sid}/hold to the loopback surface.
 /// </summary>

--- a/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
@@ -274,6 +274,11 @@ public sealed class DirectorCommandRouterTimeoutTests
             "recap-generate's own timeout must fire before the Gateway backstop, or its specific error is masked.");
         Assert.True(DirectorCommandRouter.LanguageModelCommandTimeout > CcDirector.Core.Wingman.WingmanService.ProcessTimeout,
             "wingman-ask's own timeout must fire before the Gateway backstop, or its specific error is masked.");
+        // compact-context (issue #2150) joined this family: it waits on a language model summarizing a whole
+        // conversation. Its inner bound must fire first so the caller is told "the tool never reported a
+        // finished compaction" - which says what to do next - instead of "the Director did not answer".
+        Assert.True(DirectorCommandRouter.LanguageModelCommandTimeout > CcDirector.Core.Sessions.Session.CompactionWaitTimeout,
+            "the Director's compaction wait must fire before the Gateway backstop, or its specific error is masked.");
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2581,6 +2581,28 @@ internal static class GatewayEndpoints
                 : Results.Problem("recap failed", statusCode: StatusCodes.Status502BadGateway);
         });
 
+        // Compaction (issue #2150). This gets its OWN literal route rather than riding the catch-all,
+        // for one reason: the catch-all's wait is the 30-second default, and a compaction is a language
+        // model summarizing a whole conversation - it routinely outruns that. Killing a real compaction at
+        // 30 seconds and reporting a timeout would be the failure this verb exists to prevent. So it takes
+        // the documented override, the same one recap and handover take, and it sits OUTSIDE the Director's
+        // own 2-minute compaction wait so the inner bound always fires first and says what did not happen.
+        app.MapPost("/sessions/{sid}/compact-context", async (HttpContext ctx, string sid, CompactContextRequest? req) =>
+        {
+            var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
+            if (session is null || director is null)
+                return Results.NotFound(new { error = "session not found across any director" });
+
+            FileLog.Write($"[GatewayEndpoints] POST /compact-context: sid={sid}, director={director.DirectorId}, " +
+                          $"continue={(string.IsNullOrWhiteSpace(req?.ContinuePrompt) ? "no" : "yes")}");
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "compact-context", sid,
+                new CompactContextRequest { ContinuePrompt = req?.ContinuePrompt }, ctx.RequestAborted,
+                timeout: DirectorCommandRouter.LanguageModelCommandTimeout, machineName: director.MachineName);
+            return streamResult is not null && streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                ? Results.Content(streamResult.BodyJson, "application/json")
+                : TunnelFailure(streamResult);
+        });
+
         app.MapPost("/handover", async (HttpContext ctx, HandoverRequest req) =>
         {
             // Gateway-side /handover dispatches to whichever Director owns the source

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -20,6 +20,7 @@ from . import setup_ops
 from . import workflow_ops
 from .session_ops import (
     ask_session,
+    compact_session,
     hold_session,
     interrupt_session,
     list_sessions,
@@ -170,6 +171,25 @@ _ACTIONS = [
         "args": [
             {"name": "target", "required": False},
             {"name": "minutes", "required": False},
+        ],
+    },
+    {
+        "id": "session-compact",
+        "description": (
+            "Compact a session's context, then continue it. A session whose context window is full "
+            "cannot read anything you send it - every message is swallowed and the tool reprints its "
+            "context-limit line - so this is the only way to rescue one from outside. Compaction "
+            "SUMMARIZES the conversation, so the session keeps what it has learned; clearing would "
+            "throw it away. The call waits for the compaction to finish (up to a couple of minutes on "
+            "a full session) and only then sends the follow-up, which defaults to 'continue'. Use "
+            "--then to send something else, or --compact-only to send nothing."
+        ),
+        "command": 'cc-devthrottle session compact [target] [--then "<text>"] [--compact-only]',
+        "mutatesState": True,
+        "args": [
+            {"name": "target", "required": False},
+            {"name": "then", "required": False},
+            {"name": "compact_only", "required": False},
         ],
     },
     {
@@ -711,6 +731,37 @@ def hold(
     repainting, no longer un-holds it, so a hold you set actually lasts as long as you asked for.
     """
     hold_session(target, release=release, minutes=minutes)
+
+
+@session_app.command()
+def compact(
+    target: Optional[str] = typer.Argument(
+        None, help="Session to compact. Defaults to THIS session (CC_SESSION_ID)."
+    ),
+    then: str = typer.Option(
+        "continue",
+        "--then",
+        help="What to send once the compaction finishes. Defaults to 'continue'.",
+    ),
+    compact_only: bool = typer.Option(
+        False, "--compact-only", help="Compact and send nothing afterwards."
+    ),
+) -> None:
+    """Compact a session's context, then continue it.
+
+    A session whose context window is full cannot read anything you send it - every message is
+    swallowed and the tool just reprints its context-limit line. Compaction is the only thing that
+    gets it moving again, and this is how you do it without walking to that keyboard.
+
+    Compaction SUMMARIZES the conversation, so the session keeps what it has learned. That is the
+    difference from clearing, which throws the conversation away.
+
+    This waits for the compaction to actually finish and then sends the follow-up, so it can take a
+    couple of minutes on a full session. The tool tells us when it has finished; nothing here is
+    timed on a guess. A tool that cannot report finishing can still be compacted with
+    --compact-only, but it will not accept a follow-up.
+    """
+    compact_session(target, None if compact_only else then)
 
 
 @session_app.command()

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -289,6 +289,38 @@ def hold_session(target: Optional[str], release: bool = False, minutes: Optional
     return resp if isinstance(resp, dict) else {}
 
 
+def compact_session(target: Optional[str], continue_prompt: Optional[str]) -> Dict[str, Any]:
+    """Compact a session's context and, unless asked not to, continue it. Issue #2150.
+
+    A full session cannot read anything sent to it, so this is the only rescue that works from
+    outside. The call BLOCKS until the tool reports the compaction finished - which is why the
+    timeout here is generous - and the follow-up is sent at that moment, never on a guessed delay.
+    """
+    sid = resolve_target_or_current(target)
+    body: Dict[str, Any] = {"toSessionId": sid}
+    if continue_prompt:
+        body["continuePrompt"] = continue_prompt
+    try:
+        # Outermost bound of four: this waits longer than the Gateway waits for the Director, which
+        # waits longer than the Director waits for the tool. The innermost one fires first and says
+        # what actually failed.
+        resp = director.post_json("fleet/compact", body, timeout=300)
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {escape(str(err))}")
+        raise typer.Exit(1)
+
+    short = director.short_id(sid)
+    body = resp if isinstance(resp, dict) else {}
+    detail = director.field(body, "detail", "Detail")
+    # Read the flag as a BOOLEAN, not through director.field: that helper stringifies, and str(False) is
+    # "False" - a truthy string. Routed through it, a compaction nobody watched would be announced as
+    # "Compacted", which is the one thing this line must never say without evidence.
+    observed = bool(body.get("compactionObserved", body.get("CompactionObserved", False)))
+    label = "[green]Compacted[/green]" if observed else "[yellow]Compaction submitted[/yellow]"
+    console.print(f"{label} {short}. {escape(str(detail or ''))}")
+    return resp if isinstance(resp, dict) else {}
+
+
 def read_session_buffer(target: Optional[str]) -> None:
     """Print what a session's terminal is showing. Restores the old GET /sessions/{sid}/buffer."""
     sid = resolve_target_or_current(target)

--- a/tools/cc-devthrottle/tests/test_session_compact.py
+++ b/tools/cc-devthrottle/tests/test_session_compact.py
@@ -1,0 +1,150 @@
+"""Tests for `cc-devthrottle session compact`: the fleet verb that rescues a full session (issue #2150).
+
+A session whose context window is full swallows every message sent to it, so this command is the only
+way an agent gets one moving again. Two things therefore have to be right, and both are asserted here:
+what goes out on the wire (the target, and the follow-up that is sent only after compaction finishes),
+and what comes back (a report that never dresses "submitted but not watched" up as "compacted").
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import session_ops  # noqa: E402
+
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def posted(monkeypatch):
+    """Capture the request the verb posts, and serve a chosen response - no real HTTP."""
+    calls = []
+
+    def serve(response):
+        monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+        # An explicit target is resolved against the fleet roster; serve one rather than reaching for a
+        # live Director.
+        monkeypatch.setattr(session_ops, "_get_sessions",
+                            lambda: [{"sessionId": SESSION_ID, "name": "stuck", "machineName": "M", "number": 114}])
+
+        def post_json(path, body, timeout=30):
+            calls.append({"path": path, "body": body, "timeout": timeout})
+            return response
+
+        monkeypatch.setattr(session_ops.director, "post_json", post_json)
+        return calls
+
+    return serve
+
+
+def _ok(detail="Compacted in 41 seconds, then sent the follow-up.", observed=True):
+    return {"submitted": True, "compactionObserved": observed, "waitedSeconds": 41.0,
+            "continued": True, "detail": detail}
+
+
+def test_it_posts_the_target_and_the_follow_up(posted):
+    calls = posted(_ok())
+
+    session_ops.compact_session(SESSION_ID, "continue")
+
+    assert calls[0]["path"] == "fleet/compact"
+    assert calls[0]["body"]["toSessionId"] == SESSION_ID
+    assert calls[0]["body"]["continuePrompt"] == "continue"
+
+
+def test_compact_only_sends_no_follow_up(posted):
+    # The caller asked for a compaction and nothing else. A continuePrompt smuggled in here would put
+    # words into a session the caller never agreed to send.
+    calls = posted(_ok(observed=True))
+
+    session_ops.compact_session(SESSION_ID, None)
+
+    assert "continuePrompt" not in calls[0]["body"]
+
+
+def test_it_defaults_to_this_session_when_no_target_is_given(posted):
+    calls = posted(_ok())
+
+    session_ops.compact_session(None, "continue")
+
+    assert calls[0]["body"]["toSessionId"] == SESSION_ID
+
+
+def test_it_waits_far_longer_than_the_ordinary_verb(posted):
+    # Compaction routinely runs for a minute or more, and this call deliberately waits for the FINISH.
+    # At the 30-second default the client would give up on a compaction that was working perfectly and
+    # report a failure - the exact false alarm this verb exists to avoid.
+    calls = posted(_ok())
+
+    session_ops.compact_session(SESSION_ID, "continue")
+
+    assert calls[0]["timeout"] >= 240
+
+
+def test_a_watched_compaction_reports_it_as_compacted(posted, capsys):
+    posted(_ok())
+
+    session_ops.compact_session(SESSION_ID, "continue")
+
+    out = capsys.readouterr().out
+    assert "Compacted" in out
+    assert "then sent the follow-up" in out
+
+
+def test_an_unwatched_compaction_is_not_reported_as_compacted(posted, capsys):
+    # Some tools can be told to compact but cannot report finishing. Saying "Compacted" there would tell
+    # an agent the session is moving again when nobody actually checked.
+    posted({"submitted": True, "compactionObserved": False, "waitedSeconds": 0.0, "continued": False,
+            "detail": "Compaction submitted. Codex cannot report when it finishes, so this was not watched."})
+
+    session_ops.compact_session(SESSION_ID, None)
+
+    out = capsys.readouterr().out
+    assert "Compaction submitted" in out
+    assert "Compacted " not in out
+
+
+def test_a_failure_is_reported_and_exits_nonzero(posted, monkeypatch, capsys):
+    monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+
+    def boom(path, body, timeout=30):
+        raise session_ops.director.DirectorError("director returned Timeout")
+
+    monkeypatch.setattr(session_ops.director, "post_json", boom)
+
+    with pytest.raises(typer.Exit):
+        session_ops.compact_session(None, "continue")
+
+    assert "director returned Timeout" in capsys.readouterr().out
+
+
+def test_a_bracketed_error_does_not_crash_the_verb(posted, monkeypatch, capsys):
+    # The server's error text can quote a path or a fragment of the session's own output. Interpolated
+    # raw into Rich markup, a token like [/tmp/x] raises MarkupError out of the branch whose only job is
+    # to explain a failure - the same defect already fixed for the buffer verb.
+    monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+
+    def boom(path, body, timeout=30):
+        raise session_ops.director.DirectorError("no session at [/tmp/x] on that Director")
+
+    monkeypatch.setattr(session_ops.director, "post_json", boom)
+
+    with pytest.raises(typer.Exit):
+        session_ops.compact_session(None, "continue")
+
+    assert "no session at [/tmp/x] on that Director" in capsys.readouterr().out
+
+
+def test_the_action_is_discoverable_with_its_command_line():
+    # Agents find this verb by listing actions, not by reading the source. An action missing from the
+    # catalogue does not exist as far as the fleet is concerned.
+    from src import cli  # noqa: E402
+
+    action = next(a for a in cli._ACTIONS if a["id"] == "session-compact")
+    assert "session compact" in action["command"]
+    assert action["mutatesState"] is True


### PR DESCRIPTION
Closes #2150.

## Why

A session whose context window is full goes deaf. Every prompt sent to it is swallowed and the tool reprints its context-limit line. No message, no interrupt and no amount of waiting reaches it - only compaction does, and until now only a person standing at that keyboard could perform it.

That happened on 2026-07-24: a session sat at "Context low (0% remaining)" and swallowed the same dictated instruction eight times running.

## What this adds

Compaction becomes a driver verb, so an agent can perform the rescue:

```
cc-devthrottle session compact <target> [--then "<text>"] [--compact-only]
```

Compaction SUMMARIZES the conversation, so the session keeps what it has learned. Clearing throws it away. The two are never substituted for one another.

## Two capabilities, not one

Typing a compaction command and knowing when it finished are different competences, and only claude has both.

| Flag | Meaning | Who declares it |
|---|---|---|
| `CompactContext` | this tool has a compaction command | claude, codex, pi (`/compact`); gemini (`/compress`); grok, opencode |
| `CompactCompletionReport` | this driver can observe a compaction FINISH from the tool's own records | claude only |

Copilot has no compaction command at all: it declares the capability absent and throws, rather than falling back to a clear that would destroy the work compaction exists to preserve. Cursor stays absent until live-verified, exactly as its context clear is.

## Compact AND continue

The follow-up prompt is submitted only once the finish is OBSERVED. A prompt fired into a composer that is still summarizing is swallowed exactly like the messages that were lost before it - that is the failure this whole change exists to fix. A driver that cannot report completion is refused the continuation rather than timed on a guessed delay; those tools can still be compacted with `--compact-only`.

The follow-up is Framework text, not an owner turn, so rescuing a session cannot silently end a hold its owner had set on it.

## No transcript re-link

Compaction continues under the SAME agent session id - verified against live transcripts written by claude 2.1.195 through 2.1.218, where the summary line, the file's first line and its last line all carry one id. Copying clear-context's re-link wait would hang for sixty seconds and then throw on every successful compaction.

## Timeouts nest, innermost first

Director's wait for the tool (2 min) < Gateway's wait for the Director (3 min) < relay client (4 min) < command line (5 min). So the inner bound always fires first and names what actually failed - "the tool never reported a finished compaction" - instead of the outer one masking it with "the Director did not answer". A compaction that never reports finishing fails loudly and sends no follow-up; it never reports a success it did not watch.

## Tests

68 new, across the driver layer, the transcript marker, the session orchestration and the command line. Three central behaviours were proven by MUTATION - watched failing against a deliberately broken build, not merely observed passing:

- send the follow-up before waiting for the finish -> 3 session tests fail
- compact with `/clear` instead of `/compact` -> 2 driver tests fail
- set the Director's wait longer than the Gateway's -> the ordering test fails

One test caught a real defect before it shipped: the command line read the "was it observed" flag through a helper that stringifies, and `str(False)` is truthy - so a compaction nobody watched would have printed "Compacted".

Core 3709 passed. Command line 103 passed. Gateway: the areas this touches are green (423 route, endpoint and tunnel-dispatch tests; 18 timeout-ordering tests). A clean FULL Gateway suite number could not be taken on this machine - see #2161, a port-allocation race that fails runs with "address already in use" in tests nobody touched.

## Not in this change

The cockpit and desktop Compact buttons. The verb, the Gateway route and the fleet command are what make compaction commandable by an agent; the buttons are a separate small increment on the capability flag that now exists.
