### PR TITLE
feat(cockpit): show each session's uncommitted file count in the roster

### DIFF
--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -12,6 +12,7 @@ import {
   snoozeCountdown,
   snoozeExpired,
 } from "@devthrottle/client-core/sessions/ordering";
+import { changesBadge, changesTitle } from "@devthrottle/client-core/sessions/changes";
 import { machinePortLabel } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import {
@@ -296,9 +297,15 @@ function RosterRow({
   // rides on contextLine (the stamped stateLabel); this tag adds the countdown beside it.
   const holdCountdown = snoozeCountdown(session);
   const windingDown = pendingDeletion(session);
-  // The tag row (voice / hold-time / snooze-ended / winding-down / last-seen / waiting) renders only when
-  // it has something to say, so a plain working session stays a compact two lines (name + state).
+  // How much uncommitted work this session is sitting on, in the same words the desktop rail uses. The
+  // Director measures it and the Gateway passes it through; the shared formatter decides the wording so
+  // this roster and the mobile one cannot say it two different ways. Null on a clean tree AND on an
+  // unknown one - see client-core/sessions/changes for why those stay distinct upstream.
+  const changes = changesBadge(session);
+  // The tag row (changes / voice / hold-time / snooze-ended / winding-down / last-seen / waiting) renders
+  // only when it has something to say, so a plain working session stays a compact two lines (name + state).
   const hasTags =
+    changes !== null ||
     holdCountdown !== null ||
     snoozeExpired(session) ||
     windingDown ||
@@ -331,6 +338,11 @@ function RosterRow({
           {/* Line 4 (only when there is something to show): the tags and the live waiting timer. */}
           {hasTags && (
             <span className="roster-tags">
+              {changes !== null && (
+                <span className="roster-tag changes" title={changesTitle(session) ?? undefined}>
+                  {changes}
+                </span>
+              )}
               {session.voiceMode && <span className="roster-tag voice">voice</span>}
               {windingDown && (
                 <span className="roster-tag winding-down" title={deletionReason(session) ?? "Marked for deletion"}>

--- a/apps/cockpit/src/sessions/rosterChangesBadge.test.tsx
+++ b/apps/cockpit/src/sessions/rosterChangesBadge.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// The roster's uncommitted-work badge - the "12 chg" pill the desktop rail has always shown and the
+// Cockpit roster did not, because the count never left the desktop window.
+//
+// The case worth a test is the one that is silent when it is wrong: a session whose git probe has not
+// succeeded reports NO count, and that must render as no badge - never as "0 chg", and never as a clean
+// tree. An older Director that does not know the field is the same case.
+
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  setVoiceModeAllSessions: vi.fn(async () => ({ changed: 0, skipped: 0 })),
+}));
+
+vi.mock("./SessionMenu", () => ({
+  SessionMenu: () => null,
+}));
+
+import { SessionRoster } from "./SessionRoster";
+
+type RosterSession = Record<string, unknown>;
+
+function session(overrides: RosterSession): RosterSession {
+  return {
+    sessionId: "s1",
+    directorId: "dir-A",
+    name: "a session",
+    machineName: "desk",
+    activityState: "Working",
+    effectiveColor: "blue",
+    effectiveColorHex: "#3B82F6",
+    stateLabel: "Working",
+    triageBucket: "active",
+    ...overrides,
+  };
+}
+
+function renderRoster(sessions: RosterSession[]) {
+  return render(
+    <MemoryRouter>
+      <SessionRoster
+        // The component takes SessionDto[]; the test builds the subset of fields the roster reads.
+        sessions={sessions as never}
+        directors={[]}
+        portByDirector={new Map()}
+        selectedId={undefined}
+        view="my-order"
+        error={null}
+        onView={() => {}}
+        onNewSession={() => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("the roster's uncommitted-changes badge", () => {
+  it("shows the count for a session with uncommitted work", () => {
+    renderRoster([session({ uncommittedCount: 12 })]);
+
+    const badge = screen.getByText("12 chg");
+    expect(badge).toBeTruthy();
+    expect(badge.className).toContain("changes");
+    expect(badge.getAttribute("title")).toBe("12 uncommitted files in this session's working tree");
+  });
+
+  it("shows no badge for a verified-clean tree", () => {
+    renderRoster([session({ uncommittedCount: 0 })]);
+
+    expect(screen.queryByText(/chg$/)).toBeNull();
+  });
+
+  it("shows no badge when the count is unknown, rather than reporting zero", () => {
+    // uncommittedCount null: the git probe has not succeeded. "We could not tell" is not "clean", and it
+    // is certainly not "0 chg" - so the row says nothing about git at all.
+    renderRoster([session({ uncommittedCount: null })]);
+
+    expect(screen.queryByText(/chg$/)).toBeNull();
+    expect(screen.queryByText("0 chg")).toBeNull();
+  });
+
+  it("shows no badge for a Director too old to send the field", () => {
+    renderRoster([session({})]);
+
+    expect(screen.queryByText(/chg$/)).toBeNull();
+  });
+
+  it("badges each session with its own count", () => {
+    renderRoster([
+      session({ sessionId: "s1", name: "dirty one", uncommittedCount: 3 }),
+      session({ sessionId: "s2", name: "clean one", uncommittedCount: 0 }),
+      session({ sessionId: "s3", name: "busy one", uncommittedCount: 41 }),
+    ]);
+
+    expect(screen.getByText("3 chg")).toBeTruthy();
+    expect(screen.getByText("41 chg")).toBeTruthy();
+    expect(screen.queryByText("0 chg")).toBeNull();
+  });
+});

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -906,6 +906,18 @@ body {
   color: var(--text-dim);
 }
 
+/* Uncommitted work in this session's working tree ("12 chg"), in the desktop rail's amber. A BADGE, never
+   a colour - the dot keeps telling the truth about the work. Not uppercased: "chg" is already a squeeze,
+   and shouting it does not make it clearer. Shown only for a positive count; a clean tree and an unknown
+   one both render nothing (client-core/sessions/changes). */
+.roster-tag.changes {
+  text-transform: none;
+  letter-spacing: 0;
+  background: rgba(245, 208, 96, 0.14);
+  border-color: rgba(245, 208, 96, 0.5);
+  color: #f5d060;
+}
+
 /* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour): the dot
    still tells the truth about the work while this rides beside it. Mirrors the desktop rail's badge. */
 .roster-tag.winding-down {

--- a/packages/client-core/src/sessions/changes.test.ts
+++ b/packages/client-core/src/sessions/changes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { changesBadge, changesTitle, uncommittedCount } from "./changes";
+import type { SessionDto } from "../api/client";
+
+// The badge for a session's uncommitted work. The property worth pinning is the one that is invisible
+// once it is wrong: UNKNOWN AND CLEAN BOTH RENDER NOTHING, but they are different answers, and a client
+// must never turn "the git probe failed" into a clean tree.
+const session = (uncommitted?: unknown): SessionDto =>
+  ({ sessionId: "s1", ...(uncommitted === undefined ? {} : { uncommittedCount: uncommitted }) }) as SessionDto;
+
+describe("uncommittedCount", () => {
+  it("reads a positive count", () => {
+    expect(uncommittedCount(session(12))).toBe(12);
+  });
+
+  it("reads a verified-clean tree as zero", () => {
+    expect(uncommittedCount(session(0))).toBe(0);
+  });
+
+  it("reads null, undefined and a missing field as unknown", () => {
+    expect(uncommittedCount(session(null))).toBeNull();
+    expect(uncommittedCount(session())).toBeNull();
+  });
+
+  it("coerces the numeric-string form the serializer can emit", () => {
+    expect(uncommittedCount(session("7"))).toBe(7);
+  });
+
+  it("treats an unparseable value as unknown, never as zero", () => {
+    // A zero here would be the client inventing a clean tree out of a value it could not read.
+    expect(uncommittedCount(session("banana"))).toBeNull();
+    expect(uncommittedCount(session(-3))).toBeNull();
+  });
+});
+
+describe("changesBadge", () => {
+  it("shows the count on a dirty tree", () => {
+    expect(changesBadge(session(12))).toBe("12 chg");
+    expect(changesBadge(session(1))).toBe("1 chg");
+  });
+
+  it("shows nothing on a clean tree", () => {
+    expect(changesBadge(session(0))).toBeNull();
+  });
+
+  it("shows nothing when the count is unknown", () => {
+    // Including the older-Director case, where the field simply is not on the wire.
+    expect(changesBadge(session(null))).toBeNull();
+    expect(changesBadge(session())).toBeNull();
+  });
+});
+
+describe("changesTitle", () => {
+  it("spells out what the number means, and gets the singular right", () => {
+    expect(changesTitle(session(1))).toBe("1 uncommitted file in this session's working tree");
+    expect(changesTitle(session(4))).toBe("4 uncommitted files in this session's working tree");
+  });
+
+  it("has no tooltip when there is no badge", () => {
+    expect(changesTitle(session(0))).toBeNull();
+    expect(changesTitle(session())).toBeNull();
+  });
+});

--- a/packages/client-core/src/sessions/changes.ts
+++ b/packages/client-core/src/sessions/changes.ts
@@ -1,0 +1,54 @@
+// The one place any web client turns a session's uncommitted file count into something to render.
+//
+// The count itself is a FACT and only the machine holding the checkout can measure it: the owning
+// Director's SessionGitStatusMonitor probes git and reports it on SessionDto.uncommittedCount, and the
+// Gateway passes it through untouched. What is shared here is the WORDING, so the Cockpit roster and the
+// mobile roster cannot drift into showing the same number two different ways.
+//
+// THE RULE THIS FILE EXISTS TO HOLD: null and 0 both render NOTHING, and they are not the same thing.
+// Null means the git probe has not succeeded - no git on the path, a permissions problem, a repository
+// mid-rebase, or a Director too old to know the field - and "we could not tell" must never be shown as a
+// clean tree. Zero means a probe DID run and found nothing changed. Both are silent on the row, because a
+// badge reading "0 chg" is noise; the difference matters upstream, where a false zero would overwrite a
+// real measurement (see SessionDto.UncommittedCount, issue 516).
+import type { SessionDto } from "../api/client";
+
+// The generated schema.ts does not carry this field yet, so it is augmented here - the same way
+// snoozeUntil, holdState and the other Gateway-stamped fields are augmented in ordering.ts.
+type SessionWithChanges = SessionDto & {
+  uncommittedCount?: number | string | null;
+};
+
+/**
+ * How many files are changed in this session's working tree, or null when that is unknown.
+ * Coerces the numeric-string form the serializer can emit (the same coercion inDesktopOrder does for
+ * sortOrder), and treats anything unparseable as unknown rather than as zero.
+ */
+export function uncommittedCount(session: SessionDto): number | null {
+  const raw = (session as SessionWithChanges).uncommittedCount;
+  if (raw === null || raw === undefined) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.floor(n);
+}
+
+/**
+ * The roster badge text for a session's uncommitted work ("12 chg"), or null when there is nothing to
+ * show - which is BOTH a clean tree and an unknown one. Matches the desktop rail's amber "N chg" pill.
+ */
+export function changesBadge(session: SessionDto): string | null {
+  const n = uncommittedCount(session);
+  if (n === null || n === 0) return null;
+  return `${n} chg`;
+}
+
+/**
+ * The badge's tooltip - the long form of what the number means, since "chg" is a squeeze that only makes
+ * sense once. Null whenever there is no badge.
+ */
+export function changesTitle(session: SessionDto): string | null {
+  const n = uncommittedCount(session);
+  if (n === null || n === 0) return null;
+  return n === 1 ? "1 uncommitted file in this session's working tree"
+                 : `${n} uncommitted files in this session's working tree`;
+}

--- a/src/CcDirector.Avalonia.Tests/SessionRailStateTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SessionRailStateTests.cs
@@ -272,6 +272,64 @@ public sealed class SessionRailStateTests
         Assert.Equal("", vm.RoleGlyphText);
     }
 
+    // ===== The uncommitted-work badge ("N chg") =====
+    //
+    // The rail used to compute this itself, on a timer the window owned, so the number existed only here
+    // and never reached the Gateway. It now reads the Session, which the Director's SessionGitStatusMonitor
+    // writes and ControlEndpoints.Map puts on the wire - so the rail and the Cockpit roster show one number.
+
+    [Fact]
+    public void UncommittedBadge_UnprobedSession_ShowsNoBadge()
+    {
+        var vm = new SessionViewModel(Bare());
+
+        // Null on the Session is UNKNOWN. The badge must be absent, not read "0 chg" - which would claim a
+        // clean tree nobody has measured (issue 516).
+        Assert.False(vm.HasUncommittedChanges);
+        Assert.Equal(0, vm.UncommittedCount);
+    }
+
+    [Fact]
+    public void UncommittedBadge_CleanTree_ShowsNoBadge()
+    {
+        var session = Bare();
+        session.UncommittedCount = 0;
+
+        var vm = new SessionViewModel(session);
+
+        Assert.False(vm.HasUncommittedChanges);
+    }
+
+    [Fact]
+    public void UncommittedBadge_DirtyTree_ShowsTheCountFromTheSession()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        session.UncommittedCount = 12;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.HasUncommittedChanges);
+        Assert.Equal(12, vm.UncommittedCount);
+    }
+
+    [Fact]
+    public void UncommittedBadge_CountChanges_RaisesTheRailsRepaint()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+        var repainted = new List<string>();
+        vm.PropertyChanged += (_, e) => repainted.Add(e.PropertyName ?? "");
+
+        session.UncommittedCount = 4;
+        Dispatcher.UIThread.RunJobs();
+
+        // Without this the row keeps its old badge until some unrelated event happens to repaint it - the
+        // same class of bug as a fold input with no invalidation path.
+        Assert.Contains(nameof(SessionViewModel.UncommittedCount), repainted);
+        Assert.Contains(nameof(SessionViewModel.HasUncommittedChanges), repainted);
+    }
+
     /// <summary>An inert backend: the Session needs one, these tests never run a process.</summary>
     private sealed class InertBackend : ISessionBackend
     {

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -82,11 +82,10 @@ public partial class MainWindow : Window
     private readonly SlashCommandProvider _slashCommandProvider = new();
     private List<SlashCommandItem> _filteredSlashCommands = new();
 
-    // Session git status polling
-    private readonly CcDirector.Core.Git.GitStatusProvider _gitStatusProvider = new();
+    // Rail refresh timers. The git-status probe that used to ride the first of these now runs on the
+    // Director (Core.Git.SessionGitStatusMonitor) so the count reaches every surface, not just this one.
     private global::Avalonia.Threading.DispatcherTimer? _sessionGitTimer;
     private global::Avalonia.Threading.DispatcherTimer? _dictationLockTimer;
-    private bool _sessionGitRefreshRunning;
 
     // Interactive TUI mode
     private bool _isInteractiveTuiMode;
@@ -302,16 +301,21 @@ public partial class MainWindow : Window
         HomeView.GatewayClicked += (_, _) => OpenGatewayConnectionPanel();
         UpdateHomeVisibility();
 
-        // Start session git status polling (15s interval)
+        // Refresh the rail's relative time labels and the needs-you count every 15 seconds.
+        //
+        // This timer used to ALSO probe git for each session's uncommitted file count and write it onto the
+        // view model. That poll has moved to the Director (Core.Git.SessionGitStatusMonitor), which writes
+        // Session.UncommittedCount and so puts the number on the wire for the Cockpit roster and the phone
+        // too. Computing it here meant the number existed only on this screen. The rail now subscribes to
+        // the session's own change event and renders the same count every other surface sees.
         _sessionGitTimer = new global::Avalonia.Threading.DispatcherTimer
         {
             Interval = TimeSpan.FromSeconds(15),
         };
-        _sessionGitTimer.Tick += async (_, _) =>
+        _sessionGitTimer.Tick += (_, _) =>
         {
             foreach (var vm in _sessions) vm.RefreshTimeLabels();
             UpdateNeedsYouCount();
-            await RefreshSessionGitStatusAsync();
         };
         _sessionGitTimer.Start();
 
@@ -5829,46 +5833,6 @@ public partial class MainWindow : Window
         catch (Exception ex)
         {
             FileLog.Write($"[MainWindow] CaptureStartupTextAsync FAILED: {ex.Message}");
-        }
-    }
-
-    // ==================== SESSION GIT STATUS POLLING ====================
-
-    private async Task RefreshSessionGitStatusAsync()
-    {
-        if (_sessionGitRefreshRunning) return;
-        _sessionGitRefreshRunning = true;
-
-        try
-        {
-            var sessions = _sessions.ToList();
-            using var semaphore = new SemaphoreSlim(4);
-
-            var tasks = sessions.Select(async vm =>
-            {
-                await semaphore.WaitAsync();
-                try
-                {
-                    var repoPath = vm.Session.RepoPath;
-                    if (!Directory.Exists(repoPath)) return;
-
-                    var count = await _gitStatusProvider.GetCountAsync(repoPath);
-                    // Only publish a count the probe actually produced; a failed probe leaves the
-                    // previous value rather than showing a false zero (issue 516).
-                    if (count.Success)
-                        global::Avalonia.Threading.Dispatcher.UIThread.Post(() => vm.UncommittedCount = count.Count);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            });
-
-            await Task.WhenAll(tasks);
-        }
-        finally
-        {
-            _sessionGitRefreshRunning = false;
         }
     }
 

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -82,6 +82,9 @@ public class SessionViewModel : INotifyPropertyChanged
         // session parked on its background task flips the fold from purple "Background" to red "Needs you"
         // with no overlay flag changing. Easier to miss than a flag for exactly that reason.
         session.OnWingmanEnabledChanged += OnFoldInputChangedVm;
+        // The uncommitted-file count now arrives from the Director's monitor rather than from a timer this
+        // window owns, so the badge needs its own invalidation the same way every other pushed fact does.
+        session.OnUncommittedCountChanged += OnUncommittedCountChangedVm;
 
         if (session.PromptQueue != null)
         {
@@ -528,6 +531,17 @@ public class SessionViewModel : INotifyPropertyChanged
         });
     }
 
+    /// <summary>Repaint the amber "N chg" badge when the Director's git monitor publishes a new count.
+    /// Posted to the UI thread: the monitor raises this from a background poll.</summary>
+    private void OnUncommittedCountChangedVm(int? _)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            OnPropertyChanged(nameof(UncommittedCount));
+            OnPropertyChanged(nameof(HasUncommittedChanges));
+        });
+    }
+
     public string? CustomColor
     {
         get => Session.CustomColor;
@@ -738,20 +752,20 @@ public class SessionViewModel : INotifyPropertyChanged
 
     public string RepoPath => Session.RepoPath;
 
-    private int _uncommittedCount;
-    public int UncommittedCount
-    {
-        get => _uncommittedCount;
-        set
-        {
-            if (_uncommittedCount == value) return;
-            _uncommittedCount = value;
-            OnPropertyChanged();
-            OnPropertyChanged(nameof(HasUncommittedChanges));
-        }
-    }
+    /// <summary>
+    /// How many files are changed in this session's working tree, for the rail's amber "N chg" badge.
+    /// READ STRAIGHT OFF THE SESSION - this view model no longer keeps a copy, and the window no longer
+    /// polls git for it. The count is produced once, on the Director, by <c>SessionGitStatusMonitor</c>,
+    /// which is also what puts it on the wire for the Cockpit roster and the phone. Before that it was
+    /// computed here and nowhere else, so the number existed only on this screen.
+    ///
+    /// Zero when the count is UNKNOWN (no successful probe yet) - and <see cref="HasUncommittedChanges"/>
+    /// is false in that case, so the badge is absent rather than reading "0 chg". Unknown must never render
+    /// as a verified-clean tree (issue 516).
+    /// </summary>
+    public int UncommittedCount => Session.UncommittedCount ?? 0;
 
-    public bool HasUncommittedChanges => _uncommittedCount > 0;
+    public bool HasUncommittedChanges => Session.UncommittedCount is > 0;
 
     private int _queueCount;
     public int QueueCount

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -202,6 +202,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     private Core.Activity.ActivityEventProducer? _activityProducer;
     private ActivityEventUploader? _activityUploader;
     private RepoStatePusher? _repoStatePusher;
+    private Core.Git.SessionGitStatusMonitor? _sessionGitStatusMonitor;
     private TransientErrorAutoResume? _transientErrorAutoResume;
     private TerminalSessionRecorder? _sessionRecorder;
     private Core.Storage.TurnReviewLogger? _turnReviewLogger;
@@ -771,6 +772,14 @@ public sealed class ControlApiHost : IAsyncDisposable
                 liveSessions: LiveSessionRefs);
             _repoStatePusher.Start();
         }
+
+        // Every live session's uncommitted file count, refreshed every fifteen seconds. This poll used to
+        // live in the desktop window, which meant the number existed only where it was rendered and never
+        // reached the Gateway - so the Cockpit roster had nothing to show. Here it lands on the Session,
+        // which ControlEndpoints.Map puts on the wire, and the desktop rail reads the same number rather
+        // than probing git a second time.
+        _sessionGitStatusMonitor = new Core.Git.SessionGitStatusMonitor(_sessionManager);
+        _sessionGitStatusMonitor.Start();
     }
 
     /// <summary>
@@ -983,6 +992,13 @@ public sealed class ControlApiHost : IAsyncDisposable
             // colour. Found by review of pull request 1598, after three earlier passes hunting exactly this.
             session.OnWingmanEnabledChanged += _ =>
                 _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
+
+            // The uncommitted file count. Same one-line shape and same reason as the pushes above: without
+            // it the Cockpit's "N chg" badge would only move on the ten-second full re-push, or on whatever
+            // unrelated event happened to fire first. The monitor raises this ONLY when the number actually
+            // changes, so an idle session pushes nothing.
+            session.OnUncommittedCountChanged += _ =>
+                _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
         }
 
         _sessionManager.OnSessionCreated += session =>
@@ -1121,6 +1137,8 @@ public sealed class ControlApiHost : IAsyncDisposable
         _activityUploader = null;
         _repoStatePusher?.Dispose();
         _repoStatePusher = null;
+        _sessionGitStatusMonitor?.Dispose();
+        _sessionGitStatusMonitor = null;
         _activityProducer?.Dispose();
         _activityProducer = null;
         _activityOutbox = null;

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1640,6 +1640,13 @@ internal static class ControlEndpoints
             // this roster mapper never forks git twice for the same checkout; "" when the checkout is on no
             // host we recognize, in which case the Gateway groups it by its folder name instead.
             RepoName = GitHubUrls.ResolveRepoNameCached(s.RepoPath),
+            // How many files are changed in this session's working tree, measured on this machine by
+            // SessionGitStatusMonitor - the number behind the desktop rail's amber "N chg" badge. Null
+            // until a git probe succeeds, and null is UNKNOWN, never "clean": a failed probe leaves the
+            // last known count in place rather than reporting a zero every reader would render as a clean
+            // tree (issue 516). Nothing is derived here - the Gateway passes the count through and the
+            // clients share one formatter.
+            UncommittedCount = s.UncommittedCount,
             // Issue #335: identity fields populated by the Director (not patched by the Gateway).
             MachineName = machineName,
             User = user,

--- a/src/CcDirector.Core.Tests/SessionGitStatusMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/SessionGitStatusMonitorTests.cs
@@ -1,0 +1,187 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SessionGitStatusMonitor"/> - the Director-side poll that publishes each live
+/// session's uncommitted file count onto <see cref="Session.UncommittedCount"/>, which is what puts the
+/// number on the wire for the Cockpit roster and the phone.
+///
+/// The property under test in most of these is the one that is easy to get wrong and impossible to see once
+/// it ships: A FAILED PROBE MUST NOT LOOK LIKE A CLEAN TREE (issue 516). A count of 0 and "we could not
+/// tell" render identically to a reader that collapses them, so the monitor publishes only counts a probe
+/// actually produced, and leaves the last known value alone otherwise.
+/// </summary>
+public sealed class SessionGitStatusMonitorTests
+{
+    [Fact]
+    public async Task RefreshOnce_PublishesTheCountOntoTheSession()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+
+        Assert.Null(session.UncommittedCount);   // nothing probed yet is UNKNOWN, not zero
+
+        var monitor = Monitor(manager, probe: _ => new GitCountResult(Success: true, Count: 7));
+        var published = await monitor.RefreshOnceAsync();
+
+        Assert.Equal(1, published);
+        Assert.Equal(7, session.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_CleanTreePublishesZero_WhichIsADifferentAnswerFromUnknown()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+
+        var monitor = Monitor(manager, probe: _ => new GitCountResult(Success: true, Count: 0));
+        await monitor.RefreshOnceAsync();
+
+        // A SUCCESSFUL probe that found nothing is a verified-clean tree, and 0 is the honest report of it.
+        // The distinction this test protects is against null (unknown), asserted in the tests below.
+        Assert.Equal(0, session.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_FailedProbeLeavesTheLastKnownCount_NeverAFalseZero()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+
+        var succeed = true;
+        var monitor = Monitor(manager, probe: _ => succeed
+            ? new GitCountResult(Success: true, Count: 12)
+            : new GitCountResult(Success: false, Count: 0));
+
+        await monitor.RefreshOnceAsync();
+        Assert.Equal(12, session.UncommittedCount);
+
+        // git falls over on the next cycle. The count is now UNKNOWN - and unknown must not overwrite a real
+        // measurement with a zero, which every reader downstream would render as "this tree is clean".
+        succeed = false;
+        var published = await monitor.RefreshOnceAsync();
+
+        Assert.Equal(0, published);
+        Assert.Equal(12, session.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_ProbeThatNeverSucceededLeavesTheCountNull()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+
+        var monitor = Monitor(manager, probe: _ => new GitCountResult(Success: false, Count: 0));
+        await monitor.RefreshOnceAsync();
+
+        // Null, not 0. A client renders no badge for null; a 0 here would claim a verified-clean tree we
+        // have never actually observed.
+        Assert.Null(session.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_MissingRepositoryFolderIsNotProbedAndKeepsItsLastCount()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+        session.UncommittedCount = 3;
+
+        var probed = false;
+        var monitor = Monitor(manager,
+            probe: _ => { probed = true; return new GitCountResult(Success: true, Count: 99); },
+            directoryExists: _ => false);
+
+        await monitor.RefreshOnceAsync();
+
+        // A session whose folder was deleted or moved is unreadable, not clean.
+        Assert.False(probed);
+        Assert.Equal(3, session.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_OneThrowingProbeDoesNotStopTheOtherSessions()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var bad = NewSession(@"C:\test\bad");
+        using var good = NewSession(@"C:\test\good");
+        manager.AdoptSession(bad);
+        manager.AdoptSession(good);
+
+        var monitor = Monitor(manager, probe: path => path.EndsWith("bad", StringComparison.Ordinal)
+            ? throw new InvalidOperationException("git exploded")
+            : new GitCountResult(Success: true, Count: 4));
+
+        var published = await monitor.RefreshOnceAsync();
+
+        Assert.Equal(1, published);
+        Assert.Null(bad.UncommittedCount);
+        Assert.Equal(4, good.UncommittedCount);
+    }
+
+    [Fact]
+    public async Task RefreshOnce_RaisesTheChangeEventOnlyWhenTheNumberActuallyMoves()
+    {
+        using var manager = new SessionManager(new AgentOptions());
+        using var session = NewSession();
+        manager.AdoptSession(session);
+
+        var raised = 0;
+        session.OnUncommittedCountChanged += _ => raised++;
+
+        var count = 5;
+        var monitor = Monitor(manager, probe: _ => new GitCountResult(Success: true, Count: count));
+
+        await monitor.RefreshOnceAsync();
+        await monitor.RefreshOnceAsync();   // same number - an idle session must push nothing
+        Assert.Equal(1, raised);
+
+        count = 6;
+        await monitor.RefreshOnceAsync();
+        Assert.Equal(2, raised);
+    }
+
+    private static SessionGitStatusMonitor Monitor(
+        SessionManager manager,
+        Func<string, GitCountResult> probe,
+        Func<string, bool>? directoryExists = null)
+        => new(manager,
+            interval: TimeSpan.FromHours(1),          // the loop never runs; the tests drive RefreshOnceAsync
+            probe: (path, _) => Task.FromResult(probe(path)),
+            directoryExists: directoryExists ?? (_ => true));
+
+    private static Session NewSession(string repoPath = @"C:\test\repo")
+        => new(Guid.NewGuid(), repoPath, repoPath, null, new NullBackend(), SessionBackendType.ConPty);
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public CircularTerminalBuffer? Buffer => null;
+        public int ProcessId => 1;
+        public string Status => "Null";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Kill() { }
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Core/Git/SessionGitStatusMonitor.cs
+++ b/src/CcDirector.Core/Git/SessionGitStatusMonitor.cs
@@ -1,0 +1,147 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Keeps every live session's "how many files are changed in my working tree" count up to date
+/// (<see cref="Session.UncommittedCount"/>), so the desktop rail, the Cockpit roster and the phone all read
+/// ONE number that the Director produced instead of each surface polling git for itself.
+///
+/// This poll used to live in the desktop window (<c>MainWindow.RefreshSessionGitStatusAsync</c>), which
+/// meant the number existed only where it was rendered: it never reached <c>SessionDto</c>, so the Gateway
+/// was never told and the Cockpit roster had nothing to show. Moving it here puts it on the Session, which
+/// is what the Control API maps onto the wire.
+///
+/// FAIL CLOSED, NEVER FAIL ZERO (issue 516). A git probe can fail - no git on the path, a permissions
+/// problem, a repository mid-rebase - and the count is then UNKNOWN. This monitor publishes only a count a
+/// probe actually produced; a failed probe leaves the previous value alone, and a session whose probe has
+/// never succeeded keeps a null count. Reporting 0 would tell every reader downstream "this tree is clean",
+/// which is the one thing we do not know.
+/// </summary>
+public sealed class SessionGitStatusMonitor : IDisposable
+{
+    /// <summary>The default poll interval - the same fifteen seconds the desktop rail used.</summary>
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(15);
+
+    /// <summary>How many repositories are probed at once. Matches the desktop's old limit.</summary>
+    private const int MaxConcurrentProbes = 4;
+
+    private readonly SessionManager _sessionManager;
+    private readonly Func<string, CancellationToken, Task<GitCountResult>> _probe;
+    private readonly TimeSpan _interval;
+    private readonly Func<string, bool> _directoryExists;
+
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+
+    /// <param name="sessionManager">The live session list to walk each cycle.</param>
+    /// <param name="interval">Poll interval; null uses <see cref="DefaultInterval"/>. A test seam.</param>
+    /// <param name="probe">The git probe; null uses a shared <see cref="GitStatusProvider"/>. Its ten-second
+    /// cache is keyed by path and shared across instances, so several sessions in ONE working tree cost one
+    /// <c>git status</c> call between them, not one each. A test seam.</param>
+    /// <param name="directoryExists">Existence check for a session's repository path. A test seam; production
+    /// passes null and gets <see cref="Directory.Exists"/>.</param>
+    public SessionGitStatusMonitor(
+        SessionManager sessionManager,
+        TimeSpan? interval = null,
+        Func<string, CancellationToken, Task<GitCountResult>>? probe = null,
+        Func<string, bool>? directoryExists = null)
+    {
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+        var provider = new GitStatusProvider();
+        _probe = probe ?? provider.GetCountAsync;
+        _interval = interval ?? DefaultInterval;
+        _directoryExists = directoryExists ?? Directory.Exists;
+    }
+
+    /// <summary>Start the background loop. Idempotent.</summary>
+    public void Start()
+    {
+        if (_loop is not null) return;
+        _cts = new CancellationTokenSource();
+        _loop = Task.Run(() => RunAsync(_cts.Token));
+        FileLog.Write($"[SessionGitStatusMonitor] Start: probing every {_interval.TotalSeconds:0} seconds");
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await RefreshOnceAsync(ct).ConfigureAwait(false);
+                await Task.Delay(_interval, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ordinary shutdown.
+        }
+        catch (Exception ex)
+        {
+            // The loop itself dying is the one failure the per-session catch below cannot cover, and it would
+            // silently freeze every count for the life of the process - so it is logged as loudly as it gets.
+            FileLog.Write("[SessionGitStatusMonitor] the poll loop ENDED unexpectedly; no further uncommitted "
+                + $"counts will be reported until this Director restarts: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Probe every live session once and publish the counts. Internal (not private) so a test can drive one
+    /// cycle deterministically instead of waiting on the timer. Returns how many sessions got a fresh count.
+    /// </summary>
+    internal async Task<int> RefreshOnceAsync(CancellationToken ct = default)
+    {
+        var sessions = _sessionManager.ListSessions();
+        if (sessions.Count == 0) return 0;
+
+        var published = 0;
+        using var gate = new SemaphoreSlim(MaxConcurrentProbes);
+
+        var probes = sessions.Select(async session =>
+        {
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var repoPath = session.RepoPath;
+                // A session whose folder has been deleted or moved is not "clean" - it is unreadable. Leave
+                // whatever the last successful probe said and move on.
+                if (string.IsNullOrWhiteSpace(repoPath) || !_directoryExists(repoPath)) return;
+
+                var count = await _probe(repoPath, ct).ConfigureAwait(false);
+                if (!count.Success) return;   // unknown, not zero - see the class summary
+
+                session.UncommittedCount = count.Count;
+                Interlocked.Increment(ref published);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown mid-probe; the loop's handler owns it.
+            }
+            catch (Exception ex)
+            {
+                // One unreadable repository must never stop the other sessions being probed.
+                FileLog.Write($"[SessionGitStatusMonitor] probe FAILED for session {session.Id}, "
+                    + $"leaving the last known count in place: {ex.Message}");
+            }
+            finally
+            {
+                gate.Release();
+            }
+        });
+
+        await Task.WhenAll(probes).ConfigureAwait(false);
+        FileLog.Write($"[SessionGitStatusMonitor] RefreshOnceAsync: published {published} of {sessions.Count} session counts");
+        return published;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _loop = null;
+        FileLog.Write("[SessionGitStatusMonitor] Dispose: stopped");
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1005,6 +1005,7 @@ public sealed class Session : IDisposable
 
     private bool _isBackgroundRunning;
     private string _backgroundReason = "running in background";
+    private int? _uncommittedCount;
 
     /// <summary>
     /// True when the Wingman has read the screen and determined this session is parked
@@ -1044,6 +1045,37 @@ public sealed class Session : IDisposable
     /// promptly (defect 14). NOT by the SessionStatusWingman, which this comment used to name and which has
     /// never subscribed to it - before defect 14 this event had no subscribers at all.</summary>
     public event Action<bool>? OnIsBackgroundRunningChanged;
+
+    /// <summary>
+    /// How many files are changed in this session's working tree (staged plus unstaged plus untracked),
+    /// or NULL when nobody has been able to tell yet. Written only by <c>SessionGitStatusMonitor</c>,
+    /// which polls <c>GitStatusProvider</c> on the Director; reported on <c>SessionDto.UncommittedCount</c>
+    /// so the desktop rail, the Cockpit roster and the phone all read ONE number instead of each polling
+    /// git for themselves.
+    ///
+    /// NULL IS A REAL ANSWER AND IS NEVER RENDERED AS ZERO (issue 516). A git probe can fail - a missing
+    /// git executable, a permissions problem, a repository that is mid-rebase - and reporting 0 there would
+    /// erase the difference between "this tree is clean" and "we could not tell", which every reader
+    /// downstream would show as a clean tree. The monitor therefore leaves the LAST KNOWN value in place on
+    /// a failed probe and only ever publishes a count a probe actually produced; null means no probe has
+    /// ever succeeded for this session.
+    /// </summary>
+    public int? UncommittedCount
+    {
+        get => _uncommittedCount;
+        set
+        {
+            if (_uncommittedCount == value) return;
+            _uncommittedCount = value;
+            OnUncommittedCountChanged?.Invoke(value);
+        }
+    }
+
+    /// <summary>Fires when <see cref="UncommittedCount"/> changes. Arg: the new count (null when unknown).
+    /// Subscribed by <c>ControlApiHost.WireDoorbellPush</c>, which pushes the session up the stream so the
+    /// Cockpit badge moves when the count moves rather than waiting for the next ten-second re-push, and by
+    /// the desktop rail, which re-renders the badge in place.</summary>
+    public event Action<int?>? OnUncommittedCountChanged;
 
     /// <summary>
     /// Set (or clear) the Wingman's "parked on a background task" verdict for this session.

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -706,6 +706,28 @@ public sealed class SessionDto
     public TokenTotalsDto? TokenTotals { get; set; }
 
     /// <summary>
+    /// How many files are changed in this session's working tree - staged plus unstaged plus untracked -
+    /// as the owning Director's <c>SessionGitStatusMonitor</c> last measured it. This is the number behind
+    /// the desktop rail's amber "N chg" badge, and it is on the wire so the Cockpit roster and the phone
+    /// show the SAME number rather than each polling git for themselves (or, as before this field existed,
+    /// showing nothing at all).
+    ///
+    /// A RAW FACT, not a verdict. Only the machine holding the checkout can measure it, so the Gateway
+    /// passes it through untouched; what a client DOES with it (the badge, its wording) is one shared
+    /// formatter, not a per-client rule.
+    ///
+    /// NULL MEANS UNKNOWN AND MUST NEVER BE RENDERED AS ZERO (issue 516). A git probe can fail - no git on
+    /// the path, a permissions problem, a repository mid-rebase - and "we could not tell" is a different
+    /// answer from "this tree is clean". Null is also what an older Director reports, since it does not
+    /// know the field. Clients show no badge for null AND for 0; only a positive count renders.
+    ///
+    /// Scoped to the session's OWN working tree: a session running in a worktree reports that worktree's
+    /// count, not its parent repository's. Two sessions sharing one checkout therefore report the same
+    /// number, which is correct - it is one tree.
+    /// </summary>
+    public int? UncommittedCount { get; set; }
+
+    /// <summary>
     /// Issue #1176 (Phase 1a): a copy safe to hand out from the Gateway's pushed-session cache. The
     /// <c>/sessions</c> aggregation stamps scalar fields (EffectiveColor, DirectorId, MachineName,
     /// voice/transcription overlays, etc.) on the object it serves, so callers must never receive the

--- a/src/CcDirector.Gateway.Tests/SessionUncommittedCountWireTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionUncommittedCountWireTests.cs
@@ -1,0 +1,109 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The wire for a session's uncommitted file count: the Director measures it, the mapper puts it on
+/// <see cref="SessionDto.UncommittedCount"/>, and it survives the Gateway's pushed-session cache intact so
+/// the Cockpit roster can render the same "N chg" badge the desktop rail shows.
+///
+/// WHY THIS EXISTS AT ALL. The count used to be computed in the desktop window and written onto a view
+/// model, so it never touched the DTO: the Gateway was never told, and the Cockpit roster had nothing to
+/// show. These tests pin the two joints that made that true - the mapper, and the cache copy - because a
+/// field silently dropped at either one looks exactly like the bug we just fixed.
+///
+/// The other property under test is that UNKNOWN survives as unknown. Null means the git probe has not
+/// succeeded; it must never arrive at a client as 0, which every reader renders as a verified-clean tree.
+/// </summary>
+public sealed class SessionUncommittedCountWireTests
+{
+    [Fact]
+    public void Map_CarriesTheCountOntoTheDto()
+    {
+        using var session = NewSession();
+        session.UncommittedCount = 12;
+
+        var dto = ControlEndpoints.Map(session, "dir-A");
+
+        Assert.Equal(12, dto.UncommittedCount);
+    }
+
+    [Fact]
+    public void Map_UnprobedSessionReportsNull_NotZero()
+    {
+        using var session = NewSession();
+
+        var dto = ControlEndpoints.Map(session, "dir-A");
+
+        // Null is "we have not been able to tell". A zero here would claim a clean tree nobody measured.
+        Assert.Null(dto.UncommittedCount);
+    }
+
+    [Fact]
+    public void Map_VerifiedCleanTreeReportsZero()
+    {
+        using var session = NewSession();
+        session.UncommittedCount = 0;
+
+        var dto = ControlEndpoints.Map(session, "dir-A");
+
+        // A successful probe that found nothing IS zero, and is distinguishable from the null above.
+        Assert.Equal(0, dto.UncommittedCount);
+    }
+
+    [Fact]
+    public void PushedSessionStore_ServesTheCountBackUnchanged()
+    {
+        // The store hands out Clone()d copies so one request cannot contaminate the cache for the next. A
+        // hand-written copy that forgot this field would drop the badge with no other symptom.
+        var now = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var store = new PushedSessionStore(() => now);
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[]
+        {
+            new SessionDto { SessionId = "s-dirty", ActivityState = "Working", UncommittedCount = 12 },
+            new SessionDto { SessionId = "s-clean", ActivityState = "Working", UncommittedCount = 0 },
+            new SessionDto { SessionId = "s-unknown", ActivityState = "Working", UncommittedCount = null },
+        });
+
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", TimeSpan.FromSeconds(20));
+
+        Assert.NotNull(fresh);
+        Assert.Equal(12, Assert.Single(fresh, s => s.SessionId == "s-dirty").UncommittedCount);
+        Assert.Equal(0, Assert.Single(fresh, s => s.SessionId == "s-clean").UncommittedCount);
+        Assert.Null(Assert.Single(fresh, s => s.SessionId == "s-unknown").UncommittedCount);
+    }
+
+    private static Session NewSession()
+        => new(Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null, new NullBackend(), SessionBackendType.ConPty);
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public CircularTerminalBuffer? Buffer => null;
+        public int ProcessId => 1;
+        public string Status => "Null";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Kill() { }
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
The desktop rail has always shown an amber "N chg" badge on a session sitting on uncommitted
work. The cockpit's roster showed nothing. This closes that gap.

Issue: thefrederiksen/devthrottle_internal#549

## Why it was missing

The count was computed inside the desktop window (`MainWindow.RefreshSessionGitStatusAsync`)
and written onto a view model, so the number existed only on that screen. It never reached
`SessionDto`, the Gateway was never told, and the cockpit had nothing to render.

## What this does

Moves the poll out of the window and into the Director. `SessionGitStatusMonitor` walks the
live sessions on the same fifteen-second beat, with the same probe and the same ten-second
per-path cache, and writes `Session.UncommittedCount`. From there it rides the session
snapshot the Director already pushes, plus a delta when the number changes, so the badge
moves when the work moves rather than waiting for the next full re-push.

The desktop reads that same number off the session now instead of running its own timer, so
the rail is unchanged and one measurement feeds all three surfaces.

## Null is UNKNOWN, and is never rendered as zero

A git probe can fail - no git on the path, a permissions problem, a repository mid-rebase -
and "we could not tell" is a different answer from "this tree is clean". A failed probe leaves
the last known count in place, and clients draw no badge for null and for zero alike (issue
516). An older Director sends nothing, so it simply shows no badge.

## Shape of the change

- `SessionGitStatusMonitor` (new, Core) - the poll, started by `ControlApiHost`.
- `Session.UncommittedCount` + its change event.
- `SessionDto.UncommittedCount` (nullable), one line in `ControlEndpoints.Map`, one delta push.
- Gateway: pass-through. Sessions live in memory there, so **no database migration**.
- `client-core/sessions/changes.ts` - the one shared formatter, so the cockpit and the mobile
  roster cannot word it two different ways.
- `SessionRoster.tsx` + `styles.css` - the badge, in the desktop rail's amber.

## Proof

Live, against a Gateway and a Director both built from this branch:

| session | working tree | roster |
|---|---|---|
| `devthrottle-uncommitted-badge / 78f5` | 15 changed files | **15 chg** |
| `clean-repo / 016f` | clean | no badge |

Adding one file to the dirty tree moved the badge to **16 chg** on its own.

Suites: 309 desktop, 3,734 Core, 692 client-core, 193 cockpit, plus 4 new Gateway wire tests -
all green, and every web workspace type-checks.

The guards were pulled out three times to confirm the tests fail on purpose:

- without the fail-closed probe check, 2 Core tests fail
- without the mapper line, 2 Gateway tests fail
- with the badge rendering zero and unknown, 4 cockpit tests fail

## Two things worth a reviewer's eye

**`schema.ts` was not regenerated.** It is already behind on other fields (`currentModel`,
`tokenTotals`), so regenerating here would have shipped unrelated contract drift alongside
this change. The field is augmented in `changes.ts` instead - the same pattern `ordering.ts`
already uses for `snoozeUntil` and `holdState`. The live Gateway's OpenAPI document does carry
`uncommittedCount`, so a future regeneration picks it up.

**The desktop rail's badge is covered by unit test, not by eye.** The XAML binding is untouched
and reads the same two properties, and four new tests cover unknown / clean / dirty / repaint-
on-change - but the desktop window was not put on screen and looked at. That is the one claim
here resting on tests alone.
