### PR TITLE
fix(cockpit): a mouse drag out of a dialog must not dismiss it

### DIFF
--- a/apps/cockpit/src/components/ConfirmDialog.tsx
+++ b/apps/cockpit/src/components/ConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { Button } from "./Button";
+import { useDismissOnBackdrop } from "./useDismissOnBackdrop";
 
 // The one confirmation dialog every destructive action in the Cockpit routes through (issue #1244).
 // Before this, destructive actions were handled three different ways: a good inline confirmation on the
@@ -77,6 +78,10 @@ export function ConfirmDialog({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, busy, onClose]);
 
+  // Dismissing by clicking the backdrop, but never while the action is mid-flight, and never on a
+  // drag that started inside the dialog (see useDismissOnBackdrop).
+  const dismiss = useDismissOnBackdrop(busy ? undefined : onClose);
+
   if (!open) return null;
 
   const runConfirm = async () => {
@@ -97,18 +102,12 @@ export function ConfirmDialog({
   };
 
   return (
-    <div
-      className="ui-modal-backdrop"
-      onClick={() => {
-        if (!busy) onClose();
-      }}
-    >
+    <div className="ui-modal-backdrop" {...dismiss}>
       <div
         className="ui-confirm"
         role="alertdialog"
         aria-modal="true"
         aria-label={title}
-        onClick={(event) => event.stopPropagation()}
       >
         <div className="ui-confirm-title">{title}</div>
         <div className="ui-confirm-message">{message}</div>

--- a/apps/cockpit/src/components/DataTable.tsx
+++ b/apps/cockpit/src/components/DataTable.tsx
@@ -6,6 +6,7 @@ import {
   type SortDirection,
   type SortState,
 } from "./dataTableCore";
+import { useDismissOnBackdrop } from "./useDismissOnBackdrop";
 
 // The shared Cockpit data table (issue #1245). Every list in the app used to be a bespoke <table>: no
 // sort, no search, and - at its worst on the Schedule page - a whole multi-paragraph prompt crammed
@@ -126,6 +127,11 @@ export function DataTable<T>({
 
   const rowsAreActivatable = onRowActivate !== undefined || renderDetail !== undefined;
 
+  // The detail drawer closes on a backdrop click, but only when the press STARTED on the backdrop -
+  // selecting text in the drawer and releasing outside it is a selection, not a dismissal (see
+  // useDismissOnBackdrop).
+  const dismissDetail = useDismissOnBackdrop(() => setDetailKey(null));
+
   return (
     <div className="ui-table-wrap">
       <div className="ui-table-toolbar">
@@ -211,13 +217,8 @@ export function DataTable<T>({
       )}
 
       {detailRow !== null && renderDetail !== undefined && (
-        <div className="ui-drawer-backdrop" onClick={() => setDetailKey(null)}>
-          <aside
-            className="ui-drawer"
-            role="dialog"
-            aria-modal="true"
-            onClick={(event) => event.stopPropagation()}
-          >
+        <div className="ui-drawer-backdrop" {...dismissDetail}>
+          <aside className="ui-drawer" role="dialog" aria-modal="true">
             <header className="ui-drawer-head">
               <div className="ui-drawer-title">{detailTitle !== undefined ? detailTitle(detailRow) : null}</div>
               <div className="ui-drawer-head-actions">

--- a/apps/cockpit/src/components/FileViewerModal.tsx
+++ b/apps/cockpit/src/components/FileViewerModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "@devthrottle/client-core/api/client";
 import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
 import { Button } from "./Button";
+import { useDismissOnBackdrop } from "./useDismissOnBackdrop";
 
 // Local Files mission (Phase 2): the Cockpit file viewer. A clicked file path - in the Chat tab or in
 // the terminal - opens this modal, which renders the file IN PLACE by type, streamed from the owning
@@ -75,14 +76,17 @@ export function FileViewerModal({ sessionId, path, onClose }: FileViewerModalPro
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
+  // Backdrop dismissal that survives a mouse drag - selecting text in a viewed file and releasing
+  // outside the panel must not close the viewer (see useDismissOnBackdrop).
+  const dismiss = useDismissOnBackdrop(onClose);
+
   return (
-    <div className="ui-modal-backdrop" onClick={onClose}>
+    <div className="ui-modal-backdrop" {...dismiss}>
       <div
         className="file-viewer"
         role="dialog"
         aria-modal="true"
         aria-label={name}
-        onClick={(event) => event.stopPropagation()}
       >
         <div className="file-viewer-head">
           <span className="file-viewer-name" title={path}>{name}</span>

--- a/apps/cockpit/src/components/index.ts
+++ b/apps/cockpit/src/components/index.ts
@@ -38,6 +38,9 @@ export {
 } from "./dataTableCore";
 export type { SortDirection, SortState } from "./dataTableCore";
 
+export { useDismissOnBackdrop } from "./useDismissOnBackdrop";
+export type { BackdropDismissHandlers } from "./useDismissOnBackdrop";
+
 export { useFlash } from "./useFlash";
 export type { Flash, FlashController } from "./useFlash";
 

--- a/apps/cockpit/src/components/useDismissOnBackdrop.test.tsx
+++ b/apps/cockpit/src/components/useDismissOnBackdrop.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useDismissOnBackdrop } from "./useDismissOnBackdrop";
+
+// Owner report: renaming a session from the Cockpit was impossible whenever you reached for the mouse.
+// The rename dialog came up, you pressed inside the text box and dragged left to highlight the start of
+// the name - and the dialog vanished the moment you let go of the button.
+//
+// The cause is how the browser targets a click: it fires on the nearest common ancestor of the press
+// and the release. Press in the box, release just past the edge of the panel, and that ancestor is the
+// BACKDROP - so the old `onClick={onClose}` on the backdrop ran even though the gesture began inside
+// the dialog. The panel's stopPropagation could not help; the event never went near the panel.
+//
+// These tests model the browser exactly: the drag is a mousedown on the input followed by a click
+// dispatched AT THE BACKDROP, which is what the browser really does.
+//
+// Revert-proof: drop the press test from useDismissOnBackdrop (go back to closing on any backdrop
+// click) and "a drag out of the dialog" fails. Drop the target test and "a click inside" fails.
+
+function Overlay({ onClose }: { onClose?: () => void }) {
+  const dismiss = useDismissOnBackdrop(onClose);
+  return (
+    <div data-testid="backdrop" {...dismiss}>
+      <div data-testid="panel" role="dialog">
+        <input data-testid="name" defaultValue="devthrottle / 2905" />
+        <button type="button">Save</button>
+      </div>
+    </div>
+  );
+}
+
+describe("useDismissOnBackdrop", () => {
+  beforeEach(() => cleanup());
+
+  it("keeps the dialog open when a drag starts inside it and ends on the backdrop", () => {
+    const onClose = vi.fn();
+    render(<Overlay onClose={onClose} />);
+
+    // Press in the text box, drag out, release past the edge of the panel: the browser aims the
+    // resulting click at the backdrop.
+    fireEvent.mouseDown(screen.getByTestId("name"));
+    fireEvent.click(screen.getByTestId("backdrop"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on a real backdrop click", () => {
+    const onClose = vi.fn();
+    render(<Overlay onClose={onClose} />);
+
+    fireEvent.mouseDown(screen.getByTestId("backdrop"));
+    fireEvent.click(screen.getByTestId("backdrop"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a click that bubbles up from inside the dialog", () => {
+    const onClose = vi.fn();
+    render(<Overlay onClose={onClose} />);
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not dismiss on a click with no press behind it (keyboard activation)", () => {
+    const onClose = vi.fn();
+    render(<Overlay onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("backdrop"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not carry a backdrop press over to the next click", () => {
+    const onClose = vi.fn();
+    render(<Overlay onClose={onClose} />);
+
+    fireEvent.mouseDown(screen.getByTestId("backdrop"));
+    fireEvent.click(screen.getByTestId("backdrop"));
+    // A second click with no press of its own must not dismiss again.
+    fireEvent.click(screen.getByTestId("backdrop"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches harmlessly when dismissal is switched off (mid-save dialog)", () => {
+    render(<Overlay onClose={undefined} />);
+
+    fireEvent.mouseDown(screen.getByTestId("backdrop"));
+    // Nothing to assert but "it did not throw": the backdrop is simply inert while the dialog is busy.
+    expect(() => fireEvent.click(screen.getByTestId("backdrop"))).not.toThrow();
+  });
+});

--- a/apps/cockpit/src/components/useDismissOnBackdrop.ts
+++ b/apps/cockpit/src/components/useDismissOnBackdrop.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef, type MouseEvent as ReactMouseEvent } from "react";
+
+// Click-the-backdrop-to-dismiss, done so a MOUSE DRAG can never dismiss the dialog (owner report).
+//
+// Every Cockpit overlay used to be written the same way: a backdrop with onClick={onClose}, and the
+// panel inside it stopping propagation so a click that lands on the panel is not treated as a click
+// outside. That guard is wrong, and it fails in the one case that matters most - selecting text.
+//
+// A browser fires `click` on the nearest COMMON ANCESTOR of where the button went down and where it
+// came up. Press inside the rename box, drag left to highlight the first word, release a few pixels
+// past the edge of the dialog, and the common ancestor is the BACKDROP - so the browser dispatches
+// the click straight at the backdrop. The panel is never on that event's path, its stopPropagation
+// never runs, and the dialog closes the instant the mouse button comes up, taking the typed text with
+// it. Selecting text with the mouse was simply impossible in any Cockpit dialog.
+//
+// So the dismissal does not ask "where did the click land" - it asks "where did the PRESS start":
+// only a press that began on the backdrop itself can dismiss. A drag that begins anywhere inside the
+// panel is a text selection, never a dismissal, no matter where it ends.
+//
+// The returned handlers go on the backdrop element. The panel inside no longer needs to stop
+// propagation at all: a click whose press started inside the panel is rejected by the press test, and
+// a click that merely BUBBLES from the panel is rejected because its target is not the backdrop.
+
+export interface BackdropDismissHandlers {
+  onMouseDown: (event: ReactMouseEvent) => void;
+  onClick: (event: ReactMouseEvent) => void;
+}
+
+/**
+ * Handlers for a modal backdrop that dismisses on an outside click.
+ *
+ * @param onDismiss What to run when the backdrop is genuinely clicked. Pass undefined to make the
+ *   backdrop non-dismissing for now (a dialog that is mid-save, or showing a result the person must
+ *   read); the handlers are still attached, they simply do nothing.
+ */
+export function useDismissOnBackdrop(onDismiss: (() => void) | undefined): BackdropDismissHandlers {
+  // Whether the CURRENT press started on the backdrop itself. A ref, not state: it must be readable
+  // by the click handler that follows the very same press, and it must never cause a re-render.
+  const pressedOnBackdrop = useRef(false);
+
+  const onMouseDown = useCallback((event: ReactMouseEvent) => {
+    pressedOnBackdrop.current = event.target === event.currentTarget;
+  }, []);
+
+  const onClick = useCallback(
+    (event: ReactMouseEvent) => {
+      const startedOnBackdrop = pressedOnBackdrop.current;
+      // Consume it either way, so a later keyboard-driven click (which has no preceding mousedown)
+      // can never inherit a stale "yes" from an earlier press.
+      pressedOnBackdrop.current = false;
+      if (!startedOnBackdrop) return;
+      // The press started on the backdrop AND the event is aimed at the backdrop, not bubbling up
+      // from something inside it.
+      if (event.target !== event.currentTarget) return;
+      onDismiss?.();
+    },
+    [onDismiss],
+  );
+
+  return { onMouseDown, onClick };
+}

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -22,7 +22,14 @@ import { getGatewaySettings } from "@devthrottle/client-core/settings/settingsCl
 import { classify, dotHex, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { useVisiblePolling } from "@devthrottle/client-core/polling/useVisiblePolling";
 import { clockLabel, relativeTime, repoBasename } from "../fleet/format";
-import { Button, ConfirmDialog, DataTable, PageHeader, type DataTableColumn } from "../components";
+import {
+  Button,
+  ConfirmDialog,
+  DataTable,
+  PageHeader,
+  useDismissOnBackdrop,
+  type DataTableColumn,
+} from "../components";
 import {
   absoluteUtc,
   actionShortLabel,
@@ -316,6 +323,12 @@ export function ScheduleView() {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [showForm, saving, showDirectorPicker, confirmDiscard, requestCloseForm]);
+
+  // Backdrop dismissal for the editor and the machine picker. Both close only on a press that STARTED
+  // on the backdrop, so selecting the instructions or a machine name with the mouse and releasing past
+  // the panel edge is a selection, never a dismissal (see useDismissOnBackdrop).
+  const dismissForm = useDismissOnBackdrop(requestCloseForm);
+  const dismissDirectorPicker = useDismissOnBackdrop(useCallback(() => setShowDirectorPicker(false), []));
 
   const save = useCallback(async () => {
     // The Create/Save button is disabled while invalid, but guard here too so no code path can POST
@@ -686,7 +699,7 @@ export function ScheduleView() {
       )}
 
       {showForm && (
-        <div className="sched-modal-backdrop" onClick={requestCloseForm}>
+        <div className="sched-modal-backdrop" {...dismissForm}>
           {/* The large two-tab editor (issue #1289): about 70 percent of the viewport, with a Settings
               tab for every field and an Instructions tab where the prompt editor fills the room. Save
               and Cancel sit in the shared footer, visible from either tab. */}
@@ -695,7 +708,6 @@ export function ScheduleView() {
             role="dialog"
             aria-modal="true"
             aria-label={form.editingId === null ? "New cron job" : "Edit cron job"}
-            onClick={(e) => e.stopPropagation()}
           >
             <div className="sched-modal-head sched-modal-head-tabbed">
               <span className="sched-modal-title">
@@ -925,8 +937,8 @@ export function ScheduleView() {
       )}
 
       {showDirectorPicker && (
-        <div className="sched-modal-backdrop dpicker-over" onClick={() => setShowDirectorPicker(false)}>
-          <div className="sched-modal dpicker-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="sched-modal-backdrop dpicker-over" {...dismissDirectorPicker}>
+          <div className="sched-modal dpicker-modal">
             <div className="sched-modal-head">Choose a machine</div>
             <div className="sched-modal-body">
               <input

--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@devthrottle/client-core/api/client";
 import { directorPort } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { durationLabel, useNow } from "@devthrottle/client-core/sessions/waiting";
+import { useDismissOnBackdrop } from "../components";
 
 // The desktop Cockpit "New session" dialog (issue #1023, QA sweep epic #967). The React Cockpit had
 // no way to start a session; this is the dedicated picker dialog the roster rail's "+ New session"
@@ -279,14 +280,18 @@ export function NewSessionDialog({ onClose, onCreated, initialDirectorId }: NewS
     [creating, selectedId, agents, selectedAgentType, permission.bypass, permissionKey, onCreated],
   );
 
+  // Backdrop dismissal that a mouse drag cannot trigger: highlighting the repository path with the
+  // mouse and releasing outside the panel must not throw the half-filled dialog away (see
+  // useDismissOnBackdrop).
+  const dismiss = useDismissOnBackdrop(onClose);
+
   return (
-    <div className="newsess-backdrop" onClick={onClose}>
+    <div className="newsess-backdrop" {...dismiss}>
       <div
         className="newsess-modal"
         role="dialog"
         aria-modal="true"
         aria-label="Start a new session"
-        onClick={(e) => e.stopPropagation()}
       >
         <div className="newsess-head">Start a new session</div>
 

--- a/apps/cockpit/src/sessions/SessionMenu.tsx
+++ b/apps/cockpit/src/sessions/SessionMenu.tsx
@@ -11,6 +11,7 @@ import {
 import { renameSession } from "@devthrottle/client-core/fleet/fleetClient";
 import { useSnoozeOptions } from "@devthrottle/client-core/settings/snoozeOptions";
 import { buildSnoozeMenu } from "@devthrottle/client-core/settings/snoozeMenu";
+import { useDismissOnBackdrop } from "../components";
 
 // The session menu (issue #1214): a three-dot control with Rename, Snooze / Unsnooze, Handover info,
 // and Close session. It is the SAME component on the session page and on every rail card. Every action
@@ -154,6 +155,11 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
     setError(null);
     setHandover(null);
   }, []);
+
+  // Dismissing by clicking the backdrop. It closes only on a press that STARTED on the backdrop, so
+  // highlighting the name in the rename box with the mouse and releasing past the edge of the dialog
+  // no longer throws the dialog away mid-edit (owner report) - see useDismissOnBackdrop.
+  const dismissDialog = useDismissOnBackdrop(closeDialog);
 
   const openRename = useCallback(() => {
     setOpen(false);
@@ -355,8 +361,8 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
       {error !== null && dialog === null && <span className="session-menu-error">{error}</span>}
 
       {dialog !== null && (
-        <div className="session-dialog-overlay" onClick={closeDialog}>
-          <div className="session-dialog" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
+        <div className="session-dialog-overlay" {...dismissDialog}>
+          <div className="session-dialog" role="dialog" aria-modal="true">
             {dialog === "rename" && (
               <>
                 <h3 className="session-dialog-title">Rename session</h3>

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -13,7 +13,7 @@ import {
 } from "@devthrottle/client-core/workflows/workflowsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { markdownToHtml } from "@devthrottle/client-core/history/historyMarkdown";
-import { Button, ConfirmDialog, ErrorBanner, LoadingState } from "../components";
+import { Button, ConfirmDialog, ErrorBanner, LoadingState, useDismissOnBackdrop } from "../components";
 
 // The Workflows REGISTER (register redesign, approved mockup direction A). Workflows are the rules
 // this fleet works by, and the page reads with that weight: a ledger, not cards. One row per
@@ -253,14 +253,18 @@ function WorkflowPreviewDialog({
     return () => ctrl.abort();
   }, [workflow.id, workflow.version]);
 
+  // Closes on a backdrop click, but never on a drag that started inside - reading a workflow means
+  // selecting its instructions with the mouse, which must not dismiss the preview (see
+  // useDismissOnBackdrop).
+  const dismiss = useDismissOnBackdrop(onClose);
+
   return (
-    <div className="wf-dialog-backdrop" role="presentation" onClick={onClose}>
+    <div className="wf-dialog-backdrop" role="presentation" {...dismiss}>
       <div
         className="wf-dialog wf-preview"
         role="dialog"
         aria-modal="true"
         aria-label={`Preview of ${workflow.name}`}
-        onClick={(e) => e.stopPropagation()}
       >
         <h2 className="wf-dialog-title">
           {workflow.name}
@@ -440,6 +444,13 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
     ? ""
     : `Author the '${name.trim()}' workflow (id ${createdId}). Pull it with: cc-devthrottle workflow pull ${createdId} --dir <a working directory> - write its instructions.md (the conduct agents will follow), fill workflow.json (steps, outcome criteria), then push and publish: cc-devthrottle workflow push ${createdId} --dir <the directory> && cc-devthrottle workflow publish ${createdId}`;
 
+  // The backdrop dismisses only while the form is idle: dismissing DURING the create leaves the
+  // draft half-born with its handoff prompt never shown, and dismissing the success state would
+  // lose the prompt. It also never dismisses on a drag that started inside the form - typing a name
+  // and then re-selecting part of it with the mouse must not throw the draft away (see
+  // useDismissOnBackdrop).
+  const dismiss = useDismissOnBackdrop(createdId === null && !busy ? onClose : undefined);
+
   const submit = async () => {
     setBusy(true);
     setError(null);
@@ -454,21 +465,13 @@ function AddWorkflowDialog({ onClose, onCreated }: { onClose: () => void; onCrea
     }
   };
 
-  // The backdrop dismisses only while the form is idle: dismissing DURING the create leaves the
-  // draft half-born with its handoff prompt never shown, and dismissing the success state would
-  // lose the prompt.
   return (
-    <div
-      className="wf-dialog-backdrop"
-      role="presentation"
-      onClick={createdId === null && !busy ? onClose : undefined}
-    >
+    <div className="wf-dialog-backdrop" role="presentation" {...dismiss}>
       <div
         className="wf-dialog"
         role="dialog"
         aria-modal="true"
         aria-label="Add workflow"
-        onClick={(e) => e.stopPropagation()}
       >
         {createdId === null ? (
           <>


### PR DESCRIPTION
## The report

Renaming a session from the Cockpit was impossible with the mouse. The rename dialog opened, you pressed inside the text box and dragged left to highlight the start of the name, and the dialog vanished the moment you let go of the button - typed text and all.

## Root cause

A browser fires `click` on the nearest **common ancestor** of where the button went down and where it came up. Press inside the box, release a few pixels past the edge of the panel, and that ancestor is the **backdrop** - so the browser dispatches the click straight at the backdrop, and the backdrop's `onClick={onClose}` runs. The panel's `stopPropagation` cannot help, because the event never goes near the panel.

Every Cockpit overlay was written that way, so selecting text with the mouse was impossible in all of them - this was never specific to rename.

## The fix

Dismissal now asks where the **press started**, not where the click landed: only a press that began on the backdrop itself can dismiss. A drag that begins inside the panel is a text selection, never a dismissal, wherever it ends.

One shared hook, `useDismissOnBackdrop`, replaces the pattern in all nine overlays:

- session menu dialogs (rename, close, handover)
- new-session dialog
- shared confirmation dialog
- file viewer
- data-table detail drawer
- cron editor and its machine picker
- workflow preview and add-workflow dialogs

The panels no longer stop propagation - a click that merely bubbles up from a panel is rejected because its target is not the backdrop. The two dialogs that deliberately refuse to dismiss in some states keep that behaviour: the confirmation stays put while its action is in flight, and Add workflow stays put while creating and while showing the handoff prompt.

## Proof

- Six tests on the hook, modelling the browser's real targeting: `mousedown` on the input, then the click dispatched **at the backdrop**.
- Revert-proof: removing the press test from the hook turns three of them red, including "keeps the dialog open when a drag starts inside it and ends on the backdrop".
- Whole Cockpit suite green: 194 tests, 22 files. Typecheck clean.
- Also verified in a real browser with trusted mouse events, not just jsdom: the same drag closes the old pattern and leaves the new one open, and a genuine backdrop click still dismisses.