### PR TITLE
Wingman phase 1: detect a waiting menu and refuse to answer it by voice

### DIFF
--- a/apps/cockpit/src/sessions/VoiceTab.tsx
+++ b/apps/cockpit/src/sessions/VoiceTab.tsx
@@ -31,6 +31,20 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
           <div className="composer-error" role="alert">{v.error}</div>
         )}
 
+        {/* A menu owns this session's screen, so the last spoken reply was NOT typed (issue #2193).
+            Nothing was sent and no Enter was pressed - the reply would have landed in a chooser, where
+            the trailing Enter would have confirmed whichever option happened to be highlighted. The
+            person answers it in the session itself; voice cannot pick an option yet. */}
+        {v.menuBlocked !== null && (
+          <div className="voice-menu-blocked" role="alert">
+            <span className="voice-state voice-state-yellow">Waiting on a menu</span>
+            <p className="voice-narr-body">{v.menuBlocked}</p>
+            <button type="button" className="voice-off-toggle" onClick={v.clearMenuBlocked}>
+              Dismiss
+            </button>
+          </div>
+        )}
+
         {/* TTS fallback: the Gateway folded a generic "switched to a backup voice" notice onto this turn's
             ready clip (the primary provider was temporarily overloaded). Rendered VERBATIM - never names a
             provider. Shows above whichever voice card is up while the backup clip is the current one. */}

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -1795,6 +1795,25 @@ body {
   cursor: default;
 }
 
+/* A menu owns the session's screen, so a spoken reply was refused rather than typed (issue #2193).
+   Amber, not red: nothing went wrong and nothing was lost - the session simply needs a choice made in
+   it before voice can carry on. */
+.voice-menu-blocked {
+  margin: 12px 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+}
+
+.voice-menu-blocked .voice-narr-body {
+  margin: 8px 0 0;
+}
+
+.voice-menu-blocked .voice-off-toggle {
+  margin-top: 10px;
+}
+
 .voice-off-toggle {
   display: block;
   width: 100%;

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -108,6 +108,8 @@ export function VoiceMode() {
     onTogglePlay,
     onRespondSend,
     onRespondSendAudio,
+    menuBlocked,
+    clearMenuBlocked,
   } = useVoiceMode(sessionId, {
     seededVoiceOn,
     autoSwitchOn,
@@ -300,6 +302,19 @@ export function VoiceMode() {
 
         {error !== null && (
           <div className="banner banner-error" role="alert">{error}</div>
+        )}
+
+        {/* A menu owns this session's screen, so the last spoken reply was NOT typed (issue #2193).
+            Nothing was sent and no Enter was pressed - a spoken sentence typed into a chooser does
+            nothing, and the trailing Enter would have confirmed whichever option was highlighted. The
+            wingman says this out loud too; the banner is what stays on screen afterwards. */}
+        {menuBlocked !== null && (
+          <div className="banner banner-menu banner-action" role="alert">
+            <span>{menuBlocked}</span>
+            <button type="button" className="banner-btn" onClick={clearMenuBlocked}>
+              Dismiss
+            </button>
+          </div>
         )}
 
         {autoPlayBlocked && (

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -165,6 +165,15 @@ body {
   color: var(--text);
 }
 
+/* A menu owns the session's screen, so a spoken reply was refused rather than typed (issue #2193).
+   Amber, not red: nothing went wrong and nothing was lost - the session simply needs a choice made in
+   it before voice can carry on. */
+.banner-menu {
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  color: var(--text);
+}
+
 .banner-action {
   display: flex;
   align-items: center;

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -449,6 +449,87 @@ export async function sendPrompt(
   }
 }
 
+// What a session's live screen is right now (GET /sessions/{sid}/wingman/waiting-screen). "menu" means a
+// chooser owns the screen and typing into it is meaningless; "text" is an ordinary composer; "blocked" is a
+// screen the Gateway could not positively read. Cheap on the Gateway - one terminal read, no model call.
+export interface WaitingScreen {
+  kind: "menu" | "text" | "blocked";
+  /** False ONLY on "menu" - phase 1 refuses on a recognized menu and nothing else. */
+  canType: boolean;
+  /** The line to speak when a menu is blocking; empty otherwise. */
+  spoken: string;
+  /** The line to show on screen when a menu is blocking; empty otherwise. */
+  message: string;
+}
+
+export async function getWaitingScreen(sessionId: string, signal?: AbortSignal): Promise<WaitingScreen> {
+  const sid = encodeURIComponent(sessionId);
+  // Hard-capped on purpose. The fire-and-forget voice Send asks this BEFORE it hands the recording to the
+  // durable background pipeline, so a slow answer here would hold a clip that exists only in memory. A
+  // check that cannot finish promptly is not worth a recording - the read gives up and the reply proceeds.
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/waiting-screen`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  }, { timeoutMs: POLL_TIMEOUT_MS });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET wingman/waiting-screen failed: ${res.status}`);
+  }
+  const body = (await res.json()) as Partial<WaitingScreen>;
+  const kind = body.kind === "menu" || body.kind === "text" ? body.kind : "blocked";
+  return {
+    kind,
+    canType: kind !== "menu",
+    spoken: body.spoken ?? "",
+    message: body.message ?? "",
+  };
+}
+
+// The outcome of a voice reply: either it went into the session, or a menu owned the screen and the Gateway
+// refused to type it. A refusal is a NORMAL outcome, not an error - the caller asked for exactly this - so it
+// comes back as a value rather than a thrown GatewayError.
+export interface VoicePromptResult {
+  sent: boolean;
+  blockedByMenu: boolean;
+  /** The line to speak on a refusal; empty when the prompt was sent. */
+  spoken: string;
+  /** The line to show on a refusal; empty when the prompt was sent. */
+  message: string;
+}
+
+// Send a spoken reply into the session WITH the menu guard on (POST /sessions/{sid}/prompt, menuGuard).
+// The Gateway reads the live screen one hop before the send: if a chooser owns it, nothing is typed and no
+// Enter is pressed - which matters because the Enter this call carries would otherwise confirm whichever
+// option the picker had highlighted. Only the voice reply paths use this; every typed-composer send stays on
+// the plain sendPrompt above, completely unchanged.
+export async function sendVoicePrompt(
+  sessionId: string,
+  text: string,
+  signal?: AbortSignal,
+): Promise<VoicePromptResult> {
+  const sid = encodeURIComponent(sessionId);
+  const body: PromptRequest & { menuGuard: boolean } = { text, appendEnter: true, menuGuard: true };
+  const res = await gatewayFetch(`/sessions/${sid}/prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `POST prompt failed: ${res.status}`);
+  }
+  const answer = (await res.json()) as { accepted?: boolean; blockedByMenu?: boolean; blockedSpoken?: string; error?: string };
+  if (answer.blockedByMenu === true) {
+    return {
+      sent: false,
+      blockedByMenu: true,
+      spoken: answer.blockedSpoken ?? "",
+      message: answer.error ?? "",
+    };
+  }
+  return { sent: true, blockedByMenu: false, spoken: "", message: "" };
+}
+
 // Soft-stop the current turn (the agent driver's Escape). POST /sessions/{sid}/escape.
 export async function sendEscape(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
 import {
   GatewayError,
+  getWaitingScreen,
   getWingmanVoice,
   listSessions,
   markVoiceAndExplain,
-  sendPrompt,
+  sendVoicePrompt,
   setVoiceMode,
   stopWingmanVoice,
   type SessionDto,
@@ -131,6 +132,12 @@ export interface VoiceModeView {
    *  failure instead of leaving the error behind on an abandoned screen. */
   onRespondSend: (text: string) => Promise<boolean>;
   onRespondSendAudio: (captured: CapturedUtterance) => void;
+  /** Set when the last reply was NOT sent because a menu owns the session's screen (issue #2193): the
+   *  line to show. Voice cannot pick an option yet, so the person has to open the session and choose.
+   *  Null whenever the last reply went through. Cleared as soon as Respond is opened again. */
+  menuBlocked: string | null;
+  /** Dismiss the menu-blocked notice (the person has read it, or gone and answered the menu). */
+  clearMenuBlocked: () => void;
 }
 
 export function useVoiceMode(
@@ -624,22 +631,57 @@ export function useVoiceMode(
     });
   }, [persist]);
 
+  // A menu owns the session's screen, so the last reply was refused rather than typed (issue #2193).
+  const [menuBlocked, setMenuBlocked] = useState<string | null>(null);
+  const clearMenuBlocked = useCallback(() => setMenuBlocked(null), []);
+  const openResponding = useCallback((value: boolean) => {
+    if (value) setMenuBlocked(null);
+    setResponding(value);
+  }, []);
+
+  // Say the refusal OUT LOUD through the browser's own speech synthesis. Voice mode is hands-free - a
+  // notice that only appears on screen is a notice the person driving never receives. This deliberately
+  // uses LOCAL synthesis rather than the Gateway voice, the same choice Car Mode makes for its state
+  // announcements: this is the product telling you it will not act, not the wingman reading the agent's
+  // words, so it should cost nothing, need no network, and never be the thing that fails.
+  const speakBlocked = useCallback((line: string) => {
+    if (line.length === 0) return;
+    try {
+      const synth = (window as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
+      if (synth) {
+        synth.cancel();
+        synth.speak(new SpeechSynthesisUtterance(line));
+      }
+    } catch {
+      // Speaking is on top of the on-screen notice, never instead of it; never let it throw into a send.
+    }
+  }, []);
+
   const onRespondSend = useCallback(
     async (text: string): Promise<boolean> => {
       setResponding(false);
       const trimmed = text.trim();
       if (sid.length === 0 || trimmed.length === 0) return false;
       try {
-        // Same write path the Send button uses; the transcript is already dictionary-corrected by
-        // the Gateway and is sent verbatim (transcript integrity, CodingStyle s16).
-        await sendPrompt(sid, trimmed, true);
+        // The write path a spoken reply takes: the same POST /prompt the Send button uses, but with the
+        // MENU GUARD on (issue #2193). The transcript is already dictionary-corrected by the Gateway and
+        // is sent verbatim (transcript integrity, CodingStyle s16). If a chooser owns the screen the
+        // Gateway types nothing and presses nothing, and says so - we surface that instead of pretending
+        // the reply landed.
+        const result = await sendVoicePrompt(sid, trimmed);
+        if (result.blockedByMenu) {
+          setMenuBlocked(result.message);
+          speakBlocked(result.spoken);
+          return false;
+        }
+        setMenuBlocked(null);
         return true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Send failed");
         return false;
       }
     },
-    [sid],
+    [sid, speakBlocked],
   );
 
   // Issue #949: the fast fire-and-forget Send - the SAME path the Terminal/Chat Speak use. When Send is
@@ -651,14 +693,32 @@ export function useVoiceMode(
     (captured: CapturedUtterance) => {
       setResponding(false);
       if (sid.length === 0) return;
-      void backgroundTranscribeAndSend(sid, captured, {
-        onError: (message) => setError(message),
-        // Record the session's terminal-byte position now, so a clip resumed later is not injected
-        // into a session that has moved on (issue #1006 guard).
-        baselineBufferBytes: Number(session?.totalBufferBytes ?? 0),
-      });
+      // The menu check happens BEFORE the background pipeline starts (issue #2193). This path is
+      // fire-and-forget by design - it transcodes, uploads, transcribes and delivers after the screen has
+      // closed - so there is no later moment at which a refusal could still reach the person. Asking the
+      // Gateway now costs one cheap read (no model call) and is the only place this path can be honest.
+      void (async () => {
+        try {
+          const screen = await getWaitingScreen(sid);
+          if (screen.kind === "menu") {
+            setMenuBlocked(screen.message);
+            speakBlocked(screen.spoken);
+            return;
+          }
+        } catch {
+          // The screen could not be read. Phase 1 refuses ONLY on a recognized menu, so an unreadable
+          // answer must not silently swallow the reply - deliver it exactly as before the guard existed.
+        }
+        setMenuBlocked(null);
+        void backgroundTranscribeAndSend(sid, captured, {
+          onError: (message) => setError(message),
+          // Record the session's terminal-byte position now, so a clip resumed later is not injected
+          // into a session that has moved on (issue #1006 guard).
+          baselineBufferBytes: Number(session?.totalBufferBytes ?? 0),
+        });
+      })();
     },
-    [sid, session],
+    [sid, session, speakBlocked],
   );
 
   // The speaking state (and its play-triangle) is suppressed while the agent is working again: the
@@ -709,7 +769,9 @@ export function useVoiceMode(
     regenerating,
     enableNote,
     responding,
-    setResponding,
+    // Opening Respond again clears the menu notice: the person has read it, and if they have gone and
+    // answered the menu the notice would otherwise sit there contradicting a screen that has moved on.
+    setResponding: openResponding,
     setPlaying,
     clipUrl: clip.url,
     clipPhase: clip.phase,
@@ -725,5 +787,7 @@ export function useVoiceMode(
     onTogglePlay,
     onRespondSend,
     onRespondSendAudio,
+    menuBlocked,
+    clearMenuBlocked,
   };
 }

--- a/packages/client-core/src/voice/voiceMenuGuard.test.tsx
+++ b/packages/client-core/src/voice/voiceMenuGuard.test.tsx
@@ -1,0 +1,157 @@
+// The wingman menu guard, at the surface the person actually touches (issue #2193).
+//
+// The property under test is not "a flag is set" - it is that a spoken reply aimed at a session sitting on
+// a menu NEVER starts its delivery, and that the person is told why. Both halves matter. Before this guard
+// existed the reply was typed into the picker and the Enter that rides every voice send confirmed whatever
+// option happened to be highlighted, so the failure mode was not "nothing happened" but "something you did
+// not choose happened, silently".
+//
+// The audio Send is the one worth pinning here rather than in the Gateway: it is fire-and-forget, so if the
+// check were placed wrongly the recording would either be delivered into the menu anyway or dropped without
+// a word. The text Send's refusal is enforced by the Gateway (proven in WingmanMenuGuardProofTests) - what
+// is checked here is that the hook surfaces it instead of pretending the reply landed.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+
+vi.mock("../api/client", () => ({
+  GatewayError: class GatewayError extends Error {
+    status: number;
+    constructor(status: number, message: string) { super(message); this.status = status; }
+  },
+  getWaitingScreen: vi.fn(),
+  sendVoicePrompt: vi.fn(),
+  getWingmanVoice: vi.fn(async () => null),
+  fetchWingmanVoiceAudio: vi.fn(async () => new ArrayBuffer(0)),
+  listSessions: vi.fn(async () => []),
+  markVoiceAndExplain: vi.fn(async () => ({})),
+  setVoiceMode: vi.fn(async () => {}),
+  stopWingmanVoice: vi.fn(async () => {}),
+}));
+
+vi.mock("../dictation/backgroundSend", () => ({
+  backgroundTranscribeAndSend: vi.fn(),
+}));
+
+const api = await import("../api/client");
+const bg = await import("../dictation/backgroundSend");
+const { useVoiceMode } = await import("./useVoiceMode");
+
+const waitingScreenMock = api.getWaitingScreen as unknown as ReturnType<typeof vi.fn>;
+const voicePromptMock = api.sendVoicePrompt as unknown as ReturnType<typeof vi.fn>;
+const deliverMock = bg.backgroundTranscribeAndSend as unknown as ReturnType<typeof vi.fn>;
+
+const SID = "6f0b8f52-0000-4000-8000-000000000001";
+
+type View = ReturnType<typeof useVoiceMode>;
+
+function Probe({ onReady }: { onReady: (v: View) => void }) {
+  const v = useVoiceMode(SID);
+  onReady(v);
+  return <span data-testid="menu-blocked">{v.menuBlocked ?? ""}</span>;
+}
+
+/** Render the hook and hand back its latest view object. */
+function mount(): { view: () => View } {
+  let latest: View | null = null;
+  render(<Probe onReady={(v) => { latest = v; }} />);
+  return { view: () => latest as unknown as View };
+}
+
+const captured = { blob: new Blob(["x"]), recordedMs: 1200 } as never;
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+  // The refusal is SPOKEN as well as shown - voice mode is hands-free, so a screen-only notice is no
+  // notice at all. Stubbed so the assertion can see it was said.
+  vi.stubGlobal("speechSynthesis", { cancel: vi.fn(), speak: vi.fn() });
+  vi.stubGlobal("SpeechSynthesisUtterance", class { constructor(public text: string) {} });
+  waitingScreenMock.mockReset();
+  voicePromptMock.mockReset();
+  deliverMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the wingman menu guard on a voice reply", () => {
+  it("does not start the audio delivery when a menu owns the screen, and says so out loud", async () => {
+    waitingScreenMock.mockResolvedValue({
+      kind: "menu",
+      canType: false,
+      spoken: "This session is waiting on a menu.",
+      message: "Open it and pick an option.",
+    });
+
+    const { view } = mount();
+    await act(async () => { view().onRespondSendAudio(captured); });
+
+    // THE INVARIANT: the recording never entered the delivery pipeline, so nothing reaches the picker.
+    expect(deliverMock).not.toHaveBeenCalled();
+    expect(view().menuBlocked).toBe("Open it and pick an option.");
+    const synth = (globalThis as unknown as { speechSynthesis: { speak: ReturnType<typeof vi.fn> } }).speechSynthesis;
+    expect(synth.speak).toHaveBeenCalled();
+  });
+
+  it("delivers the audio normally on an ordinary composer", async () => {
+    waitingScreenMock.mockResolvedValue({ kind: "text", canType: true, spoken: "", message: "" });
+
+    const { view } = mount();
+    await act(async () => { view().onRespondSendAudio(captured); });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(view().menuBlocked).toBeNull();
+  });
+
+  it("still delivers when the screen cannot be read at all", async () => {
+    // Phase 1 refuses ONLY on a recognized menu. A screen read that fails outright is uncertainty, not a
+    // menu, and swallowing the recording there would be a far worse regression than the gap it closes.
+    waitingScreenMock.mockRejectedValue(new Error("gateway unreachable"));
+
+    const { view } = mount();
+    await act(async () => { view().onRespondSendAudio(captured); });
+
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(view().menuBlocked).toBeNull();
+  });
+
+  it("surfaces the Gateway's refusal of a typed reply instead of reporting it as sent", async () => {
+    voicePromptMock.mockResolvedValue({
+      sent: false,
+      blockedByMenu: true,
+      spoken: "This session is waiting on a menu.",
+      message: "Open it and pick an option.",
+    });
+
+    const { view } = mount();
+    let sent: boolean | undefined;
+    await act(async () => { sent = await view().onRespondSend("yes go ahead"); });
+
+    // Reported as NOT sent: a caller that navigates away on success must stay put, and the notice must be
+    // on a screen the person is still looking at.
+    expect(sent).toBe(false);
+    expect(view().menuBlocked).toBe("Open it and pick an option.");
+  });
+
+  it("clears the notice when Respond is opened again", async () => {
+    voicePromptMock.mockResolvedValue({
+      sent: false, blockedByMenu: true, spoken: "spoken", message: "Open it and pick an option.",
+    });
+
+    const { view } = mount();
+    await act(async () => { await view().onRespondSend("yes"); });
+    expect(view().menuBlocked).toBe("Open it and pick an option.");
+
+    // They have read it - and may well have gone and answered the menu - so a stale notice would now be
+    // contradicting a screen that has moved on.
+    await act(async () => { view().setResponding(true); });
+    expect(view().menuBlocked).toBeNull();
+  });
+});

--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -74,7 +74,7 @@ public sealed class TerminalPromptInjectionChokepointTests
         var cockpit = File.ReadAllText(Path.Combine(root, "apps", "cockpit", "src", "sessions", "SessionComposer.tsx"));
         var mobileControls = File.ReadAllText(Path.Combine(root, "apps", "mobile", "src", "components", "SessionControls.tsx"));
         // Mobile Voice mode's submit was hoisted into the shared client-core hook (issue #1213), so the
-        // chokepoint assertion follows it there; it still funnels through sendPrompt, never raw terminal input.
+        // chokepoint assertion follows it there; it still funnels through the prompt route, never raw terminal input.
         var mobileVoice = File.ReadAllText(Path.Combine(root, "packages", "client-core", "src", "voice", "useVoiceMode.ts"));
         var interactive = File.ReadAllText(Path.Combine(root, "packages", "client-core", "src", "terminal", "interactive.ts"));
         var gateway = File.ReadAllText(Path.Combine(root, "src", "CcDirector.Gateway", "Api", "GatewayEndpoints.cs"));
@@ -87,7 +87,13 @@ public sealed class TerminalPromptInjectionChokepointTests
         Assert.Contains("await sendPrompt(sessionId, text, true);", cockpit);
         Assert.Contains("await sendPrompt(sessionId, text, true);", mobileControls);
         Assert.Contains("await sendPrompt(sessionId, combined, true);", mobileControls);
-        Assert.Contains("await sendPrompt(sid, trimmed, true);", mobileVoice);
+        // The voice reply moved to sendVoicePrompt (issue #2193). The CHOKEPOINT is unchanged and that is
+        // what this pins: it is still the prompt route with Enter appended, never raw terminal input - the
+        // only difference is that the Gateway is asked to refuse the send outright when a menu owns the
+        // screen. Both halves are pinned: the call site here, and (below) that the call it makes is the
+        // prompt route carrying menuGuard.
+        Assert.Contains("await sendVoicePrompt(sid, trimmed);", mobileVoice);
+        Assert.Contains("const body: PromptRequest & { menuGuard: boolean } = { text, appendEnter: true, menuGuard: true };", client);
 
         Assert.Contains("await sendPrompt(this.sessionId, chunk, false);", interactive);
         // Raw browser keystrokes go through the terminal-input verb, which calls SendInput (no submit/Enter).

--- a/src/CcDirector.Gateway.Contracts/PromptRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/PromptRequest.cs
@@ -55,6 +55,20 @@ public sealed class PromptRequest
     /// operator prompt.
     /// </summary>
     public string? DeliveryUploadId { get; set; }
+
+    /// <summary>
+    /// Wingman menu guard (issue #2193). When true, the GATEWAY reads the session's live screen immediately
+    /// before forwarding this prompt and REFUSES to send it if a menu owns that screen - answering
+    /// <see cref="PromptResponse.BlockedByMenu"/> instead. Typing a spoken sentence into an on-screen picker
+    /// achieves nothing, and because voice replies carry <see cref="AppendEnter"/> the trailing Enter would
+    /// CONFIRM whichever option happened to be highlighted - a selection the person never made and is never
+    /// told about.
+    ///
+    /// Opt-in and off by default, so the typed composer, the Chat send, and every fleet/automation caller are
+    /// completely unchanged. Only the voice reply paths set it. It is a GATEWAY field: it is consumed there
+    /// and never forwarded, so the Director's own prompt verb sees exactly what it always saw.
+    /// </summary>
+    public bool MenuGuard { get; set; }
 }
 
 /// <summary>
@@ -82,6 +96,18 @@ public sealed class PromptResponse
 
     /// <summary>Error message if Accepted == false.</summary>
     public string? Error { get; set; }
+
+    /// <summary>
+    /// Wingman menu guard (issue #2193): true when this prompt was NOT sent because a menu owns the session's
+    /// live screen and the caller asked for <see cref="PromptRequest.MenuGuard"/>. Nothing was typed and no
+    /// Enter was pressed. This is a REFUSAL, not a failure - it rides a 200 with <see cref="Accepted"/> false,
+    /// because the caller asked for exactly this behaviour and there is nothing to retry.
+    /// </summary>
+    public bool BlockedByMenu { get; set; }
+
+    /// <summary>The line to SPEAK when <see cref="BlockedByMenu"/> is true - the wingman is hands-free, so the
+    /// refusal has to reach the ear, not just a screen. Empty otherwise.</summary>
+    public string? BlockedSpoken { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/WingmanMenuGuardProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuGuardProofTests.cs
@@ -1,0 +1,336 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The wingman MENU GUARD (issue #2193), proven end-to-end against a REAL streamMode
+/// <see cref="GatewayHost"/> over the tunnel. Two claims are pinned here, and both are about what actually
+/// reaches the terminal - every dispatched command is recorded, so a test proves exactly what did and did
+/// not get sent:
+///
+///   1. A prompt sent WITH the guard is REFUSED when a menu owns the live screen. Nothing is typed and no
+///      Enter is pressed. This matters more than it sounds: a voice reply always carries AppendEnter, so a
+///      reply typed at a picker would confirm whichever option happened to be highlighted - a selection the
+///      person never made and is never told about.
+///   2. The guard is OPT-IN and changes nothing else. A prompt sent WITHOUT it is forwarded even on a menu,
+///      and the Gateway does not so much as read the screen - so the typed composer, the Chat send, and
+///      every automation caller pay neither the behaviour change nor the extra tunnel read.
+///
+/// Phase 1 refuses ONLY on a confidently-recognized menu. An unreadable screen forwards, exactly as it did
+/// before the guard existed - proven below, because getting that wrong would silently break ordinary voice
+/// replies, which is far worse than the gap it would close.
+///
+/// No wingman brain is configured in this harness. The waiting-screen endpoint answering correctly is
+/// therefore also the proof that it makes no model call - a brain call here would fail.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class WingmanMenuGuardProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-menu-guard-proof";
+    private const string DirectorId = "dir-menu-guard";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-mgproof-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Every command the Gateway dispatched over the tunnel, in order (thread-safe).</summary>
+    private readonly ConcurrentQueue<DirectorCommand> _commands = new();
+
+    /// <summary>The per-test verb dispatcher; set by each test before it drives the endpoint.</summary>
+    private Func<DirectorCommand, DirectorCommandResult> _dispatch =
+        cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+    public WingmanMenuGuardProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-mgproof-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59926/", // nothing listens here
+            MachineName = Environment.MachineName,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", cmd =>
+        {
+            _commands.Enqueue(cmd);
+            return _dispatch(cmd);
+        });
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    private Task PushAsync(long sequence, params SessionDto[] sessions) =>
+        _conn.InvokeAsync("PushSnapshot", sequence, sessions);
+
+    private static DirectorCommandResult Ok(object body) =>
+        DirectorCommandResult.Success(JsonSerializer.Serialize(body, Web));
+
+    private async Task<string> PushSessionAsync()
+    {
+        var sid = Guid.NewGuid().ToString();
+        await PushAsync(1L, new SessionDto
+        {
+            SessionId = sid,
+            Name = "a voice session",
+            Status = "WaitingForInput",
+            ActivityState = "WaitingForInput",
+            RepoPath = @"D:\repo",
+        });
+        return sid;
+    }
+
+    private List<PromptRequest> DispatchedPrompts()
+    {
+        var prompts = new List<PromptRequest>();
+        foreach (var cmd in _commands)
+            if (cmd.Verb == "prompt")
+            {
+                var req = JsonSerializer.Deserialize<PromptRequest>(cmd.PayloadJson ?? "{}", Web);
+                if (req is not null) prompts.Add(req);
+            }
+        return prompts;
+    }
+
+    // A real Claude permission menu drawn with its selection marker. Like the real Ink picker, the hardware
+    // cursor is HIDDEN and its cell is stale - the menu is owned by the drawn marker.
+    private static ScreenGridResponse MenuGrid(string sid) => new()
+    {
+        SessionId = sid,
+        Rows = new List<string> { "Do you want to proceed?", "❯ 1. Yes", "  2. No" },
+        CursorRow = 0,
+        CursorCol = -1,
+        CursorVisible = false,
+        IsAlternateScreen = true,
+        HasGrid = true,
+    };
+
+    // A Claude composer, VISIBLE cursor in the empty input box (row 2), framed by box borders and a footer.
+    private static ScreenGridResponse ComposerGrid(string sid) => new()
+    {
+        SessionId = sid,
+        Rows = new List<string>
+        {
+            "I finished the change. What next?",
+            "╭──────────────────────────────────────╮",
+            "│ >                                     │",
+            "╰──────────────────────────────────────╯",
+            "  ? for shortcuts",
+        },
+        CursorRow = 2,
+        CursorCol = 4,
+        CursorVisible = true,
+        IsAlternateScreen = false,
+        HasGrid = true,
+    };
+
+    private static PromptResponse AcceptedPrompt() => new()
+    {
+        Accepted = true,
+        SentAt = DateTime.UtcNow,
+        BufferCursor = 0,
+        ActivityState = "Working",
+    };
+
+    // ===================== The guard: a menu refuses, and NOTHING reaches the terminal =====================
+
+    [Fact]
+    public async Task Prompt_WithMenuGuard_MenuOnScreen_RefusesAndSendsNothing()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(MenuGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/prompt",
+            new { text = "yes go ahead", appendEnter = true, menuGuard = true });
+
+        // A refusal is a normal 200 outcome, not a failure: the caller asked for exactly this behaviour and
+        // there is nothing to retry.
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["blockedByMenu"]?.GetValue<bool>());
+        Assert.False(node?["accepted"]?.GetValue<bool>());
+        // The refusal has to reach the EAR - voice mode is hands-free, so a screen-only notice is no notice.
+        Assert.False(string.IsNullOrWhiteSpace(node?["blockedSpoken"]?.GetValue<string>()));
+
+        // THE INVARIANT: nothing was typed and no Enter was pressed.
+        Assert.Empty(DispatchedPrompts());
+        Assert.Contains(_commands, c => c.Verb == "screen-grid");
+    }
+
+    // ===================== A composer is forwarded exactly as before =====================
+
+    [Fact]
+    public async Task Prompt_WithMenuGuard_ComposerOnScreen_ForwardsThePrompt()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(ComposerGrid(sid)),
+            "prompt" => Ok(AcceptedPrompt()),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/prompt",
+            new { text = "add a retry to the upload path", appendEnter = true, menuGuard = true });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["accepted"]?.GetValue<bool>());
+
+        var sent = Assert.Single(DispatchedPrompts());
+        Assert.Equal("add a retry to the upload path", sent.Text);
+        Assert.True(sent.AppendEnter);
+    }
+
+    // ===================== Unreadable is NOT a menu: phase 1 changes nothing there =====================
+
+    [Fact]
+    public async Task Prompt_WithMenuGuard_UnreadableScreen_StillForwardsThePrompt()
+    {
+        // The owning Director cannot answer the screen read. That is UNCERTAINTY, not a menu. Phase 1
+        // deliberately forwards here: refusing on uncertainty would silently break ordinary voice replies on
+        // any screen the classifier cannot positively resolve, which is worse than the gap it would close.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no grid"),
+            "prompt" => Ok(AcceptedPrompt()),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/prompt",
+            new { text = "carry on", appendEnter = true, menuGuard = true });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var sent = Assert.Single(DispatchedPrompts());
+        Assert.Equal("carry on", sent.Text);
+    }
+
+    // ===================== The guard is opt-in: without it, nothing changes at all =====================
+
+    [Fact]
+    public async Task Prompt_WithoutMenuGuard_MenuOnScreen_ForwardsAndNeverReadsTheScreen()
+    {
+        // Every existing caller - the typed composer, the Chat send, the fleet relay - sends without the
+        // guard. They must be byte-for-byte unaffected: the prompt goes through even on a menu, and the
+        // Gateway does not spend a tunnel read finding out what the screen is.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb switch
+        {
+            "screen-grid" => Ok(MenuGrid(sid)),   // available, but must never be asked for
+            "prompt" => Ok(AcceptedPrompt()),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+
+        var resp = await _http.PostAsJsonAsync($"sessions/{sid}/prompt",
+            new { text = "1", appendEnter = true });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var sent = Assert.Single(DispatchedPrompts());
+        Assert.Equal("1", sent.Text);
+        Assert.DoesNotContain(_commands, c => c.Verb == "screen-grid");
+    }
+
+    // ===================== The cheap read the voice paths ask before a background send =====================
+
+    [Fact]
+    public async Task WaitingScreen_MenuOnScreen_SaysMenuAndCannotType()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(MenuGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+        var resp = await _http.GetAsync($"sessions/{sid}/wingman/waiting-screen");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("menu", node?["kind"]?.GetValue<string>());
+        Assert.False(node?["canType"]?.GetValue<bool>());
+        Assert.False(string.IsNullOrWhiteSpace(node?["spoken"]?.GetValue<string>()));
+        Assert.False(string.IsNullOrWhiteSpace(node?["message"]?.GetValue<string>()));
+
+        // Read-only: asking what the screen is must never type into the session.
+        Assert.Empty(DispatchedPrompts());
+    }
+
+    [Fact]
+    public async Task WaitingScreen_ComposerOnScreen_SaysTextAndCanType()
+    {
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => cmd.Verb == "screen-grid"
+            ? Ok(ComposerGrid(sid))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+        var resp = await _http.GetAsync($"sessions/{sid}/wingman/waiting-screen");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("text", node?["kind"]?.GetValue<string>());
+        Assert.True(node?["canType"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public async Task WaitingScreen_UnreadableScreen_SaysBlockedButStillAllowsTyping()
+    {
+        // "blocked" is the honest report of an unreadable screen - but phase 1 still lets a reply through,
+        // so canType stays true. Only a recognized menu refuses.
+        var sid = await PushSessionAsync();
+        _dispatch = cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no grid");
+
+        var resp = await _http.GetAsync($"sessions/{sid}/wingman/waiting-screen");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("blocked", node?["kind"]?.GetValue<string>());
+        Assert.True(node?["canType"]?.GetValue<bool>());
+        Assert.Equal("", node?["spoken"]?.GetValue<string>());
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1853,6 +1853,32 @@ internal static class GatewayEndpoints
 
             FileLog.Write($"[GatewayEndpoints] POST prompt: sid={sid}, director={director.DirectorId}, waitForIdle={req.WaitForIdle}");
 
+            // THE WINGMAN MENU GUARD (issue #2193), opt-in per request and off for every existing caller.
+            // A voice reply asks for it, so the live screen is read HERE - one hop before the send - rather
+            // than by the client, which would leave a window for the screen to change between the check and
+            // the send. On a menu we type nothing and press nothing: the trailing Enter this prompt carries
+            // would otherwise confirm whatever option the picker had highlighted.
+            //
+            // Only a CONFIDENTLY-recognized menu refuses. A screen the classifier cannot read is forwarded
+            // exactly as it was before this guard existed - blocking on uncertainty would silently break
+            // ordinary voice replies, which is worse than the gap it would close.
+            if (req.MenuGuard)
+            {
+                var guardRoute = new SessionVerbClient(director, sendCommand);
+                if (await Wingman.WaitingScreenReader.IsMenuAsync(guardRoute, sid, CancellationToken.None))
+                {
+                    FileLog.Write($"[GatewayEndpoints] POST prompt: sid={sid} REFUSED - a menu owns the live screen (menu guard); nothing typed, no Enter pressed");
+                    return Results.Json(new PromptResponse
+                    {
+                        Accepted = false,
+                        BlockedByMenu = true,
+                        BlockedSpoken = Wingman.WaitingScreenReader.MenuSpoken,
+                        Error = Wingman.WaitingScreenReader.MenuMessage,
+                        ActivityState = session.ActivityState,
+                    });
+                }
+            }
+
             // Post-cut: tunnel-only. A null result means the Director is not connected -> 502. The WaitForIdle
             // poll below is unchanged - it observes the session regardless of how the prompt was delivered.
             bool ok; PromptResponse? body; string? err;

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -785,6 +785,35 @@ internal static class GatewayWingmanVoiceEndpoint
             return Results.Json(MenuJson(menu));
         });
 
+        // Phase 1 menu handling (issue #2193): the CHEAP "what is this session waiting on right now?" read.
+        // Pure - one tunnel screen-grid read and the no-brain classifier, NO model call and no cost - which is
+        // what makes it usable before every spoken reply. The richer GET /wingman/menu above cannot serve this
+        // purpose: it calls the brain to extract option labels, which is both slow and billable.
+        // Returns { kind: "menu"|"text"|"blocked", canType, spoken, message }.
+        app.MapGet("/sessions/{sid}/wingman/waiting-screen", async (string sid, HttpContext ctx, CancellationToken ct) =>
+        {
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            if (!Guid.TryParse(sid, out _))
+                return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
+            var route = await ResolveRouteAsync(reqTenant.Value, sid);
+            if (route is null)
+                return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
+
+            var kind = await WaitingScreenReader.ClassifyAsync(route, sid, ct);
+            FileLog.Write($"[GatewayWingmanVoice] waiting-screen(pure) sid={sid}: {kind}");
+            return Results.Json(new
+            {
+                kind = WaitingScreenReader.KindWord(kind),
+                // Phase 1 blocks ONLY on a confidently-recognized menu, so an unreadable screen still reports
+                // canType - it keeps behaving exactly as it did before this guard existed.
+                canType = kind != WaitingScreenKind.Menu,
+                spoken = kind == WaitingScreenKind.Menu ? WaitingScreenReader.MenuSpoken : "",
+                message = kind == WaitingScreenKind.Menu ? WaitingScreenReader.MenuMessage : "",
+            });
+        });
+
         // NOTE (issue #1777, floor rescope): the raw POST /wingman/menu-press endpoint - which pressed menu
         // keystrokes into a session - was REMOVED. Nothing on this branch ever presses a key into a session.
         // Pressing menu options (fully hands-free voice-answering) is its own later issue, built with per-agent
@@ -917,17 +946,11 @@ internal static class GatewayWingmanVoiceEndpoint
     private static async Task<(WaitingScreenKind Kind, string BlockedSpoken)> ClassifyLiveScreenAtAsync(
         SessionVerbClient route, string sid, CancellationToken ct)
     {
-        Contracts.ScreenGridResponse? grid;
-        try { grid = await route.GetScreenGridAsync(sid, ct); }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayWingmanVoice] classify sid={sid}: screen-grid read threw ({ex.Message}) - fail closed");
-            return (WaitingScreenKind.Blocked, BlockedUnreadableSpoken);
-        }
-        if (grid is null)
-            return (WaitingScreenKind.Blocked, BlockedUnreadableSpoken);
-
-        var kind = WaitingScreenClassifier.Classify(grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
+        // The read-and-classify step itself lives in ONE place (issue #2193) so this endpoint, the prompt
+        // front door's menu guard, and the narration generator can never drift on what counts as a menu.
+        // The WORDING stays here, because this path fails closed on an unreadable screen too and therefore
+        // has a second thing to say; the guard refuses only on a menu and has one.
+        var kind = await WaitingScreenReader.ClassifyAsync(route, sid, ct);
         // A menu says "look at the terminal"; everything else uncertain says the generic unreadable line.
         var spoken = kind == WaitingScreenKind.Menu ? BlockedMenuSpoken : BlockedUnreadableSpoken;
         return (kind, spoken);

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenReader.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenReader.cs
@@ -1,0 +1,82 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// Reads a session's LIVE screen over the tunnel and classifies it with the pure
+/// <see cref="WaitingScreenClassifier"/> (issue #2193). This is the ONE place that read-and-classify
+/// step lives, so every surface that has to know "is this session sitting on a menu right now?" asks
+/// the same question and gets the same answer: the wingman voice endpoint, the prompt front door's
+/// menu guard, and the narration generator.
+///
+/// It costs one tunnel read and NO model call - the classifier is pure. That is what makes it usable
+/// on the send path (where a model call would add seconds to every spoken reply) and on the narration
+/// path (where it must not add provider cost to a turn).
+///
+/// Fail-closed is inherited from the classifier: an unreadable, blank, or ambiguous screen resolves to
+/// <see cref="WaitingScreenKind.Blocked"/>, never to a menu and never to a typeable composer.
+/// </summary>
+internal static class WaitingScreenReader
+{
+    /// <summary>
+    /// What the wingman says when it will not answer because a menu owns the screen. The person is in
+    /// voice mode - possibly driving - so this states the situation and the ONE thing that unblocks it,
+    /// with no jargon and no option numbers (phase 1 does not read the options aloud).
+    /// </summary>
+    public const string MenuSpoken =
+        "This session is waiting on a menu, and I can't pick an option for you yet. "
+        + "Open the session in the Cockpit or on your machine and choose one, then I can carry on from here.";
+
+    /// <summary>The short line for a card or a toast - the same fact as <see cref="MenuSpoken"/>, sized
+    /// for a screen rather than a speaker.</summary>
+    public const string MenuMessage =
+        "This session is waiting on a menu. Open it in the Cockpit or on your machine and pick an option - "
+        + "voice can't answer a menu yet.";
+
+    /// <summary>The sentence appended to a turn's spoken narration when the turn ended on a menu, so the
+    /// person hears it as the turn is read out instead of discovering it when their reply goes nowhere.</summary>
+    public const string MenuNarrationSuffix =
+        " Heads up - this session is now waiting on a menu, so you'll need to open it and pick an option; I can't answer that by voice yet.";
+
+    /// <summary>
+    /// Read the live screen grid for <paramref name="sid"/> and classify it. A read that throws, or that
+    /// the owning Director does not answer, is <see cref="WaitingScreenKind.Blocked"/> - unreadable is
+    /// never mistaken for either a menu or a composer.
+    /// </summary>
+    public static async Task<WaitingScreenKind> ClassifyAsync(
+        SessionVerbClient route, string sid, CancellationToken ct = default)
+    {
+        ScreenGridResponse? grid;
+        try { grid = await route.GetScreenGridAsync(sid, ct); }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: screen-grid read threw ({ex.Message}) - treating as unreadable");
+            return WaitingScreenKind.Blocked;
+        }
+        if (grid is null)
+            return WaitingScreenKind.Blocked;
+
+        return WaitingScreenClassifier.Classify(
+            grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
+    }
+
+    /// <summary>
+    /// True when the live screen is CONFIDENTLY a menu. This - not "not a composer" - is the phase 1 gate:
+    /// only a positively recognized menu blocks a voice reply, so a screen the classifier merely cannot
+    /// read keeps behaving exactly as it did before the guard existed. Blocking on unreadable too would be
+    /// the stricter rule, but it would silently break ordinary voice replies, which is a worse outcome than
+    /// the gap it would close.
+    /// </summary>
+    public static async Task<bool> IsMenuAsync(SessionVerbClient route, string sid, CancellationToken ct = default)
+        => await ClassifyAsync(route, sid, ct) == WaitingScreenKind.Menu;
+
+    /// <summary>The wire word for a classified screen: what the phone and the Cockpit read.</summary>
+    public static string KindWord(WaitingScreenKind kind) => kind switch
+    {
+        WaitingScreenKind.Menu => "menu",
+        WaitingScreenKind.PlainText => "text",
+        _ => "blocked",
+    };
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -865,15 +865,27 @@ public sealed class WingmanVoiceService
                 FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); the session retries on its own");
                 return false;   // nothing produced; the provider was not usefully reached
             }
-            await StoreSpokenAsync(tenant, sid, t.Spoken, lastReply, ct);
+            // Announce a waiting menu AS THE TURN IS READ (issue #2193). A turn that ends on a picker is the
+            // one case where the narration alone is misleading: the agent's words are read out, the person
+            // answers by voice, and the answer goes nowhere - because voice cannot pick an option yet. So the
+            // live screen is read once here (pure classifier, NO model call) and the fact is spoken with the
+            // turn, before they try to reply. One extra tunnel read per NARRATION - deliberately not added to
+            // the session poll, so this costs nothing per-poll across a fleet.
+            var spoken = t.Spoken;
+            if (await WaitingScreenReader.IsMenuAsync(route, sid, ct))
+            {
+                spoken += WaitingScreenReader.MenuNarrationSuffix;
+                FileLog.Write($"[WingmanVoiceService] narration announces a waiting menu: sid={sid}");
+            }
+            await StoreSpokenAsync(tenant, sid, spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
             // text-to-speech synthesis actually returned audio. Logging "voice ready"
             // unconditionally (the old behavior) hid every failed synthesis behind a success
             // line, which made a text-to-speech outage look like it was working in the log.
             if (HasVoice(tenant, sid))
-                FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
+                FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={spoken.Length}");
             else
-                FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={t.Spoken.Length}");
+                FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={spoken.Length}");
             // The model leg ran and answered - TranslateAsync returned rather than throwing
             // WingmanModelRateLimitedException. Reported as true purely so the return honestly says the
             // provider was reached (no caller acts on it now that the shared gate is gone).


### PR DESCRIPTION
Closes #2193.

## What was broken

When a coding agent stopped on an on-screen menu - a permission prompt, an
AskUserQuestion picker, any numbered chooser - voice mode had no idea. It typed the
spoken words into the picker and pressed Enter anyway.

Worse than useless: a voice reply is sent with `appendEnter`, so the Enter landed on the
picker and **confirmed whichever option happened to be highlighted**. A selection the
person never made, that they were never told about.

The fail-closed machinery from #1777 was already built, tested and correct - it was just
on a path nothing calls. `getWingmanMenu` / `pressWingmanMenu` are exported from
client-core and imported by nothing; the only hit for `voice-turn` in any `.ts`/`.tsx`
file is the generated `schema.ts`. What the Voice surfaces actually do is
`sendPrompt` -> `POST /sessions/{sid}/prompt`, with no look at the screen at all.

## What this does - phase 1: detect and refuse

It does NOT answer menus by voice. That is phase 2, and it should not be designed until
detection is proven in the real product. This makes the wingman honest about them.

- **`WaitingScreenReader`** - the read-and-classify step in ONE place, so the voice
  endpoint, the prompt guard and the narration generator can never drift on what counts
  as a menu. One tunnel read, no model call, no cost. `GatewayWingmanVoiceEndpoint`'s own
  copy now delegates to it.
- **`GET /sessions/{sid}/wingman/waiting-screen`** - the cheap read:
  `{ kind, canType, spoken, message }`. Pure classifier. (The existing `/wingman/menu`
  could not serve this - it calls the brain to extract option labels.)
- **A menu guard on `POST /sessions/{sid}/prompt`**, opt-in via `menuGuard`. The Gateway
  reads the live screen one hop before forwarding; on a menu it types nothing, presses
  nothing, and answers `blockedByMenu` with a line to speak. The guard is on the Gateway
  rather than the client so there is no window for the screen to change between the check
  and the send.
- **Both voice reply paths use it** - the text Send through the guard, and the mobile
  audio Send through a pre-check before the fire-and-forget pipeline starts (the only
  moment at which a refusal can still reach a person who is about to walk away). The
  refusal is spoken as well as shown, because voice mode is hands-free and a screen-only
  notice is no notice.
- **The narration announces it** - a turn that ends on a menu is read out with a closing
  sentence saying so, before they try to reply. One extra read per narration, deliberately
  not added to the session poll, so it costs nothing per-poll across a fleet.

## Only a confident menu blocks

`Blocked` (unreadable, blank, ambiguous) and `PlainText` both send exactly as they do
today. Refusing on uncertainty would be the stricter guard, but it would silently break
ordinary voice replies on any screen the classifier cannot positively resolve - a worse
regression than the gap it closes. Proven both server-side and client-side below.

## Proof

Gateway - `WingmanMenuGuardProofTests`, end-to-end against a real streamMode
`GatewayHost` over the tunnel, asserting on the commands that actually reached the
terminal:

- menu + guard -> refused, **zero prompts dispatched**, a spoken line returned
- composer + guard -> forwarded with the right text and `appendEnter`
- unreadable + guard -> forwarded (phase 1 changes nothing there)
- **no guard + menu -> forwarded, and the screen is never even read** - so the typed
  composer, the Chat send and every automation caller pay neither the behaviour change
  nor the extra tunnel read
- the waiting-screen read reports menu / text / blocked correctly, and types nothing

Client - `voiceMenuGuard.test.tsx`: the audio Send does not enter the delivery pipeline
on a menu and the refusal is spoken; it delivers normally on a composer; it still delivers
when the screen read fails outright; a refused text Send reports NOT sent; the notice
clears when Respond reopens.

Both guards were revert-proved: removing the real production line makes the corresponding
test fail, and restoring it makes it pass.

Suites: Gateway tests, client-core 694, cockpit 194, typecheck clean on all three web
workspaces, mobile + cockpit production builds green.

## Not in this change

Answering a menu by voice - mapping speech to an option, pressing the keystroke, per-agent
picker profiles, and the screen-version lock that makes a press safe. Phase 2, separate
issue, after this one has been used in anger.
