### PR TITLE
Make a hosted container's startup readable, and measure the deploy's real outage

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -182,6 +182,11 @@ jobs:
         run: |
           TARGET="${{ steps.short.outputs.short }}"
           LOG=/tmp/swap-poll.log; : > "$LOG"
+          # The poller is deliberately NOT killed in this step. It keeps running across the settle check
+          # and the post-swap watch below, because the outage this deploy actually causes happens MINUTES
+          # after the swap returns (issue #2203): the platform starts a fresh production container with the
+          # swapped configuration, that container fails to bind its port, and the platform stops the SITE.
+          # A window that closes 8 seconds after the swap always measured 0.0s and always missed it.
           ( while :; do
               t=$(date +%s.%N)
               body=$(curl -s -m 5 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
@@ -190,13 +195,13 @@ jobs:
               echo "$t $code ${commit:-none}" >> "$LOG"
               sleep 1
             done ) & POLL=$!
+          echo "$POLL" > /tmp/swap-poll.pid
 
           t_deploy=$(date +%s)
           az webapp deployment slot swap --resource-group "$AZURE_RG" --name "$APP" \
             --slot "$SLOT" --target-slot production --output none
           echo "Swap complete; sampling a few more seconds to catch the first sustained new-commit..."
           sleep 8
-          kill "$POLL" 2>/dev/null || true
 
           echo "--- production poll across the swap ---"; cat "$LOG"
           # last 200 whose commit is NOT the new one (old instance serving), and first 200 on the new commit.
@@ -212,10 +217,11 @@ jobs:
             outage=0
           fi
           tth=$(( $(printf '%.0f' "$first_new") - t_deploy ))
-          echo "outage_seconds=$outage" >> "$GITHUB_OUTPUT"
+          echo "swap_outage_seconds=$outage" >> "$GITHUB_OUTPUT"
           echo "time_to_healthy_seconds=$tth" >> "$GITHUB_OUTPUT"
           echo "outcome=healthy" >> "$GITHUB_OUTPUT"
-          echo "New image ${TARGET} live in production. External outage ~${outage}s (warmed swap)."
+          echo "New image ${TARGET} live in production. Gap ACROSS THE SWAP ITSELF ~${outage}s."
+          echo "This is NOT the deploy's outage - the post-swap watch below measures that."
           curl -s -m 15 "${GATEWAY_URL}/healthz"; echo
 
       # Return to steady state (one running instance) ONLY after production has proven itself STABLY healthy
@@ -252,6 +258,86 @@ jobs:
           echo "Production held a stable streak on $TARGET; stopping the staging slot."
           az webapp stop --resource-group "$AZURE_RG" --name "$APP" --slot "$SLOT" --output none
           echo "stopped_staging=yes" >> "$GITHUB_OUTPUT"
+
+      # KEEP WATCHING. This is the step that measures the outage a user actually gets (issue #2203).
+      #
+      # Every deploy on 2026-07-26 reported 0.0s and every one of them took the live service down two to
+      # four minutes LATER, long after the job used to finish. The mechanism: after the swap the platform
+      # starts a fresh production container with the swapped configuration; that container's application
+      # starts but never binds its port; the platform's startup probe correctly finds nothing, gives up,
+      # and puts the SITE into Stopped. Two of the three were caught only because someone happened to be
+      # polling by hand.
+      #
+      # Two things are watched, because /healthz alone is not enough. Through the whole failing window the
+      # front door was still being served by the warmed instance, so an external poll looked perfect while
+      # the site was being driven to Stopped underneath it. The SITE STATE is the earlier and truer signal.
+      - name: Watch production past the swap and measure the true outage
+        id: outage
+        if: always() && steps.readiness.outputs.outcome == 'healthy'
+        env:
+          WATCH_SECONDS: '600'
+          MAX_ACCEPTABLE_OUTAGE_SECONDS: '30'
+        run: |
+          LOG=/tmp/swap-poll.log
+          STATE_LOG=/tmp/site-state.log; : > "$STATE_LOG"
+          echo "Watching for ${WATCH_SECONDS}s past the swap (the failure window is 2-4 minutes out)..."
+
+          deadline=$(( $(date +%s) + WATCH_SECONDS ))
+          bad_state=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            st=$(az webapp show --resource-group "$AZURE_RG" --name "$APP" --query state --output tsv 2>/dev/null || echo "Unknown")
+            echo "$(date -u +%H:%M:%S) $st" >> "$STATE_LOG"
+            if [ "$st" != "Running" ]; then
+              bad_state="$st"
+              echo "SITE STATE LEFT Running: $st at $(date -u +%H:%M:%S)"
+            fi
+            sleep 15
+          done
+
+          # Stop the poller that has been running since before the swap.
+          if [ -f /tmp/swap-poll.pid ]; then kill "$(cat /tmp/swap-poll.pid)" 2>/dev/null || true; fi
+
+          # The whole record, from before the swap to ten minutes after it. Compute the LONGEST unbroken
+          # run of non-200 samples, in seconds, and the total. The poller samples about once a second, so a
+          # gap is measured from the last good sample to the next good one.
+          read -r longest total start_of_longest <<EOF
+          $(awk '
+            $2=="200" {
+              if (gap_start != "") { d = $1 - gap_start; total += d; if (d > longest) { longest = d; at = gap_start } ; gap_start = "" }
+              last_good = $1; next
+            }
+            { if (gap_start == "") gap_start = (last_good != "" ? last_good : $1); last_seen = $1 }
+            END {
+              # Still unavailable when the watch ended: that stretch is the WORST case, not a zero.
+              # Closing the books without it would report 0.0s for a service that never came back.
+              if (gap_start != "") { d = last_seen - gap_start; total += d; if (d > longest) { longest = d; at = gap_start } }
+              printf "%.1f %.1f %s", longest+0, total+0, (at == "" ? "-" : at)
+            }
+          ' "$LOG")
+          EOF
+
+          echo "--- site state samples ---"; cat "$STATE_LOG"
+          echo "Longest unavailable stretch: ${longest}s   Total unavailable: ${total}s"
+          echo "true_outage_seconds=$longest" >> "$GITHUB_OUTPUT"
+          echo "total_unavailable_seconds=$total" >> "$GITHUB_OUTPUT"
+          echo "site_state_left_running=${bad_state:-no}" >> "$GITHUB_OUTPUT"
+
+          fail=""
+          if [ -n "$bad_state" ]; then
+            fail="the App Service site left the Running state (saw '$bad_state')"
+          elif awk -v a="$longest" -v b="$MAX_ACCEPTABLE_OUTAGE_SECONDS" 'BEGIN{exit !(a > b)}'; then
+            fail="production was unavailable for ${longest}s, over the ${MAX_ACCEPTABLE_OUTAGE_SECONDS}s budget"
+          fi
+          if [ -n "$fail" ]; then
+            echo "ERROR: $fail."
+            echo "       The deploy SHIPPED - this is not a rollback signal, it is the outage report the old"
+            echo "       8-second window could not produce. See issue #2203. The failing container's own"
+            echo "       startup log is in the platform container log for this app; the hosted Gateway now"
+            echo "       mirrors its startup to standard output so that record is complete."
+            echo "--- full production poll ---"; cat "$LOG"
+            exit 1
+          fi
+          echo "Production stayed available for the full ${WATCH_SECONDS}s window past the swap."
 
       # Does this deploy carry a schema change to the LIVE Supabase Postgres? Diff the Postgres migration set
       # (the one Database.Migrate() applies on hosted) between the outgoing live commit and the shipped one.
@@ -297,7 +383,10 @@ jobs:
           FULL=$(git rev-parse HEAD)
           OUTCOME="${{ steps.readiness.outputs.outcome }}"; OUTCOME="${OUTCOME:-failed}"
           BUILD_S="${{ steps.build.outputs.build_seconds }}"; BUILD_S="${BUILD_S:-}"
-          OUTAGE_S="${{ steps.readiness.outputs.outage_seconds }}"
+          SWAP_S="${{ steps.readiness.outputs.swap_outage_seconds }}"
+          OUTAGE_S="${{ steps.outage.outputs.true_outage_seconds }}"
+          TOTAL_S="${{ steps.outage.outputs.total_unavailable_seconds }}"
+          STATE_LEFT="${{ steps.outage.outputs.site_state_left_running }}"; STATE_LEFT="${STATE_LEFT:-not-measured}"
           TTH_S="${{ steps.readiness.outputs.time_to_healthy_seconds }}"
           MIG="${{ steps.migration.outputs.migration }}"; MIG="${MIG:-unknown}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -313,6 +402,9 @@ jobs:
             "outcome": "$OUTCOME",
             "build_seconds": "${BUILD_S}",
             "external_outage_seconds": "${OUTAGE_S}",
+            "swap_window_gap_seconds": "${SWAP_S}",
+            "total_unavailable_seconds": "${TOTAL_S}",
+            "site_state_left_running": "${STATE_LEFT}",
             "time_to_healthy_seconds": "${TTH_S}",
             "migration": "$MIG",
             "rollback": "no"
@@ -328,7 +420,10 @@ jobs:
             echo "| commit | \`$TARGET\` |"
             echo "| outcome | $OUTCOME |"
             echo "| build | ${BUILD_S:-?}s |"
-            echo "| external outage | ${OUTAGE_S:-?}s |"
+            echo "| external outage (longest, watched 10 min past the swap) | ${OUTAGE_S:-not measured}s |"
+            echo "| total unavailable | ${TOTAL_S:-not measured}s |"
+            echo "| gap across the swap itself | ${SWAP_S:-?}s |"
+            echo "| site left Running | ${STATE_LEFT} |"
             echo "| time-to-healthy | ${TTH_S:-?}s |"
             echo "| migration | $MIG |"
             echo "| rollback | no |"
@@ -337,7 +432,7 @@ jobs:
             echo "Ledger-ready row (paste into deploy-ledger.md):"
             echo ""
             echo "\`\`\`"
-            echo "$NOW | \`$TARGET\` | ${{ github.run_id }} | build ${BUILD_S:-?}s | migration $MIG | external outage ${OUTAGE_S:-?}s | time-to-healthy ${TTH_S:-?}s | $OUTCOME"
+            echo "$NOW | \`$TARGET\` | ${{ github.run_id }} | build ${BUILD_S:-?}s | migration $MIG | external outage ${OUTAGE_S:-not measured}s (longest, 10 min watch) | time-to-healthy ${TTH_S:-?}s | $OUTCOME"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/src/CcDirector.Core.Tests/Utilities/FileLogConsoleMirrorTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogConsoleMirrorTests.cs
@@ -1,0 +1,78 @@
+using CcDirector.Core.Utilities;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Utilities;
+
+// =====================================================================================
+// FileLog's hosted seams (issue #2203). A hosted deploy runs TWO Gateway containers at
+// once against one storage mount, and the startup record of the container that fails is
+// exactly what we need. Two guarantees are pinned here:
+//   1. MirrorToConsole puts every line on standard output as well - the sink the
+//      container platform captures per container, and the one with no queue in front of
+//      it, so it survives the file-share stall that erased three startup records.
+//   2. UseUniqueInstanceId REFUSES to run after Start(), instead of quietly leaving the
+//      process writing to the shared file it was supposed to move off.
+// =====================================================================================
+public sealed class FileLogConsoleMirrorTests
+{
+    [Fact]
+    public void Write_MirrorToConsoleOn_AlsoWritesTheLineToStandardOutput()
+    {
+        var originalOut = Console.Out;
+        var captured = new StringWriter();
+        var wasMirroring = FileLog.MirrorToConsole;
+
+        using var scope = FileLog.RedirectForTests();
+        try
+        {
+            Console.SetOut(captured);
+            FileLog.MirrorToConsole = true;
+
+            FileLog.Write("[Program] CC Director Gateway starting");
+
+            Assert.Contains("[Program] CC Director Gateway starting", captured.ToString());
+        }
+        finally
+        {
+            FileLog.MirrorToConsole = wasMirroring;
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void Write_MirrorToConsoleOff_KeepsStandardOutputClean()
+    {
+        // The mirror is switched off once the Gateway binds, because copying the running log into the
+        // platform's log mount is a different outage. Off must mean silent.
+        var originalOut = Console.Out;
+        var captured = new StringWriter();
+        var wasMirroring = FileLog.MirrorToConsole;
+
+        using var scope = FileLog.RedirectForTests();
+        try
+        {
+            Console.SetOut(captured);
+            FileLog.MirrorToConsole = false;
+
+            FileLog.Write("[GatewayHost] a routine line long after startup");
+
+            Assert.DoesNotContain("a routine line long after startup", captured.ToString());
+        }
+        finally
+        {
+            FileLog.MirrorToConsole = wasMirroring;
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void UseUniqueInstanceId_AfterStart_ThrowsRatherThanSplittingTheRecord()
+    {
+        // Inside the scope the writer is running. Moving the file now would split this process's record
+        // across two files, so this must fail loudly rather than half-apply.
+        using var scope = FileLog.RedirectForTests();
+
+        var ex = Assert.Throws<InvalidOperationException>(FileLog.UseUniqueInstanceId);
+        Assert.Contains("before FileLog.Start()", ex.Message);
+    }
+}

--- a/src/CcDirector.Core.Tests/Utilities/FileLogWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogWriterTests.cs
@@ -60,7 +60,7 @@ public sealed class FileLogWriterTests : IDisposable
     [Fact]
     public void ComputeLogPath_UsesDateAndProcessId()
     {
-        var writer = new FileLogWriter(_logDir, 4242, () => new DateTime(2026, 6, 5));
+        var writer = new FileLogWriter(_logDir, "4242", () => new DateTime(2026, 6, 5));
 
         var path = writer.ComputeLogPath(new DateTime(2026, 6, 5, 0, 0, 9));
 
@@ -72,7 +72,7 @@ public sealed class FileLogWriterTests : IDisposable
     {
         // Clock starts on day 1; the test flips it to day 2 to simulate crossing midnight.
         var now = new DateTime(2026, 6, 4, 23, 59, 57);
-        var writer = new FileLogWriter(_logDir, 6524, () => now);
+        var writer = new FileLogWriter(_logDir, "6524", () => now);
         var day1Path = writer.ComputeLogPath(new DateTime(2026, 6, 4));
         var day2Path = writer.ComputeLogPath(new DateTime(2026, 6, 5));
 
@@ -106,7 +106,7 @@ public sealed class FileLogWriterTests : IDisposable
         // fault-injection hook. If the loop did not catch per-line (the old bug: one try around
         // the whole foreach), the thread would die on that throw and the line after it would
         // never be written.
-        var writer = new FileLogWriter(_logDir, 7000, () => new DateTime(2026, 6, 6, 12, 0, 0))
+        var writer = new FileLogWriter(_logDir, "7000", () => new DateTime(2026, 6, 6, 12, 0, 0))
         {
             BeforeWriteHook = line =>
             {
@@ -148,7 +148,7 @@ public sealed class FileLogWriterTests : IDisposable
         DateTime Clock() =>
             baseTime.AddTicks(FileLogWriter.FlushInterval.Ticks * 6 / 10 * Interlocked.Increment(ref reads));
 
-        var writer = new FileLogWriter(_logDir, 8000, Clock);
+        var writer = new FileLogWriter(_logDir, "8000", Clock);
         var logPath = writer.ComputeLogPath(baseTime);
 
         writer.Start();
@@ -166,6 +166,88 @@ public sealed class FileLogWriterTests : IDisposable
         }
         finally
         {
+            writer.Stop();
+        }
+    }
+
+    // =================================================================================
+    // Issue #2203 - two Gateway containers appended to ONE log file and clobbered each
+    // other, so the startup record of three failed hosted deploys was unreadable. The
+    // discriminator in the file name is the only thing keeping two processes apart, and
+    // in a container the process id is always 1, so it kept nothing apart.
+    // =================================================================================
+
+    [Fact]
+    public void ComputeLogPath_SameInstanceId_LandsOnOneSharedFile()
+    {
+        // Two containers, both running the Gateway as pid 1: this is the collision itself.
+        var containerA = new FileLogWriter(_logDir, "1", () => new DateTime(2026, 7, 26));
+        var containerB = new FileLogWriter(_logDir, "1", () => new DateTime(2026, 7, 26));
+
+        var instant = new DateTime(2026, 7, 26);
+        Assert.Equal(containerA.ComputeLogPath(instant), containerB.ComputeLogPath(instant));
+    }
+
+    [Fact]
+    public void ComputeLogPath_DifferentInstanceId_KeepsEachProcessOnItsOwnFile()
+    {
+        var containerA = new FileLogWriter(_logDir, "a1b2c3d4e5f6", () => new DateTime(2026, 7, 26));
+        var containerB = new FileLogWriter(_logDir, "0f9e8d7c6b5a", () => new DateTime(2026, 7, 26));
+
+        var instant = new DateTime(2026, 7, 26);
+        Assert.NotEqual(containerA.ComputeLogPath(instant), containerB.ComputeLogPath(instant));
+        Assert.EndsWith("director-2026-07-26-a1b2c3d4e5f6.log", containerA.ComputeLogPath(instant));
+    }
+
+    [Fact]
+    public void Constructor_BlankInstanceId_Throws()
+    {
+        // An empty discriminator would put every process back on one file - refuse it rather than
+        // compute a path that silently collides.
+        Assert.Throws<ArgumentException>(() => new FileLogWriter(_logDir, "  ", () => DateTime.Now));
+    }
+
+    [Fact]
+    public void Enqueue_WriterStalled_CountsDroppedLinesAndAnnouncesTheGap()
+    {
+        // The failure that erased the evidence: the file share stops responding, the bounded queue
+        // fills, and every further line is dropped. Silently, before this fix.
+        var release = new ManualResetEventSlim(false);
+        var stalled = new ManualResetEventSlim(false);
+        var clock = new DateTime(2026, 7, 26, 12, 0, 0);
+        var writer = new FileLogWriter(_logDir, "stall-test", () => clock);
+        var logPath = writer.ComputeLogPath(clock);
+
+        writer.BeforeWriteHook = _ =>
+        {
+            if (stalled.IsSet) return;
+            stalled.Set();
+            release.Wait(TimeSpan.FromSeconds(30));
+        };
+
+        writer.Start();
+        try
+        {
+            writer.Enqueue("first-line");
+            Assert.True(stalled.Wait(TimeSpan.FromSeconds(5)), "the writer never reached the stall hook");
+
+            // Overfill the 1024-slot queue while the writer is held.
+            for (int i = 0; i < 3000; i++)
+                writer.Enqueue($"flood-{i}");
+
+            Assert.True(writer.DroppedLines > 0, "a full queue dropped lines but reported none");
+
+            release.Set();
+
+            // Once writing resumes the file must SAY the record is incomplete.
+            WaitUntil(() => ReadShared(logPath).Contains("LOG GAP"));
+            var text = ReadShared(logPath);
+            Assert.Contains("LOG GAP", text);
+            Assert.Contains("line(s) were dropped", text);
+        }
+        finally
+        {
+            release.Set();
             writer.Stop();
         }
     }

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -14,13 +14,51 @@ public static class FileLog
 {
     private static readonly string LogDir = CcStorage.ToolLogs("director");
 
+    // What distinguishes this process's log file from another process's. The desktop uses the process id,
+    // which is unique there and is what the desktop tooling globs for. A container must call
+    // UseUniqueInstanceId() before Start(), because inside a container the process id is always 1.
+    private static string _instanceId = Environment.ProcessId.ToString();
+
     // The active writer. Production never reassigns it; the test-only RedirectForTests seam (issue
     // #862) swaps it for an isolated writer for the duration of one test, which is safe because the
     // test assemblies disable parallelization (one test owns FileLog at a time).
     private static FileLogWriter _writer =
-        new(LogDir, Environment.ProcessId, () => DateTime.Now);
+        new(LogDir, _instanceId, () => DateTime.Now);
 
     private static int _started;
+
+    /// <summary>
+    /// Also write every line to standard output. Off by default; a hosted/container deployment turns it on.
+    ///
+    /// This is a SECOND SINK, not a fallback: it is written on the caller's thread with no queue in front of
+    /// it, so it survives the exact failure that erased the evidence of three hosted startup failures - the
+    /// file share stalling, the bounded queue filling, and every line being dropped before it reached disk.
+    /// In a container, standard output is what the platform captures per container, so it is also the only
+    /// sink that is guaranteed unshared.
+    /// </summary>
+    public static bool MirrorToConsole { get; set; }
+
+    /// <summary>
+    /// Give this process its own log file, distinct from any other process writing the same directory.
+    /// Must be called BEFORE <see cref="Start"/>; calling it afterwards throws rather than silently
+    /// leaving the process on the shared file.
+    ///
+    /// A hosted Gateway needs this because the default discriminator - the process id - is always 1 inside
+    /// a container, so every container computed the same path. Two of them then appended to one file on an
+    /// SMB share mounted <c>nobrl</c>, where the FileShare.Read request is not enforced across clients, and
+    /// clobbered each other mid-record. The token is generated per process rather than read from the
+    /// environment so its uniqueness does not depend on the platform supplying anything.
+    /// </summary>
+    public static void UseUniqueInstanceId()
+    {
+        if (_started != 0)
+            throw new InvalidOperationException(
+                "FileLog.UseUniqueInstanceId() must be called before FileLog.Start(); the writer is already " +
+                "running on the shared log file and moving it now would split this process's record in two.");
+
+        _instanceId = Guid.NewGuid().ToString("N")[..12];
+        _writer = new FileLogWriter(LogDir, _instanceId, () => DateTime.Now);
+    }
 
     /// <summary>Start the background writer thread. Safe to call multiple times.</summary>
     public static void Start()
@@ -37,8 +75,15 @@ public static class FileLog
         if (_started == 0) return;
         var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {message}";
         _writer.Enqueue(line);
+        if (MirrorToConsole) Console.Out.WriteLine(line);
         System.Diagnostics.Debug.WriteLine(line);
     }
+
+    /// <summary>
+    /// Lines this process could not fit into the writer's queue - a stalled writer means the file record is
+    /// incomplete by exactly this many lines. Zero on a healthy process.
+    /// </summary>
+    public static long DroppedLines => _writer.DroppedLines;
 
     /// <summary>Flush remaining messages and stop the writer thread.</summary>
     public static void Stop()
@@ -50,7 +95,7 @@ public static class FileLog
 
     /// <summary>Returns the current log file path (useful for display).</summary>
     public static string CurrentLogPath =>
-        Path.Combine(LogDir, $"director-{DateTime.Now:yyyy-MM-dd}-{Environment.ProcessId}.log");
+        Path.Combine(LogDir, $"director-{DateTime.Now:yyyy-MM-dd}-{_instanceId}.log");
 
     /// <summary>
     /// TEST-ONLY seam (issue #862). Redirects FileLog to a private, throwaway directory for the life
@@ -79,7 +124,7 @@ public static class FileLog
             Directory.CreateDirectory(_dir);
             _previousWriter = _writer;
             _previousStarted = _started;
-            _testWriter = new FileLogWriter(_dir, Environment.ProcessId, () => DateTime.Now);
+            _testWriter = new FileLogWriter(_dir, Environment.ProcessId.ToString(), () => DateTime.Now);
             _writer = _testWriter;
             _started = 1;
             _testWriter.Start();

--- a/src/CcDirector.Core/Utilities/FileLogWriter.cs
+++ b/src/CcDirector.Core/Utilities/FileLogWriter.cs
@@ -24,11 +24,20 @@ internal sealed class FileLogWriter
     internal static readonly TimeSpan FlushInterval = TimeSpan.FromSeconds(1);
 
     private readonly string _logDir;
-    private readonly int _processId;
+    private readonly string _instanceId;
     private readonly Func<DateTime> _clock;
     private readonly BlockingCollection<string> _queue = new(1024);
 
     private Thread? _writerThread;
+
+    // Lines the bounded queue refused because the writer could not keep up. Enqueue must never block the
+    // caller (a stalled network file share would otherwise stall the application), so a full queue drops -
+    // but a SILENT drop is what made three hosted startup failures unreadable: the file share stalled, the
+    // queue filled, and every startup line vanished with nothing saying so. The count is published and the
+    // writer emits it into the log the moment it can write again, so a gap in the record always announces
+    // itself. See FileLog.MirrorToConsole for the second sink that survives the stall entirely.
+    private long _droppedLines;
+    private long _reportedDrops;
 
     /// <summary>
     /// Test-only fault-injection seam: invoked with each line just before it is written, inside the
@@ -37,15 +46,20 @@ internal sealed class FileLogWriter
     /// </summary>
     internal Action<string>? BeforeWriteHook { get; set; }
 
-    internal FileLogWriter(string logDir, int processId, Func<DateTime> clock)
+    internal FileLogWriter(string logDir, string instanceId, Func<DateTime> clock)
     {
         if (string.IsNullOrWhiteSpace(logDir))
             throw new ArgumentException("Log directory is required", nameof(logDir));
+        if (string.IsNullOrWhiteSpace(instanceId))
+            throw new ArgumentException("Instance id is required", nameof(instanceId));
 
         _logDir = logDir;
-        _processId = processId;
+        _instanceId = instanceId;
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
+
+    /// <summary>Lines the bounded queue has refused so far because the writer could not keep up.</summary>
+    internal long DroppedLines => Interlocked.Read(ref _droppedLines);
 
     /// <summary>Start the background writer thread.</summary>
     internal void Start()
@@ -60,10 +74,16 @@ internal sealed class FileLogWriter
         _writerThread.Start();
     }
 
-    /// <summary>Enqueue a pre-formatted line for the writer thread.</summary>
+    /// <summary>
+    /// Enqueue a pre-formatted line for the writer thread. Never blocks: if the queue is full because the
+    /// writer is stalled (a network file share that has stopped responding), the line is dropped and
+    /// counted rather than holding up the caller. <see cref="DroppedLines"/> makes the loss visible and the
+    /// writer records it as soon as it can write again.
+    /// </summary>
     internal void Enqueue(string line)
     {
-        _queue.TryAdd(line);
+        if (!_queue.TryAdd(line))
+            Interlocked.Increment(ref _droppedLines);
     }
 
     /// <summary>Signal the writer to drain and stop, then wait briefly for it to finish.</summary>
@@ -74,11 +94,20 @@ internal sealed class FileLogWriter
     }
 
     /// <summary>
-    /// The dated log path for the given instant: director-yyyy-MM-dd-{pid}.log. The date component
+    /// The dated log path for the given instant: director-yyyy-MM-dd-{instance}.log. The date component
     /// is what rolls over at local midnight, so this is the single place the file name is derived.
+    ///
+    /// The instance component must be unique per RUNNING PROCESS, because it is the only thing keeping two
+    /// processes off one file. On the desktop the process id supplies that (and the desktop tooling looks
+    /// logs up by it - see App.axaml.cs and scripts/agent-session-isolation.ps1, which glob
+    /// <c>director-*-{pid}.log</c>). Inside a container the process id is ALWAYS 1, so it supplies nothing:
+    /// during a slot swap two Gateway containers ran as pid 1 and appended to one file on an SMB share
+    /// mounted <c>nobrl</c>, where FileShare.Read is not enforced across clients. They clobbered each
+    /// other mid-record. Hosted therefore passes a per-process token instead - see
+    /// <see cref="FileLog.UseUniqueInstanceId"/>.
     /// </summary>
     internal string ComputeLogPath(DateTime instant) =>
-        Path.Combine(_logDir, $"director-{instant:yyyy-MM-dd}-{_processId}.log");
+        Path.Combine(_logDir, $"director-{instant:yyyy-MM-dd}-{_instanceId}.log");
 
     /// <summary>
     /// Open the dated log file for appending with FileShare.Read so live log viewers (and tests)
@@ -120,6 +149,19 @@ internal sealed class FileLogWriter
                         continue;
 
                     BeforeWriteHook?.Invoke(line);
+
+                    // A gap in the record must announce itself. If the queue overflowed while this thread
+                    // was stalled, say so in the file BEFORE the next surviving line, so a reader can never
+                    // mistake a truncated record for a quiet period.
+                    var dropped = Interlocked.Read(ref _droppedLines);
+                    if (dropped > _reportedDrops)
+                    {
+                        writer.WriteLine(
+                            $"{_clock():yyyy-MM-dd HH:mm:ss.fff} [FileLogWriter] LOG GAP: {dropped - _reportedDrops} " +
+                            "line(s) were dropped because the writer could not keep up - the record above is incomplete");
+                        _reportedDrops = dropped;
+                    }
+
                     writer.WriteLine(line);
 
                     // Flush when the queue drains, OR when the bounded interval has elapsed since the

--- a/src/CcDirector.Gateway/GatewayEntryPoint.cs
+++ b/src/CcDirector.Gateway/GatewayEntryPoint.cs
@@ -25,8 +25,35 @@ public static class GatewayEntryPoint
     /// </summary>
     public static int Run(string[] args)
     {
+        // A hosted Gateway logs differently from a desktop one, and it must, because a deploy runs TWO
+        // Gateway containers at once and they share one storage mount.
+        //
+        //  - Its own log file. The default discriminator is the process id, which is 1 in EVERY container,
+        //    so both containers computed the same path on the SMB mount and clobbered each other's records
+        //    mid-line. Must be set before FileLog.Start().
+        //  - Standard output as a second sink. The platform captures it per container, and it has no queue
+        //    in front of it, so it survives a stalled file share - the failure that erased the startup
+        //    record of three deploys and left "no listening ports were detected" with nothing to explain it.
+        //
+        // Keyed on the IMMUTABLE hosted image identity, not the CC_GATEWAY_HOSTED toggle: a slot swap or a
+        // config restore can drop the environment variable, and the moment it does is exactly when two
+        // containers are running and the logging matters most.
+        if (GatewayHostedMode.IsHostedImage)
+        {
+            FileLog.UseUniqueInstanceId();
+            FileLog.MirrorToConsole = true;
+        }
+
         FileLog.Start();
         FileLog.Write($"[Program] CC Director Gateway starting, log: {FileLog.CurrentLogPath}");
+        if (GatewayHostedMode.IsHostedImage)
+        {
+            // Correlation, not identity: the platform names containers by their id, so record what this
+            // process can see about which container it is. The log file name does not depend on any of it.
+            FileLog.Write(
+                $"[Program] hosted container: machine={Environment.MachineName} " +
+                $"pid={Environment.ProcessId} instance={Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? "<unset>"}");
+        }
 
         int port = GatewayHost.DefaultPort;
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2743,6 +2743,19 @@ public sealed class GatewayHost : IAsyncDisposable
             Port = ReadBoundPort(_app);
         FileLog.Write($"[GatewayHost] listening on http://0.0.0.0:{Port} (all interfaces, auth-gated; version {version})");
 
+        // The bind is the finish line the platform's startup probe is waiting for, so it is also where the
+        // hosted standard-output mirror stops. It exists to make the STARTUP sequence readable in the
+        // platform's per-container log (issue #2203 - three deploys produced containers that reached
+        // "Application started" and then never got here, with no record of where they stopped). Leaving it
+        // on past this point would copy the Gateway's whole running log - tens of megabytes a day - into
+        // the platform log mount, which is a different outage. From here the per-container file is the
+        // record, and FileLog.DroppedLines plus its "LOG GAP" marker report if any of it is lost.
+        if (FileLog.MirrorToConsole)
+        {
+            FileLog.Write("[GatewayHost] startup complete - standard-output log mirror off; the per-container file is the record from here");
+            FileLog.MirrorToConsole = false;
+        }
+
         // Cron firing sweep (epic #479, #483): wake ~every minute and fire due jobs. The first tick
         // also catches up a fire that came due while the Gateway was down (at most once per job).
         //


### PR DESCRIPTION
Two things that have to be true before the deploy outage in thefrederiksen/devthrottle_internal#950 can be fixed: the failing container has to be able to tell us where it stopped, and the pipeline has to stop reporting `0.0s` for a deploy that took the service down.

**This does not fix the hang yet.** It is the step that makes the next deploy name the cause instead of leaving us guessing. See the diagnosis on thefrederiksen/devthrottle_internal#950 for what is established.

## What was wrong

After a swap the platform starts a fresh production container. Its application prints `Application started` within seconds and then never binds port 7878, so the platform's startup probe correctly finds nothing, gives up, and puts the SITE into `Stopped`. That is the outage. Where those containers blocked is unknown, because **they wrote nothing at all** to the Gateway log - not even the first line a healthy process writes within half a second.

There are two reasons for that, and both are bugs.

**1. Every container wrote to the same file.** The log file name is `director-{date}-{processId}.log`. Inside a container the process id is always 1, so the discriminator discriminates nothing: during a deploy two Gateway containers both computed `director-2026-07-26-1.log` on the same Azure Files mount (`//stdevthrottlegw.file.core.windows.net/gwdata`, CIFS, mounted `nobrl`). `FileMode.Append` with `FileShare.Read` is not enforced across clients there, so both got a handle and clobbered each other mid-record. Observed live while writing this, with production and a second container running:

```
2026-07-26 23:57:2026-07-26 23:57:31.617 [GatewayStatsDatabase] Migrate: file version=5, build version=5
2026-07-26 23:57:32.487 [GatewayDatabase] Open: provider=Postgres target=postgres host=aws-1-us-east2026-07-26 23:57:32.655 [GatewayHos
```

**2. A stalled writer dropped lines silently.** `Enqueue` is `_queue.TryAdd(line)` on a bounded 1024-slot queue. That is right - logging must never block the application on a network file share - but the return value was discarded, so a stalled share filled the queue and every subsequent line vanished with nothing recording that it had.

## What changed

**`FileLogWriter` / `FileLog`**
- The file-name discriminator is now a string instance id, not the process id. The desktop still passes `Environment.ProcessId`, so desktop file names are byte-identical and the tooling that globs `director-*-{pid}.log` (`App.axaml.cs`, `scripts/agent-session-isolation.ps1`, `scripts/test-degradation.ps1`) is untouched. A container calls `FileLog.UseUniqueInstanceId()` and gets a per-process token instead. It throws if called after `Start()` rather than quietly leaving the process on the shared file, and a blank instance id is refused rather than silently collapsing back to one path.
- Dropped lines are counted and published as `FileLog.DroppedLines`, and the writer emits a `LOG GAP: N line(s) were dropped` record into the file as soon as it can write again - so a truncated record can never be misread as a quiet period.
- `FileLog.MirrorToConsole` adds standard output as a **second sink**, not a fallback: written on the caller's thread with no queue in front of it, so it survives the exact stall that erased the evidence, and in a container it is what the platform captures per container.

**`GatewayEntryPoint`** turns both on for a hosted image, keyed on `IsHostedImage` (the immutable image identity) rather than the `CC_GATEWAY_HOSTED` toggle - a slot swap can drop the environment variable, and the moment it does is exactly when two containers are running and the logging matters most. It also records machine name, process id and instance id for correlation with the platform's container ids.

**`GatewayHost`** switches the mirror off at the bind. The mirror exists to make the startup sequence readable; leaving it on would copy tens of megabytes a day into the platform log mount, which is a different outage. From the bind onward the per-container file is the record, and the drop counter reports if any of it is lost.

**`deploy-hosted-gateway.yml`** now measures what a user gets:
- The `/healthz` poller starts before the swap and is no longer killed 8 seconds after it. It runs through the settle check and a **10-minute watch past the swap**, which is where the outage actually happens.
- The reported `external_outage_seconds` is now the longest unbroken unavailable stretch across that whole window. The old 8-second figure is still reported, renamed `swap_window_gap_seconds`, because the gap across the swap itself is genuinely near zero and that is worth keeping - it just is not the deploy's outage.
- **The App Service site state is sampled every 15 seconds.** `/healthz` alone is not enough: through the whole failing window the front door was still served by the warmed instance, so an external poll looked perfect while the site was being driven to `Stopped` underneath it. The site state is the earlier and truer signal.
- The job fails if the longest gap exceeds 30 seconds or the site leaves `Running`. A red run is the alarm until thefrederiksen/devthrottle_internal#949 gives us real alerting. It is explicitly not a rollback signal - the deploy has already shipped by then.

## Tests

`src/CcDirector.Core.Tests/Utilities/FileLogWriterTests.cs`, four added:

- `ComputeLogPath_SameInstanceId_LandsOnOneSharedFile` - documents the collision itself (two containers as pid 1). This one is characterization, not a regression guard: it passes on the old code too, which is the point.
- `ComputeLogPath_DifferentInstanceId_KeepsEachProcessOnItsOwnFile`
- `Constructor_BlankInstanceId_Throws`
- `Enqueue_WriterStalled_CountsDroppedLinesAndAnnouncesTheGap` - stalls the writer through `BeforeWriteHook`, overfills the queue, and asserts both the count and the `LOG GAP` record.

Proven to fail on purpose: with the gap announcement removed, `Enqueue_WriterStalled_...` fails (`Failed: 1, Passed: 0`); restored, the file's 8 tests pass.

The workflow's gap arithmetic was tested directly against the real 17:48:28-17:49:21 outage from thefrederiksen/devthrottle_internal#950 and four edge cases - clean deploy, still-down-when-the-watch-ends, two gaps where the longest must win, and down-from-the-first-sample. The last two both returned a false `0.0s` on the first draft and were fixed; a measurement step that reports zero for a service that never came back is the bug this issue is about.

Full suites: `CcDirector.Core.Tests` 3723 passed / 8 skipped. Solution builds with 0 warnings.

## What comes next

Ship this, run one deploy, and read the startup record of whichever container fails. The candidates are all on the pre-bind path and all shared with the still-running container - the SMB mount, `Database.Migrate()` against the shared Supabase Postgres, and one S1 worker at capacity 1 running both slots. The next deploy should say which.

Closes nothing on its own. Progresses thefrederiksen/devthrottle_internal#950; thefrederiksen/devthrottle_internal#949 (no alerting) is still open and is why three of these went unnoticed.
