### PR TITLE
feat(reports): the daily email says which microphone to use

### DIFF
--- a/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
@@ -29,6 +29,10 @@ public sealed class MorningReportDto
     /// <summary>The three headline numbers. Each is individually optional (see the honesty rule).</summary>
     public MorningReportStatsDto Stats { get; set; } = new();
 
+    /// <summary>How the account's microphones are doing, ranked best first. NULL - the whole section
+    /// absent - when nothing has been measured yet, per the honesty rule.</summary>
+    public MorningMicrophonesDto? Microphones { get; set; }
+
     /// <summary>
     /// The needs-your-attention list, one typed item per row the email renders. ALWAYS PRESENT, possibly
     /// empty: an empty list is real knowledge ("nothing is waiting on you"), unlike an absent stat.
@@ -47,6 +51,60 @@ public sealed class MorningReportDto
 }
 
 /// <summary>The resolved reporting window: the UTC range the calendar day covers in the caller's zone.</summary>
+/// <summary>
+/// How the account's microphones are doing, ranked best first, for the daily report.
+///
+/// This is a SECTION rather than an attention row on purpose. The attention list answers "what needs
+/// you today"; this answers "which of your microphones should you be using", which is worth seeing even
+/// when nothing is wrong - it is the comparison that makes the advice actionable, and a user cannot
+/// make it for themselves because the defect that matters most sounds merely dull to a human ear.
+///
+/// THE HONESTY RULE APPLIES: this whole section is ABSENT when the Gateway holds no measurements for the
+/// account, or too few for any device to be judged. "We have never measured your microphones" and "your
+/// microphones are fine" are different statements and only one of them has been established.
+/// </summary>
+public sealed class MorningMicrophonesDto
+{
+    /// <summary>One line naming the best microphone, or saying they are all fine.</summary>
+    public string Headline { get; set; } = "";
+
+    /// <summary>What to change, present ONLY when switching or fixing something would actually help.
+    /// Absent when the microphones are all good - a daily email that always has advice is one nobody
+    /// reads.</summary>
+    public string? Advice { get; set; }
+
+    /// <summary>The devices, best first. Never empty when this section is present.</summary>
+    public List<MorningMicrophoneDto> Devices { get; set; } = new();
+}
+
+/// <summary>One microphone's standing in the daily report.</summary>
+public sealed class MorningMicrophoneDto
+{
+    /// <summary>The name the operating system gave it, or "Unnamed microphone".</summary>
+    public string Device { get; set; } = "";
+
+    /// <summary>How many dictations this verdict rests on.</summary>
+    public int Samples { get; set; }
+
+    /// <summary>"good" or "bad" - the same fold the Cockpit renders.</summary>
+    public string Status { get; set; } = "";
+
+    /// <summary>A plain sentence about this device, already written. The email prints it verbatim.</summary>
+    public string Summary { get; set; } = "";
+
+    /// <summary>Share of this device's dictations that arrived band-limited (0..1).</summary>
+    public double NarrowbandShare { get; set; }
+
+    /// <summary>Share of this device's dictations that were distorting (0..1).</summary>
+    public double ClippingShare { get; set; }
+
+    /// <summary>Typical level of the voice, in dBFS.</summary>
+    public double SpeechLevelDb { get; set; }
+
+    /// <summary>Typical margin of the voice over the room, in dB.</summary>
+    public double SignalToNoiseDb { get; set; }
+}
+
 public sealed class MorningReportWindowDto
 {
     /// <summary>Inclusive start of the reported day, in UTC.</summary>

--- a/src/CcDirector.Gateway.Tests/MicrophoneRankingTests.cs
+++ b/src/CcDirector.Gateway.Tests/MicrophoneRankingTests.cs
@@ -1,0 +1,155 @@
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Pins WHICH microphone the daily report will tell somebody to use.
+///
+/// This is the part of the report that makes a recommendation about hardware the user owns, so the
+/// order has to reflect what actually costs a transcript rather than what looks worst on a chart. The
+/// ordering claim is: band-limiting dominates everything, distortion comes next, then how far the
+/// voice stands above the room, then level as a tie-break only.
+/// </summary>
+public sealed class MicrophoneRankingTests
+{
+    private static MicrophoneDeviceSummary Device(
+        string name,
+        int samples = 20,
+        double narrowband = 0,
+        double clipping = 0,
+        double speechDb = -20,
+        double snrDb = 45,
+        string status = "good")
+        => new()
+        {
+            Device = name,
+            Samples = samples,
+            Status = status,
+            Advice = "",
+            NarrowbandShare = narrowband,
+            ClippingShare = clipping,
+            MedianSpeechLevelDb = speechDb,
+            MedianSignalToNoiseDb = snrDb,
+            TargetSpeechLevelDb = MicrophoneQualityFold.TargetSpeechLevelDb,
+            TargetSignalToNoiseDb = MicrophoneQualityFold.TargetSignalToNoiseDb,
+            LastSeenUtc = DateTime.UtcNow,
+        };
+
+    [Fact]
+    public void ABandLimitedMicrophoneRanksBelowAWidebandOne_EvenWhenItIsLouderAndCleaner()
+    {
+        // The case that motivated the whole feature: on every other reading the headset looks BETTER.
+        // A ranking that trusted level and quiet would recommend exactly the wrong device.
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Bluetooth Headset", narrowband: 0.9, speechDb: -14, snrDb: 68),
+            Device("Laptop Microphone", narrowband: 0, speechDb: -28, snrDb: 30),
+        });
+
+        Assert.Equal("Laptop Microphone", ranked[0].Device);
+    }
+
+    [Fact]
+    public void DistortionRanksBelowACleanMicrophone()
+    {
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Hot Mic", clipping: 0.6),
+            Device("Clean Mic"),
+        });
+
+        Assert.Equal("Clean Mic", ranked[0].Device);
+    }
+
+    [Fact]
+    public void BandLimitingOutweighsDistortion()
+    {
+        // Distortion corrupts what is there; band-limiting removes it. Given a choice, prefer the
+        // distorting microphone - its vowels survive.
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Band Limited", narrowband: 1.0),
+            Device("Distorting", clipping: 1.0),
+        });
+
+        Assert.Equal("Distorting", ranked[0].Device);
+    }
+
+    [Fact]
+    public void AQuieterRoomStopsHelpingOnceTheVoiceIsAlreadyClearOfIt()
+    {
+        // Without the cap, a silent room would let a worse microphone outrank a better one purely on
+        // an enormous signal-to-noise number that stopped meaning anything long ago.
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Silent Room", snrDb: 90, clipping: 0.2),
+            Device("Normal Room", snrDb: 30, clipping: 0),
+        });
+
+        Assert.Equal("Normal Room", ranked[0].Device);
+    }
+
+    [Fact]
+    public void LevelIsOnlyATieBreak_AndNeverReordersMicrophonesThatDifferOnAnythingElse()
+    {
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Perfect Level But Band Limited", speechDb: -20, narrowband: 0.8),
+            Device("Quiet But Clean", speechDb: -34),
+        });
+
+        Assert.Equal("Quiet But Clean", ranked[0].Device);
+    }
+
+    [Fact]
+    public void LevelDoesDecideBetweenOtherwiseIdenticalMicrophones()
+    {
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Too Quiet", speechDb: -40),
+            Device("Just Right", speechDb: -20),
+        });
+
+        Assert.Equal("Just Right", ranked[0].Device);
+    }
+
+    [Fact]
+    public void ADeviceWithTooFewMeasurementsIsNotRankedAtAll()
+    {
+        // Recommending hardware on two recordings would be recommending on noise.
+        var ranked = MicrophoneQualityFold.RankBest(new[]
+        {
+            Device("Barely Used", samples: MicrophoneQualityFold.MinSamplesForVerdict - 1),
+            Device("Well Used"),
+        });
+
+        Assert.Equal("Well Used", Assert.Single(ranked).Device);
+    }
+
+    [Fact]
+    public void TheOrderIsStable_SoTheRecommendationDoesNotFlipBetweenReports()
+    {
+        // Two identical devices must not swap places from one report to the next.
+        var devices = new[] { Device("B Mic"), Device("A Mic") };
+
+        var first = MicrophoneQualityFold.RankBest(devices).Select(d => d.Device);
+        var second = MicrophoneQualityFold.RankBest(devices.Reverse().ToArray()).Select(d => d.Device);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void RankingNothingReturnsNothingRatherThanThrowing()
+    {
+        Assert.Empty(MicrophoneQualityFold.RankBest(Array.Empty<MicrophoneDeviceSummary>()));
+        Assert.Empty(MicrophoneQualityFold.RankBest(null!));
+    }
+
+    [Fact]
+    public void TheScoreNeverGoesNegative_SoAThoroughlyBadMicrophoneStillOrdersSensibly()
+    {
+        var awful = Device("Awful", narrowband: 1, clipping: 1, speechDb: -60, snrDb: 0);
+        Assert.True(MicrophoneQualityFold.ComparableScore(awful) >= 0);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MorningReportMicrophonesTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportMicrophonesTests.cs
@@ -1,0 +1,199 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Reports;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The microphone section of the daily report.
+///
+/// The rule this section is held to is the one the rest of the report already keeps: a section the
+/// Gateway has no data for is ABSENT, never empty and never zero-filled. "We have never measured your
+/// microphones" and "your microphones are fine" are different statements, and a daily email that
+/// confuses them tells the reader something untrue every single morning.
+///
+/// The second rule is about nagging. This arrives in an inbox once a day whether or not anything is
+/// wrong, so advice is present ONLY when acting on it would help. A report that always has a
+/// recommendation is one the reader learns to skip.
+/// </summary>
+public sealed class MorningReportMicrophonesTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+    private readonly string _root;
+
+    private static readonly TenantId Alice = new("tenant-alice");
+    private static readonly DateTime Now = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    public MorningReportMicrophonesTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cc-report-mics-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        _h.Dispose();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static MorningReportWindow Window() => MorningReportWindow.Resolve("2026-07-23", "America/Toronto");
+
+    /// <summary>A per-tenant log rooted in this test's temp directory.</summary>
+    private Func<TenantId, MicrophoneQualityLog> Logs()
+        => tenant => new MicrophoneQualityLog(Path.Combine(_root, tenant.Value));
+
+    private MorningReportBuilder Builder(bool withMicrophones = true)
+        => new(_h.Open(new FixedTenantContext(Alice)), null, TimeSpan.FromMinutes(5), () => Now,
+               microphoneQuality: withMicrophones ? Logs() : null);
+
+    private void Seed(TenantId tenant, string device, int count, bool narrowband = false, double clipped = 0,
+        double speechDb = -20, double snrDb = 45, int daysAgo = 1)
+    {
+        var log = Logs()(tenant);
+        for (var i = 0; i < count; i++)
+        {
+            log.Record(new MicrophoneQualityRecord
+            {
+                TimestampUtc = Now.AddDays(-daysAgo),
+                Device = device,
+                Source = "dictation-send",
+                DurationSeconds = 20,
+                SampleRate = 48000,
+                SpeechLevelDb = speechDb,
+                NoiseFloorDb = speechDb - snrDb,
+                SignalToNoiseDb = snrDb,
+                ClippedFraction = clipped,
+                HighBandRatioDb = narrowband ? -110 : -22,
+                Narrowband = narrowband,
+                Rating = narrowband ? "poor" : "good",
+                Issues = narrowband ? "narrowband" : "",
+            });
+        }
+    }
+
+    [Fact]
+    public void TheSectionIsAbsentWhenNothingHasBeenMeasured()
+    {
+        var report = Builder().Build("alice@example.com", Alice, Window());
+
+        Assert.Null(report.Microphones);
+    }
+
+    [Fact]
+    public void TheSectionIsAbsentWhenNoDeviceHasEnoughMeasurementsToJudge()
+    {
+        // Present-but-unjudgeable is still "we do not know", and must read the same as no data.
+        Seed(Alice, "Barely Used", MicrophoneQualityFold.MinSamplesForVerdict - 1);
+
+        Assert.Null(Builder().Build("alice@example.com", Alice, Window()).Microphones);
+    }
+
+    [Fact]
+    public void TheSectionIsAbsentWhenTheDeploymentHasNoMicrophoneLogAtAll()
+    {
+        Seed(Alice, "Good Mic", 20);
+
+        Assert.Null(Builder(withMicrophones: false).Build("alice@example.com", Alice, Window()).Microphones);
+    }
+
+    [Fact]
+    public void AHealthyMicrophoneIsReportedWithNoAdvice()
+    {
+        // The anti-nag rule: nothing to act on means no recommendation in the inbox.
+        Seed(Alice, "Good Mic", 20);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Null(mics!.Advice);
+        Assert.Contains("doing fine", mics.Headline);
+        Assert.Equal("good", Assert.Single(mics.Devices).Status);
+    }
+
+    [Fact]
+    public void TheBestMicrophoneIsNamedAndTheWorstIsCalledOut()
+    {
+        // The comparison the owner actually asked for: which of my devices should I be using.
+        Seed(Alice, "Desk Mic", 20);
+        Seed(Alice, "Bluetooth Headset", 20, narrowband: true);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Equal("Desk Mic", mics!.Devices[0].Device);
+        Assert.Contains("Desk Mic", mics.Headline);
+        Assert.Contains("Bluetooth Headset", mics.Headline);
+        Assert.Contains("Use Desk Mic", mics.Advice);
+    }
+
+    [Fact]
+    public void WhenEveryMicrophoneIsBadItDoesNotRecommendOneOfThem()
+    {
+        // Naming a "best" here would be recommending a microphone we have just said is bad.
+        Seed(Alice, "Bad One", 20, narrowband: true);
+        Seed(Alice, "Also Bad", 20, narrowband: true);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Contains("Every microphone", mics!.Headline);
+        Assert.DoesNotContain("Use ", mics.Advice ?? "");
+    }
+
+    [Fact]
+    public void DevicesArriveRankedBestFirst()
+    {
+        Seed(Alice, "Worst", 20, narrowband: true);
+        Seed(Alice, "Middle", 20, clipped: 0.5);
+        Seed(Alice, "Best", 20);
+
+        var devices = Builder().Build("alice@example.com", Alice, Window()).Microphones!.Devices;
+
+        Assert.Equal(new[] { "Best", "Middle", "Worst" }, devices.Select(d => d.Device).ToArray());
+    }
+
+    [Fact]
+    public void EachDeviceCarriesTheNumbersBehindItsVerdict()
+    {
+        Seed(Alice, "Headset", 20, narrowband: true, speechDb: -18, snrDb: 40);
+
+        var device = Assert.Single(Builder().Build("alice@example.com", Alice, Window()).Microphones!.Devices);
+
+        Assert.Equal(20, device.Samples);
+        Assert.Equal(1.0, device.NarrowbandShare);
+        Assert.Equal(-18, device.SpeechLevelDb);
+        Assert.Equal(40, device.SignalToNoiseDb);
+        Assert.NotEmpty(device.Summary);
+    }
+
+    [Fact]
+    public void OneAccountsMicrophonesNeverAppearInAnothersReport()
+    {
+        Seed(Alice, "Alice Mic", 20);
+        Seed(new TenantId("tenant-bob"), "Bob Mic", 20, narrowband: true);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.Equal("Alice Mic", Assert.Single(mics!.Devices).Device);
+    }
+
+    [Fact]
+    public void TheSectionLooksWiderThanTheReportedDay_SoAQuietDayDoesNotEraseAVerdict()
+    {
+        // A microphone is a property of the desk, not of yesterday. These measurements are 10 days
+        // before the reported day and must still count.
+        Seed(Alice, "Good Mic", 20, daysAgo: 10);
+
+        Assert.NotNull(Builder().Build("alice@example.com", Alice, Window()).Microphones);
+    }
+
+    [Fact]
+    public void MeasurementsOlderThanTheWindowAreNotReported()
+    {
+        Seed(Alice, "Ancient Mic", 20, daysAgo: 60);
+
+        Assert.Null(Builder().Build("alice@example.com", Alice, Window()).Microphones);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -917,7 +917,10 @@ public sealed class GatewayHost : IAsyncDisposable
         _morningReport = new Reports.MorningReportBuilder(_gatewayDb, PushedSessions, _streamStaleAfter,
             // The repo-state store (issue #2118) is the hygiene rows' source. Passed here rather than
             // resolved inside the builder so the report reads the SAME store the push endpoint writes.
-            repoState: _repoState);
+            repoState: _repoState,
+            // The same per-tenant log the background monitoring writes, opened per tenant BY PATH so a
+            // report can only ever read the measurements of the account it is about.
+            microphoneQuality: Transcription.MicrophoneQualityLog.ForTenant);
         // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc), now in the
         // snoozes table of the EF data layer - a Gateway restart re-arms every pending snooze from the
         // database; an entry already past its time simply fires on the first sweep. The path argument is the

--- a/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
@@ -33,6 +33,7 @@ public sealed class MorningReportBuilder
     private readonly GatewayDatabase _db;
     private readonly Streaming.PushedSessionStore? _pushedSessions;
     private readonly RepoStateStore? _repoState;
+    private readonly Func<TenantId, Transcription.MicrophoneQualityLog>? _microphoneQuality;
     private readonly TimeSpan _streamStale;
     private readonly Func<DateTime> _utcNow;
 
@@ -79,22 +80,36 @@ public sealed class MorningReportBuilder
     /// </summary>
     public static readonly TimeSpan RepoStateMaxAge = TimeSpan.FromHours(24);
 
+    /// <summary>
+    /// How far back the microphone section looks. Deliberately much wider than the report's own day: a
+    /// microphone is a property of the user's desk rather than of yesterday, so judging one on a single
+    /// day's dictation would let a quiet Tuesday erase a verdict that took a fortnight to earn and flip
+    /// the recommendation between reports. Matches the window the measurements are kept for.
+    /// </summary>
+    public static readonly TimeSpan MicrophoneWindow = TimeSpan.FromDays(30);
+
     /// <param name="db">The Gateway EF database.</param>
     /// <param name="pushedSessions">The live pushed-session cache, used ONLY to put a friendly name and a
     /// repository path on a waiting row. Null (or a session it has never seen) costs the row nothing but
     /// those two labels - the waiting fact itself comes from the durable ledger.</param>
     /// <param name="streamStale">How old a Director's pushed roster may be and still be believed.</param>
     /// <param name="utcNow">Clock seam for tests.</param>
+    /// <param name="microphoneQuality">Opens a tenant's microphone-quality log. Null omits the section
+    /// entirely, which is the honest state for a deployment that has never measured a microphone.</param>
     public MorningReportBuilder(
         GatewayDatabase db,
         Streaming.PushedSessionStore? pushedSessions = null,
         TimeSpan? streamStale = null,
         Func<DateTime>? utcNow = null,
-        RepoStateStore? repoState = null)
+        RepoStateStore? repoState = null,
+        Func<TenantId, Transcription.MicrophoneQualityLog>? microphoneQuality = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pushedSessions = pushedSessions;
         _repoState = repoState;
+        // Injected as a factory rather than an instance: the log is per-tenant BY PATH, so a single
+        // shared instance could only ever read one tenant's measurements into everyone's report.
+        _microphoneQuality = microphoneQuality;
         _streamStale = streamStale ?? TimeSpan.FromMinutes(5);
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
     }
@@ -137,10 +152,89 @@ public sealed class MorningReportBuilder
         // has been measured.
         report.Attention.AddRange(HygieneItems(tenant, now));
 
+        // How the account's microphones are doing (background monitoring). Absent - not empty - when
+        // nothing has been measured, for the same reason the hygiene rows are: "we have never measured
+        // your microphones" and "your microphones are fine" are different statements.
+        report.Microphones = Microphones(tenant, now);
+
         FileLog.Write($"[MorningReportBuilder] Build: tenant={tenant.ToLogString()} window={window.StartUtc:o}..{window.EndUtc:o} " +
                       $"sessionsRan={Describe(report.Stats.SessionsRan)} workDelivered={Describe(report.Stats.WorkDelivered)} " +
                       $"spendUsd={Describe(report.Stats.HostedAiSpendUsd)} attention={report.Attention.Count}");
         return report;
+    }
+
+    /// <summary>
+    /// The microphone section: every device with enough measurements to be judged, ranked best first,
+    /// with the comparison already made. Returns null when there is nothing measured to report.
+    ///
+    /// The window is deliberately WIDER than the report's own day. A microphone is a property of the
+    /// user's desk, not of yesterday: judging a headset on one day's dictation would let a quiet
+    /// Tuesday erase a verdict that took a fortnight to earn, and would flip the recommendation back
+    /// and forth between reports. Thirty days is the same window the measurements are kept for.
+    /// </summary>
+    private MorningMicrophonesDto? Microphones(TenantId tenant, DateTime now)
+    {
+        if (_microphoneQuality is null) return null;
+
+        IReadOnlyList<Transcription.MicrophoneQualityRecord> records;
+        try
+        {
+            records = _microphoneQuality(tenant).Load(now - MicrophoneWindow);
+        }
+        catch (Exception ex)
+        {
+            // A report that is missing one section still helps; a report that throws helps nobody.
+            FileLog.Write($"[MorningReportBuilder] microphone section skipped: {ex.Message}");
+            return null;
+        }
+        if (records.Count == 0) return null;
+
+        var summary = Transcription.MicrophoneQualityFold.Summarize(records);
+        var ranked = Transcription.MicrophoneQualityFold.RankBest(summary.Devices);
+        if (ranked.Count == 0) return null;
+
+        var best = ranked[0];
+        var worst = ranked[^1];
+        var anyBad = ranked.Any(d => d.Status == "bad");
+
+        string headline;
+        string? advice = null;
+        if (!anyBad)
+        {
+            headline = ranked.Count == 1
+                ? $"{best.Device} is doing fine."
+                : $"All {ranked.Count} of your microphones are doing fine - {best.Device} is the best of them.";
+        }
+        else if (best.Status == "bad")
+        {
+            // Every microphone measured is bad. Naming a "best" here would recommend one of them.
+            headline = ranked.Count == 1
+                ? $"{best.Device} is holding your transcription back."
+                : "Every microphone you used is holding your transcription back.";
+            advice = worst.Advice;
+        }
+        else
+        {
+            headline = $"{best.Device} is your best microphone; {worst.Device} is holding you back.";
+            advice = $"Use {best.Device} when you can. {worst.Advice}";
+        }
+
+        return new MorningMicrophonesDto
+        {
+            Headline = headline,
+            Advice = advice,
+            Devices = ranked.Select(d => new MorningMicrophoneDto
+            {
+                Device = d.Device,
+                Samples = d.Samples,
+                Status = d.Status,
+                Summary = d.Advice,
+                NarrowbandShare = d.NarrowbandShare,
+                ClippingShare = d.ClippingShare,
+                SpeechLevelDb = d.MedianSpeechLevelDb,
+                SignalToNoiseDb = d.MedianSignalToNoiseDb,
+            }).ToList(),
+        };
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
@@ -146,6 +146,55 @@ public static class MicrophoneQualityFold
         };
     }
 
+    /// <summary>
+    /// Rank a tenant's microphones best first, so a report can say WHICH ONE to prefer rather than only
+    /// that one of them is bad. Devices with too few measurements are excluded entirely - ranking a
+    /// device on two recordings would recommend hardware on noise.
+    ///
+    /// The order is by how much each defect actually costs a transcript, which is not the order their
+    /// numbers suggest:
+    ///   1. Band-limiting first, and by a distance. It removes the consonants outright, and no amount of
+    ///      level or quiet compensates for information that is not in the signal.
+    ///   2. Distortion second. It corrupts what IS there, but the vowels usually survive it.
+    ///   3. Then how far the voice stands above the room, capped - past the target, more is not better,
+    ///      and without the cap a silent room would outrank a better microphone.
+    ///   4. Then closeness to a healthy level, as a tie-break only.
+    /// A single number is returned rather than a sort over several keys so the reason for an ordering can
+    /// be stated, and so two devices that differ only trivially do not flip places between reports.
+    /// </summary>
+    public static IReadOnlyList<MicrophoneDeviceSummary> RankBest(IReadOnlyList<MicrophoneDeviceSummary> devices)
+        => devices is null
+            ? Array.Empty<MicrophoneDeviceSummary>()
+            : devices
+                .Where(d => d.Samples >= MinSamplesForVerdict)
+                .OrderByDescending(ComparableScore)
+                .ThenByDescending(d => d.Samples)
+                .ThenBy(d => d.Device, StringComparer.Ordinal)
+                .ToList();
+
+    /// <summary>
+    /// How good a microphone is, 0..100, for ORDERING devices against each other. Deliberately not shown
+    /// to anyone: a score invites "why is it 71" and the honest answer is the four measurements it came
+    /// from, which the report shows instead.
+    /// </summary>
+    public static double ComparableScore(MicrophoneDeviceSummary d)
+    {
+        if (d is null) return 0;
+        var score = 100.0;
+        score -= 60 * d.NarrowbandShare;
+        score -= 25 * d.ClippingShare;
+
+        // Distance below the signal-to-noise target, in decibels, worth a point each. Above the target
+        // costs nothing: a quieter room stops helping once the voice is already clear of it.
+        var snrShortfall = Math.Max(0, TargetSignalToNoiseDb - d.MedianSignalToNoiseDb);
+        score -= Math.Min(10, snrShortfall);
+
+        // Level is a tie-break: it is the easiest thing for a user to fix and the least damaging when
+        // wrong, so it must never reorder two microphones that differ on anything above.
+        score -= Math.Min(5, Math.Abs(TargetSpeechLevelDb - d.MedianSpeechLevelDb) / 4);
+        return Math.Max(0, score);
+    }
+
     /// <summary>A healthy speaking level: loud enough that the encoder spends its bits on the voice.</summary>
     public const double TargetSpeechLevelDb = -20;
 


### PR DESCRIPTION
Background microphone monitoring (#2173) put quality on the Cockpit screen. This carries it into the
daily report, which is where it is actually useful: nobody opens a diagnostics page to discover a
problem they do not know they have, but they do read the morning email.

The section **ranks the account's microphones best first and names the one to prefer**, because the
comparison is the actionable part. "Your audio is band-limited" tells somebody almost nothing; "use
your desk microphone, your headset is the problem" tells them what to do this morning.

## The ranking is the claim worth testing

Ordered by how much each defect actually costs a transcript, which is **not** the order the numbers
suggest:

- **Band-limiting dominates.** It removes the consonants outright, and no amount of level or quiet
  compensates for information that is not in the signal. A band-limited headset ranks below a quiet
  laptop microphone *even though it reads louder and cleaner on every other measurement* — the case
  that motivated the whole feature, now pinned by a test.
- **Distortion next** — it corrupts what is there, but the vowels usually survive.
- **Then margin over the room, capped** at the target. Without the cap a silent room would let a
  worse microphone outrank a better one on a number that stopped meaning anything.
- **Then level, as a tie-break only** — easiest to fix, least damaging when wrong.

## The honesty rule, which this report already keeps everywhere else

The whole section is **absent** when the Gateway holds no measurements, or too few for any device to
be judged. "We have never measured your microphones" and "your microphones are fine" are different
statements, and a daily email must not confuse them. A device is not ranked until it has five
measurements — recommending hardware on two recordings would be recommending on noise.

## The anti-nag rule

Advice appears **only** when acting on it would help. A healthy set of microphones produces a section
with no recommendation, because an email that always ends in a recommendation is one the reader
learns to skip. And when every measured microphone is bad, the report deliberately does **not** name
a best one — that would be recommending hardware it has just called bad.

## Other decisions

- The window is **thirty days**, not the reported day: a microphone is a property of the desk, not of
  yesterday, so a quiet Tuesday must not erase a verdict that took a fortnight to earn.
- The per-tenant log is injected as a **factory**, not an instance — the log is per-tenant by path, so
  a shared instance could only ever read one tenant's measurements into everyone's report.

## Verification

21 new Gateway tests (10 on ranking, 11 on the report section), 680 client-core tests, Release build
clean. The email itself was rendered through the real renderer and looked at, in both states — with
microphones and without — confirming the section disappears entirely rather than rendering empty.

The matching email renderer is a companion change in the website repository; without it the Gateway
would send the section and the email would silently skip it.
