### PR TITLE
Stop the port bind waiting on work that does not gate readiness

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceFallbackTests.cs
@@ -51,7 +51,7 @@ public sealed class WingmanVoiceFallbackTests : IDisposable
         // StoreSpokenAsync takes the spoken text directly, so the brain is never reached here.
         Func<TenantId, Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _, _) => throw new InvalidOperationException("the brain must not be reached by a fallback header test");
-        return new WingmanVoiceService(brain, vault, Settings, persistPath, ttsHttpClient: new HttpClient(handler));
+        return Warmed(new WingmanVoiceService(brain, vault, Settings, persistPath, ttsHttpClient: new HttpClient(handler)));
     }
 
     // A unique SUBDIRECTORY per test, not a bare temp filename. The service derives its durable audio
@@ -193,5 +193,18 @@ public sealed class WingmanVoiceFallbackTests : IDisposable
         await svc.StoreSpokenAsync(TenantId.Local, "sid-other", "summary", "reply");  // a DIFFERENT session
         Assert.Equal(2, stub.Calls);
         Assert.False(stub.LastRequest!.Headers.Contains("X-DevThrottle-TTS-Prefer-Backup"));   // not armed for sid-other
+    }
+
+    /// <summary>
+    /// Wait for the ready-audio cache to finish loading before handing the service to a test. The cache is
+    /// read in the BACKGROUND in production so its cost cannot sit in front of the port bind (issue #2203);
+    /// a test that asserts on reloaded audio would otherwise be racing that read. Nothing in the serving
+    /// path waits like this - a cache still loading behaves as a miss and regenerates.
+    /// </summary>
+    private static WingmanVoiceService Warmed(WingmanVoiceService svc)
+    {
+        Assert.True(svc.ReadyAudioWarmup.Wait(TimeSpan.FromSeconds(30)),
+            "the ready-audio warm load did not finish within 30 seconds");
+        return svc;
     }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -111,7 +111,7 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _, _) => throw new InvalidOperationException("brain must not be called");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
-        return new WingmanVoiceService(brain, new KeyVault(vaultPath), Settings, persistPath);
+        return Warmed(new WingmanVoiceService(brain, new KeyVault(vaultPath), Settings, persistPath));
     }
 
     /// <summary>Remove the whole per-test directory. It deletes the DIRECTORY rather than picking out the
@@ -1032,5 +1032,18 @@ public sealed class WingmanVoiceServiceTests : IDisposable
 
         svc.Unmark(TenantId.Local, "sid-1");
         Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+    }
+
+    /// <summary>
+    /// Wait for the ready-audio cache to finish loading before handing the service to a test. The cache is
+    /// read in the BACKGROUND in production so its cost cannot sit in front of the port bind (issue #2203);
+    /// a test that asserts on reloaded audio would otherwise be racing that read. Nothing in the serving
+    /// path waits like this - a cache still loading behaves as a miss and regenerates.
+    /// </summary>
+    private static WingmanVoiceService Warmed(WingmanVoiceService svc)
+    {
+        Assert.True(svc.ReadyAudioWarmup.Wait(TimeSpan.FromSeconds(30)),
+            "the ready-audio warm load did not finish within 30 seconds");
+        return svc;
     }
 }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTenantPartitionTests.cs
@@ -262,7 +262,7 @@ public sealed class WingmanVoiceTenantPartitionTests : IDisposable
         Func<TenantId, Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _, _) => Task.FromResult<IAgentBrain>(null!);
         var vault = new KeyVault(Path.Combine(baseDir, "vault.json"));
-        return new WingmanVoiceService(brain, vault, Settings, Path.Combine(baseDir, "voice-sessions.json"));
+        return Warmed(new WingmanVoiceService(brain, vault, Settings, Path.Combine(baseDir, "voice-sessions.json")));
     }
 
     // ===== cross-tenant isolation, each with its same-tenant control =========================
@@ -638,5 +638,18 @@ public sealed class WingmanVoiceTenantPartitionTests : IDisposable
             Assert.Null(archive.Get(TenantA, turnId.ToString()));
         }
         finally { Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior); }
+    }
+
+    /// <summary>
+    /// Wait for the ready-audio cache to finish loading before handing the service to a test. The cache is
+    /// read in the BACKGROUND in production so its cost cannot sit in front of the port bind (issue #2203);
+    /// a test that asserts on reloaded audio would otherwise be racing that read. Nothing in the serving
+    /// path waits like this - a cache still loading behaves as a miss and regenerates.
+    /// </summary>
+    private static WingmanVoiceService Warmed(WingmanVoiceService svc)
+    {
+        Assert.True(svc.ReadyAudioWarmup.Wait(TimeSpan.FromSeconds(30)),
+            "the ready-audio warm load did not finish within 30 seconds");
+        return svc;
     }
 }

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -93,7 +93,32 @@ public sealed class GatewayDatabase : IDisposable
                 {
                     // Apply the Postgres migration set (its own assembly + gateway-schema history table). No
                     // PRAGMA journal_mode here - WAL is a SQLite-only setting and Postgres has its own WAL.
-                    ctx.Database.Migrate();
+                    //
+                    // ASK FIRST (issue #2203). Migrate() takes an EXCLUSIVE database-wide advisory lock before
+                    // it looks at whether there is anything to apply, and it holds that lock for the whole
+                    // call with no lock timeout and no command timeout. Every deploy runs two Gateway
+                    // containers against this one database, so the second one waits on the first: measured at
+                    // 43 seconds on a deploy carrying NO schema change, against 7 seconds with nothing else
+                    // running. That wait sits in front of the port bind, and when it pushes the bind past the
+                    // platform's 230-second startup deadline the platform stops the SITE - which is the
+                    // user-visible outage this issue is about.
+                    //
+                    // GetPendingMigrations() takes no lock: it reads the history table and compares. On a
+                    // code-only deploy - most deploys - the answer is "none" and we skip the locking call
+                    // entirely. This is NOT a fallback and it does not weaken the contract: when there ARE
+                    // migrations we still call Migrate() and still fail loudly if it throws. It only removes
+                    // a lock acquisition that had nothing to do.
+                    var pending = ctx.Database.GetPendingMigrations().ToList();
+                    if (pending.Count == 0)
+                    {
+                        FileLog.Write("[GatewayDatabase] Migrate: no pending migrations - skipping Migrate() and its database-wide lock");
+                    }
+                    else
+                    {
+                        FileLog.Write($"[GatewayDatabase] Migrate: {pending.Count} pending migration(s), applying: {string.Join(", ", pending)}");
+                        ctx.Database.Migrate();
+                        FileLog.Write($"[GatewayDatabase] Migrate: applied {pending.Count} migration(s)");
+                    }
                 }
 
                 _provider = provider;

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -376,11 +376,20 @@ public sealed class WingmanVoiceService
 
     /// <summary>Load every tenant partition present on disk. A directory whose name is not a partition key
     /// this system mints is SKIPPED loudly rather than loaded under some coerced name - the same refusal the
-    /// write path applies, so a hand-made or half-renamed folder can never become a tenant.</summary>
+    /// write path applies, so a hand-made or half-renamed folder can never become a tenant.
+    ///
+    /// The two loads are deliberately NOT equal (issue #2203). Which sessions are voice sessions is a
+    /// correctness fact - the turn-end watcher consults it the moment it starts - and it costs one small
+    /// file per tenant, so it is read here and now. The ready-AUDIO cache is a warm-start convenience that
+    /// costs one full mp3 read per cached session (measured: 106 files, 11.6 seconds off the hosted SMB
+    /// mount), and every byte of it sat in front of the port bind. A cache that is not loaded yet behaves
+    /// exactly like a cache miss, which the voice path already handles by regenerating - whereas a port that
+    /// is not open yet is an outage. So the audio warms in the background, after the bind.</summary>
     private void LoadAllPartitions()
     {
         var tenantsRoot = Path.Combine(_baseDir, "tenants");
         if (!Directory.Exists(tenantsRoot)) return;
+        var tenants = new List<TenantId>();
         foreach (var dir in Directory.EnumerateDirectories(tenantsRoot))
         {
             var name = Path.GetFileName(dir);
@@ -396,9 +405,34 @@ public sealed class WingmanVoiceService
                 continue;
             }
             LoadVoiceSessions(tenant);
-            LoadReadyAudio(tenant);
+            tenants.Add(tenant);
         }
+        WarmReadyAudio(tenants);
     }
+
+    /// <summary>
+    /// Read the cached voice audio for each tenant off the background thread pool, so the cost never lands
+    /// in front of the port bind. The work is published as <see cref="ReadyAudioWarmup"/> so a caller that
+    /// genuinely needs the cache populated can wait for it deterministically instead of racing it.
+    /// </summary>
+    private void WarmReadyAudio(List<TenantId> tenants)
+    {
+        if (tenants.Count == 0) return;
+
+        ReadyAudioWarmup = Task.Run(() =>
+        {
+            foreach (var tenant in tenants) LoadReadyAudio(tenant);
+            FileLog.Write($"[WingmanVoiceService] ready-audio warm load finished for {tenants.Count} tenant partition(s) (background; the port was already open)");
+        });
+    }
+
+    /// <summary>
+    /// Completes when the ready-audio cache has finished loading from disk. Nothing in the serving path
+    /// waits on it - a cache that is still loading behaves as a cache miss and regenerates, which is the
+    /// whole reason it was moved off the startup path (issue #2203). Tests that assert on the reloaded
+    /// cache await this rather than racing the background read.
+    /// </summary>
+    internal Task ReadyAudioWarmup { get; private set; } = Task.CompletedTask;
 
     private void LoadVoiceSessions(TenantId tenant)
     {


### PR DESCRIPTION
Cuts 55 seconds off the post-swap container's time to open its port. That time is what causes the outage in thefrederiksen/devthrottle_internal#950: Azure stops the whole site if the port is not open within 230 seconds, and the stop is the 30-60 seconds users see.

Measured from the container's own startup record on the deploy of `9e89662` - the first deploy where that record existed.

## What was slow

| phase | starting alone | post-swap (contended) |
|---|---|---|
| **`Database.Migrate()` on Postgres** | 7.3s | **43.0s** |
| **ready-voice-audio cache read off the storage mount** | 8.2s | **11.6s** |
| everything else | ~15s | ~44s |
| **process start -> `listening on http://0.0.0.0:7878`** | 30.4s | **99.1s** |

## The migration wait

`Migrate()` acquires an exclusive database-wide advisory lock **before** it checks whether there is anything to apply, and holds it with no lock timeout and no command timeout. Every deploy runs two Gateway containers against one database, so the second waits on the first - 43 seconds spent acquiring a lock on a deploy carrying **no schema change at all**.

`GetPendingMigrations()` takes no lock: it reads the history table and compares. So ask first, and skip the locking call when the answer is none - which is most deploys.

This does not weaken the contract. When migrations ARE pending, `Migrate()` still runs and still fails loudly; the only thing removed is a lock acquisition that had nothing to do. Both branches now log what they decided, so the next deploy says which happened.

## The audio cache

`LoadReadyAudio` does one full `File.ReadAllBytes` per cached session - 106 mp3 files off the hosted SMB mount - in the constructor, before the port opens.

Which sessions are voice sessions is a **correctness** fact (the turn-end watcher consults it immediately) and costs one small file per tenant, so it stays on the startup path. The audio is a **warm-start convenience**: a cache that has not loaded yet behaves exactly like a cache miss, and the voice path already handles a miss by regenerating. A port that is not open is an outage. So the audio warms in the background, after the bind.

## Tests

Four tests asserted on reloaded audio immediately after construction and went red, which is correct - the behaviour genuinely changed. They are fixed at the helper level by awaiting the new `ReadyAudioWarmup` task, so they wait deterministically instead of racing a background read. Nothing in the serving path waits on it.

Voice, wingman and narration suites: 442 passed, 0 failed. Full Gateway suite reported in the thread.

## What is NOT proven here

The migration skip cannot be unit-tested - it needs a real Postgres with a real advisory lock and two real contenders. **The proof is the next deploy's own startup record**, which will either show `no pending migrations - skipping Migrate() and its database-wide lock` with that phase near zero, or it will not. That measurement gets posted to thefrederiksen/devthrottle_internal#950 either way.

Progresses thefrederiksen/devthrottle_internal#950. Does not close it: the remaining startup cost is spread across the rest of the pre-bind path, both slots still share one S1 worker, and thefrederiksen/devthrottle_internal#949 (no alerting) is untouched.
