### PR TITLE
feat(voice): offer the transcription check only in the languages we officially support

### DIFF
--- a/apps/mobile/src/pages/TranscriptionTest.tsx
+++ b/apps/mobile/src/pages/TranscriptionTest.tsx
@@ -1,8 +1,8 @@
 import { Link } from "react-router-dom";
 import { TranscriptionTestPanel } from "@devthrottle/client-core/dictation/TranscriptionTestPanel";
 
-// "Test transcription" on the phone: read a passage in one of eight languages and see how much of it
-// came back. The whole screen is the shared panel, the same component and the same scoring the Cockpit
+// "Test transcription" on the phone: read a passage in one of the officially supported languages and
+// see how much of it came back. The whole screen is the shared panel, the same component and the same scoring the Cockpit
 // mounts, so a phone and a desktop can never report different accuracy for the same recording.
 //
 // Its own route, beside Test microphone, because they answer different questions: one is about the

--- a/packages/client-core/src/dictation/TranscriptionTestPanel.tsx
+++ b/packages/client-core/src/dictation/TranscriptionTestPanel.tsx
@@ -15,9 +15,11 @@ import "./mictest.css";
 // passage - so the answer is a percentage and a list of the exact words that were missed, rather than
 // an impression.
 //
-// It runs in eight languages because the answer is not the same in all of them, and we cannot know
-// where it is weak without measuring. The clip, the passage and the transcript are stored on the
-// Gateway, per tenant, so those comparisons can be made later across headsets, languages and releases.
+// It runs in the languages DevThrottle officially supports - and only those - because the answer is
+// not the same in all of them and we cannot know where it is weak without measuring. Testing a
+// language we do not ship would invite someone to read a poor score as a defect. The clip, the
+// passage and the transcript are stored on the Gateway, per tenant, so those comparisons can be made
+// later across headsets, languages and releases.
 
 const BAR_COUNT = 9;
 const MAX_SECONDS = 90;
@@ -185,7 +187,6 @@ export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProp
     setStage("idle");
   }, [clearCap, stopMeter]);
 
-  const passageDir = language.rightToLeft ? "rtl" : "ltr";
   const busy = stage === "recording" || stage === "transcribing";
 
   return (
@@ -223,7 +224,7 @@ export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProp
           <p className="mictest-prompt-label">
             {stage === "idle" ? "When you start, read this out loud at your normal pace:" : "Read this out loud:"}
           </p>
-          <p className="mictest-prompt mictest-passage" dir={passageDir} lang={language.code}>
+          <p className="mictest-prompt mictest-passage" lang={language.code}>
             {language.passage}
           </p>
         </>
@@ -288,7 +289,7 @@ export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProp
             <div className="mictest-playback-label">
               What came back, with the differences marked:
             </div>
-            <DiffView diff={verdict.result.diff} rtl={language.rightToLeft === true} lang={language.code} />
+            <DiffView diff={verdict.result.diff} lang={language.code} />
             <dl className="mictest-measurements">
               <div>
                 <dt>Correct</dt>
@@ -311,7 +312,7 @@ export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProp
 
           <details className="mictest-details">
             <summary>The raw transcript</summary>
-            <p className="mictest-rawtranscript" dir={passageDir} lang={language.code}>
+            <p className="mictest-rawtranscript" lang={language.code}>
               {transcript === "" ? "(nothing came back)" : transcript}
             </p>
           </details>
@@ -332,10 +333,10 @@ export function TranscriptionTestPanel({ className }: TranscriptionTestPanelProp
  * act on: a percentage says how bad it is, but only the specific misheard words tell you whether the
  * problem is your microphone, your accent, or a term that belongs in your dictionary.
  */
-function DiffView({ diff, rtl, lang }: { diff: DiffStep[]; rtl: boolean; lang: string }) {
+function DiffView({ diff, lang }: { diff: DiffStep[]; lang: string }) {
   if (diff.length === 0) return <p className="mictest-diff">(nothing to compare)</p>;
   return (
-    <p className="mictest-diff" dir={rtl ? "rtl" : "ltr"} lang={lang}>
+    <p className="mictest-diff" lang={lang}>
       {diff.map((step, i) => {
         if (step.op === "equal") {
           return (

--- a/packages/client-core/src/dictation/languages.ts
+++ b/packages/client-core/src/dictation/languages.ts
@@ -2,16 +2,16 @@ import type { TokenMode } from "./transcriptionAccuracy";
 
 // The reading passages for the "Test transcription" check, one per language.
 //
-// WHY THESE LANGUAGES: English, then the six most widely spoken languages in the world, plus Danish.
-// The six are the most-spoken reading of "top six" - the aim is to find out how DevThrottle behaves
-// for people all over the world, not to mirror any one country's developer population. Adding or
-// swapping a language is one entry in this list and nothing else: the panel, the scoring and the
-// storage are all driven from it.
+// WHICH LANGUAGES: exactly the languages DevThrottle officially supports - English, Danish, German,
+// French and Spanish. This list is deliberately the SUPPORTED set and nothing wider. Offering a test
+// in a language the product does not support invites someone to measure something we never promised
+// and then read a poor score as a defect rather than as an unsupported language. A check that reports
+// on what we do not ship is worse than no check, because the number looks official.
 //
 // WHY EACH PASSAGE IS THE SAME STORY: every language says roughly the same thing, so a score in one
 // language can be compared against a score in another. If the Danish passage were a tongue-twister
-// and the Spanish one were a nursery rhyme, the two numbers would not mean the same thing and the
-// whole point of testing many languages would be lost.
+// and the Spanish one a nursery rhyme, the two numbers would not mean the same thing, and comparing
+// languages - the entire reason for testing more than one - would be meaningless.
 //
 // WHAT MAKES A GOOD PASSAGE: 30-40 words, so it takes 15-25 seconds to read - long enough for a
 // stable score, short enough that people finish it. Ordinary prose rather than a pangram, because
@@ -19,8 +19,20 @@ import type { TokenMode } from "./transcriptionAccuracy";
 // No proper nouns, numbers written as words, no jargon: those are dictionary problems, not
 // transcription problems, and they would blame the transcriber for the wrong thing.
 //
-// NON-ASCII TEXT IS DELIBERATE HERE. These passages cannot be written in ASCII; that is the feature.
-// Console output, identifiers and comments elsewhere stay ASCII.
+// ADDING A LANGUAGE is one entry here and nothing else, PROVIDED it is written left to right with
+// spaces between words - which every currently supported language is. Two things need attention
+// otherwise, and both are easy to miss:
+//   - A language not delimited by spaces (Chinese, Japanese, Thai) must set tokenMode "characters",
+//     or a whole sentence scores as a single token and every speaker of it reads as near-zero. That
+//     scoring path is built and directly tested (transcriptionAccuracy.ts); it simply has no user in
+//     the supported set today, and the repository's own evaluation methodology requires it for
+//     zh/ja/th, so it stays.
+//   - A right-to-left language (Arabic, Hebrew) needs dir="rtl" on the passage and on the diff. That
+//     is NOT built. It was removed along with the unsupported languages rather than left behind as
+//     configuration nothing exercises - an untested rendering path rots quietly.
+//
+// NON-ASCII TEXT IS DELIBERATE HERE: Danish, German, French and Spanish cannot be written in ASCII.
+// Console output, identifiers, log lines and comments stay ASCII.
 
 export interface TestLanguage {
   /** BCP 47 tag, sent to the transcriber as the language hint and stored with the clip. */
@@ -33,8 +45,6 @@ export interface TestLanguage {
   passage: string;
   /** How this language is split for scoring. */
   tokenMode: TokenMode;
-  /** True for right-to-left scripts, so the passage is laid out correctly. */
-  rightToLeft?: boolean;
 }
 
 export const TEST_LANGUAGES: readonly TestLanguage[] = [
@@ -49,31 +59,23 @@ export const TEST_LANGUAGES: readonly TestLanguage[] = [
       "Thursday afternoon.",
   },
   {
-    code: "zh",
-    name: "Chinese (Mandarin)",
-    nativeName: "中文",
-    tokenMode: "characters",
-    passage:
-      "昨天午饭前我完成了六项小任务，然后去公园散步透透气。天气很冷，但是天空很晴朗，街道在星期四的下午安静得出奇。",
-  },
-  {
-    code: "hi",
-    name: "Hindi",
-    nativeName: "हिन्दी",
+    code: "da",
+    name: "Danish",
+    nativeName: "Dansk",
     tokenMode: "words",
     passage:
-      "कल मैंने दोपहर के भोजन से पहले छह छोटे काम पूरे किए, फिर ताज़ी हवा के लिए पार्क में टहलने गया। मौसम ठंडा लेकिन साफ़ था, " +
-      "और गुरुवार की दोपहर सड़कें बेहद शांत थीं।",
+      "I går afsluttede jeg seks små opgaver før frokost og gik derefter en tur i parken for at få " +
+      "luft. Vejret var koldt, men klart, og gaderne var overraskende stille en torsdag eftermiddag.",
   },
   {
-    code: "es",
-    name: "Spanish",
-    nativeName: "Español",
+    code: "de",
+    name: "German",
+    nativeName: "Deutsch",
     tokenMode: "words",
     passage:
-      "Ayer terminé seis tareas pequeñas antes del almuerzo y luego caminé por el parque para " +
-      "despejarme. Hacía frío pero el cielo estaba despejado, y las calles estaban sorprendentemente " +
-      "tranquilas para ser un jueves por la tarde.",
+      "Gestern habe ich vor dem Mittagessen sechs kleine Aufgaben erledigt und bin dann durch den " +
+      "Park gelaufen, um den Kopf frei zu bekommen. Das Wetter war kalt aber klar, und die Straßen " +
+      "waren an einem Donnerstagnachmittag überraschend still.",
   },
   {
     code: "fr",
@@ -86,33 +88,14 @@ export const TEST_LANGUAGES: readonly TestLanguage[] = [
       "un jeudi après-midi.",
   },
   {
-    code: "ar",
-    name: "Arabic",
-    nativeName: "العربية",
-    tokenMode: "words",
-    rightToLeft: true,
-    passage:
-      "أنهيت أمس ست مهام صغيرة قبل الغداء، ثم مشيت في الحديقة لأستنشق بعض الهواء. كان الطقس باردا لكنه " +
-      "صافيا، وكانت الشوارع هادئة بشكل مدهش في عصر يوم الخميس.",
-  },
-  {
-    code: "pt",
-    name: "Portuguese",
-    nativeName: "Português",
+    code: "es",
+    name: "Spanish",
+    nativeName: "Español",
     tokenMode: "words",
     passage:
-      "Ontem terminei seis pequenas tarefas antes do almoço e depois caminhei pelo parque para clarear " +
-      "as ideias. Estava frio mas o céu estava limpo, e as ruas estavam surpreendentemente tranquilas " +
-      "para uma quinta-feira à tarde.",
-  },
-  {
-    code: "da",
-    name: "Danish",
-    nativeName: "Dansk",
-    tokenMode: "words",
-    passage:
-      "I går afsluttede jeg seks små opgaver før frokost og gik derefter en tur i parken for at få " +
-      "luft. Vejret var koldt, men klart, og gaderne var overraskende stille en torsdag eftermiddag.",
+      "Ayer terminé seis tareas pequeñas antes del almuerzo y luego caminé por el parque para " +
+      "despejarme. Hacía frío pero el cielo estaba despejado, y las calles estaban sorprendentemente " +
+      "tranquilas para ser un jueves por la tarde.",
   },
 ];
 
@@ -127,8 +110,9 @@ export function languageByCode(code: string): TestLanguage {
 
 /**
  * The best supported language for a browser's stated preferences. Matches on the PRIMARY subtag, so
- * a browser set to Brazilian Portuguese or Swiss French still lands on Portuguese or French rather
- * than falling back to English.
+ * a browser set to Austrian German or Mexican Spanish still lands on German or Spanish rather than
+ * falling back to English. A browser set to a language we do not support gets English, which is the
+ * honest answer - there is no passage to offer it.
  */
 export function preferredLanguage(browserLanguages: readonly string[]): TestLanguage {
   for (const tag of browserLanguages) {

--- a/packages/client-core/src/dictation/mictest.css
+++ b/packages/client-core/src/dictation/mictest.css
@@ -317,10 +317,17 @@
   content: " ";
 }
 
-/* Chinese and Japanese are scored per character, so the tokens must sit flush rather than being
-   separated by the space that follows every other language's word. */
+/* The layout half of character scoring: a language written without spaces between words is scored per
+   character, so its tokens must sit flush rather than each gaining the trailing space a word needs.
+   No officially supported language uses this today - every supported language is space-delimited -
+   but it is kept rather than deleted because it pairs with the tokenMode "characters" scoring path,
+   which IS exercised by tests and which the repository's evaluation methodology requires for zh/ja/th.
+   Deleting the layout while keeping the scoring would leave a language that scores correctly and
+   renders as one unreadable run. (Contrast right-to-left support, which was removed with the
+   unsupported languages precisely because it had no tested counterpart - see languages.ts.) */
 .mictest-diff[lang="zh"] .mictest-tok::after,
-.mictest-diff[lang="ja"] .mictest-tok::after {
+.mictest-diff[lang="ja"] .mictest-tok::after,
+.mictest-diff[lang="th"] .mictest-tok::after {
   content: "";
 }
 

--- a/packages/client-core/src/dictation/transcriptionAccuracy.test.ts
+++ b/packages/client-core/src/dictation/transcriptionAccuracy.test.ts
@@ -157,13 +157,19 @@ describe("judgeAccuracy", () => {
 });
 
 describe("the language pack", () => {
-  it("offers English, the six most-spoken languages, and Danish", () => {
-    expect(TEST_LANGUAGES).toHaveLength(8);
-    const codes = TEST_LANGUAGES.map((l) => l.code);
-    expect(codes).toContain("en");
-    expect(codes).toContain("da");
-    for (const code of ["zh", "hi", "es", "fr", "ar", "pt"]) {
-      expect(codes).toContain(code);
+  // The officially supported set, and nothing wider. This test is the guard on that: offering a test
+  // in an unsupported language invites someone to measure what we never promised and read a poor
+  // score as a defect. Widening this list is a product decision, so it has to be a deliberate edit
+  // here and not a quiet append to the pack.
+  const SUPPORTED = ["en", "da", "de", "fr", "es"];
+
+  it("offers exactly the languages DevThrottle officially supports", () => {
+    expect(TEST_LANGUAGES.map((l) => l.code)).toEqual(SUPPORTED);
+  });
+
+  it("offers no language outside the supported set", () => {
+    for (const lang of TEST_LANGUAGES) {
+      expect(SUPPORTED).toContain(lang.code);
     }
   });
 
@@ -176,15 +182,12 @@ describe("the language pack", () => {
     }
   });
 
-  it("uses character scoring for Chinese and word scoring for the rest", () => {
-    expect(languageByCode("zh").tokenMode).toBe("characters");
-    expect(languageByCode("da").tokenMode).toBe("words");
-    expect(languageByCode("en").tokenMode).toBe("words");
-  });
-
-  it("marks Arabic right to left so its passage is laid out correctly", () => {
-    expect(languageByCode("ar").rightToLeft).toBe(true);
-    expect(languageByCode("en").rightToLeft).toBeUndefined();
+  it("uses word scoring for every supported language, all of which are space-delimited", () => {
+    // Character scoring exists and is tested directly above; it has no user in the supported set.
+    // If a language written without spaces is ever added, this expectation is what should fail.
+    for (const lang of TEST_LANGUAGES) {
+      expect(`${lang.code}:${lang.tokenMode}`).toBe(`${lang.code}:words`);
+    }
   });
 
   it("gives every passage enough tokens for a stable score", () => {
@@ -209,10 +212,18 @@ describe("the language pack", () => {
   });
 
   it("matches a browser language on its primary subtag, so regional variants still match", () => {
-    expect(preferredLanguage(["pt-BR"]).code).toBe("pt");
+    expect(preferredLanguage(["de-AT"]).code).toBe("de");
     expect(preferredLanguage(["fr-CH", "en"]).code).toBe("fr");
+    expect(preferredLanguage(["es-MX"]).code).toBe("es");
     expect(preferredLanguage(["da-DK"]).code).toBe("da");
-    expect(preferredLanguage(["nl-NL"]).code).toBe("en");
     expect(preferredLanguage([]).code).toBe("en");
+  });
+
+  it("offers English to a browser set to a language we do not support", () => {
+    // Not a silent nearest-match: there is no passage in Dutch or Portuguese, and pretending
+    // otherwise would score a Dutch speaker against English words.
+    expect(preferredLanguage(["nl-NL"]).code).toBe("en");
+    expect(preferredLanguage(["pt-BR"]).code).toBe("en");
+    expect(preferredLanguage(["zh-CN"]).code).toBe("en");
   });
 });

--- a/packages/client-core/src/dictation/transcriptionAccuracy.ts
+++ b/packages/client-core/src/dictation/transcriptionAccuracy.ts
@@ -12,8 +12,8 @@
 // is kept so the screen can SHOW which words were missed rather than only scoring them.
 //
 // NOTE ON NON-ASCII TEXT: this file and languages.ts necessarily carry non-ASCII characters, because
-// the passages are in Chinese, Hindi, Arabic, Danish and so on. That is the feature. Every console
-// line, identifier and comment stays ASCII.
+// the passages are in Danish, German, French and Spanish. That is the feature. Every console line,
+// identifier and comment stays ASCII.
 
 /** How a language's text is split for comparison. */
 export type TokenMode =

--- a/src/CcDirector.Gateway.Tests/TranscriptionLanguageHintTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionLanguageHintTests.cs
@@ -65,16 +65,13 @@ public sealed class TranscriptionLanguageHintTests
 
     [Theory]
     [InlineData("en")]
-    [InlineData("zh")]
-    [InlineData("hi")]
-    [InlineData("es")]
-    [InlineData("fr")]
-    [InlineData("ar")]
-    [InlineData("pt")]
     [InlineData("da")]
-    public async Task EveryLanguageTheCheckOffersIsCarriedThrough(string code)
+    [InlineData("de")]
+    [InlineData("fr")]
+    [InlineData("es")]
+    public async Task EveryOfficiallySupportedLanguageIsCarriedThrough(string code)
     {
-        // One per offered language, so adding a language to the picker without plumbing it is caught
+        // One per SUPPORTED language, so adding a language to the picker without plumbing it is caught
         // here rather than by a user in that language wondering why their results are poor.
         var body = await PostAndCaptureAsync(code);
 


### PR DESCRIPTION
The transcription check shipped in #2160 with English, the six most widely spoken languages, and
Danish. The officially supported set is **English, Danish, German, French and Spanish**, so it now
offers exactly those: German is added, and Chinese, Hindi, Arabic and Portuguese are removed.

Offering a test in a language the product does not support invites someone to measure something we
never promised, and then to read a poor score as a defect rather than as an unsupported language. A
check that reports on what we do not ship is worse than no check, because the number looks official.

## Guarding the list rather than describing it

- One test asserts the pack **is** the supported set exactly, so widening it has to be a deliberate
  edit and not a quiet append.
- One asserts a browser set to an unsupported language is offered English rather than a silent
  nearest match. There is no Dutch passage, and pretending otherwise would score a Dutch speaker
  against English words.
- The Gateway language-hint test enumerates the same five, so adding a language to the picker without
  plumbing the hint through to the provider fails there rather than in front of a user in that
  language.

The German passage tells the same story as the others, so a German score and a Danish score still
mean the same thing - that comparability is the entire reason for testing more than one language. It
round-trips to 100% against itself in the existing per-language test, which is what catches a
tokenizer that mishandles a script (`ß` and the umlauts here).

## What was removed, and what deliberately was not

**Right-to-left support is removed** with the languages that needed it. It was an optional field and
a pair of `dir` attributes with no test behind them, and an untested rendering path with no user rots
quietly.

**Character scoring for languages written without spaces is kept**, including its layout rule. Unlike
the right-to-left path it has a tested counterpart - the tokenizer and scorer are exercised directly
on character input - and this repository's own evaluation methodology (`docs/architecture/
transcription-quality-loop.md`, `tools/harnesses/dictionary-cleanup-eval`) requires character-level
scoring for Chinese, Japanese and Thai. Keeping the scoring while deleting the layout would leave such
a language scoring correctly and rendering as a single unreadable run. Both halves now carry a comment
stating they have no user in the supported set and why they survive anyway.

## Verification

674 client-core tests, 180 Cockpit tests, both web apps build, root typecheck clean, and the directly
affected Gateway tests pass (10 language-hint, 24 voice-test).
