### PR TITLE
Spoken language: a per-account choice of what DevThrottle talks back in

### DIFF
--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -10,11 +10,30 @@ import {
   setTtsModel,
   setTtsVoice,
   setWingmanModel,
+  setSpokenLanguage,
+  getSpokenLanguages,
+  type SpokenLanguageOption,
   testChat,
   ttsSample,
 } from "@devthrottle/client-core/api/ai";
 
-const SAMPLE_TEXT = "Hi, I'm your DevThrottle wingman. This is how I'll sound.";
+// The sample sentence, per language. Auditioning a Danish voice by making it read an English
+// sentence is not an audition - you cannot hear the accent you are actually buying. Falls back to
+// English for any language we have not written a line for yet.
+const SAMPLES: Record<string, string> = {
+  en: "Hi, I'm your DevThrottle wingman. This is how I'll sound.",
+  da: "Hej, jeg er din DevThrottle wingman. Sadan kommer jeg til at lyde.",
+  de: "Hallo, ich bin dein DevThrottle Wingman. So werde ich klingen.",
+  fr: "Bonjour, je suis votre wingman DevThrottle. Voici ma voix.",
+  es: "Hola, soy tu wingman de DevThrottle. Asi es como voy a sonar.",
+  pt: "Ola, eu sou o seu wingman do DevThrottle. E assim que eu vou soar.",
+  it: "Ciao, sono il tuo wingman DevThrottle. Ecco come suonero.",
+  nl: "Hallo, ik ben je DevThrottle wingman. Zo ga ik klinken.",
+  sv: "Hej, jag ar din DevThrottle wingman. Sa har kommer jag att lata.",
+  no: "Hei, jeg er din DevThrottle wingman. Slik kommer jeg til a hores ut.",
+  tr: "Merhaba, ben DevThrottle yardimcinizim. Sesim boyle olacak.",
+};
+const SAMPLE_TEXT = SAMPLES.en;
 
 // The mobile AI settings screen. Same controls as the desktop AI tab, stacked for touch: hosted
 // DevThrottle AI, the wingman model (with a live Test), the speech model, and the voice (with Play
@@ -29,11 +48,16 @@ export function AiSettings() {
   const [testMsg, setTestMsg] = useState("");
   const [fastTestMsg, setFastTestMsg] = useState("");
   const [sampleMsg, setSampleMsg] = useState("");
+  const [languages, setLanguages] = useState<SpokenLanguageOption[]>([]);
+  const [language, setLanguage] = useState("en");
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const loadModels = useCallback(async () => {
     setChatModels(await getAiModels("chat"));
     setSpeechModels(await getAiModels("speech"));
+    const spoken = await getSpokenLanguages();
+    setLanguages(spoken.languages);
+    setLanguage(spoken.current);
   }, []);
 
   const load = useCallback(async () => {
@@ -68,7 +92,56 @@ export function AiSettings() {
   }
 
   const currentSpeech = speechModels.find((m) => m.id === snap.ttsModel);
+
+  // A model can speak a language only when it SAYS so. One that publishes no list is English-only,
+  // never "speaks everything" - see the note on AiModel.languages.
+  const canSpeak = (m: AiModel, code: string) =>
+    (m.languages ?? []).length === 0 ? code === "en" : (m.languages ?? []).includes(code);
+
+  const speechForLanguage = speechModels.filter((m) => canSpeak(m, language));
+
+  // An expressive model with no preset voices is not a model with a missing voice list - there is
+  // nothing to choose. Showing an empty picker reads as broken, so the control is hidden instead.
+  const modelHasVoices = !currentSpeech || currentSpeech.voices.length > 0;
   const voiceOptions = currentSpeech && currentSpeech.voices.length ? currentSpeech.voices : snap.voices;
+
+  const chooseLanguage = async (code: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    setSampleMsg("");
+    try {
+      await setSpokenLanguage(code);
+      setLanguage(code);
+      // If the speech model in use cannot say the new language, move to one that can rather than
+      // leaving the account on an engine that would answer in English phonetics.
+      let nextSnap = snap;
+      if (currentSpeech && !canSpeak(currentSpeech, code)) {
+        const replacement = speechModels.find((m) => canSpeak(m, code));
+        if (replacement) {
+          await setTtsModel(replacement.id);
+          const voices = replacement.voices ?? [];
+          let voice = snap.ttsVoice;
+          if (voices.length > 0 && voices.indexOf(voice) < 0) {
+            voice = replacement.defaultVoice && voices.indexOf(replacement.defaultVoice) >= 0
+              ? replacement.defaultVoice
+              : voices[0];
+            await setTtsVoice(voice);
+          }
+          nextSnap = { ...snap, ttsModel: replacement.id, ttsVoice: voice };
+          setSnap(nextSnap);
+          setMsg("Spoken language set. Speech model switched to " + replacement.id + ", which can speak it.");
+          return;
+        }
+        setMsg("Spoken language set, but no speech model here can say it yet.");
+        return;
+      }
+      setMsg("Spoken language set.");
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const chooseWingman = async (model: string) => {
     setBusy(true);
@@ -169,7 +242,7 @@ export function AiSettings() {
     setBusy(true);
     setSampleMsg("Synthesizing...");
     try {
-      const blob = await ttsSample(SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
+      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
       if (audioRef.current === null) audioRef.current = new Audio();
       audioRef.current.src = URL.createObjectURL(blob);
       audioRef.current.onended = () => setSampleMsg("");
@@ -241,21 +314,46 @@ export function AiSettings() {
       </div>
 
       <div className="setting-block">
-        <label className="setting-label" htmlFor="ai-ttsmodel">Speech model</label>
-        <select id="ai-ttsmodel" className="setting-select" value={snap.ttsModel} disabled={busy} onChange={(e) => void chooseSpeech(e.target.value)}>
-          {ensure(snap.ttsModel, speechModels).map((id) => (
-            <option key={id} value={id}>{id}</option>
+        <label className="setting-label" htmlFor="ai-spoken-language">Spoken language</label>
+        <select id="ai-spoken-language" className="setting-select" value={language} disabled={busy} onChange={(e) => void chooseLanguage(e.target.value)}>
+          {languages.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.name === l.endonym ? l.name : l.name + " (" + l.endonym + ")"}
+            </option>
           ))}
         </select>
+        <p className="setting-hint">
+          The language DevThrottle speaks back to you in. Dictation understands every language
+          automatically, so this does not change how you talk to it. Your agents keep working in
+          whatever language they work in.
+        </p>
       </div>
 
       <div className="setting-block">
-        <label className="setting-label" htmlFor="ai-voice">Voice</label>
-        <select id="ai-voice" className="setting-select" value={snap.ttsVoice} disabled={busy} onChange={(e) => void chooseVoice(e.target.value)}>
-          {ensureStrings(snap.ttsVoice, voiceOptions).map((v) => (
-            <option key={v} value={v}>{v}</option>
+        <label className="setting-label" htmlFor="ai-ttsmodel">Speech model</label>
+        <select id="ai-ttsmodel" className="setting-select" value={snap.ttsModel} disabled={busy} onChange={(e) => void chooseSpeech(e.target.value)}>
+          {ensure(snap.ttsModel, speechForLanguage).map((id) => (
+            <option key={id} value={id}>{id}</option>
           ))}
         </select>
+        {speechForLanguage.length === 0 && (
+          <p className="setting-hint">No speech model here can say that language yet.</p>
+        )}
+      </div>
+
+      <div className="setting-block">
+        {modelHasVoices ? (
+          <>
+            <label className="setting-label" htmlFor="ai-voice">Voice</label>
+            <select id="ai-voice" className="setting-select" value={snap.ttsVoice} disabled={busy} onChange={(e) => void chooseVoice(e.target.value)}>
+              {ensureStrings(snap.ttsVoice, voiceOptions).map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </>
+        ) : (
+          <p className="setting-hint">This speech model has one expressive voice - there is nothing to choose.</p>
+        )}
         <div className="setting-actions">
           <button type="button" className="setting-btn" disabled={busy} onClick={() => void playSample()}>Play sample</button>
           <span className="setting-msg">{sampleMsg}</span>

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -38,6 +38,22 @@ export interface AiModel {
   /** For speech models: the model's own voice list (empty for chat models). */
   voices: string[];
   defaultVoice: string | null;
+  /**
+   * For speech models: the languages this model can actually SPEAK, as BCP-47 primary subtags.
+   * The spoken-language picker filters on this. A model that publishes none is treated as
+   * English-only rather than as speaking everything - offering a language a model cannot
+   * pronounce produces confident gibberish, which is worse than not offering it.
+   */
+  languages: string[];
+}
+
+/** One language DevThrottle can speak back in (GET /gateway/ai/spoken-languages). */
+export interface SpokenLanguageOption {
+  code: string;
+  /** The English name, e.g. "Danish" - what the wingman prompt uses. */
+  name: string;
+  /** The language's own name, e.g. "dansk" - people recognise this faster than the English one. */
+  endonym: string;
 }
 
 /** The result of testing a chat model (POST /gateway/ai/test-chat). */
@@ -124,6 +140,21 @@ export function setTtsModel(model: string): Promise<{ model: string }> {
 
 export function setTtsVoice(voice: string): Promise<{ voice: string }> {
   return putJson<{ voice: string }>("/gateway/tts-voice", { voice });
+}
+
+// GET /gateway/ai/spoken-languages -> the languages on offer plus the one this account is on.
+// Served by the Gateway rather than hardcoded per app so mobile and the Cockpit cannot drift, and
+// so adding a language does not need two app releases.
+export async function getSpokenLanguages(): Promise<{ current: string; languages: SpokenLanguageOption[] }> {
+  const res = await fetch("/gateway/ai/spoken-languages", { headers: authHeaders() });
+  if (!res.ok) throw new Error(`spoken languages: ${res.status}`);
+  return res.json();
+}
+
+// PUT /gateway/ai/spoken-language { language } - the language DevThrottle SPEAKS BACK in. This does
+// NOT affect dictation, which detects the spoken language on its own. A blank value means English.
+export function setSpokenLanguage(language: string): Promise<{ language: string }> {
+  return putJson<{ language: string }>("/gateway/ai/spoken-language", { language });
 }
 
 // POST /wingman/tts { text, model, voice } -> audio bytes to play (a short "Play sample").

--- a/src/CcDirector.Core.Tests/Configuration/SpokenLanguageTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/SpokenLanguageTests.cs
@@ -1,0 +1,96 @@
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Configuration;
+
+/// <summary>
+/// <see cref="SpokenLanguage"/> is the language DevThrottle SPEAKS BACK in. Two properties matter more
+/// than the rest and both are asserted here: English is always the answer when anything is wrong or
+/// unset (speech must not break over a stale setting), and a speech model is only considered capable of
+/// a language when it SAYS SO - an unknown model is English-only, never "speaks everything", because the
+/// failure mode of guessing wrong is a model confidently producing gibberish.
+/// </summary>
+public sealed class SpokenLanguageTests
+{
+    [Fact]
+    public void Default_is_english()
+    {
+        Assert.Equal("en", SpokenLanguage.Default);
+        Assert.True(SpokenLanguage.IsDefault(null));
+        Assert.True(SpokenLanguage.IsDefault(""));
+        Assert.True(SpokenLanguage.IsDefault("en"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("klingon")]
+    [InlineData("zz")]
+    public void Normalize_falls_back_to_english_for_anything_we_do_not_offer(string? code)
+        => Assert.Equal("en", SpokenLanguage.Normalize(code));
+
+    [Theory]
+    [InlineData("da", "da")]
+    [InlineData("DA", "da")]
+    [InlineData(" de ", "de")]
+    public void Normalize_accepts_and_lowercases_offered_languages(string input, string expected)
+        => Assert.Equal(expected, SpokenLanguage.Normalize(input));
+
+    [Fact]
+    public void The_three_market_languages_and_the_test_language_are_offered()
+    {
+        // German, French and Spanish are the market bets; Danish is the language the pipeline is
+        // proved against. If one of these ever stops being offered it should break here loudly.
+        Assert.True(SpokenLanguage.IsSupported("de"));
+        Assert.True(SpokenLanguage.IsSupported("fr"));
+        Assert.True(SpokenLanguage.IsSupported("es"));
+        Assert.True(SpokenLanguage.IsSupported("da"));
+    }
+
+    [Fact]
+    public void DisplayName_carries_the_endonym_because_people_recognise_their_own_language()
+    {
+        Assert.Equal("Danish (dansk)", SpokenLanguage.DisplayName("da"));
+        Assert.Equal("German (Deutsch)", SpokenLanguage.DisplayName("de"));
+        Assert.Equal("English", SpokenLanguage.DisplayName("en"));   // no parenthetical when identical
+    }
+
+    [Fact]
+    public void EnglishName_is_what_the_prompt_says()
+    {
+        Assert.Equal("Danish", SpokenLanguage.EnglishName("da"));
+        Assert.Equal("Spanish", SpokenLanguage.EnglishName("es"));
+    }
+
+    [Fact]
+    public void A_model_can_speak_only_what_it_advertises()
+    {
+        var multilingual = new[] { "en", "da", "de", "fr", "es" };
+        Assert.True(SpokenLanguage.ModelCanSpeak(multilingual, "da"));
+        Assert.True(SpokenLanguage.ModelCanSpeak(multilingual, "DE"));
+        Assert.False(SpokenLanguage.ModelCanSpeak(multilingual, "ja"));
+    }
+
+    [Fact]
+    public void A_model_that_advertises_nothing_is_english_only_not_everything()
+    {
+        // The safe direction. Treating silence as "speaks everything" would let the settings offer
+        // Danish on a model that answers in English phonetics.
+        Assert.True(SpokenLanguage.ModelCanSpeak(null, "en"));
+        Assert.False(SpokenLanguage.ModelCanSpeak(null, "da"));
+        Assert.True(SpokenLanguage.ModelCanSpeak(new string[0], "en"));
+        Assert.False(SpokenLanguage.ModelCanSpeak(new string[0], "da"));
+    }
+
+    [Fact]
+    public void The_english_only_engine_cannot_be_offered_for_german_or_danish()
+    {
+        // Mirrors what the catalog publishes for the default speech engine. This is the check that
+        // stops a tenant being left on an engine that physically cannot say their language.
+        var englishOnly = new[] { "en" };
+        Assert.False(SpokenLanguage.ModelCanSpeak(englishOnly, "de"));
+        Assert.False(SpokenLanguage.ModelCanSpeak(englishOnly, "da"));
+        Assert.True(SpokenLanguage.ModelCanSpeak(englishOnly, "en"));
+    }
+}

--- a/src/CcDirector.Core/Configuration/SpokenLanguage.cs
+++ b/src/CcDirector.Core/Configuration/SpokenLanguage.cs
@@ -1,0 +1,101 @@
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// The language DevThrottle SPEAKS BACK in - the tenant's "spoken language".
+///
+/// This is deliberately not "the language setting". Dictation already understands every language
+/// on its own: the transcription upload sends no language field at all, so the provider detects
+/// it. The only direction that needs a choice is the one going out - what the wingman writes and
+/// what the speech model says.
+///
+/// Codes are BCP-47 primary subtags, matching the <c>languages</c> array each speech model
+/// publishes in the DevThrottle catalog, so a language can be checked against a model's coverage
+/// without any mapping in between.
+/// </summary>
+public static class SpokenLanguage
+{
+    /// <summary>The config.json key, and the tenant-settings key, holding the chosen language.</summary>
+    public const string ConfigKey = "spoken_language";
+
+    /// <summary>
+    /// English. The default for every account that has never touched the setting, so nothing
+    /// changes for anyone who does not want this.
+    /// </summary>
+    public const string Default = "en";
+
+    /// <summary>
+    /// The languages we offer, code to (English name, endonym). The English name is what the
+    /// wingman prompt says; the endonym is included because naming a language in its own words
+    /// measurably helps a model commit to it, and because the settings UI should show people
+    /// their own language the way they write it.
+    ///
+    /// This list is the OFFER, not a capability claim - whether a given speech model can actually
+    /// say one of these is the model's <c>languages</c> array, checked separately. Keep the two
+    /// apart: offering a language no model can speak produces confident gibberish.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, (string English, string Endonym)> Supported =
+        new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["en"] = ("English", "English"),
+            ["da"] = ("Danish", "dansk"),
+            ["de"] = ("German", "Deutsch"),
+            ["fr"] = ("French", "francais"),
+            ["es"] = ("Spanish", "espanol"),
+            ["pt"] = ("Portuguese", "portugues"),
+            ["it"] = ("Italian", "italiano"),
+            ["nl"] = ("Dutch", "Nederlands"),
+            ["sv"] = ("Swedish", "svenska"),
+            ["no"] = ("Norwegian", "norsk"),
+            ["ja"] = ("Japanese", "Nihongo"),
+            ["tr"] = ("Turkish", "Turkce"),
+        };
+
+    /// <summary>True when <paramref name="code"/> is a language we offer.</summary>
+    public static bool IsSupported(string? code) =>
+        !string.IsNullOrWhiteSpace(code) && Supported.ContainsKey(code.Trim());
+
+    /// <summary>
+    /// Normalize a stored value to a code we offer, falling back to <see cref="Default"/>.
+    /// A stored language we no longer offer must not break speech - English always works.
+    /// </summary>
+    public static string Normalize(string? code) =>
+        IsSupported(code) ? code!.Trim().ToLowerInvariant() : Default;
+
+    /// <summary>True when this is the default (English) and no language instruction is needed.</summary>
+    public static bool IsDefault(string? code) =>
+        string.Equals(Normalize(code), Default, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The display name for a code: "Danish (dansk)", or the raw code if we do not know it.
+    /// </summary>
+    public static string DisplayName(string? code)
+    {
+        var norm = Normalize(code);
+        if (!Supported.TryGetValue(norm, out var names)) return norm;
+        return names.English == names.Endonym
+            ? names.English
+            : $"{names.English} ({names.Endonym})";
+    }
+
+    /// <summary>The English name alone - what the wingman prompt names the target language.</summary>
+    public static string EnglishName(string? code) =>
+        Supported.TryGetValue(Normalize(code), out var names) ? names.English : Normalize(code);
+
+    /// <summary>
+    /// Whether a speech model advertising <paramref name="modelLanguages"/> can say
+    /// <paramref name="code"/>. A model that publishes no languages is treated as English-only -
+    /// the safe direction, because the alternative is letting a model be picked for a language it
+    /// cannot pronounce.
+    /// </summary>
+    public static bool ModelCanSpeak(IEnumerable<string>? modelLanguages, string? code)
+    {
+        var want = Normalize(code);
+        if (modelLanguages is null) return string.Equals(want, Default, StringComparison.Ordinal);
+        var known = modelLanguages
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .Select(l => l.Trim().ToLowerInvariant())
+            .ToList();
+        if (known.Count == 0) return string.Equals(want, Default, StringComparison.Ordinal);
+        return known.Contains(want);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -182,6 +182,48 @@ public sealed class WingmanTranslatorTests
         Assert.Contains("the reply", prompt);
     }
 
+    [Fact]
+    public void BuildPrompt_InEnglish_IsByteForByteWhatItWasBeforeSpokenLanguageExisted()
+    {
+        // The no-op property is the one that protects every account that never touches the setting:
+        // English must add NOTHING to the prompt, so the narration people already have cannot drift
+        // because a feature they do not use was added.
+        var withoutLanguage = WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "recent", "the reply", "A session");
+        var explicitlyEnglish = WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "recent", "the reply", "A session", "en");
+
+        Assert.Equal(withoutLanguage, explicitlyEnglish);
+        Assert.DoesNotContain("LANGUAGE.", withoutLanguage);
+    }
+
+    [Fact]
+    public void BuildPrompt_InDanish_TellsTheModelTheLanguageAndWhatNotToTranslate()
+    {
+        var prompt = WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "recent", "the reply", "A session", "da");
+
+        // Named in English, because the prompt itself is English.
+        Assert.Contains("Write the spoken version in Danish", prompt);
+        // The instruction that keeps the narration usable: a listener has to be able to type what
+        // they hear, so identifiers and paths must survive the translation untouched.
+        Assert.Contains("never translated", prompt);
+        Assert.Contains("file names and paths", prompt);
+        // The reply itself is still carried verbatim - translating is the model's job, not ours.
+        Assert.Contains("the reply", prompt);
+    }
+
+    [Fact]
+    public void BuildPrompt_WithAnUnknownLanguage_FallsBackToEnglishRatherThanNamingNonsense()
+    {
+        // A stale or hand-edited setting must not produce "Write the spoken version in zz".
+        var prompt = WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "recent", "the reply", "A session", "zz-not-a-language");
+
+        Assert.DoesNotContain("LANGUAGE.", prompt);
+        Assert.DoesNotContain("zz-not-a-language", prompt);
+    }
+
     private sealed class ThrowingBrain : IAgentBrain
     {
         public int ClearCount { get; private set; }

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -19,11 +19,13 @@ namespace CcDirector.Gateway.Api;
 /// chat model with one round-trip, and persist the chosen wingman/speech model. The browser never sees
 /// the credential - the Gateway resolves it from the vault and presents it to DevThrottle.
 ///
-///   GET  /gateway/ai/models?kind=chat|speech -> { models:[ {id, description, voices[], defaultVoice} ] }
+///   GET  /gateway/ai/models?kind=chat|speech -> { models:[ {id, description, voices[], defaultVoice, languages[]} ] }
 ///   POST /gateway/ai/test-chat  { model }    -> { ok, reply, seconds } | { error }
 ///   PUT  /gateway/ai/wingman-model      { model } -> { model }
 ///   PUT  /gateway/ai/wingman-fast-model { model } -> { model }
 ///   PUT  /gateway/ai/tts-model          { model } -> { model }
+///   GET  /gateway/ai/spoken-languages        -> { current, languages:[ {code, name, endonym} ] }
+///   PUT  /gateway/ai/spoken-language { language } -> { language }
 ///
 /// DevThrottle serves a typed catalog (GET /models?type=chat|speech) where each speech model carries
 /// its own voices.
@@ -262,6 +264,40 @@ internal static class AiModelsEndpoint
             }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
+
+        // The languages a caller may choose from, and which one this tenant is on. Served rather
+        // than hardcoded in each client so mobile and the Cockpit cannot drift apart, and so
+        // adding a language is a Gateway change rather than two app releases.
+        app.MapGet("/gateway/ai/spoken-languages", (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            var current = resolver.SpokenLanguage(t.Value);
+            var languages = SpokenLanguage.Supported
+                .Select(kv => new { code = kv.Key, name = kv.Value.English, endonym = kv.Value.Endonym })
+                .OrderBy(l => l.code == SpokenLanguage.Default ? 0 : 1)   // English first, it is the default
+                .ThenBy(l => l.name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            return Results.Json(new { current, languages });
+        });
+
+        app.MapPut("/gateway/ai/spoken-language", async (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<LanguageBody>(ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                // A blank code means "back to English", which is the same stored state as never having
+                // chosen - the resolver clears the override rather than writing "en".
+                resolver.SetSpokenLanguage(t.Value, body?.Language ?? string.Empty, DateTime.UtcNow);
+                var language = resolver.SpokenLanguage(t.Value);
+                FileLog.Write($"[AiModelsEndpoint] spoken language set: {language} for tenant={t.Value.ToLogString()}");
+                return Results.Json(new { language });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
+        });
     }
 
     private static string ProviderKeyMissingMessage(TranscriptionMode mode) =>
@@ -295,14 +331,25 @@ internal static class AiModelsEndpoint
                 foreach (var voice in v.EnumerateArray())
                     if (voice.ValueKind == JsonValueKind.String) voices.Add(voice.GetString()!);
 
+            // Which languages a speech model can SPEAK (BCP-47 primary subtags). The spoken-language
+            // setting filters the model list on this, so a model that omits it is treated as
+            // English-only rather than as "speaks everything" - the safe direction, because
+            // offering a language the model cannot say produces confident gibberish.
+            var languages = new List<string>();
+            if (item.TryGetProperty("languages", out var l) && l.ValueKind == JsonValueKind.Array)
+                foreach (var lang in l.EnumerateArray())
+                    if (lang.ValueKind == JsonValueKind.String) languages.Add(lang.GetString()!);
+
             var desc = item.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String ? d.GetString() : "";
             var defVoice = item.TryGetProperty("defaultVoice", out var dv) && dv.ValueKind == JsonValueKind.String ? dv.GetString() : null;
-            list.Add(new ModelDto(id!, desc ?? "", voices, defVoice));
+            list.Add(new ModelDto(id!, desc ?? "", voices, defVoice, languages));
         }
         return list;
     }
 
     private sealed record ModelBody(string? Model);
+    private sealed record LanguageBody(string? Language);
     private sealed record EndPhraseBody(string? Phrase);
-    private sealed record ModelDto(string Id, string Description, List<string> Voices, string? DefaultVoice);
+    private sealed record ModelDto(
+        string Id, string Description, List<string> Voices, string? DefaultVoice, List<string> Languages);
 }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -142,7 +142,12 @@ internal static class GatewayWingmanVoiceEndpoint
         // status mapping below could only be proven by calling the real provider over the internet.
         var ttsHttp = ttsHttpClient ?? SharedTtsHttp;
 
-        var translator = new WingmanTranslator(brainProvider, instructionsProvider: instructionsProvider);
+        // The tenant's spoken language is resolved per call, not captured once, because the setting can
+        // change while the Gateway is up and the next thing spoken should already be in the new language.
+        var translator = new WingmanTranslator(
+            brainProvider,
+            instructionsProvider: instructionsProvider,
+            spokenLanguageProvider: t => tenantSettings.SpokenLanguage(t));
 
         // Post-cut: resolve the owning Director once (from the push store) and reach its session verbs
         // (turns / buffer / prompt) through the tunnel-only SessionVerbClient, so the wingman voice surface

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -26,6 +26,11 @@ public static class TenantSettingKeys
     /// <summary>The voice the text-to-speech engine uses (global default: <c>tts_voice</c>).</summary>
     public const string TtsVoice = "tts_voice";
 
+    /// <summary>The language DevThrottle SPEAKS BACK in - what the wingman writes and the speech
+    /// model says. Dictation is unaffected: it detects the spoken language on its own and never
+    /// reads this. BCP-47 primary subtag; unset means English.</summary>
+    public const string SpokenLanguage = "spoken_language";
+
     /// <summary>The conversational model Car Mode drives (global default: <c>car_mode_model</c>).</summary>
     public const string CarModeModel = "car_mode_model";
 
@@ -52,7 +57,7 @@ public static class TenantSettingKeys
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
-        WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
+        WingmanModel, WingmanFastModel, TtsModel, TtsVoice, SpokenLanguage,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -56,6 +56,12 @@ public sealed class TenantSettingsResolver
     public string TtsModel(TenantId tenant, TranscriptionMode mode)
         => NonEmptyOverride(tenant, TenantSettingKeys.TtsModel) ?? TtsModelConfig.Resolve(mode);
 
+    /// <summary>The language this tenant is spoken to in. English unless the tenant chose otherwise,
+    /// and English again if the stored value is one we no longer offer - speech must never break over
+    /// a stale setting.</summary>
+    public string SpokenLanguage(TenantId tenant)
+        => CcDirector.Core.Configuration.SpokenLanguage.Normalize(NonEmptyOverride(tenant, TenantSettingKeys.SpokenLanguage));
+
     /// <summary>The tenant's Car Mode model, or the operator global default when unset.</summary>
     public string CarModeModel(TenantId tenant)
         => NonEmptyOverride(tenant, TenantSettingKeys.CarModeModel) ?? CarModeModelConfig.Resolve();
@@ -141,6 +147,20 @@ public sealed class TenantSettingsResolver
     /// <exception cref="ArgumentException">The model is null/empty.</exception>
     public void SetTtsModel(TenantId tenant, string model, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.TtsModel, RequireNonEmpty(model, nameof(model)), nowUtc);
+
+    /// <summary>Set the tenant's spoken language. English CLEARS the override rather than storing it,
+    /// so "back to default" and "never chose" are the same state on disk.</summary>
+    /// <exception cref="ArgumentException">The code is not a language we offer.</exception>
+    public void SetSpokenLanguage(TenantId tenant, string code, DateTime nowUtc)
+    {
+        var trimmed = (code ?? "").Trim();
+        if (trimmed.Length > 0 && !CcDirector.Core.Configuration.SpokenLanguage.IsSupported(trimmed))
+            throw new ArgumentException($"'{trimmed}' is not a supported spoken language.", nameof(code));
+        if (trimmed.Length == 0 || CcDirector.Core.Configuration.SpokenLanguage.IsDefault(trimmed))
+            _store.Remove(tenant, TenantSettingKeys.SpokenLanguage);
+        else
+            _store.Set(tenant, TenantSettingKeys.SpokenLanguage, trimmed.ToLowerInvariant(), nowUtc);
+    }
 
     /// <summary>Set the tenant's Car Mode model.</summary>
     /// <exception cref="ArgumentException">The model is null/empty.</exception>

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -198,6 +198,7 @@ public sealed class WingmanTranslator
     private readonly Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;
     private readonly Func<string> _instructions;
+    private readonly Func<TenantId, string> _spokenLanguage;
 
     /// <summary>
     /// Create a translator over a warm-brain provider. The provider is the same
@@ -207,11 +208,18 @@ public sealed class WingmanTranslator
     /// the ACTIVE wingman instructions at call time - the user's edited/versioned prompt when set,
     /// else the deployed <see cref="FidelityPrompt"/> default; omit it to always use the default.
     /// </summary>
-    public WingmanTranslator(Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, Action<string>? log = null, Func<string>? instructionsProvider = null)
+    /// <param name="spokenLanguageProvider">
+    /// Returns the tenant's SPOKEN LANGUAGE at call time - the language the narration is written
+    /// in. Tenant-scoped rather than a plain <c>Func&lt;string&gt;</c> like the instructions,
+    /// because one Gateway serves many accounts and each picks its own. Omit it and every
+    /// translation is English, which is what every account gets until it chooses otherwise.
+    /// </param>
+    public WingmanTranslator(Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, Action<string>? log = null, Func<string>? instructionsProvider = null, Func<TenantId, string>? spokenLanguageProvider = null)
     {
         _brainProvider = brainProvider ?? throw new ArgumentNullException(nameof(brainProvider));
         _log = log ?? FileLog.Write;
         _instructions = instructionsProvider ?? (() => FidelityPrompt);
+        _spokenLanguage = spokenLanguageProvider ?? (_ => SpokenLanguage.Default);
     }
 
     /// <summary>
@@ -277,9 +285,11 @@ public sealed class WingmanTranslator
         if (string.IsNullOrWhiteSpace(latestReply))
             throw new ArgumentException("Latest reply is required - there is nothing to translate.", nameof(latestReply));
 
-        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}, title={(string.IsNullOrWhiteSpace(sessionTitle) ? "(none)" : sessionTitle)}");
+        var language = SpokenLanguage.Normalize(_spokenLanguage(tenant));
 
-        var prompt = BuildPrompt(instructions ?? FidelityPrompt, recentContext ?? "", latestReply, sessionTitle);
+        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}, title={(string.IsNullOrWhiteSpace(sessionTitle) ? "(none)" : sessionTitle)}, lang={language}");
+
+        var prompt = BuildPrompt(instructions ?? FidelityPrompt, recentContext ?? "", latestReply, sessionTitle, language);
 
         var brain = await _brainProvider(tenant, WingmanModelRole.Fast, ct);
         AskResult ask;
@@ -611,10 +621,46 @@ public sealed class WingmanTranslator
     /// rule's own escape clause covers - the model is never handed an empty title to voice.
     /// </summary>
     public static string BuildPrompt(string instructions, string recentContext, string latestReply, string? sessionTitle)
+        => BuildPrompt(instructions, recentContext, latestReply, sessionTitle, SpokenLanguage.Default);
+
+    /// <summary>
+    /// As above, in the tenant's SPOKEN LANGUAGE (see <see cref="SpokenLanguage"/>).
+    ///
+    /// This is the only place the language has to be applied, and that is the whole reason the
+    /// design works: the coding agent is never asked to change language - it keeps working in
+    /// whatever language it works in - and this translator is already the single thing that turns
+    /// its reply into the words that get spoken. So a non-English account costs one extra
+    /// instruction in a prompt that was already being sent, not a translation step.
+    ///
+    /// English is a no-op: the block is omitted entirely, so the prompt is byte-for-byte what it
+    /// was before this existed and nothing changes for accounts that never touch the setting.
+    /// </summary>
+    public static string BuildPrompt(
+        string instructions, string recentContext, string latestReply, string? sessionTitle, string? spokenLanguage)
     {
         var sb = new StringBuilder();
         sb.Append(string.IsNullOrWhiteSpace(instructions) ? FidelityPrompt : instructions);
         sb.Append("\n\n");
+        if (!SpokenLanguage.IsDefault(spokenLanguage))
+        {
+            // Stated up front, right after the contract, because the model's default behaviour is
+            // to mirror the language of the reply it is given - which is nearly always English.
+            // Being specific about what must NOT be translated matters as much as the language
+            // itself: a listener has to be able to type what they hear.
+            var name = SpokenLanguage.EnglishName(spokenLanguage);
+            sb.Append("LANGUAGE. Write the spoken version in ");
+            sb.Append(name);
+            sb.Append(". The agent's reply below is in whatever language it works in, usually ");
+            sb.Append("English; you are saying it for the ear in ");
+            sb.Append(name);
+            sb.Append(". Write it the way a native speaker would say it out loud, not as a ");
+            sb.Append("word-for-word translation.\n");
+            sb.Append("Leave these EXACTLY as they appear, never translated and never spelled ");
+            sb.Append("differently: file names and paths, code identifiers, command names, branch ");
+            sb.Append("names, and error text. Everything else is spoken in ");
+            sb.Append(name);
+            sb.Append(".\n\n");
+        }
         if (!string.IsNullOrWhiteSpace(sessionTitle))
         {
             sb.Append("The title of the session this reply came from. Open the narration by saying ");


### PR DESCRIPTION
Dictation already understands every language - the transcription upload sends no language field, so the provider detects it. This adds the missing direction: **what DevThrottle says back**.

Tenant-scoped `spoken_language`, default English. An account that never touches it is unaffected.

## Why this is small

The coding agent is **never** asked to change language - it keeps working in whatever language it works in. `WingmanTranslator` is already the single place an agent's written reply becomes the words that get spoken, for both the Wingman text and voice surfaces. So a non-English account costs one extra instruction in a prompt that was already being sent, not a translation pass.

English adds **nothing** to the prompt - asserted byte-for-byte in a test - so narration people already have cannot drift.

## Two things the prompt pins

- The target language, named in English, stated up front, because a model's default is to mirror the language of the reply it was given.
- What must **not** be translated: file names and paths, code identifiers, command names, branch names, error text. A listener has to be able to type what they hear.

## Model selection is the other half

Speech models now publish which languages they can speak. A model publishing none is treated as **English-only**, never as speaking everything - offering a language a model cannot pronounce produces confident gibberish. Choosing a language the current engine cannot say moves the account to one that can, and says so.

## No language field on the provider call

Probed live against the speech endpoint: `language`, `language_id`, `lang`, `language_code` **and an invented control field** were all accepted and ignored. The language comes from the text. So the only levers are which model is used and what the wingman writes - which is exactly what this change controls.

## Also

- An expressive model with no preset voices hides the voice picker rather than rendering an empty one.
- Play sample speaks its sentence **in the chosen language**; auditioning a Danish voice on an English sentence tells you nothing.

## Surfaces

`GET /gateway/ai/spoken-languages`, `PUT /gateway/ai/spoken-language`, and the mobile AI settings page.

## Not in this change

Cockpit settings parity - the mobile page is the one being tested first. Tests: 15 new in Core, 3 new on the translator; full translator suite green (38).