### PR TITLE
Real microphone identity, platform classification, and the detailed Cockpit view (#2183)

### DIFF
--- a/packages/client-core/src/dictation/DictationDialog.tsx
+++ b/packages/client-core/src/dictation/DictationDialog.tsx
@@ -194,7 +194,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     let lossWarning: string | null = null;
     let nativeSamples = new Float32Array(0);
     let nativeSampleRate = 0;
-    const deviceLabel = recorderRef.current.deviceLabel;
+    const device = { label: recorderRef.current.deviceLabel, deviceId: recorderRef.current.deviceId };
     try {
       const captured = await recorderRef.current.stop();
       const transcoded = await blobToWav16kMono(captured);
@@ -222,7 +222,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     // Measure the microphone in the background. AFTER the transcode and BEFORE awaiting the
     // transcription, so it rides the gap while the upload is being prepared and never sits between
     // the user and their words. Fire-and-forget by contract - see qualityReport.ts.
-    reportDictationQuality(nativeSamples, nativeSampleRate, deviceLabel, "dictation-dialog");
+    reportDictationQuality(nativeSamples, nativeSampleRate, device, "dictation-dialog");
 
     try {
       const text = await transcribeUtterance(wav, health, undefined, (uploaded, total) => {
@@ -343,6 +343,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     }
     onSendAudio({
       deviceLabel: recorderRef.current.deviceLabel,
+      deviceId: recorderRef.current.deviceId,
       blob: captured,
       recordedMs: recorderRef.current.lastRecordedMs,
       prefixText: accumulatedRef.current,

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -97,6 +97,9 @@ export interface CapturedUtterance {
   /** The microphone's name, for per-device quality reporting. Optional: a caller that does not know
    *  it still delivers its words, it just cannot say which microphone recorded them. */
   deviceLabel?: string;
+  /** The microphone's stable identifier - the value quality measurements are grouped by. Optional
+   *  for the same reason as the label. */
+  deviceId?: string;
 }
 
 /** Callbacks so the host can react to the rare hard failure (durable storage unavailable). A normal send
@@ -174,7 +177,7 @@ export async function backgroundTranscribeAndSend(
     reportDictationQuality(
       transcoded.nativeSamples,
       transcoded.nativeSampleRate,
-      captured.deviceLabel ?? "",
+      { label: captured.deviceLabel ?? "", deviceId: captured.deviceId ?? "" },
       "dictation-send",
     );
   } catch (err) {

--- a/packages/client-core/src/dictation/deviceIdentity.test.ts
+++ b/packages/client-core/src/dictation/deviceIdentity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { resolveMicrophoneIdentity, type AudioDeviceInfo } from "./deviceIdentity";
+
+// The whole reason issue #2183 exists: a capture through the browser's default slot is labelled
+// literally "Default", so every microphone the user owns reports under one name and the per-device
+// comparison has nothing to compare. These tests pin the unwrapping of that slot - and the rule
+// that the stable deviceId, not the display label, is what comes back as the grouping key.
+
+function input(deviceId: string, label: string, groupId = ""): AudioDeviceInfo {
+  return { kind: "audioinput", deviceId, label, groupId };
+}
+
+const JABRA = input("id-jabra", "Headset (Jabra Evolve2 65)", "group-jabra");
+const REALTEK = input("id-realtek", "Microphone Array (Realtek)", "group-realtek");
+
+describe("resolveMicrophoneIdentity", () => {
+  it("returns the enumerated entry when the track already names a concrete device", () => {
+    const identity = resolveMicrophoneIdentity("Headset (Jabra Evolve2 65)", "id-jabra", [JABRA, REALTEK]);
+    expect(identity).toEqual({ label: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra" });
+  });
+
+  it("unwraps the Chromium default slot to the real hardware via the shared groupId", () => {
+    // Chromium: the track label and settings id are the virtual slot; the slot's enumerated entry
+    // carries the REAL device's groupId. The resolved identity must be the hardware, not the slot.
+    const slot = input("default", "Default - Headset (Jabra Evolve2 65)", "group-jabra");
+    const identity = resolveMicrophoneIdentity("Default", "default", [slot, JABRA, REALTEK]);
+    expect(identity).toEqual({ label: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra" });
+  });
+
+  it("unwraps the communications slot the same way", () => {
+    const slot = input("communications", "Communications - Microphone Array (Realtek)", "group-realtek");
+    const identity = resolveMicrophoneIdentity("Communications", "communications", [slot, JABRA, REALTEK]);
+    expect(identity).toEqual({ label: "Microphone Array (Realtek)", deviceId: "id-realtek" });
+  });
+
+  it("falls back to the slot label suffix when groupIds do not line up", () => {
+    // Some builds stamp the slot with its own groupId. The slot label still ends with the real
+    // device's name, and suffix matching is locale-independent (the "Default - " prefix is
+    // translated by the browser; the device name is not).
+    const slot = input("default", "Standardeinstellung - Headset (Jabra Evolve2 65)", "group-slot-own");
+    const identity = resolveMicrophoneIdentity("Default", "default", [slot, JABRA, REALTEK]);
+    expect(identity).toEqual({ label: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra" });
+  });
+
+  it("resolves to the only real input when the slot cannot be matched any other way", () => {
+    const slot = input("default", "Default", "group-slot-own");
+    const identity = resolveMicrophoneIdentity("Default", "default", [slot, JABRA]);
+    expect(identity).toEqual({ label: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra" });
+  });
+
+  it("reports the honest raw values when the slot genuinely cannot be unwrapped", () => {
+    // Two real inputs, no group match, no label suffix: inventing a name here would file
+    // measurements under the wrong microphone, which is worse than an undiscriminating one.
+    const slot = input("default", "Default", "group-slot-own");
+    const identity = resolveMicrophoneIdentity("Default", "default", [slot, JABRA, REALTEK]);
+    expect(identity).toEqual({ label: "Default", deviceId: "default" });
+  });
+
+  it("copes with an empty device list (labels withheld before permission)", () => {
+    expect(resolveMicrophoneIdentity("", "", [])).toEqual({ label: "", deviceId: "" });
+  });
+
+  it("keeps the track label when the concrete enumerated entry has its label withheld", () => {
+    const unnamed = input("id-x", "");
+    const identity = resolveMicrophoneIdentity("Some Mic", "id-x", [unnamed]);
+    expect(identity).toEqual({ label: "Some Mic", deviceId: "id-x" });
+  });
+
+  it("ignores outputs and cameras in the device list", () => {
+    const speaker: AudioDeviceInfo = { kind: "audiooutput", deviceId: "id-jabra", label: "Jabra Speakers", groupId: "group-jabra" };
+    const identity = resolveMicrophoneIdentity("Headset (Jabra Evolve2 65)", "id-jabra", [speaker, JABRA]);
+    expect(identity).toEqual({ label: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra" });
+  });
+
+  it("keeps the settings id when the id names no enumerated entry at all", () => {
+    const identity = resolveMicrophoneIdentity("Ghost Mic", "id-gone", [JABRA]);
+    expect(identity).toEqual({ label: "Ghost Mic", deviceId: "id-gone" });
+  });
+});

--- a/packages/client-core/src/dictation/deviceIdentity.ts
+++ b/packages/client-core/src/dictation/deviceIdentity.ts
@@ -1,0 +1,92 @@
+// Resolving WHICH microphone actually recorded a dictation (issue #2183).
+//
+// The track label alone is not enough. When the user has not chosen a specific input, the browser
+// opens the *default device slot* and labels the track literally "Default" (Chromium also has a
+// second virtual slot, "Communications", on Windows). Every microphone the user ever plugs in then
+// reports under the same name, and the per-device quality comparison - the whole point of recording
+// the name - has nothing to compare.
+//
+// The resolution below turns (track label, live track's deviceId, the enumerateDevices list) into
+// the real hardware behind the slot. It only works while a capture is live, because a browser
+// withholds device labels until microphone permission has been granted - which is exactly when the
+// recorder calls it.
+//
+// WHY THE ID IS STORED ALONGSIDE THE LABEL. The label is display metadata: a driver update or an
+// operating system language change renames it, and a grouping keyed on it silently splits one
+// microphone into two histories. The deviceId is stable per device per origin, so it is the value
+// measurements are GROUPED by; the label is only what a human reads.
+
+/** What the resolver returns: the display name and the stable grouping key. Either may be empty
+ *  when the browser genuinely does not say - an unnamed microphone still reports its measurements. */
+export interface MicrophoneIdentity {
+  label: string;
+  deviceId: string;
+}
+
+/** The slice of MediaDeviceInfo the resolver reads. A plain interface so tests need no browser. */
+export interface AudioDeviceInfo {
+  kind: string;
+  deviceId: string;
+  groupId: string;
+  label: string;
+}
+
+/** The virtual slot ids Chromium exposes. These are ALIASES for real hardware, never hardware
+ *  themselves, so neither may become a grouping key or a display name. */
+const VIRTUAL_SLOT_IDS = new Set(["default", "communications"]);
+
+/**
+ * Resolve the real microphone behind a live capture. Pure so it can be tested without a browser.
+ *
+ * @param trackLabel the live track's label ("Default", or a real name on browsers that give one)
+ * @param settingsDeviceId the live track's getSettings().deviceId - which enumerated input is in
+ *        use. Firefox and Safari report the concrete id here; Chromium reports the virtual slot id
+ *        when the default slot was opened, which is why the slot then has to be unwrapped.
+ * @param devices the enumerateDevices() list, taken while the capture is live
+ */
+export function resolveMicrophoneIdentity(
+  trackLabel: string,
+  settingsDeviceId: string,
+  devices: readonly AudioDeviceInfo[],
+): MicrophoneIdentity {
+  const inputs = devices.filter((d) => d.kind === "audioinput");
+  const fallback: MicrophoneIdentity = { label: trackLabel, deviceId: settingsDeviceId };
+
+  // The concrete case: the track already names a real enumerated input. Trust the enumerated entry
+  // over the track label - it is the same string on healthy browsers, and the entry is the one that
+  // carries the stable id.
+  if (settingsDeviceId !== "" && !VIRTUAL_SLOT_IDS.has(settingsDeviceId)) {
+    const entry = inputs.find((d) => d.deviceId === settingsDeviceId);
+    if (entry === undefined) return fallback;
+    return { label: entry.label !== "" ? entry.label : trackLabel, deviceId: entry.deviceId };
+  }
+
+  // The virtual-slot case. Find the slot's own entry to learn which hardware it aliases.
+  const slot = inputs.find((d) => VIRTUAL_SLOT_IDS.has(d.deviceId) && (settingsDeviceId === "" || d.deviceId === settingsDeviceId));
+  const slotLabel = slot?.label ?? trackLabel;
+  const real = inputs.filter((d) => !VIRTUAL_SLOT_IDS.has(d.deviceId));
+
+  // Primary: Chromium stamps the slot entry with the REAL device's groupId, so the group match is
+  // exact and survives every locale (the slot label's "Default - " prefix is translated; the
+  // groupId is not). When several real inputs share the group, the one whose label the slot label
+  // ends with is the aliased one.
+  if (slot !== undefined && slot.groupId !== "") {
+    const grouped = real.filter((d) => d.groupId === slot.groupId);
+    const match =
+      grouped.length === 1 ? grouped[0] : grouped.find((d) => d.label !== "" && slotLabel.endsWith(d.label));
+    if (match !== undefined) return { label: match.label !== "" ? match.label : trackLabel, deviceId: match.deviceId };
+  }
+
+  // Secondary: the slot label carries the real name as a suffix ("Default - USB Microphone").
+  // Matching by suffix rather than by stripping a prefix keeps this locale-independent too.
+  const bySuffix = real.find((d) => d.label !== "" && slotLabel !== "" && slotLabel.endsWith(d.label) && slotLabel !== d.label);
+  if (bySuffix !== undefined) return { label: bySuffix.label, deviceId: bySuffix.deviceId };
+
+  // Last resort: only one real input exists, so the slot can only be aliasing it.
+  if (real.length === 1 && real[0].label !== "") return { label: real[0].label, deviceId: real[0].deviceId };
+
+  // The slot could not be unwrapped (an empty device list, or labels withheld). Report what the
+  // track said - an honest "Default" beats an invented name - and keep whatever id there was so
+  // measurements at least group consistently on this machine.
+  return fallback;
+}

--- a/packages/client-core/src/dictation/platform.test.ts
+++ b/packages/client-core/src/dictation/platform.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { classifyPlatform } from "./platform";
+
+// The platform bucket rides on every quality sample so the report can say "your phone microphone
+// beats your Windows headset". The rule worth pinning: a device that cannot be determined is
+// "unknown", never a guessed bucket - a wrong bucket poisons the comparison silently, and the raw
+// evidence must always come along so a wrong bucket can be diagnosed rather than argued about.
+
+describe("classifyPlatform", () => {
+  it("classifies from Client-Hints when the browser has them", () => {
+    expect(classifyPlatform({ userAgentData: { platform: "Windows", mobile: false } }).platform).toBe("windows");
+    expect(classifyPlatform({ userAgentData: { platform: "macOS", mobile: false } }).platform).toBe("mac");
+    expect(classifyPlatform({ userAgentData: { platform: "Android", mobile: true } }).platform).toBe("mobile");
+  });
+
+  it("trusts the mobile flag over the platform string", () => {
+    // A Windows tablet PWA declaring itself mobile IS the phone/tablet surface for this report.
+    expect(classifyPlatform({ userAgentData: { platform: "Windows", mobile: true } }).platform).toBe("mobile");
+  });
+
+  it("classifies an unfamiliar Client-Hints platform as unknown rather than guessing", () => {
+    const result = classifyPlatform({ userAgentData: { platform: "Chrome OS", mobile: false } });
+    expect(result.platform).toBe("unknown");
+    expect(result.platformRaw).toContain("Chrome OS");
+  });
+
+  it("falls back to the user agent string on browsers without Client-Hints", () => {
+    expect(
+      classifyPlatform({
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15",
+        platform: "iPhone",
+      }).platform,
+    ).toBe("mobile");
+    expect(
+      classifyPlatform({
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+      }).platform,
+    ).toBe("mac");
+    expect(
+      classifyPlatform({
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko/20100101 Firefox/128.0",
+        platform: "Win32",
+      }).platform,
+    ).toBe("windows");
+  });
+
+  it("tells an iPad apart from a Mac by its touch screen", () => {
+    // iPadOS Safari reports a desktop Mac user agent; the multi-touch screen is the tell.
+    expect(
+      classifyPlatform({
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+      }).platform,
+    ).toBe("mobile");
+  });
+
+  it("reports unknown with the evidence when nothing identifies the platform", () => {
+    const result = classifyPlatform({ userAgent: "SomethingExotic/1.0", platform: "Haiku" });
+    expect(result.platform).toBe("unknown");
+    expect(result.platformRaw).toContain("SomethingExotic");
+  });
+
+  it("caps the raw evidence so it cannot become a place to park arbitrary text", () => {
+    const result = classifyPlatform({ userAgent: "x".repeat(5000) });
+    expect(result.platformRaw.length).toBeLessThanOrEqual(160);
+  });
+});

--- a/packages/client-core/src/dictation/platform.ts
+++ b/packages/client-core/src/dictation/platform.ts
@@ -1,0 +1,82 @@
+// Which KIND of machine a dictation was captured on (issue #2183): the report should be able to
+// say "your phone microphone beats your Windows headset", not list two names with no context.
+//
+// The buckets are deliberately few - mobile, mac, windows - because that is the comparison the
+// owner actually makes; anything else is "unknown" rather than a guessed bucket. The RAW evidence
+// travels alongside the bucket so a wrong classification can be diagnosed later without guessing,
+// and it is capped because it rides on every quality sample.
+
+/** The classification buckets. "unknown" means undeterminable, never "probably windows". */
+export type PlatformBucket = "mobile" | "mac" | "windows" | "unknown";
+
+export interface PlatformClassification {
+  platform: PlatformBucket;
+  /** The raw evidence the bucket was derived from, for diagnosing a wrong bucket later. */
+  platformRaw: string;
+}
+
+/** The slice of the navigator the classifier reads. A plain interface so tests need no browser. */
+export interface NavigatorHints {
+  /** navigator.userAgentData, when the browser has it (Chromium). */
+  userAgentData?: { platform?: string; mobile?: boolean };
+  userAgent?: string;
+  platform?: string;
+  /** navigator.maxTouchPoints - how iPadOS Safari is told apart from a real Mac. */
+  maxTouchPoints?: number;
+}
+
+const RAW_CAP = 160;
+
+function cap(value: string): string {
+  return value.length <= RAW_CAP ? value : value.slice(0, RAW_CAP);
+}
+
+/**
+ * Classify the platform from navigator hints. Pure so it can be tested without a browser.
+ *
+ * Client-Hints first (Chromium ships exact strings there and they need no permission), then the
+ * user agent string, in honesty order: mobile signals are checked before desktop ones because a
+ * phone's user agent CONTAINS desktop tokens ("like Mac OS X") and the reverse is never true.
+ */
+export function classifyPlatform(hints: NavigatorHints): PlatformClassification {
+  const uaData = hints.userAgentData;
+  if (uaData !== undefined && (uaData.platform !== undefined || uaData.mobile !== undefined)) {
+    const raw = cap(`uaData platform=${uaData.platform ?? ""} mobile=${uaData.mobile === true}`);
+    if (uaData.mobile === true) return { platform: "mobile", platformRaw: raw };
+    switch (uaData.platform) {
+      case "Android":
+      case "iOS":
+        return { platform: "mobile", platformRaw: raw };
+      case "macOS":
+        return { platform: "mac", platformRaw: raw };
+      case "Windows":
+        return { platform: "windows", platformRaw: raw };
+      default:
+        return { platform: "unknown", platformRaw: raw };
+    }
+  }
+
+  const ua = hints.userAgent ?? "";
+  const navPlatform = hints.platform ?? "";
+  const touch = hints.maxTouchPoints ?? 0;
+  const raw = cap(`ua=${ua} platform=${navPlatform} touch=${touch}`);
+
+  if (/iPhone|iPad|iPod|Android/i.test(ua)) return { platform: "mobile", platformRaw: raw };
+  // iPadOS Safari masquerades as a Mac; a "Mac" with a multi-touch screen is an iPad.
+  if (/Mac/i.test(navPlatform) && touch > 1) return { platform: "mobile", platformRaw: raw };
+  if (/Windows/i.test(ua) || /^Win/i.test(navPlatform)) return { platform: "windows", platformRaw: raw };
+  if (/Mac/i.test(ua) || /^Mac/i.test(navPlatform)) return { platform: "mac", platformRaw: raw };
+  return { platform: "unknown", platformRaw: raw };
+}
+
+/** Classify the platform this code is running on, from the real navigator. */
+export function currentPlatform(): PlatformClassification {
+  if (typeof navigator === "undefined") return { platform: "unknown", platformRaw: "no navigator" };
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string; mobile?: boolean } };
+  return classifyPlatform({
+    userAgentData: nav.userAgentData,
+    userAgent: nav.userAgent,
+    platform: nav.platform,
+    maxTouchPoints: nav.maxTouchPoints,
+  });
+}

--- a/packages/client-core/src/dictation/qualityReport.test.ts
+++ b/packages/client-core/src/dictation/qualityReport.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { measureDictationQuality } from "./qualityReport";
 
+const JABRA = { label: "Jabra Evolve2", deviceId: "id-jabra" };
+
 // The background measurement runs on EVERY dictation, so what it declines to report matters as much
 // as what it reports. Two clips that must never become data: one too short to measure honestly, and
 // one with no speech in it - a false start or a moment of silence. Recording either would drag a
@@ -33,10 +35,13 @@ function speech(seconds: number, level = 0.3): Float32Array {
 
 describe("measureDictationQuality", () => {
   it("measures an ordinary dictation and reports the device it came from", () => {
-    const sample = measureDictationQuality(speech(10), RATE, "Jabra Evolve2", "dictation-send");
+    const sample = measureDictationQuality(speech(10), RATE, JABRA, "dictation-send");
 
     expect(sample).not.toBeNull();
     expect(sample?.device).toBe("Jabra Evolve2");
+    expect(sample?.deviceId).toBe("id-jabra");
+    expect(["mobile", "mac", "windows", "unknown"]).toContain(sample?.platform);
+    expect(sample?.platformRaw).toBeTruthy();
     expect(sample?.source).toBe("dictation-send");
     expect(sample?.sampleRate).toBe(RATE);
     expect(sample?.rating).toBeTruthy();
@@ -45,26 +50,29 @@ describe("measureDictationQuality", () => {
   it("declines a clip too short to measure honestly", () => {
     // Under three seconds there are too few frames for a stable noise floor, and a shaky reading
     // reported as fact is worse than no reading.
-    expect(measureDictationQuality(speech(1.5), RATE, "Mic", "dictation-send")).toBeNull();
+    expect(measureDictationQuality(speech(1.5), RATE, JABRA, "dictation-send")).toBeNull();
   });
 
   it("declines a clip with no speech in it, rather than scoring silence as a bad microphone", () => {
-    expect(measureDictationQuality(new Float32Array(RATE * 10), RATE, "Mic", "dictation-send")).toBeNull();
+    expect(measureDictationQuality(new Float32Array(RATE * 10), RATE, JABRA, "dictation-send")).toBeNull();
   });
 
   it("sends no audio and no transcript - only measurements and the device name", () => {
-    const sample = measureDictationQuality(speech(10), RATE, "Mic", "dictation-send");
+    const sample = measureDictationQuality(speech(10), RATE, JABRA, "dictation-send");
     const keys = Object.keys(sample ?? {}).sort();
 
     expect(keys).toEqual(
       [
         "clippedFraction",
         "device",
+        "deviceId",
         "durationSeconds",
         "highBandRatioDb",
         "issues",
         "narrowband",
         "noiseFloorDb",
+        "platform",
+        "platformRaw",
         "rating",
         "sampleRate",
         "signalToNoiseDb",
@@ -77,7 +85,7 @@ describe("measureDictationQuality", () => {
   it("is JSON-safe even when a measurement is infinite", () => {
     // A digitally silent high band reads as -Infinity, which JSON.stringify turns into null and the
     // Gateway would then store as zero - a value that means "wideband", the opposite of the truth.
-    const sample = measureDictationQuality(speech(10), RATE, "Mic", "dictation-send");
+    const sample = measureDictationQuality(speech(10), RATE, JABRA, "dictation-send");
     const roundTripped = JSON.parse(JSON.stringify(sample)) as Record<string, unknown>;
 
     for (const [key, value] of Object.entries(roundTripped)) {
@@ -88,6 +96,6 @@ describe("measureDictationQuality", () => {
 
   it("copes with an unnamed microphone", () => {
     // A browser withholds the label until permission has been granted at least once.
-    expect(measureDictationQuality(speech(10), RATE, "", "dictation-send")?.device).toBe("");
+    expect(measureDictationQuality(speech(10), RATE, { label: "", deviceId: "" }, "dictation-send")?.device).toBe("");
   });
 });

--- a/packages/client-core/src/dictation/qualityReport.ts
+++ b/packages/client-core/src/dictation/qualityReport.ts
@@ -1,5 +1,6 @@
 import { authHeaders, gatewayFetch } from "../api/client";
 import { analyzeMicQuality, judgeMicQuality } from "./micQuality";
+import { currentPlatform } from "./platform";
 
 // Background microphone-quality reporting for ORDINARY dictation.
 //
@@ -20,8 +21,9 @@ import { analyzeMicQuality, judgeMicQuality } from "./micQuality";
 //    performed (wav.ts hands back the native-rate mono buffer), so the only new work is the analysis
 //    itself over a clip already in memory.
 //
-// WHAT IS SENT: measurements and the microphone's name. No audio, and no transcript. The clip itself
-// stays where it was; this is a handful of numbers per dictation.
+// WHAT IS SENT: measurements, the microphone's name and stable id, and which kind of machine
+// captured it (mobile / mac / windows). No audio, and no transcript. The clip itself stays where it
+// was; this is a handful of numbers per dictation.
 
 /** Below this there is not enough audio for a stable reading, and a shaky measurement reported as
  *  fact is worse than no measurement. Chosen from real dictation: the Gateway's own archive of 212
@@ -29,11 +31,25 @@ import { analyzeMicQuality, judgeMicQuality } from "./micQuality";
  *  while keeping the short-utterance case - which has never been measured - out of the data. */
 const MIN_REPORTABLE_SECONDS = 3;
 
+/** The microphone a clip was captured with. The label is what a human reads; the deviceId is the
+ *  stable value the Gateway GROUPS measurements by, so a renamed device keeps one history. Either
+ *  may be empty when the browser withholds it. */
+export interface DeviceIdentity {
+  label: string;
+  deviceId: string;
+}
+
 export interface DictationQualitySample {
   /** Which surface produced it, so a phone and a desktop can be told apart later. */
   source: string;
   /** The microphone's name as the operating system reports it. Empty when the browser withholds it. */
   device: string;
+  /** The stable per-origin identifier of that microphone - the grouping key. Empty when unknown. */
+  deviceId: string;
+  /** "mobile" | "mac" | "windows" | "unknown" - what kind of machine captured it. */
+  platform: string;
+  /** The raw evidence behind the platform bucket, so a wrong bucket can be diagnosed. */
+  platformRaw: string;
   durationSeconds: number;
   sampleRate: number;
   speechLevelDb: number;
@@ -60,7 +76,7 @@ export interface DictationQualitySample {
 export function measureDictationQuality(
   samples: Float32Array,
   sampleRate: number,
-  device: string,
+  device: DeviceIdentity,
   source: string,
 ): DictationQualitySample | null {
   if (samples.length / sampleRate < MIN_REPORTABLE_SECONDS) return null;
@@ -69,9 +85,13 @@ export function measureDictationQuality(
   if (!report.heardSpeech) return null;
 
   const verdict = judgeMicQuality(report);
+  const platform = currentPlatform();
   return {
     source,
-    device,
+    device: device.label,
+    deviceId: device.deviceId,
+    platform: platform.platform,
+    platformRaw: platform.platformRaw,
     durationSeconds: Math.round(report.durationSeconds * 10) / 10,
     sampleRate: report.sampleRate,
     speechLevelDb: Math.round(report.speechLevelDb * 10) / 10,
@@ -95,7 +115,7 @@ export function measureDictationQuality(
 export function reportDictationQuality(
   samples: Float32Array,
   sampleRate: number,
-  device: string,
+  device: DeviceIdentity,
   source: string,
 ): void {
   let sample: DictationQualitySample | null;

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -7,6 +7,8 @@
 // stream, which the dialog draws as the equalizer. This is display-only; it never touches the
 // captured audio.
 
+import { resolveMicrophoneIdentity } from "./deviceIdentity";
+
 // Pick a MediaRecorder container the browser actually supports, preferring Opus-in-WebM (what
 // every Chromium/Firefox phone produces). The captured blob is transcoded to WAV before upload,
 // so the exact container here only needs to be decodable by the browser's own decodeAudioData.
@@ -114,9 +116,13 @@ export class MicRecorder {
   private startedAt = 0;
   private recordedMs = 0;
 
-  // The microphone's name, read once at start() and deliberately NOT cleared when the stream is
-  // released - the quality report is assembled after stop(), by which time the track is gone.
+  // The microphone's name and stable id, read at start() and deliberately NOT cleared when the
+  // stream is released - the quality report is assembled after stop(), by which time the track is
+  // gone. The label starts as the raw track label and is UPGRADED in the background by
+  // resolveMicrophoneIdentity() once enumerateDevices() answers (issue #2183: a track captured via
+  // the default slot is labelled literally "Default", which cannot discriminate between devices).
   private capturedDeviceLabel = "";
+  private capturedDeviceId = "";
 
   /** True while a segment is actively capturing. */
   get isRecording(): boolean {
@@ -135,6 +141,17 @@ export class MicRecorder {
    */
   get deviceLabel(): string {
     return this.capturedDeviceLabel;
+  }
+
+  /**
+   * The stable identifier of the microphone this segment was captured with, from the live track's
+   * getSettings().deviceId resolved through enumerateDevices(). Empty when the browser withholds
+   * it. This - not the label - is what quality measurements are GROUPED by on the Gateway: a driver
+   * update or an operating system language change renames the label, and a grouping keyed on the
+   * name would silently split one microphone into two histories.
+   */
+  get deviceId(): string {
+    return this.capturedDeviceId;
   }
 
   /** Wall-clock milliseconds the most recently stopped segment was capturing. 0 before the first stop. */
@@ -157,7 +174,14 @@ export class MicRecorder {
     // Read the device name while the track is live. A browser reports an empty label until the user
     // has granted permission at least once, so this is best-effort by design - an unnamed microphone
     // still reports its measurements, it just cannot be told apart from another unnamed one.
-    this.capturedDeviceLabel = this.stream.getAudioTracks()[0]?.label ?? "";
+    const track = this.stream.getAudioTracks()[0];
+    this.capturedDeviceLabel = track?.label ?? "";
+    this.capturedDeviceId = "";
+    // Resolve the REAL device behind the label in the background (issue #2183: a default-slot
+    // capture is labelled literally "Default"). Fire-and-forget by the standing contract - this
+    // must never delay a word of the user's dictation. It settles in milliseconds while the
+    // shortest reportable clip is three seconds, so the quality report reads the resolved identity.
+    void this.resolveDeviceIdentity(track);
 
     // Live level meter on the captured stream (display only).
     const AudioCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
@@ -288,6 +312,26 @@ export class MicRecorder {
     this.recordedMs = this.startedAt > 0 ? performance.now() - this.startedAt : 0;
     this.releaseStream();
     return captured;
+  }
+
+  /**
+   * Resolve which real microphone is behind the live track, in the background. Never throws to the
+   * caller and never delays capture: a dictation that cannot name its device still delivers every
+   * word, it just reports under the raw track label like it always did.
+   */
+  private async resolveDeviceIdentity(track: MediaStreamTrack | undefined): Promise<void> {
+    try {
+      if (track === undefined || !navigator.mediaDevices?.enumerateDevices) return;
+      const settingsId = typeof track.getSettings === "function" ? (track.getSettings().deviceId ?? "") : "";
+      // The raw id is kept immediately so even an interrupted resolution groups consistently.
+      this.capturedDeviceId = settingsId;
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const identity = resolveMicrophoneIdentity(track.label ?? "", settingsId, devices);
+      if (identity.label !== "") this.capturedDeviceLabel = identity.label;
+      if (identity.deviceId !== "") this.capturedDeviceId = identity.deviceId;
+    } catch (err) {
+      console.warn(`[MicRecorder] device identity resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   /** Release the microphone and audio graph without producing a clip (Cancel / teardown). */

--- a/packages/client-core/src/transcription/MicrophoneQualityPanel.tsx
+++ b/packages/client-core/src/transcription/MicrophoneQualityPanel.tsx
@@ -1,21 +1,25 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-  getMicrophoneQuality,
-  type MicrophoneDeviceSummary,
-  type MicrophoneQualitySummary,
+  getMicrophoneQualityDetail,
+  type MicrophoneDeviceDetail,
+  type MicrophoneMeasurement,
+  type MicrophoneQualityDetail,
+  type MicrophoneTrendPoint,
 } from "./microphoneQualityClient";
 import "./microphoneQuality.css";
 
 // "How your microphones are doing" - shared by the Cockpit's Transcription Health page and the
-// Transcription settings tab on both surfaces.
+// Transcription settings tab on both surfaces. This is the DETAILED view (issue #2183): per
+// microphone the platform it lives on, every measurement with the targets beside it, and the
+// quality-over-time trend - the daily email stays a summary and points here.
 //
 // This is the BACKGROUND half of microphone quality: every dictation is measured automatically as it
 // is sent, so this screen answers the question the on-demand Test microphone check cannot - which of
-// your microphones is letting you down, across all the dictating you actually do. A headset that is
-// bad only some of the time shows up here and nowhere else.
+// your microphones, on which machine, is letting you down, and whether it is getting better or worse.
 //
-// Every verdict, every sentence of advice and the target figures are decided on the Gateway
-// (MicrophoneQualityFold) and rendered here verbatim. This component contains no thresholds.
+// Every verdict, every sentence of advice, the platform classification and the target figures are
+// decided on the Gateway (MicrophoneQualityFold) and rendered here verbatim. This component contains
+// no thresholds: it draws the numbers the Gateway sent next to the targets the Gateway sent.
 //
 // It moved out of apps/cockpit when Settings was unified across the two surfaces: the phone shows the
 // identical panel now, so it cannot live in one app's tree. Its styling came with it and is
@@ -30,14 +34,20 @@ function formatShare(share: number): string {
   return `${Math.round(share * 100)}%`;
 }
 
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
 export function MicrophoneQualityPanel() {
-  const [summary, setSummary] = useState<MicrophoneQualitySummary | null>(null);
+  const [detail, setDetail] = useState<MicrophoneQualityDetail | null>(null);
   const [loadError, setLoadError] = useState(false);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
       setLoadError(false);
-      setSummary(await getMicrophoneQuality(30, signal));
+      setDetail(await getMicrophoneQualityDetail(30, signal));
     } catch {
       if (signal?.aborted) return;
       setLoadError(true);
@@ -66,25 +76,25 @@ export function MicrophoneQualityPanel() {
             Retry
           </button>
         </div>
-      ) : summary === null ? (
+      ) : detail === null ? (
         <div className="mq-muted">Loading...</div>
       ) : (
         <>
-          <div className={`mq-banner mq-${summary.status}`}>{summary.headline}</div>
-          <p className="mq-lede">{summary.detail}</p>
+          <div className={`mq-banner mq-${detail.status}`}>{detail.headline}</div>
+          <p className="mq-lede">{detail.detail}</p>
 
-          {summary.devices.length > 0 && (
+          {detail.devices.length > 0 && (
             <div className="mq-devices">
-              {summary.devices.map((d) => (
-                <DeviceCard key={d.device} device={d} />
+              {detail.devices.map((d) => (
+                <DeviceCard key={d.summary.deviceId !== "" ? d.summary.deviceId : d.summary.device} device={d} />
               ))}
             </div>
           )}
 
-          {summary.totalSamples > 0 && (
+          {detail.totalSamples > 0 && (
             <p className="mq-muted">
-              Based on {summary.totalSamples} measured{" "}
-              {summary.totalSamples === 1 ? "dictation" : "dictations"} over the last 30 days.
+              Based on {detail.totalSamples} measured{" "}
+              {detail.totalSamples === 1 ? "dictation" : "dictations"} over the last 30 days.
             </p>
           )}
         </>
@@ -93,40 +103,149 @@ export function MicrophoneQualityPanel() {
   );
 }
 
-function DeviceCard({ device }: { device: MicrophoneDeviceSummary }) {
+function DeviceCard({ device }: { device: MicrophoneDeviceDetail }) {
+  const s = device.summary;
   return (
-    <div className={`mq-device mq-device-${device.status}`}>
+    <div className={`mq-device mq-device-${s.status}`}>
       <div className="mq-device-head">
-        <span className="mq-device-name">{device.device}</span>
+        <span className="mq-device-name">{s.device}</span>
+        {/* The platform is folded on the Gateway; an unknown platform arrives as an empty label and
+            renders as nothing rather than a guess. */}
+        {s.platformLabel !== "" && <span className="mq-device-platform">{s.platformLabel}</span>}
         <span className="mq-device-count">
-          {device.samples} {device.samples === 1 ? "dictation" : "dictations"}
+          {s.samples} {s.samples === 1 ? "dictation" : "dictations"}
         </span>
       </div>
-      <p className="mq-device-advice">{device.advice}</p>
+      <p className="mq-device-advice">{s.advice}</p>
       <dl className="mq-measures">
         <div>
           <dt>Your voice</dt>
-          <dd>{formatDb(device.medianSpeechLevelDb)}</dd>
+          <dd>{formatDb(s.medianSpeechLevelDb)}</dd>
           {/* The target sits beside the reading rather than in a legend, so the comparison needs no
               second look and no knowledge of what a good number is. */}
-          <span className="mq-target">good is about {formatDb(device.targetSpeechLevelDb)}</span>
+          <span className="mq-target">good is about {formatDb(s.targetSpeechLevelDb)}</span>
         </div>
         <div>
           <dt>Voice above the room</dt>
-          <dd>{formatDb(device.medianSignalToNoiseDb)}</dd>
-          <span className="mq-target">good is {formatDb(device.targetSignalToNoiseDb)} or more</span>
+          <dd>{formatDb(s.medianSignalToNoiseDb)}</dd>
+          <span className="mq-target">good is {formatDb(s.targetSignalToNoiseDb)} or more</span>
         </div>
         <div>
           <dt>Telephone quality</dt>
-          <dd>{formatShare(device.narrowbandShare)}</dd>
+          <dd>{formatShare(s.narrowbandShare)}</dd>
           <span className="mq-target">of dictations</span>
         </div>
         <div>
           <dt>Distorting</dt>
-          <dd>{formatShare(device.clippingShare)}</dd>
+          <dd>{formatShare(s.clippingShare)}</dd>
           <span className="mq-target">of dictations</span>
         </div>
       </dl>
+      <TrendChart trend={device.trend} target={s.targetSignalToNoiseDb} />
+      <MeasurementList measurements={device.measurements} total={device.measurementsTotal} />
+    </div>
+  );
+}
+
+// The quality-over-time chart: the daily median of "voice above the room", drawn against the
+// Gateway's target line. One glance answers "is this microphone getting better or worse". Pure
+// layout: the values and the target both arrive from the Gateway.
+function TrendChart({ trend, target }: { trend: MicrophoneTrendPoint[]; target: number }) {
+  // A trend needs at least two days; a single day is already told by the numbers above.
+  if (trend.length < 2) return null;
+
+  const width = 260;
+  const height = 64;
+  const pad = 4;
+  const values = trend.map((p) => p.medianSignalToNoiseDb);
+  const lo = Math.min(...values, target);
+  const hi = Math.max(...values, target);
+  const span = hi - lo || 1;
+  const x = (i: number) => pad + (i * (width - 2 * pad)) / (trend.length - 1);
+  const y = (v: number) => height - pad - ((v - lo) * (height - 2 * pad)) / span;
+  const line = trend
+    .map((p, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(p.medianSignalToNoiseDb).toFixed(1)}`)
+    .join(" ");
+
+  const first = trend[0];
+  const last = trend[trend.length - 1];
+  return (
+    <div className="mq-trend">
+      <div className="mq-trend-title">Voice above the room, day by day</div>
+      <svg
+        className="mq-trend-chart"
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Daily median of voice above the room, from ${formatDb(first.medianSignalToNoiseDb)} on ${first.date} to ${formatDb(last.medianSignalToNoiseDb)} on ${last.date}. Good is ${formatDb(target)} or more.`}
+      >
+        <line
+          className="mq-trend-target"
+          x1={pad}
+          x2={width - pad}
+          y1={y(target)}
+          y2={y(target)}
+          strokeDasharray="4 3"
+        />
+        <path className="mq-trend-line" d={line} fill="none" />
+      </svg>
+      <div className="mq-trend-legend">
+        <span>{first.date}</span>
+        <span className="mq-target">dashed line is the {formatDb(target)} target</span>
+        <span>{last.date}</span>
+      </div>
+    </div>
+  );
+}
+
+// Every measurement behind the verdict, newest first, folded open on demand - the evidence table for
+// anyone who wants to see exactly which dictation measured how.
+function MeasurementList({ measurements, total }: { measurements: MicrophoneMeasurement[]; total: number }) {
+  const [open, setOpen] = useState(false);
+  if (measurements.length === 0) return null;
+  return (
+    <div className="mq-history">
+      <button type="button" className="mq-history-toggle" onClick={() => setOpen((v) => !v)}>
+        {open
+          ? "Hide the measurements"
+          : `Show ${measurements.length === 1 ? "the measurement" : `all ${measurements.length} measurements`}`}
+      </button>
+      {open && (
+        <>
+          <div className="mq-history-scroll">
+            <table className="mq-history-table">
+              <thead>
+                <tr>
+                  <th>When</th>
+                  <th>Length</th>
+                  <th>Voice</th>
+                  <th>Above room</th>
+                  <th>Distorted</th>
+                  <th>Verdict</th>
+                </tr>
+              </thead>
+              <tbody>
+                {measurements.map((m) => (
+                  <tr key={`${m.timestampUtc}-${m.source}`}>
+                    <td>{formatWhen(m.timestampUtc)}</td>
+                    <td>{Math.round(m.durationSeconds)} s</td>
+                    <td>{formatDb(m.speechLevelDb)}</td>
+                    <td>{formatDb(m.signalToNoiseDb)}</td>
+                    <td>{formatShare(m.clippedFraction)}</td>
+                    {/* The rating and its issue list are the Gateway's words, printed as sent. */}
+                    <td>{m.issues !== "" ? `${m.rating} (${m.issues})` : m.rating}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {total > measurements.length && (
+            <p className="mq-muted">
+              Showing the newest {measurements.length} of {total} measurements in the window.
+            </p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/client-core/src/transcription/microphoneQuality.css
+++ b/packages/client-core/src/transcription/microphoneQuality.css
@@ -141,3 +141,95 @@
   color: var(--text-dim);
   margin-top: 2px;
 }
+
+/* The platform chip beside the device name ("Phone or tablet", "Mac", "Windows"). The Gateway sends
+   an empty label for an unknown platform and the chip is simply not rendered. */
+.mq-device-platform {
+  font-size: 11px;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+
+/* ===== Quality over time (per device) ===== */
+.mq-trend {
+  margin-top: 12px;
+}
+.mq-trend-title {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.mq-trend-chart {
+  display: block;
+  width: 100%;
+  height: 64px;
+  background: var(--code-bg, var(--surface-2));
+  border-radius: 6px;
+}
+.mq-trend-line {
+  stroke: var(--accent, #4a9eda);
+  stroke-width: 2;
+}
+.mq-trend-target {
+  stroke: var(--text-dim);
+  stroke-width: 1;
+}
+.mq-trend-legend {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+.mq-trend-legend .mq-target {
+  display: inline;
+  margin-top: 0;
+}
+
+/* ===== The per-measurement evidence table, folded open on demand ===== */
+.mq-history {
+  margin-top: 10px;
+}
+.mq-history-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.mq-history-toggle:hover {
+  color: var(--text);
+}
+/* The table can be wider than the card on a phone; it scrolls inside its own container rather than
+   pushing the page sideways. */
+.mq-history-scroll {
+  overflow-x: auto;
+  margin-top: 8px;
+}
+.mq-history-table {
+  min-width: 460px;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.mq-history-table th,
+.mq-history-table td {
+  text-align: left;
+  padding: 4px 10px 4px 0;
+  border-bottom: 1px solid var(--border);
+}
+.mq-history-table th {
+  font-weight: 600;
+  color: var(--text-dim);
+}
+.mq-history-table td {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/packages/client-core/src/transcription/microphoneQualityClient.ts
+++ b/packages/client-core/src/transcription/microphoneQualityClient.ts
@@ -10,6 +10,13 @@ import { authHeaders, gatewayFetch, GatewayError } from "../api/client";
 
 export interface MicrophoneDeviceSummary {
   device: string;
+  /** The stable identifier the Gateway grouped this device's measurements by. Empty when unknown. */
+  deviceId: string;
+  /** "mobile" | "mac" | "windows" | "unknown" - folded on the Gateway. */
+  platform: string;
+  /** The finished display string for the platform. Empty when unknown, so the screen renders
+   *  nothing rather than a guess. */
+  platformLabel: string;
   samples: number;
   /** "good" | "learning" | "bad". Drives colour only - the words come from `advice`. */
   status: string;
@@ -33,6 +40,55 @@ export interface MicrophoneQualitySummary {
   devices: MicrophoneDeviceSummary[];
 }
 
+/** One day of one device's dictation, folded to medians and shares on the Gateway. */
+export interface MicrophoneTrendPoint {
+  /** The calendar day, UTC, as yyyy-MM-dd. */
+  date: string;
+  samples: number;
+  medianSpeechLevelDb: number;
+  medianSignalToNoiseDb: number;
+  narrowbandShare: number;
+  clippingShare: number;
+}
+
+/** One dictation's measurement - how the audio sounded, never what was said. */
+export interface MicrophoneMeasurement {
+  timestampUtc: string;
+  source: string;
+  durationSeconds: number;
+  sampleRate: number;
+  speechLevelDb: number;
+  noiseFloorDb: number;
+  signalToNoiseDb: number;
+  clippedFraction: number;
+  narrowband: boolean;
+  rating: string;
+  issues: string;
+}
+
+/** One microphone in full: the same folded verdict as the summary, plus its history. */
+export interface MicrophoneDeviceDetail {
+  summary: MicrophoneDeviceSummary;
+  /** The raw evidence behind the platform bucket, for diagnosing a wrong bucket. */
+  platformRaw: string;
+  /** One point per calendar day with data, oldest first - the quality-over-time series. */
+  trend: MicrophoneTrendPoint[];
+  /** How many measurements the window really holds; when it exceeds measurements.length the list
+   *  was capped at the newest ones and the screen must say so. */
+  measurementsTotal: number;
+  /** Individual measurements, newest first, capped by the Gateway. */
+  measurements: MicrophoneMeasurement[];
+}
+
+export interface MicrophoneQualityDetail {
+  totalSamples: number;
+  /** "empty" | "learning" | "good" | "bad" - the same verdict the summary carries. */
+  status: string;
+  headline: string;
+  detail: string;
+  devices: MicrophoneDeviceDetail[];
+}
+
 export async function getMicrophoneQuality(days?: number, signal?: AbortSignal): Promise<MicrophoneQualitySummary> {
   const query = days === undefined ? "" : `?days=${days}`;
   const res = await gatewayFetch(`/voice-quality/summary${query}`, { headers: { ...authHeaders() }, signal });
@@ -41,6 +97,18 @@ export async function getMicrophoneQuality(days?: number, signal?: AbortSignal):
     throw new GatewayError(res.status, body.error ?? `Could not read microphone quality: ${res.status}`);
   }
   return (await res.json()) as MicrophoneQualitySummary;
+}
+
+/** The detailed per-device picture (GET /voice-quality/detail): the summary's verdicts plus each
+ *  device's daily quality-over-time series and the individual measurements behind it. */
+export async function getMicrophoneQualityDetail(days?: number, signal?: AbortSignal): Promise<MicrophoneQualityDetail> {
+  const query = days === undefined ? "" : `?days=${days}`;
+  const res = await gatewayFetch(`/voice-quality/detail${query}`, { headers: { ...authHeaders() }, signal });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new GatewayError(res.status, body.error ?? `Could not read microphone detail: ${res.status}`);
+  }
+  return (await res.json()) as MicrophoneQualityDetail;
 }
 
 /** Forget every measurement for this account. Returns how many daily files were removed. */

--- a/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/MorningReportDtos.cs
@@ -73,6 +73,11 @@ public sealed class MorningMicrophonesDto
     /// reads.</summary>
     public string? Advice { get; set; }
 
+    /// <summary>A prewritten sentence pointing the reader at the Cockpit's Transcription Health page
+    /// for the per-measurement history and the quality-over-time trend. The email stays a summary by
+    /// design; this is the door to the detail. The sender prints it verbatim.</summary>
+    public string DetailHint { get; set; } = "";
+
     /// <summary>The devices, best first. Never empty when this section is present.</summary>
     public List<MorningMicrophoneDto> Devices { get; set; } = new();
 }
@@ -82,6 +87,13 @@ public sealed class MorningMicrophoneDto
 {
     /// <summary>The name the operating system gave it, or "Unnamed microphone".</summary>
     public string Device { get; set; } = "";
+
+    /// <summary>What kind of machine it lives on: "mobile", "mac", "windows" or "unknown".</summary>
+    public string Platform { get; set; } = "unknown";
+
+    /// <summary>The finished display string for the platform ("Phone or tablet", "Mac", "Windows").
+    /// Empty when unknown, so the email renders nothing rather than a guess.</summary>
+    public string PlatformLabel { get; set; } = "";
 
     /// <summary>How many dictations this verdict rests on.</summary>
     public int Samples { get; set; }

--- a/src/CcDirector.Gateway.Tests/MicrophoneQualityFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/MicrophoneQualityFoldTests.cs
@@ -21,11 +21,15 @@ public sealed class MicrophoneQualityFoldTests
         double clipped = 0,
         double speechDb = -20,
         double snrDb = 45,
-        int minutesAgo = 0)
+        int minutesAgo = 0,
+        string deviceId = "",
+        string platform = "")
         => new()
         {
             TimestampUtc = DateTime.UtcNow.AddMinutes(-minutesAgo),
             Device = device,
+            DeviceId = deviceId,
+            Platform = platform,
             Source = "dictation-send",
             DurationSeconds = 20,
             SampleRate = 48000,
@@ -170,5 +174,173 @@ public sealed class MicrophoneQualityFoldTests
         var device = Assert.Single(MicrophoneQualityFold.Summarize(records).Devices);
 
         Assert.Equal(-20, device.MedianSpeechLevelDb);
+    }
+
+    // ---- device identity: the grouping key is the ID, the name is display metadata (#2183) ----
+
+    [Fact]
+    public void ARenamedDeviceKeepsOneHistory_BecauseTheIdIsTheGroupingKey()
+    {
+        // A driver update or an operating system language change renames the device. Grouped by
+        // name, that would silently split one microphone into two histories - the exact failure
+        // the deviceId exists to prevent.
+        var records = Many(6, i => Sample(device: "Mikrofonarray (Realtek)", deviceId: "id-1", minutesAgo: i))
+            .Concat(Many(6, i => Sample(device: "Microphone Array (Realtek)", deviceId: "id-1", minutesAgo: 100 + i)))
+            .ToList();
+
+        var device = Assert.Single(MicrophoneQualityFold.Summarize(records).Devices);
+        Assert.Equal(12, device.Samples);
+        // The newest name is the one the operating system currently uses.
+        Assert.Equal("Mikrofonarray (Realtek)", device.Device);
+        Assert.Equal("id-1", device.DeviceId);
+    }
+
+    [Fact]
+    public void TwoDevicesSharingANameAreStillTwoRows_WhenTheirIdsDiffer()
+    {
+        // Two identical USB microphones report the same label; only the id can tell them apart.
+        var records = Many(6, i => Sample(device: "USB Microphone", deviceId: "id-left", minutesAgo: i))
+            .Concat(Many(6, i => Sample(device: "USB Microphone", deviceId: "id-right", narrowband: true, minutesAgo: i)))
+            .ToList();
+
+        var devices = MicrophoneQualityFold.Summarize(records).Devices;
+        Assert.Equal(2, devices.Count);
+        Assert.Equal("good", devices.Single(d => d.DeviceId == "id-left").Status);
+        Assert.Equal("bad", devices.Single(d => d.DeviceId == "id-right").Status);
+    }
+
+    [Fact]
+    public void LegacyRecordsWithoutAnIdJoinTheMatchingIdGroup_SoShippingTheIdResetsNoHistory()
+    {
+        // Records written before the id existed carry only the name. When exactly one id-group
+        // wears that name, they belong to it - otherwise every device restarts at "learning" the
+        // day the id ships.
+        var records = Many(4, i => Sample(device: "Desk Mic", minutesAgo: 500 + i))
+            .Concat(Many(3, i => Sample(device: "Desk Mic", deviceId: "id-desk", minutesAgo: i)))
+            .ToList();
+
+        var device = Assert.Single(MicrophoneQualityFold.Summarize(records).Devices);
+        Assert.Equal(7, device.Samples);
+        Assert.Equal("id-desk", device.DeviceId);
+        // Seven measurements clear the verdict bar; a split would have left 4 + 3, both "learning".
+        Assert.Equal("good", device.Status);
+    }
+
+    [Fact]
+    public void LegacyRecordsStayTheirOwnRowWhenTwoIdGroupsShareTheName()
+    {
+        // Ambiguous adoption would file measurements under the WRONG microphone, which is worse
+        // than an extra row that ages out with the retention window.
+        var records = Many(2, i => Sample(device: "USB Microphone", minutesAgo: 500 + i))
+            .Concat(Many(3, i => Sample(device: "USB Microphone", deviceId: "id-a", minutesAgo: i)))
+            .Concat(Many(3, i => Sample(device: "USB Microphone", deviceId: "id-b", minutesAgo: i)))
+            .ToList();
+
+        Assert.Equal(3, MicrophoneQualityFold.Summarize(records).Devices.Count);
+    }
+
+    // ---- platform classification ----
+
+    [Fact]
+    public void EachDeviceCarriesItsPlatform_ReadyToRender()
+    {
+        var records = Many(6, i => Sample(device: "Phone Mic", deviceId: "id-p", platform: "mobile", minutesAgo: i))
+            .Concat(Many(6, i => Sample(device: "Desk Mic", deviceId: "id-d", platform: "windows", minutesAgo: i)))
+            .ToList();
+
+        var devices = MicrophoneQualityFold.Summarize(records).Devices;
+        var phone = devices.Single(d => d.DeviceId == "id-p");
+        Assert.Equal("mobile", phone.Platform);
+        Assert.Equal("Phone or tablet", phone.PlatformLabel);
+        var desk = devices.Single(d => d.DeviceId == "id-d");
+        Assert.Equal("windows", desk.Platform);
+        Assert.Equal("Windows", desk.PlatformLabel);
+    }
+
+    [Fact]
+    public void AnUnrecognisedPlatformReadsAsUnknown_NeverAsAGuessedBucket()
+    {
+        var bogus = Assert.Single(MicrophoneQualityFold.Summarize(
+            Many(6, i => Sample(deviceId: "id-x", platform: "amiga", minutesAgo: i))).Devices);
+        Assert.Equal("unknown", bogus.Platform);
+        Assert.Equal("", bogus.PlatformLabel);
+
+        var legacy = Assert.Single(MicrophoneQualityFold.Summarize(
+            Many(6, i => Sample(deviceId: "id-y", minutesAgo: i))).Devices);
+        Assert.Equal("unknown", legacy.Platform);
+    }
+
+    // ---- the detail view: measurements + quality over time ----
+
+    [Fact]
+    public void TheDetailAgreesWithTheSummary_TheyShareEveryFold()
+    {
+        var records = Many(10, i => Sample(deviceId: "id-1", minutesAgo: i))
+            .Concat(Many(10, i => Sample(device: "Bad Headset", deviceId: "id-2", narrowband: true, minutesAgo: i)))
+            .ToList();
+
+        var summary = MicrophoneQualityFold.Summarize(records);
+        var detail = MicrophoneQualityFold.Detail(records);
+
+        Assert.Equal(summary.Status, detail.Status);
+        Assert.Equal(summary.Headline, detail.Headline);
+        Assert.Equal(summary.TotalSamples, detail.TotalSamples);
+        Assert.Equal(summary.Devices.Select(d => d.DeviceId), detail.Devices.Select(d => d.Summary.DeviceId));
+    }
+
+    [Fact]
+    public void TheDetailCarriesEveryMeasurementNewestFirst_AndOnePointPerDayOldestFirst()
+    {
+        // Three dictations yesterday, two today - the measurement list is the evidence, the daily
+        // points are the trend a chart draws left to right.
+        var records = Many(3, i => Sample(deviceId: "id-1", snrDb: 30, minutesAgo: 1500 + i))
+            .Concat(Many(2, i => Sample(deviceId: "id-1", snrDb: 40, minutesAgo: i)))
+            .ToList();
+
+        var device = Assert.Single(MicrophoneQualityFold.Detail(records).Devices);
+
+        Assert.Equal(5, device.MeasurementsTotal);
+        Assert.Equal(5, device.Measurements.Count);
+        Assert.True(device.Measurements.First().TimestampUtc >= device.Measurements.Last().TimestampUtc);
+
+        Assert.Equal(2, device.Trend.Count);
+        Assert.True(string.CompareOrdinal(device.Trend[0].Date, device.Trend[1].Date) < 0);
+        Assert.Equal(3, device.Trend[0].Samples);
+        Assert.Equal(30, device.Trend[0].MedianSignalToNoiseDb);
+        Assert.Equal(40, device.Trend[1].MedianSignalToNoiseDb);
+    }
+
+    [Fact]
+    public void TheMeasurementListIsCappedLoudly_TheTotalStillTellsTheTruth()
+    {
+        var records = Many(MicrophoneQualityFold.MaxDetailMeasurements + 25,
+            i => Sample(deviceId: "id-1", minutesAgo: i));
+
+        var device = Assert.Single(MicrophoneQualityFold.Detail(records).Devices);
+
+        Assert.Equal(MicrophoneQualityFold.MaxDetailMeasurements, device.Measurements.Count);
+        Assert.Equal(MicrophoneQualityFold.MaxDetailMeasurements + 25, device.MeasurementsTotal);
+    }
+
+    [Fact]
+    public void TwoMicrophonesOnTwoPlatformsAreTwoRows_NamedAndClassified()
+    {
+        // The acceptance line of issue #2183: two physical microphones on two platforms produce two
+        // rows, correctly named and correctly classified - never one averaged "Default" row.
+        var records = Many(8, i => Sample(device: "iPhone Microphone", deviceId: "id-phone", platform: "mobile", minutesAgo: i))
+            .Concat(Many(8, i => Sample(device: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra", platform: "windows", narrowband: true, minutesAgo: i)))
+            .ToList();
+
+        var detail = MicrophoneQualityFold.Detail(records);
+
+        Assert.Equal(2, detail.Devices.Count);
+        var phone = detail.Devices.Single(d => d.Summary.DeviceId == "id-phone");
+        Assert.Equal("iPhone Microphone", phone.Summary.Device);
+        Assert.Equal("mobile", phone.Summary.Platform);
+        Assert.Equal("good", phone.Summary.Status);
+        var jabra = detail.Devices.Single(d => d.Summary.DeviceId == "id-jabra");
+        Assert.Equal("Headset (Jabra Evolve2 65)", jabra.Summary.Device);
+        Assert.Equal("windows", jabra.Summary.Platform);
+        Assert.Equal("bad", jabra.Summary.Status);
     }
 }

--- a/src/CcDirector.Gateway.Tests/MorningReportMicrophonesTests.cs
+++ b/src/CcDirector.Gateway.Tests/MorningReportMicrophonesTests.cs
@@ -49,7 +49,7 @@ public sealed class MorningReportMicrophonesTests : IDisposable
                microphoneQuality: withMicrophones ? Logs() : null);
 
     private void Seed(TenantId tenant, string device, int count, bool narrowband = false, double clipped = 0,
-        double speechDb = -20, double snrDb = 45, int daysAgo = 1)
+        double speechDb = -20, double snrDb = 45, int daysAgo = 1, string deviceId = "", string platform = "")
     {
         var log = Logs()(tenant);
         for (var i = 0; i < count; i++)
@@ -58,6 +58,8 @@ public sealed class MorningReportMicrophonesTests : IDisposable
             {
                 TimestampUtc = Now.AddDays(-daysAgo),
                 Device = device,
+                DeviceId = deviceId,
+                Platform = platform,
                 Source = "dictation-send",
                 DurationSeconds = 20,
                 SampleRate = 48000,
@@ -195,5 +197,49 @@ public sealed class MorningReportMicrophonesTests : IDisposable
         Seed(Alice, "Ancient Mic", 20, daysAgo: 60);
 
         Assert.Null(Builder().Build("alice@example.com", Alice, Window()).Microphones);
+    }
+
+    [Fact]
+    public void TheBestAndWorstAreNamedWithTheirPlatform_SoTheComparisonHasContext()
+    {
+        // "Your phone microphone beats your Windows headset" is the sentence the owner asked for;
+        // two bare names with no platform cannot say it.
+        Seed(Alice, "iPhone Microphone", 20, deviceId: "id-phone", platform: "mobile");
+        Seed(Alice, "Bluetooth Headset", 20, deviceId: "id-headset", platform: "windows", narrowband: true);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Contains("iPhone Microphone (Phone or tablet)", mics!.Headline);
+        Assert.Contains("Bluetooth Headset (Windows)", mics.Headline);
+        Assert.Equal("mobile", mics.Devices[0].Platform);
+        Assert.Equal("Phone or tablet", mics.Devices[0].PlatformLabel);
+        Assert.Equal("windows", mics.Devices[^1].Platform);
+    }
+
+    [Fact]
+    public void AnUnknownPlatformAddsNothingToTheSentence()
+    {
+        // Legacy measurements carry no platform. "(unknown)" next to a working microphone is noise.
+        Seed(Alice, "Good Mic", 20);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Contains("Good Mic is doing fine.", mics!.Headline);
+        Assert.DoesNotContain("(", mics.Headline);
+        Assert.Equal("unknown", Assert.Single(mics.Devices).Platform);
+        Assert.Equal("", Assert.Single(mics.Devices).PlatformLabel);
+    }
+
+    [Fact]
+    public void TheEmailStaysASummary_AndPointsTheReaderAtTheCockpitForTheDetail()
+    {
+        Seed(Alice, "Good Mic", 20);
+
+        var mics = Builder().Build("alice@example.com", Alice, Window()).Microphones;
+
+        Assert.NotNull(mics);
+        Assert.Contains("Transcription Health", mics!.DetailHint);
     }
 }

--- a/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
@@ -53,11 +53,19 @@ public sealed class VoiceQualityEndpointTests : IDisposable
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, log);
     }
 
-    private static object Sample(string device = "Test Mic", bool narrowband = false, double clipped = 0)
+    private static object Sample(
+        string device = "Test Mic",
+        bool narrowband = false,
+        double clipped = 0,
+        string deviceId = "",
+        string platform = "")
         => new
         {
             source = "dictation-send",
             device,
+            deviceId,
+            platform,
+            platformRaw = platform == "" ? "" : $"uaData platform={platform} mobile={platform == "mobile"}",
             durationSeconds = 18.4,
             sampleRate = 48000,
             speechLevelDb = -19.5,
@@ -115,6 +123,76 @@ public sealed class VoiceQualityEndpointTests : IDisposable
         Assert.Equal(2, devices.Count);
         Assert.Equal("good", devices.Single(d => d.GetProperty("device").GetString() == "Desk Mic").GetProperty("status").GetString());
         Assert.Equal("bad", devices.Single(d => d.GetProperty("device").GetString() == "Headset").GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task TwoMicrophonesOnTwoPlatformsAreTwoRows_NamedAndClassified_OverRealHttp()
+    {
+        // The acceptance line of issue #2183, driven end to end: a phone and a Windows headset each
+        // post measurements, and the Cockpit reads back two rows - named, classified, never one
+        // averaged "Default" row.
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        for (var i = 0; i < 8; i++)
+            await http.PostAsJsonAsync("/voice-quality/sample",
+                Sample(device: "iPhone Microphone", deviceId: "id-phone", platform: "mobile"));
+        for (var i = 0; i < 8; i++)
+            await http.PostAsJsonAsync("/voice-quality/sample",
+                Sample(device: "Headset (Jabra Evolve2 65)", deviceId: "id-jabra", platform: "windows", narrowband: true));
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/summary"));
+        var devices = doc.RootElement.GetProperty("devices").EnumerateArray().ToList();
+        Assert.Equal(2, devices.Count);
+
+        var phone = devices.Single(d => d.GetProperty("deviceId").GetString() == "id-phone");
+        Assert.Equal("iPhone Microphone", phone.GetProperty("device").GetString());
+        Assert.Equal("mobile", phone.GetProperty("platform").GetString());
+        Assert.Equal("Phone or tablet", phone.GetProperty("platformLabel").GetString());
+
+        var jabra = devices.Single(d => d.GetProperty("deviceId").GetString() == "id-jabra");
+        Assert.Equal("windows", jabra.GetProperty("platform").GetString());
+        Assert.Equal("bad", jabra.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task TheDetailViewCarriesMeasurementsAndTheDailyTrend_PerDevice()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        for (var i = 0; i < 6; i++)
+            await http.PostAsJsonAsync("/voice-quality/sample",
+                Sample(device: "Desk Mic", deviceId: "id-desk", platform: "windows"));
+
+        using var doc = JsonDocument.Parse(await http.GetStringAsync("/voice-quality/detail"));
+        Assert.Equal(6, doc.RootElement.GetProperty("totalSamples").GetInt32());
+
+        var device = Assert.Single(doc.RootElement.GetProperty("devices").EnumerateArray().ToList());
+        Assert.Equal("Desk Mic", device.GetProperty("summary").GetProperty("device").GetString());
+        Assert.Equal("windows", device.GetProperty("summary").GetProperty("platform").GetString());
+        Assert.Equal(6, device.GetProperty("measurementsTotal").GetInt32());
+        Assert.Equal(6, device.GetProperty("measurements").GetArrayLength());
+        // Everything was posted just now, so the trend is a single day carrying all six.
+        var day = Assert.Single(device.GetProperty("trend").EnumerateArray().ToList());
+        Assert.Equal(6, day.GetProperty("samples").GetInt32());
+        // The raw platform evidence survives to where a wrong bucket would be diagnosed.
+        Assert.Contains("uaData", device.GetProperty("platformRaw").GetString());
+    }
+
+    [Fact]
+    public async Task TheDetailViewStoresNoAudioAndNoTranscriptEither()
+    {
+        // The same privacy claim the summary path makes, asserted against the detail response - the
+        // new surface must not become the place text leaks out of.
+        var (app, http, _) = await StartAsync();
+        await using var _d = app;
+
+        await http.PostAsJsonAsync("/voice-quality/sample", Sample(deviceId: "id-1", platform: "windows"));
+
+        var body = await http.GetStringAsync("/voice-quality/detail");
+        foreach (var forbidden in new[] { "transcript", "rawText", "audio", "text\"" })
+            Assert.DoesNotContain(forbidden, body, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
@@ -11,6 +11,7 @@ namespace CcDirector.Gateway.Api;
 ///
 ///   POST   /voice-quality/sample   one measurement from a finished dictation -> 204
 ///   GET    /voice-quality/summary  the folded verdict the Cockpit renders    -> 200
+///   GET    /voice-quality/detail   per-device measurements + quality over time -> 200
 ///   DELETE /voice-quality/history  forget every measurement for this tenant  -> 200 { removed }
 ///
 /// The client measures (it is where the decoded audio already is) and posts a handful of numbers plus
@@ -32,6 +33,13 @@ internal static class VoiceQualityEndpoint
     /// <summary>Longest device name stored. Real names are well under this; the cap stops a client
     /// from turning a per-dictation record into a place to park arbitrary text.</summary>
     private const int MaxDeviceChars = 200;
+
+    /// <summary>Longest device id stored. Browser deviceIds are 64-character hashes; the headroom
+    /// covers other engines without opening a text-parking hole.</summary>
+    private const int MaxDeviceIdChars = 128;
+
+    /// <summary>Longest raw platform evidence stored - one capped line of navigator hints.</summary>
+    private const int MaxPlatformRawChars = 160;
 
     public static void Map(
         IEndpointRouteBuilder app,
@@ -63,6 +71,11 @@ internal static class VoiceQualityEndpoint
             {
                 TimestampUtc = DateTime.UtcNow,
                 Device = Trim(body.Device, MaxDeviceChars),
+                DeviceId = Trim(body.DeviceId, MaxDeviceIdChars),
+                // The bucket is validated at FOLD time (anything unrecognised reads as unknown), so
+                // storing what the client sent loses nothing and keeps the record honest.
+                Platform = Trim(body.Platform, 16),
+                PlatformRaw = Trim(body.PlatformRaw, MaxPlatformRawChars),
                 Source = Trim(body.Source, 40),
                 DurationSeconds = body.DurationSeconds,
                 SampleRate = body.SampleRate,
@@ -90,6 +103,17 @@ internal static class VoiceQualityEndpoint
             return Results.Json(MicrophoneQualityFold.Summarize(log.Load(since)));
         });
 
+        group.MapGet("/detail", (HttpContext ctx) =>
+        {
+            if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
+                return GatewayDictationEndpoint.NoTenantResult();
+
+            var days = ParseDays(ctx.Request.Query["days"]);
+            var since = days is null ? (DateTime?)null : DateTime.UtcNow.AddDays(-days.Value);
+            var log = logOverride ?? MicrophoneQualityLog.ForTenant(tenant);
+            return Results.Json(MicrophoneQualityFold.Detail(log.Load(since)));
+        });
+
         group.MapDelete("/history", (HttpContext ctx) =>
         {
             if (GatewayDictationEndpoint.ResolveTenant(ctx, tenantBoundary) is not { } tenant)
@@ -115,6 +139,9 @@ internal static class VoiceQualityEndpoint
     {
         [JsonPropertyName("source")] public string? Source { get; init; }
         [JsonPropertyName("device")] public string? Device { get; init; }
+        [JsonPropertyName("deviceId")] public string? DeviceId { get; init; }
+        [JsonPropertyName("platform")] public string? Platform { get; init; }
+        [JsonPropertyName("platformRaw")] public string? PlatformRaw { get; init; }
         [JsonPropertyName("durationSeconds")] public double DurationSeconds { get; init; }
         [JsonPropertyName("sampleRate")] public int SampleRate { get; init; }
         [JsonPropertyName("speechLevelDb")] public double SpeechLevelDb { get; init; }

--- a/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
+++ b/src/CcDirector.Gateway/Reports/MorningReportBuilder.cs
@@ -197,25 +197,32 @@ public sealed class MorningReportBuilder
         var worst = ranked[^1];
         var anyBad = ranked.Any(d => d.Status == "bad");
 
+        // The email names each device WITH its platform ("Jabra Evolve2 (Windows)"), because the
+        // comparison the owner actually makes is across machines - "my phone beats my Windows
+        // headset" - and a bare name gives that sentence no context. An unknown platform adds
+        // nothing, so the name stands alone.
+        static string Named(Transcription.MicrophoneDeviceSummary d)
+            => d.PlatformLabel.Length == 0 ? d.Device : $"{d.Device} ({d.PlatformLabel})";
+
         string headline;
         string? advice = null;
         if (!anyBad)
         {
             headline = ranked.Count == 1
-                ? $"{best.Device} is doing fine."
-                : $"All {ranked.Count} of your microphones are doing fine - {best.Device} is the best of them.";
+                ? $"{Named(best)} is doing fine."
+                : $"All {ranked.Count} of your microphones are doing fine - {Named(best)} is the best of them.";
         }
         else if (best.Status == "bad")
         {
             // Every microphone measured is bad. Naming a "best" here would recommend one of them.
             headline = ranked.Count == 1
-                ? $"{best.Device} is holding your transcription back."
+                ? $"{Named(best)} is holding your transcription back."
                 : "Every microphone you used is holding your transcription back.";
             advice = worst.Advice;
         }
         else
         {
-            headline = $"{best.Device} is your best microphone; {worst.Device} is holding you back.";
+            headline = $"{Named(best)} is your best microphone; {Named(worst)} is holding you back.";
             advice = $"Use {best.Device} when you can. {worst.Advice}";
         }
 
@@ -223,9 +230,14 @@ public sealed class MorningReportBuilder
         {
             Headline = headline,
             Advice = advice,
+            // The email stays a SUMMARY by design: the trend and the per-measurement history live on
+            // the Cockpit's Transcription Health page, and this sentence is how the reader gets there.
+            DetailHint = "The full per-microphone detail, including quality over time, is on the Cockpit's Transcription Health page.",
             Devices = ranked.Select(d => new MorningMicrophoneDto
             {
                 Device = d.Device,
+                Platform = d.Platform,
+                PlatformLabel = d.PlatformLabel,
                 Samples = d.Samples,
                 Status = d.Status,
                 Summary = d.Advice,

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityFold.cs
@@ -29,6 +29,11 @@ public static class MicrophoneQualityFold
     /// by a gain setting that will keep doing it, and it is trivially fixable.</summary>
     public const double ClippingShareToWarn = 0.2;
 
+    /// <summary>The clipped-fraction floor above which one recording COUNTS as distorted. One rule,
+    /// used by every share computed anywhere in this fold, so a device summary and its own trend
+    /// points can never disagree about the same recording.</summary>
+    public const double ClippedFractionCounts = 0.001;
+
     public static MicrophoneQualitySummary Summarize(IReadOnlyList<MicrophoneQualityRecord> records)
     {
         if (records is null || records.Count == 0)
@@ -43,44 +48,12 @@ public static class MicrophoneQualityFold
             };
         }
 
-        var devices = records
-            .GroupBy(r => string.IsNullOrWhiteSpace(r.Device) ? "Unnamed microphone" : r.Device)
+        var devices = GroupByDevice(records)
             .Select(BuildDevice)
             .OrderByDescending(d => d.Samples)
             .ToList();
 
-        // The headline speaks about the WORST device that has earned a verdict, not the average of
-        // everything. Averaging a bad headset with a good desk microphone hides exactly the finding
-        // the user needs: that one of their microphones is the problem.
-        var judged = devices.Where(d => d.Samples >= MinSamplesForVerdict).ToList();
-        var worst = judged.FirstOrDefault(d => d.Status == "bad");
-
-        string headline;
-        string detail;
-        string status;
-        if (worst is not null)
-        {
-            status = "bad";
-            headline = $"{worst.Device} is holding your transcription back.";
-            detail = worst.Advice;
-        }
-        else if (judged.Count == 0)
-        {
-            status = "learning";
-            headline = "Still learning how your microphones sound.";
-            detail =
-                $"A microphone needs {MinSamplesForVerdict} measured dictations before this screen will "
-                + "judge it, so a single odd recording never accuses good hardware.";
-        }
-        else
-        {
-            status = "good";
-            headline = judged.Count == 1
-                ? "Your microphone sounds good."
-                : $"All {judged.Count} of your microphones sound good.";
-            detail = "Nothing about your audio is holding transcription back. The numbers below are the evidence.";
-        }
-
+        var (status, headline, detail) = Verdict(devices);
         return new MicrophoneQualitySummary
         {
             TotalSamples = records.Count,
@@ -91,12 +64,203 @@ public static class MicrophoneQualityFold
         };
     }
 
-    private static MicrophoneDeviceSummary BuildDevice(IGrouping<string, MicrophoneQualityRecord> group)
+    /// <summary>
+    /// The whole-account verdict over the folded devices. The headline speaks about the WORST device
+    /// that has earned a verdict, not the average of everything: averaging a bad headset with a good
+    /// desk microphone hides exactly the finding the user needs - that one of their microphones is
+    /// the problem. Shared by the summary and the detail views so the two can never disagree.
+    /// </summary>
+    private static (string Status, string Headline, string Detail) Verdict(IReadOnlyList<MicrophoneDeviceSummary> devices)
     {
-        var list = group.ToList();
+        var judged = devices.Where(d => d.Samples >= MinSamplesForVerdict).ToList();
+        var worst = judged.FirstOrDefault(d => d.Status == "bad");
+
+        if (worst is not null)
+            return ("bad", $"{worst.Device} is holding your transcription back.", worst.Advice);
+
+        if (judged.Count == 0)
+        {
+            return ("learning", "Still learning how your microphones sound.",
+                $"A microphone needs {MinSamplesForVerdict} measured dictations before this screen will "
+                + "judge it, so a single odd recording never accuses good hardware.");
+        }
+
+        var headline = judged.Count == 1
+            ? "Your microphone sounds good."
+            : $"All {judged.Count} of your microphones sound good.";
+        return ("good", headline, "Nothing about your audio is holding transcription back. The numbers below are the evidence.");
+    }
+
+    /// <summary>
+    /// How many individual measurements the detail view carries per device. Thirty days of heavy
+    /// dictating fits well under this; when a device does exceed it the response SAYS so
+    /// (<see cref="MicrophoneDeviceDetail.MeasurementsTotal"/> versus the list length) rather than
+    /// truncating silently.
+    /// </summary>
+    public const int MaxDetailMeasurements = 200;
+
+    /// <summary>
+    /// The DETAILED per-device picture the Cockpit's Transcription Health page renders: the same
+    /// verdicts as <see cref="Summarize"/> - the two share every fold, so they cannot disagree -
+    /// plus, per device, the daily quality-over-time series and the individual measurements behind
+    /// it. Still no audio and no transcript: every field is a number, a date, or a verdict string.
+    /// </summary>
+    public static MicrophoneQualityDetail Detail(IReadOnlyList<MicrophoneQualityRecord> records)
+    {
+        if (records is null || records.Count == 0)
+        {
+            var empty = Summarize(records ?? Array.Empty<MicrophoneQualityRecord>());
+            return new MicrophoneQualityDetail
+            {
+                TotalSamples = 0,
+                Status = empty.Status,
+                Headline = empty.Headline,
+                Detail = empty.Detail,
+                Devices = Array.Empty<MicrophoneDeviceDetail>(),
+            };
+        }
+
+        var built = GroupByDevice(records)
+            .Select(group => (Summary: BuildDevice(group), Records: group))
+            .OrderByDescending(pair => pair.Summary.Samples)
+            .ToList();
+
+        var (status, headline, detail) = Verdict(built.Select(p => p.Summary).ToList());
+        return new MicrophoneQualityDetail
+        {
+            TotalSamples = records.Count,
+            Status = status,
+            Headline = headline,
+            Detail = detail,
+            Devices = built.Select(p => BuildDeviceDetail(p.Summary, p.Records)).ToList(),
+        };
+    }
+
+    private static MicrophoneDeviceDetail BuildDeviceDetail(
+        MicrophoneDeviceSummary summary,
+        IReadOnlyList<MicrophoneQualityRecord> group)
+    {
+        var newestFirst = group.OrderByDescending(r => r.TimestampUtc).ToList();
+
+        // The over-time series: one point per calendar day with data, oldest first so a chart reads
+        // left to right. Medians per day for the same reason the device summary uses them - one odd
+        // recording must not move the line.
+        var trend = newestFirst
+            .GroupBy(r => r.TimestampUtc.Date)
+            .OrderBy(g => g.Key)
+            .Select(g => new MicrophoneTrendPoint
+            {
+                Date = g.Key.ToString("yyyy-MM-dd"),
+                Samples = g.Count(),
+                MedianSpeechLevelDb = Round(Median(g.Select(r => r.SpeechLevelDb))),
+                MedianSignalToNoiseDb = Round(Median(g.Select(r => r.SignalToNoiseDb))),
+                NarrowbandShare = Round((double)g.Count(r => r.Narrowband) / g.Count()),
+                ClippingShare = Round((double)g.Count(r => r.ClippedFraction >= ClippedFractionCounts) / g.Count()),
+            })
+            .ToList();
+
+        return new MicrophoneDeviceDetail
+        {
+            Summary = summary,
+            PlatformRaw = newestFirst.Select(r => r.PlatformRaw).FirstOrDefault(p => !string.IsNullOrWhiteSpace(p)) ?? "",
+            Trend = trend,
+            MeasurementsTotal = newestFirst.Count,
+            Measurements = newestFirst.Take(MaxDetailMeasurements).Select(r => new MicrophoneMeasurement
+            {
+                TimestampUtc = r.TimestampUtc,
+                Source = r.Source,
+                DurationSeconds = r.DurationSeconds,
+                SampleRate = r.SampleRate,
+                SpeechLevelDb = r.SpeechLevelDb,
+                NoiseFloorDb = r.NoiseFloorDb,
+                SignalToNoiseDb = r.SignalToNoiseDb,
+                ClippedFraction = r.ClippedFraction,
+                Narrowband = r.Narrowband,
+                Rating = r.Rating,
+                Issues = r.Issues,
+            }).ToList(),
+        };
+    }
+
+    /// <summary>
+    /// One physical microphone = one group. The grouping key is the stable deviceId when the client
+    /// sent one - the display name is metadata that a driver update or an operating system language
+    /// change rewrites, and a grouping keyed on it silently splits one microphone into two histories
+    /// (issue #2183). Records from before the id existed carry none; they are folded INTO the id
+    /// group whose display name matches theirs when exactly one does, so shipping the id does not
+    /// reset every device's earned history to "learning". A nameless, idless record still lands
+    /// under "Unnamed microphone".
+    /// </summary>
+    internal static IReadOnlyList<IReadOnlyList<MicrophoneQualityRecord>> GroupByDevice(
+        IReadOnlyList<MicrophoneQualityRecord> records)
+    {
+        static string DisplayLabel(MicrophoneQualityRecord r)
+            => string.IsNullOrWhiteSpace(r.Device) ? "Unnamed microphone" : r.Device.Trim();
+
+        var byId = records
+            .Where(r => !string.IsNullOrWhiteSpace(r.DeviceId))
+            .GroupBy(r => r.DeviceId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Which id-group does a given display name belong to? Only an UNAMBIGUOUS name may adopt
+        // legacy records - two ids sharing one name is exactly the case the id exists to separate.
+        var idGroupByLabel = byId.Values
+            .SelectMany(list => list.Select(DisplayLabel).Distinct().Select(label => (label, list)))
+            .GroupBy(pair => pair.label)
+            .Where(g => g.Count() == 1)
+            .ToDictionary(g => g.Key, g => g.First().list);
+
+        var labelGroups = new Dictionary<string, List<MicrophoneQualityRecord>>();
+        foreach (var record in records.Where(r => string.IsNullOrWhiteSpace(r.DeviceId)))
+        {
+            var label = DisplayLabel(record);
+            if (idGroupByLabel.TryGetValue(label, out var adoptedBy))
+            {
+                adoptedBy.Add(record);
+                continue;
+            }
+            if (!labelGroups.TryGetValue(label, out var group))
+            {
+                group = new List<MicrophoneQualityRecord>();
+                labelGroups[label] = group;
+            }
+            group.Add(record);
+        }
+
+        return byId.Values.Concat(labelGroups.Values).ToList();
+    }
+
+    /// <summary>The platform buckets the fold recognises. Anything else - including the empty value
+    /// on records from before the field existed - is reported as unknown rather than guessed.</summary>
+    public static string NormalizePlatform(string? platform) => platform switch
+    {
+        "mobile" or "mac" or "windows" => platform,
+        _ => "unknown",
+    };
+
+    /// <summary>The finished display string for a platform bucket. Empty for unknown, so a screen
+    /// shows nothing rather than the word "unknown" next to a working microphone.</summary>
+    public static string PlatformLabel(string platform) => platform switch
+    {
+        "mobile" => "Phone or tablet",
+        "mac" => "Mac",
+        "windows" => "Windows",
+        _ => "",
+    };
+
+    private static MicrophoneDeviceSummary BuildDevice(IReadOnlyList<MicrophoneQualityRecord> group)
+    {
+        var list = group.OrderByDescending(r => r.TimestampUtc).ToList();
         var n = list.Count;
+        // The newest values win for display metadata: the latest name is the one the operating
+        // system currently uses, and the latest platform is where the microphone now lives.
+        var label = list.Select(r => r.Device).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d))?.Trim()
+                    ?? "Unnamed microphone";
+        var deviceId = list.Select(r => r.DeviceId).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d)) ?? "";
+        var platform = NormalizePlatform(list.Select(r => r.Platform)
+            .FirstOrDefault(p => !string.IsNullOrWhiteSpace(p)));
         var narrowbandShare = (double)list.Count(r => r.Narrowband) / n;
-        var clippingShare = (double)list.Count(r => r.ClippedFraction >= 0.001) / n;
+        var clippingShare = (double)list.Count(r => r.ClippedFraction >= ClippedFractionCounts) / n;
 
         var status = "good";
         var advice = "";
@@ -130,7 +294,10 @@ public static class MicrophoneQualityFold
 
         return new MicrophoneDeviceSummary
         {
-            Device = group.Key,
+            Device = label,
+            DeviceId = deviceId,
+            Platform = platform,
+            PlatformLabel = PlatformLabel(platform),
             Samples = n,
             Status = status,
             Advice = advice,
@@ -227,6 +394,14 @@ public sealed record MicrophoneQualitySummary
 public sealed record MicrophoneDeviceSummary
 {
     public required string Device { get; init; }
+    /// <summary>The stable identifier the group was keyed on. Empty when only legacy or idless
+    /// records exist for this device.</summary>
+    public string DeviceId { get; init; } = "";
+    /// <summary>"mobile", "mac", "windows" or "unknown".</summary>
+    public string Platform { get; init; } = "unknown";
+    /// <summary>The finished display string for the platform ("Phone or tablet", "Mac", "Windows").
+    /// Empty when the platform is unknown, so screens render nothing rather than a guess.</summary>
+    public string PlatformLabel { get; init; } = "";
     public required int Samples { get; init; }
     /// <summary>"good", "learning" or "bad".</summary>
     public required string Status { get; init; }
@@ -238,4 +413,69 @@ public sealed record MicrophoneDeviceSummary
     public required double TargetSpeechLevelDb { get; init; }
     public required double TargetSignalToNoiseDb { get; init; }
     public required DateTime LastSeenUtc { get; init; }
+}
+
+/// <summary>The detailed per-device picture for the Cockpit's Transcription Health page: the same
+/// verdicts as <see cref="MicrophoneQualitySummary"/>, plus each device's over-time series and the
+/// measurements behind it. Rendered verbatim by the Cockpit.</summary>
+public sealed record MicrophoneQualityDetail
+{
+    public required int TotalSamples { get; init; }
+    /// <summary>"empty", "learning", "good" or "bad" - drives the banner colour only.</summary>
+    public required string Status { get; init; }
+    public required string Headline { get; init; }
+    public required string Detail { get; init; }
+    public required IReadOnlyList<MicrophoneDeviceDetail> Devices { get; init; }
+}
+
+/// <summary>One microphone, in full: its folded verdict, where it lives, how its quality has moved
+/// over time, and every measurement inside the window.</summary>
+public sealed record MicrophoneDeviceDetail
+{
+    /// <summary>The same folded verdict the summary view shows for this device.</summary>
+    public required MicrophoneDeviceSummary Summary { get; init; }
+
+    /// <summary>The raw evidence behind the platform bucket, so a wrong bucket can be diagnosed.</summary>
+    public string PlatformRaw { get; init; } = "";
+
+    /// <summary>One point per calendar day with data, oldest first, for the quality-over-time chart.</summary>
+    public required IReadOnlyList<MicrophoneTrendPoint> Trend { get; init; }
+
+    /// <summary>How many measurements the window really holds for this device. When it exceeds the
+    /// length of <see cref="Measurements"/>, the list was capped at the newest
+    /// <see cref="MicrophoneQualityFold.MaxDetailMeasurements"/> - the count is how a screen says so
+    /// instead of silently pretending the cap is the total.</summary>
+    public required int MeasurementsTotal { get; init; }
+
+    /// <summary>The individual measurements, newest first, capped. No audio, no transcript.</summary>
+    public required IReadOnlyList<MicrophoneMeasurement> Measurements { get; init; }
+}
+
+/// <summary>One day of one device's dictation, folded to medians and shares.</summary>
+public sealed record MicrophoneTrendPoint
+{
+    /// <summary>The calendar day, UTC, as yyyy-MM-dd.</summary>
+    public required string Date { get; init; }
+    public required int Samples { get; init; }
+    public required double MedianSpeechLevelDb { get; init; }
+    public required double MedianSignalToNoiseDb { get; init; }
+    public required double NarrowbandShare { get; init; }
+    public required double ClippingShare { get; init; }
+}
+
+/// <summary>One dictation's measurement as the detail view shows it - how the audio sounded, never
+/// what was said.</summary>
+public sealed record MicrophoneMeasurement
+{
+    public required DateTime TimestampUtc { get; init; }
+    public required string Source { get; init; }
+    public required double DurationSeconds { get; init; }
+    public required int SampleRate { get; init; }
+    public required double SpeechLevelDb { get; init; }
+    public required double NoiseFloorDb { get; init; }
+    public required double SignalToNoiseDb { get; init; }
+    public required double ClippedFraction { get; init; }
+    public required bool Narrowband { get; init; }
+    public required string Rating { get; init; }
+    public required string Issues { get; init; }
 }

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
@@ -171,6 +171,17 @@ public sealed record MicrophoneQualityRecord
     [JsonPropertyName("ts")] public DateTime TimestampUtc { get; init; }
     /// <summary>The microphone's name as the operating system reported it, or empty when unknown.</summary>
     [JsonPropertyName("device")] public string Device { get; init; } = "";
+    /// <summary>The microphone's stable per-origin identifier - the GROUPING key. The name is display
+    /// metadata (a driver update or an operating system language change renames it); this is what
+    /// keeps one microphone's history in one row. Empty on records written before it existed, or when
+    /// the browser withheld it - those group by name as before.</summary>
+    [JsonPropertyName("deviceId")] public string DeviceId { get; init; } = "";
+    /// <summary>What kind of machine captured it: "mobile", "mac", "windows" or "unknown". Empty on
+    /// records written before it existed (folded as unknown).</summary>
+    [JsonPropertyName("platform")] public string Platform { get; init; } = "";
+    /// <summary>The raw evidence behind the platform bucket, kept so a wrong bucket can be diagnosed
+    /// later without guessing.</summary>
+    [JsonPropertyName("platformRaw")] public string PlatformRaw { get; init; } = "";
     /// <summary>Which surface produced it ("dictation-dialog", "dictation-send").</summary>
     [JsonPropertyName("source")] public string Source { get; init; } = "";
     [JsonPropertyName("durationSeconds")] public double DurationSeconds { get; init; }


### PR DESCRIPTION
Closes #2183.

## What this does

Every dictation used to report its microphone as the literal name "Default", so the per-device comparison - the feature's headline promise - had nothing to compare. This pull request fixes that and delivers the two widenings the owner added to the issue.

**1. The real device name, grouped by a stable id.** The client resolves the actual hardware behind the browser's default slot: `enumerateDevices()` plus the live track's `getSettings().deviceId`, unwrapped via the shared `groupId` (locale-independent) with a label-suffix fallback, done while the capture is live because labels are withheld until permission is granted. Resolution is fire-and-forget - it can never delay a word. The Gateway now groups measurements by `deviceId` rather than by display name, so a driver update or an operating system language change no longer splits one microphone into two histories. Legacy records without an id join the id group whose name matches theirs when exactly one does, so shipping the id resets nobody's earned history.

**2. Platform classification.** Every measurement records mobile / Mac / Windows - or unknown when genuinely undeterminable, never a guess - from Client-Hints with a user-agent fallback (the iPad-pretending-to-be-a-Mac case is handled). The raw evidence is stored alongside the bucket so a wrong bucket can be diagnosed later.

**3. The Cockpit gets the detail; the email stays a summary.** A new `GET /voice-quality/detail` folds, per microphone: name, platform, every measurement with the targets beside it, and the quality-over-time series (daily medians). The Transcription Health page renders it with a per-device trend chart and a fold-open measurement table. The daily report still summarizes - it now names the best and worst device with their platform and carries a prewritten sentence pointing the reader at the Cockpit.

## The standing rules, kept

- Measurement remains fire-and-forget; the Gateway still answers 204 even to a malformed body.
- No audio and no transcript on the quality path - the existing on-disk assertion still passes, and a new test asserts the same against the detail response.
- The Gateway owns every verdict; the Cockpit holds no thresholds (the trend chart draws the values and the target the Gateway sent).
- No new warning types. The calibrated thresholds are untouched.

## Acceptance

Two physical microphones on two platforms produce two rows, correctly named and correctly classified - covered by a fold test and an end-to-end HTTP test (`TwoMicrophonesOnTwoPlatformsAreTwoRows_NamedAndClassified_OverRealHttp`).

## Testing

- client-core: 699 tests green (including new resolver, platform, and quality-report tests)
- cockpit: 188 tests green; mobile and cockpit builds green
- Gateway: fold 22 green, endpoint + morning report classes 25 green; full solution suite running in CI