### PR TITLE
feat(reports): the daily report can reach every account, not a hand-kept allowlist

### DIFF
--- a/src/CcDirector.Gateway.Tests/ReportRecipientsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/ReportRecipientsEndpointTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The recipient list for the daily report.
+///
+/// This endpoint returns EVERY account's email address, which makes it more sensitive than any single
+/// report, so the tests that matter are the refusals. It must be impossible to reach it more easily
+/// than the report itself: unconfigured token is 503 and never an open door, wrong token is 401, and
+/// neither leaks a single address on the way out.
+/// </summary>
+[Collection("ReportRecipients")] // serial: mutates the REPORT_SERVICE_TOKEN process env var
+public sealed class ReportRecipientsEndpointTests : IDisposable
+{
+    private const string Token = "test-report-token";
+    private readonly string? _previousToken;
+    private readonly GatewayDbTestHarness _h = new();
+
+    public ReportRecipientsEndpointTests()
+    {
+        _previousToken = Environment.GetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar);
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, Token);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, _previousToken);
+        _h.Dispose();
+    }
+
+    private TenantRegistry Registry() => new(_h.Open());
+
+    /// <summary>An IResult needs a service provider to execute, exactly as the report endpoint's own
+    /// tests build one.</summary>
+    private static readonly IServiceProvider Services =
+        new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+
+    private static HttpContext Ctx(string? bearer = Token)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = Services, Response = { Body = new MemoryStream() } };
+        if (bearer is not null) ctx.Request.Headers.Authorization = $"Bearer {bearer}";
+        return ctx;
+    }
+
+    private static async Task<(int Status, JsonElement Body)> ExecuteAsync(IResult result, HttpContext ctx)
+    {
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        return (ctx.Response.StatusCode, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public async Task WithNoTokenConfigured_ItRefuses_RatherThanServingUnguarded()
+    {
+        Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, null);
+
+        var ctx = Ctx();
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, status);
+    }
+
+    [Fact]
+    public async Task WithTheWrongToken_ItRefuses()
+    {
+        var ctx = Ctx("not-the-token");
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+    }
+
+    [Fact]
+    public async Task WithNoAuthorizationHeaderAtAll_ItRefuses()
+    {
+        var ctx = Ctx(bearer: null);
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+    }
+
+    [Fact]
+    public async Task ARefusalLeaksNoAddresses()
+    {
+        // The failure path must not be a quieter way to read the list.
+        var registry = Registry();
+        registry.MintOrLookupBySubject("subject-1", "leaked@example.com");
+
+        var ctx = Ctx("wrong");
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+
+        Assert.DoesNotContain("leaked@example.com", body.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItReturnsEveryAccountThatHasAnEmail()
+    {
+        var registry = Registry();
+        registry.MintOrLookupBySubject("subject-1", "alice@example.com");
+        registry.MintOrLookupBySubject("subject-2", "bob@example.com");
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var emails = body.GetProperty("recipients").EnumerateArray()
+            .Select(r => r.GetProperty("email").GetString()).ToList();
+
+        Assert.Equal(new[] { "alice@example.com", "bob@example.com" }, emails);
+    }
+
+    [Fact]
+    public async Task AnAccountWithNoEmailIsOmitted_NotReturnedBlank()
+    {
+        // A recipient with nothing to send to is not a recipient. Returning it blank would invite the
+        // sender to try anyway and fail once per morning, forever.
+        var registry = Registry();
+        registry.MintOrLookupBySubject("subject-no-email", null);
+        registry.MintOrLookupBySubject("subject-with", "real@example.com");
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var recipients = body.GetProperty("recipients").EnumerateArray().ToList();
+
+        Assert.Equal("real@example.com", Assert.Single(recipients).GetProperty("email").GetString());
+    }
+
+    [Fact]
+    public async Task TheSameAddressOnTwoAccountsIsSentToOnce()
+    {
+        // Two tenants can legitimately carry one address. Mailing it twice each morning would read as
+        // a bug to the person receiving it, and would be one.
+        var registry = Registry();
+        registry.MintOrLookupBySubject("subject-1", "same@example.com");
+        registry.MintOrLookupBySubject("subject-2", "SAME@example.com");
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+
+        Assert.Single(body.GetProperty("recipients").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task WithNoAccountsAtAll_ItReturnsAnEmptyListRatherThanFailing()
+    {
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+
+        Assert.Empty(body.GetProperty("recipients").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task TheOrderIsStable_SoASendCanBeComparedBetweenMornings()
+    {
+        var registry = Registry();
+        registry.MintOrLookupBySubject("s3", "carol@example.com");
+        registry.MintOrLookupBySubject("s1", "alice@example.com");
+        registry.MintOrLookupBySubject("s2", "bob@example.com");
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var emails = body.GetProperty("recipients").EnumerateArray()
+            .Select(r => r.GetProperty("email").GetString()).ToList();
+
+        Assert.Equal(new[] { "alice@example.com", "bob@example.com", "carol@example.com" }, emails);
+    }
+}

--- a/src/CcDirector.Gateway/Api/MorningReportEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MorningReportEndpoint.cs
@@ -69,23 +69,7 @@ internal static class MorningReportEndpoint
         TenantRegistry tenants,
         HostedTenantBoundary boundary)
     {
-        var configured = Environment.GetEnvironmentVariable(ServiceTokenEnvVar);
-        if (string.IsNullOrWhiteSpace(configured))
-        {
-            // Fail loud and CLOSED. An unconfigured token is a deployment error, not a reason to serve the
-            // report to anyone who asks; and it is not a reason to invent an allow-anything mode either.
-            FileLog.Write($"[MorningReportEndpoint] DENIED: {ServiceTokenEnvVar} is not set on this Gateway - the report endpoint refuses to serve unguarded");
-            return Results.Json(
-                new { error = $"the morning report service token ({ServiceTokenEnvVar}) is not configured on this Gateway" },
-                statusCode: StatusCodes.Status503ServiceUnavailable);
-        }
-
-        if (!PresentedTokenMatches(ctx, configured))
-        {
-            FileLog.Write("[MorningReportEndpoint] DENIED: missing or incorrect service token");
-            return Results.Json(new { error = "a valid morning report service token is required" },
-                statusCode: StatusCodes.Status401Unauthorized);
-        }
+        if (ServiceTokenDenial(ctx) is { } tokenDenial) return tokenDenial;
 
         MorningReportWindow window;
         try
@@ -165,6 +149,34 @@ internal static class MorningReportEndpoint
     /// The length difference is itself unavoidable and is handled by comparing fixed-size digests, so even
     /// the length does not leak through the comparison.
     /// </summary>
+    /// <summary>
+    /// The report service-token gate, or null when the caller is authorized. Extracted so the recipient
+    /// list endpoint enforces the SAME rule rather than growing a second, subtly different one - a list of
+    /// every account's email address must never be guarded more weakly than a single account's report.
+    /// </summary>
+    internal static IResult? ServiceTokenDenial(HttpContext ctx)
+    {
+        var configured = Environment.GetEnvironmentVariable(ServiceTokenEnvVar);
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            // Fail loud and CLOSED. An unconfigured token is a deployment error, not a reason to serve to
+            // anyone who asks; and it is not a reason to invent an allow-anything mode either.
+            FileLog.Write($"[MorningReportEndpoint] DENIED: {ServiceTokenEnvVar} is not set on this Gateway - the report endpoints refuse to serve unguarded");
+            return Results.Json(
+                new { error = $"the report service token ({ServiceTokenEnvVar}) is not configured on this Gateway" },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!PresentedTokenMatches(ctx, configured))
+        {
+            FileLog.Write("[MorningReportEndpoint] DENIED: missing or incorrect service token");
+            return Results.Json(new { error = "a valid report service token is required" },
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        return null;
+    }
+
     private static bool PresentedTokenMatches(HttpContext ctx, string configured)
     {
         var header = ctx.Request.Headers.Authorization.ToString();

--- a/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
@@ -1,0 +1,65 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Who the daily report should go to.
+///
+///   GET /gateway/reports/recipients  ->  { recipients: [ { account, email } ] }
+///
+/// The report endpoint answers "what does THIS account's day look like" and has always required the
+/// caller to already know the account. The sender therefore could only ever mail a hard-coded
+/// allowlist. This is the missing half: the list itself, so the daily email reaches every account on
+/// the Gateway without anyone maintaining a list of addresses by hand in a deployment variable.
+///
+/// SAME GATE AS THE REPORT. It presents the same service token, is public in AuthMiddleware for the
+/// same reason, and fails the same way: no token configured is 503 and never an open door; a wrong
+/// token is 401. It is deliberately NOT a second, weaker way in - a list of every account's email
+/// address is more sensitive than any single report, not less.
+///
+/// AN ACCOUNT WITH NO EMAIL IS OMITTED, not returned blank. The tenants table records the email as it
+/// was at mint time and it is nullable; a recipient with nothing to send to is not a recipient, and
+/// returning an empty address would invite the sender to try anyway.
+///
+/// WHAT THIS DOES NOT DECIDE: whether a given account WANTS the email. There is no such setting yet
+/// (the wizard cadence step is issue #2107). When it exists, the filtering belongs HERE - one place
+/// that answers "who should be mailed" - and not in the sender, so that every future channel inherits
+/// the same answer instead of each one re-deriving it.
+/// </summary>
+internal static class ReportRecipientsEndpoint
+{
+    /// <summary>The route. Exact-match public in <c>AuthMiddleware</c>; this endpoint carries its own gate.</summary>
+    public const string Path = "/gateway/reports/recipients";
+
+    public static void Map(IEndpointRouteBuilder app, TenantRegistry tenants)
+    {
+        ArgumentNullException.ThrowIfNull(tenants);
+
+        app.MapGet(Path, (HttpContext ctx) => Handle(ctx, tenants));
+
+        FileLog.Write($"[ReportRecipientsEndpoint] mapped {Path} (service-token authorized, read-only)");
+    }
+
+    internal static IResult Handle(HttpContext ctx, TenantRegistry tenants)
+    {
+        // Reuses the report endpoint's gate rather than repeating it: one token, one rule, and no
+        // chance of the two drifting so that the recipient list is guarded less well than the reports.
+        if (MorningReportEndpoint.ServiceTokenDenial(ctx) is { } denial) return denial;
+
+        var recipients = tenants.ListAll()
+            .Where(t => !string.IsNullOrWhiteSpace(t.Email))
+            .Select(t => new { account = t.Email!.Trim(), email = t.Email!.Trim() })
+            .DistinctBy(r => r.email, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(r => r.email, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Count only - the addresses themselves are personally identifying and this log is not the
+        // place for them (the tenants table says the email is never logged).
+        FileLog.Write($"[ReportRecipientsEndpoint] served {recipients.Count} recipient(s)");
+        return Results.Json(new { recipients });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2475,6 +2475,8 @@ public sealed class GatewayHost : IAsyncDisposable
         // (the caller is a server with no device key); it carries its own bearer service token from
         // REPORT_SERVICE_TOKEN and resolves the named account to exactly one tenant. Read-only.
         Api.MorningReportEndpoint.Map(_app, _morningReport, TenantRegistry, _tenantBoundary);
+        // Who that report goes to: every account on this Gateway, behind the same service token.
+        Api.ReportRecipientsEndpoint.Map(_app, TenantRegistry);
 
         // Gateway Centralization Phase 2 (issue #638): GET /account/status answers "is the Gateway
         // signed in to DevThrottle, and as whom?" computed ENTIRELY LOCALLY from the Gateway-hosted

--- a/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TenantRegistry.cs
@@ -149,6 +149,26 @@ public sealed class TenantRegistry
     }
 
     /// <summary>
+    /// Every tenant with the account email recorded for it, for the daily report's recipient list.
+    ///
+    /// Separate from <see cref="AllTenantIds"/> on purpose: that one feeds background sweeps that only ever
+    /// need an id, and widening it to drag personally-identifying columns into every sweep would be the
+    /// wrong trade. This read exists for the ONE caller that legitimately needs an address.
+    ///
+    /// The email is DISPLAY METADATA captured at mint time and it is nullable, so a caller must treat a
+    /// missing or stale address as exactly that - see <see cref="TenantEntity.Email"/>. Read through the
+    /// UNSCOPED context because the mapping table carries no tenant_id, as every other census read does.
+    /// </summary>
+    public IReadOnlyList<TenantRecipient> ListAll()
+    {
+        using var ctx = _db.CreateUnscopedContext();
+        return ctx.Tenants
+            .AsNoTracking()
+            .Select(t => new TenantRecipient(t.Id, t.Email))
+            .ToList();
+    }
+
+    /// <summary>
     /// The verified account subject a tenant maps to, or null when the tenant id is unknown. This is the
     /// REVERSE of <see cref="MintOrLookupBySubject"/> and the bridge the cancellation cutoff (MTR-15) needs:
     /// the lease and the sweep are keyed by <see cref="TenantId"/>, but the entitlement reader
@@ -263,3 +283,8 @@ public sealed class TenantRegistry
         return string.IsNullOrWhiteSpace(row?.Email) ? null : row!.Email;
     }
 }
+
+/// <summary>A tenant and the account email recorded for it, which may be absent.</summary>
+/// <param name="TenantId">The tenant's own id.</param>
+/// <param name="Email">The account email as last seen at mint time, or null.</param>
+public sealed record TenantRecipient(string TenantId, string? Email);

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -165,6 +165,7 @@ internal static class AuthMiddleware
         // /gateway/reports/morning is exempt, and it is a read-only route that returns ONE named account's
         // report, scoped to that account's tenant.
         Api.MorningReportEndpoint.Path,
+        Api.ReportRecipientsEndpoint.Path,
     };
 
     public static async Task Run(HttpContext ctx, RequireToken cfg, Func<Task> next)


### PR DESCRIPTION
The report endpoint answers "what does **this** account's day look like" and has always required the
caller to already know the account, so the sender could only ever mail a hard-coded list of addresses
in a deployment variable. This adds the missing half — the list itself.

    GET /gateway/reports/recipients  ->  { recipients: [ { account, email } ] }

## Guarded by the same gate, not a second one

It presents the same service token as the report and now **shares one gate** (extracted from
`MorningReportEndpoint`) rather than growing a parallel copy. A list of every account's email address
is more sensitive than any single report, not less, and two copies of an authorization rule is how one
of them ends up weaker.

The refusals are the tests that matter: unconfigured token is 503 and never an open door, a wrong
token is 401, and neither leaks an address on the way out.

## Small decisions with reasons

- An account with **no recorded email is omitted**, not returned blank. A recipient with nothing to
  send to is not a recipient, and an empty address would invite the sender to try anyway and fail once
  every morning forever.
- **Two accounts carrying one address are mailed once.** Mailing somebody twice each morning would
  read as a bug to them, and would be one.
- The order is stable, so one morning's send can be compared against another's.

## What this deliberately does not decide

**Whether an account wants the email.** No such setting exists yet — the wizard cadence step is thefrederiksen/devthrottle_internal#932
— so today this returns every account that has an email, and the only way to stop the mail is to
remove the account. That is worth knowing before it is switched on for a wide user base.

When the setting arrives, the filtering belongs **here**, in the one place that answers "who should be
mailed", so every future channel inherits the same answer rather than each one re-deriving it.

## Verification

9 new tests covering the refusals, omission, de-duplication, ordering and the empty case. Gateway
builds clean. The website sender that consumes this is a companion change; its recipient resolution
was exercised against a stub gateway covering the every-account path, the override path, a blank
override, a trailing-slash base URL, and a gateway refusal (which throws rather than quietly mailing
nobody).
