### PR TITLE
fix: a stale push must not report a live session as gone, and no user is shown a bare status code

### DIFF
--- a/apps/cockpit/src/components/ConfirmDialog.tsx
+++ b/apps/cockpit/src/components/ConfirmDialog.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
-import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { Button } from "./Button";
 import { useDismissOnBackdrop } from "./useDismissOnBackdrop";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from the shared confirm dialog, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-confirm";
 
 // The one confirmation dialog every destructive action in the Cockpit routes through (issue #1244).
 // Before this, destructive actions were handled three different ways: a good inline confirmation on the
@@ -40,6 +44,13 @@ export interface ConfirmDialogProps {
   /** Runs when the person confirms. Return a promise to have the dialog show a busy state and, on a
    *  thrown error, surface it inline. */
   onConfirm: () => void | Promise<void>;
+  /**
+   * What the person is trying to do, in their terms ("compact the context"). It shapes the sentence
+   * shown on a failure and labels the report sent to the Gateway (issue #2189). Defaults to the confirm
+   * button's label, which is already written in the user's words - so an existing caller reports
+   * something sensible without being touched.
+   */
+  action?: string;
   /** Runs when the person cancels, dismisses (backdrop or Escape), or the action succeeds. */
   onClose: () => void;
 }
@@ -53,6 +64,7 @@ export function ConfirmDialog({
   danger = true,
   busyLabel = "Working...",
   onConfirm,
+  action,
   onClose,
 }: ConfirmDialogProps) {
   const [busy, setBusy] = useState(false);
@@ -94,8 +106,10 @@ export function ConfirmDialog({
       }
       onClose();
     } catch (err) {
-      // Fail loudly: keep the dialog open and show precisely what went wrong.
-      setError(gatewayErrorMessage(err));
+      // Fail loudly: keep the dialog open and show precisely what went wrong - AND report it (issue
+      // #2189). This is the shared confirm surface, so every confirmed action in the Cockpit (compact,
+      // clear context, close a session) reports its failure through this one line.
+      setError(describeAndReport(SURFACE, action ?? confirmLabel.toLowerCase(), err));
     } finally {
       setBusy(false);
     }

--- a/apps/cockpit/src/sessions/QueuePanel.tsx
+++ b/apps/cockpit/src/sessions/QueuePanel.tsx
@@ -6,11 +6,15 @@ import {
   moveQueueItemDown,
   moveQueueItemUp,
   sendQueueItem,
-  gatewayErrorMessage,
   type QueueItem,
 } from "@devthrottle/client-core/api/client";
 import { ConfirmDialog } from "../components";
 import { confirmThenApply } from "./queueActions";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this view, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-queue-panel";
 
 // The prompt queue panel (issue #972) - the React port of the Blazor Cockpit queue tab. Every verb
 // goes to the owning Director through the Gateway and returns the authoritative queue, so the list is
@@ -46,7 +50,7 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
         onQueue(await verb());
         return true;
       } catch (err) {
-        setError(gatewayErrorMessage(err));
+        setError(describeAndReport(SURFACE, "update the prompt queue", err));
         return false;
       } finally {
         setBusy(false);

--- a/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
+++ b/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
@@ -3,7 +3,6 @@ import {
   deleteScreenshot,
   getScreenshots,
   screenshotFileUrl,
-  gatewayErrorMessage,
   type ScreenshotInfo,
 } from "@devthrottle/client-core/api/client";
 import {
@@ -25,6 +24,11 @@ import { ConfirmDialog } from "../components";
 // it full-size (new tab); Insert drops the Director-side path into the composer; Delete removes the
 // file from the Director's disk.
 const FETCH_COUNT = 60;
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this view, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-screenshots";
 const INITIAL_SHOWN = 12;
 const SHOW_MORE_STEP = 24;
 
@@ -63,7 +67,7 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
         setLoadedOnce(true);
       } catch (err) {
         if (signal?.aborted) return;
-        setError(gatewayErrorMessage(err));
+        setError(describeAndReport(SURFACE, "load the screenshots", err));
       } finally {
         setBusy(false);
       }

--- a/apps/cockpit/src/sessions/SessionActionBar.tsx
+++ b/apps/cockpit/src/sessions/SessionActionBar.tsx
@@ -5,9 +5,13 @@ import {
   sendEscape,
   sendHistoryPicker,
   sendInterrupt,
-  gatewayErrorMessage,
 } from "@devthrottle/client-core/api/client";
 import { ConfirmDialog } from "../components";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this bar, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-session-actions";
 
 // The driver action bar (issue #972) - the React port of the Blazor Cockpit action bar / desktop
 // SessionActionBar. Each button is rendered from the SELECTED session's declared driver capabilities
@@ -55,8 +59,11 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
     statusTimer.current = window.setTimeout(() => setStatus(null), 5000);
   }, []);
 
+  // `action` names what the user pressed, in their terms ("stop the turn"). It shapes the sentence the
+  // user reads AND labels the report that goes to the Gateway (issue #2189), so a failed button press is
+  // never a bare status number on screen and never invisible on the server.
   const act = useCallback(
-    async (verb: () => Promise<void>, done: string, failed: string) => {
+    async (verb: () => Promise<void>, done: string, action: string) => {
       if (!sessionId || acting) return;
       setActing(true);
       setError(null);
@@ -64,7 +71,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
         await verb();
         flash(done);
       } catch (err) {
-        setError(err instanceof Error ? gatewayErrorMessage(err) : failed);
+        setError(describeAndReport(SURFACE, action, err));
       } finally {
         setActing(false);
       }
@@ -93,7 +100,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           type="button"
           className="act-btn act-stop"
           disabled={acting}
-          onClick={() => sessionId && void act(() => sendEscape(sessionId), "turn stopped", "Stop failed")}
+          onClick={() => sessionId && void act(() => sendEscape(sessionId), "turn stopped", "stop the turn")}
           title="Stop the current turn (the driver's soft cancel - Esc)"
         >
           Stop
@@ -104,7 +111,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           type="button"
           className="act-btn"
           disabled={acting}
-          onClick={() => sessionId && void act(() => sendInterrupt(sessionId), "interrupted", "Interrupt failed")}
+          onClick={() => sessionId && void act(() => sendInterrupt(sessionId), "interrupted", "interrupt the session")}
           title="Hard interrupt (Ctrl+C) - stronger than Stop"
         >
           Interrupt
@@ -137,7 +144,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           type="button"
           className="act-btn"
           disabled={acting}
-          onClick={() => sessionId && void act(() => sendHistoryPicker(sessionId), "history picker opened (Esc closes)", "History failed")}
+          onClick={() => sessionId && void act(() => sendHistoryPicker(sessionId), "history picker opened (Esc closes)", "open the history picker")}
           title="Open the in-terminal history picker (Claude's double-Esc)"
         >
           History

--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -4,9 +4,10 @@ import {
   enqueuePrompt,
   sendPrompt,
   uploadImage,
-  gatewayErrorMessage,
+  GatewayError,
   type QueueItem,
 } from "@devthrottle/client-core/api/client";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { insertAt } from "@devthrottle/client-core/dictation/transcript";
 
@@ -40,6 +41,39 @@ import { insertAt } from "@devthrottle/client-core/dictation/transcript";
 //
 // The composer text is owned by the parent (SessionDetail) so the queue's Pop and the screenshot
 // gallery's Insert can drop text into it. Send/Queue are disabled while empty or a call is in flight.
+
+// The surface label on every client-error report from this composer, so a report in the Gateway log
+// and in GET /client-errors/recent names where the user was standing (issue #2189).
+const SURFACE = "cockpit-composer";
+
+// How long to wait before the single retry below. Long enough to outlast the observed hole (the Gateway
+// refuses actions on a session whose Director missed a push, and the next push closes it), short enough
+// that a person watching the button does not think it hung.
+const RETRY_DELAY_MS = 2500;
+
+/**
+ * Upload one image, retrying ONCE if the Gateway said the failure was retryable (issue #2188/#2189).
+ *
+ * Why: the reported failure was a ten-second window in which the owning Director had missed a snapshot
+ * push, so the Gateway refused every action on a session that was alive the whole time. A single retry a
+ * couple of seconds later would have succeeded. One retry, announced in the status line - not a silent
+ * loop, and not a fallback that hides a real outage: a Director that is genuinely gone fails on the
+ * retry too, and the user is told what happened.
+ */
+async function uploadWithOneRetry(
+  sessionId: string,
+  file: File,
+  onRetrying: () => void,
+): Promise<string> {
+  try {
+    return await uploadImage(sessionId, file);
+  } catch (err) {
+    if (!(err instanceof GatewayError) || !err.retryable) throw err;
+    onRetrying();
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    return await uploadImage(sessionId, file);
+  }
+}
 
 export interface SessionComposerProps {
   sessionId: string | undefined;
@@ -90,7 +124,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
       setStatus("Sent");
     } catch (err) {
       onChange(text); // restore so a failed send never loses the typed text
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "send that to the session", err));
     } finally {
       setBusy(false);
     }
@@ -108,7 +142,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
       onChange("");
       setStatus("Queued");
     } catch (err) {
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "queue that prompt", err));
     } finally {
       setBusy(false);
     }
@@ -142,7 +176,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
       try {
         const paths: string[] = [];
         for (const file of files) {
-          const path = await uploadImage(sessionId, file);
+          const path = await uploadWithOneRetry(sessionId, file, () => setStatus("Retrying..."));
           if (path) paths.push(path);
         }
         if (paths.length > 0) {
@@ -151,7 +185,8 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
           setStatus(paths.length === 1 ? "Image attached" : `${paths.length} images attached`);
         }
       } catch (err) {
-        setError(gatewayErrorMessage(err));
+        setStatus(null);
+        setError(describeAndReport(SURFACE, "attach the image", err));
       } finally {
         setBusy(false);
       }
@@ -238,7 +273,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
         setStatus("Sent");
       } catch (err) {
         onChange(combined); // restore so a failed send never loses the typed + dictated text
-        setError(gatewayErrorMessage(err));
+        setError(describeAndReport(SURFACE, "send that to the session", err));
       } finally {
         setBusy(false);
       }

--- a/apps/cockpit/src/sessions/SessionMenu.tsx
+++ b/apps/cockpit/src/sessions/SessionMenu.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
-  gatewayErrorMessage,
   getHandover,
   holdSession,
   killSession,
@@ -12,6 +11,11 @@ import { renameSession } from "@devthrottle/client-core/fleet/fleetClient";
 import { useSnoozeOptions } from "@devthrottle/client-core/settings/snoozeOptions";
 import { buildSnoozeMenu } from "@devthrottle/client-core/settings/snoozeMenu";
 import { useDismissOnBackdrop } from "../components";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this view, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-session-menu";
 
 // The session menu (issue #1214): a three-dot control with Rename, Snooze / Unsnooze, Handover info,
 // and Close session. It is the SAME component on the session page and on every rail card. Every action
@@ -182,7 +186,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
     setBusy(true);
     getHandover(sid)
       .then((h) => setHandover(h))
-      .catch((err) => setError(gatewayErrorMessage(err)))
+      .catch((err) => setError(describeAndReport(SURFACE, "load the handover information", err)))
       .finally(() => setBusy(false));
   }, [sid]);
 
@@ -195,7 +199,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
       await renameSession(sid, name);
       closeDialog();
     } catch (err) {
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "rename the session", err));
     } finally {
       setBusy(false);
     }
@@ -211,7 +215,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
     try {
       await holdSession(sid, !session.onHold);
     } catch (err) {
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "snooze the session", err));
     } finally {
       setBusy(false);
     }
@@ -229,7 +233,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
     try {
       await holdSession(sid, true, minutes);
     } catch (err) {
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "snooze the session", err));
     } finally {
       setBusy(false);
     }
@@ -244,7 +248,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
       closeDialog();
       onClosed?.();
     } catch (err) {
-      setError(gatewayErrorMessage(err));
+      setError(describeAndReport(SURFACE, "close the session", err));
     } finally {
       setBusy(false);
     }

--- a/apps/cockpit/src/sessions/SourceControlTab.tsx
+++ b/apps/cockpit/src/sessions/SourceControlTab.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getGitStatus,
-  gatewayErrorMessage,
   type GitSnapshot,
   type GitChangeEntry,
 } from "@devthrottle/client-core/api/client";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this view, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "cockpit-source-control";
 
 // The Cockpit Source Control tab (issue #1266): a READ-ONLY view of the selected session's repository -
 // branch, ahead/behind, last commit, and the staged / unstaged file lists - so a browser driver can see
@@ -64,7 +68,7 @@ export function SourceControlTab({ sessionId, onInsertPath }: SourceControlTabPr
       } catch (err) {
         if (signal?.aborted === true) return;
         // No silent failure: surface the transport error so the reader knows the state is not shown.
-        setError(gatewayErrorMessage(err));
+        setError(describeAndReport(SURFACE, "read the repository status", err));
       } finally {
         busyRef.current = false;
         setLoading(false);

--- a/apps/cockpit/src/sessions/composerAttachErrors.test.tsx
+++ b/apps/cockpit/src/sessions/composerAttachErrors.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+// Issue #2188/#2189 - the reported failure, at the surface the user actually pressed.
+//
+// What happened: Attach on the Cockpit session screen failed while the owning Director was briefly behind on
+// its snapshot pushes. The Gateway answered 404 "session not found across any director" - for a session that
+// was alive the whole time - and the composer rendered "The Gateway rejected the request (error 404)." The
+// user could not tell what had failed or whether retrying would help, nothing reached the server log, and the
+// status was reported back to an agent as "400" because a number was all the message carried.
+//
+// Three properties, each of which was broken independently:
+//   1. The user is shown the server's REASON, never a bare status number.
+//   2. The failure is REPORTED to the Gateway, so it does not exist only on the user's screen.
+//   3. A retryable failure is RETRIED once before the user is told anything - which alone turns the
+//      reported ten-second hole into a non-event.
+
+const { uploadImage, sendPrompt, enqueuePrompt } = vi.hoisted(() => ({
+  uploadImage: vi.fn(),
+  sendPrompt: vi.fn(async () => {}),
+  enqueuePrompt: vi.fn(async () => []),
+}));
+
+// The real GatewayError and the real message mapper: the sentence the user reads is exactly what shipped,
+// not a test double's idea of it. Only the network calls are faked.
+vi.mock("@devthrottle/client-core/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@devthrottle/client-core/api/client")>();
+  return { ...actual, uploadImage, sendPrompt, enqueuePrompt };
+});
+
+import { GatewayError } from "@devthrottle/client-core/api/client";
+import { SessionComposer } from "./SessionComposer";
+
+const SESSION = "1af26bff-d812-474d-b07c-ed8a4baed226";
+
+/** The exact body the Gateway now returns when the owning Director's push has gone stale. */
+function directorStaleError(): GatewayError {
+  return new GatewayError(
+    503,
+    "The machine running this session has not reported in for 26 seconds. The session is still there - "
+      + "this usually clears within a few seconds. Try again.",
+    {
+      reason:
+        "The machine running this session has not reported in for 26 seconds. The session is still there - "
+        + "this usually clears within a few seconds. Try again.",
+      code: "director_stale",
+      retryable: true,
+    },
+  );
+}
+
+function renderComposer() {
+  return render(
+    <SessionComposer sessionId={SESSION} value="" onChange={() => {}} onQueued={() => {}} />,
+  );
+}
+
+/** Drive the hidden file input the Attach button clicks. */
+function attach(file: File) {
+  const input = document.querySelector<HTMLInputElement>("input.composer-file");
+  if (input === null) throw new Error("the composer's file input is not in the document");
+  Object.defineProperty(input, "files", { value: [file], configurable: true });
+  fireEvent.change(input);
+}
+
+const PNG = () => new File([new Uint8Array([1, 2, 3])], "screenshot.png", { type: "image/png" });
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  // Real timers on purpose: the retry delay is a product decision (long enough to outlast the observed
+  // push gap, short enough that a person does not think the button hung), so the test waits it out rather
+  // than faking it away and proving nothing about the real wait.
+  uploadImage.mockReset();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Cockpit composer: a failed Attach", () => {
+  it("shows the server's reason, not a bare status number", async () => {
+    // Fail both attempts so the message is what the user is finally left with.
+    uploadImage.mockRejectedValue(directorStaleError());
+
+    renderComposer();
+    attach(PNG());
+
+    await waitFor(
+      () => expect(screen.getByText(/has not reported in for 26 seconds/)).toBeTruthy(),
+      { timeout: 10000 },
+    );
+    // The old message must be gone: this is the regression that sent a user looking for "error 400".
+    expect(screen.queryByText(/rejected the request/)).toBeNull();
+    // And it tells them what to do.
+    expect(screen.getByText(/Try again/)).toBeTruthy();
+  });
+
+  it("reports the failure to the Gateway, so it does not exist only on the screen", async () => {
+    uploadImage.mockRejectedValue(directorStaleError());
+
+    renderComposer();
+    attach(PNG());
+
+    await waitFor(
+      () => {
+        const reports = fetchMock.mock.calls.filter((c) => c[0] === "/client-errors");
+        expect(reports.length).toBeGreaterThan(0);
+        const body = JSON.parse((reports[0][1] as { body: string }).body) as Record<string, string>;
+        expect(body.surface).toBe("cockpit-composer");
+        expect(body.message).toContain("attach the image");
+        expect(body.message).toContain("has not reported in for 26 seconds");
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  it("retries ONCE on a retryable failure and succeeds without bothering the user", async () => {
+    // The observed hole was about ten seconds wide and closed on the next push. One retry is enough.
+    uploadImage
+      .mockRejectedValueOnce(directorStaleError())
+      .mockResolvedValueOnce("D:\\shots\\upload-1.png");
+
+    renderComposer();
+    attach(PNG());
+
+    await waitFor(() => expect(uploadImage).toHaveBeenCalledTimes(2), { timeout: 10000 });
+    await waitFor(() => expect(screen.getByText("Image attached")).toBeTruthy(), { timeout: 10000 });
+    // Nothing alarming was shown, and nothing was reported: this was not a failure the user needs to know
+    // about. A retry that still reported would just move the noise from the screen into the log.
+    expect(screen.queryByText(/has not reported in/)).toBeNull();
+    expect(fetchMock.mock.calls.filter((c) => c[0] === "/client-errors")).toHaveLength(0);
+  });
+
+  it("does NOT retry a failure that retrying cannot fix", async () => {
+    // A 404 for a session that genuinely does not exist is permanent. Retrying it wastes the user's time and
+    // makes the eventual message arrive later - the opposite of helpful.
+    uploadImage.mockRejectedValue(
+      new GatewayError(404, "gone", {
+        reason: "That session could not be found. It may have been closed.",
+        retryable: false,
+      }),
+    );
+
+    renderComposer();
+    attach(PNG());
+
+    await waitFor(
+      () => expect(screen.getByText(/could not be found/)).toBeTruthy(),
+      { timeout: 10000 },
+    );
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Try again/)).toBeNull();
+  });
+});

--- a/apps/cockpit/src/workflows/WorkflowsView.test.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.test.tsx
@@ -111,14 +111,19 @@ describe("WorkflowsView register actions", () => {
   });
 
   it("a failed clone lands in the page error state, never silent", async () => {
-    // A real Gateway refusal (409, id taken) - the formatter passes GatewayError statuses through
-    // as "rejected the request", and the page must SHOW it rather than swallow the failure.
+    // A real Gateway refusal (409, id taken). The page must SHOW it rather than swallow the failure.
+    //
+    // CONTRACT CHANGE (issue #2189): this used to assert the wording "rejected the request (error 409)".
+    // That phrasing is gone - it was a bare status number dressed up as a sentence. The message now says
+    // what a 409 actually means and what to do about it. The property under test is unchanged: the failure
+    // reaches the screen.
     const { GatewayError } = await import("@devthrottle/client-core/api/client");
     cloneWorkflow.mockRejectedValue(new GatewayError(409, "id taken"));
     render(<WorkflowsView />);
     fireEvent.click(await screen.findByRole("button", { name: "Clone Mission" }));
     const confirm = screen.getAllByRole("button", { name: "Clone" }).at(-1)!;
     fireEvent.click(confirm);
-    await waitFor(() => expect(screen.getByText(/rejected the request \(error 409\)/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/something else changed it first/)).toBeTruthy());
+    expect(screen.queryByText(/rejected the request/)).toBeNull();
   });
 });

--- a/apps/mobile/src/components/SessionControls.tsx
+++ b/apps/mobile/src/components/SessionControls.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
-import { gatewayErrorMessage, sendEscape, sendInterrupt, sendPrompt, uploadImage } from "@devthrottle/client-core/api/client";
+import { sendEscape, sendInterrupt, sendPrompt, uploadImage } from "@devthrottle/client-core/api/client";
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottle/client-core/dictation/backgroundSend";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { insertAt, joinText } from "@devthrottle/client-core/dictation/transcript";
@@ -10,6 +10,11 @@ import {
   KEY_ARROW_UP,
   KEY_ENTER,
 } from "@devthrottle/client-core/terminal/keys";
+import { describeAndReport } from "@devthrottle/client-core/errors/reportClientError";
+
+// The surface label on every client-error report from this view, so the Gateway log and
+// GET /client-errors/recent name where the user was standing (issue #2189).
+const SURFACE = "mobile-session-controls";
 
 // The ONE shared session control surface (issue #811): the full-width input row, the Send/Speak row
 // (Send first, Speak second, equal halves), the Enter/Esc/Stop row, and the arrow row, plus the
@@ -154,7 +159,7 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
         });
         onFlash(paths.length === 1 ? "Image attached" : `${paths.length} images attached`);
       } catch (err) {
-        onError(gatewayErrorMessage(err));
+        onError(describeAndReport(SURFACE, "attach the image", err));
       } finally {
         setUploading(false);
       }

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -184,12 +184,83 @@ function onUnauthorized(): void {
   }
 }
 
+// Issue #2189: the server's OWN sentence for a failure, carried on the thrown error instead of being
+// discarded at the throw site. Before this, every non-2xx became `new GatewayError(status, "POST x
+// failed: 404")` - the Gateway had written a perfectly good reason into `{ error: ... }` and the client
+// dropped it, so the user was shown nothing but a three-digit number.
+export interface GatewayFailureDetail {
+  /** The server's sentence, from `{ error }` / `{ detail }` / `{ message }`. Never a status number. */
+  reason?: string;
+  /** The server's machine-readable code, when it sent one (e.g. "director_stale"). */
+  code?: string;
+  /** The server said this is worth retrying. */
+  retryable?: boolean;
+}
+
 export class GatewayError extends Error {
   readonly status: number;
-  constructor(status: number, message: string) {
+  /** The server's own sentence for this failure, when it sent one. Never a status number. */
+  readonly serverReason?: string;
+  /** The server's machine-readable code, when it sent one. */
+  readonly code?: string;
+  /** True when retrying could plausibly succeed: the server said so, or the status class implies it. */
+  readonly retryable: boolean;
+  constructor(status: number, message: string, detail?: GatewayFailureDetail) {
     super(message);
     this.name = "GatewayError";
     this.status = status;
+    this.serverReason = detail?.reason;
+    this.code = detail?.code;
+    // A server `retryable` flag is authoritative. Absent one, the transport statuses that mean "the
+    // request never reached a healthy backend" are retryable by definition; a 4xx is the caller's own
+    // request being wrong and retrying it unchanged cannot help.
+    this.retryable = detail?.retryable
+      ?? (status === 0 || status === 429 || status === 502 || status === 503 || status === 504);
+  }
+
+  /**
+   * Build the error for a non-2xx response, READING the server's reason out of the body.
+   *
+   * Every `!res.ok` throw in this client must go through here. A bare `new GatewayError(res.status,
+   * "POST x failed: " + res.status)` is exactly what deleted the reason in the first place (issue #2189):
+   * the Gateway had written a usable sentence into `{ error }` and the throw site dropped it one hop from
+   * being shown, leaving the user with three digits.
+   *
+   * It consumes the response body, which is safe BY CONSTRUCTION at every call site: this is only reached
+   * on a non-2xx, where the alternative was discarding the body unread. The few call sites that parse an
+   * error body themselves (create session, the transcription legs) build their own error and never come
+   * here, so nothing reads a body twice.
+   *
+   * `what` names the action in the user's terms ("attach the image"), never the method and path.
+   */
+  static async from(res: Response, what: string): Promise<GatewayError> {
+    const detail = await readFailureDetail(res);
+    return new GatewayError(res.status, detail.reason ?? `Could not ${what} (error ${res.status}).`, detail);
+  }
+}
+
+/** Pull the server's reason, code and retryable flag out of a failed response. Best-effort by
+ *  construction: a body that is missing, empty, unreadable or not JSON yields an empty detail, and this
+ *  must never turn a failed request into a thrown parse error. */
+async function readFailureDetail(res: Response): Promise<GatewayFailureDetail> {
+  try {
+    const text = await res.text();
+    if (!text.trim()) return {};
+    try {
+      const body = JSON.parse(text) as Record<string, unknown>;
+      return {
+        reason: stringFromErrorBody(body),
+        code: typeof body.code === "string" ? body.code : undefined,
+        retryable: typeof body.retryable === "boolean" ? body.retryable : undefined,
+      };
+    } catch {
+      // A non-JSON body is still a reason, provided it is short enough to be a sentence rather than an
+      // HTML error page from something in front of the Gateway.
+      if (text.length <= 300 && !text.trimStart().startsWith("<")) return { reason: text.trim() };
+      return {};
+    }
+  } catch {
+    return {};
   }
 }
 
@@ -335,18 +406,77 @@ export const POLL_TIMEOUT_MS = 10000;
 
 // Map any error thrown by a Gateway read/write into ONE user-facing line, never leaking the internal
 // "METHOD /path failed: NNN" diagnostic the client throws on a non-2xx, nor the browser's bare
-// "Failed to fetch" when the backend is down (issue #1028). An unreachable Gateway collapses to the
-// shared friendly, retry-implying line; a GatewayError that already carries human copy (a 401 re-auth
-// prompt, a 402 credits notice) is returned verbatim; any other reachable-but-erroring status is
-// reported by its number only, without the raw method and path.
-export function gatewayErrorMessage(err: unknown): string {
-  if (isGatewayUnreachable(err)) return GATEWAY_UNREACHABLE_MESSAGE;
+// "Failed to fetch" when the backend is down (issue #1028).
+//
+// THE RULE (issue #2189): a number is not an error message. Whatever this returns must say what
+// happened, and say whether trying again is worth it. It may mention the status in parentheses for
+// support purposes; the status may never BE the message. The old behaviour - everything that was not a
+// 401 collapsing to "The Gateway rejected the request (error 404)." - is what left the user with three
+// digits and nothing else after a failed image attach, on a session that was alive the whole time.
+//
+// Order of preference:
+//  1. The server's own sentence, when it sent one (the Gateway writes good ones - see the retryable
+//     "has not reported in for N seconds ... try again" copy on a stale Director).
+//  2. Human copy already carried on the error (a 401 re-auth prompt, a 402 credits notice).
+//  3. A plain sentence for the status class, naming the action when the caller supplied one.
+//
+// `what` names the action in the user's terms - "attach the image", "send the prompt". Optional so the
+// many existing poll call sites keep compiling; supply it anywhere a person is watching.
+export function gatewayErrorMessage(err: unknown, what?: string): string {
   if (err instanceof CreditsError) return err.message;
   if (err instanceof GatewayError) {
+    // The server's reason wins over every generic line we could write here.
+    if (err.serverReason) return withRetryHint(err.serverReason, err.retryable);
     if (err.status === 401) return err.message;
-    return `The Gateway rejected the request (error ${err.status}).`;
+    // No reason from the server. A background POLL that could not reach the backend keeps the shared
+    // line from issue #1028 - it is already a real sentence and it already implies the retry those
+    // pages perform. Naming an action means a person pressed something and is waiting, so they get the
+    // specific sentence instead.
+    if (!what && isUnreachableStatus(err.status)) return GATEWAY_UNREACHABLE_MESSAGE;
+    return withRetryHint(statusSentence(err.status, what), err.retryable);
   }
+  if (isGatewayUnreachable(err)) return GATEWAY_UNREACHABLE_MESSAGE;
   return GATEWAY_UNREACHABLE_MESSAGE;
+}
+
+/** The statuses that mean the request never reached a healthy backend. */
+function isUnreachableStatus(status: number): boolean {
+  return status === 0 || status === 502 || status === 503 || status === 504;
+}
+
+/** Add the retry advice unless the reason already gives it, so a retryable failure always tells the
+ *  user that trying again is the right move (and a permanent one never suggests it). */
+function withRetryHint(sentence: string, retryable: boolean): string {
+  if (!retryable) return sentence;
+  if (/try again|retrying|retry/i.test(sentence)) return sentence;
+  return `${sentence} Try again.`;
+}
+
+/** The fallback sentence when the server sent no reason of its own. Never a bare number. */
+function statusSentence(status: number, what?: string): string {
+  const action = what ? `could not ${what}` : "could not complete that";
+  if (status === 0 || status === 502 || status === 503 || status === 504) {
+    return `DevThrottle ${action} - the machine running this session could not be reached (error ${status}).`;
+  }
+  if (status === 404) {
+    return `DevThrottle ${action} - the session could not be found (error 404). It may have been closed.`;
+  }
+  if (status === 409) {
+    return `DevThrottle ${action} - something else changed it first (error 409). Reload and try again.`;
+  }
+  if (status === 413) {
+    return `DevThrottle ${action} - the file is too large (error 413).`;
+  }
+  if (status === 423) {
+    return `DevThrottle ${action} - this session is on hold (error 423). Take it off hold first.`;
+  }
+  if (status === 429) {
+    return `DevThrottle ${action} - too many requests in a row (error 429).`;
+  }
+  if (status >= 500) {
+    return `DevThrottle ${action} - the Gateway hit an internal error (error ${status}).`;
+  }
+  return `DevThrottle ${action} (error ${status}).`;
 }
 
 type GatewayErrorBody = {
@@ -399,7 +529,7 @@ export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> 
     throw new GatewayError(res.status, "This device is no longer authorized. Please sign in again.");
   }
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET /sessions failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the session list");
   }
   return (await res.json()) as SessionDto[];
 }
@@ -422,7 +552,7 @@ export async function getSessionHistory(
     signal,
   }, { timeoutMs: POLL_TIMEOUT_MS });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET history failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the conversation history");
   }
   return (await res.json()) as SessionHistoryDto;
 }
@@ -445,7 +575,7 @@ export async function sendPrompt(
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST prompt failed: ${res.status}`);
+    throw await GatewayError.from(res, "send that to the session");
   }
 }
 
@@ -458,7 +588,7 @@ export async function sendEscape(sessionId: string, signal?: AbortSignal): Promi
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST escape failed: ${res.status}`);
+    throw await GatewayError.from(res, "send Escape to the session");
   }
 }
 
@@ -471,7 +601,7 @@ export async function sendInterrupt(sessionId: string, signal?: AbortSignal): Pr
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST interrupt failed: ${res.status}`);
+    throw await GatewayError.from(res, "interrupt the session");
   }
 }
 
@@ -486,7 +616,7 @@ export async function sendClearContext(sessionId: string, signal?: AbortSignal):
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST clear-context failed: ${res.status}`);
+    throw await GatewayError.from(res, "clear the session context");
   }
 }
 
@@ -545,7 +675,7 @@ export async function sendCompactContext(
     { timeoutMs: COMPACT_CONTEXT_TIMEOUT_MS },
   );
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST compact-context failed: ${res.status}`);
+    throw await GatewayError.from(res, "compact the session context");
   }
   return (await res.json()) as CompactContextResult;
 }
@@ -560,7 +690,7 @@ export async function sendHistoryPicker(sessionId: string, signal?: AbortSignal)
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST history-picker failed: ${res.status}`);
+    throw await GatewayError.from(res, "open the history picker");
   }
 }
 
@@ -580,9 +710,11 @@ export interface QueueItem {
 
 // Read the response's { items } as the authoritative queue. Shared by every queue verb so the
 // parse lives in one place; a non-2xx throws so the caller surfaces it (no silent empty queue).
-async function readQueue(res: Response, label: string): Promise<QueueItem[]> {
+// `what` names the action for the user (issue #2189), so a failed queue verb reads as "DevThrottle
+// could not queue that prompt", never as a status number.
+async function readQueue(res: Response, what: string): Promise<QueueItem[]> {
   if (!res.ok) {
-    throw new GatewayError(res.status, `${label} failed: ${res.status}`);
+    throw await GatewayError.from(res, what);
   }
   const body = (await res.json().catch(() => ({}))) as { items?: QueueItem[] };
   return body.items ?? [];
@@ -596,7 +728,7 @@ export async function getQueue(sessionId: string, signal?: AbortSignal): Promise
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "GET queue");
+  return readQueue(res, "load the prompt queue");
 }
 
 // ===== Source control (issue #1266) =====
@@ -638,7 +770,7 @@ export async function getGitStatus(sessionId: string, signal?: AbortSignal): Pro
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET git failed: ${res.status}`);
+    throw await GatewayError.from(res, "read the repository status");
   }
   const body = (await res.json()) as GitSnapshot;
   return {
@@ -657,7 +789,7 @@ export async function enqueuePrompt(sessionId: string, text: string, signal?: Ab
     body: JSON.stringify({ text }),
     signal,
   });
-  return readQueue(res, "POST queue");
+  return readQueue(res, "queue that prompt");
 }
 
 // DELETE /sessions/{sid}/queue/{itemId} - remove one item; returns the remaining queue.
@@ -669,7 +801,7 @@ export async function deleteQueueItem(sessionId: string, itemId: string, signal?
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "DELETE queue item");
+  return readQueue(res, "remove that queued prompt");
 }
 
 // POST /sessions/{sid}/queue/{itemId}/send - submit one queued item now; returns the remaining queue.
@@ -681,7 +813,7 @@ export async function sendQueueItem(sessionId: string, itemId: string, signal?: 
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "POST queue send");
+  return readQueue(res, "send that queued prompt");
 }
 
 // PATCH /sessions/{sid}/queue/{itemId} { text } - edit one item's text; returns the updated queue.
@@ -694,7 +826,7 @@ export async function editQueueItem(sessionId: string, itemId: string, text: str
     body: JSON.stringify({ text }),
     signal,
   });
-  return readQueue(res, "PATCH queue item");
+  return readQueue(res, "edit that queued prompt");
 }
 
 // POST /sessions/{sid}/queue/{itemId}/move-up - move one item earlier; returns the reordered queue.
@@ -706,7 +838,7 @@ export async function moveQueueItemUp(sessionId: string, itemId: string, signal?
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "POST queue move-up");
+  return readQueue(res, "move that queued prompt up");
 }
 
 // POST /sessions/{sid}/queue/{itemId}/move-down - move one item later; returns the reordered queue.
@@ -718,7 +850,7 @@ export async function moveQueueItemDown(sessionId: string, itemId: string, signa
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "POST queue move-down");
+  return readQueue(res, "move that queued prompt down");
 }
 
 // DELETE /sessions/{sid}/queue - clear the whole queue; returns the (empty) queue.
@@ -729,7 +861,7 @@ export async function clearQueue(sessionId: string, signal?: AbortSignal): Promi
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  return readQueue(res, "DELETE queue");
+  return readQueue(res, "clear the prompt queue");
 }
 
 // ===== Screenshots gallery (issue #972): the captured-screenshots folder on the owning Director =====
@@ -794,7 +926,7 @@ export async function fetchSessionFileText(sessionId: string, path: string, sign
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET file failed: ${res.status}`);
+    throw await GatewayError.from(res, "open that file");
   }
   return res.text();
 }
@@ -816,7 +948,7 @@ export async function fetchSessionFileSize(sessionId: string, path: string, sign
   });
   // 206 (range honored) and 200 (range ignored, full body) are both "ok"; anything else is a real error.
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET file size failed: ${res.status}`);
+    throw await GatewayError.from(res, "read that file's size");
   }
   // We never read the body - drop it so a 200 (full-file) response does not stream needlessly.
   void res.body?.cancel();
@@ -845,7 +977,7 @@ export async function getScreenshots(sessionId: string, count = 0, signal?: Abor
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET screenshots failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the screenshots");
   }
   const body = (await res.json().catch(() => ({}))) as Partial<ScreenshotsResult>;
   return {
@@ -864,7 +996,7 @@ export async function deleteScreenshot(sessionId: string, fileName: string, sign
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `DELETE screenshot failed: ${res.status}`);
+    throw await GatewayError.from(res, "delete that screenshot");
   }
 }
 
@@ -883,7 +1015,7 @@ export async function uploadImage(sessionId: string, file: File, signal?: AbortS
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST upload-image failed: ${res.status}`);
+    throw await GatewayError.from(res, "attach the image");
   }
   const body = (await res.json().catch(() => ({}))) as { path?: string };
   return body.path ?? "";
@@ -915,7 +1047,7 @@ export async function getHandover(sessionId: string, signal?: AbortSignal): Prom
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET handover failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the handover information");
   }
   const body = (await res.json().catch(() => ({}))) as Partial<SessionHandover>;
   return {
@@ -942,7 +1074,7 @@ export async function getGatewayHealth(signal?: AbortSignal): Promise<GatewayHea
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET /healthz failed: ${res.status}`);
+    throw await GatewayError.from(res, "reach the Gateway");
   }
   return (await res.json()) as GatewayHealth;
 }
@@ -973,7 +1105,7 @@ export async function getNetDiagEcho(signal?: AbortSignal): Promise<NetDiagEcho>
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   }, { timeoutMs: POLL_TIMEOUT_MS });
-  if (!res.ok) throw new GatewayError(res.status, `GET /diag/echo failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "run the echo check");
   return (await res.json()) as NetDiagEcho;
 }
 
@@ -1019,7 +1151,7 @@ export async function measureDownload(bytes: number, signal?: AbortSignal): Prom
     headers: { ...authHeaders() },
     signal,
   });
-  if (!res.ok) throw new GatewayError(res.status, `GET /diag/payload failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "run the download check");
   const buf = await res.arrayBuffer();
   const ms = performance.now() - t0;
   return { bytes: buf.byteLength, ms, mbps: megabitsPerSecond(buf.byteLength, ms) };
@@ -1036,7 +1168,7 @@ export async function measureUpload(bytes: number, signal?: AbortSignal): Promis
     body,
     signal,
   });
-  if (!res.ok) throw new GatewayError(res.status, `POST /diag/payload failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "run the upload check");
   await res.arrayBuffer();
   const ms = performance.now() - t0;
   return { bytes, ms, mbps: megabitsPerSecond(bytes, ms) };
@@ -1097,7 +1229,7 @@ export async function getNetworkDiag(signal?: AbortSignal): Promise<NetworkDiag>
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   }, { timeoutMs: 20000 });
-  if (!res.ok) throw new GatewayError(res.status, `GET /diag/network failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "run the network check");
   return (await res.json()) as NetworkDiag;
 }
 
@@ -1131,7 +1263,7 @@ export async function postNetDiagResult(result: NetDiagResult, signal?: AbortSig
     body: JSON.stringify(result),
     signal,
   });
-  if (!res.ok) throw new GatewayError(res.status, `POST /diag/result failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "record the check result");
 }
 
 // GET /diag/results - recent logged results, newest first. Backs the Cockpit history view and lets an
@@ -1142,7 +1274,7 @@ export async function getNetDiagResults(signal?: AbortSignal): Promise<NetDiagRe
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   }, { timeoutMs: POLL_TIMEOUT_MS });
-  if (!res.ok) throw new GatewayError(res.status, `GET /diag/results failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "load the check results");
   return (await res.json()) as NetDiagResult[];
 }
 
@@ -1174,7 +1306,7 @@ export async function getNetDiagRollup(signal?: AbortSignal): Promise<NetDiagRol
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   }, { timeoutMs: POLL_TIMEOUT_MS });
-  if (!res.ok) throw new GatewayError(res.status, `GET /diag/rollup failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "load the network summary");
   return (await res.json()) as NetDiagRollupBucket[];
 }
 
@@ -1189,7 +1321,7 @@ export async function getDirectors(signal?: AbortSignal): Promise<DirectorInfo[]
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET /directors failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the machine list");
   }
   const raw = (await res.json()) as Array<Record<string, unknown>>;
   const list: DirectorInfo[] = raw
@@ -1221,7 +1353,7 @@ export async function getRepos(directorId: string, signal?: AbortSignal): Promis
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET /directors/${directorId}/repos failed: ${res.status}`);
+    throw await GatewayError.from(res, "load that machine's repositories");
   }
   const raw = (await res.json()) as Array<Record<string, unknown>>;
   const list: RepoInfo[] = raw
@@ -1247,7 +1379,7 @@ export async function getAgents(directorId: string, signal?: AbortSignal): Promi
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET /directors/${directorId}/agents failed: ${res.status}`);
+    throw await GatewayError.from(res, "load that machine's agents");
   }
   const raw = (await res.json()) as Array<Record<string, unknown>>;
   return raw
@@ -1350,7 +1482,7 @@ export async function holdSession(
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST hold failed: ${res.status}`);
+    throw await GatewayError.from(res, "put the session on hold");
   }
   const result = (await res.json().catch(() => ({}))) as { onHold?: boolean; pending?: boolean };
   return { onHold: result.onHold ?? onHold, pending: result.pending ?? false };
@@ -1376,7 +1508,7 @@ export async function setTranscribing(
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST transcribing failed: ${res.status}`);
+    throw await GatewayError.from(res, "update the transcribing state");
   }
 }
 
@@ -1391,7 +1523,7 @@ export async function killSession(sessionId: string, signal?: AbortSignal): Prom
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `DELETE session failed: ${res.status}`);
+    throw await GatewayError.from(res, "close that session");
   }
 }
 
@@ -1956,7 +2088,7 @@ export async function markVoiceAndExplain(sessionId: string, signal?: AbortSigna
   if (!res.ok) {
     // Switching a session to voice mode ran into out-of-credits (issue #942): the shared notice.
     if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
-    throw new GatewayError(res.status, `POST wingman/explain failed: ${res.status}`);
+    throw await GatewayError.from(res, "ask the wingman to explain");
   }
   const body = (await res.json()) as Partial<WingmanExplain>;
   return {
@@ -1977,7 +2109,7 @@ export async function getWingmanVoice(sessionId: string, signal?: AbortSignal): 
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET wingman/voice failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the wingman voice state");
   }
   const body = (await res.json()) as Partial<WingmanVoice>;
   return {
@@ -2001,7 +2133,7 @@ export async function fetchWingmanVoiceAudio(sessionId: string, signal?: AbortSi
   if (!res.ok) {
     // Narration audio unavailable because of credits (issue #942): a 402 body is JSON even here.
     if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
-    throw new GatewayError(res.status, `GET wingman/voice/audio failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the wingman audio");
   }
   return res.arrayBuffer();
 }
@@ -2017,7 +2149,7 @@ export async function getWingmanMenu(sessionId: string, signal?: AbortSignal): P
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `GET wingman/menu failed: ${res.status}`);
+    throw await GatewayError.from(res, "load the wingman menu");
   }
   const body = (await res.json()) as Partial<WingmanMenu> & { options?: Partial<WingmanMenuOption>[] };
   return {
@@ -2055,7 +2187,7 @@ export async function pressWingmanMenu(
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST wingman/menu-press failed: ${res.status}`);
+    throw await GatewayError.from(res, "press that wingman menu item");
   }
 }
 
@@ -2075,7 +2207,7 @@ export async function setVoiceMode(sessionId: string, enabled: boolean, signal?:
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST voice-mode failed: ${res.status}`);
+    throw await GatewayError.from(res, "change voice mode");
   }
 }
 
@@ -2094,7 +2226,7 @@ export async function stopWingmanVoice(sessionId: string, signal?: AbortSignal):
     signal,
   });
   if (!res.ok) {
-    throw new GatewayError(res.status, `POST wingman/voice/stop failed: ${res.status}`);
+    throw await GatewayError.from(res, "stop the wingman voice");
   }
 }
 
@@ -2131,7 +2263,7 @@ export async function getVoiceModeAllSessions(signal?: AbortSignal): Promise<boo
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
-  if (!res.ok) throw new GatewayError(res.status, `GET voice-mode/all failed: ${res.status}`);
+  if (!res.ok) throw await GatewayError.from(res, "load the voice-mode states");
   const body = (await res.json()) as { enabled?: unknown };
   return Boolean(body.enabled);
 }
@@ -2153,7 +2285,7 @@ export async function setVoiceModeAllSessions(enabled: boolean, signal?: AbortSi
   });
   if (!res.ok) {
     if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
-    throw new GatewayError(res.status, `POST voice-mode/all failed: ${res.status}`);
+    throw await GatewayError.from(res, "change voice mode for every session");
   }
   const body = (await res.json()) as Partial<VoiceModeAllResult>;
   return {

--- a/packages/client-core/src/api/errorReporting.test.ts
+++ b/packages/client-core/src/api/errorReporting.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GatewayError, gatewayErrorMessage } from "./client";
+import { describeAndReport, resetReportWindow } from "../errors/reportClientError";
+
+// Issue #2189: THE RULE - a number is not an error message.
+//
+// The failure these pin: attaching a picture from the Cockpit session screen produced
+// "The Gateway rejected the request (error 404)." on screen and nothing at all on the server. The user
+// could not tell what had failed, could not tell whether retrying would help, and reported the status as
+// "400" because three digits were the only thing the message gave them to hold onto. Meanwhile the Gateway
+// HAD written a good reason into the response body, and the client threw it away at the throw site.
+//
+// Three properties are pinned, and they are independent:
+//   1. The server's reason survives to the screen.
+//   2. NO message is ever only a status number - for any status, with or without a reason.
+//   3. Showing an error also reports it, so an on-screen error cannot exist only on the user's screen.
+
+describe("gatewayErrorMessage: the server's reason reaches the user", () => {
+  it("prefers the server's sentence over anything we would write ourselves", () => {
+    const reason =
+      "The machine running this session has not reported in for 26 seconds. The session is still there - "
+      + "this usually clears within a few seconds. Try again.";
+    const err = new GatewayError(503, "ignored diagnostic", { reason, retryable: true });
+
+    expect(gatewayErrorMessage(err, "attach the image")).toBe(reason);
+  });
+
+  it("does not leak the internal diagnostic when a reason is present", () => {
+    const err = new GatewayError(503, "POST upload-image failed: 503", {
+      reason: "That machine is catching up. Try again.",
+    });
+    const msg = gatewayErrorMessage(err, "attach the image");
+
+    expect(msg).not.toContain("POST");
+    expect(msg).not.toContain("upload-image");
+    expect(msg).not.toContain("failed:");
+  });
+
+  it("adds a retry hint when the server said the failure is retryable and the reason omits one", () => {
+    const err = new GatewayError(503, "x", { reason: "That machine is catching up.", retryable: true });
+
+    expect(gatewayErrorMessage(err, "attach the image")).toContain("Try again");
+  });
+
+  it("does not duplicate the retry hint when the reason already gives it", () => {
+    const err = new GatewayError(503, "x", { reason: "Still catching up - try again.", retryable: true });
+    const msg = gatewayErrorMessage(err, "attach the image");
+
+    expect(msg.match(/try again/gi)?.length).toBe(1);
+  });
+
+  it("never invites a retry for a failure retrying cannot fix", () => {
+    // A 404 for an unknown session is permanent. Telling the user to try again would have them press the
+    // button forever.
+    const err = new GatewayError(404, "x", {
+      reason: "That session could not be found. It may have been closed.",
+      retryable: false,
+    });
+
+    expect(gatewayErrorMessage(err, "attach the image")).not.toContain("Try again");
+  });
+});
+
+describe("gatewayErrorMessage: never a bare status number", () => {
+  // The guard for the whole issue. This is the assertion that fails against the pre-fix code, where every
+  // status other than 401 collapsed to "The Gateway rejected the request (error NNN)."
+  const statuses = [400, 403, 404, 409, 413, 423, 429, 500, 502, 503, 504];
+
+  it("always says what failed, for every status, when an action is named", () => {
+    for (const status of statuses) {
+      const msg = gatewayErrorMessage(new GatewayError(status, `x failed: ${status}`), "attach the image");
+
+      // It names the action the user took...
+      expect(msg, `status ${status}`).toContain("attach the image");
+      // ...and it is a sentence, not a code with punctuation around it.
+      expect(msg.replace(/[^a-z]/gi, "").length, `status ${status}`).toBeGreaterThan(25);
+      // ...and it never leaks the internal diagnostic.
+      expect(msg, `status ${status}`).not.toContain("failed:");
+    }
+  });
+
+  it("says something even with no action named and no server reason", () => {
+    // The passive read case: still a sentence, never a naked number.
+    const msg = gatewayErrorMessage(new GatewayError(500, "GET /directors/abc failed: 500"));
+
+    expect(msg).not.toBe("The Gateway rejected the request (error 500).");
+    expect(msg.replace(/[^a-z]/gi, "").length).toBeGreaterThan(25);
+    expect(msg).not.toContain("/directors");
+  });
+
+  it("marks the transport statuses retryable without the server having to say so", () => {
+    for (const status of [0, 429, 502, 503, 504]) {
+      expect(new GatewayError(status, "x").retryable, `status ${status}`).toBe(true);
+    }
+    for (const status of [400, 403, 404, 409, 413, 423, 500]) {
+      expect(new GatewayError(status, "x").retryable, `status ${status}`).toBe(false);
+    }
+  });
+
+  it("lets the server's retryable flag override the status class in both directions", () => {
+    // A Gateway that knows better than the status class must be believed - that is the point of the flag.
+    expect(new GatewayError(404, "x", { retryable: true }).retryable).toBe(true);
+    expect(new GatewayError(503, "x", { retryable: false }).retryable).toBe(false);
+  });
+});
+
+describe("describeAndReport: showing an error also records it", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    resetReportWindow();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the sentence AND posts the report to the Gateway", () => {
+    const err = new GatewayError(503, "x", { reason: "That machine is catching up.", retryable: true });
+
+    const shown = describeAndReport("cockpit-composer", "attach the image", err);
+
+    // What the user reads.
+    expect(shown).toContain("That machine is catching up.");
+    // What the server records. Before this, the report simply did not happen: the whole product had one
+    // explicit report call site, so finding this failure meant grepping a Gateway log by hand.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/client-errors");
+    const body = JSON.parse((init as { body: string }).body) as Record<string, string>;
+    expect(body.surface).toBe("cockpit-composer");
+    expect(body.message).toContain("attach the image");
+    expect(body.message).toContain("That machine is catching up.");
+  });
+
+  it("still returns the sentence when reporting itself fails", () => {
+    // Reporting an error must never become an error the user sees.
+    fetchMock.mockImplementation(() => {
+      throw new Error("network down");
+    });
+
+    const shown = describeAndReport("cockpit-composer", "attach the image", new GatewayError(500, "x"));
+
+    expect(shown).toContain("attach the image");
+  });
+});

--- a/packages/client-core/src/api/gatewayError.test.ts
+++ b/packages/client-core/src/api/gatewayError.test.ts
@@ -11,6 +11,9 @@ import {
 // show the internal "METHOD /path failed: NNN" diagnostic the client throws on a non-2xx, nor the
 // browser's bare "Failed to fetch". gatewayErrorMessage() collapses every thrown error into one clean
 // line. These tests pin the exact mapping the pages rely on.
+// Issue #2189 note: the unreachable-collapse cases below are UNCHANGED on purpose. A background poll (no
+// named action, no server reason) still gets the shared "Can't reach the Gateway - retrying." line, which is
+// already a real sentence with retry advice. What changed is everything else - see errorReporting.test.ts.
 describe("gatewayErrorMessage", () => {
   it("collapses a raw 'GET /path failed: 503' GatewayError to the friendly unreachable line", () => {
     const msg = gatewayErrorMessage(new GatewayError(503, "GET /directors failed: 503"));
@@ -60,12 +63,18 @@ describe("gatewayErrorMessage", () => {
     expect(gatewayErrorMessage(new CreditsError(info))).toBe(info.text);
   });
 
-  it("reports a reachable-but-erroring status by number only, never the raw path", () => {
+  // CONTRACT CHANGE (issue #2189): this used to assert the message WAS
+  // "The Gateway rejected the request (error 500)." - a bare status number and nothing else. That is now
+  // forbidden: a number is not an error message. The rest of the original contract (never the raw method
+  // and path) is unchanged and still asserted here.
+  it("reports a reachable-but-erroring status as a sentence, never the raw path and never a bare number", () => {
     const msg = gatewayErrorMessage(new GatewayError(500, "GET /directors/abc/settings failed: 500"));
 
-    expect(msg).toBe("The Gateway rejected the request (error 500).");
+    expect(msg).not.toBe("The Gateway rejected the request (error 500).");
     expect(msg).not.toContain("/directors");
     expect(msg).not.toContain("failed:");
+    // It is a sentence a person can act on, not a code.
+    expect(msg.replace(/[^a-z]/gi, "").length).toBeGreaterThan(25);
   });
 
   it("falls back to the friendly line for a non-Error throw", () => {

--- a/packages/client-core/src/api/handover.test.ts
+++ b/packages/client-core/src/api/handover.test.ts
@@ -65,16 +65,24 @@ describe("getHandover", () => {
     expect(info.version).toBe("");
   });
 
-  it("throws GatewayError on a 404 (session unknown)", async () => {
-    vi.stubGlobal("fetch", mockFetch(404, { error: "session not found across any director" }));
+  // CONTRACT CHANGE (issue #2189): these used to assert the thrown message was the internal diagnostic
+  // "GET handover failed: NNN". That string was the problem - it reached the user as a bare status number and
+  // it discarded the reason the server had already written. The throw now CARRIES the server's sentence.
+  it("throws GatewayError on a 404, carrying the server's own reason", async () => {
+    vi.stubGlobal("fetch", mockFetch(404, { error: "That session could not be found." }));
 
     await expect(getHandover("missing")).rejects.toBeInstanceOf(GatewayError);
-    await expect(getHandover("missing")).rejects.toThrow(/GET handover failed: 404/);
+    await expect(getHandover("missing")).rejects.toThrow(/That session could not be found/);
+    // The internal diagnostic must not survive onto the error a surface may render.
+    await expect(getHandover("missing")).rejects.not.toThrow(/GET handover failed/);
   });
 
-  it("throws GatewayError on a 502 (owning Director offline)", async () => {
+  it("throws GatewayError on a 502 (owning Director offline), as a sentence not a number", async () => {
     vi.stubGlobal("fetch", mockFetch(502, {}));
 
-    await expect(getHandover("s1")).rejects.toThrow(/GET handover failed: 502/);
+    // No reason in the body, so the fallback names the action - still never a bare status.
+    await expect(getHandover("s1")).rejects.toBeInstanceOf(GatewayError);
+    await expect(getHandover("s1")).rejects.toThrow(/handover information/);
+    await expect(getHandover("s1")).rejects.not.toThrow(/GET handover failed/);
   });
 });

--- a/packages/client-core/src/errors/reportClientError.ts
+++ b/packages/client-core/src/errors/reportClientError.ts
@@ -12,7 +12,7 @@
 // - The report carries what a debugging agent needs (surface, page, message, detail, stack) and nothing
 //   personal beyond it.
 
-import { authHeaders } from "../api/client";
+import { authHeaders, gatewayErrorMessage } from "../api/client";
 
 /** Client-side cap: at most this many reports per minute; the rest are counted and dropped. The server
  *  enforces its own cap too - this one exists so a render-loop error does not even leave the browser. */
@@ -94,4 +94,28 @@ export function installGlobalErrorReporting(surface: string): void {
     const message = reason instanceof Error ? reason.message : String(reason ?? "Unhandled promise rejection");
     reportClientError(`${surface}-global`, window.location.pathname, message, reason);
   });
+}
+
+/**
+ * Render AND report, in one act (issue #2189).
+ *
+ * This is the ONE way a shell turns a caught error into on-screen text. It returns the sentence to
+ * display and reports the same failure to the Gateway, so an error the user is looking at can no
+ * longer exist only on the user's screen.
+ *
+ * The reason this exists as a function rather than as a rule: the global catcher in
+ * installGlobalErrorReporting only sees errors NOBODY handled. An error a page catches and renders -
+ * which is nearly all of them - never reaches it. Before this, the whole product had exactly one
+ * explicit report call site, so a failed image attach was invisible to the server and finding it
+ * meant grepping a fifty-four megabyte Gateway log by hand. A call site that formats a message
+ * without reporting it is the bug this function exists to prevent, so the two cannot be separated.
+ *
+ * `action` names what the user was trying to do, in their terms: "attach the image", "send that to
+ * the session". It shapes the sentence AND labels the server-side record.
+ */
+export function describeAndReport(surface: string, action: string, err: unknown): string {
+  const message = gatewayErrorMessage(err, action);
+  const page = typeof window === "undefined" ? "" : window.location.pathname;
+  reportClientError(surface, page, `could not ${action}: ${message}`, err);
+  return message;
 }

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -130,17 +130,48 @@ public sealed class GatewayStreamClient : IAsyncDisposable
 
     // Timer callback (a boundary): re-push the full snapshot so a quiet session's pushed cache stays fresh.
     // Skips when disposed, when disconnected, or when a prior re-push is still in flight (no overlap).
+    //
+    // Issue #2188: every skip and every slow push is now LOGGED. This tick is the heartbeat that keeps the
+    // Gateway's pushed cache fresh, and a missed one is what makes an entire Director's sessions read as
+    // non-existent - on 2026-07-26 two missed ticks refused every action on fourteen live sessions for about
+    // ten seconds. Both skip paths used to return in silence, so the single event that caused the outage
+    // left no trace at all and the investigation had to infer it from a thirty-second hole between two
+    // success lines. An event that can take the fleet offline must never be invisible.
     private void RePushTick()
     {
         if (_disposed) return;
         var conn = _connection;
-        if (conn is null || conn.State != HubConnectionState.Connected) return;
-        if (Interlocked.Exchange(ref _rePushInFlight, 1) == 1) return;
+        if (conn is null || conn.State != HubConnectionState.Connected)
+        {
+            // Expected while the tunnel is re-dialing; logged because it is also how a long silence begins.
+            FileLog.Write($"[GatewayStreamClient] re-push tick SKIPPED: connection state={conn?.State.ToString() ?? "none"}");
+            return;
+        }
+        if (Interlocked.Exchange(ref _rePushInFlight, 1) == 1)
+        {
+            var running = _rePushStartedUtc == DateTime.MinValue
+                ? "unknown"
+                : $"{(DateTime.UtcNow - _rePushStartedUtc).TotalSeconds:F1}s";
+            FileLog.Write($"[GatewayStreamClient] re-push tick SKIPPED: previous push still in flight after {running}");
+            return;
+        }
         _ = RePushAsync();
     }
 
+    /// <summary>When the in-flight re-push started, so a skipped tick can report how long it has been
+    ///  waiting. Written only by the single re-push allowed in flight at a time.</summary>
+    private DateTime _rePushStartedUtc = DateTime.MinValue;
+
+    /// <summary>A re-push that takes longer than this is reported. The cadence is <c>_rePushInterval</c>, so
+    ///  anything at or past one whole interval has already cost the next tick - and two lost ticks is what
+    ///  ages the Gateway's cache past its staleness cut (issue #2188).</summary>
+    private static readonly TimeSpan SlowRePushThreshold = TimeSpan.FromSeconds(
+        GatewayConfig.DefaultStreamStaleAfterSeconds / 2.0);
+
     private async Task RePushAsync()
     {
+        var startedUtc = DateTime.UtcNow;
+        _rePushStartedUtc = startedUtc;
         try
         {
             // ReseedAsync sends Hello + a full PushSnapshot with an incrementing sequence (the same path used
@@ -149,6 +180,16 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         }
         finally
         {
+            // Report a SLOW push, not only a failed one. A push that succeeds but takes a whole cadence has
+            // already eaten the following tick, which is the observed path to the cache going stale - and it
+            // is otherwise indistinguishable from a healthy push in the log.
+            var elapsed = DateTime.UtcNow - startedUtc;
+            if (elapsed >= SlowRePushThreshold)
+            {
+                FileLog.Write($"[GatewayStreamClient] re-push SLOW: took {elapsed.TotalSeconds:F1}s "
+                    + $"(cadence {SlowRePushThreshold.TotalSeconds:F0}s) - the next tick was likely skipped");
+            }
+            _rePushStartedUtc = DateTime.MinValue;
             Interlocked.Exchange(ref _rePushInFlight, 0);
         }
     }

--- a/src/CcDirector.ControlApi/SessionByteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionByteExecutor.cs
@@ -39,12 +39,33 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
             "upload-image-begin" => UploadImageBegin(context.SessionManager, command),
             "upload-image-chunk" => UploadImageChunk(command),
             "upload-image-complete" => UploadImageComplete(command),
-            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"),
+            _ => FailLogged("dispatch", DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"),
         };
         return Task.FromResult(result);
     }
 
     // ---------------------------------------------------------------- chunked upload-image (Phase 2) ----
+
+    /// <summary>
+    /// Issue #2190: fail a byte verb and LOG it. Every rejection path in this file goes through here.
+    ///
+    /// Before this, only the SUCCESS paths logged. The three upload verbs returned genuinely useful
+    /// sentences - an unsupported image type, an incomplete upload with both byte counts, an out-of-order
+    /// chunk with both sequence numbers - and wrote nothing anywhere, so the reason existed for exactly as
+    /// long as the response took to travel and then vanished. During the upload investigation of
+    /// 2026-07-26 the ABSENCE of a log line was read as proof the Director had never been asked. That
+    /// happened to be true that time; on any other occasion it would have been a wrong conclusion drawn
+    /// from missing evidence.
+    ///
+    /// A bare <c>DirectorCommandResult.Fail</c> in this file is the bug this helper exists to prevent.
+    /// </summary>
+    private static DirectorCommandResult FailLogged(
+        string verb, DirectorCommandStatus status, string reason, string? context = null)
+    {
+        FileLog.Write($"[SessionByteExecutor] {verb} REJECTED: status={status}, reason={reason}"
+            + (string.IsNullOrEmpty(context) ? "" : $", {context}"));
+        return DirectorCommandResult.Fail(status, reason);
+    }
 
     /// <summary>An in-flight chunked upload's reassembly state, keyed by its upload id in <see cref="_uploads"/>.</summary>
     private sealed class UploadReassembly
@@ -73,25 +94,29 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     internal static DirectorCommandResult UploadImageBegin(SessionManager sessionManager, DirectorCommand command)
     {
         if (!Guid.TryParse(command.SessionId, out var guid))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.BadRequest, "invalid session id format", $"sid={command.SessionId}");
         if (sessionManager.GetSession(guid) is null)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.NotFound, "session not found", $"sid={command.SessionId}");
 
         var request = SessionCommandExecutor.Deserialize<UploadImageBeginRequest>(command.PayloadJson);
         if (request is null || string.IsNullOrEmpty(request.UploadId))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.BadRequest, "upload id is required", $"sid={command.SessionId}");
 
         var ext = Path.GetExtension(request.FileName).ToLowerInvariant();
         if (!UploadAllowedExtensions.Contains(ext))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.BadRequest,
+                $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}",
+                $"sid={command.SessionId}, file={request.FileName}");
         if (request.TotalBytes <= 0 || request.TotalBytes > MaxUploadBytes)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"image size {request.TotalBytes} is out of range (max {MaxUploadBytes})");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.BadRequest,
+                $"image size {request.TotalBytes} is out of range (max {MaxUploadBytes})",
+                $"sid={command.SessionId}, file={request.FileName}");
 
         SweepStaleUploads();
 
         var entry = new UploadReassembly { FileName = request.FileName, TotalBytes = request.TotalBytes };
         if (!_uploads.TryAdd(request.UploadId, entry))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "upload id already in use");
+            return FailLogged("upload-image-begin", DirectorCommandStatus.Conflict, "upload id already in use", $"id={request.UploadId}");
 
         FileLog.Write($"[SessionByteExecutor] upload-image-begin: id={request.UploadId}, file={request.FileName}, total={request.TotalBytes}");
         return DirectorCommandResult.Success();
@@ -105,15 +130,16 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     {
         var request = SessionCommandExecutor.Deserialize<UploadImageChunkRequest>(command.PayloadJson);
         if (request is null || string.IsNullOrEmpty(request.UploadId))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+            return FailLogged("upload-image-chunk", DirectorCommandStatus.BadRequest, "upload id is required", $"sid={command.SessionId}");
 
         if (!_uploads.TryGetValue(request.UploadId, out var entry))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "unknown or expired upload id");
+            return FailLogged("upload-image-chunk", DirectorCommandStatus.BadRequest, "unknown or expired upload id", $"id={request.UploadId}");
 
         if (request.Seq != entry.NextSeq)
         {
             _uploads.TryRemove(request.UploadId, out _);
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"out-of-order chunk (expected {entry.NextSeq}, got {request.Seq})");
+            return FailLogged("upload-image-chunk", DirectorCommandStatus.BadRequest,
+                $"out-of-order chunk (expected {entry.NextSeq}, got {request.Seq})", $"id={request.UploadId}");
         }
 
         byte[] chunk;
@@ -124,13 +150,14 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         catch (FormatException)
         {
             _uploads.TryRemove(request.UploadId, out _);
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "chunk bytes must be base64");
+            return FailLogged("upload-image-chunk", DirectorCommandStatus.BadRequest, "chunk bytes must be base64", $"id={request.UploadId}");
         }
 
         if (entry.Buffer.Length + chunk.Length > entry.TotalBytes || entry.Buffer.Length + chunk.Length > MaxUploadBytes)
         {
             _uploads.TryRemove(request.UploadId, out _);
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload exceeded its declared size");
+            return FailLogged("upload-image-chunk", DirectorCommandStatus.BadRequest, "upload exceeded its declared size",
+                $"id={request.UploadId}, declared={entry.TotalBytes}");
         }
 
         entry.Buffer.Write(chunk, 0, chunk.Length);
@@ -147,15 +174,16 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     {
         var request = SessionCommandExecutor.Deserialize<UploadImageCompleteRequest>(command.PayloadJson);
         if (request is null || string.IsNullOrEmpty(request.UploadId))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+            return FailLogged("upload-image-complete", DirectorCommandStatus.BadRequest, "upload id is required", $"sid={command.SessionId}");
 
         if (!_uploads.TryRemove(request.UploadId, out var entry))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "unknown or expired upload id");
+            return FailLogged("upload-image-complete", DirectorCommandStatus.BadRequest, "unknown or expired upload id", $"id={request.UploadId}");
 
         try
         {
             if (entry.Buffer.Length != entry.TotalBytes)
-                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"incomplete upload ({entry.Buffer.Length} of {entry.TotalBytes} bytes)");
+                return FailLogged("upload-image-complete", DirectorCommandStatus.BadRequest,
+                    $"incomplete upload ({entry.Buffer.Length} of {entry.TotalBytes} bytes)", $"id={request.UploadId}");
 
             FileLog.Write($"[SessionByteExecutor] upload-image-complete: id={request.UploadId}, bytes={entry.Buffer.Length}");
             return SaveImageBytes(entry.FileName, entry.Buffer.ToArray());
@@ -238,11 +266,11 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         FileLog.Write($"[SessionByteExecutor] upload-image: sid={command.SessionId}");
 
         if (!Guid.TryParse(command.SessionId, out var guid))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+            return FailLogged("upload-image", DirectorCommandStatus.BadRequest, "invalid session id format", $"sid={command.SessionId}");
 
         var session = sessionManager.GetSession(guid);
         if (session is null)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+            return FailLogged("upload-image", DirectorCommandStatus.NotFound, "session not found", $"sid={command.SessionId}");
 
         var request = SessionCommandExecutor.Deserialize<UploadImageRequest>(command.PayloadJson);
         return SaveUploadedImage(request);
@@ -259,11 +287,12 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     internal static DirectorCommandResult SaveUploadedImage(UploadImageRequest? request)
     {
         if (request is null || string.IsNullOrEmpty(request.BytesBase64))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");
+            return FailLogged("upload-image", DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");
 
         var ext = Path.GetExtension(request.FileName).ToLowerInvariant();
         if (!UploadAllowedExtensions.Contains(ext))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
+            return FailLogged("upload-image", DirectorCommandStatus.BadRequest,
+                $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}", $"file={request.FileName}");
 
         byte[] bytes;
         try
@@ -272,7 +301,7 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         }
         catch (FormatException)
         {
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "image bytes must be base64");
+            return FailLogged("upload-image", DirectorCommandStatus.BadRequest, "image bytes must be base64", $"file={request.FileName}");
         }
 
         return SaveImageBytes(request.FileName, bytes);
@@ -288,10 +317,11 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     {
         var ext = Path.GetExtension(fileName).ToLowerInvariant();
         if (!UploadAllowedExtensions.Contains(ext))
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
+            return FailLogged("upload-image save", DirectorCommandStatus.BadRequest,
+                $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}", $"file={fileName}");
 
         if (bytes.Length == 0)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");
+            return FailLogged("upload-image save", DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'", $"file={fileName}");
 
         var dir = CcStorage.Screenshots();
         var name = $"upload-{DateTime.Now:yyyyMMdd-HHmmss-fff}{ext}";
@@ -322,7 +352,7 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
 
         var full = ControlEndpoints.ResolveScreenshot(name);
         if (full is null)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "screenshot not found");
+            return FailLogged("screenshot-delete", DirectorCommandStatus.NotFound, "screenshot not found", $"name={name}");
 
         File.Delete(full);
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenshotDeleteResponse

--- a/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
@@ -49,8 +49,14 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
     private const string SessA = "sess-a";
     private const string SessB = "sess-b";
 
-    /// <summary>The exact body the session locator produces when it finds nothing. This IS the defect's signature.</summary>
-    private const string NotLocated = "session not found across any director";
+    /// <summary>
+    /// The signature of "the locator found nothing". Issue #2188 replaced the old prose body
+    /// ("session not found across any director") with a plain sentence plus a MACHINE-READABLE code, and this
+    /// anchors on the code rather than the prose: the sentence is user-facing copy and may be reworded, the
+    /// code is the contract. Anchoring on the prose is also what made the negative assertions below fragile -
+    /// reword the sentence and a "does not contain" check passes for the wrong reason.
+    /// </summary>
+    private const string NotLocated = "session_not_found";
 
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
@@ -200,6 +206,12 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
         var resp = await Send(method, $"sessions/{SessA}{suffix}", _keyA, body);
         var text = await resp.Content.ReadAsStringAsync();
 
+        // Assert the POSITIVE fact, not merely the absence of a string: the route must not have refused this
+        // as unlocatable at all. A bare "does not contain" would also hold if the body were empty, or if the
+        // refusal were reworded - which is exactly how an absence-only assertion stops proving anything.
+        Assert.False(resp.StatusCode == HttpStatusCode.NotFound,
+            $"{method} /sessions/{{sid}}{suffix} could not locate its OWN tenant's session - " +
+            $"status {(int)resp.StatusCode}, body: {text}");
         Assert.False(text.Contains(NotLocated, StringComparison.Ordinal),
             $"{method} /sessions/{{sid}}{suffix} could not locate its OWN tenant's session - " +
             $"status {(int)resp.StatusCode}, body: {text}");
@@ -214,8 +226,12 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
         var resp = await Send(method, $"sessions/{SessA}{suffix}", _keyB, body);
         var text = await resp.Content.ReadAsStringAsync();
 
+        // Still a 404 carrying the not-found CODE - never the retryable 503 that issue #2188 introduced for a
+        // stale Director. Tenant B must not be told "that machine is catching up, try again", because that
+        // would confirm the session exists and invite retries against another tenant's id.
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         Assert.Contains(NotLocated, text, StringComparison.Ordinal);
+        Assert.DoesNotContain("director_stale", text, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -226,7 +242,9 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
         var roster = await (await Send("GET", "sessions", _keyA, null)).Content.ReadAsStringAsync();
         Assert.Contains(SessA, roster, StringComparison.Ordinal);
 
-        var buffer = await (await Send("GET", $"sessions/{SessA}/buffer", _keyA, null)).Content.ReadAsStringAsync();
+        var bufferResp = await Send("GET", $"sessions/{SessA}/buffer", _keyA, null);
+        var buffer = await bufferResp.Content.ReadAsStringAsync();
+        Assert.NotEqual(HttpStatusCode.NotFound, bufferResp.StatusCode);
         Assert.False(buffer.Contains(NotLocated, StringComparison.Ordinal));
     }
 

--- a/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedSessionCommandRouteTenancyTests.cs
@@ -253,12 +253,21 @@ public sealed class HostedSessionCommandRouteTenancyTests : IAsyncLifetime
     {
         // Not reachable from the route table: /handover names its session in the BODY, not the path. It was
         // one of the six converted sites the first version of this proof did not cover.
+        // CONTRACT CHANGE (issue #2188): this route used to answer with its own prose,
+        // "source session not found across any director". It now goes through the one shared responder every
+        // other per-session route uses, so the body carries the same machine-readable code as the rest -
+        // which is what this now anchors on. The tenancy property under test is unchanged.
         var own = await Send("POST", "handover", _keyA, $"{{\"fromSessionId\":\"{SessA}\",\"toRepoPath\":\"/repo\"}}");
-        Assert.DoesNotContain("source session not found", await own.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        Assert.NotEqual(HttpStatusCode.NotFound, own.StatusCode);
+        Assert.DoesNotContain(NotLocated, await own.Content.ReadAsStringAsync(), StringComparison.Ordinal);
 
         var cross = await Send("POST", "handover", _keyB, $"{{\"fromSessionId\":\"{SessA}\",\"toRepoPath\":\"/repo\"}}");
         Assert.Equal(HttpStatusCode.NotFound, cross.StatusCode);
-        Assert.Contains("source session not found", await cross.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        var crossBody = await cross.Content.ReadAsStringAsync();
+        Assert.Contains(NotLocated, crossBody, StringComparison.Ordinal);
+        // Never the retryable "that machine is catching up" answer: telling tenant B to try again would
+        // confirm tenant A's session exists and invite retries against another tenant's id.
+        Assert.DoesNotContain("director_stale", crossBody, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/SessionByteExecutorRejectionLoggingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionByteExecutorRejectionLoggingTests.cs
@@ -1,0 +1,276 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2190: every image-upload rejection must leave a line in the Director log.
+///
+/// Before this, only the SUCCESS paths logged. The three upload verbs returned genuinely useful sentences -
+/// an unsupported image type with the accepted list, an incomplete upload with both byte counts, an
+/// out-of-order chunk with both sequence numbers - and wrote nothing anywhere. The reason existed for
+/// exactly as long as the response took to travel, then vanished.
+///
+/// The existing <see cref="SessionByteExecutorTests"/> cover the same rejections but assert only the
+/// returned STATUS, so they passed the whole time the log line was missing. Asserting the status is not
+/// asserting the record; these tests assert the record.
+///
+/// They are written to FAIL against the pre-fix code: each one requires a "REJECTED" line that simply did
+/// not exist before, and each also asserts the line carries the REASON, so a bare
+/// "[SessionByteExecutor] rejected" would not satisfy them either.
+///
+/// In the "DirectorRoot" collection because the upload verbs resolve the screenshots folder through
+/// CC_DIRECTOR_ROOT, and that collection serializes root-touching tests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SessionByteExecutorRejectionLoggingTests : IAsyncLifetime
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // A tiny valid 1x1 PNG, so a rejection can only come from the guard under test and never from the bytes.
+    private static readonly byte[] OnePngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string _shotsDir = null!;
+
+    public SessionByteExecutorRejectionLoggingTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-reject-log-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _shotsDir = Path.Combine(_root, "shots");
+        Directory.CreateDirectory(_shotsDir);
+        Directory.CreateDirectory(CcStorage.Config());
+        await File.WriteAllTextAsync(CcStorage.ConfigJson(),
+            JsonSerializer.Serialize(new { screenshots = new { source_directory = _shotsDir } }));
+    }
+
+    public Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        return Task.CompletedTask;
+    }
+
+    private static (SessionManager, Session) NewSession()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var session = sm.CreateSession(Path.GetTempPath());
+        return (sm, session);
+    }
+
+    private static DirectorCommand Command(string verb, string sid, object payload) => new()
+    {
+        CommandId = "rl1",
+        Verb = verb,
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(payload, Json),
+    };
+
+    /// <summary>Dispatch one command with FileLog captured, and return the result plus the lines written.</summary>
+    private static async Task<(DirectorCommandResult Result, IReadOnlyList<string> Lines)> DispatchCapturing(
+        SessionManager sm, DirectorCommand command)
+    {
+        using var capture = CcDirector.Core.Utilities.FileLog.RedirectForTests();
+        var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+        return (result, capture.DrainAndReadLines());
+    }
+
+    private static void AssertRejectionLogged(
+        IReadOnlyList<string> lines, string verb, params string[] reasonFragments)
+    {
+        var rejections = lines
+            .Where(l => l.Contains("[SessionByteExecutor]", StringComparison.Ordinal)
+                     && l.Contains("REJECTED", StringComparison.Ordinal)
+                     && l.Contains(verb, StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(rejections.Count > 0,
+            $"expected a logged rejection for '{verb}'. Lines written:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, lines));
+
+        // The line must carry the REASON, not merely the fact of a rejection. A record that says something
+        // failed without saying what is the same dead end as the bare status code this work removed.
+        foreach (var fragment in reasonFragments)
+        {
+            Assert.Contains(fragment, string.Join(Environment.NewLine, rejections), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // ---------------------------------------------------------------- upload-image-begin ----
+
+    [Fact]
+    public async Task UploadImageBegin_UnsupportedExtension_LogsTheRejectionWithTheAcceptedList()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-begin", session.Id.ToString(),
+                new UploadImageBeginRequest { UploadId = "u1", FileName = "diagram.svg", TotalBytes = 100 }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            // The user chose this file, so the record must name the extension AND what would have worked.
+            AssertRejectionLogged(lines, "upload-image-begin", "unsupported image type", ".svg", ".png");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task UploadImageBegin_OversizeDeclaredTotal_LogsTheRejectionWithBothNumbers()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-begin", session.Id.ToString(),
+                new UploadImageBeginRequest { UploadId = "u2", FileName = "photo.jpg", TotalBytes = 40L * 1024 * 1024 }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image-begin", "out of range", "41943040");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task UploadImageBegin_UnknownSession_LogsTheRejection()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-begin", Guid.NewGuid().ToString(),
+                new UploadImageBeginRequest { UploadId = "u3", FileName = "photo.png", TotalBytes = 100 }));
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+            AssertRejectionLogged(lines, "upload-image-begin", "session not found");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------------------------------------------------------------- upload-image-chunk ----
+
+    [Fact]
+    public async Task UploadImageChunk_UnknownUploadId_LogsTheRejection()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-chunk", session.Id.ToString(),
+                new UploadImageChunkRequest { UploadId = "never-opened", Seq = 0, BytesBase64 = "AAAA" }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image-chunk", "unknown or expired upload id");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task UploadImageChunk_OutOfOrder_LogsTheRejectionWithBothSequenceNumbers()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var sid = session.Id.ToString();
+            // Open a real upload first, so the rejection under test is the ordering guard and nothing else.
+            var begin = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("upload-image-begin", sid,
+                new UploadImageBeginRequest { UploadId = "u4", FileName = "photo.png", TotalBytes = OnePngBytes.Length }));
+            Assert.Equal(DirectorCommandStatus.Ok, begin.Status);
+
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-chunk", sid,
+                new UploadImageChunkRequest { UploadId = "u4", Seq = 5, BytesBase64 = Convert.ToBase64String(OnePngBytes) }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image-chunk", "out-of-order chunk", "expected 0", "got 5");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------------------------------------------------------------- upload-image-complete ----
+
+    [Fact]
+    public async Task UploadImageComplete_ByteCountMismatch_LogsTheRejectionWithBothCounts()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var sid = session.Id.ToString();
+            // Declare more bytes than are ever sent, then complete: the classic truncated upload.
+            var begin = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("upload-image-begin", sid,
+                new UploadImageBeginRequest { UploadId = "u5", FileName = "photo.png", TotalBytes = OnePngBytes.Length + 500 }));
+            Assert.Equal(DirectorCommandStatus.Ok, begin.Status);
+            var chunk = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("upload-image-chunk", sid,
+                new UploadImageChunkRequest { UploadId = "u5", Seq = 0, BytesBase64 = Convert.ToBase64String(OnePngBytes) }));
+            Assert.Equal(DirectorCommandStatus.Ok, chunk.Status);
+
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-complete", sid,
+                new UploadImageCompleteRequest { UploadId = "u5" }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image-complete", "incomplete upload",
+                OnePngBytes.Length.ToString(), (OnePngBytes.Length + 500).ToString());
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task UploadImageComplete_UnknownUploadId_LogsTheRejection()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image-complete", session.Id.ToString(),
+                new UploadImageCompleteRequest { UploadId = "never-opened" }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image-complete", "unknown or expired upload id");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------------------------------------------------------------- the single-shot verb ----
+
+    [Fact]
+    public async Task UploadImage_UnsupportedExtension_LogsTheRejection()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image", session.Id.ToString(),
+                new UploadImageRequest { FileName = "notes.txt", BytesBase64 = Convert.ToBase64String(OnePngBytes) }));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            AssertRejectionLogged(lines, "upload-image", "unsupported image type", ".txt");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------------------------------------------------------------- the positive control ----
+
+    [Fact]
+    public async Task UploadImage_Success_LogsNoRejection()
+    {
+        // The other arm. Without it, an AssertRejectionLogged helper that matched too loosely - or a change
+        // that logged "REJECTED" on every dispatch - would leave every test above green while saying nothing.
+        var (sm, session) = NewSession();
+        try
+        {
+            var (result, lines) = await DispatchCapturing(sm, Command("upload-image", session.Id.ToString(),
+                new UploadImageRequest { FileName = "photo.png", BytesBase64 = Convert.ToBase64String(OnePngBytes) }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.DoesNotContain(lines, l => l.Contains("REJECTED", StringComparison.Ordinal));
+            // And the success record is still there, so this is not passing because logging is off entirely.
+            Assert.Contains(lines, l => l.Contains("upload-image saved", StringComparison.Ordinal));
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionByteExecutorRejectionLoggingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionByteExecutorRejectionLoggingTests.cs
@@ -63,10 +63,20 @@ public sealed class SessionByteExecutorRejectionLoggingTests : IAsyncLifetime
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// A session with an EMBEDDED test backend, never a real one.
+    ///
+    /// <see cref="SessionManager.CreateSession(string, string)"/> launches an actual agent process through
+    /// ConPty. That happens to work on a developer machine with an agent installed and fails with
+    /// "CreateProcess failed" on a clean build agent, which is a test depending on the machine it runs on
+    /// rather than on the code under test. These tests are about a LOG LINE; they need a session id to
+    /// address, not a process. <see cref="SessionByteExecutorTests"/> alongside this file uses the same
+    /// embedded backend for the same reason.
+    /// </summary>
     private static (SessionManager, Session) NewSession()
     {
         var sm = new SessionManager(new AgentOptions());
-        var session = sm.CreateSession(Path.GetTempPath());
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
         return (sm, session);
     }
 

--- a/src/CcDirector.Gateway.Tests/SessionLocateStalePushTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionLocateStalePushTests.cs
@@ -1,0 +1,148 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2188: a live session must not report as "not found" because its Director missed one snapshot push.
+///
+/// The failure these pin: on 2026-07-26 a Director's re-push tick was missed twice in a row (a clean ten
+/// second cadence became a thirty second gap). The Gateway's pushed cache aged past its twenty second
+/// staleness cut, and for about ten seconds EVERY per-session route - attaching an image was the one a
+/// person happened to press - answered 404 "session not found across any director" for fourteen sessions
+/// that were alive the whole time. The very next prompt, once a push landed, returned 200.
+///
+/// Two properties are pinned here, and they are different properties:
+///  1. TOLERANCE - one missed push cycle must still resolve the session (the hole closes).
+///  2. HONESTY - past the tolerance, the refusal must distinguish "the Director is stale" (retryable) from
+///     "no Director has ever pushed this id" (permanent). Collapsing those two was the original defect, and
+///     a tolerance alone would not have fixed it.
+/// </summary>
+public sealed class SessionLocateStalePushTests
+{
+    private DateTime _now = new(2026, 7, 26, 13, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan StaleAfter =
+        TimeSpan.FromSeconds(GatewayConfig.DefaultStreamStaleAfterSeconds);
+
+    private PushedSessionStore NewStoreWithSession(string directorId, string sessionId)
+    {
+        var store = new PushedSessionStore(() => _now);
+        store.RegisterConnection(TenantId.Local, directorId, "conn-1");
+        var applied = store.ApplySnapshot(TenantId.Local, directorId, "conn-1", 0, new[]
+        {
+            new SessionDto { SessionId = sessionId, ActivityState = "Working" },
+        });
+        Assert.True(applied);
+        return store;
+    }
+
+    // ---------------------------------------------------------------- the tolerance (property 1) ----
+
+    [Fact]
+    public void LocateGrace_IsOneWholePushCycle_NotAnArbitraryNumber()
+    {
+        // The cadence is staleAfterSeconds / 2, so the grace must be exactly one cycle: enough to absorb a
+        // single missed tick, and no more. A number picked by feel would either fail to close the observed
+        // hole or keep serving a Director that is genuinely gone.
+        Assert.Equal(TimeSpan.FromSeconds(GatewayConfig.DefaultStreamStaleAfterSeconds / 2.0),
+            GatewayEndpoints.LocateGrace);
+    }
+
+    [Fact]
+    public void TryLocate_PushOneCycleLate_StillResolvesTheSession()
+    {
+        // Arrange: a session whose Director last pushed 26 seconds ago - past the 20 second staleness cut,
+        // inside the 20 + 10 tolerance. This is the exact shape of the observed 26.9 second gap.
+        var store = NewStoreWithSession("dir-A", "sess-1");
+        _now = _now.AddSeconds(26);
+
+        // Act
+        var located = store.TryLocate(TenantId.Local, "sess-1", StaleAfter + GatewayEndpoints.LocateGrace);
+
+        // Assert: the regression. Before the fix this was null and the route answered 404 for a live session.
+        Assert.NotNull(located);
+        Assert.Equal("dir-A", located!.Value.DirectorId);
+        Assert.Equal("sess-1", located.Value.Session.SessionId);
+    }
+
+    [Fact]
+    public void TryLocate_WithoutTheGrace_WouldHaveRefusedTheSameSession()
+    {
+        // The other arm: the SAME state, read with only the roster's freshness cut, is refused. Without this
+        // the test above could pass for a reason unrelated to the grace window (a store that never expires,
+        // a clock that never advances), and would keep passing if the grace were removed again.
+        var store = NewStoreWithSession("dir-A", "sess-1");
+        _now = _now.AddSeconds(26);
+
+        Assert.Null(store.TryLocate(TenantId.Local, "sess-1", StaleAfter));
+    }
+
+    [Fact]
+    public void TryLocate_PushWellPastTheGrace_IsStillRefused()
+    {
+        // The tolerance is bounded. A Director silent for two minutes is a real outage and must not be served
+        // as if it were reachable - this is a defined grace window, not a fallback that hides an outage.
+        var store = NewStoreWithSession("dir-A", "sess-1");
+        _now = _now.AddMinutes(2);
+
+        Assert.Null(store.TryLocate(TenantId.Local, "sess-1", StaleAfter + GatewayEndpoints.LocateGrace));
+    }
+
+    // ---------------------------------------------------------------- the honesty (property 2) ----
+
+    [Fact]
+    public void TryLocateIgnoringFreshness_SessionPresentButPushStale_NamesTheOwnerAndTheAge()
+    {
+        // Arrange: 90 seconds of silence - genuinely stale, well past any tolerance.
+        var store = NewStoreWithSession("dir-A", "sess-1");
+        _now = _now.AddSeconds(90);
+
+        // Act
+        var known = store.TryLocateIgnoringFreshness(TenantId.Local, "sess-1");
+
+        // Assert: the session is KNOWN. This is what lets the route answer a retryable 503 that names the
+        // delay, instead of telling the user their session does not exist.
+        Assert.NotNull(known);
+        Assert.Equal("dir-A", known!.Value.DirectorId);
+        Assert.Equal(90, (int)Math.Round(known.Value.PushAge.TotalSeconds));
+    }
+
+    [Fact]
+    public void TryLocateIgnoringFreshness_UnknownSessionId_IsNotFound()
+    {
+        // The permanent case must stay distinguishable, or the fix would turn every genuine 404 into a
+        // "try again" the user could retry forever.
+        var store = NewStoreWithSession("dir-A", "sess-1");
+
+        Assert.Null(store.TryLocateIgnoringFreshness(TenantId.Local, "sess-does-not-exist"));
+    }
+
+    [Fact]
+    public void TryLocateIgnoringFreshness_SessionInAnotherTenant_IsNotFound()
+    {
+        // The reason for a refusal must never leak across a tenant boundary: a caller in tenant B asking about
+        // tenant A's session id gets "not found", never "that machine has not reported in for 90 seconds"
+        // (which would confirm the session exists and name the owning Director).
+        var store = NewStoreWithSession("dir-A", "sess-1");
+        _now = _now.AddSeconds(90);
+
+        Assert.Null(store.TryLocateIgnoringFreshness(new TenantId("t#other"), "sess-1"));
+    }
+
+    [Fact]
+    public void TryLocateIgnoringFreshness_DirectorThatNeverPushed_ReportsMaximallyStale_NotZero()
+    {
+        // A Director registered but with no snapshot has no meaningful age. Reporting zero would read as
+        // "pushed just now" and produce the sentence "has not reported in for 0 seconds", which is worse than
+        // saying nothing.
+        var store = new PushedSessionStore(() => _now);
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+
+        // No snapshot applied, so the session id is unknown - the correct answer is still "not found".
+        Assert.Null(store.TryLocateIgnoringFreshness(TenantId.Local, "sess-1"));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1475,7 +1475,7 @@ internal static class GatewayEndpoints
             // SessionRole null and fold a colour from it. We take our instance from the fleet instead.
             var (director, _) = await LocateSessionAsync(registry, sid, pushedSessions, streamStaleResolved, reqTenant.Value, owners);
             if (director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             // Defect 15: this route returned EffectiveColor / StateLabel / TriageBucket as NULL and left the
             // expired-snooze override unapplied, because it never ran the fold - StampFleetRolesAndFold was
@@ -1490,7 +1490,7 @@ internal static class GatewayEndpoints
             var fleet = byDirector.Values.SelectMany(x => x).ToList();
             var session = fleet.FirstOrDefault(x => string.Equals(x.SessionId, sid, StringComparison.Ordinal));
             if (session is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             var baseUrl = DeriveDirectorBaseUrl(ctx, director);
             session.DirectorId = director.DirectorId;
@@ -1514,7 +1514,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Post-cut: tunnel-only. A null result (Director not connected) stays 502 like a failed kill, but now
             // says so. This verb is the sharpest case for explaining itself: on a timeout or a mid-flight drop the
             // session may or may not have been killed, and a bare 502 left the user with no idea which.
@@ -1532,7 +1532,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only. The Ok result is success and synthesizes the { pendingDeletion } body; a null result
             // (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "request-deletion", sid, body, ct, machineName: director.MachineName);
@@ -1546,7 +1546,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Gateway Cleanup (Phase 2, PR C): tunnel-first, HTTP fallback on a null return (byte-identical).
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "cancel-deletion", sid, null, ct, machineName: director.MachineName);
@@ -1561,7 +1561,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only. The Ok body IS the WingmanViewDto JSON, passed through exactly as the HTTP body.
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "wingman-view", sid, null, ct, machineName: director.MachineName);
@@ -1579,7 +1579,7 @@ internal static class GatewayEndpoints
                 return Results.BadRequest(new WingmanAskResult { Status = "bad_request", Error = "question is required" });
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Gateway Cleanup (Phase 2, PR C): tunnel-first. This is a SLOW LLM call - the request ct threads
             // straight into the SignalR invocation (which has no per-invocation timeout; keep-alive pings sustain
             // the long await), so the synchronous browser contract is byte-identical to the HTTP forward. A null
@@ -1598,7 +1598,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             var goalReq = req ?? new WingmanGoalRequest();
             // Post-cut: tunnel-only. The Ok stream body IS the { goal, goalSetAt, goalState } JSON; a null
             // result (Director not connected) or a non-Ok result collapses to 502.
@@ -1615,7 +1615,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             var roleReq = req ?? new SetRoleRequest();
             // Post-cut: tunnel-only. The Ok stream body is the updated SessionDto JSON; a null or non-Ok result collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "set-role", sid, roleReq, ct, machineName: director.MachineName);
@@ -1637,7 +1637,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             var holdReq = req ?? new HoldRequest();
             // Issue #1500: an explicit per-call snooze length. Validate it BEFORE recording the hold, so a
             // bad value fails loudly (no fallback / no silent clamp) and never parks the session. Null = use
@@ -1772,7 +1772,7 @@ internal static class GatewayEndpoints
                 return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             var transcribing = req?.Transcribing ?? false;
             if (transcribing)
                 transcribingSessions.Begin(reqTenant, sid);
@@ -1788,7 +1788,7 @@ internal static class GatewayEndpoints
 
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             FileLog.Write($"[GatewayEndpoints] PATCH /sessions/{sid}: name=\"{req.Name}\", director={director.DirectorId}");
 
@@ -1817,10 +1817,10 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             if (director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             // Post-cut: tunnel-only. The query params ride in a BufferRequest payload the Director's buffer
             // verb reads. A null result (Director not connected) collapses to 502.
@@ -1849,7 +1849,7 @@ internal static class GatewayEndpoints
 
             var (director, session) = await LocateSessionForRequestAsync(httpCtx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(httpCtx, tenantBoundary, pushedSessions, sid);
 
             FileLog.Write($"[GatewayEndpoints] POST prompt: sid={sid}, director={director.DirectorId}, waitForIdle={req.WaitForIdle}");
 
@@ -1914,7 +1914,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "interrupt", sid, null, CancellationToken.None, machineName: director.MachineName);
@@ -1928,7 +1928,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "escape", sid, null, CancellationToken.None, machineName: director.MachineName);
@@ -1945,7 +1945,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             if (!ctx.Request.HasFormContentType)
                 return Results.BadRequest(new { error = "expected multipart/form-data with an image file field 'file'" });
@@ -1973,8 +1973,12 @@ internal static class GatewayEndpoints
                 machineName: director.MachineName);
             if (begin is not null)
             {
+                // Issue #2190: carry the Director's OWN status out, instead of flattening every rejection to
+                // 502. Uploading a file type we do not accept is the caller's request being wrong (400 with
+                // the accepted list), not a broken gateway - and a 5xx made the client retry something that
+                // could never succeed. A genuinely dropped tunnel still answers 502, through the same map.
                 if (!begin.Ok)
-                    return Results.Json(new { error = DirectorCommandRouter.DescribeFailure(begin) }, statusCode: StatusCodes.Status502BadGateway);
+                    return MapDirectorFailure(begin);
 
                 for (var off = 0; off < bytes.Length; off += DirectorStreamLimits.UploadChunkRawBytes)
                 {
@@ -1987,20 +1991,47 @@ internal static class GatewayEndpoints
                     };
                     var cr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "upload-image-chunk", sid, chunk, ctx.RequestAborted, machineName: director.MachineName);
                     if (cr is null || !cr.Ok)
-                        return Results.Json(new { error = cr is null ? "tunnel dropped mid-upload" : DirectorCommandRouter.DescribeFailure(cr) }, statusCode: StatusCodes.Status502BadGateway);
+                    {
+                        FileLog.Write($"[GatewayEndpoints] upload-image FAILED mid-upload: sid={sid}, uploadId={uploadId}, "
+                            + $"seq={chunk.Seq}, reason={(cr is null ? "tunnel dropped" : DirectorCommandRouter.DescribeFailure(cr))}");
+                        return cr is null
+                            ? Results.Json(new { error = "The connection to the machine running this session dropped part-way through the upload. Try again.", retryable = true },
+                                statusCode: StatusCodes.Status502BadGateway)
+                            : MapDirectorFailure(cr);
+                    }
                 }
 
                 var done = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "upload-image-complete", sid,
                     new UploadImageCompleteRequest { UploadId = uploadId }, ctx.RequestAborted,
                     machineName: director.MachineName);
                 if (done is null || !done.Ok || string.IsNullOrEmpty(done.BodyJson))
-                    return Results.Json(new { error = done is null ? "tunnel dropped mid-upload" : DirectorCommandRouter.DescribeFailure(done) }, statusCode: StatusCodes.Status502BadGateway);
+                {
+                    FileLog.Write($"[GatewayEndpoints] upload-image FAILED at complete: sid={sid}, uploadId={uploadId}, "
+                        + $"reason={(done is null ? "tunnel dropped" : DirectorCommandRouter.DescribeFailure(done))}");
+                    if (done is null)
+                        return Results.Json(new { error = "The connection to the machine running this session dropped just before the upload finished. Try again.", retryable = true },
+                            statusCode: StatusCodes.Status502BadGateway);
+                    // An Ok result with an empty body is a contract breach, not a Director rejection: say so
+                    // rather than returning a bodyless status the user cannot act on.
+                    return done.Ok
+                        ? Results.Json(new { error = "The image was uploaded but the machine running this session did not report where it was saved.", retryable = true },
+                            statusCode: StatusCodes.Status502BadGateway)
+                        : MapDirectorFailure(done);
+                }
 
                 return Results.Content(done.BodyJson, "application/json"); // { path, fileName }
             }
 
-            // Post-cut: tunnel-only. A null begin means the Director is not connected -> 502.
-            return Results.Json(new { error = "director not connected to the tunnel" }, statusCode: StatusCodes.Status502BadGateway);
+            // Post-cut: tunnel-only. A null begin means the Director is not connected -> 502. Say it in words
+            // and mark it retryable (issue #2189), because a Director that just dropped is usually back
+            // within a push cycle.
+            FileLog.Write($"[GatewayEndpoints] upload-image REFUSED: sid={sid}, director={director.DirectorId} is not connected to the tunnel");
+            return Results.Json(new
+            {
+                error = $"The machine running this session ({director.MachineName}) is not connected right now, so the image could not be delivered. Try again.",
+                code = "director_not_connected",
+                retryable = true,
+            }, statusCode: StatusCodes.Status502BadGateway);
         });
 
         app.MapGet("/directors/{id}/repos", async (HttpContext ctx, string id, CancellationToken ct) =>
@@ -2489,10 +2520,10 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only. The Director's summary core sets DirectorId in its body, so the pass-through matches.
             if (director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "summary", sid, null, ct, machineName: director.MachineName);
             return streamResult is not null && streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
@@ -2516,7 +2547,7 @@ internal static class GatewayEndpoints
             // instead of a full fleet fan-out (the same fast path every other per-session route now uses).
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only (verb "git-status"). The Ok body IS the GitSnapshot JSON, passed through unchanged.
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "git-status", sid, null, ctx.RequestAborted, machineName: director.MachineName);
@@ -2537,7 +2568,7 @@ internal static class GatewayEndpoints
             // Issue #1240: resolve the owner through the same cache fast path as every other per-session route.
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only. The Director's handover core sets DirectorId in its body, so the pass-through matches.
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "handover", sid, null, ct, machineName: director.MachineName);
@@ -2553,7 +2584,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             // Tunnel-only (read the cached recap). This is the READ; the slow generate (POST) is handled separately.
             // Post-cut: tunnel-only. A null result (Director not connected) collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "recap", sid, null, ct, machineName: director.MachineName);
@@ -2566,7 +2597,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
             var model = ctx.Request.Query["model"].ToString();
             FileLog.Write($"[GatewayEndpoints] POST /recap: sid={sid}, director={director.DirectorId}, model={model ?? "(default)"}");
             // Gateway Cleanup (Phase 2, PR C): tunnel-first. Like wingman-ask this is a SLOW LLM call, so the
@@ -2593,7 +2624,7 @@ internal static class GatewayEndpoints
         {
             var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
-                return Results.NotFound(new { error = "session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
 
             FileLog.Write($"[GatewayEndpoints] POST /compact-context: sid={sid}, director={director.DirectorId}, " +
                           $"continue={(string.IsNullOrWhiteSpace(req?.ContinuePrompt) ? "no" : "yes")}");
@@ -2622,7 +2653,7 @@ internal static class GatewayEndpoints
 
             var (sourceDirector, sourceSession) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, req.FromSessionId, pushedSessions, streamStaleResolved, owners);
             if (sourceSession is null || sourceDirector is null)
-                return Results.NotFound(new { error = "source session not found across any director" });
+                return SessionUnavailable(ctx, tenantBoundary, pushedSessions, req.FromSessionId);
 
             DirectorDto? targetDirector = null;
             if (!string.IsNullOrEmpty(req.ToDirectorId)
@@ -3479,8 +3510,76 @@ internal static class GatewayEndpoints
                 statusCode: StatusCodes.Status504GatewayTimeout),
             DirectorCommandStatus.TunnelDropped => Results.Json(new { error = sr.Error ?? "The connection to the Director dropped while the command was being sent." },
                 statusCode: StatusCodes.Status502BadGateway),
-            _ => Results.StatusCode(StatusCodes.Status502BadGateway),
+            // Issue #2190: a Conflict or a Locked is the CALLER's situation, not a broken gateway, and the
+            // Director wrote a real sentence for each. Both used to land in the bodyless 502 below, which
+            // told the user the gateway was broken and gave a retry-implying 5xx for something retrying
+            // cannot fix.
+            DirectorCommandStatus.Conflict => Results.Json(new { error = sr.Error ?? "That conflicts with the session's current state." },
+                statusCode: StatusCodes.Status409Conflict),
+            DirectorCommandStatus.Locked => Results.Json(new { error = sr.Error ?? "This session is on hold." },
+                statusCode: StatusCodes.Status423Locked),
+            // Anything else really is a server-side failure - but it must still say so in words. A bodyless
+            // 502 is exactly the bare status a person cannot act on (issue #2189).
+            _ => Results.Json(new { error = sr.Error ?? "The command failed on the machine running this session." },
+                statusCode: StatusCodes.Status502BadGateway),
         };
+    }
+
+    /// <summary>
+    /// Issue #2188/#2189: the ONE answer for "we could not resolve this session", and the reason no route
+    /// hand-rolls <c>Results.NotFound(new { error = "session not found across any director" })</c> any more.
+    ///
+    /// That single line was the whole defect. It was returned for two completely different situations:
+    ///  - the session exists and its Director simply has not pushed recently (transient, retryable), and
+    ///  - no Director in this tenant has ever pushed this session id (permanent).
+    ///
+    /// A person who attached an image during a ten-second push gap was told their live session did not
+    /// exist, in a message the client then reduced to "error 404". This helper asks the store which of the
+    /// two it actually is, and answers accordingly:
+    ///  - stale Director  -> 503 + Retry-After, <c>retryable: true</c>, and a sentence that names the delay
+    ///                       and tells the user to try again.
+    ///  - unknown session -> 404, <c>retryable: false</c>, and a sentence that says the session is gone.
+    ///
+    /// Both bodies carry <c>error</c>, <c>code</c> and <c>retryable</c>, which is the shape the browser
+    /// client reads to build the sentence it shows and to decide whether to retry once on its own.
+    /// </summary>
+    private static IResult SessionUnavailable(
+        HttpContext ctx,
+        Tenancy.HostedTenantBoundary? tenantBoundary,
+        Streaming.PushedSessionStore? pushedSessions,
+        string sid)
+    {
+        var tenant = ResolveReadTenant(ctx, tenantBoundary);
+        var known = tenant is null || pushedSessions is null
+            ? null
+            : pushedSessions.TryLocateIgnoringFreshness(tenant.Value, sid);
+
+        if (known is not null)
+        {
+            var (directorId, pushAge) = known.Value;
+            var seconds = pushAge == TimeSpan.MaxValue ? -1 : (int)Math.Round(pushAge.TotalSeconds);
+            var delay = seconds < 0 ? "in a while" : $"for {seconds} seconds";
+            FileLog.Write($"[GatewayEndpoints] session {sid} UNAVAILABLE (retryable): owning director={directorId} "
+                + $"has not pushed {delay}; answering 503");
+            ctx.Response.Headers.RetryAfter = "5";
+            return Results.Json(new
+            {
+                error = $"The machine running this session has not reported in {delay}. The session is still "
+                    + "there - this usually clears within a few seconds. Try again.",
+                code = "director_stale",
+                retryable = true,
+                pushAgeSeconds = seconds,
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        FileLog.Write($"[GatewayEndpoints] session {sid} NOT FOUND: no director in this tenant has pushed it; answering 404");
+        return Results.Json(new
+        {
+            error = "That session could not be found. It may have been closed, or it may belong to a "
+                + "machine that is no longer signed in.",
+            code = "session_not_found",
+            retryable = false,
+        }, statusCode: StatusCodes.Status404NotFound);
     }
 
     // Locate the Director that owns a session. Every session endpoint calls this first,
@@ -3523,6 +3622,28 @@ internal static class GatewayEndpoints
     // no fresh push is not connected to the tunnel, so its sessions are unreachable and location returns null -
     // the same not-found the old HTTP-pull fallback produced when a Director was down. Kept Task-returning so
     // the many `await LocateSessionAsync(...)` call sites (and SessionVerbClient.ResolveAsync) are unchanged.
+    /// <summary>
+    /// Issue #2188: how much LATER than the roster's freshness cut a session may still be acted on.
+    ///
+    /// A Director re-pushes its full snapshot every <c>staleAfterSeconds / 2</c>, so ONE missed tick is
+    /// ordinary jitter, not an outage - and it must not make a live session unusable. The observed failure
+    /// was exactly this: two pushes ten seconds apart went missing, the pushed cache aged past the twenty
+    /// second cut, and for about ten seconds every action on fourteen live sessions was refused as
+    /// "session not found across any director". The very next prompt, once a push landed, returned 200.
+    ///
+    /// This is a defined tolerance, NOT a fallback that hides an outage. The tunnel send is still the
+    /// authority: if the Director is genuinely gone, <c>DirectorCommandRouter.TrySendAsync</c> returns null
+    /// and the existing 502 answers. All this does is stop a one-cycle gap from being reported to the user
+    /// as a deleted session.
+    ///
+    /// Deliberately NOT applied to the roster read (<c>GET /sessions</c>), which has its own presentation
+    /// grace window in <see cref="Discovery.FleetRosterCache"/>. Acting on a session is allowed to be more
+    /// tolerant than presenting it, because the action itself proves reachability and a refusal costs the
+    /// user real work.
+    /// </summary>
+    internal static readonly TimeSpan LocateGrace =
+        TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds / 2.0);
+
     internal static Task<(DirectorDto? director, SessionDto? session)> LocateSessionAsync(
         DirectorRegistry registry, string sid,
         Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale,
@@ -3531,7 +3652,7 @@ internal static class GatewayEndpoints
     {
         if (pushedSessions is not null)
         {
-            var located = pushedSessions.TryLocate(tenant, sid, streamStale);
+            var located = pushedSessions.TryLocate(tenant, sid, streamStale + LocateGrace);
             if (located is not null)
             {
                 var (directorId, pushedSession) = located.Value;

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -337,6 +337,48 @@ public sealed class PushedSessionStore
     }
 
     /// <summary>
+    /// Issue #2188: the owning Director for a session id IGNORING the freshness cut, plus how long ago that
+    /// Director's newest push landed.
+    ///
+    /// This exists so a caller can tell two very different things apart, which <see cref="TryLocate"/>
+    /// collapses into the same null:
+    ///  - the session IS known to a Director whose push has simply gone stale (retryable - the Director is
+    ///    expected back within one push cycle), and
+    ///  - no Director in this tenant has ever pushed this session id (genuinely not found).
+    ///
+    /// Collapsing them is what made a live session report "session not found across any director" during a
+    /// ten-second push gap, telling the user their session had been deleted when it was working the whole
+    /// time. This read NEVER decides reachability - the tunnel send remains the authority on that. It only
+    /// supplies the honest reason for a refusal.
+    ///
+    /// Scoped to one tenant, exactly like <see cref="TryLocate"/>, so a session id in one tenant can never
+    /// name a Director in another.
+    /// </summary>
+    public (string DirectorId, TimeSpan PushAge)? TryLocateIgnoringFreshness(TenantId tenant, string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return null;
+
+        var now = _utcNow();
+        foreach (var kvp in DirectorsFor(tenant))
+        {
+            var entry = kvp.Value;
+            lock (entry.Gate)
+            {
+                if (!entry.Sessions.ContainsKey(sessionId))
+                    continue;
+                // A Director that has never pushed has no meaningful age; report it as maximally stale
+                // rather than as a nonsense negative or zero age.
+                var age = entry.ReceivedAtUtc == DateTime.MinValue
+                    ? TimeSpan.MaxValue
+                    : now - entry.ReceivedAtUtc;
+                return (kvp.Key, age < TimeSpan.Zero ? TimeSpan.Zero : age);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Issue #1200 (auto-dismiss sweep): enumerate every FRESH pushed session across <paramref name="tenant"/>'s
     /// stream-connected Directors, each paired with its owning directorId so the caller can address a command
     /// DOWN that Director's stream. Applies the same active-connection + freshness rules as


### PR DESCRIPTION
Fixes #2188, fixes #2189, fixes #2190.

## What was reported

Attaching a picture from the Cockpit session screen failed. The screen said:

> The Gateway rejected the request (error 404).

That sentence is most of the problem. It does not say what failed, does not say the session was only
briefly unreachable, does not say to try again, and gives the reader nothing but three digits - which
is why the failure was first reported as a "400 error". Nothing about it reached the server, so
finding the actual click meant grepping a fifty-four megabyte Gateway log on the Azure file share by
hand.

## What actually happened

The owning Director re-pushes its full session snapshot every ten seconds; the Gateway treats that
snapshot as stale after twenty. Two consecutive pushes went missing:

```
09:09:29.630  reseeded full snapshot     <- last good push
09:10:00.214  reseeded full snapshot     <- 30.6 second gap
09:10:27.131  reseeded full snapshot     <- another 26.9 second gap
```

Every other tick that minute was a clean ten seconds. From about 09:09:49.6 to 09:10:00.2 the Gateway
held no fresh snapshot, so all fourteen of that Director's sessions read as non-existent. The click
landed six seconds into that hole. The next prompt, at 09:11:21, returned 200.

The tunnel never dropped - it stalled. A command sent at 13:09:36.993 reached the Director at
13:09:58.745, twenty-two seconds late, in a backlog burst on the same hub connection.

**Why the two ticks were missed is not established.** A slow round-trip eating the following tick
through the re-entrancy guard fits the evidence, and so does a timer or thread-pool stall; the log
cannot separate them because the skip path was silent. Fixing that silence is part of this change.
Naming a cause is not.

## The changes

### Gateway - a missed push cycle is not a deleted session (#2188)

- **`LocateGrace`**: the per-session locator tolerates exactly one missed push cycle. A defined grace
  window, not a fallback that hides an outage - the tunnel send remains the authority, and a Director
  that is genuinely gone still fails, with the existing 502.
- **One shared responder** replaces twenty-six hand-rolled
  `Results.NotFound(new { error = "session not found across any director" })` returns. That single
  line was answering two completely different situations. It now asks the store which one this is:
  - stale Director -> `503` + `Retry-After`, `retryable: true`, and a sentence naming the delay
  - unknown session id -> `404`, `retryable: false`, and a sentence saying it may have been closed
- This was never attach-specific. Every per-session route went through the same locator; attach is
  just the button that got pressed.

### Clients - a number is not an error message (#2189)

- **The server's reason survives.** `GatewayError.from` reads the response body; the reason, a
  machine-readable code, and a retryable flag travel on the error. Thirty-nine throw sites converted.
- **`gatewayErrorMessage` cannot return a bare status number** for any status. It says what failed and
  whether retrying is worth it. A test asserts this for eleven status codes, and fails against the
  previous behaviour.
- **`describeAndReport`** makes showing an error and recording it a single act. The client error
  channel was built, deployed and working - the whole product had one explicit report call site, so no
  error the Cockpit showed anyone ever reached it. The interactive session surfaces are converted:
  composer, session menu, action bar, queue, screenshots, source control, the shared confirm dialog,
  and the mobile session controls.
- **Attach retries once** on a retryable failure, announced in the status line. The observed hole was
  about ten seconds wide, so this alone turns the reported failure into a non-event.

### Director - rejections leave a record and blame the right side (#2190)

- Every rejection in the upload verbs goes through `FailLogged`. They returned genuinely useful
  sentences - the unsupported type with the accepted list, both byte counts, both sequence numbers -
  and wrote nothing anywhere.
- A rejection caused by the request now returns `400`/`404`/`409`/`423` with the Director's own words
  rather than a blanket `502`. Uploading an unaccepted file type used to report that the gateway was
  broken, and a 5xx invited the client to retry something that could never succeed. A genuinely
  dropped tunnel still returns `502`.

## Verification

- `SessionLocateStalePushTests` - 8 tests. Pins both properties separately: the tolerance closes the
  observed hole, AND the same state read without the grace is still refused (so the test cannot pass
  for an unrelated reason), AND past the tolerance stale is still distinguishable from absent,
  including across a tenant boundary.
- `SessionByteExecutorRejectionLoggingTests` - 9 tests asserting the log lines carry the reason, plus
  a positive control that a success logs no rejection. **Verified to fail against the pre-fix code**:
  reverting one `FailLogged` to the old silent form fails the matching test.
- `errorReporting.test.ts` - 11 tests, including the guard that no message is ever only a status
  number, across eleven statuses.
- `composerAttachErrors.test.tsx` - 4 tests at the surface that was actually pressed: the reason is
  shown, the failure is reported, a retryable failure retries once and succeeds silently, and a
  permanent one does not retry.
- Full suites green locally: client-core 693, Cockpit 198. All three web workspaces typecheck; both
  shells build.
- Three superseded test contracts updated in place, each with the reason written down. The hosted
  tenancy suite is re-anchored on the machine-readable code, and its two absence-only assertions are
  given a positive fact to check so they cannot pass vacuously after a rewording.

## Known scope limit

The `describeAndReport` conversion covers the interactive session surfaces - where a person presses
something and waits, which is the reported class of failure. The passive read and poll views
(Schedule, Dictionary, Transcripts, Workflows, Account, Settings, Diagnostics) get the improved
messages automatically but do not yet report. That sweep is tracked as follow-up work on #2189 rather
than bundled here.
