### PR TITLE
fix(schedule): refuse to write a cron job to a tenant you are not pointed at (#2201)

### DIFF
--- a/tools/cc-devthrottle/src/schedule_ops.py
+++ b/tools/cc-devthrottle/src/schedule_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -18,7 +19,7 @@ _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
-from cc_shared.config import CCDirectorConfig  # noqa: E402
+from cc_shared.config import CCDirectorConfig, get_config_path  # noqa: E402
 
 LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
 TIMEOUT_SECONDS = 10
@@ -158,7 +159,86 @@ def _fail(message: str) -> None:
     raise typer.Exit(1)
 
 
+def _director_ports_in_this_root() -> List[int]:
+    """The Control API ports of the Directors registered in the root we are about to read.
+
+    Each data root records one <director-id>.port file per Director it owns, so this is the
+    cheapest local way to ask "does the Director the caller is pointing at actually belong
+    to the configuration I am about to use?".
+    """
+    # config.json's own directory IS the root's config dir, so this follows
+    # CC_DIRECTOR_ROOT exactly as the Gateway address and token do.
+    ports_dir = get_config_path().parent / "director" / "ports"
+    if not ports_dir.is_dir():
+        return []
+    found: List[int] = []
+    for entry in ports_dir.glob("*.port"):
+        try:
+            found.append(int(entry.read_text(encoding="utf-8").strip()))
+        except (OSError, ValueError):
+            continue
+    return found
+
+
+def assert_scope_is_unambiguous() -> None:
+    """Refuse when the caller is pointed at a Director this configuration does not own.
+
+    Issue #2201. Two different environment variables steer two halves of cc-devthrottle,
+    and neither implies the other:
+
+      CC_DIRECTOR_API   the Director Control API - session, message and mission commands
+      CC_DIRECTOR_ROOT  the data root, and so config.json - which is where the SCHEDULE
+                        commands read the Gateway address and, critically, the Gateway
+                        TOKEN that decides WHICH TENANT is written
+
+    So `CC_DIRECTOR_API=<an isolated Director> cc-devthrottle schedule create ...` scopes
+    the session half and silently leaves the schedule half reading the DEFAULT root - which
+    on a normal machine is the owner's real fleet. It then SUCCEEDS, returns a real id, and
+    prints a confirmation. That is how two jobs were written to the owner's live fleet on
+    2026-07-26 while working against an isolated demo Director.
+
+    THE TEST IS A MISMATCH, NOT MERE PRESENCE. Every agent running inside a DevThrottle
+    session has CC_DIRECTOR_API set, pointing at the owner's own Director, and that is the
+    normal case which must keep working. So this refuses only on POSITIVE EVIDENCE that the
+    two disagree: this root records which Directors it owns, and the port the caller is
+    aimed at is not one of them. When the root records no ports at all there is nothing to
+    contradict, and we do not block on an absence of evidence.
+
+    Failing here is deliberate. A scheduled job runs an agent unattended in a working
+    directory, so landing one on the wrong tenant is not a display bug, and there is no safe
+    default to guess once the caller has expressed two different intentions.
+
+    Note that `--gateway` does NOT resolve the ambiguity: it overrides the ADDRESS while the
+    token still comes from config, and on the shared hosted Gateway it is the token that
+    selects the tenant. So the guard is checked regardless of any override.
+    """
+    api = os.environ.get("CC_DIRECTOR_API", "").strip()
+    if not api:
+        return
+    port = urlparse(api).port
+    if port is None:
+        return
+    known = _director_ports_in_this_root()
+    if not known or port in known:
+        return
+
+    root = os.environ.get("CC_DIRECTOR_ROOT", "").strip() or "the default root"
+    _fail(
+        f"CC_DIRECTOR_API points at a Director on port {port}, but {root} owns "
+        f"{', '.join(str(p) for p in sorted(known))}.\n\n"
+        "  Schedule commands read the Gateway address and token from config.json, which "
+        "lives under CC_DIRECTOR_ROOT - CC_DIRECTOR_API does not redirect them. Running "
+        "anyway would write to whichever account THIS root is signed in as, which is not "
+        "the Director you are pointing at.\n\n"
+        "  Set CC_DIRECTOR_ROOT to that Director's own data root and run it again, for "
+        "example:\n"
+        "      CC_DIRECTOR_ROOT=D:\\demo\\_root cc-devthrottle schedule list\n\n"
+        "  If you did mean this root's fleet, unset CC_DIRECTOR_API for this command."
+    )
+
+
 def _client() -> ScheduleClient:
+    assert_scope_is_unambiguous()
     return ScheduleClient(base_url=gateway_override)
 
 
@@ -348,6 +428,10 @@ def create_job(
     console.print(f"  Id:        {_fmt(created.get('id'))}")
     console.print(f"  Name:      {_fmt(created.get('name'))}")
     console.print(f"  Next run:  {_fmt(created.get('nextRunUtc'))} UTC")
+    # Say WHERE it landed. A scheduled job runs an agent unattended, so "which fleet did
+    # that just go to" must be answerable from this output rather than by cross-checking
+    # `schedule list` afterwards and recognising somebody else's jobs (issue #2201).
+    console.print(f"  Gateway:   {gateway_override or resolve_base_url()}")
 
 
 def run_now(job_id: str, json_output: bool) -> None:

--- a/tools/cc-devthrottle/tests/test_schedule_ops.py
+++ b/tools/cc-devthrottle/tests/test_schedule_ops.py
@@ -10,10 +10,14 @@ import requests
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+import typer  # noqa: E402
+
 from src.schedule_ops import (  # noqa: E402
     LOOPBACK_DEFAULT,
     GatewayError,
     ScheduleClient,
+    _client,
+    assert_scope_is_unambiguous,
     resolve_base_url,
 )
 
@@ -171,3 +175,55 @@ class TestEnableDisable:
         assert second_url == "http://127.0.0.1:7878/cron/jobs/job-9"
         assert req.call_args_list[1].kwargs["json"]["enabled"] is False
         assert result["enabled"] is False
+
+
+class TestScopeGuard:
+    """Issue #2201: refuse when the caller is aimed at a Director this root does not own.
+
+    CC_DIRECTOR_API steers the session commands; CC_DIRECTOR_ROOT steers config.json, and so
+    the Gateway token that selects the TENANT the schedule commands write to. Setting only the
+    first used to succeed against the owner's real fleet and print a confirmation.
+
+    Every test here patches the recorded ports rather than reading the machine's own, so the
+    outcome is decided by the case under test and not by whatever Directors happen to be
+    installed on the box running the suite.
+    """
+
+    @staticmethod
+    def _with_ports(ports):
+        return patch("src.schedule_ops._director_ports_in_this_root", return_value=ports)
+
+    def test_refuses_when_aimed_at_a_director_this_root_does_not_own(self, monkeypatch):
+        monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:7880")
+        with self._with_ports([7879]):
+            with pytest.raises(typer.Exit):
+                assert_scope_is_unambiguous()
+
+    def test_allows_the_director_this_root_does_own(self, monkeypatch):
+        """The normal case: an agent inside a session, pointed at its own Director."""
+        monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:7879")
+        with self._with_ports([7879]):
+            assert assert_scope_is_unambiguous() is None
+
+    def test_allows_when_the_root_records_no_ports(self, monkeypatch):
+        """No recorded ports is an absence of evidence, not evidence of a mismatch."""
+        monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:7880")
+        with self._with_ports([]):
+            assert assert_scope_is_unambiguous() is None
+
+    def test_allows_when_director_api_is_unset(self, monkeypatch):
+        monkeypatch.delenv("CC_DIRECTOR_API", raising=False)
+        with self._with_ports([7879]):
+            assert assert_scope_is_unambiguous() is None
+
+    def test_allows_a_director_api_with_no_port(self, monkeypatch):
+        monkeypatch.setenv("CC_DIRECTOR_API", "not-a-url")
+        with self._with_ports([7879]):
+            assert assert_scope_is_unambiguous() is None
+
+    def test_the_guard_is_wired_into_every_command(self, monkeypatch):
+        """_client() is the single choke point every schedule command goes through."""
+        monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:7880")
+        with self._with_ports([7879]):
+            with pytest.raises(typer.Exit):
+                _client()


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#2201.

## The problem

The CLI has two steering wheels that do not talk to each other:

| | steers |
|---|---|
| `CC_DIRECTOR_API` | the Director Control API - `session`, `message`, `mission` |
| `CC_DIRECTOR_ROOT` | the data root, and so `config.json` - where the **schedule** commands read the Gateway address and the Gateway **token** |

On the shared hosted Gateway it is the token that selects the tenant. So pointing
`CC_DIRECTOR_API` at an isolated Director scoped the session half and silently left the
schedule half reading the default root. `schedule create` then SUCCEEDED against the owner's
real fleet, returned a real id, and printed a confirmation.

That happened on 2026-07-26: two cron jobs were written to the owner's live fleet while
working against an isolated demo Director. They were noticed only because a later
`schedule list` showed somebody else's jobs, and were deleted before either fired.

A scheduled job runs an agent unattended in a working directory, so landing one on the wrong
tenant is not a display bug. thefrederiksen/devthrottle_internal#948 is the same root cause in the email command, where it fails
safely with a 401; here it failed dangerously, by succeeding.

## The fix

Every schedule command passes through `_client()`, so the guard goes there once. It refuses
when the Director being pointed at is not one this root owns, and names what to set.

```
Error: CC_DIRECTOR_API points at a Director on port 7880, but the default root owns 7879.

  Schedule commands read the Gateway address and token from config.json, which lives under
  CC_DIRECTOR_ROOT - CC_DIRECTOR_API does not redirect them. Running anyway would write to
  whichever account THIS root is signed in as, which is not the Director you are pointing at.

  Set CC_DIRECTOR_ROOT to that Director's own data root and run it again...
```

`schedule create` now also prints the Gateway it wrote to, so "which fleet did that land on"
is answerable from the output rather than by recognising other people's jobs in a later list.

## The design call worth reviewing

**The test is a mismatch, not mere presence.** The first cut refused whenever
`CC_DIRECTOR_API` was set without `CC_DIRECTOR_ROOT`. The suite caught it immediately: every
agent running inside a DevThrottle session has `CC_DIRECTOR_API` set, so that version would
have broken schedule commands for the entire fleet.

Each data root records the Control API ports of the Directors it owns
(`config/director/ports/*.port`), so the guard compares against that list and refuses only on
positive evidence of a conflict. A root recording no ports is an absence of evidence, not
evidence of a conflict, and does not block.

Note `--gateway` does not resolve the ambiguity: it overrides the address while the token
still comes from config, so the guard is checked regardless of any override.

## Verification

111 tests pass. Five new tests cover the guard and patch the recorded ports rather than
reading the machine's, so the suite decides the outcome rather than whatever Directors happen
to be installed on the box running it.

Driven against the real CLI on one machine, three ways:

| Case | Result |
|---|---|
| The command that caused the incident (`API=7880`, default root) | **Refused** |
| Normal in-session use (`API=7879`, default root) | Proceeds - lists the owner's 4 schedules |
| Correctly scoped demo use (both vars set) | Proceeds - reads the **demo** tenant's own empty list |

The third case is the load-bearing one: same command, same machine, now reading the demo
account's token instead of the owner's.

## Not covered here

thefrederiksen/devthrottle_internal#948 remains open. It is the same root cause but needs a different fix - the hosted Gateway
resolving the recipient from the caller's tenant rather than from a Gateway-held credential.
Worth auditing the remaining `cc-devthrottle` subcommands for the same pattern, since two have
now been found independently.
