### PR TITLE
Fix: the Gateway moves the speech model with the language; offer five languages, not twelve

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -23,6 +23,9 @@ import {
   setCarModeEndPhrase,
   setWingmanFastModel,
   setTtsModel,
+  setSpokenLanguage,
+  getSpokenLanguages,
+  type SpokenLanguageOption,
   setTtsVoice,
   setWingmanModel,
   testChat,
@@ -65,7 +68,16 @@ import {
 // address). Responsive (CodingStyle.md): each tab renders immediately with a loading line and loads
 // asynchronously; on a failure it shows an explicit error banner, never a fabricated value.
 
-const SAMPLE_TEXT = "Hi, I'm your DevThrottle wingman. This is how I'll sound.";
+// One sample sentence per language. Auditioning a Danish voice by making it read English tells you
+// nothing about the accent you are actually choosing.
+const SAMPLES: Record<string, string> = {
+  en: "Hi, I'm your DevThrottle wingman. This is how I'll sound.",
+  fr: "Bonjour, je suis votre wingman DevThrottle. Voici ma voix.",
+  de: "Hallo, ich bin dein DevThrottle Wingman. So werde ich klingen.",
+  es: "Hola, soy tu wingman de DevThrottle. Asi es como voy a sonar.",
+  da: "Hej, jeg er din DevThrottle wingman. Sadan kommer jeg til at lyde.",
+};
+const SAMPLE_TEXT = SAMPLES.en;
 
 export function SettingsView() {
   const [params] = useSearchParams();
@@ -553,6 +565,8 @@ function AiTab() {
   const [snap, setSnap] = useState<AiProviderSnapshot | null>(null);
   const [chatModels, setChatModels] = useState<AiModel[]>([]);
   const [speechModels, setSpeechModels] = useState<AiModel[]>([]);
+  const [languages, setLanguages] = useState<SpokenLanguageOption[]>([]);
+  const [language, setLanguage] = useState("en");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState("");
@@ -567,6 +581,36 @@ function AiTab() {
     setSpeechModels(await getAiModels("speech"));
   }, []);
 
+  // The language list is served by the Gateway and does NOT depend on the model catalog, so it works
+  // on hosted where the catalog is refused. Loaded separately for exactly that reason.
+  const loadLanguages = useCallback(async () => {
+    const spoken = await getSpokenLanguages();
+    setLanguages(spoken.languages);
+    setLanguage(spoken.current);
+  }, []);
+
+  const chooseLanguage = async (code: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    setSampleMsg("");
+    try {
+      // The Gateway switches the speech model to one that can say this and tells us what it picked.
+      // The browser does not decide: on hosted it cannot even see the model catalog.
+      const res = await setSpokenLanguage(code);
+      setLanguage(res.language);
+      if (res.ttsModel && snap) {
+        setSnap({ ...snap, ttsModel: res.ttsModel, ttsVoice: res.ttsVoice ?? "" });
+      }
+      setMsg(res.switched
+        ? "Spoken language set. Speech model switched to " + res.ttsModel + ", which can speak it."
+        : "Spoken language set.");
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const load = useCallback(async () => {
     try {
       setError(null);
@@ -576,6 +620,7 @@ function AiTab() {
       // (issue #2022); the Gateway says so via catalogAvailable. Skip the catalog fetch there so the tab
       // renders clean with the account's saved selections instead of painting a load error.
       if (s.catalogAvailable !== false) await loadModels();
+      await loadLanguages();
     } catch (e) {
       setError(errText(e));
     }
@@ -683,7 +728,7 @@ function AiTab() {
     setBusy(true);
     setSampleMsg("Synthesizing...");
     try {
-      const blob = await ttsSample(SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
+      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
       if (audioRef.current === null) audioRef.current = new Audio();
       audioRef.current.src = URL.createObjectURL(blob);
       audioRef.current.onended = () => setSampleMsg("");
@@ -772,6 +817,29 @@ function AiTab() {
             {fastTestMsg || "Used for spoken turn summaries, menus, and choice mapping."}
           </span>
         </div>
+      </div>
+
+      <div className="settings-field">
+        <label htmlFor="settings-ai-spoken-language">Spoken language</label>
+        <select
+          id="settings-ai-spoken-language"
+          className="settings-select"
+          value={language}
+          disabled={busy}
+          onChange={(e) => void chooseLanguage(e.target.value)}
+        >
+          {languages.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.name === l.endonym ? l.name : l.name + " (" + l.endonym + ")"}
+            </option>
+          ))}
+        </select>
+        <p className="settings-hint">
+          The language DevThrottle speaks back to you in. Dictation understands every language
+          automatically, so this does not change how you talk to it, and your agents keep working in
+          whatever language they work in. Choosing a language moves the speech model to one that can
+          say it.
+        </p>
       </div>
 
       <div className="settings-field">

--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -93,13 +93,6 @@ export function AiSettings() {
 
   const currentSpeech = speechModels.find((m) => m.id === snap.ttsModel);
 
-  // A model can speak a language only when it SAYS so. One that publishes no list is English-only,
-  // never "speaks everything" - see the note on AiModel.languages.
-  const canSpeak = (m: AiModel, code: string) =>
-    (m.languages ?? []).length === 0 ? code === "en" : (m.languages ?? []).includes(code);
-
-  const speechForLanguage = speechModels.filter((m) => canSpeak(m, language));
-
   // An expressive model with no preset voices is not a model with a missing voice list - there is
   // nothing to choose. Showing an empty picker reads as broken, so the control is hidden instead.
   const modelHasVoices = !currentSpeech || currentSpeech.voices.length > 0;
@@ -110,32 +103,16 @@ export function AiSettings() {
     setMsg("Saving...");
     setSampleMsg("");
     try {
-      await setSpokenLanguage(code);
-      setLanguage(code);
-      // If the speech model in use cannot say the new language, move to one that can rather than
-      // leaving the account on an engine that would answer in English phonetics.
-      let nextSnap = snap;
-      if (currentSpeech && !canSpeak(currentSpeech, code)) {
-        const replacement = speechModels.find((m) => canSpeak(m, code));
-        if (replacement) {
-          await setTtsModel(replacement.id);
-          const voices = replacement.voices ?? [];
-          let voice = snap.ttsVoice;
-          if (voices.length > 0 && voices.indexOf(voice) < 0) {
-            voice = replacement.defaultVoice && voices.indexOf(replacement.defaultVoice) >= 0
-              ? replacement.defaultVoice
-              : voices[0];
-            await setTtsVoice(voice);
-          }
-          nextSnap = { ...snap, ttsModel: replacement.id, ttsVoice: voice };
-          setSnap(nextSnap);
-          setMsg("Spoken language set. Speech model switched to " + replacement.id + ", which can speak it.");
-          return;
-        }
-        setMsg("Spoken language set, but no speech model here can say it yet.");
-        return;
+      // The Gateway decides which speech model can say this and switches it; we only report what
+      // it did. The browser cannot make that call on hosted - the model catalog is refused there.
+      const res = await setSpokenLanguage(code);
+      setLanguage(res.language);
+      if (res.ttsModel) {
+        setSnap({ ...snap, ttsModel: res.ttsModel, ttsVoice: res.ttsVoice ?? "" });
       }
-      setMsg("Spoken language set.");
+      setMsg(res.switched
+        ? "Spoken language set. Speech model switched to " + res.ttsModel + ", which can speak it."
+        : "Spoken language set.");
     } catch (e) {
       setMsg(e instanceof Error ? e.message : String(e));
     } finally {
@@ -332,13 +309,10 @@ export function AiSettings() {
       <div className="setting-block">
         <label className="setting-label" htmlFor="ai-ttsmodel">Speech model</label>
         <select id="ai-ttsmodel" className="setting-select" value={snap.ttsModel} disabled={busy} onChange={(e) => void chooseSpeech(e.target.value)}>
-          {ensure(snap.ttsModel, speechForLanguage).map((id) => (
+          {ensure(snap.ttsModel, speechModels).map((id) => (
             <option key={id} value={id}>{id}</option>
           ))}
         </select>
-        {speechForLanguage.length === 0 && (
-          <p className="setting-hint">No speech model here can say that language yet.</p>
-        )}
       </div>
 
       <div className="setting-block">

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -153,8 +153,18 @@ export async function getSpokenLanguages(): Promise<{ current: string; languages
 
 // PUT /gateway/ai/spoken-language { language } - the language DevThrottle SPEAKS BACK in. This does
 // NOT affect dictation, which detects the spoken language on its own. A blank value means English.
-export function setSpokenLanguage(language: string): Promise<{ language: string }> {
-  return putJson<{ language: string }>("/gateway/ai/spoken-language", { language });
+// The Gateway moves the speech model with the language and reports what it ended up as - the client
+// deliberately does not decide this. On the hosted Gateway the model catalog is refused (it spends the
+// shared deployment credential), so a browser has no model list to reason about and would leave the
+// account on an engine that cannot say the chosen language. Deciding server-side also keeps mobile and
+// the Cockpit from drifting, because neither of them decides anything.
+export function setSpokenLanguage(language: string): Promise<{
+  language: string;
+  ttsModel: string | null;
+  ttsVoice: string | null;
+  switched: boolean;
+}> {
+  return putJson("/gateway/ai/spoken-language", { language });
 }
 
 // POST /wingman/tts { text, model, voice } -> audio bytes to play (a short "Play sample").

--- a/src/CcDirector.Core.Tests/Configuration/SpokenLanguageTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/SpokenLanguageTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CcDirector.Core.Configuration;
 using Xunit;
 
@@ -38,6 +39,26 @@ public sealed class SpokenLanguageTests
         => Assert.Equal(expected, SpokenLanguage.Normalize(input));
 
     [Fact]
+    public void Exactly_five_languages_are_offered_in_a_deliberate_order()
+    {
+        // The offer is a commercial decision, not a capability list. An earlier version listed twelve
+        // - everything the speech engine could manage - which is the mistake this test exists to catch.
+        Assert.Equal(5, SpokenLanguage.Offered.Count);
+        Assert.Equal(
+            new[] { "en", "fr", "de", "es", "da" },
+            SpokenLanguage.Offered.Select(l => l.Code).ToArray());
+    }
+
+    [Fact]
+    public void English_is_first_and_Danish_is_last()
+    {
+        // English leads because it is the default; Danish trails because it is carried for testing
+        // the pipeline, not as a market, and must not sit above a language somebody might buy in.
+        Assert.Equal("en", SpokenLanguage.Offered[0].Code);
+        Assert.Equal("da", SpokenLanguage.Offered[^1].Code);
+    }
+
+    [Fact]
     public void The_three_market_languages_and_the_test_language_are_offered()
     {
         // German, French and Spanish are the market bets; Danish is the language the pipeline is
@@ -69,6 +90,10 @@ public sealed class SpokenLanguageTests
         var multilingual = new[] { "en", "da", "de", "fr", "es" };
         Assert.True(SpokenLanguage.ModelCanSpeak(multilingual, "da"));
         Assert.True(SpokenLanguage.ModelCanSpeak(multilingual, "DE"));
+        // A language the model does not list, and one we do not offer either - both must be false.
+        // ModelCanSpeak deliberately does NOT normalize: asking "can it say Japanese?" must not
+        // quietly become "can it say English?" just because we do not sell Japanese.
+        Assert.False(SpokenLanguage.ModelCanSpeak(multilingual, "it"));
         Assert.False(SpokenLanguage.ModelCanSpeak(multilingual, "ja"));
     }
 

--- a/src/CcDirector.Core/Configuration/SpokenLanguage.cs
+++ b/src/CcDirector.Core/Configuration/SpokenLanguage.cs
@@ -24,31 +24,36 @@ public static class SpokenLanguage
     public const string Default = "en";
 
     /// <summary>
-    /// The languages we offer, code to (English name, endonym). The English name is what the
-    /// wingman prompt says; the endonym is included because naming a language in its own words
-    /// measurably helps a model commit to it, and because the settings UI should show people
-    /// their own language the way they write it.
+    /// The languages we offer, IN THE ORDER THEY ARE SHOWN. Five, not more.
     ///
-    /// This list is the OFFER, not a capability claim - whether a given speech model can actually
-    /// say one of these is the model's <c>languages</c> array, checked separately. Keep the two
-    /// apart: offering a language no model can speak produces confident gibberish.
+    /// This is the OFFER, and it is a commercial decision, not a capability list. The speech engine
+    /// can say 23 languages; we sell five, because each one we list has to be translated, supported
+    /// and kept current on a product that ships weekly. An earlier version of this file listed
+    /// twelve - everything the engine could manage - which is exactly the capability-for-offer
+    /// mistake the note below warns against. Adding a language here is a decision, not a courtesy.
+    ///
+    /// The order is deliberate: English first because it is the default and the language everything
+    /// is authored in; then the three market languages alphabetically; then Danish last, because it
+    /// is carried for testing the pipeline rather than as a market, and it should not sit above a
+    /// language somebody might actually buy in.
+    ///
+    /// Whether a given speech model can SAY one of these is a separate question, answered by the
+    /// model's own languages list. Keep the two apart: offering a language no model can speak
+    /// produces confident gibberish.
     /// </summary>
-    public static readonly IReadOnlyDictionary<string, (string English, string Endonym)> Supported =
-        new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase)
+    public static readonly IReadOnlyList<(string Code, string English, string Endonym)> Offered =
+        new[]
         {
-            ["en"] = ("English", "English"),
-            ["da"] = ("Danish", "dansk"),
-            ["de"] = ("German", "Deutsch"),
-            ["fr"] = ("French", "francais"),
-            ["es"] = ("Spanish", "espanol"),
-            ["pt"] = ("Portuguese", "portugues"),
-            ["it"] = ("Italian", "italiano"),
-            ["nl"] = ("Dutch", "Nederlands"),
-            ["sv"] = ("Swedish", "svenska"),
-            ["no"] = ("Norwegian", "norsk"),
-            ["ja"] = ("Japanese", "Nihongo"),
-            ["tr"] = ("Turkish", "Turkce"),
+            ("en", "English", "English"),
+            ("fr", "French", "francais"),
+            ("de", "German", "Deutsch"),
+            ("es", "Spanish", "espanol"),
+            ("da", "Danish", "dansk"),
         };
+
+    /// <summary>The offered languages by code, for lookup. <see cref="Offered"/> holds the order.</summary>
+    public static readonly IReadOnlyDictionary<string, (string English, string Endonym)> Supported =
+        Offered.ToDictionary(l => l.Code, l => (l.English, l.Endonym), StringComparer.OrdinalIgnoreCase);
 
     /// <summary>True when <paramref name="code"/> is a language we offer.</summary>
     public static bool IsSupported(string? code) =>
@@ -89,13 +94,18 @@ public static class SpokenLanguage
     /// </summary>
     public static bool ModelCanSpeak(IEnumerable<string>? modelLanguages, string? code)
     {
-        var want = Normalize(code);
-        if (modelLanguages is null) return string.Equals(want, Default, StringComparison.Ordinal);
+        // NOT normalized. This asks a question about the MODEL, not about our offer: "can this engine
+        // say xx?" is a fact independent of whether we sell xx. Normalizing first was a real bug -
+        // it turned a question about an unoffered language into a question about English, and any
+        // model that speaks English answered yes.
+        var want = (code ?? "").Trim().ToLowerInvariant();
+        if (want.Length == 0) return false;
+        if (modelLanguages is null) return want == Default;
         var known = modelLanguages
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .Select(l => l.Trim().ToLowerInvariant())
             .ToList();
-        if (known.Count == 0) return string.Equals(want, Default, StringComparison.Ordinal);
+        if (known.Count == 0) return want == Default;
         return known.Contains(want);
     }
 }

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -91,7 +91,7 @@ internal static class AiModelsEndpoint
         // The per-account model/voice setters SERVE on hosted (issue #2022): each resolves the caller's tenant
         // and writes only that tenant's override, answering 403 on an unresolved identity - never Local. They
         // take the ungrouped builder because they are NOT denied; their fail-closed is ResolveReadTenant.
-        MapServedRoutes(outer, resolver, tenantBoundary);
+        MapServedRoutes(outer, resolver, tenantBoundary, vault);
 
         // The catalog (GET /gateway/ai/models) and test-chat (POST /gateway/ai/test-chat) STAY denied on hosted:
         // they spend the SHARED deployment provider credential (vault key DEVTHROTTLE_API_KEY) with no per-caller
@@ -177,7 +177,7 @@ internal static class AiModelsEndpoint
     /// ones that stay denied (see <see cref="MapDeniedRoutes"/>).
     /// </summary>
     private static void MapServedRoutes(IEndpointRouteBuilder app,
-        TenantSettingsResolver resolver, HostedTenantBoundary? tenantBoundary)
+        TenantSettingsResolver resolver, HostedTenantBoundary? tenantBoundary, KeyVault vault)
     {
 
         app.MapPut("/gateway/ai/wingman-model", async (HttpContext ctx) =>
@@ -273,31 +273,123 @@ internal static class AiModelsEndpoint
             var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (t is null) return TenantRequired();
             var current = resolver.SpokenLanguage(t.Value);
-            var languages = SpokenLanguage.Supported
-                .Select(kv => new { code = kv.Key, name = kv.Value.English, endonym = kv.Value.Endonym })
-                .OrderBy(l => l.code == SpokenLanguage.Default ? 0 : 1)   // English first, it is the default
-                .ThenBy(l => l.name, StringComparer.OrdinalIgnoreCase)
+            // Declared order, not sorted here: SpokenLanguage.Offered IS the running order (English
+            // first, the market languages alphabetically, Danish last). Re-sorting in the endpoint
+            // would silently override an intentional decision made in one place.
+            var languages = SpokenLanguage.Offered
+                .Select(l => new { code = l.Code, name = l.English, endonym = l.Endonym })
                 .ToList();
             return Results.Json(new { current, languages });
         });
 
-        app.MapPut("/gateway/ai/spoken-language", async (HttpContext ctx) =>
+        app.MapPut("/gateway/ai/spoken-language", async (HttpContext ctx, CancellationToken ct) =>
         {
             var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (t is null) return TenantRequired();
             try
             {
-                var body = await JsonSerializer.DeserializeAsync<LanguageBody>(ctx.Request.Body, JsonOpts, ctx.RequestAborted);
-                // A blank code means "back to English", which is the same stored state as never having
-                // chosen - the resolver clears the override rather than writing "en".
-                resolver.SetSpokenLanguage(t.Value, body?.Language ?? string.Empty, DateTime.UtcNow);
+                var body = await JsonSerializer.DeserializeAsync<LanguageBody>(ctx.Request.Body, JsonOpts, ct);
+                var requested = SpokenLanguage.Normalize(body?.Language);
+
+                // THE SPEECH MODEL MOVES WITH THE LANGUAGE, AND THE GATEWAY DOES IT - not the client.
+                //
+                // The browser cannot make this decision on the hosted Gateway: GET /gateway/ai/models is
+                // refused there (it spends the shared deployment credential), so a client has no model
+                // list to reason about and would silently leave the account on an engine that cannot say
+                // the chosen language. That is exactly what happened before this: choosing Danish saved
+                // the language and left the tenant on the English-only engine. Deciding here also means
+                // mobile and the Cockpit cannot drift, because neither decides anything.
+                var switched = await EnsureSpeechModelSpeaksAsync(t.Value, requested, resolver, vault, ct);
+                if (switched.Error is not null)
+                    return Results.Json(new { error = switched.Error }, statusCode: StatusCodes.Status502BadGateway);
+
+                resolver.SetSpokenLanguage(t.Value, requested, DateTime.UtcNow);
                 var language = resolver.SpokenLanguage(t.Value);
-                FileLog.Write($"[AiModelsEndpoint] spoken language set: {language} for tenant={t.Value.ToLogString()}");
-                return Results.Json(new { language });
+                FileLog.Write($"[AiModelsEndpoint] spoken language set: {language} for tenant={t.Value.ToLogString()}" +
+                              (switched.Changed ? $"; speech model -> {switched.Model} (voice {switched.Voice ?? "none"})" : ""));
+                return Results.Json(new
+                {
+                    language,
+                    ttsModel = switched.Model,
+                    ttsVoice = switched.Voice,
+                    switched = switched.Changed,
+                });
             }
             catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
+    }
+
+    /// <summary>The outcome of making the tenant's speech model match the language they asked for.</summary>
+    private readonly record struct SpeechSwitch(string? Model, string? Voice, bool Changed, string? Error);
+
+    /// <summary>
+    /// Make sure the tenant's speech model can actually SAY <paramref name="language"/>, switching it if
+    /// not, and returning what the model and voice ended up as.
+    ///
+    /// Fails LOUDLY rather than half-applying. If the catalog cannot be reached we do not know which
+    /// engines speak the language, and setting the language anyway would leave the account believing it
+    /// is speaking Danish while an English engine reads Danish text - the worst of both. So the caller
+    /// turns that into a 502 and the language is not stored.
+    /// </summary>
+    private static async Task<SpeechSwitch> EnsureSpeechModelSpeaksAsync(
+        TenantId tenant, string language, TenantSettingsResolver resolver, KeyVault vault, CancellationToken ct)
+    {
+        var mode = TranscriptionModeConfig.Get();
+        var currentModel = resolver.TtsModel(tenant, mode);
+        var currentVoice = resolver.TtsVoice(tenant, mode);
+
+        var ep = TranscriptionEndpointResolver.ResolveTts(mode);
+        var key = vault.Get(ep.KeyName);
+        if (string.IsNullOrWhiteSpace(key))
+            return new SpeechSwitch(currentModel, currentVoice, false, ProviderKeyMissingMessage(mode));
+
+        List<ModelDto> models;
+        try
+        {
+            models = await ListModelsAsync(ep.BaseUrl, key!, "speech", ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[AiModelsEndpoint] spoken language: could not read the speech catalog: {ex.Message}");
+            return new SpeechSwitch(currentModel, currentVoice, false,
+                "could not check which speech models can say that language: " + ex.Message);
+        }
+
+        var current = models.FirstOrDefault(m => string.Equals(m.Id, currentModel, StringComparison.OrdinalIgnoreCase));
+        if (current is not null && SpokenLanguage.ModelCanSpeak(current.Languages, language))
+        {
+            // Nothing to switch. Report the voice as none when this model has no preset voices, rather
+            // than echoing the global default: a stored voice id from some other engine is not the
+            // voice in use, and showing one in the UI would be a lie the user cannot act on.
+            var voiceInUse = current.Voices.Count > 0 ? currentVoice : null;
+            return new SpeechSwitch(currentModel, voiceInUse, false, null);
+        }
+
+        var replacement = models.FirstOrDefault(m => SpokenLanguage.ModelCanSpeak(m.Languages, language));
+        if (replacement is null)
+            return new SpeechSwitch(currentModel, currentVoice, false,
+                $"no speech model available can speak {SpokenLanguage.EnglishName(language)}");
+
+        resolver.SetTtsModel(tenant, replacement.Id, DateTime.UtcNow);
+
+        // The voice belongs to the OLD model. Carrying a Kokoro voice id onto an expressive model is
+        // meaningless (it is ignored upstream, but it would still be shown in the UI as the voice in
+        // use). Take the new model's own default, its first voice, or none at all when it has no
+        // preset voices - which is a real case, not a gap to fill.
+        string? voice = null;
+        if (replacement.Voices.Count > 0)
+        {
+            voice = !string.IsNullOrWhiteSpace(replacement.DefaultVoice) && replacement.Voices.Contains(replacement.DefaultVoice!)
+                ? replacement.DefaultVoice
+                : replacement.Voices[0];
+            resolver.SetTtsVoice(tenant, voice!, DateTime.UtcNow);
+        }
+        else
+        {
+            resolver.ClearTtsVoice(tenant);
+        }
+        return new SpeechSwitch(replacement.Id, voice, true, null);
     }
 
     private static string ProviderKeyMissingMessage(TranscriptionMode mode) =>

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -157,6 +157,11 @@ public sealed class TenantSettingsResolver
     public void SetTtsVoice(TenantId tenant, string voice, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.TtsVoice, RequireNonEmpty(voice, nameof(voice)), nowUtc);
 
+    /// <summary>Remove the tenant's voice override entirely - the honest state when the speech model in
+    /// use has no preset voices to choose from. Distinct from setting an empty string, which the setter
+    /// rejects.</summary>
+    public void ClearTtsVoice(TenantId tenant) => _store.Remove(tenant, TenantSettingKeys.TtsVoice);
+
     /// <summary>Set the tenant's text-to-speech model.</summary>
     /// <exception cref="ArgumentException">The model is null/empty.</exception>
     public void SetTtsModel(TenantId tenant, string model, DateTime nowUtc)


### PR DESCRIPTION
Two defects, both found by **using** the feature rather than reading it.

## 1. Choosing a language did not change the speech model

The switch was decided in the browser from the model catalog. On the hosted Gateway that catalog is **refused** - `GET /gateway/ai/models` answers 404 because it spends the shared deployment credential. So the client had an empty model list, the guard never fired, and the account stayed on the English-only engine while believing it had switched to Danish.

Confirmed against production before touching anything:

| Check | Result |
|---|---|
| `GET /gateway/ai/models?kind=speech` | `404 the model settings are not available on the hosted gateway` |
| `GET /gateway/ai-provider` | `catalogAvailable: false`, `ttsModel: hexgrad/Kokoro-82M` |

**The decision now belongs to the Gateway**, which can read the catalog with the deployment credential regardless of what the tenant-facing route exposes. `PUT /gateway/ai/spoken-language` checks whether the current engine can say the language, switches to one that can, moves the voice with it, and returns `{ language, ttsModel, ttsVoice, switched }`. The clients report; they no longer decide - so mobile and the Cockpit cannot drift.

It **fails loudly**: if the catalog cannot be read, the language is not stored and the caller gets a 502. Storing it anyway would leave an account convinced it is speaking Danish while an English engine reads Danish text.

## 2. The dropdown offered twelve languages

Now five: **English, French, German, Spanish, Danish** - English first as the default, the market languages alphabetically, Danish last because it is carried to test the pipeline rather than as a market. The old list was populated from what the engine is *capable* of, which is precisely the capability-for-offer mistake the comment in that file warns against.

## Also

- `ModelCanSpeak` no longer normalizes the language it is asked about - that turned "can it say Japanese?" into "can it say English?", so any English-capable model answered yes. A test caught it when the offer shrank.
- A model with no preset voices reports **no voice**, rather than echoing a stored id from a different engine.
- **Cockpit settings gets the picker**, and loads the language list even when the catalog is refused - the hosted case, which is the broken one.
- Both surfaces speak the Play-sample sentence in the chosen language.

## Verified against a running Gateway, not just compiled

| Check | Result |
|---|---|
| `GET spoken-languages` | five, ordered en, fr, de, es, da |
| `PUT da` | `switched: true`, model -> multilingual, stale voice cleared |
| `PUT en` | `switched: false` - the engine already speaks it |
| Play sample, Danish | **200, 34,440 bytes of audio/mpeg** |

Tests: 17 Core, 38 translator, all green; workspace typecheck clean.

## Separate finding, not from this change

Play sample on the **default English engine** took **49.6 s** on production and exceeded the 60 s deadline on a local rig. That is upstream latency on the default voice path, unrelated to this feature, but it means the English sample button is currently marginal. Worth its own issue.