### PR TITLE
Cockpit: Sessions first in the rail, and the Needs you group is a waiting line

### DIFF
--- a/apps/cockpit/src/AppShell.test.tsx
+++ b/apps/cockpit/src/AppShell.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// The left rail's ORDER is a product decision, not an accident of the array literal, so it is pinned
+// here: Sessions first, then Fleet Map, then Assistant. The sessions are the work, so the destination
+// reached for most sits at the top. Without this test the order is one careless re-sort away from
+// changing silently - nothing else in the app reads it.
+
+vi.mock("@devthrottle/client-core/net/useKeepWarm", () => ({
+  useKeepWarm: () => {},
+}));
+
+vi.mock("@devthrottle/client-core/dictation/dictionaryClient", () => ({
+  getSuggestionCount: vi.fn(async () => 0),
+}));
+
+vi.mock("./network/CockpitStatusPill", () => ({
+  CockpitStatusPill: () => null,
+}));
+
+import { AppShell } from "./AppShell";
+
+function railLabels(): string[] {
+  const list = document.querySelector(".nav-list:not(.nav-list-foot)");
+  if (list === null) throw new Error("the shell rendered no main nav list");
+  return Array.from(list.querySelectorAll(".nav-link-label")).map((el) => el.textContent ?? "");
+}
+
+describe("Cockpit left rail", () => {
+  beforeEach(() => {
+    // This project runs vitest without globals, so testing-library's automatic cleanup is not
+    // registered - without this, each render leaks into the next test's document.
+    cleanup();
+  });
+
+  it("opens with Sessions, then Fleet Map, then Assistant", () => {
+    render(
+      <MemoryRouter initialEntries={["/sessions"]}>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    expect(railLabels().slice(0, 3)).toEqual(["Sessions", "Fleet Map", "Assistant"]);
+  });
+
+  it("leaves the rest of the rail where it was", () => {
+    render(
+      <MemoryRouter initialEntries={["/sessions"]}>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    expect(railLabels()).toEqual([
+      "Sessions",
+      "Fleet Map",
+      "Assistant",
+      "Directors",
+      "Schedule",
+      "Workflows",
+      "Dictionary",
+      "Voice Recorder",
+      "Transcription",
+      "Network",
+    ]);
+  });
+});

--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -36,8 +36,10 @@ import { CockpitStatusPill } from "./network/CockpitStatusPill";
 // DEVELOPER page (the Director processes on the Gateway's own machine, and the local_builds slots), so
 // putting it in an end-user rail was the mistake, not leaving it out.
 //
-// The Fleet Map is first and is the default landing (issue #1303): a fresh boot at "/" redirects to
-// it, so the Cockpit opens on the whole-fleet picture (main.tsx). Sessions lives at its own /sessions
+// Sessions is first, then Fleet Map, then Assistant: the sessions are the work, so the destination you
+// reach for most sits at the top of the rail, with the whole-fleet picture and the assistant behind it.
+// The Fleet Map remains the default landing (issue #1303): a fresh boot at "/" redirects to it, so the
+// Cockpit still opens on the whole-fleet picture (main.tsx). Sessions lives at its own /sessions
 // home. `subtree` marks a destination active for a route family that does NOT share its path prefix:
 // the session detail routes into "/session/:id" - a different path from "/sessions" - so Sessions
 // needs an explicit subtree to stay highlighted while a session is being driven (the Directors item
@@ -62,9 +64,9 @@ interface NavItem {
 // Workflows sits with Schedule on purpose - Schedule is what runs when, Workflows is how work runs,
 // and it is next to the place you start work rather than filed away under settings.
 const NAV_MAIN: ReadonlyArray<NavItem> = [
+  { to: "/sessions", label: "Sessions", icon: "sessions", subtree: "/session" },
   { to: "/fleet-map", label: "Fleet Map", icon: "fleet-map" },
   { to: "/assistant", label: "Assistant", icon: "assistant" },
-  { to: "/sessions", label: "Sessions", icon: "sessions", subtree: "/session" },
   { to: "/directors", label: "Directors", icon: "directors" },
   { to: "/schedule", label: "Schedule", icon: "schedule" },
   { to: "/workflows", label: "Workflows", icon: "workflows" },

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -8,6 +8,7 @@ import {
   dotHex,
   groupByDirector,
   inBucket,
+  inWaitingOrder,
   pendingDeletion,
   snoozeCountdown,
   snoozeExpired,
@@ -193,9 +194,15 @@ function VoiceAllButton({ sessions }: { sessions: SessionDto[] }) {
   );
 }
 
-// Opt-in attention view: needs-you first, then active, then on-hold. Each bucket keeps its members in
-// desktop order (inBucket), so a session holds its slot within its bucket and does not reshuffle. These
-// buckets mix machines, so - unlike the grouped "My order" view - each card still shows its own
+// Opt-in attention view: needs-you first, then active, then on-hold.
+//
+// The needs-you group is a WAITING LINE (inWaitingOrder), the same order the phone roster uses: the
+// session that has been asking for you the LONGEST sits at the top, and a session that only just
+// started needing you joins at the BOTTOM. Work it from the top down and it is first-in, first-handled,
+// and it never reshuffles under you as new work arrives. The active and on-hold groups below keep their
+// members in desktop order (inBucket), so a session holds its slot within its bucket.
+//
+// These buckets mix machines, so - unlike the grouped "My order" view - each card still shows its own
 // "computer:port" line so you can see which cc-director a needs-you session lives on.
 function AttentionGroups({
   sessions,
@@ -208,7 +215,7 @@ function AttentionGroups({
   portByDirector: Map<string, string>;
   selectedId: string | undefined;
 }) {
-  const needs = inBucket(sessions, "needsYou");
+  const needs = inWaitingOrder(sessions);
   const active = inBucket(sessions, "active");
   const held = inBucket(sessions, "onHold");
   return (

--- a/apps/cockpit/src/sessions/attentionOrder.test.tsx
+++ b/apps/cockpit/src/sessions/attentionOrder.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+
+// "Attention first" -> the Needs you group is a WAITING LINE, not the drag-to-reorder desktop order.
+// The session that has been asking for you the longest is at the TOP; one that only just started
+// needing you joins at the BOTTOM. That is the same order the phone roster uses, and it is what makes
+// working the list from the top down first-in, first-handled.
+//
+// The distinguishing test is the second one: the desktop sortOrder is set to the EXACT OPPOSITE of the
+// wait order, so a roster that fell back to the old inBucket ordering renders the reverse and fails.
+
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  setVoiceModeAllSessions: vi.fn(async () => {}),
+}));
+
+vi.mock("./SessionMenu", () => ({
+  SessionMenu: () => null,
+}));
+
+import { SessionRoster } from "./SessionRoster";
+
+function needsYou(sessionId: string, needsYouSince: string, sortOrder: number): SessionDto {
+  return {
+    sessionId,
+    name: sessionId,
+    createdAt: "2026-07-26T08:00:00Z",
+    sortOrder,
+    directorId: "d1",
+    machineName: "SOREN_NORTH",
+    repoPath: "D:\\ReposFred\\devthrottle",
+    effectiveColor: "red",
+    effectiveColorHex: "#EF4444",
+    stateLabel: "Needs you",
+    triageBucket: "needsYou",
+    needsYouSince,
+  } as unknown as SessionDto;
+}
+
+function renderAttention(sessions: SessionDto[]) {
+  render(
+    <MemoryRouter initialEntries={["/sessions"]}>
+      <SessionRoster
+        sessions={sessions}
+        directors={[]}
+        portByDirector={new Map()}
+        selectedId={undefined}
+        view="attention"
+        onView={() => {}}
+        error={null}
+        onNewSession={() => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+// The rendered order of the Needs you group, read off the DOM rather than off the sort function, so
+// the test fails if the roster stops passing the waiting order through to the rows.
+function needsYouRowOrder(): string[] {
+  const bucket = Array.from(document.querySelectorAll(".roster-bucket")).find(
+    (b) => b.querySelector(".roster-bucket-head.needs") !== null,
+  );
+  if (bucket === undefined) throw new Error("the attention view rendered no 'Needs you' bucket");
+  return Array.from(bucket.querySelectorAll(".roster-name-text")).map((el) => el.textContent ?? "");
+}
+
+describe("Attention first - the Needs you waiting line", () => {
+  beforeEach(() => {
+    // This project runs vitest without globals, so testing-library's automatic cleanup is not
+    // registered - without this, each render leaks into the next test's document.
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("puts the longest wait at the top and the newest at the bottom", () => {
+    renderAttention([
+      needsYou("newest", "2026-07-26T09:50:00Z", 1),
+      needsYou("oldest", "2026-07-26T08:10:00Z", 2),
+      needsYou("middle", "2026-07-26T09:00:00Z", 3),
+    ]);
+
+    expect(needsYouRowOrder()).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("ignores the drag-to-reorder desktop order inside the group", () => {
+    // sortOrder is the exact reverse of the wait order: the old behaviour renders newest-first.
+    renderAttention([
+      needsYou("oldest", "2026-07-26T08:10:00Z", 30),
+      needsYou("middle", "2026-07-26T09:00:00Z", 20),
+      needsYou("newest", "2026-07-26T09:50:00Z", 10),
+    ]);
+
+    expect(needsYouRowOrder()).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("sorts a session the Gateway never stamped with a wait time to the bottom", () => {
+    const unstamped = needsYou("unstamped", "2026-07-26T08:00:00Z", 1);
+    delete (unstamped as unknown as Record<string, unknown>).needsYouSince;
+
+    renderAttention([unstamped, needsYou("waiting", "2026-07-26T09:50:00Z", 2)]);
+
+    expect(needsYouRowOrder()).toEqual(["waiting", "unstamped"]);
+  });
+});


### PR DESCRIPTION
Two small ordering corrections to the desktop Cockpit, both reported from the running app.

## 1. The left rail order

The rail now reads **Sessions, Fleet Map, Assistant**, then Directors, Schedule, Workflows, Dictionary, Voice Recorder, Transcription, Network exactly as before. The sessions are the work, so the destination reached for most sits at the top of the rail.

Nothing else moves, and the default landing route is unchanged - a fresh boot at `/` still opens the Fleet Map.

## 2. The Needs you group is a waiting line

In the "Attention first" view, the Needs you group was ordered by the owning Director's drag-to-reorder `sortOrder`. It is now ordered by how long each session has been waiting: the session that has been asking for you the **longest sits at the top**, and one that only just started needing you joins at the **bottom**. Work it from the top down and it is first-in, first-handled.

This uses `inWaitingOrder` from `client-core/sessions/ordering`, which already existed and which the phone roster already uses - so the Cockpit and the phone now show the same order. No Gateway change was needed: `needsYouSince` is already stamped on the wire and is already what renders the "waiting 1m" chip on these exact rows.

The Active and Snoozed groups below keep the desktop order they had.

## Tests

New: `apps/cockpit/src/AppShell.test.tsx` (rail order and the full label list) and `apps/cockpit/src/sessions/attentionOrder.test.tsx` (the waiting-line order read off the rendered rows, plus the unstamped-session-to-the-bottom case).

The distinguishing test sets the desktop `sortOrder` to the exact reverse of the wait order, so a regression to the old ordering renders backwards and fails.

Both changes were reverted temporarily to confirm all five new tests go red with the right diffs, then restored.

- cockpit: 23 files, 194 tests passed
- client-core: 65 files, 694 tests passed
- typecheck clean across client-core, cockpit and mobile; eslint clean on the changed files