### PR TITLE
Returning to a language your old engine speaks restores that engine

### DIFF
--- a/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
@@ -22,6 +22,102 @@ public sealed class TenantSettingsResolverTests
     private static TenantSettingsResolver NewResolver(GatewayDbTestHarness h)
         => new(new TenantSettingsStore(h.Open()));
 
+    // ---- the spoken language, and the model it moves ------------------------------------------
+
+    [Fact]
+    public void SpokenLanguage_Unset_IsEnglish()
+    {
+        using var h = new GatewayDbTestHarness();
+        Assert.Equal("en", NewResolver(h).SpokenLanguage(TenantA));
+    }
+
+    [Fact]
+    public void SpokenLanguage_English_ClearsRatherThanStoring()
+    {
+        // "back to default" and "never chose" must be the same state on disk, so nothing has to
+        // interpret a stored "en" differently from an absent value.
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpokenLanguage(TenantA, "da", Now);
+        r.SetSpokenLanguage(TenantA, "en", Now);
+        Assert.Equal("en", r.SpokenLanguage(TenantA));
+    }
+
+    [Fact]
+    public void SpokenLanguage_RejectsALanguageWeDoNotOffer()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        Assert.Throws<ArgumentException>(() => r.SetSpokenLanguage(TenantA, "kl", Now));
+    }
+
+    [Fact]
+    public void SpokenLanguage_IsPerTenant()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpokenLanguage(TenantA, "da", Now);
+        Assert.Equal("da", r.SpokenLanguage(TenantA));
+        Assert.Equal("en", r.SpokenLanguage(TenantB));
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_RoundTripsModelAndVoice()
+    {
+        // This memo is what lets a trip to Danish and back put the account on the engine it started
+        // on, instead of stranding it on a costlier multilingual one it no longer needs.
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "hexgrad/Kokoro-82M", "af_bella", Now);
+        var memo = r.SpeechBeforeLanguageSwitch(TenantA);
+
+        Assert.NotNull(memo);
+        Assert.Equal("hexgrad/Kokoro-82M", memo!.Value.Model);
+        Assert.Equal("af_bella", memo.Value.Voice);
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_RemembersAModelThatHadNoVoice()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "some/expressive-model", null, Now);
+        var memo = r.SpeechBeforeLanguageSwitch(TenantA);
+
+        Assert.NotNull(memo);
+        Assert.Null(memo!.Value.Voice);
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_Unset_IsNull()
+    {
+        using var h = new GatewayDbTestHarness();
+        Assert.Null(NewResolver(h).SpeechBeforeLanguageSwitch(TenantA));
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_Cleared_IsNull()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "hexgrad/Kokoro-82M", "af_bella", Now);
+        r.ClearSpeechBeforeLanguageSwitch(TenantA);
+        Assert.Null(r.SpeechBeforeLanguageSwitch(TenantA));
+    }
+
+    [Fact]
+    public void ClearTtsVoice_RemovesTheOverrideRatherThanStoringABlank()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetTtsVoice(TenantA, "af_bella", Now);
+        r.ClearTtsVoice(TenantA);
+        // Falls back to the operator default, which is the honest "no tenant choice" answer.
+        Assert.Equal(TtsVoiceConfig.Resolve(Mode), r.TtsVoice(TenantA, Mode));
+    }
+
     [Fact]
     public void CarModeModel_OverrideSet_ReturnsOverride()
     {

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -258,6 +258,8 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 resolver.SetTtsModel(t.Value, body.Model, DateTime.UtcNow);
+                // A deliberate choice supersedes the model we were holding to restore later.
+                resolver.ClearSpeechBeforeLanguageSwitch(t.Value);
                 var model = body.Model.Trim();
                 FileLog.Write($"[AiModelsEndpoint] tts model set: {model} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { model });
@@ -357,6 +359,29 @@ internal static class AiModelsEndpoint
         }
 
         var current = models.FirstOrDefault(m => string.Equals(m.Id, currentModel, StringComparison.OrdinalIgnoreCase));
+
+        // FIRST: can we put the account BACK where it was? If a previous language change moved it off
+        // a model, and that model can speak the language now being chosen, restore it. Without this a
+        // trip to Danish and back to English strands the account on the multilingual engine forever -
+        // which still works, but costs 61% more per character than the default for a language that
+        // never needed it. Restores the REMEMBERED model, not "the default", so a deliberate choice
+        // the tenant made themselves is not quietly replaced by ours.
+        var memo = resolver.SpeechBeforeLanguageSwitch(tenant);
+        if (memo is not null && !string.Equals(memo.Value.Model, currentModel, StringComparison.OrdinalIgnoreCase))
+        {
+            var remembered = models.FirstOrDefault(m => string.Equals(m.Id, memo.Value.Model, StringComparison.OrdinalIgnoreCase));
+            if (remembered is not null && SpokenLanguage.ModelCanSpeak(remembered.Languages, language))
+            {
+                resolver.SetTtsModel(tenant, remembered.Id, DateTime.UtcNow);
+                if (!string.IsNullOrWhiteSpace(memo.Value.Voice))
+                    resolver.SetTtsVoice(tenant, memo.Value.Voice!, DateTime.UtcNow);
+                else
+                    resolver.ClearTtsVoice(tenant);
+                resolver.ClearSpeechBeforeLanguageSwitch(tenant);
+                return new SpeechSwitch(remembered.Id, memo.Value.Voice, true, null);
+            }
+        }
+
         if (current is not null && SpokenLanguage.ModelCanSpeak(current.Languages, language))
         {
             // Nothing to switch. Report the voice as none when this model has no preset voices, rather
@@ -370,6 +395,12 @@ internal static class AiModelsEndpoint
         if (replacement is null)
             return new SpeechSwitch(currentModel, currentVoice, false,
                 $"no speech model available can speak {SpokenLanguage.EnglishName(language)}");
+
+        // Remember where we came from BEFORE moving, so the return trip can undo exactly this.
+        // Only the first auto-switch is recorded: hopping Danish -> French must still remember the
+        // English engine we originally left, not the multilingual one we are already on.
+        if (memo is null)
+            resolver.SetSpeechBeforeLanguageSwitch(tenant, currentModel, currentVoice, DateTime.UtcNow);
 
         resolver.SetTtsModel(tenant, replacement.Id, DateTime.UtcNow);
 

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -31,6 +31,12 @@ public static class TenantSettingKeys
     /// reads this. BCP-47 primary subtag; unset means English.</summary>
     public const string SpokenLanguage = "spoken_language";
 
+    /// <summary>What the speech model and voice were BEFORE a spoken-language change auto-switched
+    /// them, as JSON. Held so that returning to a language the old engine can speak puts the account
+    /// back where it was, instead of stranding it on a costlier engine it no longer needs. Absent
+    /// whenever nothing has been auto-switched.</summary>
+    public const string SpeechBeforeLanguageSwitch = "speech_before_language_switch";
+
     /// <summary>The conversational model Car Mode drives (global default: <c>car_mode_model</c>).</summary>
     public const string CarModeModel = "car_mode_model";
 
@@ -68,7 +74,7 @@ public static class TenantSettingKeys
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
-        WingmanModel, WingmanFastModel, TtsModel, TtsVoice, SpokenLanguage,
+        WingmanModel, WingmanFastModel, TtsModel, TtsVoice, SpokenLanguage, SpeechBeforeLanguageSwitch,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
         VoiceModeAll,
     };

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -157,6 +157,36 @@ public sealed class TenantSettingsResolver
     public void SetTtsVoice(TenantId tenant, string voice, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.TtsVoice, RequireNonEmpty(voice, nameof(voice)), nowUtc);
 
+    /// <summary>What the speech model/voice were before an auto-switch, or null when nothing is
+    /// remembered. A corrupt value reads as null - a bad memo must never break a language change.</summary>
+    public (string Model, string? Voice)? SpeechBeforeLanguageSwitch(TenantId tenant)
+    {
+        var raw = _store.Get(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch);
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(raw);
+            var model = doc.RootElement.TryGetProperty("model", out var m) ? m.GetString() : null;
+            if (string.IsNullOrWhiteSpace(model)) return null;
+            var voice = doc.RootElement.TryGetProperty("voice", out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
+                ? v.GetString() : null;
+            return (model!, voice);
+        }
+        catch (System.Text.Json.JsonException) { return null; }
+    }
+
+    /// <summary>Remember the speech model/voice we are about to auto-switch away from.</summary>
+    public void SetSpeechBeforeLanguageSwitch(TenantId tenant, string model, string? voice, DateTime nowUtc)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new { model, voice });
+        _store.Set(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch, json, nowUtc);
+    }
+
+    /// <summary>Forget the remembered speech model - after restoring it, or once the tenant picks a
+    /// model themselves, because a deliberate choice supersedes anything we were holding for them.</summary>
+    public void ClearSpeechBeforeLanguageSwitch(TenantId tenant)
+        => _store.Remove(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch);
+
     /// <summary>Remove the tenant's voice override entirely - the honest state when the speech model in
     /// use has no preset voices to choose from. Distinct from setting an empty string, which the setter
     /// rejects.</summary>


### PR DESCRIPTION
Choosing Danish moves the account to the multilingual engine, which is right. Choosing English again left it there, which is not.

Nothing was broken by that - the multilingual engine speaks English perfectly well. It just costs **61% more per character** for a language that never needed it, and nothing ever moved the account back. A round trip silently upgraded the bill.

| Engine | Rate card | Per million characters |
|---|---|---|
| Default | 1.24 u$/char | $1.24 |
| Multilingual | 2.00 u$/char | $2.00 |

At a ~500-character narration that is +$0.23/month for light use, +$1.14 steady, +$5.70 for a heavy voice user. Small money, but nobody should pay it by accident.

## What changed

The Gateway remembers what it switched away from, and restores it the moment the remembered engine can speak the language being chosen.

Three details that make it behave rather than merely work:

- **Restores the remembered model, not "the default."** A tenant who deliberately picked an engine gets that engine back, not ours.
- **Only the first auto-switch is recorded**, so hopping Danish to French to English still returns to the English engine originally left, not the multilingual one it was already sitting on.
- **Picking a model by hand clears the memo** - a deliberate choice supersedes anything we were holding.

## Verified on a running Gateway, the whole cycle

| Step | Result |
|---|---|
| Start on the default engine, English | `switched: false` |
| Choose Danish | -> multilingual, stale voice cleared |
| Back to English | **-> default engine restored, with its voice** |
| Danish, then French | stays multilingual (the default engine cannot speak French) |
| Then English | **-> default engine restored** |

Nine new resolver tests cover the stored state, including a corrupt memo reading as "nothing remembered" so a bad value can never break a language change.