### PR TITLE
Stop blaming the network for a Gateway-side deny

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorCommandRouterOutcomeWordingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCommandRouterOutcomeWordingTests.cs
@@ -1,0 +1,64 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The router's outcome line must not blame the network for a Gateway-side refusal.
+///
+/// A null result from the send has TWO causes and the router cannot see which: the Director is not
+/// tunnel-connected, or the Gateway refused the send before it ever left (the hosted no-tenant-scope deny in
+/// GatewayHost.SendCommandAsync). The line used to assert the first one - "director not tunnel-connected
+/// (unroutable)".
+///
+/// That single word cost a day. When the voice-mode sweep lost its tenant scope, every dropped command was
+/// logged as an unreachable Director - on a Director that answered a different verb 70 milliseconds later, in
+/// the same log. A Gateway bug dressed as an infrastructure flake reads as something to wait out rather than
+/// something to fix, and the log actively argued against the true diagnosis for anyone who went looking.
+///
+/// The message is therefore the deliverable here, not an incidental string, so it is pinned like any other
+/// behaviour. These assertions are positive on purpose: an absence-only check ("does not say
+/// tunnel-connected") would still pass if the line were deleted altogether, which would be a worse outcome
+/// than the wrong wording.
+/// </summary>
+public sealed class DirectorCommandRouterOutcomeWordingTests
+{
+    [Fact]
+    public void NoResult_namesBothCauses_andAssertsNeither()
+    {
+        var outcome = DirectorCommandRouter.DescribeSendOutcome(null);
+
+        // It says what was actually observed: nothing came back.
+        Assert.Contains("no result", outcome);
+        // Both causes are offered...
+        Assert.Contains("not tunnel-connected", outcome);
+        Assert.Contains("refused the send", outcome);
+        // ...as alternatives, never as a settled verdict, and it points at the line that does know.
+        Assert.Contains("OR", outcome);
+        Assert.Contains("[GatewayHost]", outcome);
+
+        // The exact phrasing that made the Gateway bug look like a network fault is gone. Paired with the
+        // positive assertions above, this cannot pass by the line having disappeared.
+        Assert.DoesNotContain("unroutable", outcome);
+    }
+
+    [Theory]
+    [InlineData(DirectorCommandStatus.Ok)]
+    [InlineData(DirectorCommandStatus.NotFound)]
+    [InlineData(DirectorCommandStatus.Timeout)]
+    [InlineData(DirectorCommandStatus.TunnelDropped)]
+    public void AResult_reportsItsStatus_andNeverSpeculatesAboutTheTunnel(DirectorCommandStatus status)
+    {
+        // A result of ANY status means the send reached the stream and came back. The two-cause hedge belongs
+        // only to the null case; repeating it here would make every ordinary outcome read like a failure.
+        var outcome = DirectorCommandRouter.DescribeSendOutcome(
+            status == DirectorCommandStatus.Ok
+                ? DirectorCommandResult.Success("{}")
+                : DirectorCommandResult.Fail(status, "some reason"));
+
+        Assert.Equal($"stream status={status}", outcome);
+        Assert.DoesNotContain("no result", outcome);
+        Assert.DoesNotContain("refused the send", outcome);
+    }
+}

--- a/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
+++ b/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
@@ -58,8 +58,11 @@ internal static class DirectorCommandRouter
 
     /// <summary>
     /// Try to route a command down the stream, waiting at most <paramref name="timeout"/> for the Director to
-    /// answer. Returns null when the Director is not tunnel-connected (post-cut there is no HTTP fallback, so
-    /// the caller surfaces null as a 502); a <see cref="DirectorCommandStatus.Timeout"/> result when the
+    /// answer. Returns null when the command produced no result at all - either the Director is not
+    /// tunnel-connected, or the Gateway itself refused the send (the hosted no-tenant-scope deny in
+    /// <c>GatewayHost.SendCommandAsync</c>, which is always a Gateway bug: the caller failed to enter a tenant
+    /// scope). This layer cannot tell those apart, so it must not report one as the other. Post-cut there is no
+    /// HTTP fallback, so the caller surfaces null as a 502; a <see cref="DirectorCommandStatus.Timeout"/> result when the
     /// Director is connected but answers nothing in time; and a <see cref="DirectorCommandStatus.TunnelDropped"/>
     /// result when the tunnel drops mid-command. The caller's own <paramref name="ct"/> still cancels promptly -
     /// its cancellation propagates rather than being reported as a timeout.
@@ -92,7 +95,7 @@ internal static class DirectorCommandRouter
         try
         {
             var result = await sendCommand(directorId, command, timeoutSource.Token);
-            FileLog.Write($"[DirectorCommandRouter] {verb} sid={sessionId} director={directorId}: {(result is null ? "director not tunnel-connected (unroutable)" : $"stream status={result.Status}")}");
+            FileLog.Write($"[DirectorCommandRouter] {verb} sid={sessionId} director={directorId}: {DescribeSendOutcome(result)}");
             return result;
         }
         catch (Exception) when (timeoutSource.IsCancellationRequested && !ct.IsCancellationRequested)
@@ -145,6 +148,27 @@ internal static class DirectorCommandRouter
         string.IsNullOrWhiteSpace(machineName)
             ? "The connection to the Director dropped while the command was being sent. It is not known whether the command was carried out."
             : $"The connection to the Director on {machineName} dropped while the command was being sent. It is not known whether the command was carried out.";
+
+    /// <summary>
+    /// How the send went, for the log. A null result has TWO causes and THIS LAYER CANNOT SEE WHICH: the
+    /// Director is not tunnel-connected, or the Gateway refused the send before it ever left (the hosted
+    /// no-tenant-scope deny in <c>GatewayHost.SendCommandAsync</c>).
+    ///
+    /// It used to name only the first - "director not tunnel-connected (unroutable)" - which is how the
+    /// voice-mode sweep spent a day reporting a Director as unreachable while that same Director answered
+    /// other verbs in the same millisecond. A Gateway bug wearing a network error's clothes reads as an
+    /// infrastructure flake, so it gets waited out instead of fixed. The line must state what was OBSERVED
+    /// (no result came back) and point at the line that does know the cause, rather than picking the more
+    /// familiar of the two and asserting it as fact.
+    ///
+    /// Extracted as a pure function so the wording is a tested behaviour rather than an incidental string:
+    /// this message IS the diagnostic, so it is the thing worth pinning.
+    /// </summary>
+    internal static string DescribeSendOutcome(DirectorCommandResult? result) =>
+        result is null
+            ? "no result - the Director is not tunnel-connected, OR the Gateway refused the send before it left " +
+              "(the preceding [GatewayHost] line names which)"
+            : $"stream status={result.Status}";
 
     /// <summary>Deserialize a verb response DTO carried in <see cref="DirectorCommandResult.BodyJson"/>.</summary>
     public static T? ReadBody<T>(DirectorCommandResult result) where T : class =>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1605,8 +1605,12 @@ public sealed class GatewayHost : IAsyncDisposable
                     }
                     else
                     {
-                        // Left for a later pass on purpose - that is what a standing intent means.
-                        FileLog.Write($"[GatewayHost] voice-mode sweep: sid={sid} not reachable on director={directorId} - will retry next pass");
+                        // Left for a later pass on purpose - that is what a standing intent means. Says NOT
+                        // SWITCHED ON rather than "not reachable": the sweep sees only that no Ok came back,
+                        // and an unreachable Director is just one of the ways that happens. Claiming the
+                        // Director was unreachable is how this line spent a day blaming the network for a
+                        // Gateway-side deny; the preceding router line carries the outcome that was observed.
+                        FileLog.Write($"[GatewayHost] voice-mode sweep: sid={sid} NOT switched on (director={directorId}) - will retry next pass");
                     }
                 }
             }).ConfigureAwait(false);
@@ -3228,7 +3232,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // No scope on hosted is a DENY: send nothing, exactly as an unconnected Director behaves.
         if (_tenantPass.Current is not { } commandTenant)
         {
-            FileLog.Write($"[GatewayHost] SendCommandAsync: DENIED (no tenant in scope) director={directorId}, verb={command.Verb}");
+            // Say plainly that this is OUR bug and that the command was destroyed, not delayed. The deny is a
+            // safety net, not a normal path: a request and a tunnel connection both arrive already scoped, so
+            // the only way here is a background loop that failed to enter a tenant scope - and the cost is a
+            // command silently dropped on every tick, forever, with nothing downstream able to tell that from
+            // an offline Director. Name the fix in the line, so whoever greps it does not have to rediscover it.
+            FileLog.Write($"[GatewayHost] SendCommandAsync: GATEWAY BUG - command DROPPED, no tenant scope in effect. " +
+                          $"director={directorId}, verb={command.Verb}. A background loop must run its work inside " +
+                          $"ITenantPass.ForEachTenant/ForEachTenantAsync; this is NOT an unreachable Director.");
             return null;
         }
         var connectionId = PushedSessions.GetActiveConnectionId(commandTenant, directorId);


### PR DESCRIPTION
## What was wrong

When a command is dropped because no tenant scope is in effect, three log lines described it, and two of them asserted a cause nobody had observed:

| Layer | Said | Actually knew |
|---|---|---|
| `GatewayHost` | `DENIED (no tenant in scope)` | the truth |
| `DirectorCommandRouter` | `director not tunnel-connected (unroutable)` | only that nothing came back |
| voice-mode sweep | `sid=... not reachable on director=...` | only that no `Ok` arrived |

Both guesses blamed the network. A Gateway bug wearing a network error's clothes reads as an infrastructure flake, so it gets waited out instead of fixed - and the log actively argues against the true diagnosis for anyone who goes looking.

That is not hypothetical. It is what the voice-mode sweep did for a full day: it reported a Director as unreachable while that same Director answered a `history` verb 70 milliseconds later, in the same log file.

## The fix

The router genuinely **cannot** tell the two causes apart - a null result means either the Director is not tunnel-connected, or the Gateway refused the send before it ever left. So it no longer picks one:

```
no result - the Director is not tunnel-connected, OR the Gateway refused the send
before it left (the preceding [GatewayHost] line names which)
```

- `GatewayHost`'s deny line now says plainly that this is a **Gateway bug**, that the command was **dropped** rather than delayed, and names the fix (`run the work inside ITenantPass.ForEachTenant/ForEachTenantAsync`).
- The sweep says `NOT switched on` instead of asserting the machine was unreachable.

## Scope - this was never user-facing

Worth stating, because the wording made it sound worse than it is: this deny is reachable **only from background work**. A request and a tunnel connection both arrive already scoped, and all 188 denials in the live hosted log came from the sweep, none from a request. Nobody ever saw a 502 from it. This was a diagnostic failure, not a user-facing one - which is also why the fix is confined to the messages rather than converting `null` into a typed status across ~76 call sites.

## Proof

The wording IS the deliverable, so it is pinned rather than left as an incidental string. The message is extracted into a pure function (`DescribeSendOutcome`) so it can be tested without reading log files.

Revert-proved - restore the old string and the test goes red:

```
Assert.Contains() Failure: Sub-string not found
String:    "director not tunnel-connected (unroutable"...
Not found: "no result"
```

The assertions are positive (names both causes, points at the `[GatewayHost]` line) rather than absence-only, so the test cannot pass by the line having been deleted altogether.

## A note on the local test run

The targeted run - the router suite, both voice-mode sweep suites, and the new wording tests - is green (32 passed).

The **full** local suite is not a usable signal on this machine right now: it came back with 421 failures, on a box running 85 `dotnet` processes and two other test hosts from concurrent sessions. The signature is contention, not regression - two `address already in use` bind failures killing shared fixtures, with hundreds of instant `401 Unauthorized` cascades behind them. Running the failing classes **alone** passes 63/63, and this same code passed 3999/0 earlier tonight when the machine was quiet. CI runs on a clean runner, so treat the checks on this pull request as the authoritative full-suite result.
