### PR TITLE
Repair main after compact-and-continue: it does not compile, plus two stale capability tests

### DIFF
--- a/src/CcDirector.HostedAgent.Tests/DriverRegistryTests.cs
+++ b/src/CcDirector.HostedAgent.Tests/DriverRegistryTests.cs
@@ -100,12 +100,12 @@ public class DriverRegistryTests
     }
 
     [Fact]
-    public void PiDriver_DeclaresCancelClearContextContextUsageAndModelReport()
+    public void PiDriver_DeclaresCancelClearContextContextUsageModelReportAndCompactContext()
     {
         var caps = new PiDriver().Capabilities;
         Assert.Equal(
             DriverCapabilities.Cancel | DriverCapabilities.ClearContext | DriverCapabilities.ContextUsage
-            | DriverCapabilities.ModelReport,
+            | DriverCapabilities.ModelReport | DriverCapabilities.CompactContext,
             caps);
     }
 
@@ -136,13 +136,16 @@ public class DriverRegistryTests
     }
 
     [Fact]
-    public void CodexDriver_DeclaresCancelInterruptClearContextUsageAndModelReport()
+    public void CodexDriver_DeclaresCancelInterruptClearContextUsageModelReportAndCompactContext()
     {
         var caps = new CodexDriver().Capabilities;
 
+        // CompactContext but NOT CompactCompletionReport - codex's records are not readable by the
+        // Director, so it can start a compaction but cannot observe one finishing (see CodexDriver).
         Assert.Equal(
             DriverCapabilities.Cancel | DriverCapabilities.Interrupt | DriverCapabilities.ClearContext
-            | DriverCapabilities.ContextUsage | DriverCapabilities.ModelReport,
+            | DriverCapabilities.ContextUsage | DriverCapabilities.ModelReport
+            | DriverCapabilities.CompactContext,
             caps);
     }
 

--- a/src/CcDirector.HostedAgent.Tests/Fakes.cs
+++ b/src/CcDirector.HostedAgent.Tests/Fakes.cs
@@ -230,6 +230,14 @@ public sealed class FakeTranscriptReader : ITranscriptReader
 
     public List<(string ClaudeSessionId, DateTime LastWriteUtc)> Transcripts { get; } = new();
 
+    /// <summary>
+    /// The newest compaction mark per transcript - the completion signal compact-and-continue waits on
+    /// (issue #2150). Dictionary-backed like the members beside it so a test can say "this session has
+    /// been compacted, at this moment" without touching disk. Absent means never compacted, which is the
+    /// same answer the real reader gives for a file with no marker.
+    /// </summary>
+    public Dictionary<string, DateTime> Compactions { get; } = new();
+
     public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) =>
         Widgets.TryGetValue(claudeSessionId, out var w) ? new List<TurnWidgetDto>(w) : new List<TurnWidgetDto>();
 
@@ -238,4 +246,7 @@ public sealed class FakeTranscriptReader : ITranscriptReader
 
     public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) =>
         new(Transcripts);
+
+    public DateTime? LastCompactionUtc(string claudeSessionId, string repoPath) =>
+        Compactions.TryGetValue(claudeSessionId, out var at) ? at : null;
 }


### PR DESCRIPTION
## main is red

`origin/main` has not compiled for roughly two hours, and once it does compile, two tests fail. Both come from the same incomplete merge - compact-and-continue (#2150, merged as #2162).

**This fails EVERY open pull request**, regardless of its own content, and the errors name files the author never touched - so it reads like your own break. That is how I found it: it failed a change that only edits log message wording.

### 1. It does not compile

```
Fakes.cs(225,44): error CS0535: 'FakeTranscriptReader' does not implement
interface member 'ITranscriptReader.LastCompactionUtc(string, string)'
```

`LastCompactionUtc` was added to `ITranscriptReader` and implemented on the real `ClaudeTranscriptReader`, but not on the test fake.

The fake gets the same dictionary-backed shape as the members beside it, so a test can say "this session was compacted, at this moment" without touching disk. Absent means never compacted - the same answer the real reader gives for a transcript with no marker.

### 2. Two driver capability tests are stale

```
Expected: ClearContext | Cancel | ContextUsage | ModelReport
Actual:   ClearContext | Cancel | ContextUsage | ModelReport | CompactContext
```

`DriverCapabilities.CompactContext` was added to the Pi and Codex drivers, but the two tests asserting the exact capability set were not updated.

**The production behaviour is correct here and the tests are stale**, so the tests move - and I checked in that direction before touching them rather than assuming it. Claude, Codex, Pi and Generic all declare the capability alongside a real `CompactContextAsync` implementation, with documented reasoning. It is a deliberate feature, not a leaked flag. A stale test asserting an exact set reads exactly like a regression, which is the trap worth naming.

Test names were updated too: a name that lists the capabilities goes stale the same way the assertion does.

## Proof

- `dotnet build cc-director.sln` - Build succeeded, 0 warnings, 0 errors. Fails on `origin/main` without this.
- `CcDirector.HostedAgent.Tests` - 86 passed, 0 failed.

Deliberately its own pull request rather than folded into whatever change happened to hit it, so it merges immediately and unblocks everyone else.
