### PR TITLE
Ask before clearing a session's context on the desktop (#2169)

### DIFF
--- a/src/CcDirector.Avalonia.Tests/ClearContextConfirmationTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ClearContextConfirmationTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Headless.XUnit;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Issue #2169 - the desktop asks before clearing a session's context.
+///
+/// Clearing destroys the whole conversation and cannot be undone. The button used to fire on the first
+/// click, sitting inches from Interrupt and beside a context gauge that turns red - which is exactly when
+/// somebody reaches for a button. Worse, the Cockpit had asked since issue #1244, so the SAME action behaved
+/// differently depending on which surface you were looking at, and the surface with a real mouse was the
+/// unguarded one.
+///
+/// The decisive test here is the declined one: the driver must receive NOTHING. A test that only checked
+/// "a dialog appears" would still pass if the clear were submitted behind it.
+/// </summary>
+public class ClearContextConfirmationTests
+{
+    [AvaloniaFact]
+    public async Task DecliningTheConfirmation_SubmitsNothingToTheDriver()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = new SessionActionBar();
+        bar.Configure(sessionManager: null!, session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(false);
+
+        await bar.ClearContextWithConfirmationAsync();
+
+        Assert.Equal(0, driver.ClearCalls);
+    }
+
+    [AvaloniaFact]
+    public async Task ConfirmingTheDialog_ClearsTheContext()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = new SessionActionBar();
+        bar.Configure(sessionManager: null!, session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(true);
+
+        await bar.ClearContextWithConfirmationAsync();
+
+        Assert.Equal(1, driver.ClearCalls);
+    }
+
+    /// <summary>
+    /// The guard against the defect quietly coming back. Every other test here drives
+    /// ClearContextWithConfirmationAsync, which asks by construction - so if a future edit moved the clear
+    /// back into the click handler ahead of the question, they would all still pass. This one pins the
+    /// ordering: the confirmation must have been ASKED before the driver is touched.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task TheQuestionIsAskedBeforeTheDriverIsTouched()
+    {
+        var order = new List<string>();
+        var driver = new RecordingDriver { OnClear = () => order.Add("cleared") };
+        using var session = NewSession(driver);
+        var bar = new SessionActionBar();
+        bar.Configure(sessionManager: null!, session);
+        bar.ConfirmOverride = (_, _) =>
+        {
+            order.Add("asked");
+            return Task.FromResult(true);
+        };
+
+        await bar.ClearContextWithConfirmationAsync();
+
+        Assert.Equal(new[] { "asked", "cleared" }, order);
+    }
+
+    /// <summary>
+    /// A confirmation that cannot be shown is not permission to proceed. If the dialog throws - no owner
+    /// window, a broken window stack - the safe answer is to do nothing, not to fall through to the clear.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AConfirmationThatFails_DoesNotClear()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = new SessionActionBar();
+        bar.Configure(sessionManager: null!, session);
+        bar.ConfirmOverride = (_, _) => throw new InvalidOperationException("no owner window");
+
+        await bar.ClearContextWithConfirmationAsync();
+
+        Assert.Equal(0, driver.ClearCalls);
+    }
+
+    /// <summary>
+    /// The desktop and the Cockpit describe the same action the same way. The message must also say what
+    /// SURVIVES - "clear" alone reads to some people as "kill my session", and the useful fact is that the
+    /// process keeps running and only the conversation goes.
+    /// </summary>
+    [Fact]
+    public void TheWordingMatchesTheCockpit_AndSaysWhatSurvives()
+    {
+        Assert.Equal("Clear this session's context?", SessionActionBar.ClearContextConfirmTitle);
+        Assert.Contains("resets the conversation in place", SessionActionBar.ClearContextConfirmMessage);
+        Assert.Contains("running process keeps going", SessionActionBar.ClearContextConfirmMessage);
+        Assert.Contains("cannot be undone", SessionActionBar.ClearContextConfirmMessage);
+    }
+
+    private static Session NewSession(IAgentDriver driver)
+    {
+        var session = new Session(
+            Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new NullBackend(), claudeSessionId: "agent-1",
+            activityState: ActivityState.WaitingForInput, createdAt: DateTimeOffset.UtcNow,
+            customName: null, customColor: null);
+        session.DriverOverride = driver;
+        return session;
+    }
+
+    /// <summary>A driver that records whether the destructive verb was ever submitted.</summary>
+    private sealed class RecordingDriver : IAgentDriver
+    {
+        public int ClearCalls { get; private set; }
+        public Action? OnClear { get; init; }
+
+        public AgentKind Kind => AgentKind.ClaudeCode;
+        public DriverCapabilities Capabilities => DriverCapabilities.ClearContext;
+        public IReadOnlyList<AgentSlashCommand> SlashCommands => [];
+        public string ModelFlag => "";
+        public IReadOnlyList<AgentModelOption> KnownModels => [];
+        public string? ReadConfiguredDefaultModel() => null;
+        public string ResolveExecutable(string? configuredPath) => throw new NotSupportedException();
+        public AgentLaunchSpec BuildLaunchSpec(string? baseArgs, string? resumeSessionId) => throw new NotSupportedException();
+        public Task SubmitAsync(ISessionBackend backend, string text) => Task.CompletedTask;
+        public Task CancelAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task InterruptAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task ShowHistoryAsync(ISessionBackend backend) => Task.CompletedTask;
+
+        public Task ClearContextAsync(ISessionBackend backend)
+        {
+            ClearCalls++;
+            OnClear?.Invoke();
+            return Task.CompletedTask;
+        }
+
+        public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) => new();
+        public SessionUsageDto? ReadUsage(string agentSessionId, string workingDirectory) => null;
+        public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) => new();
+    }
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public int ProcessId => 1;
+        public string Status => "Running";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface, never raised here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -179,13 +179,81 @@ public partial class SessionActionBar : UserControl
         }
     }
 
+    /// <summary>
+    /// The question asked before a context clear. Kept as constants so the desktop and the Cockpit say the
+    /// SAME thing about the same action - the wording matches
+    /// <c>apps/cockpit/src/sessions/SessionActionBar.tsx</c>.
+    ///
+    /// It states what SURVIVES as well as what is lost. "Clear" on its own reads to some people as "kill my
+    /// session"; the useful fact is that the process keeps running and only the conversation goes.
+    /// </summary>
+    internal const string ClearContextConfirmTitle = "Clear this session's context?";
+
+    internal const string ClearContextConfirmMessage =
+        "This resets the conversation in place. The running process keeps going, but the agent loses the " +
+        "current conversation. This cannot be undone.";
+
+    /// <summary>
+    /// How the bar asks before a destructive verb. Null in the running application, where it opens the real
+    /// modal <see cref="ConfirmDialog"/>. Tests replace it: a modal cannot be answered in a headless run, so
+    /// without this seam the decision - the whole point of issue #2169 - could only be verified by hand.
+    /// </summary>
+    internal Func<string, string, Task<bool>>? ConfirmOverride { get; set; }
+
+    private async Task<bool> ConfirmAsync(string title, string message, string confirmLabel)
+    {
+        if (ConfirmOverride is not null)
+            return await ConfirmOverride(title, message);
+
+        var owner = TopLevel.GetTopLevel(this) as Window
+            ?? throw new InvalidOperationException(
+                "[SessionActionBar] No owner window, so the confirmation cannot be shown. Refusing to run a " +
+                "destructive action unasked.");
+        return await new ConfirmDialog(title, message, confirmLabel).ShowDialog<bool?>(owner) == true;
+    }
+
     private async void BtnClearContext_Click(object? sender, RoutedEventArgs e)
+    {
+        await ClearContextWithConfirmationAsync();
+    }
+
+    /// <summary>
+    /// Ask, then clear (issue #2169). Clearing destroys the session's whole conversation and cannot be
+    /// undone, and this button sits inches from Interrupt and beside a context gauge that turns red -
+    /// exactly when somebody reaches for a button. It used to fire on the first click; the Cockpit has asked
+    /// since issue #1244, so the same action behaved differently depending on which surface you were looking
+    /// at, and the surface with a real mouse was the unguarded one.
+    ///
+    /// Internal rather than private so the decision is testable: a test can decline the confirmation and
+    /// assert that NOTHING was submitted to the driver.
+    /// </summary>
+    internal async Task ClearContextWithConfirmationAsync()
     {
         var session = _session;
         if (session is null) return;
+
+        bool confirmed;
         try
         {
-            FileLog.Write($"[SessionActionBar] Clear context clicked: session={session.Id}");
+            confirmed = await ConfirmAsync(ClearContextConfirmTitle, ClearContextConfirmMessage, "Clear context");
+        }
+        catch (Exception ex)
+        {
+            // A confirmation that cannot be shown is not permission to proceed.
+            FileLog.Write($"[SessionActionBar] Clear context confirmation FAILED: {ex.Message}");
+            ShowStatus($"clear failed: {ex.Message}");
+            return;
+        }
+
+        if (!confirmed)
+        {
+            FileLog.Write($"[SessionActionBar] Clear context declined at the confirmation: session={session.Id}");
+            return;
+        }
+
+        try
+        {
+            FileLog.Write($"[SessionActionBar] Clear context confirmed: session={session.Id}");
             ShowStatus("clearing context...");
             var newId = await session.ClearContextAsync();
             if (newId is not null)


### PR DESCRIPTION
Closes #2169.

## The defect

`BtnClearContext_Click` called `session.ClearContextAsync()` immediately. One click destroyed a session's whole conversation, with nothing asked and no way back.

Two things made it worse than an ordinary misclick:

- The button sits inches from Interrupt and beside the live context gauge. The moment somebody is most likely to reach for a button is when that gauge turns red - and the nearest one was the destructive one, offering the wrong answer to "my context is full".
- The session keeps running afterwards, so nothing looks broken. The agent simply has no idea what it was doing - a failure nobody connects back to the click that caused it.

The Cockpit has asked since #1244. The same button in the same action bar behaved differently depending on the surface, and the surface with a real mouse was the unguarded one.

## The change

Routed through the desktop's existing `ConfirmDialog` - the same one "Clear all screenshots" uses (#1494) - with wording taken verbatim from the Cockpit, so one action reads one way everywhere.

The message says what SURVIVES as well as what is lost. "Clear" on its own reads to some people as "kill my session"; the useful fact is that the process keeps running and only the conversation goes.

A confirmation that cannot be shown is not permission to proceed: if the dialog throws (no owner window, a broken window stack), nothing is submitted.

The decision sits behind an internal seam. A modal cannot be answered in a headless run, so without it this guard could only ever be verified by hand - which, for a guard against data loss, is no verification at all.

## Tests

Five new; the desktop suite is 299 green.

- Declining submits **nothing** to the driver. This is the decisive one: a test that merely checked "a dialog appears" would still pass if the clear were submitted behind it.
- Confirming clears, exactly as before.
- A confirmation that throws does not clear.
- The wording matches the Cockpit and names what survives.
- **The order is pinned**: the question must be asked before the driver is touched. Every other test drives the method that asks by construction, so an edit moving the clear back ahead of the question would leave them all green. This one fails.

Restoring the one-click behaviour reddens three of the five; the other two correctly stay green (confirming still clears, and the wording is unchanged). Watched failing, not assumed.

## Related

#2167 adds a Compact button to both surfaces, also confirmed. The two dialogs must read DIFFERENTLY: clear destroys the conversation and says so, compact preserves it and must not imply loss - otherwise people learn one reflex for two opposite outcomes.
