### PR TITLE
Bind an assigned port instead of probing and releasing one (#2161)

### DIFF
--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -95,7 +95,7 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
         _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _instancesDir);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -253,11 +253,4 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
         return doc.RootElement.Clone();
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/Account/RevokeDownEnforcedGatewayProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/RevokeDownEnforcedGatewayProofTests.cs
@@ -97,7 +97,7 @@ public sealed class RevokeDownEnforcedGatewayProofTests : IAsyncLifetime
         // Boot a REAL Gateway with the host-wide auth gate ENFORCED (issue #917) on an ephemeral loopback
         // port, isolated to this test's temp dir so it never touches the developer's live registry.
         _gateway = new GatewayHost(
-            port: AllocateFreePort(),
+            port: GatewayHost.OperatingSystemAssignedPort,
             token: "shared-machine-token-924-proof",
             authEnabled: true,
             instancesDirectory: Path.Combine(_tempDir, "instances"),
@@ -116,14 +116,6 @@ public sealed class RevokeDownEnforcedGatewayProofTests : IAsyncLifetime
         await _gateway.StopAsync();
         try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
         catch { /* best-effort temp cleanup */ }
-    }
-
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     private HttpClient NewClientWithKey() => new()

--- a/src/CcDirector.Gateway.Tests/Activity/ActivityLedgerTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/ActivityLedgerTenantIsolationTests.cs
@@ -60,7 +60,7 @@ public sealed class ActivityLedgerTenantIsolationTests : IAsyncLifetime
         _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
 
-        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -171,11 +171,4 @@ public sealed class ActivityLedgerTenantIsolationTests : IAsyncLifetime
         return await resp.Content.ReadAsStringAsync();
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -37,7 +37,7 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -121,12 +121,4 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
             (await _http.PutAsync("gateway/ai/tts-model", new StringContent("[1,2]", Encoding.UTF8, "application/json"))).StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
@@ -36,7 +36,7 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -175,12 +175,4 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/BoundPort.cs
+++ b/src/CcDirector.Gateway.Tests/BoundPort.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Reads the port a started test host actually bound (issue #2161).
+///
+/// Tests that spin a bare <see cref="WebApplication"/> - rather than a real <see cref="GatewayHost"/> - bind
+/// their own listener and then dial it. They used to compute the port in advance with a probe that released
+/// it before the bind, which is the race this issue removes. Binding port 0 fixes the bind; this fixes the
+/// other half, because the CLIENT still has to learn the number, and "0" is not an address anything can
+/// connect to. Call it AFTER StartAsync.
+///
+/// It throws rather than returning 0 for the same reason <see cref="GatewayHost"/> does: a zero here becomes
+/// a base address of http://127.0.0.1:0, and the failure then surfaces as an unhelpful socket error far from
+/// the code that caused it.
+/// </summary>
+internal static class BoundPort
+{
+    /// <summary>The port <paramref name="app"/> is listening on. Only valid once the app has started.</summary>
+    internal static int Of(WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var addresses = app.Services.GetService<IServer>()?.Features.Get<IServerAddressesFeature>()?.Addresses;
+        if (addresses is not null)
+        {
+            foreach (var address in addresses)
+            {
+                if (Uri.TryCreate(address, UriKind.Absolute, out var uri) && uri.Port > 0)
+                    return uri.Port;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "The test host reported no bound address with a usable port. Call BoundPort.Of only AFTER " +
+            "StartAsync, and bind with port 0 so the operating system assigns one.");
+    }
+
+    /// <summary>The loopback base address of a started test host, ready for an HttpClient.</summary>
+    internal static Uri LoopbackBase(WebApplication app) => new($"http://127.0.0.1:{Of(app)}/");
+}

--- a/src/CcDirector.Gateway.Tests/BrowserPageRoutesTests.cs
+++ b/src/CcDirector.Gateway.Tests/BrowserPageRoutesTests.cs
@@ -32,7 +32,7 @@ public sealed class BrowserPageRoutesTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -189,10 +189,4 @@ public sealed class BrowserPageRoutesTests : IAsyncLifetime
         }
     }
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        return ((IPEndPoint)l.LocalEndpoint).Port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeDiagnosticsEndpointPartitionTests.cs
@@ -71,8 +71,8 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        var port = AllocateFreePort();
-        _app.Urls.Add($"http://127.0.0.1:{port}");
+        // Issue #2161: bind an operating-system-assigned port; the address is read back after start.
+        _app.Urls.Add($"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}");
 
         // The real host-wide gate, exactly as GatewayHost installs it.
         var requireToken = new AuthMiddleware.RequireToken { Token = SharedMachineToken, Devices = devices };
@@ -80,7 +80,7 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
 
         CarModeEndpoint.Map(_app, brain, brain, new CarModeTurnCache(_ => { }), diagnostics, warmup, null!);
         await _app.StartAsync();
-        _baseAddress = $"http://127.0.0.1:{port}";
+        _baseAddress = $"http://127.0.0.1:{BoundPort.Of(_app)}";
     }
 
     public async Task DisposeAsync()
@@ -91,14 +91,6 @@ public sealed class CarModeDiagnosticsEndpointPartitionTests : IAsyncLifetime
         if (File.Exists(_registryPath)) File.Delete(_registryPath);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 
     private HttpClient Client() => new() { BaseAddress = new Uri(_baseAddress) };
 

--- a/src/CcDirector.Gateway.Tests/CockpitAuthServingTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitAuthServingTests.cs
@@ -32,7 +32,7 @@ public sealed class CockpitAuthServingTests : IAsyncLifetime
         // The React bundle is not built into this Debug host, so a request that PASSES the gate and is
         // served the Cockpit shell answers the 404 "not built" notice - never a redirect and never 401.
         // That is itself proof the gate accepted the request and handed it to the shell path.
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -175,12 +175,4 @@ public sealed class CockpitAuthServingTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.OK, health.StatusCode);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CockpitReactAppServingTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitReactAppServingTests.cs
@@ -43,7 +43,7 @@ public sealed class CockpitReactAppServingTests : IAsyncLifetime
             + "<body>" + ShellMarker + "</body></html>");
         await File.WriteAllTextAsync(Path.Combine(webRoot, "assets", "index-abc123.js"), AssetBody);
 
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -119,10 +119,4 @@ public sealed class CockpitReactAppServingTests : IAsyncLifetime
         Assert.DoesNotContain(ShellMarker, await resp.Content.ReadAsStringAsync());
     }
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        return ((IPEndPoint)l.LocalEndpoint).Port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
@@ -136,7 +136,7 @@ public sealed class CockpitUrlEndpointTests
         Environment.SetEnvironmentVariable(GatewayPublicUrl.PublicBaseUrlEnvVar, configuredBase);
 
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-cockpiturl-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -171,11 +171,4 @@ public sealed class CockpitUrlEndpointTests
                ?? throw new InvalidOperationException($"{path} returned no body");
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/ContextLessDatabaseRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessDatabaseRouteTenancyTests.cs
@@ -80,7 +80,7 @@ public sealed class ContextLessDatabaseRouteTenancyTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: SharedToken, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: SharedToken, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             cronJobsPath: Path.Combine(_instancesDir, "cron", "cronjobs.json"),
@@ -541,11 +541,4 @@ public sealed class ContextLessDatabaseRouteTenancyTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CronJobEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronJobEndpointsTests.cs
@@ -30,15 +30,17 @@ public sealed class CronJobEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        _app.Urls.Add(baseUrl);
+        _app.Urls.Add(bindUrl);
         CronJobEndpoints.Map(_app, new CronJobStore(_h.Open(), _storePath));
         await _app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 
         _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
@@ -237,12 +239,4 @@ public sealed class CronJobEndpointsTests : IAsyncLifetime
         Assert.Equal("https://example.com/h2", dto.NotifyWebhookUrl);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CronNotifyTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronNotifyTests.cs
@@ -192,7 +192,7 @@ public sealed class CronNotifyTests : IDisposable
         var notifier = new GatewayCronNotifier(
             events,
             directorId => directorId == "director-1" ? "https://host.ts.net" : null,
-            "http://127.0.0.1:7879",
+            () => "http://127.0.0.1:7879",
             http);
 
         var job = SeedJob(CronNotify.Always, webhook: "https://example.com/hook");
@@ -239,7 +239,7 @@ public sealed class CronNotifyTests : IDisposable
     {
         var events = new DirectorEventLog();
         using var http = new HttpClient(new CapturingHandler());
-        var notifier = new GatewayCronNotifier(events, _ => null, "http://127.0.0.1:7879", http);
+        var notifier = new GatewayCronNotifier(events, _ => null, () => "http://127.0.0.1:7879", http);
 
         var job = SeedJob(CronNotify.Always);
         job.Id = "cj_fail";
@@ -271,7 +271,7 @@ public sealed class CronNotifyTests : IDisposable
         var events = new DirectorEventLog();
         var capture = new CapturingHandler();
         using var http = new HttpClient(capture);
-        var notifier = new GatewayCronNotifier(events, _ => "https://host.ts.net", "http://127.0.0.1:7879", http);
+        var notifier = new GatewayCronNotifier(events, _ => "https://host.ts.net", () => "http://127.0.0.1:7879", http);
 
         var job = SeedJob(CronNotify.Always, webhook: null);
         job.Id = "cj_nohook";

--- a/src/CcDirector.Gateway.Tests/CronResolverCrossTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronResolverCrossTenantTests.cs
@@ -51,7 +51,7 @@ public sealed class CronResolverCrossTenantTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -117,11 +117,4 @@ public sealed class CronResolverCrossTenantTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronRunEndpointsTests.cs
@@ -32,8 +32,9 @@ public sealed class CronRunEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var db = _h.Open();
         _store = new CronJobStore(db, _jobsPath);
@@ -43,9 +44,10 @@ public sealed class CronRunEndpointsTests : IAsyncLifetime
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        _app.Urls.Add(baseUrl);
+        _app.Urls.Add(bindUrl);
         CronRunEndpoints.Map(_app, engine, history);
         await _app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 
         _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
@@ -132,12 +134,4 @@ public sealed class CronRunEndpointsTests : IAsyncLifetime
             throw new InvalidOperationException("seed-job endpoint test must not trigger the work-list runner");
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/CrossTenantDuplicateDirectorIdTests.cs
+++ b/src/CcDirector.Gateway.Tests/CrossTenantDuplicateDirectorIdTests.cs
@@ -62,7 +62,7 @@ public sealed class CrossTenantDuplicateDirectorIdTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -165,11 +165,4 @@ public sealed class CrossTenantDuplicateDirectorIdTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DeviceListTenantScopingTests.cs
@@ -53,7 +53,7 @@ public sealed class DeviceListTenantScopingTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -117,13 +117,6 @@ public sealed class DeviceListTenantScopingTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/DevopsAdapterDispatchProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/DevopsAdapterDispatchProofTests.cs
@@ -45,7 +45,7 @@ public sealed class DevopsAdapterDispatchProofTests : IAsyncLifetime
     {
         Environment.SetEnvironmentVariable("CC_GATEWAY_NO_TAILSCALE", "1");
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -132,14 +132,6 @@ public sealed class DevopsAdapterDispatchProofTests : IAsyncLifetime
         var dir = Path.Combine(Path.GetTempPath(), "cc300-repo");
         Directory.CreateDirectory(dir);
         return dir;
-    }
-
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     private sealed record RunDto(string ListName, string Consumer, bool ConsumerReleased, List<RunItemDto> Items);

--- a/src/CcDirector.Gateway.Tests/DictationSessionLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationSessionLockTests.cs
@@ -94,7 +94,7 @@ public sealed class DictationSessionLockTests : IAsyncLifetime
     }
 
     private GatewayHost NewGateway() => new(
-        port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
+        port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: false,
         instancesDirectory: _instancesDir,
         workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
 
@@ -109,11 +109,4 @@ public sealed class DictationSessionLockTests : IAsyncLifetime
         return http;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTenantIsolationTests.cs
@@ -86,7 +86,7 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
 
-        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -432,11 +432,4 @@ public sealed class DictationTenantIsolationTests : IAsyncLifetime
         return http;
     }
 
-    private static int FreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
@@ -105,15 +105,17 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
         SeedTerm(transcripts, Base.AddHours(1),
             new[] { ("Frederiksen", 60), ("Fredriksson", 18), ("Fredrickson", 12) });
 
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         var app = builder.Build();
-        app.Urls.Add(baseUrl);
+        app.Urls.Add(bindUrl);
         RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
             suggestions: suggestions, dismissals: dismissals);
         await app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
 
         try
         {
@@ -195,14 +197,6 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
         {
             await app.StopAsync();
         }
-    }
-
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     // Response shapes (camelCase from the endpoint; case-insensitive binding).

--- a/src/CcDirector.Gateway.Tests/DirectorErrorMessageReachesTheHumanTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorErrorMessageReachesTheHumanTests.cs
@@ -65,7 +65,7 @@ public sealed class DirectorErrorMessageReachesTheHumanTests
 
         public async Task InitializeAsync()
         {
-            _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
                 instancesDirectory: _instancesDir,
                 workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
                 streamMode: true);
@@ -105,14 +105,6 @@ public sealed class DirectorErrorMessageReachesTheHumanTests
             Assert.Equal(DirectorWords, doc.RootElement.GetProperty("error").GetString());
         }
 
-        private static int AllocateFreePort()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
-        }
     }
 
     // ============ LEG 2: the Director's relay surfaces them instead of discarding them ============

--- a/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorEventsAndFactsTests.cs
@@ -38,7 +38,7 @@ public sealed class DirectorEventsAndFactsTests : IAsyncLifetime
             instancesDirectory: _instancesDir);
         await _director.StartAsync();
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -215,11 +215,4 @@ public sealed class DirectorEventsAndFactsTests : IAsyncLifetime
         Assert.Fail("condition not reached within timeout");
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRouteTenantScopingTests.cs
@@ -73,7 +73,7 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -419,11 +419,4 @@ public sealed class DirectorRouteTenantScopingTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DirectorShutdownGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorShutdownGateTests.cs
@@ -35,7 +35,7 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -234,14 +234,6 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
 
         await gate.Director.PushSnapshotAsync(sessions.ToArray());
         return gate;
-    }
-
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     private static int DeadPort()

--- a/src/CcDirector.Gateway.Tests/DisplayPushTenantEnrichmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/DisplayPushTenantEnrichmentTests.cs
@@ -59,7 +59,7 @@ public sealed class DisplayPushTenantEnrichmentTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -149,11 +149,4 @@ public sealed class DisplayPushTenantEnrichmentTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/DoorbellColourFactPushTests.cs
+++ b/src/CcDirector.Gateway.Tests/DoorbellColourFactPushTests.cs
@@ -58,7 +58,7 @@ public sealed class DoorbellColourFactPushTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _gatewayInstances,
             workListsPath: Path.Combine(_gatewayInstances, "worklists", "worklists.json"),
             streamMode: true);
@@ -97,14 +97,6 @@ public sealed class DoorbellColourFactPushTests : IAsyncLifetime
         TryDelete(_root);
     }
 
-    private static int AllocateFreePort()
-    {
-        var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        l.Start();
-        var p = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
-        return p;
-    }
 
     private static void TryDelete(string dir)
     {

--- a/src/CcDirector.Gateway.Tests/DurableDictationDedupeTests.cs
+++ b/src/CcDirector.Gateway.Tests/DurableDictationDedupeTests.cs
@@ -219,7 +219,7 @@ public sealed class DurableDictationDedupeTests : IAsyncLifetime
     }
 
     private GatewayHost NewGateway() => new(
-        port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
+        port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: false,
         instancesDirectory: _instancesDir,
         workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
 
@@ -234,11 +234,4 @@ public sealed class DurableDictationDedupeTests : IAsyncLifetime
         return http;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/EventsFeedSelfHostedTests.cs
+++ b/src/CcDirector.Gateway.Tests/EventsFeedSelfHostedTests.cs
@@ -26,7 +26,7 @@ public sealed class EventsFeedSelfHostedTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
 
         _gateway = new GatewayHost(
-            port: FreePort(),
+            port: GatewayHost.OperatingSystemAssignedPort,
             token: Token,
             authEnabled: true,
             instancesDirectory: _instancesDir,
@@ -80,11 +80,4 @@ public sealed class EventsFeedSelfHostedTests : IAsyncLifetime
         throw new EndOfStreamException("The events feed closed before publishing an event.");
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
+++ b/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
@@ -28,7 +28,7 @@ public sealed class FanoutAndEventsTests : IAsyncLifetime
             instancesDirectory: _instancesDir);
         await _director.StartAsync();
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -226,11 +226,4 @@ public sealed class FanoutAndEventsTests : IAsyncLifetime
         }
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayClientTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayClientTests.cs
@@ -24,7 +24,7 @@ public sealed class GatewayClientTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "", authEnabled: false,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "", authEnabled: false,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -58,11 +58,4 @@ public sealed class GatewayClientTests : IAsyncLifetime
         }
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayDirectoryRegistrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayDirectoryRegistrationTests.cs
@@ -29,7 +29,7 @@ public sealed class GatewayDirectoryRegistrationTests : IAsyncLifetime
     {
         // cockpitProxyPort: a dead port so "/" hits the interstitial, never a real
         // Cockpit that may be running on the dev machine.
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -242,11 +242,4 @@ public sealed class GatewayDirectoryRegistrationTests : IAsyncLifetime
             $"expected the Cockpit shell to answer text; got {mediaType}");
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayHostAssignedPortTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostAssignedPortTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Sockets;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2161 - the Gateway binds an operating-system-assigned port and reports back the number it got.
+///
+/// This replaces a pattern that was copied into 92 files: ask the operating system for a free port, RELEASE
+/// it, then bind that number a moment later. In the gap the port is unheld, so anything on the machine can
+/// take it, and the bind fails with "address already in use" - in a test that touched nothing. That is what
+/// reddened whole suite runs. Assignment and bind now happen in one step, so there is no gap to lose.
+///
+/// The tests below pin the three things a caller depends on: the number comes back, it is the number the
+/// host is actually reachable on, and two hosts started the same way never collide.
+/// </summary>
+public sealed class GatewayHostAssignedPortTests
+{
+    private static GatewayHost NewHost(string instancesDir) =>
+        new(port: GatewayHost.OperatingSystemAssignedPort,
+            token: "test-token-assigned-port",
+            authEnabled: false,
+            instancesDirectory: instancesDir);
+
+    private static string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-assigned-port-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public async Task StartAsync_WithAnAssignedPort_ReportsTheRealPortItBound()
+    {
+        var dir = TempDir();
+        await using var gateway = NewHost(dir);
+
+        await gateway.StartAsync();
+
+        Assert.NotEqual(GatewayHost.OperatingSystemAssignedPort, gateway.Port);
+        Assert.InRange(gateway.Port, 1, 65535);
+    }
+
+    /// <summary>
+    /// The number must be the one the host is REACHABLE on. A port that is merely non-zero would satisfy the
+    /// test above while pointing at nothing - and every caller builds its base address out of this value.
+    /// </summary>
+    [Fact]
+    public async Task TheReportedPort_IsTheOneTheHostAnswersOn()
+    {
+        var dir = TempDir();
+        await using var gateway = NewHost(dir);
+        await gateway.StartAsync();
+
+        using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+        using var response = await http.GetAsync("healthz");
+
+        Assert.True(response.IsSuccessStatusCode, $"the reported port {gateway.Port} did not answer /healthz");
+    }
+
+    /// <summary>
+    /// The point of the whole change: two hosts started the same way, at the same time, land on different
+    /// ports and both serve. Under the old probe-and-release pattern this is precisely the case that could
+    /// hand the same number to both.
+    /// </summary>
+    [Fact]
+    public async Task TwoHostsStartedTogether_GetDifferentPorts_AndBothServe()
+    {
+        await using var first = NewHost(TempDir());
+        await using var second = NewHost(TempDir());
+
+        await first.StartAsync();
+        await second.StartAsync();
+
+        Assert.NotEqual(first.Port, second.Port);
+
+        using var firstHttp = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{first.Port}/") };
+        using var secondHttp = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{second.Port}/") };
+        Assert.True((await firstHttp.GetAsync("healthz")).IsSuccessStatusCode);
+        Assert.True((await secondHttp.GetAsync("healthz")).IsSuccessStatusCode);
+    }
+
+    /// <summary>
+    /// An explicitly chosen port is still honoured verbatim - the assigned-port mode is opt-in, and the
+    /// shipped Gateway names its own port. This is the guard against "read back whatever we bound" quietly
+    /// becoming "ignore what the caller asked for".
+    /// </summary>
+    [Fact]
+    public async Task AnExplicitPort_IsHonouredUnchanged()
+    {
+        var chosen = ReserveAPortNobodyElseWillTake(out var reservation);
+        using (reservation)
+        {
+            // held until the moment before we hand it over, which is the closest an explicit-port test can
+            // safely get to "this port is free"
+        }
+
+        await using var gateway = new GatewayHost(port: chosen, token: "t", authEnabled: false,
+            instancesDirectory: TempDir());
+        await gateway.StartAsync();
+
+        Assert.Equal(chosen, gateway.Port);
+    }
+
+    private static int ReserveAPortNobodyElseWillTake(out IDisposable reservation)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        reservation = new ListenerHandle(listener);
+        return port;
+    }
+
+    private sealed class ListenerHandle(TcpListener listener) : IDisposable
+    {
+        public void Dispose() => listener.Stop();
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayHostBrainToolGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostBrainToolGuardTests.cs
@@ -23,7 +23,7 @@ public sealed class GatewayHostBrainToolGuardTests
     public void Construction_WithNonHostableBrainTool_ThrowsAtConstruction(AgentKind tool)
     {
         var ex = Assert.Throws<InvalidOperationException>(() => new GatewayHost(
-            port: FreePort(), token: "test-token", authEnabled: true,
+            port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: InstancesDir(), brainTool: tool));
         Assert.Contains("cannot be hosted", ex.Message);
     }
@@ -33,7 +33,7 @@ public sealed class GatewayHostBrainToolGuardTests
     {
         var dir = InstancesDir();
         await using var gateway = new GatewayHost(
-            port: FreePort(), token: "test-token", authEnabled: true,
+            port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: dir, brainTool: AgentKind.ClaudeCode);
 
         Assert.Equal(AgentKind.ClaudeCode, gateway.BrainTool);
@@ -41,12 +41,4 @@ public sealed class GatewayHostBrainToolGuardTests
         try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { }
     }
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        l.Start();
-        var port = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -57,7 +57,7 @@ public sealed class GatewayHostTests : IAsyncLifetime
         // in-memory store so the test host never reads the developer machine's REAL Windows Data
         // Protection credential blob - without this, the signed-out assertions depend on whether the
         // machine happens to be signed in to DevThrottle.
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             // Isolate the device registry to this test's temp dir. Without this the DeviceRegistry falls
@@ -359,11 +359,4 @@ public sealed class GatewayHostTests : IAsyncLifetime
         // Don't fail here - tests will fail with clearer assertions if discovery didn't work
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayInterruptedTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInterruptedTests.cs
@@ -34,7 +34,7 @@ public sealed class GatewayInterruptedTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -246,13 +246,6 @@ public sealed class GatewayInterruptedTests : IAsyncLifetime
         fake.Director = await FakeTunnelDirector.StartAsync(_gateway, Token, fake.DirectorId, machine, fake.Dispatch);
         _fakes.Add(fake);
         return fake;
-    }
-
-    private static int FreePort()
-    {
-        var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        try { return ((IPEndPoint)l.LocalEndpoint).Port; } finally { l.Stop(); }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
@@ -36,7 +36,7 @@ public sealed class GatewayStreamClientTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -173,12 +173,4 @@ public sealed class GatewayStreamClientTests : IAsyncLifetime
         throw new TimeoutException($"Timed out waiting for {what}");
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionLiveProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionLiveProofTests.cs
@@ -46,7 +46,7 @@ public sealed class GatewayTranscriptionLiveProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "", authEnabled: false,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "", authEnabled: false,
             instancesDirectory: _instancesDir, keyVaultPath: _keyVaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -98,11 +98,4 @@ public sealed class GatewayTranscriptionLiveProofTests : IAsyncLifetime
         Assert.Equal("no audio in the request body", doc.RootElement.GetProperty("error").GetString());
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HandoverInfoEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HandoverInfoEndpointTests.cs
@@ -34,7 +34,7 @@ public sealed class HandoverInfoTunnelTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -118,12 +118,6 @@ public sealed class HandoverInfoTunnelTests : IAsyncLifetime
         ActivityState = "WaitingForInput",
     };
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        return ((IPEndPoint)l.LocalEndpoint).Port;
-    }
 }
 
 /// <summary>
@@ -148,7 +142,7 @@ public sealed class HandoverInfoGatewayTests : IAsyncLifetime
     {
         _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: GatewayToken, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -182,11 +176,4 @@ public sealed class HandoverInfoGatewayTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HealthzCommitFieldTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzCommitFieldTests.cs
@@ -61,7 +61,7 @@ public sealed class HealthzCommitFieldTests
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
         Environment.SetEnvironmentVariable("COCKPIT_COMMIT", commitEnv);
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-hz-commit-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -90,11 +90,4 @@ public sealed class HealthzCommitFieldTests
         }
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
@@ -75,7 +75,7 @@ public sealed class HealthzTenantLeakTests
         var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-hz-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -114,11 +114,4 @@ public sealed class HealthzTenantLeakTests
         }
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedAccountDevicesServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedAccountDevicesServeTests.cs
@@ -64,7 +64,7 @@ public sealed class HostedAccountDevicesServeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),

--- a/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedContentReadDenyTests.cs
@@ -231,7 +231,7 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -378,13 +378,6 @@ public sealed class HostedContentReadDenyTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>
@@ -483,7 +476,7 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -962,12 +955,5 @@ public sealed class HostedContentReadSelfHostControlTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 

--- a/src/CcDirector.Gateway.Tests/HostedDictationWiringCanaryTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedDictationWiringCanaryTests.cs
@@ -95,7 +95,7 @@ public sealed class HostedDictationWiringCanaryTests : IAsyncLifetime
         _priorSweepSchedule = GatewayHost.VoiceTurnUploadSweepScheduleForTests;
         GatewayHost.VoiceTurnUploadSweepScheduleForTests = TimeSpan.FromMilliseconds(200);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -293,11 +293,4 @@ public sealed class HostedDictationWiringCanaryTests : IAsyncLifetime
         return http;
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherHubDenyTests.cs
@@ -74,7 +74,7 @@ public sealed class HostedLauncherHubDenyTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : "0");
         Assert.Equal(hosted, GatewayHostedMode.IsHosted);
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -155,12 +155,4 @@ public sealed class HostedLauncherHubDenyTests : IAsyncLifetime
         return conn;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherMachineDenyTests.cs
@@ -268,7 +268,7 @@ public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
         Assert.True(GatewayHostedMode.IsHosted);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -415,13 +415,6 @@ public sealed class HostedLauncherMachineDenyTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
@@ -129,14 +129,14 @@ public sealed class HostedNetworkDiagEndpointTests
         var priorHosted = Environment.GetEnvironmentVariable(GatewayHostedMode.HostedEnvVar);
         Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, hosted ? "1" : null);
         var instancesDirectory = Path.Combine(Path.GetTempPath(), "cc-netstatus-" + Guid.NewGuid().ToString("N"));
-        var port = FreePort();
         WebApplication? app = null;
         DirectorRegistry? registry = null;
         var started = false;
         try
         {
             var builder = WebApplication.CreateBuilder();
-            builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
+            // Issue #2161: bind an operating-system-assigned port; the number is read back after start.
+            builder.WebHost.UseUrls($"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}");
             app = builder.Build();
             app.Use(async (context, next) =>
             {
@@ -153,6 +153,7 @@ public sealed class HostedNetworkDiagEndpointTests
                 token: "test-token",
                 collectNetworkDiagnostic: collectNetworkDiagnostic);
             await app.StartAsync();
+            var port = BoundPort.Of(app);
             started = true;
             using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
             await assertion(http);
@@ -167,20 +168,6 @@ public sealed class HostedNetworkDiagEndpointTests
             }
             registry?.Dispose();
             Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, priorHosted);
-        }
-    }
-
-    private static int FreePort()
-    {
-        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try
-        {
-            return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        }
-        finally
-        {
-            listener.Stop();
         }
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsDenyTests.cs
@@ -204,7 +204,7 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
@@ -298,13 +298,6 @@ public sealed class HostedOwnerSettingsDenyTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.Unauthorized, (await anonymous.GetAsync("gateway/settings")).StatusCode);
     }
 
-    internal static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>
@@ -396,7 +389,7 @@ public sealed class HostedOwnerSettingsGroupFilterTests : IAsyncLifetime
     {
         // A real, started GatewayHost, because SettingsEndpoints.Map needs one. Its own routes are not
         // driven here; the probe application maps a second copy of the family and is what the tests call.
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: "probe-token",
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "probe-token",
             authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -83,7 +83,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
     public async Task InitializeAsync()
     {
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
@@ -487,7 +487,7 @@ public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: "probe-token",
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "probe-token",
             authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),

--- a/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
@@ -59,7 +59,7 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));

--- a/src/CcDirector.Gateway.Tests/HostedProcessControlDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedProcessControlDenyTests.cs
@@ -101,7 +101,7 @@ public sealed class HostedProcessControlDenyTests
         var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-procctl-b2-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -210,7 +210,7 @@ public sealed class HostedProcessControlDenyTests
         var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-procctl-b2-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -267,11 +267,4 @@ public sealed class HostedProcessControlDenyTests
         return proc;
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedRecordingServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedRecordingServeTests.cs
@@ -64,7 +64,7 @@ public sealed class HostedRecordingServeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             keyVaultPath: _vaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
@@ -196,13 +196,6 @@ public sealed class HostedRecordingServeTests : IAsyncLifetime
             : Array.Empty<string>();
     }
 
-    internal static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
@@ -103,7 +103,7 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
         const int maximumAttempts = 3;
         for (var attempt = 1; attempt <= maximumAttempts; attempt++)
         {
-            _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
                 instancesDirectory: _instancesDir,
                 workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
                 snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -318,11 +318,4 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedSessionNumberRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionNumberRouteTenancyTests.cs
@@ -48,7 +48,7 @@ public sealed class HostedSessionNumberRouteTenancyTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -128,11 +128,4 @@ public sealed class HostedSessionNumberRouteTenancyTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedShutdownDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedShutdownDenyTests.cs
@@ -84,7 +84,7 @@ public sealed class HostedShutdownDenyTests
         var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
         var instancesDir = Path.Combine(Path.GetTempPath(), "cc-shutdown-b2-" + Guid.NewGuid().ToString("N"));
-        var gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: instancesDir,
             workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
@@ -128,11 +128,4 @@ public sealed class HostedShutdownDenyTests
         }
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedSnoozeLifecycleTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSnoozeLifecycleTenancyTests.cs
@@ -64,7 +64,7 @@ public sealed class HostedSnoozeLifecycleTenancyTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -204,11 +204,4 @@ public sealed class HostedSnoozeLifecycleTenancyTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedStatsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsServeTests.cs
@@ -64,7 +64,7 @@ public sealed class HostedStatsServeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: HostedOwnerSettingsDenyTests.FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),

--- a/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTranscriptionServeTests.cs
@@ -58,7 +58,7 @@ public sealed class HostedTranscriptionServeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -169,11 +169,4 @@ public sealed class HostedTranscriptionServeTests : IAsyncLifetime
         return JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
     }
 
-    internal static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedUtteranceTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedUtteranceTenantIsolationTests.cs
@@ -68,7 +68,7 @@ public sealed class HostedUtteranceTenantIsolationTests : IAsyncLifetime
         _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
 
-        _gateway = new GatewayHost(port: FreePort(), token: GatewayToken, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -199,11 +199,4 @@ public sealed class HostedUtteranceTenantIsolationTests : IAsyncLifetime
         return http;
     }
 
-    private static int FreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedVaultDenyTests.cs
@@ -124,7 +124,7 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         // hand back. A deny tested against an empty vault proves nothing.
         new KeyVault(_vaultPath).Set(SecretName, SecretValue);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             keyVaultPath: _vaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
@@ -283,13 +283,6 @@ public sealed class HostedVaultDenyTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    internal static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>
@@ -723,7 +716,7 @@ public sealed class SelfHostVaultControlTests : IAsyncLifetime
 
         new KeyVault(_vaultPath).Set(SecretName, SecretValue);
 
-        _gateway = new GatewayHost(port: HostedVaultDenyTests.FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             keyVaultPath: _vaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),

--- a/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
@@ -77,7 +77,7 @@ public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
         // The key must be present or the complete path bails before it ever transcribes, let alone delivers.
         new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_test_key");
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             keyVaultPath: _vaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
@@ -350,11 +350,4 @@ public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
     private static string Sha256Hex(byte[] bytes)
         => Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant();
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/ItemStatusEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/ItemStatusEndpointTests.cs
@@ -23,7 +23,7 @@ public sealed class ItemStatusEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -95,10 +95,4 @@ public sealed class ItemStatusEndpointTests : IAsyncLifetime
         Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("title").GetString()));
     }
 
-    private static int FreePort()
-    {
-        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        return ((IPEndPoint)l.LocalEndpoint).Port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/LauncherRegistryEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherRegistryEndpointTests.cs
@@ -30,7 +30,7 @@ public sealed class LauncherRegistryEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -337,12 +337,4 @@ public sealed class LauncherRegistryEndpointTests : IAsyncLifetime
             StartedAt = DateTime.UtcNow,
         };
 
-    private static int FreePort()
-    {
-        using var listener = new System.Net.Sockets.TcpListener(
-            System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
@@ -37,7 +37,7 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -133,12 +133,4 @@ public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
         return conn;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/MachineRelaySlotGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineRelaySlotGuardTests.cs
@@ -30,7 +30,7 @@ public sealed class MachineRelaySlotGuardTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -140,12 +140,4 @@ public sealed class MachineRelaySlotGuardTests : IAsyncLifetime
             : await _http.PostAsJsonAsync($"machines/{Machine}/{verb}", body);
     }
 
-    private static int FreePort()
-    {
-        using var listener = new System.Net.Sockets.TcpListener(
-            System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/MissionNotesEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionNotesEndpointTests.cs
@@ -34,7 +34,7 @@ public sealed class MissionNotesEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: InstancesDir,
             workListsPath: Path.Combine(_dir, "worklists.json"),
             missionNotesPath: MissionNotesPath);
@@ -138,7 +138,7 @@ public sealed class MissionNotesEndpointTests : IAsyncLifetime
 
         // A Gateway restart: a second host over the SAME store file re-serves the WHY - it is durable.
         await _gateway.StopAsync();
-        var restarted = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var restarted = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: InstancesDir,
             workListsPath: Path.Combine(_dir, "worklists.json"),
             missionNotesPath: MissionNotesPath);
@@ -194,12 +194,4 @@ public sealed class MissionNotesEndpointTests : IAsyncLifetime
         return null;
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/MobileAuthServingTests.cs
+++ b/src/CcDirector.Gateway.Tests/MobileAuthServingTests.cs
@@ -29,7 +29,7 @@ public sealed class MobileAuthServingTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -143,12 +143,4 @@ public sealed class MobileAuthServingTests : IAsyncLifetime
         }
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/MobileRedirectTests.cs
+++ b/src/CcDirector.Gateway.Tests/MobileRedirectTests.cs
@@ -27,7 +27,7 @@ public sealed class MobileRedirectTests : IAsyncLifetime
     {
         // A DESKTOP navigation that falls through is served the in-process React Cockpit (shell, or the
         // 404 not-built notice in a Debug build) - the observable proof it was NOT redirected to /mobile/.
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: false,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: false,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -169,12 +169,4 @@ public sealed class MobileRedirectTests : IAsyncLifetime
         Assert.Contains("openapi", body);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagTenantPartitionTests.cs
@@ -500,7 +500,7 @@ public sealed class NetDiagEndpointTenantIsolationTests : IAsyncLifetime
         Directory.CreateDirectory(_root);
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: Path.Combine(_root, "instances"),
             workListsPath: Path.Combine(_root, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_root, "snooze", "snooze.json"),
@@ -684,13 +684,6 @@ public sealed class NetDiagEndpointTenantIsolationTests : IAsyncLifetime
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }
 
 /// <summary>
@@ -725,7 +718,7 @@ public sealed class NetDiagSelfHostControlTests : IAsyncLifetime
         Directory.CreateDirectory(_root);
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: Path.Combine(_root, "instances"),
             workListsPath: Path.Combine(_root, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_root, "snooze", "snooze.json"),
@@ -783,11 +776,4 @@ public sealed class NetDiagSelfHostControlTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptLogTenantIsolationTests.cs
@@ -60,7 +60,7 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
         // The prompt log is pinned into a throwaway directory; it otherwise defaults to the running user's real one.
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _tempDir,
             workListsPath: Path.Combine(_tempDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_tempDir, "snooze", "snooze.json"),
@@ -341,11 +341,4 @@ public sealed class PromptLogTenantIsolationTests : IAsyncLifetime
         return _http.SendAsync(req);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/Proof/RemoteSignInLiveProof.cs
+++ b/src/CcDirector.Gateway.Tests/Proof/RemoteSignInLiveProof.cs
@@ -60,7 +60,7 @@ public sealed class RemoteSignInLiveProof
             var account = GatewayAccountFactory.Build(new InMemoryTokenStore());
 
             gateway = new GatewayHost(
-                port: FreePort(),
+                port: GatewayHost.OperatingSystemAssignedPort,
                 token: GatewayToken,
                 authEnabled: true,
                 instancesDirectory: instancesDir,
@@ -187,12 +187,4 @@ public sealed class RemoteSignInLiveProof
         public void Clear() => _tokens = null;
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/RecordingCompletenessGateHttpTests.cs
+++ b/src/CcDirector.Gateway.Tests/RecordingCompletenessGateHttpTests.cs
@@ -101,14 +101,16 @@ public sealed class RecordingCompletenessGateHttpTests
 
     private static async Task WithEndpointsAsync(Func<HttpClient, Task> body)
     {
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         var app = builder.Build();
-        app.Urls.Add(baseUrl);
+        app.Urls.Add(bindUrl);
         RecordingEndpoints.Map(app);
         await app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
         try
         {
             using var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
@@ -120,11 +122,4 @@ public sealed class RecordingCompletenessGateHttpTests
         }
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/RecordingEndpointsE2ETests.cs
+++ b/src/CcDirector.Gateway.Tests/RecordingEndpointsE2ETests.cs
@@ -37,15 +37,17 @@ public sealed class RecordingEndpointsE2ETests
         var clips = FindPhase0Clips();
         Assert.NotEmpty(clips);
 
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         var app = builder.Build();
-        app.Urls.Add(baseUrl);
+        app.Urls.Add(bindUrl);
         RecordingEndpoints.Map(app);
         await app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
 
         try
         {
@@ -106,14 +108,6 @@ public sealed class RecordingEndpointsE2ETests
         {
             await app.StopAsync();
         }
-    }
-
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     private static List<string> FindPhase0Clips()

--- a/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
@@ -105,14 +105,14 @@ public sealed class RepositoriesEndpointServeFoldTests
     private static async Task WithGateway(PushedRepositoryStore store, Func<HttpClient, Task> assertion)
     {
         var instancesDirectory = Path.Combine(Path.GetTempPath(), "cc-repofold-" + Guid.NewGuid().ToString("N"));
-        var port = FreePort();
         WebApplication? app = null;
         DirectorRegistry? registry = null;
         var started = false;
         try
         {
             var builder = WebApplication.CreateBuilder();
-            builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
+            // Issue #2161: bind an operating-system-assigned port; the number is read back after start.
+            builder.WebHost.UseUrls($"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}");
             app = builder.Build();
             registry = new DirectorRegistry(instancesDirectory);
             GatewayEndpoints.Map(
@@ -122,6 +122,7 @@ public sealed class RepositoriesEndpointServeFoldTests
                 token: "test-token",
                 pushedRepositories: store);
             await app.StartAsync();
+            var port = BoundPort.Of(app);
             started = true;
             using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
             await assertion(http);
@@ -135,20 +136,6 @@ public sealed class RepositoriesEndpointServeFoldTests
                 await app.DisposeAsync();
             }
             registry?.Dispose();
-        }
-    }
-
-    private static int FreePort()
-    {
-        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try
-        {
-            return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        }
-        finally
-        {
-            listener.Stop();
         }
     }
 }

--- a/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingLoopIsolationTests.cs
@@ -70,7 +70,7 @@ public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -258,11 +258,4 @@ public sealed class SessionServingLoopIsolationTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionServingReadIsolationTests.cs
@@ -76,7 +76,7 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
     private async Task InitializeHostedAsync()
     {
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -331,11 +331,4 @@ public sealed class SessionServingReadIsolationTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionWsProxyEndpointsTests.cs
@@ -43,7 +43,7 @@ public sealed class SessionWsProxyEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -159,10 +159,4 @@ public sealed class SessionWsProxyEndpointsTests : IAsyncLifetime
         ActivityState = "WaitingForInput",
     };
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        return ((IPEndPoint)l.LocalEndpoint).Port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -43,7 +43,7 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -852,7 +852,7 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
             User = user,
             // A plausible advertised endpoint that is NEVER dialed - the roster comes from the push store, so a
             // working result proves the tunnel (tunnel-by-construction).
-            BaseUrl = $"http://127.0.0.1:{FreePort()}",
+            BaseUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}",
             Sessions = sessions,
             Connected = connected,
         };
@@ -895,14 +895,6 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         CreatedAt = DateTime.UtcNow,
         LastActivityAt = DateTime.UtcNow,
     };
-
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 
     /// <summary>
     /// A registered Director stand-in for the aggregation. Post-cut it delivers its roster ONLY over the tunnel

--- a/src/CcDirector.Gateway.Tests/SignInStartAuthServingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SignInStartAuthServingTests.cs
@@ -25,7 +25,7 @@ public sealed class SignInStartAuthServingTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -115,12 +115,4 @@ public sealed class SignInStartAuthServingTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.OK, res.StatusCode);
     }
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
@@ -82,7 +82,7 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
     // disposing the first) is a genuine Gateway restart that must re-arm the persisted registry.
     private async Task<(GatewayHost, HttpClient)> StartGatewayAsync()
     {
-        var gw = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        var gw = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_root, "worklists", "worklists.json"),
             snoozePath: _snoozePath,
@@ -569,14 +569,6 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
         await fake.ConnectAsync(_gw, Token);
         _fakes.Add(fake);
         return fake;
-    }
-
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/SpaFallbackNonGetTests.cs
+++ b/src/CcDirector.Gateway.Tests/SpaFallbackNonGetTests.cs
@@ -50,7 +50,7 @@ public sealed class SpaFallbackNonGetTests : IAsyncLifetime
             _createdWebRoot = true;
         }
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: false);
@@ -94,12 +94,4 @@ public sealed class SpaFallbackNonGetTests : IAsyncLifetime
         Assert.Equal("text/html", resp.Content.Headers.ContentType?.MediaType);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
@@ -48,7 +48,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _gatewayInstances,
             workListsPath: Path.Combine(_gatewayInstances, "worklists", "worklists.json"),
             streamMode: true);
@@ -390,7 +390,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
     public async Task StreamModeOff_PatchEndpoint_StaysOnHttp()
     {
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offp-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offp", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offp", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -466,7 +466,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
     public async Task StreamModeOff_WingmanGoalEndpoint_StaysOnHttp()
     {
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offg-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offg", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offg", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -579,7 +579,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
         // the HTTP pull - which against an empty control endpoint finds nothing => 404, exactly as today. This
         // pins that the pushed-cache location is INERT when the flag is off (byte-identical behaviour).
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offloc-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offloc", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offloc", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -693,7 +693,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
     public async Task StreamModeOff_CreateEndpoint_StaysOnHttp()
     {
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offc-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offc", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offc", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -734,7 +734,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
     public async Task StreamModeOff_KillEndpoint_StaysOnHttp()
     {
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offk-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offk", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offk", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -769,7 +769,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
     public async Task StreamModeOff_InterruptEndpoint_StaysOnHttp()
     {
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-offi-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-offi", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-offi", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -807,7 +807,7 @@ public sealed class StreamCommandTests : IAsyncLifetime
         // so a prompt can only be attempted over HTTP - which fails - proving no stream path is used and
         // behaviour matches today's HTTP-only Gateway.
         var offInstances = Path.Combine(Path.GetTempPath(), "cc-streamcmd-off-" + Guid.NewGuid().ToString("N"));
-        var off = new GatewayHost(port: AllocateFreePort(), token: "t-off", authEnabled: true,
+        var off = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "t-off", authEnabled: true,
             instancesDirectory: offInstances,
             workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
             streamMode: false);
@@ -929,12 +929,4 @@ public sealed class StreamCommandTests : IAsyncLifetime
         try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch (Exception) { /* best effort */ }
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/StreamIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamIntegrationTests.cs
@@ -37,7 +37,7 @@ public sealed class StreamIntegrationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -180,12 +180,4 @@ public sealed class StreamIntegrationTests : IAsyncLifetime
         return null;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
@@ -41,7 +41,7 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
     public Task InitializeAsync()
     {
         _gateway = new GatewayHost(
-            port: AllocateFreePort(),
+            port: GatewayHost.OperatingSystemAssignedPort,
             token: "runtime-settings-test-token",
             authEnabled: false,
             instancesDirectory: _instances,
@@ -150,14 +150,6 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
         Assert.Equal(input, json.RootElement.GetProperty("input").GetString());
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 
     private sealed class RecordingSpeechHandler : HttpMessageHandler
     {

--- a/src/CcDirector.Gateway.Tests/TranscriptionBatchEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionBatchEndpointTests.cs
@@ -43,15 +43,17 @@ public sealed class TranscriptionBatchEndpointTests : IAsyncLifetime
         Directory.CreateDirectory(Path.GetDirectoryName(CcStorage.ConfigJson())!);
         _vaultPath = Path.Combine(Path.GetTempPath(), "cc-vault-txbatch-" + Guid.NewGuid().ToString("N") + ".json");
 
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        _app.Urls.Add(baseUrl);
+        _app.Urls.Add(bindUrl);
         TranscriptionBatchEndpoint.Map(_app, new KeyVault(_vaultPath));
         await _app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 
         _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
@@ -98,12 +100,4 @@ public sealed class TranscriptionBatchEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelDirectorReadProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelDirectorReadProofTests.cs
@@ -53,7 +53,7 @@ public sealed class TunnelDirectorReadProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -268,12 +268,4 @@ public sealed class TunnelDirectorReadProofTests : IAsyncLifetime
 
     // -------------------------------------------------------------------------------------- helpers ----
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
@@ -54,7 +54,7 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -289,12 +289,4 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
 
     // -------------------------------------------------------------------------------------- helpers ----
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelGitHubSessionProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelGitHubSessionProofTests.cs
@@ -47,7 +47,7 @@ public sealed class TunnelGitHubSessionProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -111,12 +111,4 @@ public sealed class TunnelGitHubSessionProofTests : IAsyncLifetime
         Assert.Equal("devthrottle", (string?)payload["repo"]);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelIdleWaitFanoutRestoreProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelIdleWaitFanoutRestoreProofTests.cs
@@ -57,7 +57,7 @@ public sealed class TunnelIdleWaitFanoutRestoreProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -198,12 +198,4 @@ public sealed class TunnelIdleWaitFanoutRestoreProofTests : IAsyncLifetime
         Assert.Contains("interrupted-remove", verbs); // journal cleanup (was client.RemoveInterruptedSessionAsync)
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
@@ -65,7 +65,7 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -438,12 +438,4 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
         for (var i = 0; i < attempts && !condition(); i++) await Task.Delay(15);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelReposHandoverMgmtProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelReposHandoverMgmtProofTests.cs
@@ -36,7 +36,7 @@ public sealed class TunnelReposHandoverMgmtProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -333,11 +333,4 @@ public sealed class TunnelReposHandoverMgmtProofTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelRosterPushReadProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelRosterPushReadProofTests.cs
@@ -50,7 +50,7 @@ public sealed class TunnelRosterPushReadProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -217,12 +217,4 @@ public sealed class TunnelRosterPushReadProofTests : IAsyncLifetime
         Assert.Equal(1, node?["liveSessionCount"]?.GetValue<int>());
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelShutdownHandoverProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelShutdownHandoverProofTests.cs
@@ -55,7 +55,7 @@ public sealed class TunnelShutdownHandoverProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -180,12 +180,4 @@ public sealed class TunnelShutdownHandoverProofTests : IAsyncLifetime
         Assert.Contains(_targetCommands, c => c.Verb == "create");           // spawn on the target over the tunnel
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelWingmanVoiceProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelWingmanVoiceProofTests.cs
@@ -48,7 +48,7 @@ public sealed class TunnelWingmanVoiceProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -136,12 +136,4 @@ public sealed class TunnelWingmanVoiceProofTests : IAsyncLifetime
         Assert.Equal(sid, _lastCommand.SessionId);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
@@ -57,7 +57,7 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -153,11 +153,4 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VaultEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/VaultEndpointsTests.cs
@@ -26,15 +26,17 @@ public sealed class VaultEndpointsTests : IAsyncLifetime
     {
         _vaultPath = Path.Combine(Path.GetTempPath(), "cc-vault-ep-" + Guid.NewGuid().ToString("N") + ".json");
 
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        _app.Urls.Add(baseUrl);
+        _app.Urls.Add(bindUrl);
         VaultEndpoints.Map(_app, new KeyVault(_vaultPath));
         await _app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 
         _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
@@ -98,12 +100,4 @@ public sealed class VaultEndpointsTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, get.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VaultGatewayIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VaultGatewayIntegrationTests.cs
@@ -31,7 +31,7 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir, keyVaultPath: _keyVaultPath,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -150,11 +150,4 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
         Assert.Equal("dt_live_late_gateway", await resolver.ResolveAsync());
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeAllEndpointProofTests.cs
@@ -54,7 +54,7 @@ public sealed class VoiceModeAllEndpointProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -265,12 +265,4 @@ public sealed class VoiceModeAllEndpointProofTests : IAsyncLifetime
         Assert.False(_gateway.VoiceService?.IsVoiceSession(Core.Tenancy.TenantId.Local, sid));
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceModeSweepHostedTenantScopeTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceModeSweepHostedTenantScopeTests.cs
@@ -62,7 +62,7 @@ public sealed class VoiceModeSweepHostedTenantScopeTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -174,11 +174,4 @@ public sealed class VoiceModeSweepHostedTenantScopeTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
@@ -66,7 +66,7 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -187,11 +187,4 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
         LastActivityAt = DateTime.UtcNow,
     };
 
-    private static int FreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceServingReadIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingReadIsolationTests.cs
@@ -60,7 +60,7 @@ public sealed class VoiceServingReadIsolationTests : IAsyncLifetime
         _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
         Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
 
-        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
@@ -168,11 +168,4 @@ public sealed class VoiceServingReadIsolationTests : IAsyncLifetime
         return doc.RootElement.GetProperty("ready").GetBoolean();
     }
 
-    private static int FreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceTurnUploadSweepWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTurnUploadSweepWiringTests.cs
@@ -74,7 +74,7 @@ public sealed class VoiceTurnUploadSweepWiringTests : IAsyncLifetime
         // Compress only the SCHEDULE. The age cut-off stays production's.
         GatewayHost.VoiceTurnUploadSweepScheduleForTests = TimeSpan.FromMilliseconds(150);
         _gateway = new GatewayHost(
-            port: AllocateFreePort(), token: GatewayToken, authEnabled: false,
+            port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: false,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -111,11 +111,4 @@ public sealed class VoiceTurnUploadSweepWiringTests : IAsyncLifetime
         return !Directory.Exists(dir);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WindowsOnlyEndpointsGatingTests.cs
+++ b/src/CcDirector.Gateway.Tests/WindowsOnlyEndpointsGatingTests.cs
@@ -27,7 +27,7 @@ public sealed class WindowsOnlyEndpointsGatingTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -67,12 +67,4 @@ public sealed class WindowsOnlyEndpointsGatingTests : IAsyncLifetime
             $"expected 405 or 404 for POST /directors off Windows, got {(int)resp.StatusCode}");
     }
 
-    private static int FreePort()
-    {
-        using var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        l.Start();
-        var port = ((IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanAskForwardingTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanAskForwardingTests.cs
@@ -36,7 +36,7 @@ public sealed class WingmanAskForwardingTests : IAsyncLifetime
             instancesDirectory: _instancesDir);
         await _director.StartAsync();
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token", authEnabled: false,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token", authEnabled: false,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -133,11 +133,4 @@ public sealed class WingmanAskForwardingTests : IAsyncLifetime
         }
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -56,7 +56,7 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -425,12 +425,4 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         return result;
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WorkListEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkListEndpointsTests.cs
@@ -30,15 +30,17 @@ public sealed class WorkListEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var port = AllocateFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
+        // Issue #2161: bind an operating-system-assigned port, then learn the number it gave us. The
+        // address cannot be built up front any more - "0" is not something a client can dial.
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         _app = builder.Build();
-        _app.Urls.Add(baseUrl);
+        _app.Urls.Add(bindUrl);
         WorkListEndpoints.Map(_app, new WorkListStore(_h.Open(), _storePath));
         await _app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 
         _http = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
@@ -204,12 +206,4 @@ public sealed class WorkListEndpointsTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WorkListRunnerEndpointProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkListRunnerEndpointProofTests.cs
@@ -39,7 +39,7 @@ public sealed class WorkListRunnerEndpointProofTests : IAsyncLifetime
     {
         Environment.SetEnvironmentVariable("CC_GATEWAY_NO_TAILSCALE", "1");
 
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             streamMode: true);
@@ -255,14 +255,6 @@ public sealed class WorkListRunnerEndpointProofTests : IAsyncLifetime
             count += Directory.GetFiles(d, "ImplLoopTerminalSignal*.cs", SearchOption.AllDirectories).Length;
         }
         return count;
-    }
-
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-        finally { listener.Stop(); }
     }
 
     private sealed record RunDto(string ListName, string Consumer, bool ConsumerReleased, List<RunItemDto> Items);

--- a/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEnableSwitchTests.cs
@@ -127,7 +127,7 @@ public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -188,12 +188,4 @@ public sealed class WorkflowEnableSwitchEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
@@ -35,7 +35,7 @@ public sealed class WorkflowEndpointsTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
         await _gateway.StartAsync();
@@ -240,12 +240,4 @@ public sealed class WorkflowEndpointsTests : IAsyncLifetime
         Assert.DoesNotContain("\"humanCheckpoint\"", body);
     }
 
-    private static int AllocateFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -147,7 +147,9 @@ internal static class GatewayEndpoints
         // Port, and run-mode label. The mode is a delegate (resolved per request) because SettingsHooks is set
         // on the host AFTER Map runs. Null/zero (older callers, bare test hosts) means "not started"/unknown.
         DateTime? gatewayStartedAtUtc = null,
-        int gatewayPort = 0,
+        // Issue #2161: a delegate, resolved per request, for the same reason the mode label is one - Map runs
+        // before the listener binds, and on an operating-system-assigned port the number does not exist yet.
+        Func<int>? gatewayPort = null,
         Func<string>? gatewayModeLabel = null,
         // devthrottle #2075: the dictionary-suggestions engine and the dismissal store, threaded into the
         // /ingest/dictionary/suggestions routes. Null (older callers, recording-only test harnesses) simply
@@ -587,7 +589,7 @@ internal static class GatewayEndpoints
                 // read-only, both surfaces. State is "Running" whenever this endpoint answers; the address is the
                 // auto-resolved public base (manual addressing was dropped).
                 State = "Running",
-                Port = gatewayPort,
+                Port = gatewayPort?.Invoke() ?? 0,
                 UptimeSeconds = gatewayStartedAtUtc is { } startedAt ? (long)(DateTime.UtcNow - startedAt).TotalSeconds : 0,
                 Directors = aboutTenant is { } t ? registry.ListDirectors(t).Count : 0,
                 Mode = gatewayModeLabel?.Invoke() ?? "unknown",

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -18,6 +18,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.SignalR; // Issue #1176: ClientProxyExtensions.InvokeAsync (client results) for the down-channel
 using Microsoft.Extensions.DependencyInjection;
@@ -36,7 +38,26 @@ public sealed class GatewayHost : IAsyncDisposable
 {
     public const int DefaultPort = 7878;
 
-    public int Port { get; }
+    /// <summary>
+    /// Passed as the port to mean "let the operating system assign a free one" (issue #2161). The bind and
+    /// the assignment then happen in ONE step, and <see cref="Port"/> carries the assigned number the moment
+    /// <see cref="StartAsync"/> returns.
+    ///
+    /// This exists because the alternative - ask the operating system for a free port, release it, and bind
+    /// that number a moment later - leaves the port unheld in between, where any process on the machine can
+    /// take it. Tests did that 92 times over and lost the race often enough to redden whole runs with
+    /// "address already in use" in code nobody had touched.
+    /// </summary>
+    public const int OperatingSystemAssignedPort = 0;
+
+    /// <summary>
+    /// The port this Gateway listens on. Settable only from inside: when the host was constructed with
+    /// <see cref="OperatingSystemAssignedPort"/> this holds 0 until the listener binds, and the ACTUAL
+    /// assigned port from then on. Nothing may capture this value before <see cref="StartAsync"/> has
+    /// bound - read it late (the collaborators below take a delegate for exactly that reason), or a
+    /// consumer built at construction time keeps the placeholder forever.
+    /// </summary>
+    public int Port { get; private set; }
     public string Token { get; }
     public DirectorRegistry Registry { get; }
 
@@ -752,7 +773,7 @@ public sealed class GatewayHost : IAsyncDisposable
             FileLog.Write($"[GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set {AuthDisabledEnvVar}=1 to disable for debugging)");
         else
             FileLog.Write($"[GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)");
-        _serveProvisioner = new TailscaleServeProvisioner(Registry, Port);
+        _serveProvisioner = new TailscaleServeProvisioner(Registry, () => Port);
 
         // The Gateway's in-process warm brain (issue #184): supervisor only - the chosen tool
         // spawns lazily. Its former consumers have since moved off it: the wingman narration now
@@ -1102,7 +1123,7 @@ public sealed class GatewayHost : IAsyncDisposable
             // the drain runner read the same seam); on self-host it is always Local.
             tenant => Registry.ListDirectors(tenant),
             () => _tenantPass.Current,
-            new Running.RelayDirectorLauncher(Port, Token));
+            new Running.RelayDirectorLauncher(() => Port, Token));
         // The single resolve-then-create path shared by the cron firing engine and the interactive
         // POST /machines/{machine}/sessions relay ("start a session on another computer"). Gateway Cleanup
         // Phase 2 (PR E-B2): both the spawner and the work-list drain driver ride the tunnel. Tunnel-only:
@@ -1141,7 +1162,9 @@ public sealed class GatewayHost : IAsyncDisposable
                 var d = Registry.Get(t, directorId);
                 return d is null ? null : (d.TailnetEndpoint ?? d.ControlEndpoint);
             },
-            $"http://127.0.0.1:{Port}",
+            // Issue #2161: a delegate, not a string. This runs in the constructor, long before the listener
+            // binds, so a formatted address here would freeze the pre-bind port into every deep link.
+            () => $"http://127.0.0.1:{Port}",
             new HttpClient { Timeout = TimeSpan.FromSeconds(10) },
             // MTR-01 (Codex round 1): file the run-complete event into the current cron pass's OWN tenant ring,
             // the same per-tenant seam the deep-link resolver above reads. On self-host this is always Local.
@@ -1207,9 +1230,12 @@ public sealed class GatewayHost : IAsyncDisposable
             // heartbeat cycle; the resolvers never throw (they report an unresolved address as unresolved).
             var tailnetResolver = new Core.Network.TailnetIdentityResolver();
             var lanResolver = new Core.Network.LanIdentityResolver();
-            var gatewayPort = Port;
             Func<IReadOnlyList<string>> resolveEndpointUrls = () =>
             {
+                // Issue #2161: read the port HERE, per call. Hoisting it to a local outside this lambda captured
+                // the pre-bind value, which is 0 on an operating-system-assigned port - so every published
+                // endpoint URL would have advertised a port nothing listens on.
+                var gatewayPort = Port;
                 // Do the I/O here (probe Tailscale and the LAN), then hand the resolved pieces to the pure
                 // BuildOrderedEndpointUrls assembler so the ordering/dedup/loopback-skip logic is unit-tested
                 // without a real network. Passing no config override to the resolvers yields the PURE
@@ -1646,9 +1672,33 @@ public sealed class GatewayHost : IAsyncDisposable
         return Task.FromResult(brain);
     }
 
+    /// <summary>
+    /// The port Kestrel actually bound, read from the running server's own addresses (issue #2161). Only
+    /// called when the caller asked for an operating-system-assigned port. Throws rather than returning a
+    /// placeholder: every consumer of <see cref="Port"/> builds a URL from it, so a silent 0 here would
+    /// surface far away as an unreachable address with no trace of where it came from.
+    /// </summary>
+    private static int ReadBoundPort(WebApplication app)
+    {
+        var addresses = app.Services.GetService<IServer>()?.Features.Get<IServerAddressesFeature>()?.Addresses;
+        if (addresses is null || addresses.Count == 0)
+            throw new InvalidOperationException(
+                "[GatewayHost] The listener reported no bound address, so the operating-system-assigned port " +
+                "cannot be read back. The host is listening on an unknown port and nothing can reach it.");
+
+        foreach (var address in addresses)
+        {
+            if (Uri.TryCreate(address, UriKind.Absolute, out var uri) && uri.Port > 0)
+                return uri.Port;
+        }
+
+        throw new InvalidOperationException(
+            $"[GatewayHost] No bound address carried a usable port (addresses: {string.Join(", ", addresses)}).");
+    }
+
     public async Task StartAsync()
     {
-        FileLog.Write($"[GatewayHost] StartAsync: port={Port}");
+        FileLog.Write($"[GatewayHost] StartAsync: port={(Port == OperatingSystemAssignedPort ? "operating-system-assigned" : Port.ToString())}");
 
         // Seed the central vault from a DevThrottle account-key environment value once when present.
         // The vault is the live source of truth thereafter and SetIfAbsent never clobbers it.
@@ -2018,7 +2068,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // after the machine settings left the Cockpit Settings page. The mode is a delegate resolved per
             // request because SettingsHooks is assigned on this host after Map has run.
             gatewayStartedAtUtc: StartedAtUtc,
-            gatewayPort: Port,
+            // Issue #2161: a delegate - Map runs before the listener binds.
+            gatewayPort: () => Port,
             gatewayModeLabel: () => SettingsHooks?.Mode?.Invoke() ?? "unknown",
             // Store injection points: hand the phone-recorder ingest (RecordingEndpoints) the host's single
             // key vault + transcription history + audio archive, so it stops newing its own copies.
@@ -2670,6 +2721,14 @@ public sealed class GatewayHost : IAsyncDisposable
         Tenancy.HostedRefusalRouteSpace.ValidateBeforeStart(_app);
 
         await _app.StartAsync();
+
+        // Issue #2161: when the caller asked for an operating-system-assigned port, the number only exists
+        // once Kestrel has bound - so read it back from the server itself. This is the whole point of the
+        // mode: assignment and bind are one atomic step, so there is no window in which another process can
+        // take the port out from under us. Fail loudly if the address cannot be read: a Gateway whose Port
+        // still says 0 would hand that 0 to every consumer below and produce unreachable URLs.
+        if (Port == OperatingSystemAssignedPort)
+            Port = ReadBoundPort(_app);
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");
 
         // Cron firing sweep (epic #479, #483): wake ~every minute and fire due jobs. The first tick

--- a/src/CcDirector.Gateway/Running/GatewayCronNotifier.cs
+++ b/src/CcDirector.Gateway/Running/GatewayCronNotifier.cs
@@ -34,7 +34,7 @@ public sealed class GatewayCronNotifier : ICronNotifier
     private readonly DirectorEventLog _events;
     private readonly Func<string, string?> _resolveDirectorEndpoint;
     private readonly Func<TenantId?> _resolveTenant;
-    private readonly string _gatewayBaseUrl;
+    private readonly Func<string> _gatewayBaseUrl;
     private readonly HttpClient _webhookHttp;
 
     /// <param name="events">The per-Director event ring this notification rides (the existing channel).</param>
@@ -59,14 +59,14 @@ public sealed class GatewayCronNotifier : ICronNotifier
     public GatewayCronNotifier(
         DirectorEventLog events,
         Func<string, string?> resolveDirectorEndpoint,
-        string gatewayBaseUrl,
+        Func<string> gatewayBaseUrl,
         HttpClient webhookHttp,
         Func<TenantId?>? resolveTenant = null)
     {
         _events = events ?? throw new ArgumentNullException(nameof(events));
         _resolveDirectorEndpoint = resolveDirectorEndpoint ?? throw new ArgumentNullException(nameof(resolveDirectorEndpoint));
         _resolveTenant = resolveTenant ?? (() => TenantId.Local);
-        _gatewayBaseUrl = (gatewayBaseUrl ?? "").TrimEnd('/');
+        _gatewayBaseUrl = gatewayBaseUrl ?? throw new ArgumentNullException(nameof(gatewayBaseUrl));
         _webhookHttp = webhookHttp ?? throw new ArgumentNullException(nameof(webhookHttp));
     }
 
@@ -80,7 +80,11 @@ public sealed class GatewayCronNotifier : ICronNotifier
         var endpoint = string.IsNullOrEmpty(directorId) ? null : _resolveDirectorEndpoint(directorId);
         if (string.IsNullOrEmpty(endpoint)) return "";
         var baseUrl = endpoint.TrimEnd('/');
-        var gw = string.IsNullOrEmpty(_gatewayBaseUrl) ? "" : $"?gw={Uri.EscapeDataString(_gatewayBaseUrl)}";
+        // Issue #2161: the Gateway's own address is resolved per notification, never captured. It carries this
+        // Gateway's port, and on an operating-system-assigned port that number does not exist until the
+        // listener binds - after this notifier is built. A captured string would put a dead port in every link.
+        var gatewayUrl = (_gatewayBaseUrl() ?? "").TrimEnd('/');
+        var gw = string.IsNullOrEmpty(gatewayUrl) ? "" : $"?gw={Uri.EscapeDataString(gatewayUrl)}";
         return $"{baseUrl}/sessions/{sessionId}/view{gw}";
     }
 

--- a/src/CcDirector.Gateway/Running/IDirectorLauncher.cs
+++ b/src/CcDirector.Gateway/Running/IDirectorLauncher.cs
@@ -18,12 +18,17 @@ public interface IDirectorLauncher
 /// <summary>Production launcher: posts the shipped relay on the local Gateway (#331).</summary>
 public sealed class RelayDirectorLauncher : IDirectorLauncher
 {
-    private readonly int _gatewayPort;
+    private readonly Func<int> _gatewayPort;
     private readonly string _token;
 
-    public RelayDirectorLauncher(int gatewayPort, string token)
+    /// <param name="gatewayPort">
+    /// Read LATE, never captured (issue #2161). A Gateway started on an operating-system-assigned port does
+    /// not know its own number until the listener binds, which happens after this launcher is constructed -
+    /// so an int here would freeze the placeholder 0 and every relay would dial a port nothing serves.
+    /// </param>
+    public RelayDirectorLauncher(Func<int> gatewayPort, string token)
     {
-        _gatewayPort = gatewayPort;
+        _gatewayPort = gatewayPort ?? throw new ArgumentNullException(nameof(gatewayPort));
         _token = token ?? "";
     }
 
@@ -33,7 +38,7 @@ public sealed class RelayDirectorLauncher : IDirectorLauncher
             return false;
         try
         {
-            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gatewayPort}/"), Timeout = TimeSpan.FromSeconds(15) };
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gatewayPort()}/"), Timeout = TimeSpan.FromSeconds(15) };
             if (!string.IsNullOrEmpty(_token))
                 http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
             var resp = await http.PostAsync($"machines/{Uri.EscapeDataString(machine)}/director/start", content: null, ct);

--- a/src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs
+++ b/src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs
@@ -70,7 +70,7 @@ public sealed class TailscaleServeProvisioner : IDisposable
     /// `serve status --json` read per tick; it only ever asserts, never sweeps.</summary>
     private static readonly TimeSpan FrontDoorWatchInterval = TimeSpan.FromSeconds(60);
 
-    private readonly int _gatewayPort;
+    private readonly Func<int> _gatewayPort;
     private readonly bool _enabled;
     private readonly object _cliGate = new();
     private Timer? _reconcileTimer;
@@ -79,10 +79,15 @@ public sealed class TailscaleServeProvisioner : IDisposable
     private int _frontDoorRunning;
     private bool _disposed;
 
-    public TailscaleServeProvisioner(DirectorRegistry registry, int gatewayPort)
+    /// <param name="gatewayPort">
+    /// Read LATE, never captured (issue #2161). This provisioner is constructed before the listener binds,
+    /// and a Gateway on an operating-system-assigned port does not know its own number until it does - an
+    /// int here would freeze the placeholder 0 and publish a front door pointing at nothing.
+    /// </param>
+    public TailscaleServeProvisioner(DirectorRegistry registry, Func<int> gatewayPort)
     {
         _ = registry; // post-cut: no per-Director mappings, so the registry is no longer consulted
-        _gatewayPort = gatewayPort;
+        _gatewayPort = gatewayPort ?? throw new ArgumentNullException(nameof(gatewayPort));
 
         // Dev/test isolation: CC_GATEWAY_NO_TAILSCALE=1 lets a second Gateway run on this machine
         // for local end-to-end testing WITHOUT touching the production Tailscale Serve mappings
@@ -106,11 +111,11 @@ public sealed class TailscaleServeProvisioner : IDisposable
     public void Start()
     {
         if (!_enabled) return;
-        FileLog.Write($"[TailscaleServeProvisioner] Start: gatewayPort={_gatewayPort}");
+        FileLog.Write($"[TailscaleServeProvisioner] Start: gatewayPort={_gatewayPort()}");
 
         // Front door: https://<tailnet>/ -> gateway. Idempotent. The Cockpit is the Gateway's own
         // in-process front door (issue #979), so it never gets its own tailnet port.
-        QueueServeOn(FrontDoorHttpsPort, _gatewayPort, "gateway");
+        QueueServeOn(FrontDoorHttpsPort, _gatewayPort(), "gateway");
 
         // One-time cleanup of the pre-one-URL world: drop the legacy direct Cockpit mapping
         // (https://<tailnet>:7470) if this machine still carries one. Idempotent and safe
@@ -169,7 +174,7 @@ public sealed class TailscaleServeProvisioner : IDisposable
                 statusJson = stdout;
             }
 
-            var actions = ComputeReconcileActions(statusJson, _gatewayPort, desired);
+            var actions = ComputeReconcileActions(statusJson, _gatewayPort(), desired);
 
             if (actions.AssertFrontDoor)
             {
@@ -177,8 +182,8 @@ public sealed class TailscaleServeProvisioner : IDisposable
                 // only forensic trace of whoever clobbered the mapping, and it evaporates the
                 // moment we heal (issue #200 - the rogue port was only identified by a live
                 // probe during the outage).
-                FileLog.Write($"[TailscaleServeProvisioner] Reconcile: 443 front door missing or wrong backend (observed: {actions.FrontDoorBackend ?? "absent"}, expected: http://localhost:{_gatewayPort}) - re-asserting (issue #179)");
-                ServeOn(FrontDoorHttpsPort, _gatewayPort, "gateway (reconcile)");
+                FileLog.Write($"[TailscaleServeProvisioner] Reconcile: 443 front door missing or wrong backend (observed: {actions.FrontDoorBackend ?? "absent"}, expected: http://localhost:{_gatewayPort()}) - re-asserting (issue #179)");
+                ServeOn(FrontDoorHttpsPort, _gatewayPort(), "gateway (reconcile)");
             }
 
             foreach (var port in actions.PortsToMap)
@@ -288,11 +293,11 @@ public sealed class TailscaleServeProvisioner : IDisposable
                 statusJson = stdout;
             }
 
-            var actions = ComputeReconcileActions(statusJson, _gatewayPort, []);
+            var actions = ComputeReconcileActions(statusJson, _gatewayPort(), []);
             if (actions.AssertFrontDoor)
             {
-                FileLog.Write($"[TailscaleServeProvisioner] FrontDoorWatch: 443 front door missing or wrong backend (observed: {actions.FrontDoorBackend ?? "absent"}, expected: http://localhost:{_gatewayPort}) - re-asserting (issue #200)");
-                ServeOn(FrontDoorHttpsPort, _gatewayPort, "gateway (front-door watch)");
+                FileLog.Write($"[TailscaleServeProvisioner] FrontDoorWatch: 443 front door missing or wrong backend (observed: {actions.FrontDoorBackend ?? "absent"}, expected: http://localhost:{_gatewayPort()}) - re-asserting (issue #200)");
+                ServeOn(FrontDoorHttpsPort, _gatewayPort(), "gateway (front-door watch)");
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes #2161.

## The race

Gateway runs failed with `Failed to bind to address http://0.0.0.0:59467: address already in use` in tests nobody had touched. The suite already gave each Gateway its own port. The defect was in HOW that port was chosen - a pattern copied into 92 files:

```csharp
var listener = new TcpListener(IPAddress.Loopback, 0);
listener.Start();
try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
finally { listener.Stop(); }        // released HERE
...
new GatewayHost(port: FreePort())   // bound some time LATER
```

Between the release and the bind nothing holds the port, so anything on the machine can take it. The probe also asked about `IPAddress.Loopback` while `GatewayHost` binds `0.0.0.0` - so a port could read free and still be occupied on the interface that mattered, which is exactly what the quoted failure says.

## The fix

Assignment and bind become ONE step. `GatewayHost` accepts `OperatingSystemAssignedPort` (0), binds it, and reads the assigned number back from the server's own addresses the moment the listener is up. No interval, nothing to race.

**The part that needed care.** Four collaborators read `Port` BEFORE the listener binds: the Tailscale front-door provisioner, the Director relay launcher, the deep links in cron notifications, and the published endpoint list. Each froze a plain `int` at construction, so each would have captured the placeholder 0 and published addresses pointing at nothing. Each now reads the port late, at the moment of use, and says why in a comment. `Port` gained a private setter and a remark stating that nothing may capture it before the bind.

**The other half, for bare test hosts.** Eleven classes start a plain `WebApplication` rather than a `GatewayHost` and dial it themselves. Binding 0 is correct for them, but the CLIENT still has to learn the number - `127.0.0.1:0` is not something anything can connect to. A shared `BoundPort` helper reads it from the started host, and those eleven now build their base address after `StartAsync` instead of before.

Removes all 92 copies of the probe helper, so there is nothing left to call and a 93rd copy cannot appear.

## The lock stays

`GatewayTestSuiteLock` is untouched. This removes ONE shared resource, not all of them: the per-user storage root under `%LOCALAPPDATA%` is a separate question, and the lock's own comments are explicit that "no collision was found" is not "no collision exists". Relaxing it needs each remaining shared resource proven isolated - separate work.

## Evidence

- **Gateway suite: 4007 passed, 0 failed**, on a run holding the lock with the machine otherwise quiet.
- The read-back is **mutation-proved**: with it removed, three of the four new tests go red; the explicit-port test correctly stays green, because it does not depend on it.
- New tests: the reported port is non-zero; it is the port the host actually answers `/healthz` on; two hosts started together get different ports and both serve; an explicitly chosen port is still honoured verbatim (the guard against "read back what we bound" quietly becoming "ignore what the caller asked").

An earlier run of this branch failed 47 tests. That was this change, not contention: the eleven bare-host classes were dialling `127.0.0.1:0`. Recorded here because the same branch had a ready-made excuse available - the machine HAD been contended earlier - and the failure count alone would not have distinguished them.
