### PR TITLE
Dictionary suggestions block for the daily report email

### DIFF
--- a/src/CcDirector.Gateway.Tests/SuggestionEmailBlockEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/SuggestionEmailBlockEndpointTests.cs
@@ -1,0 +1,227 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.AgentBrain;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Settings;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// HTTP end-to-end for the daily-email block route (issue #2074, mockup screen 5):
+/// <c>POST /ingest/dictionary/suggestions/email-block</c>. Boots the real <see cref="RecordingEndpoints"/> with
+/// a real composer over an isolated SQLite database and an isolated CC_DIRECTOR_ROOT, then drives the whole
+/// cadence over the wire - preview, two real sends, and the quiet third - because the property that matters is
+/// what a daily-report composer would actually receive, not what the service returns in process.
+/// </summary>
+public sealed class SuggestionEmailBlockEndpointTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-email-block-http-" + Guid.NewGuid().ToString("N"));
+    private readonly string? _prevRoot;
+    private readonly GatewayDbTestHarness _dbh = new();
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+    private static readonly DateTime Base = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    public SuggestionEmailBlockEndpointTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        _dbh.Dispose();
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task EmailBlockRoute_PreviewsFreelyThenMentionsTwiceAndGoesQuiet()
+    {
+        var db = _dbh.Open();
+        var transcripts = new TranscriptStore(db);
+        var dismissals = new DictionarySuggestionDismissalStore(db);
+        var suggestions = BuildSuggestions(db, transcripts, dismissals);
+        var settings = new TenantSettingsResolver(new TenantSettingsStore(db));
+        var composer = new SuggestionEmailComposer(
+            suggestions.GetSuggestions, settings, () => "https://gw.example.com", () => Base);
+
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add(bindUrl);
+        RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
+            suggestions: suggestions, dismissals: dismissals, emailComposer: composer);
+        await app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
+
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+
+            // 1. Nothing to say yet: the report carries no block, and the reason says why rather than
+            //    leaving a composer to guess from an empty payload.
+            var empty = await Post(http, null);
+            Assert.False(empty!.Include);
+            Assert.Equal("nosuggestions", empty.Reason);
+            Assert.Null(empty.Html);
+            Assert.Equal(0, empty.TermCount);
+
+            // 2. The user starts being misheard.
+            SeedTerm(transcripts, Base, new[] { ("mindzie", 44), ("Mindsee", 20), ("Mindsy", 15), ("Mindzee", 12) });
+            await suggestions.RunScanAsync(TenantId.Local);
+
+            // 3. A preview (no body at all) returns the finished block and spends nothing.
+            var preview = await Post(http, null);
+            Assert.True(preview!.Include);
+            Assert.Equal("included", preview.Reason);
+            Assert.Equal(0, preview.Mentions);
+            Assert.Equal(2, preview.MaxMentions);
+            Assert.Equal("Dictation: 1 word worth adding to your dictionary", preview.Heading);
+            Assert.Contains("mindzie", preview.Text, StringComparison.Ordinal);
+            Assert.Contains("https://gw.example.com/dictionary", preview.Html, StringComparison.Ordinal);
+            Assert.Contains("Suggestions in my daily email", preview.Footer, StringComparison.Ordinal);
+
+            // 4. Two real sends, both included, the mention count climbing.
+            Assert.Equal(1, (await Post(http, true))!.Mentions);
+            var second = await Post(http, true);
+            Assert.True(second!.Include);
+            Assert.Equal(2, second.Mentions);
+            Assert.Equal(preview.Batch, second.Batch);
+
+            // 5. The third goes quiet - the badge on the Dictionary page carries it from here. The term count
+            //    is still reported, so a composer can log "1 pending, deliberately not mentioned".
+            var third = await Post(http, true);
+            Assert.False(third!.Include);
+            Assert.Equal("alreadymentioned", third.Reason);
+            Assert.Null(third.Html);
+            Assert.Equal(1, third.TermCount);
+
+            // 6. Turning the setting off is the user's own override, and it is reported as such.
+            settings.SetSuggestionsInDailyEmail(TenantId.Local, false, Base);
+            var off = await Post(http, true);
+            Assert.False(off!.Include);
+            Assert.Equal("settingoff", off.Reason);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    /// <summary>Malformed JSON is rejected with a clear 400, not swallowed into a "no block" answer that would
+    /// look identical to a quiet day.</summary>
+    [Fact]
+    public async Task EmailBlockRoute_BadJson_IsRejected()
+    {
+        var db = _dbh.Open();
+        var transcripts = new TranscriptStore(db);
+        var dismissals = new DictionarySuggestionDismissalStore(db);
+        var suggestions = BuildSuggestions(db, transcripts, dismissals);
+        var composer = new SuggestionEmailComposer(
+            suggestions.GetSuggestions, new TenantSettingsResolver(new TenantSettingsStore(db)),
+            () => null, () => Base);
+
+        var bindUrl = $"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}";
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add(bindUrl);
+        RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
+            suggestions: suggestions, dismissals: dismissals, emailComposer: composer);
+        await app.StartAsync();
+        var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
+
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            var response = await http.PostAsync("/ingest/dictionary/suggestions/email-block",
+                new StringContent("{not json", Encoding.UTF8, "application/json"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    private static async Task<EmailBlockBody?> Post(HttpClient http, bool? markMentioned)
+    {
+        var content = markMentioned is null
+            ? null
+            : new StringContent($"{{\"markMentioned\":{markMentioned.Value.ToString().ToLowerInvariant()}}}",
+                Encoding.UTF8, "application/json");
+        var response = await http.PostAsync("/ingest/dictionary/suggestions/email-block", content);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<EmailBlockBody>(Json);
+    }
+
+    private static void SeedTerm(TranscriptStore store, DateTime at, (string spelling, int times)[] spellings)
+    {
+        var i = 0;
+        foreach (var (spelling, times) in spellings)
+            for (var n = 0; n < times; n++)
+                store.Append(TenantId.Local, "dictation", $"we shipped the {spelling} change", null, false,
+                    turnId: null, nowUtc: at.AddSeconds(i++));
+    }
+
+    /// <summary>A screening brain that approves every candidate in the prompt; counts calls so the test can
+    /// pin "a term is judged at most once, ever" through the HTTP surface.</summary>
+    private sealed class ApprovingBrain : IAgentBrain
+    {
+        public int Calls;
+        public string? SessionId => null;
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Calls++;
+            var verdicts = new List<object>();
+            foreach (var line in prompt.Split('\n'))
+            {
+                var t = line.Trim();
+                var dot = t.IndexOf(". \"", StringComparison.Ordinal);
+                if (dot < 0 || dot > 4) continue;
+                var start = dot + 3;
+                var end = t.IndexOf('"', start);
+                if (end < 0) continue;
+                verdicts.Add(new { term = t[start..end], approved = true, reason = "stub" });
+            }
+            return Task.FromResult(new AskResult { Text = JsonSerializer.Serialize(verdicts) });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
+    /// <summary>The suggestions engine on the shape current main gives it: four stores plus a screening brain.
+    /// The brain approves everything, so what reaches the email block is exactly what the miner found - the
+    /// screening is proved elsewhere and is not what this test is about.</summary>
+    private static DictionarySuggestionService BuildSuggestions(
+        CcDirector.Gateway.Data.GatewayDatabase db, TranscriptStore transcripts, DictionarySuggestionDismissalStore dismissals)
+        => new(
+            transcripts, dismissals,
+            new DictionarySuggestionVerdictStore(db),
+            new DictionarySuggestionScanStore(db),
+            TenantGlossary.Load,
+            (_, _) => Task.FromResult<(CcDirector.AgentBrain.IAgentBrain, string)>(
+                (new ApprovingBrain(), "stub-model")),
+            now: () => Base);
+
+    private sealed record EmailBlockBody(
+        bool Include, string Reason, string? Heading, string? Html, string? Text, string Footer,
+        int TermCount, string Batch, int Mentions, int MaxMentions);
+}

--- a/src/CcDirector.Gateway.Tests/SuggestionEmailBlockTests.cs
+++ b/src/CcDirector.Gateway.Tests/SuggestionEmailBlockTests.cs
@@ -1,0 +1,218 @@
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The daily-email suggestions block (issue #2074, mockup screen 5) and the batch fingerprint the send cadence
+/// is keyed on. The renderer is pure, so these assert the EXACT text the owner would receive rather than
+/// paraphrasing it - the whole point of a pure renderer is that the message is testable before it is sent.
+/// </summary>
+public sealed class SuggestionEmailBlockTests
+{
+    private static MistranscriptionSuggestion Sug(string term, int wrong, int total, params (string heard, int count)[] variants)
+        => new(term, variants.Select(v => new MistranscriptionVariant(v.heard, v.count)).ToList(), wrong, total);
+
+    private static IReadOnlyList<MistranscriptionSuggestion> FourTerms() => new[]
+    {
+        Sug("mindzie", 53, 97, ("Mindsee", 25), ("Mindsy", 16), ("Mindzee", 12)),
+        Sug("ConPty", 80, 144, ("Con-TY", 55), ("ConTY", 25)),
+        Sug("Frederiksen", 98, 364, ("Fredriksson", 60), ("Fredrickson", 38)),
+        Sug("Kubernetes", 4, 20, ("Cooper Netties", 4)),
+    };
+
+    // ---- the fingerprint ------------------------------------------------------------------------------
+
+    /// <summary>The same set of terms fingerprints the same however the miner happened to rank them. Ranking
+    /// shifts as counts move; a fingerprint that shifted with it would mint a "new batch" on every send and the
+    /// cadence would never go quiet, which is the exact failure it exists to prevent.</summary>
+    [Fact]
+    public void Fingerprint_IgnoresOrder()
+    {
+        var forward = FourTerms();
+        var reversed = forward.Reverse().ToList();
+
+        Assert.Equal(SuggestionEmailBlock.Fingerprint(forward), SuggestionEmailBlock.Fingerprint(reversed));
+    }
+
+    /// <summary>Counts tick up every time the user speaks. The batch is about WHICH WORDS, not how often, so a
+    /// changed count is the same batch.</summary>
+    [Fact]
+    public void Fingerprint_IgnoresCounts()
+    {
+        var a = new[] { Sug("mindzie", 3, 10, ("Mindsee", 3)) };
+        var b = new[] { Sug("mindzie", 900, 4000, ("Mindsee", 900), ("Mindsy", 12)) };
+
+        Assert.Equal(SuggestionEmailBlock.Fingerprint(a), SuggestionEmailBlock.Fingerprint(b));
+    }
+
+    /// <summary>A different word IS a different batch - which is what earns a new set of mentions.</summary>
+    [Fact]
+    public void Fingerprint_ChangesWhenATermChanges()
+    {
+        var a = new[] { Sug("mindzie", 3, 10, ("Mindsee", 3)) };
+        var b = new[] { Sug("ConPty", 3, 10, ("Con-TY", 3)) };
+
+        Assert.NotEqual(SuggestionEmailBlock.Fingerprint(a), SuggestionEmailBlock.Fingerprint(b));
+    }
+
+    /// <summary>Adding a term changes the batch, so a genuinely new word is never silenced by an earlier
+    /// batch's spent mentions.</summary>
+    [Fact]
+    public void Fingerprint_ChangesWhenATermIsAdded()
+    {
+        var one = new[] { Sug("mindzie", 3, 10, ("Mindsee", 3)) };
+        var two = one.Concat(new[] { Sug("ConPty", 3, 10, ("Con-TY", 3)) }).ToList();
+
+        Assert.NotEqual(SuggestionEmailBlock.Fingerprint(one), SuggestionEmailBlock.Fingerprint(two));
+    }
+
+    /// <summary>Casing and punctuation are not identity: the miner's canonical spelling can settle without
+    /// minting a new batch.</summary>
+    [Fact]
+    public void Fingerprint_IsCaseAndPunctuationInsensitive()
+    {
+        var a = new[] { Sug("ConPty", 3, 10, ("Con-TY", 3)) };
+        var b = new[] { Sug("con-pty.", 3, 10, ("Con-TY", 3)) };
+
+        Assert.Equal(SuggestionEmailBlock.Fingerprint(a), SuggestionEmailBlock.Fingerprint(b));
+    }
+
+    [Fact]
+    public void Fingerprint_EmptyBatch_IsEmpty()
+        => Assert.Equal("", SuggestionEmailBlock.Fingerprint(Array.Empty<MistranscriptionSuggestion>()));
+
+    // ---- the rendered block ---------------------------------------------------------------------------
+
+    /// <summary>The heading counts ALL pending terms, not the three that are shown - the reader is being told
+    /// how much is waiting, and the "+ 1 more" line is what reconciles the two numbers.</summary>
+    [Fact]
+    public void Render_HeadingCountsEveryPendingTerm()
+    {
+        var r = SuggestionEmailBlock.Render(FourTerms(), "https://gw.example.com/dictionary");
+
+        Assert.Equal("Dictation: 4 words worth adding to your dictionary", r.Heading);
+        Assert.Contains(r.Heading, r.Html, StringComparison.Ordinal);
+        Assert.StartsWith(r.Heading, r.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_OneTerm_UsesTheSingular()
+    {
+        var r = SuggestionEmailBlock.Render(new[] { Sug("mindzie", 3, 10, ("Mindsee", 3)) }, null);
+
+        Assert.Equal("Dictation: 1 word worth adding to your dictionary", r.Heading);
+    }
+
+    /// <summary>Top three in full, the rest summarized. The email is a doorbell, not a workbench.</summary>
+    [Fact]
+    public void Render_ShowsTopThreeAndSummarizesTheRest()
+    {
+        var r = SuggestionEmailBlock.Render(FourTerms(), "https://gw.example.com/dictionary");
+
+        Assert.Contains("mindzie", r.Text, StringComparison.Ordinal);
+        Assert.Contains("ConPty", r.Text, StringComparison.Ordinal);
+        Assert.Contains("Frederiksen", r.Text, StringComparison.Ordinal);
+        // The fourth term is NOT given a row of its own - it appears only on the summary line, named.
+        Assert.Contains("+ 1 more: Kubernetes", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Cooper Netties", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The evidence is the reason to care, so it travels with the term: what was heard, and how often
+    /// the word was got wrong out of how many times it was said.</summary>
+    [Fact]
+    public void Render_CarriesTheEvidenceForEachShownTerm()
+    {
+        var r = SuggestionEmailBlock.Render(FourTerms(), null);
+
+        Assert.Contains("(heard as Mindsee, Mindsy, Mindzee)", r.Text, StringComparison.Ordinal);
+        Assert.Contains("wrong 53 of 97 times", r.Text, StringComparison.Ordinal);
+        Assert.Contains("wrong 98 of 364 times", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>Only the most frequent few misheardings are listed - a term the model gets wrong a dozen
+    /// different ways would otherwise push the whole block off a phone screen.</summary>
+    [Fact]
+    public void Render_CapsTheVariantsListedPerTerm()
+    {
+        var many = new[]
+        {
+            Sug("mindzie", 30, 60,
+                ("Mindsee", 12), ("Mindsy", 8), ("Mindzee", 6), ("Mind Z", 3), ("Mind Sea", 1)),
+        };
+
+        var r = SuggestionEmailBlock.Render(many, null);
+
+        Assert.Contains("(heard as Mindsee, Mindsy, Mindzee)", r.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Mind Sea", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>Large counts are grouped so the evidence stays readable in a message.</summary>
+    [Fact]
+    public void Render_GroupsLargeCounts()
+    {
+        var r = SuggestionEmailBlock.Render(new[] { Sug("mindzie", 1234, 56789, ("Mindsee", 1234)) }, null);
+
+        Assert.Contains("wrong 1,234 of 56,789 times", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The one action in the block is a link to the page where the real approve flow lives - never an
+    /// accept action in the message itself.</summary>
+    [Fact]
+    public void Render_LinksToTheDictionaryPage()
+    {
+        var r = SuggestionEmailBlock.Render(FourTerms(), "https://gw.example.com/dictionary");
+
+        Assert.Contains("href=\"https://gw.example.com/dictionary\"", r.Html, StringComparison.Ordinal);
+        Assert.Contains("Review and add in Dictionary: https://gw.example.com/dictionary", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>With no publicly reachable address there is no honest link, so the block NAMES the page instead
+    /// of emitting a dead one. A localhost link in a message read on a phone is worse than no link.</summary>
+    [Fact]
+    public void Render_NoPublicAddress_NamesThePageInsteadOfLinking()
+    {
+        var r = SuggestionEmailBlock.Render(FourTerms(), null);
+
+        Assert.DoesNotContain("href=", r.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("http", r.Text, StringComparison.Ordinal);
+        Assert.Contains("Review and add on the Dictionary page in your Cockpit", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every term and heard-variant is user speech that arrived through a transcription model, so it is escaped
+    /// on the way into the markup. A term that happened to be heard as markup must render as those characters,
+    /// not run as them in the reader's mail client.
+    /// </summary>
+    [Fact]
+    public void Render_EscapesSpeechInTheMarkup()
+    {
+        var hostile = new[] { Sug("<script>alert(1)</script>", 5, 10, ("\"quoted\" & odd", 5)) };
+
+        var r = SuggestionEmailBlock.Render(hostile, "https://gw.example.com/dictionary");
+
+        Assert.DoesNotContain("<script>", r.Html, StringComparison.Ordinal);
+        Assert.Contains("&lt;script&gt;", r.Html, StringComparison.Ordinal);
+        Assert.Contains("&quot;quoted&quot; &amp; odd", r.Html, StringComparison.Ordinal);
+        // The plain-text rendering is the same content with no markup, so it is NOT escaped there.
+        Assert.Contains("<script>alert(1)</script>", r.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>An empty batch has no block. The caller decides that before rendering, so being handed one is a
+    /// programming error and says so rather than producing an empty block that looks like a rendering bug.</summary>
+    [Fact]
+    public void Render_EmptyBatch_Throws()
+        => Assert.Throws<ArgumentException>(() =>
+            SuggestionEmailBlock.Render(Array.Empty<MistranscriptionSuggestion>(), null));
+
+    /// <summary>The footer names the exact setting that controls the block, closing the loop with the Settings
+    /// screen inside the message itself.</summary>
+    [Fact]
+    public void Footer_NamesTheSettingThatControlsIt()
+    {
+        Assert.Contains("Suggestions in my daily email", SuggestionEmailBlock.Footer, StringComparison.Ordinal);
+        Assert.Contains("Settings", SuggestionEmailBlock.Footer, StringComparison.Ordinal);
+    }
+
+}

--- a/src/CcDirector.Gateway.Tests/SuggestionEmailComposerTests.cs
+++ b/src/CcDirector.Gateway.Tests/SuggestionEmailComposerTests.cs
@@ -1,0 +1,333 @@
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Settings;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The daily-email decision: whether this tenant's daily report carries a dictionary-suggestions block, why,
+/// and the once-per-batch cadence that keeps the email from nagging.
+///
+/// The settings store is REAL, on an isolated SQLite database, because the cadence has to survive a restart
+/// and an in-memory double would prove nothing about that. The suggestions are handed in as a list, which is
+/// exactly what the composer takes - it reads the stored scan and never triggers one.
+///
+/// The four answers and their directions:
+///   * setting off  -> quiet, and nothing else is even consulted (the user's choice wins first).
+///   * no pending   -> quiet, no block (the report simply does not have the section).
+///   * pending      -> included, twice, then quiet - and a NEW batch earns its own two.
+///   * previewing   -> never spends a mention, so a preview cannot silence a real send.
+/// </summary>
+public sealed class SuggestionEmailComposerTests : IDisposable
+{
+    private static readonly TenantId TenantA = new("tenant-a");
+    private static readonly TenantId TenantB = new("tenant-b");
+    private static readonly DateTime Base = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly GatewayDbTestHarness _dbh = new();
+
+    public void Dispose() => _dbh.Dispose();
+
+    private static MistranscriptionSuggestion Sug(string term, params (string heard, int count)[] v)
+        => new(term, v.Select(x => new MistranscriptionVariant(x.heard, x.count)).ToList(),
+               v.Sum(x => x.count), v.Sum(x => x.count) * 2);
+
+    private static readonly MistranscriptionSuggestion Mindzie =
+        Sug("mindzie", ("Mindsee", 20), ("Mindsy", 15), ("Mindzee", 12));
+    private static readonly MistranscriptionSuggestion Frederiksen =
+        Sug("Frederiksen", ("Fredriksson", 18), ("Fredrickson", 12));
+
+    private sealed record Rig(SuggestionEmailComposer Composer, TenantSettingsResolver Settings);
+
+    /// <param name="pending">What each tenant has waiting. A tenant absent from the map has nothing.</param>
+    private Rig Build(
+        Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>> pending,
+        string? baseUrl = "https://gw.example.com")
+    {
+        var settings = new TenantSettingsResolver(new TenantSettingsStore(_dbh.Open()));
+        var composer = new SuggestionEmailComposer(
+            t => pending.TryGetValue(t.Value, out var list) ? list : Array.Empty<MistranscriptionSuggestion>(),
+            settings, () => baseUrl, () => Base);
+        return new Rig(composer, settings);
+    }
+
+    /// <summary>Both tenants have the same one term waiting, so a difference in outcome can only come from
+    /// the per-tenant setting or cadence - never from one of them having nothing to say.</summary>
+    private Rig BothTenantsPending()
+        => Build(new Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>>
+        {
+            [TenantA.Value] = new[] { Mindzie },
+            [TenantB.Value] = new[] { Mindzie },
+        });
+
+    private Rig BuildWith(params MistranscriptionSuggestion[] forTenantA)
+        => Build(new Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>>
+        {
+            [TenantA.Value] = forTenantA,
+        });
+
+    // ---- the four reasons -----------------------------------------------------------------------------
+
+    /// <summary>The user's choice wins, and wins FIRST. With the setting off the block is withheld even though
+    /// there is a perfectly good batch waiting - which is the only way to tell this apart from "nothing to
+    /// say".</summary>
+    [Fact]
+    public void SettingOff_WithholdsTheBlockEvenWhenTermsArePending()
+    {
+        var rig = BuildWith(Mindzie); // there IS something to say
+        rig.Settings.SetSuggestionsInDailyEmail(TenantA, false, Base);
+
+        var d = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.False(d.Include);
+        Assert.Equal(SuggestionEmailComposer.BlockReason.SettingOff, d.Reason);
+        Assert.Null(d.Block);
+    }
+
+    /// <summary>Nothing pending, nothing said. The block simply is not in the report.</summary>
+    [Fact]
+    public void NoSuggestions_WithholdsTheBlock()
+    {
+        var rig = BuildWith(); // nothing pending
+
+        var d = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.False(d.Include);
+        Assert.Equal(SuggestionEmailComposer.BlockReason.NoSuggestions, d.Reason);
+        Assert.Null(d.Block);
+        Assert.Equal(0, d.TermCount);
+    }
+
+    /// <summary>The default is ON, so a tenant who has never opened Settings gets the block - the feature has
+    /// to work for the people it is meant to help.</summary>
+    [Fact]
+    public void DefaultOn_IncludesTheBlockWithNoSettingWritten()
+    {
+        var rig = BuildWith(Mindzie);
+
+        var d = rig.Composer.Compose(TenantA, markMentioned: false);
+        Assert.True(d.Include);
+        Assert.Equal(SuggestionEmailComposer.BlockReason.Included, d.Reason);
+        Assert.NotNull(d.Block);
+        Assert.Contains("mindzie", d.Block!.Text, StringComparison.Ordinal);
+    }
+
+    // ---- the cadence ----------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A batch is mentioned twice and then the email goes quiet. The badge on the Dictionary page is the
+    /// durable signal; the email is the doorbell and does not keep ringing.
+    /// </summary>
+    [Fact]
+    public void OneBatch_IsMentionedTwiceThenGoesQuiet()
+    {
+        var rig = BuildWith(Mindzie);
+
+        var first = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.True(first.Include);
+        Assert.Equal(1, first.Mentions);
+
+        var second = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.True(second.Include);
+        Assert.Equal(2, second.Mentions);
+        Assert.Equal(first.Batch, second.Batch);
+
+        var third = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.False(third.Include);
+        Assert.Equal(SuggestionEmailComposer.BlockReason.AlreadyMentioned, third.Reason);
+        Assert.Null(third.Block);
+        // The count did NOT keep climbing on the refused call - a withheld mention is not a mention.
+        Assert.Equal(2, third.Mentions);
+    }
+
+    /// <summary>New evidence earns new mentions: a batch that gains a term is a different batch, and its two
+    /// mentions start over. Without this, a genuinely new word would be silenced by the previous batch's
+    /// spent count.</summary>
+    [Fact]
+    public void NewEvidence_RestartsTheMentions()
+    {
+        // The scan result the composer reads is swapped under it, which is what a nightly rescan does.
+        var pending = new Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>>
+        {
+            [TenantA.Value] = new[] { Mindzie },
+        };
+        var rig = Build(pending);
+
+        rig.Composer.Compose(TenantA, markMentioned: true);
+        var second = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.False(rig.Composer.Compose(TenantA, markMentioned: true).Include); // quiet
+
+        // A second term starts being got wrong.
+        pending[TenantA.Value] = new[] { Mindzie, Frederiksen };
+
+        var afterNewEvidence = rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.True(afterNewEvidence.Include);
+        Assert.NotEqual(second.Batch, afterNewEvidence.Batch);
+        Assert.Equal(1, afterNewEvidence.Mentions);
+        Assert.Equal(2, afterNewEvidence.TermCount);
+    }
+
+    /// <summary>
+    /// PREVIEWING IS FREE. Asking without committing must not spend a mention - otherwise a settings preview,
+    /// a dry run, or a retry that never sent would quietly consume the batch's budget and the owner would get
+    /// one real email instead of two, or none instead of one.
+    /// </summary>
+    [Fact]
+    public void Preview_DoesNotSpendAMention()
+    {
+        var rig = BuildWith(Mindzie);
+
+        for (var i = 0; i < 5; i++)
+        {
+            var preview = rig.Composer.Compose(TenantA, markMentioned: false);
+            Assert.True(preview.Include);
+            Assert.Equal(0, preview.Mentions);
+        }
+
+        // Both real sends are still available.
+        Assert.True(rig.Composer.Compose(TenantA, markMentioned: true).Include);
+        Assert.True(rig.Composer.Compose(TenantA, markMentioned: true).Include);
+        Assert.False(rig.Composer.Compose(TenantA, markMentioned: true).Include);
+    }
+
+    /// <summary>The cadence is PER TENANT. One account exhausting its mentions must never silence another's -
+    /// the cadence state lives in that account's own settings partition.</summary>
+    [Fact]
+    public void Cadence_IsPerTenant()
+    {
+        var rig = BothTenantsPending();
+
+        rig.Composer.Compose(TenantA, markMentioned: true);
+        rig.Composer.Compose(TenantA, markMentioned: true);
+        Assert.False(rig.Composer.Compose(TenantA, markMentioned: true).Include);
+
+        // B has said nothing yet, so B still gets both of its own.
+        Assert.True(rig.Composer.Compose(TenantB, markMentioned: true).Include);
+        Assert.True(rig.Composer.Compose(TenantB, markMentioned: true).Include);
+        Assert.False(rig.Composer.Compose(TenantB, markMentioned: true).Include);
+    }
+
+    /// <summary>And one account's setting never reaches another's: A turning the email off leaves B included.</summary>
+    [Fact]
+    public void Setting_IsPerTenant()
+    {
+        var rig = BothTenantsPending();
+        rig.Settings.SetSuggestionsInDailyEmail(TenantA, false, Base);
+
+        Assert.False(rig.Composer.Compose(TenantA, markMentioned: false).Include);
+        Assert.True(rig.Composer.Compose(TenantB, markMentioned: false).Include);
+    }
+
+    /// <summary>The mention is recorded durably, not in memory: a Gateway restart does not hand a batch two
+    /// fresh mentions. Proved by building a SECOND composer over the same database, which is what a restart
+    /// looks like from the store's point of view.</summary>
+    [Fact]
+    public void Cadence_SurvivesARestart()
+    {
+        var rig = BuildWith(Mindzie);
+        rig.Composer.Compose(TenantA, markMentioned: true);
+        rig.Composer.Compose(TenantA, markMentioned: true);
+
+        // A second composer over the SAME database file - what a restart looks like from the store's side.
+        var afterRestart = BuildWith(Mindzie);
+        var d = afterRestart.Composer.Compose(TenantA, markMentioned: true);
+
+        Assert.False(d.Include);
+        Assert.Equal(SuggestionEmailComposer.BlockReason.AlreadyMentioned, d.Reason);
+    }
+
+    /// <summary>
+    /// THE LINK MUST BE A ROUTE THAT EXISTS. The Cockpit's router is mounted at the ROOT, so its Dictionary
+    /// page is <c>{base}/dictionary</c>. Building the link off the <c>{base}/cockpit</c> surface URL instead
+    /// produces <c>{base}/cockpit/dictionary</c>, which the Cockpit matches against its
+    /// <c>/cockpit/{sessionId}</c> session-redirect route and resolves to nothing - a link that looks right in
+    /// review, passes any "does it contain a URL" check, and dead-ends for the reader. This asserts the exact
+    /// path, and asserts the wrong one is ABSENT, because that is the only version of the check that fails.
+    /// </summary>
+    [Fact]
+    public void Block_LinksToTheDictionaryRouteThatActuallyExists()
+    {
+        var withUrl = BuildWith(Mindzie);
+        var linked = withUrl.Composer.Compose(TenantA, markMentioned: false);
+
+        Assert.Contains("https://gw.example.com/dictionary", linked.Block!.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("/cockpit/dictionary", linked.Block.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("/cockpit/dictionary", linked.Block.Html, StringComparison.Ordinal);
+    }
+
+    /// <summary>A trailing slash on the base must not produce a double slash in the link.</summary>
+    [Fact]
+    public void Block_LinkSurvivesATrailingSlashOnTheBase()
+    {
+        var rig = Build(
+            new Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>> { [TenantA.Value] = new[] { Mindzie } },
+            baseUrl: "https://gw.example.com/");
+
+        var linked = rig.Composer.Compose(TenantA, markMentioned: false);
+        Assert.Contains("https://gw.example.com/dictionary", linked.Block!.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("//dictionary", linked.Block.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>With no publicly reachable address there is no honest link, so the block names the page instead
+    /// - never a localhost address in a message read on a phone.</summary>
+    [Fact]
+    public void Block_WithNoPublicAddress_HasNoLink()
+    {
+        var noUrl = Build(
+            new Dictionary<string, IReadOnlyList<MistranscriptionSuggestion>> { [TenantB.Value] = new[] { Mindzie } },
+            baseUrl: null);
+
+        var unlinked = noUrl.Composer.Compose(TenantB, markMentioned: false);
+        Assert.DoesNotContain("http", unlinked.Block!.Text, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// The cadence state itself (issue #2074) - the small rules the composer above leans on, stated in isolation
+/// so a change to them fails here first with a plain message.
+/// </summary>
+public sealed class DictationEmailCadenceStateTests
+{
+    private static readonly DateTime Base = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void None_MayMentionAnything()
+        => Assert.True(DictationEmailCadenceState.None.MayMention("batch-1"));
+
+    [Fact]
+    public void SameBatch_MayBeMentionedUpToTheCap()
+    {
+        var s = DictationEmailCadenceState.None.Mentioned("batch-1", Base);
+        Assert.Equal(1, s.Mentions);
+        Assert.True(s.MayMention("batch-1"));
+
+        s = s.Mentioned("batch-1", Base.AddDays(1));
+        Assert.Equal(2, s.Mentions);
+        Assert.False(s.MayMention("batch-1"));
+    }
+
+    [Fact]
+    public void DifferentBatch_RestartsTheCount()
+    {
+        var s = DictationEmailCadenceState.None
+            .Mentioned("batch-1", Base)
+            .Mentioned("batch-1", Base.AddDays(1));
+        Assert.False(s.MayMention("batch-1"));
+
+        Assert.True(s.MayMention("batch-2"));
+        var next = s.Mentioned("batch-2", Base.AddDays(2));
+        Assert.Equal("batch-2", next.Batch);
+        Assert.Equal(1, next.Mentions);
+    }
+
+    [Fact]
+    public void Mentioned_StampsTheTimeInUtc()
+    {
+        var local = new DateTime(2026, 7, 24, 8, 0, 0, DateTimeKind.Local);
+        var s = DictationEmailCadenceState.None.Mentioned("batch-1", local);
+
+        Assert.NotNull(s.LastMentionUtc);
+        Assert.Equal(DateTimeKind.Utc, s.LastMentionUtc!.Value.Kind);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -158,7 +158,10 @@ internal static class GatewayEndpoints
         // /ingest/dictionary/suggestions routes. Null (older callers, recording-only test harnesses) simply
         // does not expose the suggestion routes; production wires both.
         Transcription.DictionarySuggestionService? dictionarySuggestions = null,
-        Transcription.DictionarySuggestionDismissalStore? dictionaryDismissals = null)
+        Transcription.DictionarySuggestionDismissalStore? dictionaryDismissals = null,
+        // Composes the daily email's suggestions block for the caller's tenant. Null (older callers,
+        // recording-only test harnesses) simply does not expose the email-block route.
+        Transcription.SuggestionEmailComposer? suggestionEmailComposer = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -348,7 +351,7 @@ internal static class GatewayEndpoints
 
         // Phone recorder ingest (offline-recorded audio -> transcription -> vault).
         RecordingEndpoints.Map(app, tenantBoundary, recordingKeyVault, transcriptionHistory, transcriptionAudioArchive,
-            dictionarySuggestions, dictionaryDismissals);
+            dictionarySuggestions, dictionaryDismissals, suggestionEmailComposer);
 
         // Read-only view of the Communication Manager approval queue (see the phone's
         // pending drafts remotely). Step 1 of centralizing the comm queue on the Gateway.

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -116,7 +116,8 @@ internal static class RecordingEndpoints
         TranscriptionHistoryLog? history = null,
         TranscriptionAudioArchive? audioArchive = null,
         DictionarySuggestionService? suggestions = null,
-        DictionarySuggestionDismissalStore? dismissals = null)
+        DictionarySuggestionDismissalStore? dismissals = null,
+        SuggestionEmailComposer? emailComposer = null)
     {
         FileLog.Write($"[RecordingEndpoints] mapping {Prefix} recording + dictionary routes PER-TENANT (issues #2058/#2060); hosted={GatewayHostedMode.IsHosted} - each route resolves the caller's tenant and answers 403 when none resolves");
 
@@ -124,7 +125,7 @@ internal static class RecordingEndpoints
         // being refused on hosted. They map under the same prefix on the ungrouped builder; each handler
         // resolves the caller's tenant and dispatches to that tenant's own recording store / glossary.
         var app = outer.MapGroup(Prefix);
-        MapRoutes(app, tenantBoundary, keyVault, history, audioArchive, suggestions, dismissals);
+        MapRoutes(app, tenantBoundary, keyVault, history, audioArchive, suggestions, dismissals, emailComposer);
     }
 
     /// <summary>
@@ -140,7 +141,8 @@ internal static class RecordingEndpoints
         TranscriptionHistoryLog? history,
         TranscriptionAudioArchive? audioArchive,
         DictionarySuggestionService? suggestions = null,
-        DictionarySuggestionDismissalStore? dismissals = null)
+        DictionarySuggestionDismissalStore? dismissals = null,
+        SuggestionEmailComposer? emailComposer = null)
     {
         // Lazily built on FIRST USE, not at host startup: constructing the service resolves
         // the OpenAI API key (the transcriber needs it), and the Gateway must boot on machines
@@ -372,6 +374,11 @@ internal static class RecordingEndpoints
         // route: resolve the caller's tenant, 403 when none resolves, never the Local partition on hosted.
         if (suggestions is not null && dismissals is not null)
             MapSuggestionRoutes(app, tenantBoundary, suggestions, dismissals);
+
+        // The daily-email block, mapped on its own condition because it depends on the composer rather than on
+        // the dismissal store - a harness that wires one need not wire the other.
+        if (emailComposer is not null)
+            MapSuggestionEmailRoute(app, tenantBoundary, emailComposer);
 
         app.MapGet("/recordings", (HttpContext ctx) =>
         {
@@ -620,6 +627,60 @@ internal static class RecordingEndpoints
             // The term is eligible again on the NEXT scan (daily, or the page's "Scan now"); the stored
             // result is not edited here because a restored term has no fresh mining evidence to show yet.
             return Results.Json(new { ok = true, restored });
+        });
+    }
+
+    /// <summary>
+    /// The daily-email block route (issue #2074, mockup screen 5): <c>POST /ingest/dictionary/suggestions/
+    /// email-block</c>. Whatever composes this tenant's daily report asks here whether the report should carry
+    /// a dictionary-suggestions block, and gets the finished block back - it never decides for itself
+    /// (critical rule 7). Same tenant idiom as every other route in this group.
+    ///
+    /// A POST rather than a GET because it can COMMIT: <c>markMentioned</c> spends one of the batch's two
+    /// mentions, and a GET that changes state would be spent by a link preview or a retry. Omit it, or send
+    /// false, to preview the block without spending anything.
+    /// </summary>
+    private static void MapSuggestionEmailRoute(
+        IEndpointRouteBuilder app,
+        Tenancy.HostedTenantBoundary? tenantBoundary,
+        SuggestionEmailComposer composer)
+    {
+        app.MapPost("/dictionary/suggestions/email-block", async (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+
+            // An absent or empty body is the common case (preview), so it is valid and means markMentioned
+            // false - the caller that commits says so explicitly.
+            SuggestionEmailBlockRequest? req = null;
+            if (ctx.Request.ContentLength is > 0)
+            {
+                try
+                {
+                    req = await JsonSerializer.DeserializeAsync<SuggestionEmailBlockRequest>(
+                        ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                }
+                catch (JsonException ex)
+                {
+                    FileLog.Write($"[RecordingEndpoints] email-block bad JSON: {ex.Message}");
+                    return Results.BadRequest(new { error = "invalid JSON" });
+                }
+            }
+
+            var decision = composer.Compose(t.Value, req?.MarkMentioned ?? false);
+            return Results.Json(new SuggestionEmailBlockResponse(
+                decision.Include,
+                // The reason travels as a lower-case word rather than the enum's name, so it reads the same
+                // in a log line, a test assertion, and a report the owner sees.
+                decision.Reason.ToString().ToLowerInvariant(),
+                decision.Block?.Heading,
+                decision.Block?.Html,
+                decision.Block?.Text,
+                SuggestionEmailBlock.Footer,
+                decision.TermCount,
+                decision.Batch,
+                decision.Mentions,
+                Settings.DictationEmailCadenceState.MaxMentionsPerBatch));
         });
     }
 
@@ -890,3 +951,26 @@ internal sealed record DismissedTermDto(
 
 /// <summary>GET /ingest/dictionary/dismissed - the dismissed terms, newest first.</summary>
 internal sealed record DismissedResponse(List<DismissedTermDto> Dismissed);
+
+/// <summary>POST /ingest/dictionary/suggestions/email-block request (issue #2074). The body is optional;
+/// omitting it previews the block without spending one of the batch's mentions.</summary>
+/// <param name="MarkMentioned">True only from the caller that is actually sending the report.</param>
+internal sealed record SuggestionEmailBlockRequest(bool? MarkMentioned);
+
+/// <summary>
+/// POST /ingest/dictionary/suggestions/email-block response (issue #2074) - the Gateway's finished verdict on
+/// whether this tenant's daily report carries a suggestions block, and the block itself when it does.
+/// </summary>
+/// <param name="Include">Whether the report should carry the block. When false, every block field is null.</param>
+/// <param name="Reason">Why: "included", "settingoff", "nosuggestions", or "alreadymentioned".</param>
+/// <param name="Heading">The block's heading line; null when not included.</param>
+/// <param name="Html">The block as HTML; null when not included.</param>
+/// <param name="Text">The block as plain text; null when not included.</param>
+/// <param name="Footer">The sentence naming the setting that controls the block, for the report's foot.</param>
+/// <param name="TermCount">How many terms are pending, whether or not the block is included.</param>
+/// <param name="Batch">The batch fingerprint the cadence is keyed on; empty when there are no suggestions.</param>
+/// <param name="Mentions">How many times this batch has been mentioned, after any commit this call made.</param>
+/// <param name="MaxMentions">The cap a batch may be mentioned, so the caller can render "1 of 2".</param>
+internal sealed record SuggestionEmailBlockResponse(
+    bool Include, string Reason, string? Heading, string? Html, string? Text, string Footer,
+    int TermCount, string Batch, int Mentions, int MaxMentions);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -614,6 +614,8 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Transcription.DictionarySuggestionVerdictStore _dictionaryVerdicts;
     private readonly Transcription.DictionarySuggestionScanStore _dictionaryScans;
     private readonly Transcription.DictionarySuggestionService _dictionarySuggestions;
+    // Composes the daily email's suggestions block for a tenant, cadence included.
+    private readonly Transcription.SuggestionEmailComposer _suggestionEmailComposer;
     private Transcription.DictionarySuggestionDailySweep? _suggestionDailySweep;
     // The voice-turn staging root, likewise bound to an explicitly-named partition. This path stages a clip
     // for the duration of one turn and then deletes it; it writes no delivery record and performs no
@@ -1084,6 +1086,12 @@ public sealed class GatewayHost : IAsyncDisposable
                     ep.BaseUrl, key, model, log: FileLog.Write, callTimeout: TimeSpan.FromMinutes(3));
                 return Task.FromResult((brain, model));
             });
+        // The daily-email block composer. It folds the tenant's "Suggestions in my daily email" choice,
+        // whether there is anything pending, and the once-per-batch cadence into ONE verdict, so whatever
+        // composes the daily report renders the answer rather than deciding for itself (rule 7). It is handed
+        // the READ of the stored scan, never the service, so it can never trigger a scan of its own.
+        _suggestionEmailComposer = new Transcription.SuggestionEmailComposer(
+            _dictionarySuggestions.GetSuggestions, _tenantSettingsResolver, GatewayPublicUrl.ResolveBase);
         // Cron-job definitions persist across a Gateway restart (epic #479, #482) in the cron_jobs table
         // (next-run times recomputed on load). The path argument is the LEGACY cronjobs.json, imported once
         // on first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real
@@ -2085,6 +2093,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // /ingest/dictionary/suggestions routes serve per tenant.
             dictionarySuggestions: _dictionarySuggestions,
             dictionaryDismissals: _dictionaryDismissals,
+            // The daily-email block route for the caller's tenant.
+            suggestionEmailComposer: _suggestionEmailComposer,
             requestShutdown: () =>
             {
                 var handler = OnShutdownRequested;

--- a/src/CcDirector.Gateway/Settings/DictationEmailCadenceState.cs
+++ b/src/CcDirector.Gateway/Settings/DictationEmailCadenceState.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Gateway.Settings;
+
+/// <summary>
+/// The per-tenant memory behind the daily email's suggestion cadence (issue #2074, mockup screen 5): which
+/// BATCH of pending suggestions was last mentioned, and how many times it has been mentioned.
+///
+/// The cadence decision this type exists to hold: a given batch is mentioned AT MOST
+/// <see cref="MaxMentionsPerBatch"/> times, then the email stays quiet until new evidence arrives. The durable
+/// signal is the red badge on the Dictionary page, which never goes quiet - the email is only the doorbell, so
+/// repeating it indefinitely would be nagging about something the user can already see.
+///
+/// "New evidence arrives" is expressed as a change of <see cref="Batch"/>, a fingerprint of the pending terms.
+/// Any change to the set - a term added by fresh mining, a term removed by being applied or dismissed - is a
+/// different batch and earns its own mentions. That is deliberately generous in ONE direction only: it can
+/// cost an extra mention after the user acts, never silence a genuinely new term.
+///
+/// Stored as JSON under <see cref="TenantSettingKeys.DictationEmailCadence"/>, so it needs no table of its own.
+/// </summary>
+/// <param name="Batch">The fingerprint of the batch last mentioned; empty when nothing has been mentioned.</param>
+/// <param name="Mentions">How many times that batch has been mentioned.</param>
+/// <param name="LastMentionUtc">When the most recent mention was emitted; null when there has been none.</param>
+public sealed record DictationEmailCadenceState(
+    [property: JsonPropertyName("batch")] string Batch,
+    [property: JsonPropertyName("mentions")] int Mentions,
+    [property: JsonPropertyName("lastMentionUtc")] DateTime? LastMentionUtc)
+{
+    /// <summary>How many times one batch may be mentioned in the daily email before it goes quiet.</summary>
+    public const int MaxMentionsPerBatch = 2;
+
+    /// <summary>The state of a tenant that has never had a batch mentioned.</summary>
+    public static readonly DictationEmailCadenceState None = new("", 0, null);
+
+    /// <summary>
+    /// Whether <paramref name="batch"/> may still be mentioned. A batch this state has never seen always may
+    /// (its count restarts at zero); the batch it is already tracking may only until it reaches
+    /// <see cref="MaxMentionsPerBatch"/>.
+    /// </summary>
+    public bool MayMention(string batch)
+        => !string.Equals(Batch, batch, StringComparison.Ordinal) || Mentions < MaxMentionsPerBatch;
+
+    /// <summary>
+    /// This state advanced by one mention of <paramref name="batch"/>. A different batch restarts the count at
+    /// one; the same batch increments it.
+    /// </summary>
+    public DictationEmailCadenceState Mentioned(string batch, DateTime nowUtc)
+        => string.Equals(Batch, batch, StringComparison.Ordinal)
+            ? this with { Mentions = Mentions + 1, LastMentionUtc = nowUtc.ToUniversalTime() }
+            : new DictationEmailCadenceState(batch, 1, nowUtc.ToUniversalTime());
+}

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -60,11 +60,27 @@ public static class TenantSettingKeys
     /// sweep applies it to sessions as they appear.</summary>
     public const string VoiceModeAll = "voice_mode_all";
 
+    /// <summary>
+    /// Whether pending dictionary suggestions are mentioned in this tenant's daily report email. Stored as
+    /// "true"/"false". Like <see cref="VoiceModeAll"/> there is no operator global default to fall back to -
+    /// this is a per-tenant choice about a per-tenant email - and its default is ON, so the mention reaches the
+    /// people who never open Settings, which is who the suggestions feature exists for.
+    /// </summary>
+    public const string DictationSuggestionsInDailyEmail = "dictation_suggestions_in_daily_email";
+
+    /// <summary>
+    /// The per-tenant state behind the daily email's "mention a batch at most twice" cadence, serialized as one
+    /// JSON object so the batch identity and the send count stay consistent with each other. Not a setting the
+    /// user edits - it is written by the email-block route and read by nothing else - but it lives here because
+    /// it is exactly a small per-tenant value and needs no table of its own.
+    /// </summary>
+    public const string DictationEmailCadence = "dictation_email_cadence";
+
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
         WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
-        VoiceModeAll,
+        VoiceModeAll, DictationSuggestionsInDailyEmail, DictationEmailCadence,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -124,6 +124,37 @@ public sealed class TenantSettingsResolver
     public bool VoiceModeAll(TenantId tenant)
         => string.Equals(_store.Get(tenant, TenantSettingKeys.VoiceModeAll), "true", StringComparison.Ordinal);
 
+    /// <summary>
+    /// Whether pending dictionary suggestions are mentioned in this tenant's daily report email. Defaults to
+    /// <see cref="SuggestionsInDailyEmailDefault"/> when the tenant has set no choice, and ALSO when the stored
+    /// value is not a boolean: a corrupt override degrades to the documented default rather than to whichever
+    /// boolean a lenient parse happened to leave behind.
+    /// </summary>
+    public bool SuggestionsInDailyEmail(TenantId tenant)
+        => ParseBool(_store.Get(tenant, TenantSettingKeys.DictationSuggestionsInDailyEmail))
+           ?? SuggestionsInDailyEmailDefault;
+
+    /// <summary>
+    /// This tenant's daily-email cadence state, or <see cref="DictationEmailCadenceState.None"/> when nothing
+    /// has been sent yet or the stored state cannot be read. Degrading an unreadable state to "nothing sent" is
+    /// the safe direction for a cadence whose whole job is to stay QUIET: it can cost at most one extra mention
+    /// of a batch, where the opposite default would silence a batch that was never mentioned at all.
+    /// </summary>
+    public DictationEmailCadenceState DictationEmailCadence(TenantId tenant)
+    {
+        var raw = _store.Get(tenant, TenantSettingKeys.DictationEmailCadence);
+        if (string.IsNullOrEmpty(raw)) return DictationEmailCadenceState.None;
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<DictationEmailCadenceState>(raw)
+                   ?? DictationEmailCadenceState.None;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return DictationEmailCadenceState.None;
+        }
+    }
+
     // ---- writes: validate like the global setters, then persist a per-tenant override -------------------
 
     /// <summary>Set the tenant's wingman model for a role.</summary>
@@ -214,7 +245,27 @@ public sealed class TenantSettingsResolver
         _store.Set(tenant, TenantSettingKeys.SnoozeDefaultMinutes, defaultMinutes.ToString(), nowUtc);
     }
 
+    /// <summary>Set whether pending suggestions are mentioned in this tenant's daily report email.</summary>
+    public void SetSuggestionsInDailyEmail(TenantId tenant, bool include, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.DictationSuggestionsInDailyEmail, include ? "true" : "false", nowUtc);
+
+    /// <summary>Record this tenant's daily-email cadence state after a mention is emitted.</summary>
+    public void SetDictationEmailCadence(TenantId tenant, DictationEmailCadenceState state, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.DictationEmailCadence,
+            System.Text.Json.JsonSerializer.Serialize(state), nowUtc);
+
     // ---- helpers ----------------------------------------------------------------------------------------
+
+    /// <summary>The default for <see cref="SuggestionsInDailyEmail"/> when a tenant has expressed no choice:
+    /// ON. The suggestions feature exists to help people who never open Settings, so the one place it reaches
+    /// them when they are not in the app has to be on by default.</summary>
+    public const bool SuggestionsInDailyEmailDefault = true;
+
+    /// <summary>Parse a stored boolean override; null when absent or not a boolean, so the caller falls back to
+    /// the documented default rather than guessing.</summary>
+    private static bool? ParseBool(string? raw)
+        => bool.TryParse(raw, out var value) ? value : null;
+
 
     /// <summary>An override value only when it is present AND non-empty; null otherwise (so the caller falls
     /// back to the operator global default rather than to an empty string).</summary>

--- a/src/CcDirector.Gateway/Transcription/SuggestionEmailBlock.cs
+++ b/src/CcDirector.Gateway/Transcription/SuggestionEmailBlock.cs
@@ -84,7 +84,7 @@ public static class SuggestionEmailBlock
     /// empty block that looks like a rendering bug.</param>
     /// <param name="dictionaryUrl">The absolute link to the Dictionary page. When null (self-host with no
     /// reachable public address), the block renders WITHOUT a link and names the page instead - it never emits
-    /// a localhost address, which would be a dead link in a message read on a phone.</param>
+    /// a machine-local address, which would be a dead link in a message read on a phone.</param>
     /// <exception cref="ArgumentException">The suggestion list is empty.</exception>
     public static Rendered Render(IReadOnlyList<MistranscriptionSuggestion> suggestions, string? dictionaryUrl)
     {

--- a/src/CcDirector.Gateway/Transcription/SuggestionEmailBlock.cs
+++ b/src/CcDirector.Gateway/Transcription/SuggestionEmailBlock.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using CcDirector.Core.Dictation.Models;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The rendered "words worth adding to your dictionary" block for the daily report email (issue #2074, mockup
+/// screen 5), plus the batch fingerprint the send cadence is keyed on.
+///
+/// PURE AND STATIC, like <see cref="CcDirector.Core.Dictation.MistranscriptionMiner"/>: it takes the
+/// suggestions and a link and returns text. It reads no clock, no store, and no tenant - the caller has already
+/// resolved all of that - so the exact bytes the owner will receive can be asserted in a unit test.
+///
+/// WHAT THE BLOCK IS FOR, and therefore what it deliberately is NOT: the email is a DOORBELL, not a workbench.
+/// It carries the top <see cref="TopTerms"/> terms with their evidence, a count of the rest, and ONE link to
+/// the Dictionary page where the real approve flow lives. There is no accept action in the email, because
+/// nothing may be added to a person's dictionary by their clicking a link in a message - approval happens on
+/// the page, against the live evidence.
+///
+/// It is also a BLOCK, not an email: no subject, no greeting, no signature, no sender. It is meant to be
+/// dropped into the existing daily report between that report's own sections, which is what keeps this feature
+/// from becoming a second email stream with its own unsubscribe to manage (mockup screen 5, note 1).
+///
+/// ESCAPING: every term and heard-variant is user speech that reached us through a transcription model, so all
+/// of it is HTML-escaped on the way into the markup. The plain-text rendering is the same content with no
+/// markup at all, for the text part of a multipart message.
+/// </summary>
+public static class SuggestionEmailBlock
+{
+    /// <summary>How many terms are shown in full. The rest are summarized as a "+ N more" line.</summary>
+    public const int TopTerms = 3;
+
+    /// <summary>How many heard-variants are listed for one term before the list is truncated.</summary>
+    public const int VariantsPerTerm = 3;
+
+    /// <summary>The Cockpit path the block's one link points at - where the approve flow lives.</summary>
+    public const string DictionaryPath = "/dictionary";
+
+    /// <summary>One rendered block: the same content as markup and as plain text, plus the heading so a caller
+    /// can log or preview what was produced without parsing the markup back apart.</summary>
+    /// <param name="Heading">The block's own heading line, e.g. "Dictation: 4 words worth adding to your dictionary".</param>
+    /// <param name="Html">The block as HTML, ready to drop between the daily report's other sections.</param>
+    /// <param name="Text">The same block as plain text, for the text part of the message.</param>
+    public sealed record Rendered(string Heading, string Html, string Text);
+
+    /// <summary>
+    /// A stable fingerprint of a batch of suggestions - the identity the "mention a batch at most twice"
+    /// cadence is keyed on (<see cref="Settings.DictationEmailCadenceState"/>).
+    ///
+    /// Built from the TERMS ONLY, normalized and sorted: a batch is "the same batch" when it is about the same
+    /// words. Deliberately NOT sensitive to the counts, which tick up every time the user speaks - folding
+    /// those in would make every send a new batch and the cadence would never go quiet, which is the one
+    /// failure this whole mechanism exists to prevent. Sorting means the miner's ranking can reshuffle without
+    /// inventing a new batch.
+    ///
+    /// An empty batch fingerprints as the empty string; there is nothing to mention, so it never reaches the
+    /// cadence at all.
+    /// </summary>
+    public static string Fingerprint(IReadOnlyList<MistranscriptionSuggestion> suggestions)
+    {
+        if (suggestions is null) throw new ArgumentNullException(nameof(suggestions));
+        if (suggestions.Count == 0) return "";
+
+        var terms = suggestions
+            .Select(s => Normalize(s.Term))
+            .Where(t => t.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal);
+
+        var joined = string.Join("\n", terms);
+        if (joined.Length == 0) return "";
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(joined));
+        return Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Render the block for a batch of suggestions.
+    /// </summary>
+    /// <param name="suggestions">The pending suggestions, in the miner's ranked order. Required, non-empty -
+    /// an empty batch has no block, and the caller decides that before rendering rather than being handed an
+    /// empty block that looks like a rendering bug.</param>
+    /// <param name="dictionaryUrl">The absolute link to the Dictionary page. When null (self-host with no
+    /// reachable public address), the block renders WITHOUT a link and names the page instead - it never emits
+    /// a localhost address, which would be a dead link in a message read on a phone.</param>
+    /// <exception cref="ArgumentException">The suggestion list is empty.</exception>
+    public static Rendered Render(IReadOnlyList<MistranscriptionSuggestion> suggestions, string? dictionaryUrl)
+    {
+        if (suggestions is null) throw new ArgumentNullException(nameof(suggestions));
+        if (suggestions.Count == 0)
+            throw new ArgumentException("An empty batch has no block; check the count before rendering.", nameof(suggestions));
+
+        var heading = $"Dictation: {Plural(suggestions.Count, "word", "words")} worth adding to your dictionary";
+        const string lede = "Your dictation keeps getting these wrong. Review takes one press - nothing is added until you approve it.";
+
+        var shown = suggestions.Take(TopTerms).ToList();
+        var rest = suggestions.Skip(TopTerms).ToList();
+
+        var html = new StringBuilder();
+        html.Append("<div style=\"border:1px solid #d8dee8;border-left:3px solid #c8102e;border-radius:6px;padding:14px 16px;margin:16px 0;\">");
+        html.Append("<h3 style=\"margin:0 0 4px;font-size:15px;\">").Append(Escape(heading)).Append("</h3>");
+        html.Append("<p style=\"margin:0 0 10px;font-size:13px;color:#5a6472;\">").Append(Escape(lede)).Append("</p>");
+        foreach (var s in shown)
+            html.Append(RowHtml(s));
+        if (rest.Count > 0)
+            html.Append(MoreRowHtml(rest));
+        html.Append("<p style=\"margin:14px 0 2px;\">");
+        html.Append(dictionaryUrl is null
+            ? "<span style=\"font-size:13px;font-weight:600;\">Review and add on the Dictionary page in your Cockpit</span>"
+            : $"<a href=\"{Escape(dictionaryUrl)}\" style=\"font-size:13px;font-weight:600;\">Review and add in Dictionary</a>");
+        html.Append("</p></div>");
+
+        var text = new StringBuilder();
+        text.Append(heading).Append('\n');
+        text.Append(lede).Append("\n\n");
+        foreach (var s in shown)
+            text.Append(RowText(s)).Append('\n');
+        if (rest.Count > 0)
+            text.Append(MoreRowText(rest)).Append('\n');
+        text.Append('\n');
+        text.Append(dictionaryUrl is null
+            ? "Review and add on the Dictionary page in your Cockpit."
+            : $"Review and add in Dictionary: {dictionaryUrl}");
+
+        return new Rendered(heading, html.ToString(), text.ToString());
+    }
+
+    /// <summary>The one-sentence footer naming the setting that controls this block, so the loop back to the
+    /// Settings screen is closed inside the message itself (mockup screen 5, note 3). Returned separately from
+    /// the block because it belongs at the foot of the whole report, not inside the block.</summary>
+    public const string Footer =
+        "You are getting suggestion notes because \"Suggestions in my daily email\" is on in Settings. " +
+        "Turn it off there any time.";
+
+    // ---- rows -------------------------------------------------------------------------------------------
+
+    private static string RowHtml(MistranscriptionSuggestion s)
+    {
+        var sb = new StringBuilder();
+        sb.Append("<div style=\"display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-top:1px solid #eef1f5;\">");
+        sb.Append("<div><span style=\"font-weight:600;font-size:13px;\">").Append(Escape(s.Term)).Append("</span>");
+        var heard = HeardList(s);
+        if (heard.Length > 0)
+            sb.Append("<div style=\"font-size:12px;color:#5a6472;\">heard as ").Append(Escape(heard)).Append("</div>");
+        sb.Append("</div>");
+        sb.Append("<span style=\"font-size:12px;color:#5a6472;white-space:nowrap;\">").Append(Escape(WrongOf(s))).Append("</span>");
+        sb.Append("</div>");
+        return sb.ToString();
+    }
+
+    private static string RowText(MistranscriptionSuggestion s)
+    {
+        var heard = HeardList(s);
+        var evidence = heard.Length > 0 ? $" (heard as {heard})" : "";
+        return $"  {s.Term}{evidence} - {WrongOf(s)}";
+    }
+
+    // The "+ N more" line names the remaining terms rather than only counting them: a bare "+ 1 more" tells the
+    // reader nothing about whether it is worth opening the page, and the terms are short.
+    private static string MoreRowHtml(IReadOnlyList<MistranscriptionSuggestion> rest)
+        => "<div style=\"display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-top:1px solid #eef1f5;\">"
+           + "<div><span style=\"font-weight:600;font-size:13px;\">+ " + rest.Count + " more</span>"
+           + "<div style=\"font-size:12px;color:#5a6472;\">" + Escape(string.Join(", ", rest.Select(r => r.Term))) + "</div>"
+           + "</div></div>";
+
+    private static string MoreRowText(IReadOnlyList<MistranscriptionSuggestion> rest)
+        => $"  + {rest.Count} more: {string.Join(", ", rest.Select(r => r.Term))}";
+
+    /// <summary>The heard-variants for one term, most frequent first, capped at <see cref="VariantsPerTerm"/>.</summary>
+    private static string HeardList(MistranscriptionSuggestion s)
+        => string.Join(", ", s.Variants
+            .OrderByDescending(v => v.Count)
+            .ThenBy(v => v.Heard, StringComparer.Ordinal)
+            .Take(VariantsPerTerm)
+            .Select(v => v.Heard));
+
+    /// <summary>The evidence line: "wrong 53 of 97 times". Thousands are grouped so a large count stays
+    /// readable in a message.</summary>
+    private static string WrongOf(MistranscriptionSuggestion s)
+        => $"wrong {s.WrongCount.ToString("N0", CultureInfo.InvariantCulture)} of "
+           + $"{s.TotalCount.ToString("N0", CultureInfo.InvariantCulture)} times";
+
+    private static string Plural(int n, string one, string many)
+        => $"{n.ToString("N0", CultureInfo.InvariantCulture)} {(n == 1 ? one : many)}";
+
+    /// <summary>Letters and digits only, lower-cased - the same normalization the suggestion service uses to
+    /// match a term, so the fingerprint and the term lookup agree on what "the same word" means.</summary>
+    private static string Normalize(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        foreach (var c in s)
+            if (char.IsLetterOrDigit(c))
+                sb.Append(char.ToLowerInvariant(c));
+        return sb.ToString();
+    }
+
+    private static string Escape(string s)
+        => s.Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal);
+}

--- a/src/CcDirector.Gateway/Transcription/SuggestionEmailComposer.cs
+++ b/src/CcDirector.Gateway/Transcription/SuggestionEmailComposer.cs
@@ -45,7 +45,7 @@ public sealed class SuggestionEmailComposer
     /// <c>{base}/cockpit</c> surface URL: the Cockpit's router is mounted at the root, so its Dictionary page
     /// is <c>{base}/dictionary</c> - a <c>{base}/cockpit/dictionary</c> link would be swallowed by the
     /// <c>/cockpit/{sessionId}</c> route and land the reader nowhere. A null means the block renders with no
-    /// link rather than with a dead localhost one.</param>
+    /// link rather than with a dead machine-local one.</param>
     /// <param name="now">Clock for the cadence timestamp; <see cref="DateTime.UtcNow"/> when null.</param>
     public SuggestionEmailComposer(
         Func<TenantId, IReadOnlyList<MistranscriptionSuggestion>> pendingFor,
@@ -138,7 +138,7 @@ public sealed class SuggestionEmailComposer
 
     /// <summary>
     /// The absolute link to the Dictionary page, or null when this Gateway has no publicly reachable address.
-    /// Null is a truthful answer, not a failure: a link to 127.0.0.1 in a message read on a phone is a dead
+    /// Null is a truthful answer, not a failure: a link to the Gateway's own machine, read on a phone, is a dead
     /// link, and the block is written to name the page instead when there is nothing real to point at.
     /// </summary>
     private string? BuildDictionaryUrl()

--- a/src/CcDirector.Gateway/Transcription/SuggestionEmailComposer.cs
+++ b/src/CcDirector.Gateway/Transcription/SuggestionEmailComposer.cs
@@ -1,0 +1,150 @@
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Settings;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// Decides whether this tenant's daily report should carry a dictionary-suggestions block right now, and
+/// renders it when the answer is yes (issue #2074, mockup screen 5).
+///
+/// THE GATEWAY OWNS THE VERDICT (critical rule 7). Whatever composes the daily report asks this one question
+/// and renders the answer verbatim; it never re-derives "are there suggestions", "is the setting on", or "have
+/// we already said this". Every reason to stay quiet is folded here and named in
+/// <see cref="EmailBlockDecision.Reason"/>, so a report that omits the block can always say why - which is what
+/// makes a missing block debuggable instead of a mystery.
+///
+/// THE FOUR REASONS TO STAY QUIET, in the order they are checked:
+///   1. The tenant turned "Suggestions in my daily email" off. Their choice, checked first so nothing else runs.
+///   2. There are no pending suggestions. Nothing to say; the block simply is not there (screen 5, note 1).
+///   3. This exact batch has already been mentioned <see cref="DictationEmailCadenceState.MaxMentionsPerBatch"/>
+///      times. The badge on the Dictionary page is the durable signal; the email is a doorbell and does not
+///      keep ringing.
+///   4. Nothing - the block is included.
+///
+/// MENTIONING IS AN EXPLICIT COMMIT, not a side effect of asking. <see cref="Compose"/> answers without writing
+/// anything unless <c>markMentioned</c> is set, so a caller can preview the block (a settings page, a dry run,
+/// a test) without spending one of the batch's two mentions. Only the caller that is actually about to SEND
+/// commits the count.
+/// </summary>
+public sealed class SuggestionEmailComposer
+{
+    private readonly Func<TenantId, IReadOnlyList<MistranscriptionSuggestion>> _pendingFor;
+    private readonly TenantSettingsResolver _settings;
+    private readonly Func<string?> _baseUrl;
+    private readonly Func<DateTime> _now;
+
+    /// <param name="pendingFor">The tenant's pending suggestions - production passes
+    /// <see cref="DictionarySuggestionService.GetSuggestions"/>. Deliberately the LIST and not the whole
+    /// service: this class reads what is already stored and never triggers a scan, and a narrow dependency is
+    /// what makes that impossible to get wrong later. Required.</param>
+    /// <param name="settings">The per-tenant settings the toggle and cadence state live in. Required.</param>
+    /// <param name="baseUrl">Resolves this Gateway's public BASE address, or null when it has no remotely
+    /// reachable one; production passes <see cref="GatewayPublicUrl.ResolveBase()"/>. The base, not the
+    /// <c>{base}/cockpit</c> surface URL: the Cockpit's router is mounted at the root, so its Dictionary page
+    /// is <c>{base}/dictionary</c> - a <c>{base}/cockpit/dictionary</c> link would be swallowed by the
+    /// <c>/cockpit/{sessionId}</c> route and land the reader nowhere. A null means the block renders with no
+    /// link rather than with a dead localhost one.</param>
+    /// <param name="now">Clock for the cadence timestamp; <see cref="DateTime.UtcNow"/> when null.</param>
+    public SuggestionEmailComposer(
+        Func<TenantId, IReadOnlyList<MistranscriptionSuggestion>> pendingFor,
+        TenantSettingsResolver settings,
+        Func<string?> baseUrl,
+        Func<DateTime>? now = null)
+    {
+        _pendingFor = pendingFor ?? throw new ArgumentNullException(nameof(pendingFor));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _baseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
+        _now = now ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>Why the block is or is not in this report. A closed set, so the caller renders a verdict rather
+    /// than interpreting one.</summary>
+    public enum BlockReason
+    {
+        /// <summary>The block is included.</summary>
+        Included,
+
+        /// <summary>The tenant turned "Suggestions in my daily email" off.</summary>
+        SettingOff,
+
+        /// <summary>There are no pending suggestions to mention.</summary>
+        NoSuggestions,
+
+        /// <summary>This batch has already had its mentions; the badge carries it from here.</summary>
+        AlreadyMentioned,
+    }
+
+    /// <summary>
+    /// The composed answer. <see cref="Block"/> is non-null exactly when <see cref="Include"/> is true, so a
+    /// caller cannot render a block the decision said to withhold.
+    /// </summary>
+    /// <param name="Include">Whether the daily report should carry the block.</param>
+    /// <param name="Reason">Why - including why not.</param>
+    /// <param name="Block">The rendered block when included; null otherwise.</param>
+    /// <param name="TermCount">How many terms are pending, whether or not the block is included.</param>
+    /// <param name="Batch">The batch fingerprint; empty when there are no suggestions.</param>
+    /// <param name="Mentions">How many times this batch has now been mentioned (after any commit).</param>
+    public sealed record EmailBlockDecision(
+        bool Include,
+        BlockReason Reason,
+        SuggestionEmailBlock.Rendered? Block,
+        int TermCount,
+        string Batch,
+        int Mentions);
+
+    /// <summary>
+    /// Decide and, when included and <paramref name="markMentioned"/> is set, record the mention.
+    /// </summary>
+    /// <param name="tenant">The tenant whose report is being composed. Required and valid.</param>
+    /// <param name="markMentioned">True only from the caller that is actually sending, so a preview never
+    /// spends one of the batch's mentions.</param>
+    /// <exception cref="ArgumentException">The tenant is invalid.</exception>
+    public EmailBlockDecision Compose(TenantId tenant, bool markMentioned)
+    {
+        if (!_settings.SuggestionsInDailyEmail(tenant))
+            return new EmailBlockDecision(false, BlockReason.SettingOff, null, 0, "", 0);
+
+        var suggestions = _pendingFor(tenant);
+        if (suggestions.Count == 0)
+            return new EmailBlockDecision(false, BlockReason.NoSuggestions, null, 0, "", 0);
+
+        var batch = SuggestionEmailBlock.Fingerprint(suggestions);
+        var cadence = _settings.DictationEmailCadence(tenant);
+        if (!cadence.MayMention(batch))
+        {
+            FileLog.Write($"[SuggestionEmailComposer] quiet tenant={tenant.ToLogString()} batch={batch} " +
+                          $"mentions={cadence.Mentions} - already at the cap");
+            return new EmailBlockDecision(false, BlockReason.AlreadyMentioned, null, suggestions.Count, batch, cadence.Mentions);
+        }
+
+        var url = BuildDictionaryUrl();
+        var rendered = SuggestionEmailBlock.Render(suggestions, url);
+
+        var mentions = cadence.Mentions;
+        if (markMentioned)
+        {
+            var nowUtc = _now().ToUniversalTime();
+            var next = cadence.Mentioned(batch, nowUtc);
+            _settings.SetDictationEmailCadence(tenant, next, nowUtc);
+            mentions = next.Mentions;
+            FileLog.Write($"[SuggestionEmailComposer] mentioned tenant={tenant.ToLogString()} batch={batch} " +
+                          $"terms={suggestions.Count} mention={mentions} of {DictationEmailCadenceState.MaxMentionsPerBatch}");
+        }
+
+        return new EmailBlockDecision(true, BlockReason.Included, rendered, suggestions.Count, batch, mentions);
+    }
+
+    /// <summary>
+    /// The absolute link to the Dictionary page, or null when this Gateway has no publicly reachable address.
+    /// Null is a truthful answer, not a failure: a link to 127.0.0.1 in a message read on a phone is a dead
+    /// link, and the block is written to name the page instead when there is nothing real to point at.
+    /// </summary>
+    private string? BuildDictionaryUrl()
+    {
+        var root = _baseUrl();
+        if (string.IsNullOrWhiteSpace(root)) return null;
+        return root.TrimEnd('/') + SuggestionEmailBlock.DictionaryPath;
+    }
+}


### PR DESCRIPTION
The suggestions the Gateway already mines are only visible to someone who opens the Dictionary page. This produces the block that surfaces them in a daily report, and the verdict on whether that report should carry one.

**What is here**

- A pure renderer producing the block as HTML and as plain text: the top three terms with their evidence, the rest named on a summary line, one link to the Dictionary page. There is no accept action in the message - nothing may be added to a person's dictionary by their clicking a link in an email.
- A composer that folds the account's "Suggestions in my daily email" choice, whether anything is pending, and the cadence into ONE verdict, so whatever composes the report renders the answer rather than deciding for itself. It takes the read of the stored scan, never the suggestions service, so it can never trigger a scan of its own.
- A cadence: a batch is mentioned at most twice, then the email goes quiet until new evidence arrives. It is keyed on a fingerprint of the terms, not their counts - counts move every time you speak, so folding them in would mint a new batch on every send and it would never go quiet.
- `POST /ingest/dictionary/suggestions/email-block`, returning the verdict and the block. Four named answers - included, setting off, nothing pending, already mentioned - so a report that omits the block can always say why.

Previewing spends nothing; only the caller that is actually sending commits a mention.

**No migration.** The setting and the cadence state live in the existing per-account settings table.

**Nothing sends this yet.** The real daily email is a separate service in another repository and is an admin digest, not a per-customer report. Wiring it is a separate decision, deliberately not taken here.

**Proof.** Whole Gateway suite green: 4,184 passed, 0 failed, 17 skipped (the live-Postgres ones, which need a database the build host has not got).
