### PR TITLE
feat(voice): measure every dictation's microphone in the background and show it in the Cockpit

### DIFF
--- a/apps/cockpit/src/transcription/MicrophoneQualityPanel.tsx
+++ b/apps/cockpit/src/transcription/MicrophoneQualityPanel.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getMicrophoneQuality,
+  type MicrophoneDeviceSummary,
+  type MicrophoneQualitySummary,
+} from "@devthrottle/client-core/transcription/microphoneQualityClient";
+
+// "How your microphones are doing" on the Transcription Health page.
+//
+// This is the BACKGROUND half of microphone quality: every dictation is measured automatically as it
+// is sent, so this screen answers the question the on-demand Test microphone check cannot - which of
+// your microphones is letting you down, across all the dictating you actually do. A headset that is
+// bad only some of the time shows up here and nowhere else.
+//
+// Every verdict, every sentence of advice and the target figures are decided on the Gateway
+// (MicrophoneQualityFold) and rendered here verbatim. This component contains no thresholds.
+
+function formatDb(value: number): string {
+  return `${Math.round(value)} dB`;
+}
+
+function formatShare(share: number): string {
+  return `${Math.round(share * 100)}%`;
+}
+
+export function MicrophoneQualityPanel() {
+  const [summary, setSummary] = useState<MicrophoneQualitySummary | null>(null);
+  const [loadError, setLoadError] = useState(false);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setLoadError(false);
+      setSummary(await getMicrophoneQuality(30, signal));
+    } catch {
+      if (signal?.aborted) return;
+      setLoadError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  return (
+    <div className="txh-section mq">
+      <h2>How your microphones are doing</h2>
+      <p className="txh-lede">
+        Every dictation you send is measured automatically, so a microphone that is quietly spoiling
+        your transcripts shows up here without you having to go looking. Nothing is recorded - only how
+        the audio measured.
+      </p>
+
+      {loadError ? (
+        <div className="txh-error">
+          Couldn&apos;t load microphone quality from the Gateway.
+          <button type="button" className="txh-retry" onClick={() => void load()}>
+            Retry
+          </button>
+        </div>
+      ) : summary === null ? (
+        <div className="txh-loading">Loading...</div>
+      ) : (
+        <>
+          <div className={`txh-banner mq-${summary.status}`}>{summary.headline}</div>
+          <p className="txh-lede">{summary.detail}</p>
+
+          {summary.devices.length > 0 && (
+            <div className="mq-devices">
+              {summary.devices.map((d) => (
+                <DeviceCard key={d.device} device={d} />
+              ))}
+            </div>
+          )}
+
+          {summary.totalSamples > 0 && (
+            <p className="txh-muted">
+              Based on {summary.totalSamples} measured {summary.totalSamples === 1 ? "dictation" : "dictations"}{" "}
+              over the last 30 days.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function DeviceCard({ device }: { device: MicrophoneDeviceSummary }) {
+  return (
+    <div className={`mq-device mq-device-${device.status}`}>
+      <div className="mq-device-head">
+        <span className="mq-device-name">{device.device}</span>
+        <span className="mq-device-count">
+          {device.samples} {device.samples === 1 ? "dictation" : "dictations"}
+        </span>
+      </div>
+      <p className="mq-device-advice">{device.advice}</p>
+      <dl className="mq-measures">
+        <div>
+          <dt>Your voice</dt>
+          <dd>{formatDb(device.medianSpeechLevelDb)}</dd>
+          {/* The target sits beside the reading rather than in a legend, so the comparison needs no
+              second look and no knowledge of what a good number is. */}
+          <span className="mq-target">good is about {formatDb(device.targetSpeechLevelDb)}</span>
+        </div>
+        <div>
+          <dt>Voice above the room</dt>
+          <dd>{formatDb(device.medianSignalToNoiseDb)}</dd>
+          <span className="mq-target">good is {formatDb(device.targetSignalToNoiseDb)} or more</span>
+        </div>
+        <div>
+          <dt>Telephone quality</dt>
+          <dd>{formatShare(device.narrowbandShare)}</dd>
+          <span className="mq-target">of dictations</span>
+        </div>
+        <div>
+          <dt>Distorting</dt>
+          <dd>{formatShare(device.clippingShare)}</dd>
+          <span className="mq-target">of dictations</span>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
+++ b/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { MicTestPanel } from "@devthrottle/client-core/dictation/MicTestPanel";
+import { MicrophoneQualityPanel } from "./MicrophoneQualityPanel";
 import { TranscriptionTestPanel } from "@devthrottle/client-core/dictation/TranscriptionTestPanel";
 import {
   clearTranscriptionHistory,
@@ -242,6 +243,11 @@ export function TranscriptionHealthView() {
           there are no stats to show - a Gateway that cannot be reached, or a first run with no
           history - because that is when the user is asking "is my microphone even working?". It
           needs nothing from the Gateway, so a load failure above must not take it down with it. */}
+      {/* The background half first: it answers "is anything wrong" without the user doing anything,
+          which is the question they arrived with. The on-demand checks below are what they reach for
+          once they know something IS wrong. */}
+      <MicrophoneQualityPanel />
+
       <div className="txh-section">
         <MicTestPanel />
       </div>

--- a/apps/cockpit/src/transcription/transcriptionhealth.css
+++ b/apps/cockpit/src/transcription/transcriptionhealth.css
@@ -178,3 +178,109 @@
   padding: 1px 5px;
   font-size: 12px;
 }
+
+/* ===== How your microphones are doing =====
+   The background microphone-quality section. Status colours only; every word on the screen is folded
+   by the Gateway (MicrophoneQualityFold), so nothing here decides what a state means. */
+.mq-good {
+  border-left-color: var(--txh-ok);
+}
+
+.mq-bad {
+  border-left-color: var(--attention);
+}
+
+.mq-learning,
+.mq-empty {
+  border-left-color: var(--text-dim);
+}
+
+.mq-devices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  margin: 14px 0;
+}
+
+.mq-device {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.mq-device-bad {
+  border-left-color: var(--attention);
+}
+
+.mq-device-good {
+  border-left-color: var(--txh-ok);
+}
+
+.mq-device-learning {
+  border-left-color: var(--text-dim);
+}
+
+.mq-device-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.mq-device-name {
+  font-weight: 600;
+  color: var(--text);
+  /* A device name can be long ("Headset Microphone (Jabra Evolve2 65 Hands-free)") and must not push
+     the sample count off the card. */
+  overflow-wrap: anywhere;
+}
+
+.mq-device-count {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.mq-device-advice {
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.mq-measures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.mq-measures > div {
+  background: var(--code-bg);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.mq-measures dt {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+
+.mq-measures dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.mq-target {
+  display: block;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}

--- a/packages/client-core/src/dictation/DictationDialog.tsx
+++ b/packages/client-core/src/dictation/DictationDialog.tsx
@@ -6,6 +6,7 @@ import { playReadyCue } from "./readyCue";
 import { MicRecorder } from "./recorder";
 import { joinText } from "./transcript";
 import { blobToWav16kMono } from "./wav";
+import { reportDictationQuality } from "./qualityReport";
 // The dialog carries its own styles (issue #1288): every shell that mounts this component gets the
 // dictate-* rules from one copy, so the Cockpit renders it as a centered overlay just like the phone
 // instead of unstyled elements at the page bottom. The rules formerly lived only in the mobile
@@ -191,10 +192,15 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     let wav: Blob;
     let health;
     let lossWarning: string | null = null;
+    let nativeSamples = new Float32Array(0);
+    let nativeSampleRate = 0;
+    const deviceLabel = recorderRef.current.deviceLabel;
     try {
       const captured = await recorderRef.current.stop();
       const transcoded = await blobToWav16kMono(captured);
       wav = transcoded.wav;
+      nativeSamples = transcoded.nativeSamples;
+      nativeSampleRate = transcoded.nativeSampleRate;
       // Capture-health (issue #863): compare the recording wall-clock to the decoded audio
       // duration to detect audio dropped before transcription. Logged locally AND sent to the
       // Gateway so it persists into the same dictation session log every other surface writes.
@@ -213,6 +219,11 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       setHint(err instanceof Error ? err.message : "Could not capture the recording.");
       return null;
     }
+    // Measure the microphone in the background. AFTER the transcode and BEFORE awaiting the
+    // transcription, so it rides the gap while the upload is being prepared and never sits between
+    // the user and their words. Fire-and-forget by contract - see qualityReport.ts.
+    reportDictationQuality(nativeSamples, nativeSampleRate, deviceLabel, "dictation-dialog");
+
     try {
       const text = await transcribeUtterance(wav, health, undefined, (uploaded, total) => {
         // A short clip uploads in one chunk (no progress line needed); a long recording uploads in
@@ -331,6 +342,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       return;
     }
     onSendAudio({
+      deviceLabel: recorderRef.current.deviceLabel,
       blob: captured,
       recordedMs: recorderRef.current.lastRecordedMs,
       prefixText: accumulatedRef.current,

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -3,6 +3,7 @@ import { captureLossWarning, logCaptureHealth } from "./captureHealth";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
 import { blobToWav16kMono } from "./wav";
+import { reportDictationQuality } from "./qualityReport";
 
 // The durable Send pipeline + background retry driver for the mobile Speak dialog (issue #1006,
 // strengthened for #1182). The instant the user hits Send the dialog hands the recorded audio here and
@@ -93,6 +94,9 @@ export interface CapturedUtterance {
   /** Earlier Pause/Resume dictation segments, already turned to text, joined ahead of this final
    *  segment. Empty in the common "just talk and Send" case. */
   prefixText: string;
+  /** The microphone's name, for per-device quality reporting. Optional: a caller that does not know
+   *  it still delivers its words, it just cannot say which microphone recorded them. */
+  deviceLabel?: string;
 }
 
 /** Callbacks so the host can react to the rare hard failure (durable storage unavailable). A normal send
@@ -164,6 +168,15 @@ export async function backgroundTranscribeAndSend(
     // mic DID capture should still be delivered - so instead the deficit rides along as a caution shown with
     // the delivered `done` status, and stored durably so a resumed send still carries it.
     captureWarning = captureLossWarning(health) ?? undefined;
+    // Measure the microphone in the background. Inside the try because it needs the decode, and
+    // deliberately AFTER captureWarning so a measurement problem can never cost the user the
+    // dropped-audio warning, which is about their words rather than about our analytics.
+    reportDictationQuality(
+      transcoded.nativeSamples,
+      transcoded.nativeSampleRate,
+      captured.deviceLabel ?? "",
+      "dictation-send",
+    );
   } catch (err) {
     console.warn(
       `[backgroundSend] decode failed; uploading the raw recording unpadded (delivery is unaffected): ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/client-core/src/dictation/qualityReport.test.ts
+++ b/packages/client-core/src/dictation/qualityReport.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { measureDictationQuality } from "./qualityReport";
+
+// The background measurement runs on EVERY dictation, so what it declines to report matters as much
+// as what it reports. Two clips that must never become data: one too short to measure honestly, and
+// one with no speech in it - a false start or a moment of silence. Recording either would drag a
+// device's averages down and eventually accuse a microphone that is fine.
+
+const RATE = 48000;
+
+/** Speech-like: syllables with quiet gaps, plus broadband content so the bandwidth check is honest. */
+function speech(seconds: number, level = 0.3): Float32Array {
+  const n = Math.round(RATE * seconds);
+  const out = new Float32Array(n);
+  const syl = Math.round(0.22 * RATE);
+  const gap = Math.round(0.09 * RATE);
+  let seed = 7;
+  const rand = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  for (let start = 0; start + syl < n; start += syl + gap) {
+    for (let i = 0; i < syl; i++) {
+      const env = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (syl - 1)));
+      const t = (start + i) / RATE;
+      let v = 0;
+      for (let h = 1; h * 120 < 3400; h++) v += Math.sin(2 * Math.PI * h * 120 * t) / h;
+      out[start + i] = (v / 2.5 + (rand() * 2 - 1) * 0.05) * env * level;
+    }
+  }
+  return out;
+}
+
+describe("measureDictationQuality", () => {
+  it("measures an ordinary dictation and reports the device it came from", () => {
+    const sample = measureDictationQuality(speech(10), RATE, "Jabra Evolve2", "dictation-send");
+
+    expect(sample).not.toBeNull();
+    expect(sample?.device).toBe("Jabra Evolve2");
+    expect(sample?.source).toBe("dictation-send");
+    expect(sample?.sampleRate).toBe(RATE);
+    expect(sample?.rating).toBeTruthy();
+  });
+
+  it("declines a clip too short to measure honestly", () => {
+    // Under three seconds there are too few frames for a stable noise floor, and a shaky reading
+    // reported as fact is worse than no reading.
+    expect(measureDictationQuality(speech(1.5), RATE, "Mic", "dictation-send")).toBeNull();
+  });
+
+  it("declines a clip with no speech in it, rather than scoring silence as a bad microphone", () => {
+    expect(measureDictationQuality(new Float32Array(RATE * 10), RATE, "Mic", "dictation-send")).toBeNull();
+  });
+
+  it("sends no audio and no transcript - only measurements and the device name", () => {
+    const sample = measureDictationQuality(speech(10), RATE, "Mic", "dictation-send");
+    const keys = Object.keys(sample ?? {}).sort();
+
+    expect(keys).toEqual(
+      [
+        "clippedFraction",
+        "device",
+        "durationSeconds",
+        "highBandRatioDb",
+        "issues",
+        "narrowband",
+        "noiseFloorDb",
+        "rating",
+        "sampleRate",
+        "signalToNoiseDb",
+        "source",
+        "speechLevelDb",
+      ].sort(),
+    );
+  });
+
+  it("is JSON-safe even when a measurement is infinite", () => {
+    // A digitally silent high band reads as -Infinity, which JSON.stringify turns into null and the
+    // Gateway would then store as zero - a value that means "wideband", the opposite of the truth.
+    const sample = measureDictationQuality(speech(10), RATE, "Mic", "dictation-send");
+    const roundTripped = JSON.parse(JSON.stringify(sample)) as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(roundTripped)) {
+      expect(`${key}:${value === null ? "NULL" : "ok"}`).toBe(`${key}:ok`);
+    }
+    expect(Number.isFinite(sample?.highBandRatioDb)).toBe(true);
+  });
+
+  it("copes with an unnamed microphone", () => {
+    // A browser withholds the label until permission has been granted at least once.
+    expect(measureDictationQuality(speech(10), RATE, "", "dictation-send")?.device).toBe("");
+  });
+});

--- a/packages/client-core/src/dictation/qualityReport.ts
+++ b/packages/client-core/src/dictation/qualityReport.ts
@@ -1,0 +1,117 @@
+import { authHeaders, gatewayFetch } from "../api/client";
+import { analyzeMicQuality, judgeMicQuality } from "./micQuality";
+
+// Background microphone-quality reporting for ORDINARY dictation.
+//
+// The Test microphone check answers "how is my microphone right now", once, when someone goes
+// looking. This answers the question nobody goes looking for: how is my microphone across all the
+// dictating I actually do, and is a particular headset the reason my transcripts are poor. That is
+// the one a user cannot answer for themselves, because the defect that matters most - a Bluetooth
+// hands-free link - sounds merely dull to a human ear.
+//
+// THREE RULES THIS FILE EXISTS TO KEEP:
+//
+// 1. IT NEVER DELAYS A WORD. Measuring runs after the caller already has its transcript on the way,
+//    and the send is fire-and-forget. A user's dictation must never wait on our analytics.
+// 2. IT NEVER FAILS A DICTATION. Every path here swallows its own errors to a console line. A
+//    Gateway that is unreachable, an account with no tenant, a decode that went wrong - none of them
+//    may turn a working dictation into an error the user sees.
+// 3. IT COSTS NO SECOND DECODE. The samples come from the transcode the dictation path already
+//    performed (wav.ts hands back the native-rate mono buffer), so the only new work is the analysis
+//    itself over a clip already in memory.
+//
+// WHAT IS SENT: measurements and the microphone's name. No audio, and no transcript. The clip itself
+// stays where it was; this is a handful of numbers per dictation.
+
+/** Below this there is not enough audio for a stable reading, and a shaky measurement reported as
+ *  fact is worse than no measurement. Chosen from real dictation: the Gateway's own archive of 212
+ *  real clips had nothing shorter than 2.3 seconds, so this discards almost nothing in practice
+ *  while keeping the short-utterance case - which has never been measured - out of the data. */
+const MIN_REPORTABLE_SECONDS = 3;
+
+export interface DictationQualitySample {
+  /** Which surface produced it, so a phone and a desktop can be told apart later. */
+  source: string;
+  /** The microphone's name as the operating system reports it. Empty when the browser withholds it. */
+  device: string;
+  durationSeconds: number;
+  sampleRate: number;
+  speechLevelDb: number;
+  noiseFloorDb: number;
+  signalToNoiseDb: number;
+  clippedFraction: number;
+  highBandRatioDb: number;
+  narrowband: boolean;
+  /** "good" | "fair" | "poor", folded by the same rules the Test microphone screen renders. */
+  rating: string;
+  /** Identifiers of the issues found, joined by "+". Empty when the microphone is good. */
+  issues: string;
+}
+
+/**
+ * Measure a finished dictation clip and post the result. Returns the sample it sent, or null when
+ * there was nothing worth reporting - callers ignore the return; it exists so tests can assert what
+ * would have been sent without a network.
+ *
+ * A clip with no detectable speech is deliberately NOT reported. It is far more likely to be a
+ * false start or a moment of silence than a broken microphone, and recording it would drag every
+ * average down and eventually produce a warning about a microphone that is fine.
+ */
+export function measureDictationQuality(
+  samples: Float32Array,
+  sampleRate: number,
+  device: string,
+  source: string,
+): DictationQualitySample | null {
+  if (samples.length / sampleRate < MIN_REPORTABLE_SECONDS) return null;
+
+  const report = analyzeMicQuality(samples, sampleRate);
+  if (!report.heardSpeech) return null;
+
+  const verdict = judgeMicQuality(report);
+  return {
+    source,
+    device,
+    durationSeconds: Math.round(report.durationSeconds * 10) / 10,
+    sampleRate: report.sampleRate,
+    speechLevelDb: Math.round(report.speechLevelDb * 10) / 10,
+    noiseFloorDb: Math.round(report.noiseFloorDb * 10) / 10,
+    signalToNoiseDb: Math.round(report.signalToNoiseDb * 10) / 10,
+    clippedFraction: report.clippedFraction,
+    // A silent high band reads as -Infinity, which is not JSON. Floor it at a value that still says
+    // "nothing up there" without becoming null on the wire.
+    highBandRatioDb: Number.isFinite(report.highBandRatioDb) ? Math.round(report.highBandRatioDb * 10) / 10 : -120,
+    narrowband: report.narrowband,
+    rating: verdict.rating,
+    issues: verdict.issues.map((i) => i.id).join("+"),
+  };
+}
+
+/**
+ * Measure and send, swallowing every failure. Call this AFTER the dictation is already on its way.
+ * Deliberately returns void: there is no outcome a caller should branch on, and offering one would
+ * invite somebody to await it on the path that carries the user's words.
+ */
+export function reportDictationQuality(
+  samples: Float32Array,
+  sampleRate: number,
+  device: string,
+  source: string,
+): void {
+  let sample: DictationQualitySample | null;
+  try {
+    sample = measureDictationQuality(samples, sampleRate, device, source);
+  } catch (err) {
+    console.warn(`[quality] could not measure the clip: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  if (sample === null) return;
+
+  void gatewayFetch("/voice-quality/sample", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(sample),
+  }).catch((err: unknown) => {
+    console.warn(`[quality] could not report the sample: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -114,9 +114,27 @@ export class MicRecorder {
   private startedAt = 0;
   private recordedMs = 0;
 
+  // The microphone's name, read once at start() and deliberately NOT cleared when the stream is
+  // released - the quality report is assembled after stop(), by which time the track is gone.
+  private capturedDeviceLabel = "";
+
   /** True while a segment is actively capturing. */
   get isRecording(): boolean {
     return this.recorder !== null && this.recorder.state === "recording";
+  }
+
+  /**
+   * The name of the microphone this segment was captured with, as the operating system reports it
+   * ("Headset (Jabra Evolve2 65)", "Microphone Array (Realtek)"). Empty when the browser withholds
+   * it, which it does until the user has granted microphone permission at least once.
+   *
+   * This is what makes quality reporting actionable rather than merely true. "Your audio is
+   * band-limited" tells someone almost nothing; "your Jabra headset is band-limited and your laptop
+   * microphone is not" tells them which one to stop using. Captured at start() and kept after the
+   * stream is released, so the label survives to be reported alongside the finished measurement.
+   */
+  get deviceLabel(): string {
+    return this.capturedDeviceLabel;
   }
 
   /** Wall-clock milliseconds the most recently stopped segment was capturing. 0 before the first stop. */
@@ -135,6 +153,11 @@ export class MicRecorder {
     this.stream = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: true, noiseSuppression: true, channelCount: 1 },
     });
+
+    // Read the device name while the track is live. A browser reports an empty label until the user
+    // has granted permission at least once, so this is best-effort by design - an unnamed microphone
+    // still reports its measurements, it just cannot be told apart from another unnamed one.
+    this.capturedDeviceLabel = this.stream.getAudioTracks()[0]?.label ?? "";
 
     // Live level meter on the captured stream (display only).
     const AudioCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;

--- a/packages/client-core/src/dictation/wav.ts
+++ b/packages/client-core/src/dictation/wav.ts
@@ -38,6 +38,13 @@ export interface TranscodeResult {
   wav: Blob;
   decodedSeconds: number;
   sourceBytes: number;
+  /** The clip at the microphone's NATIVE rate, mono - the form the microphone-quality measurement
+   *  needs (micQuality.ts), which the 16 kHz WAV above cannot answer because resampling discards
+   *  everything above 8 kHz and with it the evidence that tells a wideband microphone from a
+   *  telephone-grade link. Handed back from the decode this function already performs so background
+   *  quality reporting costs no second decode of a multi-megabyte clip on the dictation path. */
+  nativeSamples: Float32Array;
+  nativeSampleRate: number;
 }
 
 export async function blobToWav16kMono(blob: Blob): Promise<TranscodeResult> {
@@ -71,6 +78,8 @@ export async function blobToWav16kMono(blob: Blob): Promise<TranscodeResult> {
     wav: encodeWav(padded, TARGET_SAMPLE_RATE),
     decodedSeconds: decoded.duration,
     sourceBytes,
+    nativeSamples: monoFrom(decoded),
+    nativeSampleRate: decoded.sampleRate,
   };
 }
 
@@ -102,11 +111,17 @@ export async function decodeToMono(blob: Blob): Promise<DecodedClip> {
     void decodeCtx.close();
   }
 
-  if (decoded.numberOfChannels === 1) {
-    return { samples: decoded.getChannelData(0), sampleRate: decoded.sampleRate };
-  }
-  // Average the channels rather than taking the first: a headset that feeds only one side would
-  // otherwise measure as silence on the channel we happened to pick.
+  return { samples: monoFrom(decoded), sampleRate: decoded.sampleRate };
+}
+
+/**
+ * One mono channel from a decoded buffer. A mono source is returned as-is (a view over memory that
+ * already exists, so this costs nothing on the dictation path, where capture requests one channel).
+ * Several channels are AVERAGED rather than picking the first: a headset that feeds only one side
+ * would otherwise measure as silence whenever we happened to choose the empty channel.
+ */
+function monoFrom(decoded: AudioBuffer): Float32Array {
+  if (decoded.numberOfChannels === 1) return decoded.getChannelData(0);
   const frames = decoded.length;
   const mixed = new Float32Array(frames);
   for (let ch = 0; ch < decoded.numberOfChannels; ch++) {
@@ -114,7 +129,7 @@ export async function decodeToMono(blob: Blob): Promise<DecodedClip> {
     for (let i = 0; i < frames; i++) mixed[i] += data[i];
   }
   for (let i = 0; i < frames; i++) mixed[i] /= decoded.numberOfChannels;
-  return { samples: mixed, sampleRate: decoded.sampleRate };
+  return mixed;
 }
 
 // Build a canonical 16-bit PCM WAV (RIFF) blob from mono float samples in -1..1.

--- a/packages/client-core/src/transcription/microphoneQualityClient.ts
+++ b/packages/client-core/src/transcription/microphoneQualityClient.ts
@@ -1,0 +1,56 @@
+import { authHeaders, gatewayFetch, GatewayError } from "../api/client";
+
+// Reads the folded microphone-quality verdict from the Gateway (GET /voice-quality/summary).
+//
+// Every judgement below - the headline, the per-device status, the advice sentence, and what "good"
+// looks like - arrives ALREADY DECIDED. This client applies no thresholds and derives no verdicts;
+// it is a typed hole in the wall. That is the standing rule for this product: one place folds the
+// meaning, the screens render it, so a new verdict is one Gateway edit rather than a new branch in
+// every client.
+
+export interface MicrophoneDeviceSummary {
+  device: string;
+  samples: number;
+  /** "good" | "learning" | "bad". Drives colour only - the words come from `advice`. */
+  status: string;
+  advice: string;
+  narrowbandShare: number;
+  clippingShare: number;
+  medianSpeechLevelDb: number;
+  medianSignalToNoiseDb: number;
+  /** What a healthy microphone reads, folded alongside so the screen can COMPARE, not just display. */
+  targetSpeechLevelDb: number;
+  targetSignalToNoiseDb: number;
+  lastSeenUtc: string;
+}
+
+export interface MicrophoneQualitySummary {
+  totalSamples: number;
+  /** "empty" | "learning" | "good" | "bad". */
+  status: string;
+  headline: string;
+  detail: string;
+  devices: MicrophoneDeviceSummary[];
+}
+
+export async function getMicrophoneQuality(days?: number, signal?: AbortSignal): Promise<MicrophoneQualitySummary> {
+  const query = days === undefined ? "" : `?days=${days}`;
+  const res = await gatewayFetch(`/voice-quality/summary${query}`, { headers: { ...authHeaders() }, signal });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new GatewayError(res.status, body.error ?? `Could not read microphone quality: ${res.status}`);
+  }
+  return (await res.json()) as MicrophoneQualitySummary;
+}
+
+/** Forget every measurement for this account. Returns how many daily files were removed. */
+export async function clearMicrophoneQuality(signal?: AbortSignal): Promise<number> {
+  const res = await gatewayFetch("/voice-quality/history", {
+    method: "DELETE",
+    headers: { ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw new GatewayError(res.status, `Could not clear microphone quality: ${res.status}`);
+  const body = (await res.json().catch(() => ({}))) as { removed?: number };
+  return body.removed ?? 0;
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -265,6 +265,11 @@ public static class CcStorage
     /// transcription quality can be compared across languages, headsets and releases.</summary>
     public static string VoiceTestClips() => Path.Combine(Base(), "voice-test-clips");
 
+    /// <summary>Per-dictation microphone measurements behind the Cockpit's microphone-quality
+    /// section: base/microphone-quality/. Numbers only - no audio and no transcript text - so it
+    /// answers "which of my microphones is bad" without keeping any record of what was said.</summary>
+    public static string MicrophoneQuality() => Path.Combine(Base(), "microphone-quality");
+
     /// <summary>Terminal screen captures: base/terminal-captures/.</summary>
     public static string TerminalCaptures() => Path.Combine(Base(), "terminal-captures");
 

--- a/src/CcDirector.Gateway.Tests/MicrophoneQualityFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/MicrophoneQualityFoldTests.cs
@@ -1,0 +1,174 @@
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Pins the microphone-quality verdict, which is the whole point of the background monitoring: a
+/// number nobody acts on is worthless, and a warning about a microphone that is fine is worse than
+/// worthless because it teaches the user to ignore the screen.
+///
+/// The calibration behind these thresholds is not a guess. The check was run over 212 REAL dictations
+/// from a healthy setup: warning on every imperfection would have complained about roughly one
+/// dictation in nine, while warning only on the two unambiguous defects would have said nothing at
+/// all. These tests encode that: silence on a good setup, and a clear accusation on a bad one.
+/// </summary>
+public sealed class MicrophoneQualityFoldTests
+{
+    private static MicrophoneQualityRecord Sample(
+        string device = "Good Mic",
+        bool narrowband = false,
+        double clipped = 0,
+        double speechDb = -20,
+        double snrDb = 45,
+        int minutesAgo = 0)
+        => new()
+        {
+            TimestampUtc = DateTime.UtcNow.AddMinutes(-minutesAgo),
+            Device = device,
+            Source = "dictation-send",
+            DurationSeconds = 20,
+            SampleRate = 48000,
+            SpeechLevelDb = speechDb,
+            NoiseFloorDb = speechDb - snrDb,
+            SignalToNoiseDb = snrDb,
+            ClippedFraction = clipped,
+            HighBandRatioDb = narrowband ? -110 : -22,
+            Narrowband = narrowband,
+            Rating = narrowband || clipped >= 0.01 ? "poor" : "good",
+            Issues = narrowband ? "narrowband" : clipped >= 0.01 ? "clipping" : "",
+        };
+
+    private static List<MicrophoneQualityRecord> Many(int count, Func<int, MicrophoneQualityRecord> make)
+        => Enumerable.Range(0, count).Select(make).ToList();
+
+    [Fact]
+    public void NoMeasurementsYet_SaysSo_AndDoesNotPretendAnythingIsWrong()
+    {
+        var s = MicrophoneQualityFold.Summarize(Array.Empty<MicrophoneQualityRecord>());
+
+        Assert.Equal("empty", s.Status);
+        Assert.Equal(0, s.TotalSamples);
+        Assert.Empty(s.Devices);
+        Assert.Contains("No dictation has been measured", s.Headline);
+    }
+
+    [Fact]
+    public void AHealthyMicrophoneIsNeverComplainedAbout()
+    {
+        // The property that matters most. This is the shape of the real 212-clip sample.
+        var s = MicrophoneQualityFold.Summarize(Many(40, _ => Sample()));
+
+        Assert.Equal("good", s.Status);
+        Assert.Contains("sounds good", s.Headline);
+        Assert.Equal("good", Assert.Single(s.Devices).Status);
+    }
+
+    [Fact]
+    public void TooFewMeasurementsIsHeldBack_RatherThanJudgedOnOneOddRecording()
+    {
+        var s = MicrophoneQualityFold.Summarize(Many(MicrophoneQualityFold.MinSamplesForVerdict - 1, _ => Sample(narrowband: true)));
+
+        // Narrowband on every clip, but not enough of them: it must NOT accuse yet.
+        Assert.Equal("learning", s.Status);
+        Assert.Equal("learning", Assert.Single(s.Devices).Status);
+    }
+
+    [Fact]
+    public void AMostlyBandLimitedMicrophoneIsNamedAndExplained()
+    {
+        var s = MicrophoneQualityFold.Summarize(Many(20, _ => Sample(device: "Jabra Hands-Free", narrowband: true)));
+
+        Assert.Equal("bad", s.Status);
+        Assert.Contains("Jabra Hands-Free", s.Headline);
+        Assert.Contains("Bluetooth", s.Detail);
+    }
+
+    [Fact]
+    public void OccasionalBandLimitingIsNotEnoughToAccuse()
+    {
+        // A Bluetooth link that dropped to hands-free for one call is not a bad headset.
+        var s = MicrophoneQualityFold.Summarize(Many(20, i => Sample(narrowband: i < 3)));
+
+        Assert.Equal("good", s.Status);
+    }
+
+    [Fact]
+    public void PersistentDistortionIsCalledOut()
+    {
+        var s = MicrophoneQualityFold.Summarize(Many(20, i => Sample(device: "Hot Mic", clipped: i < 10 ? 0.05 : 0)));
+
+        Assert.Equal("bad", s.Status);
+        Assert.Contains("Hot Mic", s.Headline);
+        Assert.Contains("input level", s.Detail);
+    }
+
+    [Fact]
+    public void QuietOrNoisyAudioAloneNeverProducesAWarning()
+    {
+        // Deliberate: on the real sample these fired on about one dictation in nine. They are shown
+        // as measurements on the device card, never as an accusation.
+        var s = MicrophoneQualityFold.Summarize(Many(30, _ => Sample(speechDb: -35, snrDb: 14)));
+
+        Assert.Equal("good", s.Status);
+        Assert.Equal("good", Assert.Single(s.Devices).Status);
+    }
+
+    [Fact]
+    public void TheWorstMicrophoneLeadsRatherThanTheAverageOfAllOfThem()
+    {
+        // The finding a user needs is "one of your microphones is the problem". Averaging a bad
+        // headset with a good desk microphone would hide exactly that.
+        var records = Many(20, _ => Sample(device: "Good Desk Mic"))
+            .Concat(Many(20, _ => Sample(device: "Bad Headset", narrowband: true)))
+            .ToList();
+
+        var s = MicrophoneQualityFold.Summarize(records);
+
+        Assert.Equal("bad", s.Status);
+        Assert.Contains("Bad Headset", s.Headline);
+        Assert.Equal(2, s.Devices.Count);
+        Assert.Equal("good", s.Devices.Single(d => d.Device == "Good Desk Mic").Status);
+        Assert.Equal("bad", s.Devices.Single(d => d.Device == "Bad Headset").Status);
+    }
+
+    [Fact]
+    public void EachDeviceIsScoredSeparately_WhichIsThePointOfRecordingTheName()
+    {
+        var records = Many(10, _ => Sample(device: "A"))
+            .Concat(Many(6, _ => Sample(device: "B", clipped: 0.05)))
+            .ToList();
+
+        var s = MicrophoneQualityFold.Summarize(records);
+
+        Assert.Equal(1.0, s.Devices.Single(d => d.Device == "B").ClippingShare);
+        Assert.Equal(0.0, s.Devices.Single(d => d.Device == "A").ClippingShare);
+    }
+
+    [Fact]
+    public void AnUnnamedMicrophoneIsStillReported_UnderAReadableName()
+    {
+        var s = MicrophoneQualityFold.Summarize(Many(10, _ => Sample(device: "")));
+
+        Assert.Equal("Unnamed microphone", Assert.Single(s.Devices).Device);
+    }
+
+    [Fact]
+    public void EveryDeviceCarriesWhatGoodLooksLike_SoTheScreenCanCompare()
+    {
+        var device = Assert.Single(MicrophoneQualityFold.Summarize(Many(10, _ => Sample())).Devices);
+
+        Assert.Equal(MicrophoneQualityFold.TargetSpeechLevelDb, device.TargetSpeechLevelDb);
+        Assert.Equal(MicrophoneQualityFold.TargetSignalToNoiseDb, device.TargetSignalToNoiseDb);
+    }
+
+    [Fact]
+    public void TheMedianIsReported_SoOneOddRecordingCannotMoveTheNumber()
+    {
+        var records = Many(20, _ => Sample(speechDb: -20)).Append(Sample(speechDb: -90)).ToList();
+
+        var device = Assert.Single(MicrophoneQualityFold.Summarize(records).Devices);
+
+        Assert.Equal(-20, device.MedianSpeechLevelDb);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Transcription;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Drives the REAL /voice-quality routes over real HTTP: a browser posts a measurement, the Cockpit
+/// reads back a folded verdict.
+///
+/// The behaviour worth pinning is what happens when something is WRONG with the post. This runs after
+/// a dictation has already succeeded, so nothing here may be turned into an error a user could see -
+/// a malformed body is dropped and answered 204, never 400. A 400 would be a lie about the user's
+/// dictation, which worked.
+/// </summary>
+[Collection("VoiceQualityEndpoint")] // serial: mutates the CC_DIRECTOR_ROOT process env var
+public sealed class VoiceQualityEndpointTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+
+    public VoiceQualityEndpointTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-voice-quality-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private async Task<(WebApplication App, HttpClient Http, MicrophoneQualityLog Log)> StartAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var log = new MicrophoneQualityLog(Path.Combine(_root, "quality"));
+        VoiceQualityEndpoint.Map(app, tenantBoundary: null, logOverride: log);
+
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, log);
+    }
+
+    private static object Sample(string device = "Test Mic", bool narrowband = false, double clipped = 0)
+        => new
+        {
+            source = "dictation-send",
+            device,
+            durationSeconds = 18.4,
+            sampleRate = 48000,
+            speechLevelDb = -19.5,
+            noiseFloorDb = -64.5,
+            signalToNoiseDb = 45.0,
+            clippedFraction = clipped,
+            highBandRatioDb = narrowband ? -110.0 : -22.0,
+            narrowband,
+            rating = narrowband ? "poor" : "good",
+            issues = narrowband ? "narrowband" : "",
+        };
+
+    [Fact]
+    public async Task APostedMeasurementComesBackInTheSummary()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        var post = await http.PostAsJsonAsync("/voice-quality/sample", Sample());
+        Assert.Equal(HttpStatusCode.NoContent, post.StatusCode);
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary"));
+        Assert.Equal(1, doc.RootElement.GetProperty("totalSamples").GetInt32());
+        var device = doc.RootElement.GetProperty("devices")[0];
+        Assert.Equal("Test Mic", device.GetProperty("device").GetString());
+    }
+
+    [Fact]
+    public async Task TheSummaryCarriesAFinishedVerdict_NotRawNumbersForTheBrowserToJudge()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        for (var i = 0; i < 20; i++)
+            await http.PostAsJsonAsync("/voice-quality/sample", Sample(device: "Bad Headset", narrowband: true));
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary"));
+        Assert.Equal("bad", doc.RootElement.GetProperty("status").GetString());
+        Assert.Contains("Bad Headset", doc.RootElement.GetProperty("headline").GetString());
+        // The advice sentence is decided here, not composed in the browser.
+        Assert.Contains("Bluetooth", doc.RootElement.GetProperty("detail").GetString());
+    }
+
+    [Fact]
+    public async Task EachMicrophoneIsScoredSeparately()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        for (var i = 0; i < 10; i++) await http.PostAsJsonAsync("/voice-quality/sample", Sample(device: "Desk Mic"));
+        for (var i = 0; i < 10; i++) await http.PostAsJsonAsync("/voice-quality/sample", Sample(device: "Headset", narrowband: true));
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary"));
+        var devices = doc.RootElement.GetProperty("devices").EnumerateArray().ToList();
+        Assert.Equal(2, devices.Count);
+        Assert.Equal("good", devices.Single(d => d.GetProperty("device").GetString() == "Desk Mic").GetProperty("status").GetString());
+        Assert.Equal("bad", devices.Single(d => d.GetProperty("device").GetString() == "Headset").GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task AMalformedBodyIsDropped_NotTurnedIntoAnErrorAboutADictationThatWorked()
+    {
+        var (app, http, log) = await StartAsync();
+        await using var _d = app;
+
+        var res = await http.PostAsync("/voice-quality/sample",
+            new StringContent("{ not json", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NoContent, res.StatusCode);
+        Assert.Empty(log.Load());
+    }
+
+    [Fact]
+    public async Task AnOverlongDeviceNameIsTrimmedRatherThanStoredWhole()
+    {
+        var (app, http, log) = await StartAsync();
+        await using var _d = app;
+
+        await http.PostAsJsonAsync("/voice-quality/sample", Sample(device: new string('x', 5000)));
+
+        var stored = Assert.Single(log.Load());
+        Assert.True(stored.Device.Length <= 200);
+    }
+
+    [Fact]
+    public async Task TheWindowCanBeNarrowed_SoAnOldBadHeadsetDoesNotHauntAGoodOne()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        await http.PostAsJsonAsync("/voice-quality/sample", Sample());
+
+        // Everything posted just now is inside a one-day window and outside a zero-length one; the
+        // parameter is rejected when nonsensical rather than silently ignoring the caller's intent.
+        using var withinWindow = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary?days=1"));
+        Assert.Equal(1, withinWindow.RootElement.GetProperty("totalSamples").GetInt32());
+    }
+
+    [Fact]
+    public async Task DeletingTheHistoryLeavesNothingBehind()
+    {
+        var (app, http, log) = await StartAsync();
+        await using var _d = app;
+
+        await http.PostAsJsonAsync("/voice-quality/sample", Sample());
+        var del = await http.DeleteAsync("/voice-quality/history");
+
+        Assert.Equal(HttpStatusCode.OK, del.StatusCode);
+        Assert.Empty(log.Load());
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary"));
+        Assert.Equal("empty", doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task NothingStoredCarriesAudioOrTranscriptText()
+    {
+        // The privacy claim made on the screen, asserted against what is actually written to disk.
+        var (app, http, log) = await StartAsync();
+        await using var _d = app;
+
+        await http.PostAsJsonAsync("/voice-quality/sample", Sample());
+
+        var written = Directory.GetFiles(log.Directory, "microphone-*.jsonl").Single();
+        var text = await File.ReadAllTextAsync(written);
+        foreach (var forbidden in new[] { "transcript", "rawText", "audio", "text\"" })
+            Assert.DoesNotContain(forbidden, text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
@@ -1,0 +1,129 @@
+using System.Text.Json.Serialization;
+using CcDirector.Gateway.Transcription;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Background microphone-quality monitoring for ordinary dictation.
+///
+///   POST   /voice-quality/sample   one measurement from a finished dictation -> 204
+///   GET    /voice-quality/summary  the folded verdict the Cockpit renders    -> 200
+///   DELETE /voice-quality/history  forget every measurement for this tenant  -> 200 { removed }
+///
+/// The client measures (it is where the decoded audio already is) and posts a handful of numbers plus
+/// the microphone's name. No audio and no transcript are involved, so this route carries nothing that
+/// could identify what was said - only how it sounded.
+///
+/// THE POST ANSWERS 204 AND MEANS IT. A dictation has already succeeded by the time this is called, so
+/// there is no failure here worth telling the client about: a rejected sample is dropped and logged,
+/// never turned into an error the user could see. The client sends fire-and-forget for the same
+/// reason (qualityReport.ts).
+///
+/// The verdict on GET is FOLDED ON THE GATEWAY (MicrophoneQualityFold), not assembled in the browser -
+/// the standing rule that a client renders a decision and never re-derives one.
+/// </summary>
+internal static class VoiceQualityEndpoint
+{
+    private const string Prefix = "/voice-quality";
+
+    /// <summary>Longest device name stored. Real names are well under this; the cap stops a client
+    /// from turning a per-dictation record into a place to park arbitrary text.</summary>
+    private const int MaxDeviceChars = 200;
+
+    public static void Map(
+        IEndpointRouteBuilder app,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        MicrophoneQualityLog? logOverride = null)
+    {
+        var group = app.MapGroup(Prefix);
+
+        group.MapPost("/sample", async (HttpContext ctx, CancellationToken ct) =>
+        {
+            // Stores a per-account record, so it uses the refusing resolver: on hosted, a request with
+            // no bound tenant is denied rather than silently written into the self-host partition.
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+
+            SampleRequest? body;
+            try
+            {
+                body = await ctx.Request.ReadFromJsonAsync<SampleRequest>(ct);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return Results.NoContent();
+            }
+            if (body is null) return Results.NoContent();
+
+            var log = logOverride ?? MicrophoneQualityLog.ForTenant(tenant);
+            log.Record(new MicrophoneQualityRecord
+            {
+                TimestampUtc = DateTime.UtcNow,
+                Device = Trim(body.Device, MaxDeviceChars),
+                Source = Trim(body.Source, 40),
+                DurationSeconds = body.DurationSeconds,
+                SampleRate = body.SampleRate,
+                SpeechLevelDb = body.SpeechLevelDb,
+                NoiseFloorDb = body.NoiseFloorDb,
+                SignalToNoiseDb = body.SignalToNoiseDb,
+                ClippedFraction = body.ClippedFraction,
+                HighBandRatioDb = body.HighBandRatioDb,
+                Narrowband = body.Narrowband,
+                Rating = Trim(body.Rating, 16),
+                Issues = Trim(body.Issues, 120),
+            });
+
+            return Results.NoContent();
+        });
+
+        group.MapGet("/summary", (HttpContext ctx) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+
+            var days = ParseDays(ctx.Request.Query["days"]);
+            var since = days is null ? (DateTime?)null : DateTime.UtcNow.AddDays(-days.Value);
+            var log = logOverride ?? MicrophoneQualityLog.ForTenant(tenant);
+            return Results.Json(MicrophoneQualityFold.Summarize(log.Load(since)));
+        });
+
+        group.MapDelete("/history", (HttpContext ctx) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+            var log = logOverride ?? MicrophoneQualityLog.ForTenant(tenant);
+            return Results.Json(new { removed = log.Clear() });
+        });
+    }
+
+    private static int? ParseDays(string? raw)
+        => int.TryParse(raw, out var days) && days > 0 && days <= 365 ? days : null;
+
+    private static string Trim(string? value, int maxChars)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "";
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxChars ? trimmed : trimmed[..maxChars];
+    }
+
+    /// <summary>The measurement as the browser sends it. Mirrors DictationQualitySample in
+    /// qualityReport.ts; the two are one contract and change together.</summary>
+    private sealed record SampleRequest
+    {
+        [JsonPropertyName("source")] public string? Source { get; init; }
+        [JsonPropertyName("device")] public string? Device { get; init; }
+        [JsonPropertyName("durationSeconds")] public double DurationSeconds { get; init; }
+        [JsonPropertyName("sampleRate")] public int SampleRate { get; init; }
+        [JsonPropertyName("speechLevelDb")] public double SpeechLevelDb { get; init; }
+        [JsonPropertyName("noiseFloorDb")] public double NoiseFloorDb { get; init; }
+        [JsonPropertyName("signalToNoiseDb")] public double SignalToNoiseDb { get; init; }
+        [JsonPropertyName("clippedFraction")] public double ClippedFraction { get; init; }
+        [JsonPropertyName("highBandRatioDb")] public double HighBandRatioDb { get; init; }
+        [JsonPropertyName("narrowband")] public bool Narrowband { get; init; }
+        [JsonPropertyName("rating")] public string? Rating { get; init; }
+        [JsonPropertyName("issues")] public string? Issues { get; init; }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2577,6 +2577,11 @@ public sealed class GatewayHost : IAsyncDisposable
                 _keyVault, history: _transcriptionHistory, audioArchive: _transcriptionAudioArchive, transcripts: _transcripts),
             _tenantBoundary);
 
+        // Background microphone-quality monitoring: the browser measures every dictation it sends and
+        // posts a handful of numbers here, so the Cockpit can say WHICH microphone is letting the user
+        // down. No audio and no transcript reach this route.
+        Api.VoiceQualityEndpoint.Map(_app, _tenantBoundary);
+
         // Text-in / text-out cleanup: run ONLY the deterministic dictionary correction over supplied
         // text + a supplied term list (no audio). The engine the multilingual eval harness drives, and
         // a way for any agent to test cleanup on arbitrary text/terms.

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
@@ -1,0 +1,192 @@
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// Turns a tenant's raw microphone measurements into the finished verdict the Cockpit renders.
+///
+/// THE CLIENT IS DUMB (CLAUDE.md #7). Every judgement here - which microphone is worst, whether it is
+/// worth telling the user about, and the sentence that says so - is decided ONCE, on the Gateway, and
+/// stamped onto the response. The Cockpit lays it out; it never re-derives what a state means. Adding
+/// a new verdict is an edit here, not a new branch in a React component.
+///
+/// WHAT IT DELIBERATELY DOES NOT DO: nag. Measured against 212 real dictations from a healthy setup,
+/// reporting every imperfection would have flagged about one dictation in nine - which is the rate
+/// that teaches somebody to ignore the screen. So a microphone is only ever called BAD on the two
+/// defects that are unambiguous and worth acting on (a band-limited link, and real distortion), and
+/// the softer readings are shown as measurements rather than as complaints.
+/// </summary>
+public static class MicrophoneQualityFold
+{
+    /// <summary>Below this a device has not been used enough for its average to mean anything, and a
+    /// verdict on two clips would swing wildly with the next one.</summary>
+    public const int MinSamplesForVerdict = 5;
+
+    /// <summary>A device is called band-limited only when MOST of its dictation is. One narrowband
+    /// reading can be a Bluetooth link that connected in hands-free mode for a single call; a
+    /// majority is the headset itself.</summary>
+    public const double NarrowbandShareToWarn = 0.5;
+
+    /// <summary>Distortion is a fault at a much lower share than band-limiting, because it is caused
+    /// by a gain setting that will keep doing it, and it is trivially fixable.</summary>
+    public const double ClippingShareToWarn = 0.2;
+
+    public static MicrophoneQualitySummary Summarize(IReadOnlyList<MicrophoneQualityRecord> records)
+    {
+        if (records is null || records.Count == 0)
+        {
+            return new MicrophoneQualitySummary
+            {
+                TotalSamples = 0,
+                Headline = "No dictation has been measured yet.",
+                Detail = "Dictate something and your microphone quality will appear here automatically.",
+                Status = "empty",
+                Devices = Array.Empty<MicrophoneDeviceSummary>(),
+            };
+        }
+
+        var devices = records
+            .GroupBy(r => string.IsNullOrWhiteSpace(r.Device) ? "Unnamed microphone" : r.Device)
+            .Select(BuildDevice)
+            .OrderByDescending(d => d.Samples)
+            .ToList();
+
+        // The headline speaks about the WORST device that has earned a verdict, not the average of
+        // everything. Averaging a bad headset with a good desk microphone hides exactly the finding
+        // the user needs: that one of their microphones is the problem.
+        var judged = devices.Where(d => d.Samples >= MinSamplesForVerdict).ToList();
+        var worst = judged.FirstOrDefault(d => d.Status == "bad");
+
+        string headline;
+        string detail;
+        string status;
+        if (worst is not null)
+        {
+            status = "bad";
+            headline = $"{worst.Device} is holding your transcription back.";
+            detail = worst.Advice;
+        }
+        else if (judged.Count == 0)
+        {
+            status = "learning";
+            headline = "Still learning how your microphones sound.";
+            detail =
+                $"A microphone needs {MinSamplesForVerdict} measured dictations before this screen will "
+                + "judge it, so a single odd recording never accuses good hardware.";
+        }
+        else
+        {
+            status = "good";
+            headline = judged.Count == 1
+                ? "Your microphone sounds good."
+                : $"All {judged.Count} of your microphones sound good.";
+            detail = "Nothing about your audio is holding transcription back. The numbers below are the evidence.";
+        }
+
+        return new MicrophoneQualitySummary
+        {
+            TotalSamples = records.Count,
+            Headline = headline,
+            Detail = detail,
+            Status = status,
+            Devices = devices,
+        };
+    }
+
+    private static MicrophoneDeviceSummary BuildDevice(IGrouping<string, MicrophoneQualityRecord> group)
+    {
+        var list = group.ToList();
+        var n = list.Count;
+        var narrowbandShare = (double)list.Count(r => r.Narrowband) / n;
+        var clippingShare = (double)list.Count(r => r.ClippedFraction >= 0.001) / n;
+
+        var status = "good";
+        var advice = "";
+        if (n >= MinSamplesForVerdict && narrowbandShare >= NarrowbandShareToWarn)
+        {
+            status = "bad";
+            advice =
+                "It is sending telephone-quality audio, which strips out the consonants the transcriber "
+                + "needs. This is almost always a Bluetooth headset running in hands-free mode. Switch it "
+                + "to its headphones profile and pick a different microphone, use its USB dongle instead "
+                + "of Bluetooth, or use a wired microphone. This one change usually matters more than "
+                + "everything else on this page put together.";
+        }
+        else if (n >= MinSamplesForVerdict && clippingShare >= ClippingShareToWarn)
+        {
+            status = "bad";
+            advice =
+                "Its audio is distorting, which means the input level is too high and the loudest parts "
+                + "are being cut flat. Move it further from your mouth, or turn the input level down in "
+                + "your operating system's sound settings.";
+        }
+        else if (n < MinSamplesForVerdict)
+        {
+            status = "learning";
+            advice = $"Measured {n} times so far; {MinSamplesForVerdict} are needed before this is judged.";
+        }
+        else
+        {
+            advice = "Nothing wrong with this microphone.";
+        }
+
+        return new MicrophoneDeviceSummary
+        {
+            Device = group.Key,
+            Samples = n,
+            Status = status,
+            Advice = advice,
+            NarrowbandShare = Round(narrowbandShare),
+            ClippingShare = Round(clippingShare),
+            MedianSpeechLevelDb = Round(Median(list.Select(r => r.SpeechLevelDb))),
+            MedianSignalToNoiseDb = Round(Median(list.Select(r => r.SignalToNoiseDb))),
+            LastSeenUtc = list.Max(r => r.TimestampUtc),
+            // What good looks like, carried next to the reading so the Cockpit compares rather than
+            // just displays. Folded here so the two can never drift apart.
+            TargetSpeechLevelDb = TargetSpeechLevelDb,
+            TargetSignalToNoiseDb = TargetSignalToNoiseDb,
+        };
+    }
+
+    /// <summary>A healthy speaking level: loud enough that the encoder spends its bits on the voice.</summary>
+    public const double TargetSpeechLevelDb = -20;
+
+    /// <summary>Where a voice stands clear of the room well enough for the model not to struggle.</summary>
+    public const double TargetSignalToNoiseDb = 20;
+
+    private static double Median(IEnumerable<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        if (sorted.Count == 0) return 0;
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+
+    private static double Round(double value) => Math.Round(value, 2);
+}
+
+/// <summary>The finished microphone-quality verdict, rendered verbatim by the Cockpit.</summary>
+public sealed record MicrophoneQualitySummary
+{
+    public required int TotalSamples { get; init; }
+    /// <summary>"empty", "learning", "good" or "bad" - drives the banner colour only.</summary>
+    public required string Status { get; init; }
+    public required string Headline { get; init; }
+    public required string Detail { get; init; }
+    public required IReadOnlyList<MicrophoneDeviceSummary> Devices { get; init; }
+}
+
+/// <summary>How one microphone is doing, with what good looks like carried alongside.</summary>
+public sealed record MicrophoneDeviceSummary
+{
+    public required string Device { get; init; }
+    public required int Samples { get; init; }
+    /// <summary>"good", "learning" or "bad".</summary>
+    public required string Status { get; init; }
+    public required string Advice { get; init; }
+    public required double NarrowbandShare { get; init; }
+    public required double ClippingShare { get; init; }
+    public required double MedianSpeechLevelDb { get; init; }
+    public required double MedianSignalToNoiseDb { get; init; }
+    public required double TargetSpeechLevelDb { get; init; }
+    public required double TargetSignalToNoiseDb { get; init; }
+    public required DateTime LastSeenUtc { get; init; }
+}

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The per-tenant record of how good each dictation SOUNDED, one line per dictation, so the Cockpit
+/// can say which microphone is letting a user down.
+///
+/// WHY THIS IS SEPARATE FROM <see cref="TranscriptionHistoryLog"/>. That log is written by the Gateway
+/// at transcription time and records how the TRANSCRIBER behaved - latency, outcome, corrections. The
+/// measurement here is made by the CLIENT, from the audio, and only exists after the clip has been
+/// decoded in the browser. It therefore cannot be a column on a record the Gateway has already
+/// written. The two share a shape and a retention window on purpose, so an operator learns one layout
+/// rather than two, and they are joined by nothing - the quality picture is an aggregate, not a
+/// per-turn lookup.
+///
+/// WHAT IS NOT IN HERE: audio and transcript text. This is a handful of numbers per dictation plus the
+/// microphone's name. It exists to answer "which of my microphones is bad", which needs no recording
+/// of what was said.
+///
+/// RETENTION: 30 days, matching the transcript-text window and the Transcription Health history, so
+/// the product keeps ONE answer to how long it holds on to anything derived from a user's voice.
+/// </summary>
+public sealed class MicrophoneQualityLog
+{
+    /// <summary>How long a daily file is kept.</summary>
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly object _gate = new();
+    private readonly string _directory;
+
+    public static string DefaultDirectory() => CcStorage.MicrophoneQuality();
+
+    /// <summary>
+    /// This tenant's partition. The tenant is in the PATH, so no code path can write one account's
+    /// measurements into another's folder. The single Local tenant keeps the flat directory, matching
+    /// how the transcription history lays itself out, so a self-host install has one obvious place.
+    /// </summary>
+    public static string DirectoryFor(Core.Tenancy.TenantId tenant)
+    {
+        if (tenant == Core.Tenancy.TenantId.Local) return DefaultDirectory();
+        var chars = tenant.Value.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray();
+        return Path.Combine(DefaultDirectory(), new string(chars));
+    }
+
+    public static MicrophoneQualityLog ForTenant(Core.Tenancy.TenantId tenant) => new(DirectoryFor(tenant));
+
+    public MicrophoneQualityLog(string? directory = null)
+    {
+        _directory = directory ?? DefaultDirectory();
+    }
+
+    public string Directory => _directory;
+
+    private string FileFor(DateTime utcNow) => Path.Combine(_directory, $"microphone-{utcNow:yyyyMMdd}.jsonl");
+
+    /// <summary>
+    /// Append one measurement and prune expired days. NEVER throws: a dictation that already
+    /// succeeded must not be turned into an error because our bookkeeping failed.
+    /// </summary>
+    public void Record(MicrophoneQualityRecord record)
+    {
+        if (record is null) return;
+        try
+        {
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(_directory);
+                File.AppendAllText(FileFor(DateTime.UtcNow), JsonSerializer.Serialize(record, JsonOptions) + Environment.NewLine);
+                PruneExpired();
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MicrophoneQualityLog] Record FAILED (swallowed): {ex.Message}");
+        }
+    }
+
+    /// <summary>Every measurement inside the window, newest first. One unreadable line is skipped
+    /// rather than taking the whole history down with it.</summary>
+    public IReadOnlyList<MicrophoneQualityRecord> Load(DateTime? sinceUtc = null)
+    {
+        lock (_gate)
+        {
+            if (!System.IO.Directory.Exists(_directory)) return Array.Empty<MicrophoneQualityRecord>();
+            var records = new List<MicrophoneQualityRecord>();
+            foreach (var file in new DirectoryInfo(_directory).GetFiles("microphone-*.jsonl"))
+            {
+                foreach (var line in ReadLines(file.FullName))
+                {
+                    try
+                    {
+                        var rec = JsonSerializer.Deserialize<MicrophoneQualityRecord>(line, JsonOptions);
+                        if (rec is not null && (sinceUtc is null || rec.TimestampUtc >= sinceUtc.Value)) records.Add(rec);
+                    }
+                    catch (JsonException)
+                    {
+                        // A torn final line from a crash mid-append. Skip it; the rest is still good.
+                    }
+                }
+            }
+            return records.OrderByDescending(r => r.TimestampUtc).ToList();
+        }
+    }
+
+    private static IEnumerable<string> ReadLines(string path)
+    {
+        try
+        {
+            return File.ReadAllLines(path).Where(l => !string.IsNullOrWhiteSpace(l));
+        }
+        catch (IOException ex)
+        {
+            FileLog.Write($"[MicrophoneQualityLog] could not read {Path.GetFileName(path)}: {ex.Message}");
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>Delete every measurement for this tenant. Returns how many files were removed.</summary>
+    public int Clear()
+    {
+        lock (_gate)
+        {
+            if (!System.IO.Directory.Exists(_directory)) return 0;
+            var removed = 0;
+            foreach (var file in new DirectoryInfo(_directory).GetFiles("microphone-*.jsonl"))
+            {
+                try
+                {
+                    file.Delete();
+                    removed++;
+                }
+                catch (IOException ex)
+                {
+                    FileLog.Write($"[MicrophoneQualityLog] could not delete {file.Name}: {ex.Message}");
+                }
+            }
+            return removed;
+        }
+    }
+
+    private void PruneExpired()
+    {
+        var cutoff = DateTime.UtcNow - Retention;
+        foreach (var file in new DirectoryInfo(_directory).GetFiles("microphone-*.jsonl"))
+        {
+            if (file.LastWriteTimeUtc >= cutoff) continue;
+            try
+            {
+                file.Delete();
+            }
+            catch (IOException ex)
+            {
+                FileLog.Write($"[MicrophoneQualityLog] prune could not delete {file.Name}: {ex.Message}");
+            }
+        }
+    }
+}
+
+/// <summary>One dictation's acoustic measurement. No audio, no transcript - only how it sounded.</summary>
+public sealed record MicrophoneQualityRecord
+{
+    [JsonPropertyName("ts")] public DateTime TimestampUtc { get; init; }
+    /// <summary>The microphone's name as the operating system reported it, or empty when unknown.</summary>
+    [JsonPropertyName("device")] public string Device { get; init; } = "";
+    /// <summary>Which surface produced it ("dictation-dialog", "dictation-send").</summary>
+    [JsonPropertyName("source")] public string Source { get; init; } = "";
+    [JsonPropertyName("durationSeconds")] public double DurationSeconds { get; init; }
+    [JsonPropertyName("sampleRate")] public int SampleRate { get; init; }
+    [JsonPropertyName("speechLevelDb")] public double SpeechLevelDb { get; init; }
+    [JsonPropertyName("noiseFloorDb")] public double NoiseFloorDb { get; init; }
+    [JsonPropertyName("signalToNoiseDb")] public double SignalToNoiseDb { get; init; }
+    [JsonPropertyName("clippedFraction")] public double ClippedFraction { get; init; }
+    [JsonPropertyName("highBandRatioDb")] public double HighBandRatioDb { get; init; }
+    [JsonPropertyName("narrowband")] public bool Narrowband { get; init; }
+    /// <summary>"good", "fair" or "poor" - folded by the same rules the Test microphone screen shows.</summary>
+    [JsonPropertyName("rating")] public string Rating { get; init; } = "";
+    /// <summary>Issue identifiers joined by "+", empty when the microphone is good.</summary>
+    [JsonPropertyName("issues")] public string Issues { get; init; } = "";
+}


### PR DESCRIPTION
The Test microphone check (#2160) answers "how is my microphone right now", once, when somebody goes
looking. This answers the question nobody goes looking for and cannot answer alone: **across all the
dictating I actually do, is one of my microphones the reason my transcripts are poor?**

Every dictation is now measured as it is sent, tagged with **which microphone** recorded it, and the
Cockpit's dictation page shows a verdict per device. Recording the device name is what makes this
actionable rather than merely true — "your audio is band-limited" tells someone almost nothing, while
"your Jabra headset is band-limited and your laptop microphone is not" tells them which one to stop
using.

**Nothing is emailed.** That is a later, separate decision; this puts the picture on the screen.

## The thresholds are calibrated against real audio

Running the check over **212 real dictations** from a healthy setup showed:

- Warning on every imperfection would have complained about **roughly one dictation in nine** — the
  rate that teaches somebody to ignore the screen.
- Warning only on the two unambiguous, actionable defects would have said **nothing at all**.

So a microphone is called bad only when most of its dictation is band-limited, or a fifth of it is
distorting. Quiet audio and a noisy room appear as measurements beside what good looks like, never as
an accusation. A device is not judged until it has five measurements, so one odd recording never
convicts good hardware. The headline speaks about the **worst** device rather than an average —
averaging a bad headset with a good desk microphone would hide exactly the finding the user needs.

## Three rules the reporting path keeps

- **It never delays a word.** Measurement runs after the transcript is already on its way, and the
  send is fire-and-forget.
- **It never fails a dictation.** Every path swallows its own errors to a console line, and the
  Gateway answers 204 even to a malformed body — a 400 would be a lie about a dictation that worked.
- **It costs no second decode.** `blobToWav16kMono` now hands back the native-rate mono buffer it
  already produced, so the only new work is the analysis itself over a clip already in memory.

## What is stored

A handful of numbers per dictation plus the microphone's name, per tenant, for thirty days — matching
the window already applied to transcript text, so the product keeps one answer to how long it holds
anything derived from a voice. No audio and no transcript reach this route, and a test asserts that
against **what is actually written to disk** rather than against the intent.

The verdict is folded on the Gateway (`MicrophoneQualityFold`) and rendered verbatim; the Cockpit
panel contains no thresholds.

## Verification

680 client-core tests, 180 Cockpit tests, 26 new Gateway tests (12 on the fold, 8 on the endpoint over
real HTTP, 6 on the client measurement), both web apps build, root typecheck clean. The panel was
rendered in a real browser against the fold's actual response shape — three microphones, one bad, one
good, one still learning.
