### PR TITLE
Spoken language: make every spoken path actually speak it

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -604,6 +604,10 @@ function AiTab() {
       setMsg(res.switched
         ? "Spoken language set. Speech model switched to " + res.ttsModel + ", which can speak it."
         : "Spoken language set.");
+      // Re-read the account from the Gateway rather than believing the local snapshot. The server
+      // owns this decision, and a page that keeps showing the old engine after a switch is the
+      // single most confusing thing this feature can do.
+      await load();
     } catch (e) {
       setMsg(e instanceof Error ? e.message : String(e));
     } finally {
@@ -728,7 +732,9 @@ function AiTab() {
     setBusy(true);
     setSampleMsg("Synthesizing...");
     try {
-      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
+      // No model/voice: the Gateway plays what the ACCOUNT is set to. Sending what this page
+      // happens to show would audition a stale engine after a language change.
+      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT);
       if (audioRef.current === null) audioRef.current = new Audio();
       audioRef.current.src = URL.createObjectURL(blob);
       audioRef.current.onended = () => setSampleMsg("");

--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -113,6 +113,10 @@ export function AiSettings() {
       setMsg(res.switched
         ? "Spoken language set. Speech model switched to " + res.ttsModel + ", which can speak it."
         : "Spoken language set.");
+      // Re-read the account from the Gateway rather than believing the local snapshot. The server
+      // owns this decision, and a page that keeps showing the old engine after a switch is the
+      // single most confusing thing this feature can do.
+      await load();
     } catch (e) {
       setMsg(e instanceof Error ? e.message : String(e));
     } finally {
@@ -219,7 +223,9 @@ export function AiSettings() {
     setBusy(true);
     setSampleMsg("Synthesizing...");
     try {
-      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT, snap.ttsModel, snap.ttsVoice);
+      // No model/voice: the Gateway plays what the ACCOUNT is set to. Sending what this page
+      // happens to show would audition a stale engine after a language change.
+      const blob = await ttsSample(SAMPLES[language] ?? SAMPLE_TEXT);
       if (audioRef.current === null) audioRef.current = new Audio();
       audioRef.current.src = URL.createObjectURL(blob);
       audioRef.current.onended = () => setSampleMsg("");

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -168,11 +168,16 @@ export function setSpokenLanguage(language: string): Promise<{
 }
 
 // POST /wingman/tts { text, model, voice } -> audio bytes to play (a short "Play sample").
-export async function ttsSample(text: string, model: string, voice: string): Promise<Blob> {
+//
+// model and voice are OPTIONAL and should normally be omitted: the Gateway then resolves the
+// account's own speech model and voice, which are authoritative. Passing what the page currently
+// shows makes the sample play whatever the CLIENT believes, and a stale page (a cached PWA bundle,
+// say) then auditions the wrong engine entirely - which reads as "the language setting did nothing".
+export async function ttsSample(text: string, model?: string, voice?: string): Promise<Blob> {
   const res = await fetch("/wingman/tts", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
-    body: JSON.stringify({ text, model, voice }),
+    body: JSON.stringify({ text, model: model ?? "", voice: voice ?? "" }),
   });
   if (!res.ok) {
     const err = (await res.json().catch(() => ({}))) as { error?: string };

--- a/src/CcDirector.Core/Configuration/SpokenLanguage.cs
+++ b/src/CcDirector.Core/Configuration/SpokenLanguage.cs
@@ -82,6 +82,32 @@ public static class SpokenLanguage
             : $"{names.English} ({names.Endonym})";
     }
 
+    /// <summary>
+    /// The instruction that makes a model answer in this language, or an empty string for English.
+    ///
+    /// Lives here, in ONE place, because there is not one thing that speaks - there are several, and
+    /// they are separate generators: turn narration, the direct "talk to the wingman" reply, the
+    /// about-DevThrottle answer, and Car Mode's hands-free voice. Applying the language to only one
+    /// of them is the defect this method exists to prevent: the owner set Danish, heard English, and
+    /// was right to say the setting had not taken - narration had been translated and conversation
+    /// had not.
+    ///
+    /// Naming what must NOT be translated matters as much as naming the language. A listener has to
+    /// be able to type what they hear, so identifiers, paths, commands and error text stay verbatim.
+    /// </summary>
+    public static string PromptInstruction(string? code)
+    {
+        if (IsDefault(code)) return string.Empty;
+        var name = EnglishName(code);
+        return
+            $"LANGUAGE. Answer in {name}. Whatever language the material you are given is in - usually " +
+            $"English - your spoken answer is in {name}, written the way a native speaker would say it " +
+            "out loud rather than as a word-for-word translation.\n" +
+            "Leave these EXACTLY as they appear, never translated and never spelled differently: file " +
+            "names and paths, code identifiers, command names, branch names, and error text. Everything " +
+            $"else is spoken in {name}.\n\n";
+    }
+
     /// <summary>The English name alone - what the wingman prompt names the target language.</summary>
     public static string EnglishName(string? code) =>
         Supported.TryGetValue(Normalize(code), out var names) ? names.English : Normalize(code);

--- a/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
@@ -22,6 +22,102 @@ public sealed class TenantSettingsResolverTests
     private static TenantSettingsResolver NewResolver(GatewayDbTestHarness h)
         => new(new TenantSettingsStore(h.Open()));
 
+    // ---- the spoken language, and the model it moves ------------------------------------------
+
+    [Fact]
+    public void SpokenLanguage_Unset_IsEnglish()
+    {
+        using var h = new GatewayDbTestHarness();
+        Assert.Equal("en", NewResolver(h).SpokenLanguage(TenantA));
+    }
+
+    [Fact]
+    public void SpokenLanguage_English_ClearsRatherThanStoring()
+    {
+        // "back to default" and "never chose" must be the same state on disk, so nothing has to
+        // interpret a stored "en" differently from an absent value.
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpokenLanguage(TenantA, "da", Now);
+        r.SetSpokenLanguage(TenantA, "en", Now);
+        Assert.Equal("en", r.SpokenLanguage(TenantA));
+    }
+
+    [Fact]
+    public void SpokenLanguage_RejectsALanguageWeDoNotOffer()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        Assert.Throws<ArgumentException>(() => r.SetSpokenLanguage(TenantA, "kl", Now));
+    }
+
+    [Fact]
+    public void SpokenLanguage_IsPerTenant()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpokenLanguage(TenantA, "da", Now);
+        Assert.Equal("da", r.SpokenLanguage(TenantA));
+        Assert.Equal("en", r.SpokenLanguage(TenantB));
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_RoundTripsModelAndVoice()
+    {
+        // This memo is what lets a trip to Danish and back put the account on the engine it started
+        // on, instead of stranding it on a costlier multilingual one it no longer needs.
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "hexgrad/Kokoro-82M", "af_bella", Now);
+        var memo = r.SpeechBeforeLanguageSwitch(TenantA);
+
+        Assert.NotNull(memo);
+        Assert.Equal("hexgrad/Kokoro-82M", memo!.Value.Model);
+        Assert.Equal("af_bella", memo.Value.Voice);
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_RemembersAModelThatHadNoVoice()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "some/expressive-model", null, Now);
+        var memo = r.SpeechBeforeLanguageSwitch(TenantA);
+
+        Assert.NotNull(memo);
+        Assert.Null(memo!.Value.Voice);
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_Unset_IsNull()
+    {
+        using var h = new GatewayDbTestHarness();
+        Assert.Null(NewResolver(h).SpeechBeforeLanguageSwitch(TenantA));
+    }
+
+    [Fact]
+    public void SpeechBeforeLanguageSwitch_Cleared_IsNull()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetSpeechBeforeLanguageSwitch(TenantA, "hexgrad/Kokoro-82M", "af_bella", Now);
+        r.ClearSpeechBeforeLanguageSwitch(TenantA);
+        Assert.Null(r.SpeechBeforeLanguageSwitch(TenantA));
+    }
+
+    [Fact]
+    public void ClearTtsVoice_RemovesTheOverrideRatherThanStoringABlank()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+        r.SetTtsVoice(TenantA, "af_bella", Now);
+        r.ClearTtsVoice(TenantA);
+        // Falls back to the operator default, which is the honest "no tenant choice" answer.
+        Assert.Equal(TtsVoiceConfig.Resolve(Mode), r.TtsVoice(TenantA, Mode));
+    }
+
     [Fact]
     public void CarModeModel_OverrideSet_ReturnsOverride()
     {

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -203,8 +203,9 @@ public sealed class WingmanTranslatorTests
         var prompt = WingmanTranslator.BuildPrompt(
             WingmanTranslator.FidelityPrompt, "recent", "the reply", "A session", "da");
 
-        // Named in English, because the prompt itself is English.
-        Assert.Contains("Write the spoken version in Danish", prompt);
+        // Named in English, because the prompt itself is English. Wording now comes from the one
+        // shared instruction every speaking path uses, so narration and conversation cannot drift.
+        Assert.Contains("Answer in Danish", prompt);
         // The instruction that keeps the narration usable: a listener has to be able to type what
         // they hear, so identifiers and paths must survive the translation untouched.
         Assert.Contains("never translated", prompt);
@@ -222,6 +223,64 @@ public sealed class WingmanTranslatorTests
 
         Assert.DoesNotContain("LANGUAGE.", prompt);
         Assert.DoesNotContain("zz-not-a-language", prompt);
+    }
+
+    // ---- EVERY speaking path carries the language, not just narration ---------------------------
+    // The original change applied the language to turn narration only. Narration is not the only thing
+    // that speaks: the direct "talk to the wingman" reply and the about-DevThrottle answer are separate
+    // generators with their own prompts, and they kept answering in English. An account set to Danish
+    // was told "it is set" and then spoken to in English, which is indistinguishable from broken.
+    // These assert each generator by itself, so adding a new one and forgetting the language shows up
+    // as a missing test rather than as a user reporting it.
+
+    [Fact]
+    public void BuildDirectPrompt_InDanish_TellsTheModelToAnswerInDanish()
+    {
+        var prompt = WingmanTranslator.BuildDirectPrompt("how many sessions are running?", "da");
+
+        Assert.Contains("Answer in Danish", prompt);
+        Assert.Contains("never translated", prompt);
+        Assert.Contains("how many sessions are running?", prompt);
+    }
+
+    [Fact]
+    public void BuildDirectPrompt_InEnglish_IsUnchanged()
+    {
+        Assert.Equal(
+            WingmanTranslator.BuildDirectPrompt("hello"),
+            WingmanTranslator.BuildDirectPrompt("hello", "en"));
+        Assert.DoesNotContain("LANGUAGE.", WingmanTranslator.BuildDirectPrompt("hello", "en"));
+    }
+
+    [Fact]
+    public void BuildDevThrottlePrompt_InDanish_TellsTheModelToAnswerInDanish()
+    {
+        var prompt = WingmanTranslator.BuildDevThrottlePrompt("what is the gateway?", "da");
+
+        Assert.Contains("Answer in Danish", prompt);
+        Assert.Contains("what is the gateway?", prompt);
+    }
+
+    [Fact]
+    public void BuildDevThrottlePrompt_InEnglish_IsUnchanged()
+    {
+        Assert.Equal(
+            WingmanTranslator.BuildDevThrottlePrompt("q"),
+            WingmanTranslator.BuildDevThrottlePrompt("q", "en"));
+    }
+
+    [Fact]
+    public void EverySpeakingPath_UsesTheSameLanguageInstruction()
+    {
+        // One instruction, one place. If a path grows its own wording, translation quality drifts
+        // between narration and conversation for no reason the user can see.
+        var expected = CcDirector.Core.Configuration.SpokenLanguage.PromptInstruction("da");
+        Assert.NotEqual(string.Empty, expected);
+
+        Assert.Contains(expected, WingmanTranslator.BuildDirectPrompt("x", "da"));
+        Assert.Contains(expected, WingmanTranslator.BuildDevThrottlePrompt("x", "da"));
+        Assert.Contains(expected, WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "ctx", "reply", "title", "da"));
     }
 
     private sealed class ThrowingBrain : IAgentBrain

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -258,6 +258,8 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 resolver.SetTtsModel(t.Value, body.Model, DateTime.UtcNow);
+                // A deliberate choice supersedes the model we were holding to restore later.
+                resolver.ClearSpeechBeforeLanguageSwitch(t.Value);
                 var model = body.Model.Trim();
                 FileLog.Write($"[AiModelsEndpoint] tts model set: {model} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { model });
@@ -357,6 +359,29 @@ internal static class AiModelsEndpoint
         }
 
         var current = models.FirstOrDefault(m => string.Equals(m.Id, currentModel, StringComparison.OrdinalIgnoreCase));
+
+        // FIRST: can we put the account BACK where it was? If a previous language change moved it off
+        // a model, and that model can speak the language now being chosen, restore it. Without this a
+        // trip to Danish and back to English strands the account on the multilingual engine forever -
+        // which still works, but costs 61% more per character than the default for a language that
+        // never needed it. Restores the REMEMBERED model, not "the default", so a deliberate choice
+        // the tenant made themselves is not quietly replaced by ours.
+        var memo = resolver.SpeechBeforeLanguageSwitch(tenant);
+        if (memo is not null && !string.Equals(memo.Value.Model, currentModel, StringComparison.OrdinalIgnoreCase))
+        {
+            var remembered = models.FirstOrDefault(m => string.Equals(m.Id, memo.Value.Model, StringComparison.OrdinalIgnoreCase));
+            if (remembered is not null && SpokenLanguage.ModelCanSpeak(remembered.Languages, language))
+            {
+                resolver.SetTtsModel(tenant, remembered.Id, DateTime.UtcNow);
+                if (!string.IsNullOrWhiteSpace(memo.Value.Voice))
+                    resolver.SetTtsVoice(tenant, memo.Value.Voice!, DateTime.UtcNow);
+                else
+                    resolver.ClearTtsVoice(tenant);
+                resolver.ClearSpeechBeforeLanguageSwitch(tenant);
+                return new SpeechSwitch(remembered.Id, memo.Value.Voice, true, null);
+            }
+        }
+
         if (current is not null && SpokenLanguage.ModelCanSpeak(current.Languages, language))
         {
             // Nothing to switch. Report the voice as none when this model has no preset voices, rather
@@ -370,6 +395,12 @@ internal static class AiModelsEndpoint
         if (replacement is null)
             return new SpeechSwitch(currentModel, currentVoice, false,
                 $"no speech model available can speak {SpokenLanguage.EnglishName(language)}");
+
+        // Remember where we came from BEFORE moving, so the return trip can undo exactly this.
+        // Only the first auto-switch is recorded: hopping Danish -> French must still remember the
+        // English engine we originally left, not the multilingual one we are already on.
+        if (memo is null)
+            resolver.SetSpeechBeforeLanguageSwitch(tenant, currentModel, currentVoice, DateTime.UtcNow);
 
         resolver.SetTtsModel(tenant, replacement.Id, DateTime.UtcNow);
 

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -31,6 +31,7 @@ public sealed class CarModeBrain
     private readonly CarModeSubjectStore _subjects;
     private readonly Action<string> _log;
     private readonly string _systemPrompt;
+    private readonly Func<TenantId, string> _spokenLanguage;
 
     /// <param name="fleetForCaller">Resolves the fleet view for one authenticated caller credential
     ///  (issue #2129, hosted tenant isolation): every fleet tool call must run AS the calling device, so
@@ -40,7 +41,11 @@ public sealed class CarModeBrain
     /// <param name="surface">Which surface this brain instance speaks to. Car (the default) keeps the
     ///  hands-free one-or-two-sentence style; Desk (the cockpit Assistant screen) appends the desk-surface
     ///  overrides. Everything else - loop, tools, stores, model - is identical.</param>
-    public CarModeBrain(ICarModeChat chat, Func<string, ICarModeFleet> fleetForCaller, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null, CarModeSurface surface = CarModeSurface.Car)
+    /// <param name="spokenLanguageProvider">Returns the caller tenant's SPOKEN LANGUAGE. Car Mode is a
+    ///  separate generator from the wingman's turn narration, with its own system prompt, so it needs the
+    ///  language instruction in its own right - narration being translated while the hands-free voice
+    ///  kept answering in English is exactly the defect this closes. Omit it and every turn is English.</param>
+    public CarModeBrain(ICarModeChat chat, Func<string, ICarModeFleet> fleetForCaller, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null, CarModeSurface surface = CarModeSurface.Car, Func<TenantId, string>? spokenLanguageProvider = null)
     {
         _chat = chat ?? throw new ArgumentNullException(nameof(chat));
         _fleetForCaller = fleetForCaller ?? throw new ArgumentNullException(nameof(fleetForCaller));
@@ -49,6 +54,7 @@ public sealed class CarModeBrain
         _subjects = subjects ?? throw new ArgumentNullException(nameof(subjects));
         _log = log ?? FileLog.Write;
         _systemPrompt = surface == CarModeSurface.Desk ? SystemPrompt + DeskAddendum : SystemPrompt;
+        _spokenLanguage = spokenLanguageProvider ?? (_ => CcDirector.Core.Configuration.SpokenLanguage.Default);
     }
 
     /// <summary>
@@ -160,7 +166,8 @@ public sealed class CarModeBrain
         }
 
         var messages = new List<object>();
-        messages.Add(new { role = "system", content = _systemPrompt });
+        var languageBlock = CcDirector.Core.Configuration.SpokenLanguage.PromptInstruction(_spokenLanguage(tenant));
+        messages.Add(new { role = "system", content = languageBlock + _systemPrompt });
         foreach (var m in _conversations.GetHistory(deviceKey))
             messages.Add(new { role = m.Role, content = m.Content });
         messages.Add(new { role = "user", content = userText });

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2378,11 +2378,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // credential on the request at all, and the machine token is the same identity every client uses.
         Func<string, CarMode.ICarModeFleet> carModeFleetForCaller = callerCredential =>
             new CarMode.LoopbackCarModeFleet(Port, string.IsNullOrEmpty(callerCredential) ? Token : callerCredential);
-        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects);
+        // Car Mode speaks in the caller tenant's chosen language, resolved per turn like every other
+        // speaking path - it is its own generator and would otherwise stay English forever.
+        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects,
+            spokenLanguageProvider: t => _tenantSettingsResolver.SpokenLanguage(t));
         // The cockpit Assistant (POST /assistant/turn): the SAME loop, tools, stores, model, and turn cache
         // as Car Mode, with only the desk-surface speech style. Sharing the stores means a device that uses
         // both surfaces keeps one conversation and one armed-confirmation state - no split-brain.
-        var assistantBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects, surface: CarMode.CarModeSurface.Desk);
+        var assistantBrain = new CarMode.CarModeBrain(carModeChat, carModeFleetForCaller, _carModeConversations, _carModePending, _carModeSubjects, surface: CarMode.CarModeSurface.Desk,
+            spokenLanguageProvider: t => _tenantSettingsResolver.SpokenLanguage(t));
         // Keep-warm (Car Mode performance round): warm the SAME hosted model the brain uses and the SAME
         // text-to-speech target /wingman/tts uses, resolved fresh each warmup so a settings change applies.
         var carModeWarmup = new CarMode.CarModeWarmup(

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -31,6 +31,12 @@ public static class TenantSettingKeys
     /// reads this. BCP-47 primary subtag; unset means English.</summary>
     public const string SpokenLanguage = "spoken_language";
 
+    /// <summary>What the speech model and voice were BEFORE a spoken-language change auto-switched
+    /// them, as JSON. Held so that returning to a language the old engine can speak puts the account
+    /// back where it was, instead of stranding it on a costlier engine it no longer needs. Absent
+    /// whenever nothing has been auto-switched.</summary>
+    public const string SpeechBeforeLanguageSwitch = "speech_before_language_switch";
+
     /// <summary>The conversational model Car Mode drives (global default: <c>car_mode_model</c>).</summary>
     public const string CarModeModel = "car_mode_model";
 
@@ -68,7 +74,7 @@ public static class TenantSettingKeys
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
-        WingmanModel, WingmanFastModel, TtsModel, TtsVoice, SpokenLanguage,
+        WingmanModel, WingmanFastModel, TtsModel, TtsVoice, SpokenLanguage, SpeechBeforeLanguageSwitch,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
         VoiceModeAll,
     };

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -157,6 +157,36 @@ public sealed class TenantSettingsResolver
     public void SetTtsVoice(TenantId tenant, string voice, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.TtsVoice, RequireNonEmpty(voice, nameof(voice)), nowUtc);
 
+    /// <summary>What the speech model/voice were before an auto-switch, or null when nothing is
+    /// remembered. A corrupt value reads as null - a bad memo must never break a language change.</summary>
+    public (string Model, string? Voice)? SpeechBeforeLanguageSwitch(TenantId tenant)
+    {
+        var raw = _store.Get(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch);
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(raw);
+            var model = doc.RootElement.TryGetProperty("model", out var m) ? m.GetString() : null;
+            if (string.IsNullOrWhiteSpace(model)) return null;
+            var voice = doc.RootElement.TryGetProperty("voice", out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
+                ? v.GetString() : null;
+            return (model!, voice);
+        }
+        catch (System.Text.Json.JsonException) { return null; }
+    }
+
+    /// <summary>Remember the speech model/voice we are about to auto-switch away from.</summary>
+    public void SetSpeechBeforeLanguageSwitch(TenantId tenant, string model, string? voice, DateTime nowUtc)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new { model, voice });
+        _store.Set(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch, json, nowUtc);
+    }
+
+    /// <summary>Forget the remembered speech model - after restoring it, or once the tenant picks a
+    /// model themselves, because a deliberate choice supersedes anything we were holding for them.</summary>
+    public void ClearSpeechBeforeLanguageSwitch(TenantId tenant)
+        => _store.Remove(tenant, TenantSettingKeys.SpeechBeforeLanguageSwitch);
+
     /// <summary>Remove the tenant's voice override entirely - the honest state when the speech model in
     /// use has no preset voices to choose from. Distinct from setting an empty string, which the setter
     /// rejects.</summary>

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -330,7 +330,7 @@ public sealed class WingmanTranslator
             throw new ArgumentException("A message is required to ask the wingman.", nameof(userMessage));
 
         _log($"[WingmanTranslator] AskDirectAsync: userLen={userMessage.Length}");
-        var prompt = BuildDirectPrompt(userMessage);
+        var prompt = BuildDirectPrompt(userMessage, SpokenLanguage.Normalize(_spokenLanguage(tenant)));
 
         var brain = await _brainProvider(tenant, WingmanModelRole.Thinking, ct);
         AskResult ask;
@@ -366,7 +366,7 @@ public sealed class WingmanTranslator
             throw new ArgumentException("A question is required to ask about DevThrottle.", nameof(question));
 
         _log($"[WingmanTranslator] AskAboutDevThrottleAsync: questionLen={question.Length}");
-        var prompt = BuildDevThrottlePrompt(question);
+        var prompt = BuildDevThrottlePrompt(question, SpokenLanguage.Normalize(_spokenLanguage(tenant)));
 
         var brain = await _brainProvider(tenant, WingmanModelRole.Thinking, ct);
         AskResult ask;
@@ -390,8 +390,16 @@ public sealed class WingmanTranslator
     /// <summary>The DevThrottle product/docs Q&amp;A prompt (issue #472). Public so a test can assert
     /// it grounds the brain as DevThrottle's in-product help and carries the user's question.</summary>
     public static string BuildDevThrottlePrompt(string question)
+        => BuildDevThrottlePrompt(question, SpokenLanguage.Default);
+
+    /// <summary>The about-DevThrottle answer, in the tenant's spoken language. Spoken output, so it
+    /// needs the instruction like every other speaking path.</summary>
+    public static string BuildDevThrottlePrompt(string question, string? spokenLanguage)
     {
+        // The language goes first so it frames everything that follows.
+        var languageBlock = SpokenLanguage.PromptInstruction(spokenLanguage);
         var sb = new StringBuilder();
+        sb.Append(languageBlock);
         sb.Append("You are DevThrottle's in-product help assistant, answering a question typed on the ");
         sb.Append("Learning page of the DevThrottle Cockpit (the fleet web dashboard). DevThrottle ");
         sb.Append("(the app and command-line tools are named cc-director) is an open-source tool that ");
@@ -585,6 +593,12 @@ public sealed class WingmanTranslator
 
     /// <summary>The direct-to-wingman prompt. Public so a test can assert its contract.</summary>
     public static string BuildDirectPrompt(string userMessage)
+        => BuildDirectPrompt(userMessage, SpokenLanguage.Default);
+
+    /// <summary>The direct reply in the tenant's spoken language. CONVERSATION is a different
+    /// generator from turn narration, and needs the language instruction of its own - it did not
+    /// have one, which is why an account set to Danish was still answered in English.</summary>
+    public static string BuildDirectPrompt(string userMessage, string? spokenLanguage)
     {
         var sb = new StringBuilder();
         sb.Append("You are the wingman, talking directly to a person in a spoken back-and-forth ");
@@ -595,6 +609,7 @@ public sealed class WingmanTranslator
         sb.Append("in words (\"first ... second ...\"), never as a \"1.\" list. ");
         sb.Append("You do NOT edit files or run commands yourself; if the request needs real code ");
         sb.Append("work, say so plainly and suggest sending it to the working session.\n\n");
+        sb.Append(SpokenLanguage.PromptInstruction(spokenLanguage));
         sb.Append("The person said:\n");
         sb.Append(userMessage.Trim());
         sb.Append("\n\n");
@@ -641,26 +656,10 @@ public sealed class WingmanTranslator
         var sb = new StringBuilder();
         sb.Append(string.IsNullOrWhiteSpace(instructions) ? FidelityPrompt : instructions);
         sb.Append("\n\n");
-        if (!SpokenLanguage.IsDefault(spokenLanguage))
-        {
-            // Stated up front, right after the contract, because the model's default behaviour is
-            // to mirror the language of the reply it is given - which is nearly always English.
-            // Being specific about what must NOT be translated matters as much as the language
-            // itself: a listener has to be able to type what they hear.
-            var name = SpokenLanguage.EnglishName(spokenLanguage);
-            sb.Append("LANGUAGE. Write the spoken version in ");
-            sb.Append(name);
-            sb.Append(". The agent's reply below is in whatever language it works in, usually ");
-            sb.Append("English; you are saying it for the ear in ");
-            sb.Append(name);
-            sb.Append(". Write it the way a native speaker would say it out loud, not as a ");
-            sb.Append("word-for-word translation.\n");
-            sb.Append("Leave these EXACTLY as they appear, never translated and never spelled ");
-            sb.Append("differently: file names and paths, code identifiers, command names, branch ");
-            sb.Append("names, and error text. Everything else is spoken in ");
-            sb.Append(name);
-            sb.Append(".\n\n");
-        }
+        // ONE instruction, shared by every speaking path (see SpokenLanguage.PromptInstruction):
+        // narration, the direct reply, the about-DevThrottle answer, and Car Mode. Applying it to
+        // only one of them is exactly how "I set Danish and it still speaks English" happens.
+        sb.Append(SpokenLanguage.PromptInstruction(spokenLanguage));
         if (!string.IsNullOrWhiteSpace(sessionTitle))
         {
             sb.Append("The title of the session this reply came from. Open the narration by saying ");


### PR DESCRIPTION
Reported from a phone, in voice mode, on an account set to Danish: **"you are still speaking English to me."** Correct - and my earlier diagnosis was wrong.

## The real defect: I wired the language into one generator out of four

I claimed the wingman translator was "the single place" spoken words are produced. It is not. It is the single place **turn narration** is produced - which is what its own doc comment says, and I over-read it. Conversation comes from separate generators with their own prompts:

| Generator | Speaks | Before |
|---|---|---|
| `TranslateWithAsync` | turn narration | had the language |
| `AskDirectAsync` | **talking to the wingman** | English |
| `AskAboutDevThrottleAsync` | in-product help | English |
| `CarModeBrain` | **hands-free voice** | English |

So an account could be genuinely set to Danish, have its narration translated, and still be answered in English the moment it was spoken to conversationally - indistinguishable from the setting doing nothing.

The instruction now lives in **one place** (`SpokenLanguage.PromptInstruction`) and every generator applies it, including Car Mode's system prompt, resolved per turn since the tenant is only known then. English stays a byte-for-byte no-op on every path.

**A test asserts each generator individually AND that they all use the identical instruction**, so a new speaking path that forgets the language fails a test rather than being reported from a car. It caught two real misses while being written.

## Also in here

**The Play sample played what the PAGE believed, not what the ACCOUNT was set to.** `ttsSample` sent the model and voice from the page snapshot; on a stale bundle that is the old engine, so the sample auditioned English while the account was on Danish. Model and voice are now omitted and the Gateway resolves the account's own. Confirmed live: 200, 28,176 bytes of Danish audio.

**The page never re-read the server after a switch** - both surfaces now reload the provider snapshot instead of patching local state.

**Returning to English restores the engine you started on.** Danish moves you to the multilingual engine correctly; going back used to leave you there at **61% more per character** ($2.00 vs $1.24 per million) for a language that never needed it. Restores the *remembered* model rather than the default, records only the first auto-switch so a Danish-French-English hop still returns home, and a manual model choice clears the memo.

## Verified on a running Gateway

| Check | Result |
|---|---|
| Language list | five, ordered en, fr, de, es, da |
| English to Danish | switched to multilingual, stale voice cleared |
| Danish to English | original engine and voice restored |
| Danish to French to English | still restores the original |
| Sample, server-resolved | 200, Danish audio |

43 translator tests, 17 Core, 21 resolver - all green; workspace typecheck clean.

## Known gap, not hidden

`BuildMenuSpoken` composes spoken menu text in code from English fragments rather than through a model, so spoken menus stay English. Smaller surface than conversation, needs its own change, filed separately.