### PR TITLE
About page: the Gateway, Cockpit and mobile app versions (the Director leaves)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,9 +146,19 @@ ENV COCKPIT_COMMIT=${COCKPIT_COMMIT}
 
 USER gateway
 
-# The Gateway binds to loopback (127.0.0.1:7878) by design - it is reached over the tunnel, not a public
-# port. Exercise it from inside the container (docker exec ... curl 127.0.0.1:7878/...); this EXPOSE is
-# documentation of the internal port, not a public bind.
+# 7878 is the container's INTERNAL port and nothing outside the container ever connects to it. App Service
+# terminates TLS on the public 443 and forwards to this port, so every real client reaches the Gateway over
+# https on 443 at CC_GATEWAY_PUBLIC_URL and no customer network or firewall ever sees 7878. That is why the
+# port does not need to be (and must not be) 443 here: the platform owns the public port, and binding a
+# privileged one inside the container would buy nothing.
+#
+# The bind is 0.0.0.0:7878, NOT loopback (GatewayHost.ConfigureKestrel listens on IPAddress.Any in both
+# hosted and self-hosted mode) - which is exactly what lets the App Service front end reach it. An earlier
+# version of this comment claimed loopback; it was wrong. Reachable-but-authenticated, not open: every route
+# except /healthz, /login and /logout requires a credential.
+#
+# Exercise it from inside the container with: docker exec ... curl 127.0.0.1:7878/healthz
+# This EXPOSE documents the internal port; it is not a public bind.
 EXPOSE 7878
 
 ENTRYPOINT ["dotnet", "CcDirector.Gateway.Host.dll", "--port", "7878"]

--- a/apps/cockpit/src/about/AboutView.test.tsx
+++ b/apps/cockpit/src/about/AboutView.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import type { AboutInfo } from "@devthrottle/client-core/about/aboutClient";
+
+// The About page renders whatever the Gateway ruled (CLAUDE.md rule 7). These tests pin the two things a
+// regression would quietly get wrong: an unstamped bundle is REPORTED as unstamped rather than rendered as
+// a blank build, and the internal listen port appears only when the Gateway hands one over - the hosted
+// service omits it because it composes with nothing a caller can reach.
+const getAboutMock = vi.fn();
+vi.mock("@devthrottle/client-core/about/aboutClient", () => ({
+  getAbout: (...args: unknown[]) => getAboutMock(...args),
+}));
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  gatewayErrorMessage: (e: unknown) => String(e),
+}));
+
+import { AboutView, formatBundle, formatUptime } from "./AboutView";
+
+function about(overrides: Partial<AboutInfo> = {}): AboutInfo {
+  return {
+    version: "0.6.15+abcdef1",
+    buildDate: "2026-07-26 09:00:00",
+    cockpit: { commit: "aaaaaaa", buildTime: "2026-07-26T09:38:49.000Z" },
+    mobile: { commit: "bbbbbbb", buildTime: "2026-07-26T09:38:49.000Z" },
+    deployment: "Self-hosted",
+    address: "https://box.tailnet.ts.net",
+    cockpitUrl: "https://box.tailnet.ts.net/cockpit",
+    port: 7878,
+    uptimeSeconds: 3 * 86400 + 4 * 3600 + 5 * 60,
+    serverTime: "2026-07-26T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  getAboutMock.mockReset();
+});
+
+describe("formatUptime", () => {
+  it("drops the days and hours that are zero and always keeps minutes", () => {
+    expect(formatUptime(0)).toBe("just started");
+    expect(formatUptime(90)).toBe("1m");
+    expect(formatUptime(3 * 3600 + 5 * 60)).toBe("3h 5m");
+    expect(formatUptime(2 * 86400 + 60)).toBe("2d 1m");
+  });
+});
+
+describe("formatBundle", () => {
+  it("names the commit and the build time", () => {
+    expect(formatBundle({ commit: "a1b2c3d", buildTime: "2026-07-26T09:38:49.000Z" })).toBe(
+      "a1b2c3d (built 2026-07-26 09:38:49 UTC)",
+    );
+  });
+
+  it("falls back to the commit alone when the stamp carries no time", () => {
+    expect(formatBundle({ commit: "a1b2c3d", buildTime: null })).toBe("a1b2c3d");
+  });
+
+  it("says plainly that an unstamped bundle is not built in, never a blank build", () => {
+    // The quiet failure: an empty string here renders an empty value cell that reads as a real build.
+    expect(formatBundle(null)).toBe("(not built into this Gateway)");
+    expect(formatBundle(undefined)).toBe("(not built into this Gateway)");
+  });
+});
+
+describe("AboutView", () => {
+  it("shows all three product versions", async () => {
+    getAboutMock.mockResolvedValue(about());
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getByText("0.6.15+abcdef1")).toBeTruthy());
+    expect(screen.getByText("aaaaaaa (built 2026-07-26 09:38:49 UTC)")).toBeTruthy();
+    expect(screen.getByText("bbbbbbb (built 2026-07-26 09:38:49 UTC)")).toBeTruthy();
+    expect(screen.getByText("Self-hosted")).toBeTruthy();
+  });
+
+  it("reports an unstamped bundle instead of an empty value", async () => {
+    getAboutMock.mockResolvedValue(about({ cockpit: null, mobile: null }));
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getAllByText("(not built into this Gateway)").length).toBe(2));
+  });
+
+  it("shows the listen port when the Gateway gives one", async () => {
+    getAboutMock.mockResolvedValue(about({ port: 7878 }));
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getByText("Listening on port")).toBeTruthy());
+    expect(screen.getByText("7878")).toBeTruthy();
+  });
+
+  it("renders NO port row when the Gateway omits it (the hosted service)", async () => {
+    getAboutMock.mockResolvedValue(about({ port: null, deployment: "Hosted service" }));
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getByText("Hosted service")).toBeTruthy());
+    expect(screen.queryByText("Listening on port")).toBeNull();
+  });
+
+  it("never shows the install root, machine name, run mode or installed components", async () => {
+    // Those left the payload entirely (the install root spelled out the Gateway box's operating-system user
+    // name). This is the page-side half of the proof; the payload half is in the Gateway tests.
+    getAboutMock.mockResolvedValue(about());
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getByText("Self-hosted")).toBeTruthy());
+    expect(screen.queryByText("Install root")).toBeNull();
+    expect(screen.queryByText("Machine")).toBeNull();
+    expect(screen.queryByText("Mode")).toBeNull();
+    expect(screen.queryByText(/INSTALLED COMPONENTS/i)).toBeNull();
+  });
+
+  it("shows an explicit error banner when the Gateway call fails", async () => {
+    getAboutMock.mockRejectedValue(new Error("boom"));
+    render(<AboutView />);
+
+    await waitFor(() => expect(screen.getByText(/Could not load About info/)).toBeTruthy());
+  });
+});

--- a/apps/cockpit/src/about/AboutView.tsx
+++ b/apps/cockpit/src/about/AboutView.tsx
@@ -1,13 +1,21 @@
 import { useEffect, useState } from "react";
-import { getAbout, type AboutInfo } from "@devthrottle/client-core/about/aboutClient";
+import { getAbout, type AboutInfo, type BundleStamp } from "@devthrottle/client-core/about/aboutClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
-// The About page (issue #978, epic #967) - the React port of the Blazor Cockpit About.razor. Read-only
-// diagnostics of what this Gateway is running and what is installed on its box, from GET /gateway/about.
+// The About page: the version of each of the three SERVER-SIDE products - this Gateway, the Cockpit
+// bundle it serves, and the mobile app bundle it serves - plus how the Gateway is reached, from
+// GET /gateway/about.
+//
+// The Director is deliberately absent (owner ruling 2026-07-26): it has its own About box and its own
+// Cockpit screen, so this page is about server versions. Gone with it: the install root (which printed
+// the Gateway box's operating-system user name to any enrolled device), the machine name, the run mode,
+// and the installer's component manifest - all internal detail about infrastructure a hosted caller does
+// not own.
+//
 // Responsive (CodingStyle.md): renders immediately with a loading state and loads asynchronously; on a
 // load failure it shows an explicit error banner (the no-fallback rule).
 
-/** One label/value row in the diagnostics grid. */
+/** One label/value row. */
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="abt-row">
@@ -17,9 +25,8 @@ function Row({ label, value }: { label: string; value: string }) {
   );
 }
 
-// Compact "1d 2h 3m" uptime, from seconds since the Gateway process started (issue #2022 - the diagnostic
-// relocated here from the retired "This machine" Settings tab).
-function formatUptime(totalSeconds: number): string {
+// Compact "1d 2h 3m" uptime, from seconds since the Gateway process started.
+export function formatUptime(totalSeconds: number): string {
   if (totalSeconds <= 0) return "just started";
   const days = Math.floor(totalSeconds / 86400);
   const hours = Math.floor((totalSeconds % 86400) / 3600);
@@ -31,9 +38,9 @@ function formatUptime(totalSeconds: number): string {
   return parts.join(" ");
 }
 
-// Format the Gateway's ISO server time to the compact "yyyy-MM-dd HH:mm:ss" (UTC) the Blazor page
-// showed. When the value is missing or unparseable, show it verbatim rather than fabricating a time.
-function formatServerTime(iso: string): string {
+// Format an ISO timestamp to the compact "yyyy-MM-dd HH:mm:ss" (UTC) this page shows. A missing value is
+// reported as unknown and an unparseable one is shown verbatim - never a fabricated time.
+export function formatServerTime(iso: string): string {
   if (iso.length === 0) return "(unknown)";
   const parsed = new Date(iso);
   if (Number.isNaN(parsed.getTime())) return iso;
@@ -42,6 +49,18 @@ function formatServerTime(iso: string): string {
     `${parsed.getUTCFullYear()}-${pad(parsed.getUTCMonth() + 1)}-${pad(parsed.getUTCDate())} ` +
     `${pad(parsed.getUTCHours())}:${pad(parsed.getUTCMinutes())}:${pad(parsed.getUTCSeconds())}`
   );
+}
+
+/**
+ * One served bundle's version line: the commit it was built from, and when. A bundle with no stamp says
+ * so plainly - a Gateway built without the web apps (a routine Debug build) serves no bundle at all, and
+ * naming a build it does not have would be worse than admitting it.
+ */
+export function formatBundle(stamp: BundleStamp | null | undefined): string {
+  if (!stamp) return "(not built into this Gateway)";
+  const built = stamp.buildTime ?? "";
+  if (built.length === 0) return stamp.commit;
+  return `${stamp.commit} (built ${formatServerTime(built)} UTC)`;
 }
 
 export function AboutView() {
@@ -61,25 +80,20 @@ export function AboutView() {
     return () => controller.abort();
   }, []);
 
-  // The installed components, sorted case-insensitively by id (matching the Blazor OrderBy).
-  const components =
-    about === null
-      ? []
-      : Object.entries(about.installedComponents).sort((a, b) =>
-          a[0].localeCompare(b[0], undefined, { sensitivity: "base" }),
-        );
-
   return (
     <div className="page abt">
       <div className="page-head">
         <h1>About DevThrottle</h1>
       </div>
-      <p className="abt-lede">What this Gateway is running and what&apos;s installed.</p>
-      {/* The cockpit's own build identity, stamped into the static bundle at build time (see
-          vite.config.ts). Always shown - even if the Gateway /about call fails - so you can always
-          confirm which cockpit is deployed, independently of the Gateway version below. */}
+      <p className="abt-lede">The versions this Gateway is serving, and how it is reached.</p>
+      {/* The build of the bundle THIS TAB is running, stamped into the static files at build time (see
+          vite.config.ts). Shown always - even when the Gateway call below fails - so you can always
+          identify the page you are looking at. It is a different fact from the "Cockpit" row below, which
+          is the bundle the Gateway currently SERVES: when the two disagree, this tab is stale and a reload
+          will move it forward. */}
       <p className="abt-cockpit-build">
-        Cockpit build: <strong>{__COCKPIT_COMMIT__}</strong> (built {formatServerTime(__COCKPIT_BUILD_TIME__)} UTC)
+        This browser tab is running cockpit <strong>{__COCKPIT_COMMIT__}</strong> (built{" "}
+        {formatServerTime(__COCKPIT_BUILD_TIME__)} UTC)
       </p>
 
       {error !== null ? (
@@ -88,39 +102,30 @@ export function AboutView() {
         <p className="abt-loading">Loading...</p>
       ) : (
         <>
+          <h2 className="abt-h2">VERSIONS</h2>
           <div className="abt-card">
-            <Row label="Product" value={about.product} />
-            <Row label="Gateway version" value={about.version} />
-            <Row label="Cockpit build" value={`${__COCKPIT_COMMIT__} (${formatServerTime(__COCKPIT_BUILD_TIME__)} UTC)`} />
-            <Row label="Build date" value={about.buildDate ?? "(unknown)"} />
-            <Row label="Machine" value={about.machineName} />
-            <Row label="Install root" value={about.installRoot} />
-            <Row label="Cockpit URL" value={about.cockpitUrl ?? "(Tailscale unavailable)"} />
-            <Row label="Gateway time (UTC)" value={formatServerTime(about.serverTime)} />
+            <Row label="Gateway" value={about.version} />
+            <Row label="Gateway built" value={about.buildDate ?? "(unknown)"} />
+            {/* The two served bundles as the GATEWAY sees them on disk, not as the browser running this
+                page sees itself. That distinction is the point: a Cockpit-only redeploy replaces the bundle
+                under a live Gateway and an already-open tab keeps running the OLD one, so reading the
+                server means this page reports what is DEPLOYED. */}
+            <Row label="Cockpit" value={formatBundle(about.cockpit)} />
+            <Row label="Mobile app" value={formatBundle(about.mobile)} />
           </div>
 
-          {/* The live process diagnostics relocated here from the retired "This machine" Settings tab (issue
-              #2022): read-only on both surfaces. The manual network-addressing choice is gone - the address is
-              resolved automatically and shown here. */}
-          <h2 className="abt-h2">DIAGNOSTICS</h2>
+          <h2 className="abt-h2">THIS GATEWAY</h2>
           <div className="abt-card">
-            <Row label="State" value={about.state} />
+            <Row label="Deployment" value={about.deployment} />
             <Row label="Address" value={about.address ?? "(Tailscale unavailable)"} />
-            <Row label="Port" value={String(about.port)} />
-            <Row label="Mode" value={about.mode} />
+            <Row label="Cockpit URL" value={about.cockpitUrl ?? "(Tailscale unavailable)"} />
+            {/* Rendered only when the Gateway hands one over. It does not on the hosted service, where
+                clients arrive through the address above on 443 and the internal port composes with nothing
+                a caller could use. The client does not decide that - it renders what it is given
+                (CLAUDE.md rule 7). */}
+            {typeof about.port === "number" && <Row label="Listening on port" value={String(about.port)} />}
             <Row label="Uptime" value={formatUptime(about.uptimeSeconds)} />
-            <Row label="Directors" value={String(about.directors)} />
-          </div>
-
-          <h2 className="abt-h2">INSTALLED COMPONENTS</h2>
-          <div className="abt-card">
-            {components.length === 0 ? (
-              <div className="abt-empty">
-                (no installed.json - the Gateway may be running from a dev build)
-              </div>
-            ) : (
-              components.map(([id, version]) => <Row key={id} label={id} value={version} />)
-            )}
+            <Row label="Gateway time (UTC)" value={formatServerTime(about.serverTime)} />
           </div>
         </>
       )}

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 
 // Stamp the cockpit's OWN build identity at build time so the About page can show exactly which
@@ -22,6 +22,27 @@ const cockpitCommit =
     ? commitFromEnvironment
     : execSync("git rev-parse --short HEAD").toString().trim();
 const cockpitBuildTime = new Date().toISOString();
+
+// The SAME two facts, written to a file the SERVER can read: dist/build.json, which the Gateway's
+// MSBuild target copies to wwwroot/c/build.json. The defines above are compiled into the minified
+// bundle, so they are readable only by the browser running that bundle - the Gateway process has no
+// way to learn them, and before this file existed the About page could only report the cockpit build
+// of the bundle it was itself served from, never the mobile app's, and never from a server-side call.
+// One derivation, two destinations: both come from the two constants above, so the file and the
+// bundle can never disagree about which build this is.
+function buildStampPlugin(commit: string, buildTime: string): Plugin {
+  return {
+    name: "devthrottle-build-stamp",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "build.json",
+        source: `${JSON.stringify({ commit, buildTime }, null, 2)}\n`,
+      });
+    },
+  };
+}
 
 // The desktop Cockpit is the Gateway's canonical front door: it is served at the site root "/"
 // (epic #967 cutover, issue #979 - the Blazor Server Cockpit is retired). Every asset URL is
@@ -93,7 +114,7 @@ export default defineConfig({
     __COCKPIT_COMMIT__: JSON.stringify(cockpitCommit),
     __COCKPIT_BUILD_TIME__: JSON.stringify(cockpitBuildTime),
   },
-  plugins: [react()],
+  plugins: [react(), buildStampPlugin(cockpitCommit, cockpitBuildTime)],
   server: {
     proxy: devProxy,
   },

--- a/apps/mobile/src/pages/About.tsx
+++ b/apps/mobile/src/pages/About.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getGatewayHealth, gatewayErrorMessage, type GatewayHealth } from "@devthrottle/client-core/api/client";
 
 export function About() {
   const [health, setHealth] = useState<GatewayHealth | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const bundle = useMemo(() => currentBundleName(), []);
   const sw = serviceWorkerState();
   const displayMode = isStandalone() ? "Installed PWA" : "Browser tab";
 
@@ -47,7 +46,11 @@ export function About() {
       </section>
 
       <section className="about-list" aria-label="Runtime details">
-        <AboutRow label="Mobile bundle" value={bundle} />
+        {/* The build this app was made from, stamped in at build time (see vite.config.ts). It replaced
+            the content-hashed script filename this row used to scrape out of the live DOM: that hash
+            changed on every build and named nothing you could look up, so it could not answer the one
+            question the row is for - which build am I running. */}
+        <AboutRow label="Mobile app build" value={mobileBuild()} />
         <AboutRow label="Gateway status" value={health?.status ?? "Loading..."} />
         <AboutRow label="Gateway time" value={formatTime(health?.serverTime)} />
         <AboutRow label="Directors" value={formatCount(health, health?.directors)} />
@@ -68,14 +71,11 @@ function AboutRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-function currentBundleName(): string {
-  if (typeof document === "undefined") return "unknown";
-  const scripts = Array.from(document.scripts)
-    .map((s) => s.getAttribute("src") ?? "")
-    .filter((src) => src.includes("/assets/") && src.endsWith(".js"));
-  const src = scripts.at(-1);
-  if (!src) return "unknown";
-  return src.substring(src.lastIndexOf("/") + 1);
+/** This app's build: the commit it was built from and when, from the build-time stamp. */
+function mobileBuild(): string {
+  const built = new Date(__MOBILE_BUILD_TIME__);
+  if (Number.isNaN(built.getTime())) return __MOBILE_COMMIT__;
+  return `${__MOBILE_COMMIT__} (${built.toLocaleString()})`;
 }
 
 function serviceWorkerState(): string {

--- a/apps/mobile/src/vite-env.d.ts
+++ b/apps/mobile/src/vite-env.d.ts
@@ -1,2 +1,8 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+// Build-time constants stamped by vite.config.ts (define) so the About page can show this app's own
+// build identity instead of the opaque content hash of its script filename. Replaced with string
+// literals at build time.
+declare const __MOBILE_COMMIT__: string;
+declare const __MOBILE_BUILD_TIME__: string;

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -1,6 +1,42 @@
-import { defineConfig } from "vite";
+import { execSync } from "node:child_process";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
+
+// Stamp the mobile app's OWN build identity, exactly as apps/cockpit/vite.config.ts stamps the
+// cockpit's. Until this existed the mobile bundle had NO version identity anywhere: its About page
+// showed the content-hashed script filename it scraped out of the live DOM (an opaque hash, not a
+// build), and the Gateway had no way at all to say which mobile app it was serving.
+//
+// Two SOURCES for the one fact, never a fallback to an invented value (the same rule the cockpit
+// config documents at length): git HEAD in every normal build path, or COCKPIT_COMMIT when the build
+// runs inside the container image, whose build context excludes .git so git cannot answer. If neither
+// yields a commit the build fails loudly rather than stamping "unknown".
+const commitFromEnvironment = process.env.COCKPIT_COMMIT?.trim();
+const mobileCommit =
+  commitFromEnvironment && commitFromEnvironment.length > 0
+    ? commitFromEnvironment
+    : execSync("git rev-parse --short HEAD").toString().trim();
+const mobileBuildTime = new Date().toISOString();
+
+// The same two facts as a file the SERVER can read: dist/build.json, copied by the Gateway's MSBuild
+// target to wwwroot/mobile/build.json. The defines feed the phone's own About page; the file lets the
+// Gateway report the served mobile build to the Cockpit About page, which cannot run this bundle.
+// Not precached by the service worker (workbox globPatterns covers only icons/fonts), so a reload
+// always reads the deployed file rather than a cached copy of an older one.
+function buildStampPlugin(commit: string, buildTime: string): Plugin {
+  return {
+    name: "devthrottle-build-stamp",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "build.json",
+        source: `${JSON.stringify({ commit, buildTime }, null, 2)}\n`,
+      });
+    },
+  };
+}
 
 // Dev-only: the mobile shell calls the Gateway through root-relative URLs, so a local Vite run
 // needs an explicit Gateway front door for enrollment and the real app APIs. Without this proxy,
@@ -54,11 +90,16 @@ const devProxy = proxyTarget
 // MSBuild target copies into wwwroot/mobile/.
 export default defineConfig({
   base: "/mobile/",
+  define: {
+    __MOBILE_COMMIT__: JSON.stringify(mobileCommit),
+    __MOBILE_BUILD_TIME__: JSON.stringify(mobileBuildTime),
+  },
   server: {
     proxy: devProxy,
   },
   plugins: [
     react(),
+    buildStampPlugin(mobileCommit, mobileBuildTime),
     VitePWA({
       registerType: "autoUpdate",
       // The injected token script in index.html must survive into the served shell, and the

--- a/packages/client-core/src/about/aboutClient.ts
+++ b/packages/client-core/src/about/aboutClient.ts
@@ -7,39 +7,55 @@
 // the Gateway and carries the same Bearer via authHeaders().
 import { authHeaders, GatewayError } from "../api/client";
 
-/** The GET /gateway/about body: what this Gateway is running and what is installed on its box. */
+/**
+ * The build identity of one web bundle the Gateway serves, from the build.json its Vite build emits.
+ * The bundles carry no semantic version of their own (they ship with the Gateway), so the commit plus
+ * the build time IS their version.
+ */
+export interface BundleStamp {
+  /** The short commit the bundle was built from. */
+  commit: string;
+  /** When the bundle was built (ISO 8601 UTC), or null when the stamp carries no time. */
+  buildTime?: string | null;
+}
+
+/**
+ * The GET /gateway/about body: what the three SERVER-SIDE products are running - this Gateway, the
+ * Cockpit bundle it serves, and the mobile app bundle it serves - plus how it is reached.
+ *
+ * The Director is deliberately absent (owner ruling 2026-07-26): it has its own About box and its own
+ * Cockpit screen. The install root, machine name, run mode and installer component manifest went with
+ * it - internal detail on the hosted service, and the install root leaked the operating-system user
+ * name to every enrolled device.
+ */
 export interface AboutInfo {
-  product: string;
-  /** Full informational version, e.g. "0.6.15+sha". */
+  /** Full informational version of the running Gateway, e.g. "0.6.15+sha". */
   version: string;
-  /** Build date of the running Gateway exe ("yyyy-MM-dd HH:mm:ss"), or null. */
+  /** Build date of the running Gateway executable ("yyyy-MM-dd HH:mm:ss"), or null. */
   buildDate?: string | null;
-  machineName: string;
-  /** The per-user install root on the Gateway box. */
-  installRoot: string;
+  /** The Cockpit bundle this Gateway serves, or null when no built bundle is staged. */
+  cockpit?: BundleStamp | null;
+  /** The mobile app bundle this Gateway serves, or null when no built bundle is staged. */
+  mobile?: BundleStamp | null;
+  /** The folded deployment label, rendered verbatim: "Hosted service" or "Self-hosted". */
+  deployment: string;
+  /**
+   * The auto-resolved public base address this Gateway is reached at (no surface path), or null in
+   * self-host when Tailscale is down. Manual network addressing was dropped in issue #2022.
+   */
+  address?: string | null;
   /** The one front-door URL the Cockpit is reached at, or null when Tailscale is down. */
   cockpitUrl?: string | null;
-  /** Installed component id -> version (from installed.json on the Gateway box). */
-  installedComponents: Record<string, string>;
   /**
-   * Whether this is the shared HOSTED Gateway rather than a self-hosted one on the owner's own machine
-   * (issue #2017). The Settings page reads this always-available flag to choose its tab set, so the surface
-   * is Gateway-owned, not guessed from a failed fetch.
+   * The Gateway's own listen port, or NULL on the hosted service, where callers reach it only through
+   * `address` on 443 and the internal port composes with nothing. Gateway-owned: the client renders the
+   * row when a port is given and omits it when it is not - it never decides which deployment "should"
+   * have one.
    */
-  hosted: boolean;
+  port?: number | null;
+  uptimeSeconds: number;
   /** The Gateway's current time (ISO 8601 UTC). */
   serverTime: string;
-  /**
-   * The live process diagnostics relocated here from the retired "This machine" Settings tab (issue #2022):
-   * read-only on both surfaces. State is "Running" whenever the endpoint answers; address is the auto-resolved
-   * public base (manual network addressing was dropped), null in self-host when Tailscale is down.
-   */
-  state: string;
-  port: number;
-  uptimeSeconds: number;
-  directors: number;
-  mode: string;
-  address?: string | null;
 }
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
@@ -71,20 +87,27 @@ export async function getAbout(signal?: AbortSignal): Promise<AboutInfo> {
   if (!res.ok) throw await gatewayErrorFrom(res, "GET /gateway/about");
   const body = (await res.json()) as Partial<AboutInfo> | null;
   return {
-    product: body?.product ?? "",
     version: body?.version ?? "",
     buildDate: body?.buildDate ?? null,
-    machineName: body?.machineName ?? "",
-    installRoot: body?.installRoot ?? "",
-    cockpitUrl: body?.cockpitUrl ?? null,
-    installedComponents: body?.installedComponents ?? {},
-    hosted: body?.hosted ?? false,
-    serverTime: body?.serverTime ?? "",
-    state: body?.state ?? "",
-    port: Number(body?.port ?? 0),
-    uptimeSeconds: Number(body?.uptimeSeconds ?? 0),
-    directors: Number(body?.directors ?? 0),
-    mode: body?.mode ?? "unknown",
+    cockpit: bundleStamp(body?.cockpit),
+    mobile: bundleStamp(body?.mobile),
+    deployment: body?.deployment ?? "",
     address: body?.address ?? null,
+    cockpitUrl: body?.cockpitUrl ?? null,
+    // A MISSING port and a port of 0 are different answers and must not collapse: hosted omits the
+    // field on purpose, and the page renders no port row for it. Coercing absence to 0 would print
+    // "Port 0", which is a lie about a real listening socket.
+    port: typeof body?.port === "number" ? body.port : null,
+    uptimeSeconds: Number(body?.uptimeSeconds ?? 0),
+    serverTime: body?.serverTime ?? "",
   };
+}
+
+// A bundle stamp survives only if it actually names a build. An object with no commit is not a stamp,
+// and reporting it as one would show an empty build on the About page instead of saying plainly that
+// this Gateway serves no built bundle.
+function bundleStamp(value: BundleStamp | null | undefined): BundleStamp | null {
+  const commit = value?.commit?.trim() ?? "";
+  if (commit.length === 0) return null;
+  return { commit, buildTime: value?.buildTime ?? null };
 }

--- a/src/CcDirector.Gateway.Contracts/AboutDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AboutDto.cs
@@ -1,66 +1,80 @@
 namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
-/// GET /about response: the "what is this Gateway running and what's installed" diagnostics the
-/// Cockpit About page renders. Built on the Gateway box (it owns installed.json + its own version).
+/// GET /gateway/about response: what the three SERVER-SIDE products are running - this Gateway, the
+/// Cockpit bundle it serves, and the mobile app bundle it serves - plus how it is reached.
+///
+/// It is deliberately NOT a report on the box. The Director is absent: it has its own About box (see
+/// CcDirector.Core AboutInfo.SharedRows) and its own screen in the Cockpit, and its facts do not belong
+/// on a page about server versions. The install root, the operating-system machine name, the run-mode
+/// label and the installer's component manifest are all gone with it - on the hosted service they were
+/// internal detail about somebody else's infrastructure, and on a self-hosted Gateway the install root
+/// leaked the operating-system user name into a page any enrolled device could read.
 /// </summary>
 public sealed class AboutDto
 {
-    public string Product { get; set; } = "Director";
-
-    /// <summary>Full informational version, e.g. "0.6.15+sha".</summary>
+    /// <summary>Full informational version of the running Gateway, e.g. "0.6.15+sha".</summary>
     public string Version { get; set; } = "";
 
-    /// <summary>Build date of the running Gateway exe ("yyyy-MM-dd HH:mm:ss"), or null.</summary>
+    /// <summary>Build date of the running Gateway executable ("yyyy-MM-dd HH:mm:ss"), or null.</summary>
     public string? BuildDate { get; set; }
 
-    public string MachineName { get; set; } = "";
+    /// <summary>
+    /// The build stamp of the Cockpit bundle this Gateway serves at /c, or null when no built bundle is
+    /// staged (a routine Debug build does not build the web apps). Read from wwwroot/c/build.json - the
+    /// Gateway cannot read the commit compiled into the bundle's own JavaScript.
+    /// </summary>
+    public BundleStampDto? Cockpit { get; set; }
 
-    /// <summary>The per-user install root on the Gateway box (%LOCALAPPDATA%\cc-director).</summary>
-    public string InstallRoot { get; set; } = "";
+    /// <summary>
+    /// The build stamp of the mobile app bundle this Gateway serves at /mobile, or null when no built
+    /// bundle is staged. Read from wwwroot/mobile/build.json.
+    /// </summary>
+    public BundleStampDto? Mobile { get; set; }
+
+    /// <summary>
+    /// The folded deployment label the client renders verbatim - "Hosted service" or "Self-hosted"
+    /// (CLAUDE.md rule 7: the Gateway owns the verdict, the client never re-derives it from a flag).
+    /// </summary>
+    public string Deployment { get; set; } = "";
+
+    /// <summary>
+    /// The auto-resolved public base address this Gateway is reached at (no surface path), or null in
+    /// self-host when Tailscale is down. Manual network addressing was retired in issue #2022 - the
+    /// address is resolved automatically and shown read-only, never chosen on a settings page.
+    /// </summary>
+    public string? Address { get; set; }
 
     /// <summary>The one front-door URL the Cockpit is reached at, or null when Tailscale is down.</summary>
     public string? CockpitUrl { get; set; }
 
-    /// <summary>Installed component id -> version (from installed.json on the Gateway box).</summary>
-    public Dictionary<string, string> InstalledComponents { get; set; } = new();
-
     /// <summary>
-    /// The live process diagnostics the "This machine" Settings tab used to show, relocated here read-only
-    /// on BOTH surfaces (issue #2022): the machine settings left the Cockpit Settings page, so the facts a
-    /// user still needs to see about a Gateway host live on the About page, which works everywhere. These
-    /// have no per-tenant dimension - they describe the host process, not an account - so they are shown as
-    /// they are, not partitioned.
+    /// The Gateway's own listen port, or NULL on the hosted service. Hosted clients reach the Gateway
+    /// only through <see cref="Address"/> on 443 (the platform terminates TLS there and forwards to the
+    /// container's internal port), so the internal number composes with nothing a caller can use: shown
+    /// beside an https address it reads as a reachable port and is not one. Self-hosted it IS the port
+    /// the Gateway is listening on and is worth showing, so the Gateway decides here and the client just
+    /// renders what it is given.
     /// </summary>
-    public string State { get; set; } = "Running";
-
-    /// <summary>The Gateway's listen port on its own box.</summary>
-    public int Port { get; set; }
+    public int? Port { get; set; }
 
     /// <summary>Seconds since this Gateway process started.</summary>
     public long UptimeSeconds { get; set; }
 
-    /// <summary>The number of Directors this Gateway currently sees.</summary>
-    public int Directors { get; set; }
-
-    /// <summary>The run mode label ("managed" | "dev" | "unknown"), from the host process.</summary>
-    public string Mode { get; set; } = "unknown";
-
-    /// <summary>
-    /// The auto-resolved public base address this Gateway is reached at (no surface path), or null in
-    /// self-host when Tailscale is down. Manual network addressing (Tailscale vs LAN) was retired in issue
-    /// #2022 - the address is resolved automatically and shown here read-only, never chosen on a settings page.
-    /// </summary>
-    public string? Address { get; set; }
-
-    /// <summary>
-    /// Whether this is the shared HOSTED Gateway (CC_GATEWAY_HOSTED=1) rather than a self-hosted one on the
-    /// owner's own machine (issue #2017). The Settings page reads this ALWAYS-AVAILABLE, public flag to choose
-    /// which tabs to render - Gateway-owned tab selection (CLAUDE.md rule 7), never guessed by the client from
-    /// a failed fetch: on hosted the machine-scoped "This machine" tab is absent and every kept setting is
-    /// scoped to the caller's account; self-host shows the machine tab and one-Gateway scope.
-    /// </summary>
-    public bool Hosted { get; set; }
-
+    /// <summary>The Gateway's current time (UTC).</summary>
     public DateTime ServerTime { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// The build identity of one served web bundle, read from the <c>build.json</c> its Vite build emits.
+/// The bundles carry no meaningful semantic version of their own (they ship with the Gateway), so the
+/// commit plus the build time IS their version.
+/// </summary>
+public sealed class BundleStampDto
+{
+    /// <summary>The short commit the bundle was built from.</summary>
+    public string Commit { get; set; } = "";
+
+    /// <summary>When the bundle was built (UTC), or null when the stamp carries no time.</summary>
+    public DateTime? BuildTime { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/BundleStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/BundleStampTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using CcDirector.Gateway.Diagnostics;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Gateway's reader for the build stamp a served web bundle ships with (wwwroot/{c,mobile}/build.json).
+/// Deterministic: every case writes its own temporary bundle root, so none of these depends on whether the
+/// build configuration happened to stage a real bundle.
+///
+/// This is the only server-side source for "which Cockpit / mobile app am I serving": each bundle's commit
+/// is otherwise compiled into JavaScript the Gateway never executes.
+/// </summary>
+public sealed class BundleStampTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "bundle-stamp-" + Guid.NewGuid().ToString("N"));
+
+    public BundleStampTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private void WriteStamp(string json) => File.WriteAllText(Path.Combine(_root, BundleStamp.FileName), json);
+
+    [Fact]
+    public void Read_StampedBundle_ReturnsCommitAndBuildTime()
+    {
+        WriteStamp("""{ "commit": "a1b2c3d", "buildTime": "2026-07-26T09:38:49.000Z" }""");
+
+        var stamp = BundleStamp.Read(_root);
+
+        Assert.NotNull(stamp);
+        Assert.Equal("a1b2c3d", stamp!.Commit);
+        Assert.Equal(new DateTime(2026, 7, 26, 9, 38, 49, DateTimeKind.Utc), stamp.BuildTime!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Read_NoBundleStaged_ReturnsNull()
+    {
+        // A routine Debug build does not build the web apps at all, so there is no bundle and no stamp. Null is
+        // the honest answer; the About page renders it as "(not built into this Gateway)".
+        Assert.Null(BundleStamp.Read(_root));
+    }
+
+    [Fact]
+    public void Read_MissingWebRoot_ReturnsNull()
+    {
+        Assert.Null(BundleStamp.Read(Path.Combine(_root, "does-not-exist")));
+    }
+
+    [Fact]
+    public void Read_CorruptStamp_ReturnsNull()
+    {
+        // A truncated / non-JSON stamp is a broken deploy. It must not throw (that would take down the whole
+        // About payload, hiding the Gateway version too) and must not invent a commit.
+        WriteStamp("{ this is not json");
+
+        Assert.Null(BundleStamp.Read(_root));
+    }
+
+    [Fact]
+    public void Read_StampWithoutCommit_ReturnsNull()
+    {
+        // The quiet failure this guards: a stamp object whose commit is empty would otherwise surface as a
+        // stamp that names nothing, and the page would print a blank build as though it were a real one.
+        WriteStamp("""{ "commit": "   ", "buildTime": "2026-07-26T09:38:49.000Z" }""");
+
+        Assert.Null(BundleStamp.Read(_root));
+    }
+
+    [Fact]
+    public void Read_StampWithoutBuildTime_ReturnsCommitOnly()
+    {
+        // The commit alone still identifies the build, so it serves with a null time rather than being
+        // discarded wholesale.
+        WriteStamp("""{ "commit": "deadbee" }""");
+
+        var stamp = BundleStamp.Read(_root);
+
+        Assert.NotNull(stamp);
+        Assert.Equal("deadbee", stamp!.Commit);
+        Assert.Null(stamp.BuildTime);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitUrlEndpointTests.cs
@@ -78,6 +78,35 @@ public sealed class CockpitUrlEndpointTests
     }
 
     [Fact]
+    public async Task Hosted_about_omits_the_internal_listen_port()
+    {
+        // Owner ruling 2026-07-26. On the hosted service a caller reaches this Gateway ONLY through the public
+        // address on 443 - the platform terminates TLS there and forwards to the container's internal port - so
+        // the internal number composes with nothing the caller can use. Printed beside an https address it
+        // reads as a reachable port and is not one, which is what made the old page look broken.
+        //
+        // The Gateway decides this, not the page (CLAUDE.md rule 7), so it is asserted on the PAYLOAD: a client
+        // that never receives a port cannot render one, whereas a page-only fix would still ship the misleading
+        // number to every other reader of this endpoint.
+        await WithHostedGateway(PublicBase, async (http, gateway) =>
+        {
+            var deviceKey = HostedTestEnrollment.Enroll(
+                gateway,
+                "about-port-subject",
+                "about-port@example.com",
+                "about-port",
+                "PHONE").DeviceKey;
+
+            var about = await GetJson<AboutDto>(http, "gateway/about", bearer: deviceKey);
+
+            Assert.Null(about.Port);
+            Assert.Equal("Hosted service", about.Deployment);
+            // The public address IS served - it is the one address a hosted client can actually use.
+            Assert.Equal(PublicBase, about.Address);
+        });
+    }
+
+    [Fact]
     public async Task Hosted_settings_route_serves_per_account_and_carries_no_cockpit_url()
     {
         await WithHostedGateway(PublicBase, async (http, gateway) =>

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -230,16 +230,53 @@ public sealed class GatewayHostTests : IAsyncLifetime
     [Fact]
     public async Task GatewayAbout_returns_runtime_diagnostics()
     {
-        // Issue #2022: the live process diagnostics the "This machine" tab used to show now live read-only on
-        // the About page, on both surfaces. A bare host sets no SettingsHooks, so the mode is "unknown".
+        // Issue #2022: the live process diagnostics the "This machine" tab used to show live read-only on the
+        // About page, on both surfaces. Self-hosted, the listen port IS a real reachable port, so it serves.
         var obj = await _http.GetFromJsonAsync<JsonObject>("gateway/about");
         Assert.NotNull(obj);
-        Assert.Equal("Running", (string?)obj!["state"]);
-        Assert.Equal(_gatewayPort, (int?)obj["port"]);
+        Assert.Equal(_gatewayPort, (int?)obj!["port"]);
         Assert.False(string.IsNullOrEmpty((string?)obj["version"]));
-        Assert.Equal("unknown", (string?)obj["mode"]);
+        Assert.Equal("Self-hosted", (string?)obj["deployment"]);
         Assert.True(obj.ContainsKey("uptimeSeconds"));
-        Assert.True(obj.ContainsKey("directors"));
+        Assert.True(obj.ContainsKey("serverTime"));
+    }
+
+    [Fact]
+    public async Task GatewayAbout_carries_no_director_or_host_internals()
+    {
+        // Owner ruling 2026-07-26: About is a page about the three SERVER-SIDE products, not a report on the
+        // box. The Director has its own About box and its own Cockpit screen, so its facts left this payload -
+        // and with them the host internals. This is a PAYLOAD assertion, not a page one: the install root
+        // (which spells out the operating-system user name, e.g. C:\Users\soren\AppData\Local\cc-director) was
+        // readable by any enrolled device even while the page rendered it, so removing the row alone would not
+        // have stopped it leaving the Gateway. A regression that re-adds any of these reddens here.
+        var obj = await _http.GetFromJsonAsync<JsonObject>("gateway/about");
+        Assert.NotNull(obj);
+        Assert.False(obj!.ContainsKey("installRoot"));
+        Assert.False(obj.ContainsKey("machineName"));
+        Assert.False(obj.ContainsKey("installedComponents"));
+        Assert.False(obj.ContainsKey("directors"));
+        Assert.False(obj.ContainsKey("product"));
+        Assert.False(obj.ContainsKey("mode"));
+        Assert.False(obj.ContainsKey("state"));
+    }
+
+    [Fact]
+    public async Task GatewayAbout_bundle_stamps_are_either_absent_or_named()
+    {
+        // The bundle stamps are present exactly when a built bundle is staged in wwwroot, which depends on the
+        // build configuration: a Debug test run stages nothing, a Release one stages both. So this asserts the
+        // invariant that holds EITHER WAY - a stamp is either absent, or it names a build - rather than a
+        // nullness that would pass in Debug and redden on a Release CI run for no real defect. The exact
+        // absent/present/corrupt behaviour is proved deterministically in BundleStampTests.
+        var obj = await _http.GetFromJsonAsync<JsonObject>("gateway/about");
+        Assert.NotNull(obj);
+        foreach (var key in new[] { "cockpit", "mobile" })
+        {
+            Assert.True(obj!.ContainsKey(key));
+            if (obj[key] is JsonObject stamp)
+                Assert.False(string.IsNullOrWhiteSpace((string?)stamp["commit"]));
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -8,8 +8,11 @@ using CcDirector.Core.Network;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Cockpit;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Diagnostics;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Mobile;
 using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -142,15 +145,15 @@ internal static class GatewayEndpoints
         // SnoozeDefaultMinutes(tenant) instead of the process-global config. Null (older callers, tests that
         // do not exercise the default) keeps the global read, matching every other optional store here.
         Settings.TenantSettingsResolver? tenantSettings = null,
-        // Issue #2022: the live process diagnostics the About page now shows read-only on both surfaces, after
-        // the machine settings left the Cockpit Settings page. Supplied by the host as its own StartedAtUtc,
-        // Port, and run-mode label. The mode is a delegate (resolved per request) because SettingsHooks is set
-        // on the host AFTER Map runs. Null/zero (older callers, bare test hosts) means "not started"/unknown.
+        // Issue #2022: the live process diagnostics the About page shows read-only on both surfaces, after the
+        // machine settings left the Cockpit Settings page. Supplied by the host as its own StartedAtUtc and
+        // Port. Null (older callers, bare test hosts) means "not started". The run-mode label went with the
+        // Director facts when About became a server-versions page (owner ruling 2026-07-26): the served
+        // bundles' build stamps say which build this is far more precisely than "managed" versus "dev" did.
         DateTime? gatewayStartedAtUtc = null,
-        // Issue #2161: a delegate, resolved per request, for the same reason the mode label is one - Map runs
-        // before the listener binds, and on an operating-system-assigned port the number does not exist yet.
+        // Issue #2161: a delegate, resolved per request - Map runs before the listener binds, and on an
+        // operating-system-assigned port the number does not exist yet.
         Func<int>? gatewayPort = null,
-        Func<string>? gatewayModeLabel = null,
         // devthrottle #2075: the dictionary-suggestions engine and the dismissal store, threaded into the
         // /ingest/dictionary/suggestions routes. Null (older callers, recording-only test harnesses) simply
         // does not expose the suggestion routes; production wires both.
@@ -559,41 +562,40 @@ internal static class GatewayEndpoints
             return Results.Json(netDiagRollup?.All(reqTenant.Value) ?? new List<NetDiagRollupStore.HourBucket>());
         });
 
-        // About / diagnostics: product, version, build date, install root, the one Cockpit URL, and
-        // the installed component versions (from installed.json on this box). Feeds the Cockpit About
-        // page; loopback-reachable like the rest of the read API.
-        // Route is /gateway/about so the /about path passes through to the Cockpit's Blazor page.
+        // About: the three SERVER-SIDE products - this Gateway, the Cockpit bundle it serves, and the
+        // mobile app bundle it serves - plus how it is reached. Feeds the Cockpit About page;
+        // loopback-reachable like the rest of the read API.
+        //
+        // The Director is deliberately NOT here (owner ruling 2026-07-26): it has its own About box and
+        // its own Cockpit screen, so this page is about server versions only. The install root, machine
+        // name, run mode and installer component manifest went with it - on the hosted service they were
+        // internal detail about infrastructure the caller does not own, and the install root leaked the
+        // operating-system user name to every enrolled device.
+        //
         // CockpitUrl comes from GatewayPublicUrl.ResolveCockpit(): {base}/cockpit, where base is the
         // configured public URL in hosted mode and the tailnet front door (null when Tailscale is down)
         // self-hosted. One derivation rule, both modes (owner ruling 2026-07-20).
-        app.MapGet("/gateway/about", (HttpContext ctx) =>
+        app.MapGet("/gateway/about", () =>
         {
-            // Issue #1847: the director list is tenant-scoped (the fleet-wide list was an enumeration
-            // surface), so the diagnostic COUNT here is counted for THIS request's tenant - Local on
-            // self-host. A request with no bound tenant has no attributable directors, so the count is 0;
-            // the rest of the About diagnostics are machine facts and still serve.
-            var aboutTenant = ResolveReadTenant(ctx, tenantBoundary);
             return Results.Json(new AboutDto
             {
-                Product = AboutInfo.ProductName,
                 Version = AboutInfo.VersionFull,
                 BuildDate = AboutInfo.BuildDate()?.ToString("yyyy-MM-dd HH:mm:ss"),
-                MachineName = Environment.MachineName,
-                InstallRoot = AboutInfo.InstallRoot,
-                CockpitUrl = GatewayPublicUrl.ResolveCockpit(),
-                InstalledComponents = new Dictionary<string, string>(AboutInfo.InstalledComponents()),
-                // Issue #2017: the always-available public hosted/self-host signal the Settings page reads to
-                // choose its tab set, so tab selection is Gateway-owned rather than guessed from a failed fetch.
-                Hosted = GatewayHostedMode.IsHosted,
-                // Issue #2022: the live process diagnostics relocated here from the retired "This machine" tab -
-                // read-only, both surfaces. State is "Running" whenever this endpoint answers; the address is the
-                // auto-resolved public base (manual addressing was dropped).
-                State = "Running",
-                Port = gatewayPort?.Invoke() ?? 0,
-                UptimeSeconds = gatewayStartedAtUtc is { } startedAt ? (long)(DateTime.UtcNow - startedAt).TotalSeconds : 0,
-                Directors = aboutTenant is { } t ? registry.ListDirectors(t).Count : 0,
-                Mode = gatewayModeLabel?.Invoke() ?? "unknown",
+                // The served bundles name themselves through the build.json each Vite build emits; the
+                // Gateway cannot read the commit compiled into their JavaScript. Null when no built bundle
+                // is staged, which the page reports as such rather than guessing a build.
+                Cockpit = BundleStamp.Read(CockpitReactApp.WebRoot),
+                Mobile = BundleStamp.Read(MobileApp.WebRoot),
+                // Folded here, not in the client (CLAUDE.md rule 7).
+                Deployment = GatewayHostedMode.IsHosted ? "Hosted service" : "Self-hosted",
                 Address = GatewayPublicUrl.ResolveBase(),
+                CockpitUrl = GatewayPublicUrl.ResolveCockpit(),
+                // The internal listen port is meaningful ONLY self-hosted. On hosted, callers reach this
+                // Gateway through Address on 443 and the platform forwards to the container's internal
+                // port; printing that number beside an https address reads as a reachable port and is not
+                // one. So it is omitted there - the Gateway decides, the client renders.
+                Port = GatewayHostedMode.IsHosted ? null : gatewayPort?.Invoke(),
+                UptimeSeconds = gatewayStartedAtUtc is { } startedAt ? (long)(DateTime.UtcNow - startedAt).TotalSeconds : 0,
                 ServerTime = DateTime.UtcNow,
             });
         });

--- a/src/CcDirector.Gateway/Diagnostics/BundleStamp.cs
+++ b/src/CcDirector.Gateway/Diagnostics/BundleStamp.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Diagnostics;
+
+/// <summary>
+/// Reads the build stamp a served web bundle ships with: <c>build.json</c>, emitted by that app's Vite
+/// build and staged into the Gateway's wwwroot by the release-gated MSBuild targets on
+/// CcDirector.Gateway.csproj.
+///
+/// This is the ONLY way the Gateway process can name the Cockpit and mobile builds it is serving. Each
+/// app's commit is also compiled into its own minified bundle (the <c>__COCKPIT_COMMIT__</c> /
+/// <c>__MOBILE_COMMIT__</c> defines), but the server never executes that JavaScript, so before this
+/// stamp existed the About page could report only the build of the bundle the browser was already
+/// running - never the other surface's, and never from a server-side call at all.
+///
+/// Read on EVERY request, deliberately not cached: a Cockpit-only redeploy replaces wwwroot/c under a
+/// live Gateway without restarting it, so a cached stamp would keep naming the previous build - which
+/// is precisely the staleness this stamp exists to expose. The file is a few dozen bytes and About is
+/// not a hot path.
+/// </summary>
+public static class BundleStamp
+{
+    /// <summary>The file each app's build emits into its bundle root.</summary>
+    public const string FileName = "build.json";
+
+    /// <summary>
+    /// The stamp for the bundle served out of <paramref name="webRoot"/>, or null when that bundle
+    /// carries no stamp. Null is a real, reportable state, not a substituted value: a routine Debug
+    /// build does not build the web apps at all, so wwwroot is absent and the caller says so plainly
+    /// rather than inventing a commit. A stamp that is PRESENT but unreadable is a broken deploy and
+    /// is logged as a failure - it is never quietly reported as "no bundle".
+    /// </summary>
+    public static BundleStampDto? Read(string webRoot)
+    {
+        var path = Path.Combine(webRoot, FileName);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            var stamp = JsonSerializer.Deserialize<StampFile>(File.ReadAllText(path));
+            if (stamp is null || string.IsNullOrWhiteSpace(stamp.Commit))
+            {
+                FileLog.Write($"[BundleStamp] Read FAILED: {path} carries no commit - the bundle staged here was built without a stamp");
+                return null;
+            }
+            return new BundleStampDto { Commit = stamp.Commit.Trim(), BuildTime = stamp.BuildTime };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BundleStamp] Read FAILED: {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>The on-disk shape written by the apps' Vite build-stamp plugin.</summary>
+    private sealed class StampFile
+    {
+        [JsonPropertyName("commit")]
+        public string? Commit { get; set; }
+
+        [JsonPropertyName("buildTime")]
+        public DateTime? BuildTime { get; set; }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2071,13 +2071,11 @@ public sealed class GatewayHost : IAsyncDisposable
             // Issue #2017: the snooze-default consumer at POST /sessions/{sid}/hold reads the caller tenant's
             // default through the resolver instead of the process-global config.
             tenantSettings: _tenantSettingsResolver,
-            // Issue #2022: the live process diagnostics the About page now shows read-only on both surfaces,
-            // after the machine settings left the Cockpit Settings page. The mode is a delegate resolved per
-            // request because SettingsHooks is assigned on this host after Map has run.
+            // Issue #2022: the live process diagnostics the About page shows read-only on both surfaces,
+            // after the machine settings left the Cockpit Settings page.
             gatewayStartedAtUtc: StartedAtUtc,
             // Issue #2161: a delegate - Map runs before the listener binds.
             gatewayPort: () => Port,
-            gatewayModeLabel: () => SettingsHooks?.Mode?.Invoke() ?? "unknown",
             // Store injection points: hand the phone-recorder ingest (RecordingEndpoints) the host's single
             // key vault + transcription history + audio archive, so it stops newing its own copies.
             recordingKeyVault: _keyVault,


### PR DESCRIPTION
## Why

The About page was a relic of the days we hosted the Gateway ourselves. It reported the wrong things about the wrong product:

- **"Product: Director"** - a hard-coded string, on a page whose next row is labelled "Gateway version". The Director has its own About box, its own tray window and its own Cockpit screen; its facts do not belong here.
- **Install root** - it printed `C:\Users\<user>\AppData\Local\cc-director`, spelling out the operating-system user name of the Gateway box to any enrolled device that reads the endpoint.
- **Installed components** - the installer's manifest from `installed.json` on that box.
- **Machine name and run mode** - internal detail about infrastructure a hosted caller does not own.
- **Port 7878 printed directly beneath a public HTTPS address**, where the two do not compose into anything reachable. This is what made the page look broken.

## What it shows now

Three server-side products, and how the Gateway is reached.

| | |
|---|---|
| Gateway | version, build date |
| Cockpit | the bundle this Gateway serves: commit and build time |
| Mobile app | the bundle this Gateway serves: commit and build time |
| This Gateway | deployment, public address, Cockpit URL, uptime, Gateway time, and the listen port **self-hosted only** |

### The bundle versions needed a build stamp

The Gateway could not name either bundle it serves. Each app's commit is compiled into its minified JavaScript, which the server never executes, so the old page could only report the build of the bundle the browser was *already running* - never the mobile app's, and never from a server-side call.

Both builds now emit a `build.json` (commit and build time) into their bundle, staged into `wwwroot/c` and `wwwroot/mobile` by the existing recursive copies in the release MSBuild targets. `BundleStamp` reads it **per request and deliberately does not cache**: a Cockpit-only redeploy replaces the bundle under a live Gateway, so a cached stamp would keep naming the previous build - precisely the staleness the stamp exists to expose.

The **mobile app gained a build identity it never had anywhere**. Its About row showed the content-hashed script filename scraped out of the live page (`index-CUHLjBg5.js`) - a value that changed every build and named nothing you could look up.

The Cockpit page also keeps an always-visible line naming the bundle **this tab** is running. That is a different fact from the served bundle: when the two disagree, the tab is stale. It renders even when the Gateway call fails.

### Why the port is not 443, and why it is now omitted on hosted

7878 is correct and stays. Nothing outside the container ever connects to it: App Service terminates encryption on the public 443 and forwards inward, so no customer network or firewall sees 7878. Self-hosted, Tailscale Serve maps 443 to it the same way. Binding 443 inside the container would buy nothing, and on a self-hosted Windows box it would fight whatever else wants that port.

So the port was never the defect - **printing it was**. It is now served only when self-hosted, where it is a real reachable port. On hosted it is absent from the payload, so no client can render it. The Gateway decides; the page renders what it is given.

### Removed from the payload, not merely hidden

`Product`, `MachineName`, `InstallRoot`, `InstalledComponents`, `Directors`, `Mode`, `State` are gone from the response object, not just from the page. The install root is why this matters: it was readable by any enrolled device even while the page rendered it, so deleting the row alone would not have stopped it leaving the Gateway.

Also corrects a wrong `Dockerfile` comment: it claimed the Gateway binds loopback. It binds `0.0.0.0`, which is exactly what lets the App Service front end reach it.

## Proof

- Full `CcDirector.Gateway.Tests` suite: **still running at the time of opening**; will be reported in a comment below. Continuous integration also runs it on this branch.
- Other six .NET test projects, zero failures: Core 3710, Engine 62, Avalonia 305, Launcher 27, HostedAgent 86, Terminal.Avalonia 23.
- Cockpit vitest: 199/199 including 10 new About tests.
- New `BundleStampTests`: 6/6 - stamped, no bundle staged, missing root, corrupt JSON, commit-less stamp, time-less stamp.
- Targeted endpoint tests: 24/24 across the About, Cockpit-URL and public-URL suites.
- Zero-warning builds of Gateway, Gateway.Host, Gateway.Tests and Avalonia.
- Typecheck clean across all three npm workspaces.
- **Revert-proof**: reinstating the old unconditional port reddened the new hosted test with `Expected: null, Actual: 60875`. The test fails for the right reason rather than passing by accident.
- Verified the emitted stamps carry the correct commit, and that the mobile bundle now contains a commit literal where it previously had none.
- Both rendered variants checked in a browser: self-hosted shows `Listening on port 7878`; hosted shows no port row, no filesystem paths, and `Deployment: Hosted service`.

## Note

`packages/client-core/src/api/schema.ts` is a generated OpenAPI snapshot that still lists the old About fields. Nothing type-checks against it for this endpoint, and regenerating needs a live Gateway and would sweep in every unrelated endpoint change since the last run - so it is left exactly as stale as it already was.
