### PR TITLE
Compact and compact-and-continue are two different things (#2167)

### DIFF
--- a/apps/cockpit/src/sessions/SessionActionBar.tsx
+++ b/apps/cockpit/src/sessions/SessionActionBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   sendClearContext,
+  sendCompactContext,
   sendEscape,
   sendHistoryPicker,
   sendInterrupt,
@@ -15,6 +16,7 @@ import { ConfirmDialog } from "../components";
 //
 //   Stop (Cancel cap)          -> POST /sessions/{sid}/escape    (the driver's soft cancel - Esc)
 //   Interrupt (Interrupt cap)  -> POST /sessions/{sid}/interrupt (hard Ctrl+C, stronger than Stop)
+//   Compact (CompactContext cap) -> POST /sessions/{sid}/compact-context (summarize + continue)
 //   Clear context (ClearContext cap) -> POST /sessions/{sid}/clear-context (/clear in place)
 //   History (History cap)      -> POST /sessions/{sid}/history-picker (the in-terminal history picker)
 
@@ -31,6 +33,14 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
   // Clear context resets the session's whole conversation in place; it is destructive, so it asks
   // through the shared ConfirmDialog (issue #1244) instead of firing on the first click.
   const [confirmClear, setConfirmClear] = useState(false);
+  // Compaction asks too (issue #2167). Note the dialogs deliberately READ DIFFERENTLY: clearing
+  // destroys the conversation, compaction preserves it. Two confirmations worded alike would train one
+  // reflex for two opposite outcomes, which is worse than one.
+  const [confirmCompact, setConfirmCompact] = useState(false);
+  // A compaction is a language model summarizing a whole conversation - it routinely runs past a
+  // minute. The other verbs return in milliseconds, so the shared `acting` flag alone would leave the
+  // bar looking dead for the entire wait with nothing to explain it.
+  const [compacting, setCompacting] = useState(false);
   const statusTimer = useRef<number | null>(null);
 
   useEffect(() => {
@@ -100,6 +110,17 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           Interrupt
         </button>
       )}
+      {has("CompactContext") && (
+        <button
+          type="button"
+          className="act-btn"
+          disabled={acting}
+          onClick={() => setConfirmCompact(true)}
+          title="Summarize the conversation and continue - frees context window, keeps what the session has learned"
+        >
+          {compacting ? "Compacting..." : "Compact"}
+        </button>
+      )}
       {has("ClearContext") && (
         <button
           type="button"
@@ -124,6 +145,35 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
       )}
       {status !== null && <span className="action-status">{status}</span>}
       {error !== null && <span className="action-error">{error}</span>}
+
+      <ConfirmDialog
+        open={confirmCompact}
+        title="Compact this session's context?"
+        message={
+          "This summarizes the conversation so far and continues from the summary, freeing room in the " +
+          "context window. The session keeps what it has learned. It can take a minute or two."
+        }
+        confirmLabel="Compact"
+        busyLabel="Compacting..."
+        onConfirm={async () => {
+          if (sessionId === undefined) return;
+          setCompacting(true);
+          try {
+            // The follow-up is only sent to a driver that can report when the compaction FINISHED.
+            // Without that signal the Gateway refuses a continuation rather than firing it at a
+            // guessed moment - so read the capability here instead of discovering it as an error.
+            const continuePrompt = has("CompactCompletionReport") ? "continue" : undefined;
+            const result = await sendCompactContext(sessionId, continuePrompt);
+            // Render the Gateway's own sentence verbatim. It is the only thing that knows whether the
+            // compaction was watched to completion or merely submitted, and composing a second message
+            // here is how "Compacted" ends up on screen for a compaction nobody observed.
+            flash(result.detail);
+          } finally {
+            setCompacting(false);
+          }
+        }}
+        onClose={() => setConfirmCompact(false)}
+      />
 
       <ConfirmDialog
         open={confirmClear}

--- a/apps/cockpit/src/sessions/SessionActionBar.tsx
+++ b/apps/cockpit/src/sessions/SessionActionBar.tsx
@@ -16,7 +16,7 @@ import { ConfirmDialog } from "../components";
 //
 //   Stop (Cancel cap)          -> POST /sessions/{sid}/escape    (the driver's soft cancel - Esc)
 //   Interrupt (Interrupt cap)  -> POST /sessions/{sid}/interrupt (hard Ctrl+C, stronger than Stop)
-//   Compact (CompactContext cap) -> POST /sessions/{sid}/compact-context (summarize + continue)
+//   Compact (CompactContext cap) -> POST /sessions/{sid}/compact-context (summarize in place)
 //   Clear context (ClearContext cap) -> POST /sessions/{sid}/clear-context (/clear in place)
 //   History (History cap)      -> POST /sessions/{sid}/history-picker (the in-terminal history picker)
 
@@ -116,7 +116,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           className="act-btn"
           disabled={acting}
           onClick={() => setConfirmCompact(true)}
-          title="Summarize the conversation and continue - frees context window, keeps what the session has learned"
+          title="Summarize the conversation - frees context window, keeps what the session has learned"
         >
           {compacting ? "Compacting..." : "Compact"}
         </button>
@@ -150,8 +150,8 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
         open={confirmCompact}
         title="Compact this session's context?"
         message={
-          "This summarizes the conversation so far and continues from the summary, freeing room in the " +
-          "context window. The session keeps what it has learned. It can take a minute or two."
+          "This summarizes the conversation so far, freeing room in the context window. The session keeps " +
+          "what it has learned, and stays where it is - nothing is sent to it. It can take a minute or two."
         }
         confirmLabel="Compact"
         busyLabel="Compacting..."
@@ -159,11 +159,12 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           if (sessionId === undefined) return;
           setCompacting(true);
           try {
-            // The follow-up is only sent to a driver that can report when the compaction FINISHED.
-            // Without that signal the Gateway refuses a continuation rather than firing it at a
-            // guessed moment - so read the capability here instead of discovering it as an error.
-            const continuePrompt = has("CompactCompletionReport") ? "continue" : undefined;
-            const result = await sendCompactContext(sessionId, continuePrompt);
+            // Compact ONLY - no follow-up prompt. The button frees room in the context window and
+            // stops there; deciding what the session should do next is the person's, and they are
+            // sitting right here with a composer. Compact-and-continue is a separate verb, for the
+            // command line, where a supervising agent rescuing a stuck session has nobody to type
+            // the next prompt.
+            const result = await sendCompactContext(sessionId);
             // Render the Gateway's own sentence verbatim. It is the only thing that knows whether the
             // compaction was watched to completion or merely submitted, and composing a second message
             // here is how "Compacted" ends up on screen for a compaction nobody observed.

--- a/apps/cockpit/src/sessions/compactButton.test.tsx
+++ b/apps/cockpit/src/sessions/compactButton.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+// Issue #2167 - the Cockpit Compact button.
+//
+// Compaction summarizes the conversation and carries on; clearing throws it away. They sit next to each
+// other, so the tests that matter here are the ones about the DIFFERENCE: compaction never clears, the
+// follow-up only goes to a driver that can time it, and a compaction nobody watched is never reported as
+// "Compacted".
+
+const { sendCompactContext, sendClearContext } = vi.hoisted(() => ({
+  sendCompactContext: vi.fn(async () => ({
+    submitted: true,
+    compactionObserved: true,
+    waitedSeconds: 41,
+    continued: true,
+    detail: "Compacted in 41 seconds, then sent the follow-up.",
+  })),
+  sendClearContext: vi.fn(async () => {}),
+}));
+
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  sendCompactContext,
+  sendClearContext,
+  sendEscape: vi.fn(async () => {}),
+  sendInterrupt: vi.fn(async () => {}),
+  sendHistoryPicker: vi.fn(async () => {}),
+  gatewayErrorMessage: (err: Error) => err.message,
+}));
+
+import { SessionActionBar } from "./SessionActionBar";
+
+const SESSION = "11111111-2222-3333-4444-555555555555";
+const CLAUDE_CAPS = ["Cancel", "Interrupt", "ClearContext", "CompactContext", "CompactCompletionReport"];
+
+// The action bar's own button, distinguished from the dialog's confirm button of the same name by the
+// class the bar puts on its buttons. Both legitimately read "Compact" - that is the point of the label.
+function compactButton(): HTMLElement {
+  const match = document.querySelector<HTMLElement>("button.act-btn[title^='Summarize']");
+  if (match === null) throw new Error("the action bar has no Compact button");
+  return match;
+}
+
+function dialogConfirmButton(): HTMLElement {
+  const match = document.querySelector<HTMLElement>(".ui-confirm-actions button:last-of-type");
+  if (match === null) throw new Error("no confirmation dialog is open");
+  return match;
+}
+
+async function clickCompactAndConfirm() {
+  fireEvent.click(compactButton());
+  await waitFor(() => expect(document.querySelector(".ui-confirm")).toBeTruthy());
+  fireEvent.click(dialogConfirmButton());
+}
+
+describe("Compact button", () => {
+  beforeEach(() => {
+    // This project runs vitest without globals, so testing-library's automatic cleanup is not
+    // registered - without this, each render leaks into the next test's document.
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("is shown for a driver that declares compaction, and hidden for one that does not", () => {
+    const { unmount } = render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+    expect(compactButton()).toBeTruthy();
+    unmount();
+
+    render(<SessionActionBar sessionId={SESSION} capabilities={["Cancel", "ClearContext"]} />);
+    expect(document.querySelector("button.act-btn[title^='Summarize']")).toBeNull();
+  });
+
+  it("asks before compacting, and sends nothing if the question is not answered", () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+
+    fireEvent.click(compactButton());
+
+    expect(sendCompactContext).not.toHaveBeenCalled();
+  });
+
+  it("compacts with a follow-up when the driver can report the finish", async () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+
+    await clickCompactAndConfirm();
+
+    await waitFor(() => expect(sendCompactContext).toHaveBeenCalledWith(SESSION, "continue"));
+  });
+
+  // The Gateway REFUSES a continuation it cannot time. The button must know that from the declared
+  // capability rather than sending one and catching the refusal.
+  it("sends no follow-up to a driver that cannot report the finish", async () => {
+    render(
+      <SessionActionBar sessionId={SESSION} capabilities={["ClearContext", "CompactContext"]} />,
+    );
+
+    await clickCompactAndConfirm();
+
+    await waitFor(() => expect(sendCompactContext).toHaveBeenCalledWith(SESSION, undefined));
+  });
+
+  it("never clears when asked to compact", async () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+
+    await clickCompactAndConfirm();
+
+    await waitFor(() => expect(sendCompactContext).toHaveBeenCalled());
+    expect(sendClearContext).not.toHaveBeenCalled();
+  });
+
+  it("shows the Gateway's own sentence, verbatim", async () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+
+    await clickCompactAndConfirm();
+
+    expect(
+      await screen.findByText("Compacted in 41 seconds, then sent the follow-up."),
+    ).toBeTruthy();
+  });
+
+  // A compaction that was submitted but never watched is NOT a compaction anyone can vouch for. The
+  // Gateway says so in its own sentence; rendering that verbatim is what keeps the screen honest, and
+  // composing a cheerful message here is exactly how "Compacted" ends up on screen for one nobody saw.
+  it("does not claim a compaction that was never observed", async () => {
+    sendCompactContext.mockResolvedValueOnce({
+      submitted: true,
+      compactionObserved: false,
+      waitedSeconds: 0,
+      continued: false,
+      detail: "Compaction submitted. Codex cannot report when it finishes, so this was not watched.",
+    });
+    render(
+      <SessionActionBar sessionId={SESSION} capabilities={["ClearContext", "CompactContext"]} />,
+    );
+
+    await clickCompactAndConfirm();
+
+    const status = await screen.findByText(/Compaction submitted/);
+    expect(status.textContent).not.toMatch(/^Compacted/);
+  });
+});

--- a/apps/cockpit/src/sessions/compactButton.test.tsx
+++ b/apps/cockpit/src/sessions/compactButton.test.tsx
@@ -79,24 +79,26 @@ describe("Compact button", () => {
     expect(sendCompactContext).not.toHaveBeenCalled();
   });
 
-  it("compacts with a follow-up when the driver can report the finish", async () => {
+  // The button compacts and stops there. A person clicking it has a composer in front of them and can
+  // say what happens next; putting words into their session unasked is not the button's business.
+  // Compact-AND-CONTINUE is a separate verb on the command line, for an agent rescuing a stuck session
+  // that has nobody at its keyboard.
+  it("compacts and sends the session nothing", async () => {
     render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
 
     await clickCompactAndConfirm();
 
-    await waitFor(() => expect(sendCompactContext).toHaveBeenCalledWith(SESSION, "continue"));
+    await waitFor(() => expect(sendCompactContext).toHaveBeenCalledWith(SESSION));
   });
 
-  // The Gateway REFUSES a continuation it cannot time. The button must know that from the declared
-  // capability rather than sending one and catching the refusal.
-  it("sends no follow-up to a driver that cannot report the finish", async () => {
-    render(
-      <SessionActionBar sessionId={SESSION} capabilities={["ClearContext", "CompactContext"]} />,
-    );
+  it("sends nothing even for a driver that could time a follow-up", async () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
 
     await clickCompactAndConfirm();
 
-    await waitFor(() => expect(sendCompactContext).toHaveBeenCalledWith(SESSION, undefined));
+    await waitFor(() => expect(sendCompactContext).toHaveBeenCalled());
+    // One argument only: no continuation, whatever the driver is capable of.
+    expect(sendCompactContext.mock.calls[0]).toHaveLength(1);
   });
 
   it("never clears when asked to compact", async () => {
@@ -106,6 +108,16 @@ describe("Compact button", () => {
 
     await waitFor(() => expect(sendCompactContext).toHaveBeenCalled());
     expect(sendClearContext).not.toHaveBeenCalled();
+  });
+
+  it("says what the dialog promises - nothing is sent to the session", () => {
+    render(<SessionActionBar sessionId={SESSION} capabilities={CLAUDE_CAPS} />);
+
+    fireEvent.click(compactButton());
+
+    const dialog = document.querySelector(".ui-confirm");
+    expect(dialog?.textContent).toMatch(/nothing is sent to it/);
+    expect(dialog?.textContent).not.toMatch(/cannot be undone/);
   });
 
   it("shows the Gateway's own sentence, verbatim", async () => {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -490,6 +490,66 @@ export async function sendClearContext(sessionId: string, signal?: AbortSignal):
   }
 }
 
+/**
+ * What POST /sessions/{sid}/compact-context answers (issue #2150). Mirrors the Gateway's
+ * CompactContextResponse; hand-declared here because the checked-in OpenAPI schema is regenerated at
+ * build time and does not carry this route yet.
+ */
+export interface CompactContextResult {
+  /** The compaction command reached the tool. */
+  submitted: boolean;
+  /**
+   * The tool's own records confirm the compaction FINISHED. False means it was submitted and not
+   * watched - a stated limit of that tool, not a failure. Never render this case as "compacted".
+   */
+  compactionObserved: boolean;
+  /** Seconds between submitting and seeing it finish; 0 when not watched. */
+  waitedSeconds: number;
+  /** The follow-up prompt was submitted after the compaction finished. */
+  continued: boolean;
+  /** One plain-English sentence describing what happened. Render it verbatim. */
+  detail: string;
+}
+
+/**
+ * How long the client waits for a compaction. A compaction is a language model summarizing a whole
+ * conversation and routinely runs past a minute; the Gateway allows three, and the Director's own wait
+ * is two. This sits OUTSIDE all of them so the innermost bound always fires first and reports what
+ * actually failed - a client that gave up sooner would report a failure over a compaction that was
+ * working perfectly, which is the exact false alarm this feature exists to remove.
+ */
+export const COMPACT_CONTEXT_TIMEOUT_MS = 4 * 60 * 1000;
+
+/**
+ * Summarize the conversation in place, freeing context window while keeping what the session has
+ * learned, and optionally send a follow-up once it FINISHES. POST /sessions/{sid}/compact-context.
+ *
+ * Distinct from sendClearContext, which throws the conversation away. Gate the button on the
+ * CompactContext capability; only pass continuePrompt when the driver also declares
+ * CompactCompletionReport, because the Gateway refuses a continuation it cannot time.
+ */
+export async function sendCompactContext(
+  sessionId: string,
+  continuePrompt?: string,
+  signal?: AbortSignal,
+): Promise<CompactContextResult> {
+  const sid = encodeURIComponent(sessionId);
+  const res = await gatewayFetch(
+    `/sessions/${sid}/compact-context`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+      body: JSON.stringify(continuePrompt ? { continuePrompt } : {}),
+      signal,
+    },
+    { timeoutMs: COMPACT_CONTEXT_TIMEOUT_MS },
+  );
+  if (!res.ok) {
+    throw new GatewayError(res.status, `POST compact-context failed: ${res.status}`);
+  }
+  return (await res.json()) as CompactContextResult;
+}
+
 // Open the tool's in-terminal history / rewind picker (Claude's double-Esc). POST
 // /sessions/{sid}/history-picker. Gated on the History capability - a visible-terminal feature.
 export async function sendHistoryPicker(sessionId: string, signal?: AbortSignal): Promise<void> {

--- a/src/CcDirector.Avalonia.Tests/CompactButtonTests.cs
+++ b/src/CcDirector.Avalonia.Tests/CompactButtonTests.cs
@@ -38,8 +38,14 @@ public class CompactButtonTests
         Assert.Equal(0, driver.CompactCalls);
     }
 
+    /// <summary>
+    /// The button compacts and stops there. A person clicking it has a composer in front of them and can
+    /// say what happens next; putting words into their session unasked is not the button's business.
+    /// Compact-AND-CONTINUE is a separate verb on the command line, for an agent rescuing a stuck session
+    /// with nobody at its keyboard.
+    /// </summary>
     [AvaloniaFact]
-    public async Task ConfirmingIt_CompactsAndSendsTheFollowUp()
+    public async Task ConfirmingIt_CompactsAndSendsTheSessionNothing()
     {
         var driver = new RecordingDriver();
         using var session = NewSession(driver);
@@ -49,18 +55,14 @@ public class CompactButtonTests
         await bar.CompactContextWithConfirmationAsync();
 
         Assert.Equal(1, driver.CompactCalls);
-        Assert.Equal("continue", Assert.Single(((RecordingBackend)session.Backend).SentTexts));
+        Assert.Empty(((RecordingBackend)session.Backend).SentTexts);
     }
 
-    /// <summary>
-    /// A driver that can compact but cannot report the FINISH gets no follow-up. The Gateway would refuse
-    /// one; the button must know that from the declared capability rather than discovering it as an error,
-    /// because an exception is not control flow.
-    /// </summary>
+    /// <summary>Still nothing sent, even for a driver that COULD time a follow-up.</summary>
     [AvaloniaFact]
-    public async Task ADriverThatCannotReportCompletion_IsCompactedWithoutAFollowUp()
+    public async Task ADriverThatCanTimeAFollowUp_IsStillSentNothing()
     {
-        var driver = new RecordingDriver { CanReportCompletion = false };
+        var driver = new RecordingDriver { CanReportCompletion = true };
         using var session = NewSession(driver);
         var bar = NewBar(session);
         bar.ConfirmOverride = (_, _) => Task.FromResult(true);
@@ -111,6 +113,8 @@ public class CompactButtonTests
         Assert.DoesNotContain("cannot be undone", SessionActionBar.CompactContextConfirmMessage);
         Assert.DoesNotContain("loses", SessionActionBar.CompactContextConfirmMessage);
         Assert.Contains("keeps what it has learned", SessionActionBar.CompactContextConfirmMessage);
+        // The dialog promises the session is left alone; the button must not then send it something.
+        Assert.Contains("nothing is sent to it", SessionActionBar.CompactContextConfirmMessage);
     }
 
     private static SessionActionBar NewBar(Session session)

--- a/src/CcDirector.Avalonia.Tests/CompactButtonTests.cs
+++ b/src/CcDirector.Avalonia.Tests/CompactButtonTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Headless.XUnit;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Issue #2167 - the desktop Compact button.
+///
+/// It sits beside a context gauge that turns red, which is exactly when somebody reaches for a button.
+/// Before this the only thing offered there was Clear context, which throws the conversation away - the
+/// wrong answer to "my context is full", and an easy wrong click.
+///
+/// The tests that matter are the ones about what is NOT sent: no continuation to a driver that cannot time
+/// one, and nothing at all when the confirmation is declined.
+/// </summary>
+public class CompactButtonTests
+{
+    [AvaloniaFact]
+    public async Task DecliningTheConfirmation_CompactsNothing()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = NewBar(session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(false);
+
+        await bar.CompactContextWithConfirmationAsync();
+
+        Assert.Equal(0, driver.CompactCalls);
+    }
+
+    [AvaloniaFact]
+    public async Task ConfirmingIt_CompactsAndSendsTheFollowUp()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = NewBar(session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(true);
+
+        await bar.CompactContextWithConfirmationAsync();
+
+        Assert.Equal(1, driver.CompactCalls);
+        Assert.Equal("continue", Assert.Single(((RecordingBackend)session.Backend).SentTexts));
+    }
+
+    /// <summary>
+    /// A driver that can compact but cannot report the FINISH gets no follow-up. The Gateway would refuse
+    /// one; the button must know that from the declared capability rather than discovering it as an error,
+    /// because an exception is not control flow.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ADriverThatCannotReportCompletion_IsCompactedWithoutAFollowUp()
+    {
+        var driver = new RecordingDriver { CanReportCompletion = false };
+        using var session = NewSession(driver);
+        var bar = NewBar(session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(true);
+
+        await bar.CompactContextWithConfirmationAsync();
+
+        Assert.Equal(1, driver.CompactCalls);
+        Assert.Empty(((RecordingBackend)session.Backend).SentTexts);
+    }
+
+    /// <summary>Compaction must never be substituted with a clear - they differ by one word and by
+    /// everything that matters.</summary>
+    [AvaloniaFact]
+    public async Task Compacting_NeverClears()
+    {
+        var driver = new RecordingDriver();
+        using var session = NewSession(driver);
+        var bar = NewBar(session);
+        bar.ConfirmOverride = (_, _) => Task.FromResult(true);
+
+        await bar.CompactContextWithConfirmationAsync();
+
+        Assert.Equal(0, driver.ClearCalls);
+    }
+
+    [AvaloniaFact]
+    public void TheButtonFollowsTheDeclaredCapability()
+    {
+        using var withCompaction = NewSession(new RecordingDriver());
+        var bar = NewBar(withCompaction);
+        Assert.True(bar.CompactButtonVisible);
+
+        using var without = NewSession(new RecordingDriver { CanCompact = false });
+        var bar2 = NewBar(without);
+        Assert.False(bar2.CompactButtonVisible);
+    }
+
+    /// <summary>
+    /// The two confirmations must not read alike. Clearing destroys the conversation and says so;
+    /// compaction preserves it and must not imply loss, or people learn one reflex for two opposite
+    /// outcomes - and the one they learn to click through is the destructive one.
+    /// </summary>
+    [Fact]
+    public void TheCompactionQuestionDoesNotReadLikeTheClearQuestion()
+    {
+        Assert.NotEqual(SessionActionBar.ClearContextConfirmTitle, SessionActionBar.CompactContextConfirmTitle);
+        Assert.Contains("cannot be undone", SessionActionBar.ClearContextConfirmMessage);
+        Assert.DoesNotContain("cannot be undone", SessionActionBar.CompactContextConfirmMessage);
+        Assert.DoesNotContain("loses", SessionActionBar.CompactContextConfirmMessage);
+        Assert.Contains("keeps what it has learned", SessionActionBar.CompactContextConfirmMessage);
+    }
+
+    private static SessionActionBar NewBar(Session session)
+    {
+        var bar = new SessionActionBar();
+        bar.Configure(sessionManager: null!, session);
+        return bar;
+    }
+
+    private static Session NewSession(IAgentDriver driver)
+    {
+        var session = new Session(
+            Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new RecordingBackend(), claudeSessionId: "agent-1",
+            activityState: ActivityState.WaitingForInput, createdAt: DateTimeOffset.UtcNow,
+            customName: null, customColor: null);
+        session.DriverOverride = driver;
+        return session;
+    }
+
+    /// <summary>A driver that compacts instantly and records what it was asked to do.</summary>
+    private sealed class RecordingDriver : IAgentDriver
+    {
+        public bool CanCompact { get; init; } = true;
+        public bool CanReportCompletion { get; init; } = true;
+        public int CompactCalls { get; private set; }
+        public int ClearCalls { get; private set; }
+
+        public AgentKind Kind => AgentKind.ClaudeCode;
+
+        public DriverCapabilities Capabilities =>
+            DriverCapabilities.ClearContext
+            | (CanCompact ? DriverCapabilities.CompactContext : DriverCapabilities.None)
+            | (CanCompact && CanReportCompletion ? DriverCapabilities.CompactCompletionReport : DriverCapabilities.None);
+
+        public IReadOnlyList<AgentSlashCommand> SlashCommands => [];
+        public string ModelFlag => "";
+        public IReadOnlyList<AgentModelOption> KnownModels => [];
+        public string? ReadConfiguredDefaultModel() => null;
+        public string ResolveExecutable(string? configuredPath) => throw new NotSupportedException();
+        public AgentLaunchSpec BuildLaunchSpec(string? baseArgs, string? resumeSessionId) => throw new NotSupportedException();
+        public Task SubmitAsync(ISessionBackend backend, string text) => backend.SendTextAsync(text);
+        public Task CancelAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task InterruptAsync(ISessionBackend backend) => Task.CompletedTask;
+        public Task ShowHistoryAsync(ISessionBackend backend) => Task.CompletedTask;
+
+        public Task ClearContextAsync(ISessionBackend backend)
+        {
+            ClearCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task CompactContextAsync(ISessionBackend backend)
+        {
+            if (!CanCompact) throw new NotSupportedException("stub declares no compaction");
+            CompactCalls++;
+            return Task.CompletedTask;
+        }
+
+        // Reports the compaction as finished on the first look, so the button's wait resolves at once.
+        public bool HasCompactedSince(string agentSessionId, string workingDirectory, DateTime sinceUtc)
+        {
+            if (!CanReportCompletion) throw new NotSupportedException("stub cannot report completion");
+            return true;
+        }
+
+        public List<TurnWidgetDto> ReadWidgets(string agentSessionId, string workingDirectory) => new();
+        public SessionUsageDto? ReadUsage(string agentSessionId, string workingDirectory) => null;
+        public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) => new();
+    }
+
+    private sealed class RecordingBackend : ISessionBackend
+    {
+        public List<string> SentTexts { get; } = new();
+
+        public int ProcessId => 1;
+        public string Status => "Running";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface, never raised here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+
+        public Task SendTextAsync(string text)
+        {
+            SentTexts.Add(text);
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
@@ -32,7 +32,7 @@
             Background="{DynamicResource ButtonBackground}" Foreground="{DynamicResource TextForeground}"
             BorderThickness="0" CornerRadius="3"
             Cursor="Hand"
-            ToolTip.Tip="Summarize the conversation and continue - frees context window, keeps what the session has learned" />
+            ToolTip.Tip="Summarize the conversation - frees context window, keeps what the session has learned" />
     <Button x:Name="BtnClearContext"
             Content="Clear context"
             Click="BtnClearContext_Click"

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
@@ -24,6 +24,15 @@
             BorderThickness="0" CornerRadius="3"
             Cursor="Hand"
             ToolTip.Tip="Hard interrupt (Ctrl+C) - stronger than Stop" />
+    <Button x:Name="BtnCompact"
+            Content="Compact"
+            Click="BtnCompact_Click"
+            IsVisible="False"
+            Height="24" Padding="10,2" FontSize="11"
+            Background="{DynamicResource ButtonBackground}" Foreground="{DynamicResource TextForeground}"
+            BorderThickness="0" CornerRadius="3"
+            Cursor="Hand"
+            ToolTip.Tip="Summarize the conversation and continue - frees context window, keeps what the session has learned" />
     <Button x:Name="BtnClearContext"
             Content="Clear context"
             Click="BtnClearContext_Click"

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -206,11 +206,8 @@ public partial class SessionActionBar : UserControl
     internal const string CompactContextConfirmTitle = "Compact this session's context?";
 
     internal const string CompactContextConfirmMessage =
-        "This summarizes the conversation so far and continues from the summary, freeing room in the " +
-        "context window. The session keeps what it has learned. It can take a minute or two.";
-
-    /// <summary>The follow-up sent once a compaction finishes, matching the command line's default.</summary>
-    private const string CompactContinuePrompt = "continue";
+        "This summarizes the conversation so far, freeing room in the context window. The session keeps " +
+        "what it has learned, and stays where it is - nothing is sent to it. It can take a minute or two.";
 
     /// <summary>Whether the Compact button is showing - the capability gate, readable by tests.</summary>
     internal bool CompactButtonVisible => BtnCompact.IsVisible;
@@ -244,6 +241,10 @@ public partial class SessionActionBar : UserControl
     /// summarizes the conversation and carries on, where Clear context beside it would throw the
     /// conversation away.
     ///
+    /// It compacts and stops there - no follow-up prompt. A person clicking this has a composer in front of
+    /// them and can say what happens next; compact-AND-CONTINUE is a separate verb on the command line, where
+    /// an agent rescuing a stuck session has nobody to type the next prompt.
+    ///
     /// The button shows a working state for the duration and the status line reports the outcome VERBATIM
     /// from the session, because only the session knows whether the compaction was watched to completion or
     /// merely submitted. Composing a cheerful message here is how "compacted" ends up on screen for a
@@ -274,19 +275,15 @@ public partial class SessionActionBar : UserControl
             return;
         }
 
-        // A follow-up can only be timed by a driver that reports when the compaction FINISHED. Read the
-        // capability rather than sending one and catching the refusal - an exception is not control flow.
-        var continuePrompt = session.Driver.Capabilities.HasFlag(DriverCapabilities.CompactCompletionReport)
-            ? CompactContinuePrompt
-            : null;
-
         BtnCompact.Content = "Compacting...";
         try
         {
-            FileLog.Write($"[SessionActionBar] Compact confirmed: session={session.Id}, " +
-                          $"continue={(continuePrompt is null ? "no" : "yes")}");
+            FileLog.Write($"[SessionActionBar] Compact confirmed: session={session.Id}");
             ShowStatus("compacting...");
-            var outcome = await session.CompactContextAsync(continuePrompt);
+            // Compact ONLY - no follow-up. See the Cockpit's note: the person is sitting here with a
+            // composer, so what happens next is theirs to decide. Compact-and-continue is the command
+            // line's verb, for an agent rescuing a session with nobody at its keyboard.
+            var outcome = await session.CompactContextAsync(continuePrompt: null);
             ShowStatus(outcome.Detail);
         }
         catch (Exception ex)

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -54,6 +54,7 @@ public partial class SessionActionBar : UserControl
         var caps = session?.Driver.Capabilities ?? DriverCapabilities.None;
         BtnStopTurn.IsVisible = caps.HasFlag(DriverCapabilities.Cancel);
         BtnInterrupt.IsVisible = caps.HasFlag(DriverCapabilities.Interrupt);
+        BtnCompact.IsVisible = caps.HasFlag(DriverCapabilities.CompactContext);
         BtnClearContext.IsVisible = caps.HasFlag(DriverCapabilities.ClearContext);
         BtnHistory.IsVisible = caps.HasFlag(DriverCapabilities.History);
         // A session switch clears any transcribing lock left over from the outgoing session; the
@@ -81,6 +82,7 @@ public partial class SessionActionBar : UserControl
     /// </summary>
     public void SetTranscribingLock(bool locked)
     {
+        BtnCompact.IsEnabled = !locked;
         BtnClearContext.IsEnabled = !locked;
         BtnHistory.IsEnabled = !locked;
         TranscribingLabel.IsVisible = locked;
@@ -194,6 +196,26 @@ public partial class SessionActionBar : UserControl
         "current conversation. This cannot be undone.";
 
     /// <summary>
+    /// The question asked before a compaction (issue #2167), matching the Cockpit's wording.
+    ///
+    /// It deliberately reads NOTHING like the clear question above. Clearing destroys the conversation and
+    /// says so; compaction preserves it, which is the entire reason it exists. Two confirmations worded
+    /// alike would teach one reflex for two opposite outcomes - and the danger runs the wrong way: somebody
+    /// who learns to click through the harmless one is being trained on the destructive one.
+    /// </summary>
+    internal const string CompactContextConfirmTitle = "Compact this session's context?";
+
+    internal const string CompactContextConfirmMessage =
+        "This summarizes the conversation so far and continues from the summary, freeing room in the " +
+        "context window. The session keeps what it has learned. It can take a minute or two.";
+
+    /// <summary>The follow-up sent once a compaction finishes, matching the command line's default.</summary>
+    private const string CompactContinuePrompt = "continue";
+
+    /// <summary>Whether the Compact button is showing - the capability gate, readable by tests.</summary>
+    internal bool CompactButtonVisible => BtnCompact.IsVisible;
+
+    /// <summary>
     /// How the bar asks before a destructive verb. Null in the running application, where it opens the real
     /// modal <see cref="ConfirmDialog"/>. Tests replace it: a modal cannot be answered in a headless run, so
     /// without this seam the decision - the whole point of issue #2169 - could only be verified by hand.
@@ -210,6 +232,72 @@ public partial class SessionActionBar : UserControl
                 "[SessionActionBar] No owner window, so the confirmation cannot be shown. Refusing to run a " +
                 "destructive action unasked.");
         return await new ConfirmDialog(title, message, confirmLabel).ShowDialog<bool?>(owner) == true;
+    }
+
+    private async void BtnCompact_Click(object? sender, RoutedEventArgs e)
+    {
+        await CompactContextWithConfirmationAsync();
+    }
+
+    /// <summary>
+    /// Ask, then compact (issue #2167). This is the safe answer to a context gauge that has gone red - it
+    /// summarizes the conversation and carries on, where Clear context beside it would throw the
+    /// conversation away.
+    ///
+    /// The button shows a working state for the duration and the status line reports the outcome VERBATIM
+    /// from the session, because only the session knows whether the compaction was watched to completion or
+    /// merely submitted. Composing a cheerful message here is how "compacted" ends up on screen for a
+    /// compaction nobody observed.
+    ///
+    /// Internal rather than private so the decision is testable, exactly as the clear path is.
+    /// </summary>
+    internal async Task CompactContextWithConfirmationAsync()
+    {
+        var session = _session;
+        if (session is null) return;
+
+        bool confirmed;
+        try
+        {
+            confirmed = await ConfirmAsync(CompactContextConfirmTitle, CompactContextConfirmMessage, "Compact");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionActionBar] Compact confirmation FAILED: {ex.Message}");
+            ShowStatus($"compact failed: {ex.Message}");
+            return;
+        }
+
+        if (!confirmed)
+        {
+            FileLog.Write($"[SessionActionBar] Compact declined at the confirmation: session={session.Id}");
+            return;
+        }
+
+        // A follow-up can only be timed by a driver that reports when the compaction FINISHED. Read the
+        // capability rather than sending one and catching the refusal - an exception is not control flow.
+        var continuePrompt = session.Driver.Capabilities.HasFlag(DriverCapabilities.CompactCompletionReport)
+            ? CompactContinuePrompt
+            : null;
+
+        BtnCompact.Content = "Compacting...";
+        try
+        {
+            FileLog.Write($"[SessionActionBar] Compact confirmed: session={session.Id}, " +
+                          $"continue={(continuePrompt is null ? "no" : "yes")}");
+            ShowStatus("compacting...");
+            var outcome = await session.CompactContextAsync(continuePrompt);
+            ShowStatus(outcome.Detail);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionActionBar] Compact FAILED: {ex.Message}");
+            ShowStatus($"compact failed: {ex.Message}");
+        }
+        finally
+        {
+            BtnCompact.Content = "Compact";
+        }
     }
 
     private async void BtnClearContext_Click(object? sender, RoutedEventArgs e)

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -176,20 +176,33 @@ _ACTIONS = [
     {
         "id": "session-compact",
         "description": (
-            "Compact a session's context, then continue it. A session whose context window is full "
-            "cannot read anything you send it - every message is swallowed and the tool reprints its "
-            "context-limit line - so this is the only way to rescue one from outside. Compaction "
-            "SUMMARIZES the conversation, so the session keeps what it has learned; clearing would "
-            "throw it away. The call waits for the compaction to finish (up to a couple of minutes on "
-            "a full session) and only then sends the follow-up, which defaults to 'continue'. Use "
-            "--then to send something else, or --compact-only to send nothing."
+            "Compact a session's context and send it NOTHING afterwards. Compaction SUMMARIZES the "
+            "conversation, so the session keeps what it has learned - unlike clearing, which throws it "
+            "away. This is the housekeeping verb: use it on a session whose context is filling up but "
+            "which is still working fine. It frees room and leaves the session where it was. For a "
+            "session that is STUCK, use session-compact-continue instead. Waits for the compaction to "
+            "finish, so it can take a minute or two."
         ),
-        "command": 'cc-devthrottle session compact [target] [--then "<text>"] [--compact-only]',
+        "command": "cc-devthrottle session compact [target]",
+        "mutatesState": True,
+        "args": [{"name": "target", "required": False}],
+    },
+    {
+        "id": "session-compact-continue",
+        "description": (
+            "Compact a session's context and THEN send it a message - the rescue for a stuck session. A "
+            "session whose context window is full cannot read anything sent to it: every message is "
+            "swallowed and the tool reprints its context-limit line. This unblocks it and gets it moving "
+            "again, so a supervising agent can rescue a worker with nobody at its keyboard. The message "
+            "(default 'continue') is sent only once the compaction has actually FINISHED, never on a "
+            "timer. Tools that cannot report finishing are refused rather than guessed at - compact those "
+            "with session-compact and send the message yourself."
+        ),
+        "command": 'cc-devthrottle session compact-continue [target] ["<message>"]',
         "mutatesState": True,
         "args": [
             {"name": "target", "required": False},
-            {"name": "then", "required": False},
-            {"name": "compact_only", "required": False},
+            {"name": "message", "required": False},
         ],
     },
     {
@@ -738,30 +751,48 @@ def compact(
     target: Optional[str] = typer.Argument(
         None, help="Session to compact. Defaults to THIS session (CC_SESSION_ID)."
     ),
-    then: str = typer.Option(
-        "continue",
-        "--then",
-        help="What to send once the compaction finishes. Defaults to 'continue'.",
-    ),
-    compact_only: bool = typer.Option(
-        False, "--compact-only", help="Compact and send nothing afterwards."
-    ),
 ) -> None:
-    """Compact a session's context, then continue it.
-
-    A session whose context window is full cannot read anything you send it - every message is
-    swallowed and the tool just reprints its context-limit line. Compaction is the only thing that
-    gets it moving again, and this is how you do it without walking to that keyboard.
+    """Compact a session's context. Sends it nothing afterwards.
 
     Compaction SUMMARIZES the conversation, so the session keeps what it has learned. That is the
     difference from clearing, which throws the conversation away.
 
-    This waits for the compaction to actually finish and then sends the follow-up, so it can take a
-    couple of minutes on a full session. The tool tells us when it has finished; nothing here is
-    timed on a guess. A tool that cannot report finishing can still be compacted with
-    --compact-only, but it will not accept a follow-up.
+    Use this for housekeeping - a session whose context is filling up but which is still working
+    fine. It frees room and leaves the session exactly where it was.
+
+    If the session is STUCK - full, and swallowing everything you send it - use
+    `cc-devthrottle session compact-continue` instead, which also gets it moving again.
+
+    This waits for the compaction to actually finish, so it can take a minute or two.
     """
-    compact_session(target, None if compact_only else then)
+    compact_session(target, None)
+
+
+@session_app.command("compact-continue")
+def compact_continue(
+    target: Optional[str] = typer.Argument(
+        None, help="Session to compact. Defaults to THIS session (CC_SESSION_ID)."
+    ),
+    message: str = typer.Argument(
+        "continue", help="What to send once the compaction finishes. Defaults to 'continue'."
+    ),
+) -> None:
+    """Compact a session's context, then send it a message - the rescue for a STUCK session.
+
+    A session whose context window is full cannot read anything you send it: every message is
+    swallowed and the tool just reprints its context-limit line. Compaction is the only thing that
+    unblocks it, and this verb also gets it moving again afterwards, so a supervising agent can
+    rescue a worker with nobody at its keyboard.
+
+    The message is sent only once the compaction has actually FINISHED - never on a timer. A prompt
+    fired while the tool is still summarizing gets swallowed exactly like the ones that were lost
+    before it.
+
+    Some tools can be compacted but cannot report when they finished (codex, pi, gemini, grok,
+    opencode today). This verb refuses them rather than guessing a moment: compact those with
+    `cc-devthrottle session compact` and send the message yourself once the session is idle.
+    """
+    compact_session(target, message)
 
 
 @session_app.command()

--- a/tools/cc-devthrottle/tests/test_session_compact.py
+++ b/tools/cc-devthrottle/tests/test_session_compact.py
@@ -57,6 +57,32 @@ def test_it_posts_the_target_and_the_follow_up(posted):
     assert calls[0]["body"]["continuePrompt"] == "continue"
 
 
+def test_plain_compact_sends_no_message(posted):
+    # `session compact` is the housekeeping verb: it frees room and leaves the session where it was.
+    # A continuation smuggled in here would put words into a session the caller never agreed to send -
+    # which is exactly why this is a separate verb from compact-continue rather than a default.
+    calls = posted(_ok())
+
+    session_ops.compact_session(SESSION_ID, None)
+
+    assert "continuePrompt" not in calls[0]["body"]
+
+
+def test_the_two_verbs_are_separately_discoverable(monkeypatch):
+    # An agent picks a verb by listing actions. Rolling both behaviours into one entry would hide the
+    # side-effecting one inside a flag description, and whichever became the default would be what
+    # happens when nobody thinks about it.
+    from src import cli  # noqa: E402
+
+    plain = next(a for a in cli._ACTIONS if a["id"] == "session-compact")
+    both = next(a for a in cli._ACTIONS if a["id"] == "session-compact-continue")
+
+    assert "compact-continue" not in plain["command"]
+    assert "NOTHING afterwards" in plain["description"]
+    assert "compact-continue" in both["command"]
+    assert "THEN send it a message" in both["description"]
+
+
 def test_compact_only_sends_no_follow_up(posted):
     # The caller asked for a compaction and nothing else. A continuePrompt smuggled in here would put
     # words into a session the caller never agreed to send.
@@ -140,11 +166,12 @@ def test_a_bracketed_error_does_not_crash_the_verb(posted, monkeypatch, capsys):
     assert "no session at [/tmp/x] on that Director" in capsys.readouterr().out
 
 
-def test_the_action_is_discoverable_with_its_command_line():
-    # Agents find this verb by listing actions, not by reading the source. An action missing from the
+def test_the_actions_are_discoverable_with_their_command_lines():
+    # Agents find these verbs by listing actions, not by reading the source. An action missing from the
     # catalogue does not exist as far as the fleet is concerned.
     from src import cli  # noqa: E402
 
-    action = next(a for a in cli._ACTIONS if a["id"] == "session-compact")
-    assert "session compact" in action["command"]
-    assert action["mutatesState"] is True
+    for action_id in ("session-compact", "session-compact-continue"):
+        action = next(a for a in cli._ACTIONS if a["id"] == action_id)
+        assert "session compact" in action["command"]
+        assert action["mutatesState"] is True


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#2167.

## Why

Compaction shipped in thefrederiksen/devthrottle#2150 as a driver verb, a Gateway route and a fleet command, so an AGENT could rescue a session whose context window was full. A person could not, without opening a terminal. This adds the button - and, on review, separates two operations that had been rolled into one.

## The separation

They were one operation with the side-effecting behaviour as the DEFAULT: the command line sent "continue" unless you passed `--compact-only`, and the first draft of the button sent it too. Whichever behaviour is the default is what happens when a caller does not think about it, and the default should be the one that does less.

**The button compacts and stops.** A person clicking it has a composer in front of them and can say what happens next; putting words into their session unasked is not the button's business. Its dialog promises exactly that - "stays where it is - nothing is sent to it" - and a test pins the promise against the behaviour.

**The command line has two verbs**, because the caller there genuinely wants both:

| Verb | For | Sends |
|---|---|---|
| `session compact [target]` | housekeeping - context filling up, session still working fine | nothing |
| `session compact-continue [target] ["message"]` | the rescue - a STUCK session swallowing everything | the message (default "continue") after the compaction finishes |

Two verbs rather than one with a flag, because an agent picks a verb by listing actions: two entries put the choice at the point of discovery, where one entry buries the side-effecting behaviour inside a flag description. Both are in the discoverable catalogue and a test asserts they stay distinct. `--compact-only` and `--then` are gone - the verb name says which one you get.

## Where the button sits, and why

Beside the live context gauge on the desktop. You watch that bar fill red, and until now the only thing to click there was **Clear context**, which throws the conversation away - the wrong answer to "my context is full", and the only answer on offer. Compact is placed BEFORE it on both surfaces, so the safe verb is reached first.

## Both verbs ask, and the questions read differently

Per the owner's decision, compaction is confirmed too.

- **Clear**: "the agent loses the current conversation. This cannot be undone."
- **Compact**: "summarizes the conversation so far... The session keeps what it has learned, and stays where it is - nothing is sent to it."

Two confirmations worded alike would teach one reflex for two opposite outcomes, and the danger runs the wrong way: somebody who learns to click through the harmless one has been trained on the destructive one. A test pins that the compaction wording does NOT say "cannot be undone" and DOES say what survives.

## Two details that carry the risk

**The result line is the Gateway's own sentence, verbatim.** Only the Gateway knows whether the compaction was watched to completion or merely submitted. Composing a cheerful message client-side is exactly how "Compacted" ends up on screen for a compaction nobody observed - the same defect the command line already had to fix, where `false` read through a stringifying helper came out truthy.

**A working state throughout.** A compaction routinely runs past a minute; every other verb in this bar returns in milliseconds, so the shared "acting" flag alone would leave the bar looking dead with nothing to explain it. The shared client waits four minutes - outside the Gateway's three and the Director's two - so the innermost bound fires first and names what actually failed.

## Tests

8 cockpit, 6 desktop, 105 command line. Mutation-proved: composing our own "Compacted." instead of the Gateway's sentence reddens both honesty tests, including the one that catches claiming a compaction nobody watched. Also covered: the button follows the declared capability (absent for Copilot), declining the confirmation sends nothing, compacting never clears, and plain `compact` never smuggles in a continuation.

Suites: desktop 305, cockpit 188, shared client 674, command line 105, typecheck clean across every workspace.

## Note on the shared client type

`CompactContextResult` is hand-declared in `client.ts` rather than read from the generated OpenAPI schema, which is regenerated at build time and does not carry this route yet. Several response types in that file are hand-declared the same way.

## Related

thefrederiksen/devthrottle_internal#943 is still open and matters most for trusting any of this: compaction has never been run against a session that is genuinely full.
