### PR TITLE
Session supervision phase 1: the Director counts turns and keeps the honest waiting clock (internal#625)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1647,6 +1647,13 @@ internal static class ControlEndpoints
             // tree (issue 516). Nothing is derived here - the Gateway passes the count through and the
             // clients share one formatter.
             UncommittedCount = s.UncommittedCount,
+            // Supervision facts (internal#625 Phase 1): the completed-turn counter and the honest
+            // waiting clock, kept by the Session at the activity flip. Raw facts; the Gateway
+            // passes them through and the clients share one formatter. Always reported by this
+            // Director - only an older build leaves them null on the wire.
+            TurnCount = s.TurnCount,
+            WaitingSince = s.WaitingSince,
+            CumulativeIdleSeconds = s.CumulativeIdleSeconds,
             // Issue #335: identity fields populated by the Director (not patched by the Gateway).
             MachineName = machineName,
             User = user,

--- a/src/CcDirector.Core.Tests/Sessions/SessionSupervisionFactsTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionSupervisionFactsTests.cs
@@ -1,0 +1,151 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// The supervision facts a session keeps for itself at the activity flip (internal#625 Phase 1):
+/// the completed-turn counter (one flip to WaitingForInput == one turn - the same rule
+/// TurnReviewLogger writes records by), the waiting anchor, and the accumulated
+/// waiting-on-the-user clock. Sessions are driven through ApplyTerminalActivityState exactly as
+/// the terminal detector drives production. The clock is injected so accumulation is asserted
+/// exactly, never with sleeps.
+/// </summary>
+public sealed class SessionSupervisionFactsTests
+{
+    [Fact]
+    public void FreshSession_ReportsZeroTurns_NoAnchor_NoIdle()
+    {
+        using var session = NewSession();
+
+        Assert.Equal(0, session.TurnCount);
+        Assert.Null(session.WaitingSince);
+        Assert.Equal(0, session.CumulativeIdleSeconds);
+    }
+
+    [Fact]
+    public void TurnCount_IncrementsOnlyOnTheFlipToWaitingForInput()
+    {
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(1, session.TurnCount);
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        Assert.Equal(1, session.TurnCount);
+
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(2, session.TurnCount);
+    }
+
+    [Fact]
+    public void TurnCount_APermissionPromptIsNotATurn()
+    {
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForPerm);
+
+        // Waiting on a permission answer mid-turn: nothing finished, nothing to count.
+        Assert.Equal(0, session.TurnCount);
+    }
+
+    [Fact]
+    public void TurnCount_ARepeatedSameStateApplicationIsNotASecondTurn()
+    {
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        // Cosmetic repaints re-apply the same state; SetActivityState dedupes, so no double count.
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+
+        Assert.Equal(1, session.TurnCount);
+    }
+
+    [Fact]
+    public void WaitingSince_AnchorsOnEnteringWaiting_AndClearsOnWorking()
+    {
+        using var session = NewSession();
+        var now = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        session.SupervisionClock = () => now;
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        Assert.Null(session.WaitingSince);
+
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(now, session.WaitingSince);
+
+        now = now.AddSeconds(30);
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        Assert.Null(session.WaitingSince);
+    }
+
+    [Fact]
+    public void WaitingSince_SurvivesThePermToInputTransition_OneWaitOneAnchor()
+    {
+        using var session = NewSession();
+        var t0 = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var now = t0;
+        session.SupervisionClock = () => now;
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForPerm);
+        Assert.Equal(t0, session.WaitingSince);
+
+        // Still the user's wait - the anchor must not move, and no idle closes yet.
+        now = t0.AddSeconds(20);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(t0, session.WaitingSince);
+        Assert.Equal(0, session.CumulativeIdleSeconds);
+    }
+
+    [Fact]
+    public void CumulativeIdle_SumsClosedWaits_AndExcludesTheOpenOne()
+    {
+        using var session = NewSession();
+        var t0 = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var now = t0;
+        session.SupervisionClock = () => now;
+
+        // First wait: 60 seconds.
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        now = t0.AddSeconds(10);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        now = t0.AddSeconds(70);
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        Assert.Equal(60, session.CumulativeIdleSeconds);
+
+        // Second wait opens but has not closed: the total must not move yet.
+        now = t0.AddSeconds(100);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        now = t0.AddSeconds(400);
+        Assert.Equal(60, session.CumulativeIdleSeconds);
+
+        // It closes: 300 more seconds land in the total.
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        Assert.Equal(360, session.CumulativeIdleSeconds);
+    }
+
+    [Fact]
+    public void CumulativeIdle_AnExitWhileWaitingClosesTheStretch()
+    {
+        using var session = NewSession();
+        var t0 = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var now = t0;
+        session.SupervisionClock = () => now;
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        now = t0.AddSeconds(45);
+        session.ApplyTerminalActivityState(ActivityState.Exited);
+
+        Assert.Equal(45, session.CumulativeIdleSeconds);
+        Assert.Null(session.WaitingSince);
+    }
+
+    private static Session NewSession()
+        => new(Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null, new StubSessionBackend(), SessionBackendType.ConPty);
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1077,6 +1077,66 @@ public sealed class Session : IDisposable
     /// the desktop rail, which re-renders the badge in place.</summary>
     public event Action<int?>? OnUncommittedCountChanged;
 
+    private int _turnCount;
+    private DateTime? _waitingSince;
+    private double _cumulativeIdleSeconds;
+
+    /// <summary>Clock for the supervision facts below. A test seam; production never sets it.</summary>
+    internal Func<DateTime> SupervisionClock { private get; set; } = static () => DateTime.UtcNow;
+
+    /// <summary>
+    /// How many turns the agent has completed in this run of the session: one flip of
+    /// <see cref="ActivityState"/> to <see cref="ActivityState.WaitingForInput"/> equals one turn -
+    /// the same rule <c>TurnReviewLogger</c> writes its records by. Kept as a running count at the
+    /// flip so no reader ever re-parses a transcript, and so it works for every agent kind (the
+    /// on-demand <c>ComputeTurnCount</c> is a full JSONL re-parse and Claude-only).
+    /// Reported on <c>SessionDto.TurnCount</c>.
+    /// </summary>
+    public int TurnCount => _turnCount;
+
+    /// <summary>
+    /// UTC moment this session last entered a waiting-on-the-user state (WaitingForInput or
+    /// WaitingForPerm), or null while it is not waiting. An absolute anchor, not a duration:
+    /// readers derive the ticking "sitting on you for X" clock from it. Survives the
+    /// WaitingForPerm-to-WaitingForInput transition - one uninterrupted wait, one anchor.
+    /// </summary>
+    public DateTime? WaitingSince => _waitingSince;
+
+    /// <summary>
+    /// Total seconds this session has spent waiting on the user, summed over CLOSED waiting
+    /// stretches. The stretch currently open (<see cref="WaitingSince"/> non-null) is NOT yet
+    /// included - a reader adds it for the live total. This is the honest idle clock the cards
+    /// show; it is NOT the byte-silence <c>IdleSeconds</c> in the mapper, which resets on any
+    /// terminal output.
+    /// </summary>
+    public double CumulativeIdleSeconds => _cumulativeIdleSeconds;
+
+    /// <summary>
+    /// Supervision bookkeeping (internal#625 Phase 1): the turn counter and the waiting clock.
+    /// Runs INSIDE <see cref="SetActivityState"/> before <see cref="OnActivityStateChanged"/> fires,
+    /// so the delta push wired to that event always carries the numbers this very flip produced -
+    /// a subscriber could run after the push and ship stale values. Reporting only, no rulings.
+    /// </summary>
+    private void RecordSupervisionFacts(ActivityState old, ActivityState @new)
+    {
+        var wasWaiting = old is ActivityState.WaitingForInput or ActivityState.WaitingForPerm;
+        var isWaiting = @new is ActivityState.WaitingForInput or ActivityState.WaitingForPerm;
+
+        if (@new == ActivityState.WaitingForInput)
+            _turnCount++;
+
+        if (!wasWaiting && isWaiting)
+        {
+            _waitingSince = SupervisionClock();
+        }
+        else if (wasWaiting && !isWaiting)
+        {
+            if (_waitingSince is { } since)
+                _cumulativeIdleSeconds += Math.Max(0, (SupervisionClock() - since).TotalSeconds);
+            _waitingSince = null;
+        }
+    }
+
     /// <summary>
     /// Set (or clear) the Wingman's "parked on a background task" verdict for this session.
     /// Sole caller is <c>ProactiveExplainService</c> after an explain briefing. Pass a short
@@ -2541,6 +2601,9 @@ public sealed class Session : IDisposable
         Interlocked.Increment(ref _activityGeneration);
         // Log the transition (blue<->red) to the in-memory ring the Wingman tab renders.
         RecordStateChange(old, newState);
+        // Turn counter and waiting clock - must run before the event so the delta push
+        // that rides OnActivityStateChanged carries this flip's numbers, not the last one's.
+        RecordSupervisionFacts(old, newState);
         OnActivityStateChanged?.Invoke(old, newState);
     }
 

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -728,6 +728,39 @@ public sealed class SessionDto
     public int? UncommittedCount { get; set; }
 
     /// <summary>
+    /// How many turns the agent has completed in this run of the session, counted by the owning
+    /// Director at the activity flip: one flip to WaitingForInput equals one turn - the same rule
+    /// <c>TurnReviewLogger</c> writes its records by - so it works for every agent kind and no
+    /// reader ever re-parses a transcript. A RAW FACT the Gateway passes through untouched.
+    ///
+    /// NULL MEANS UNKNOWN, NEVER ZERO: null is what an older Director reports, since it does not
+    /// know the field. A live Director always reports a number, and 0 from one genuinely means
+    /// "no turn has completed yet". Distinct from <see cref="InputStats"/>, which counts turns
+    /// the user SUBMITTED, not turns the agent finished.
+    /// </summary>
+    public int? TurnCount { get; set; }
+
+    /// <summary>
+    /// UTC moment the session last entered a waiting-on-the-user state (WaitingForInput or
+    /// WaitingForPerm), or null while it is not waiting. An ABSOLUTE ANCHOR, not a duration:
+    /// clients derive the ticking "sitting on you for X" clock from it locally, the same way the
+    /// waiting label already ticks between roster polls (the durationLabel precedent, issue #844).
+    /// Distinct from <see cref="IdleSeconds"/>, which is byte-silence and resets on any output,
+    /// and from <see cref="NeedsYouSince"/>, which is the Gateway's red-state verdict clock -
+    /// this one is the Director's raw fact about the terminal's turn state.
+    /// </summary>
+    public DateTime? WaitingSince { get; set; }
+
+    /// <summary>
+    /// Total seconds this session has spent waiting on the user, summed over CLOSED waiting
+    /// stretches, as measured by the owning Director. While <see cref="WaitingSince"/> is set the
+    /// current open stretch is NOT yet included - a reader adds (now - WaitingSince) for the live
+    /// total, so the number keeps moving between pushes without the Director re-pushing. Null when
+    /// an older Director does not report it; unknown, never zero.
+    /// </summary>
+    public double? CumulativeIdleSeconds { get; set; }
+
+    /// <summary>
     /// Issue #1176 (Phase 1a): a copy safe to hand out from the Gateway's pushed-session cache. The
     /// <c>/sessions</c> aggregation stamps scalar fields (EffectiveColor, DirectorId, MachineName,
     /// voice/transcription overlays, etc.) on the object it serves, so callers must never receive the

--- a/src/CcDirector.Gateway.Tests/SessionSupervisionWireTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionSupervisionWireTests.cs
@@ -1,0 +1,128 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The wire for the session supervision facts (internal#625 Phase 1): the Director counts turns
+/// and keeps the waiting clock at the activity flip, the mapper puts all three on
+/// <see cref="SessionDto.TurnCount"/> / <see cref="SessionDto.WaitingSince"/> /
+/// <see cref="SessionDto.CumulativeIdleSeconds"/>, and they survive the Gateway's pushed-session
+/// cache intact so every card renders the numbers the Director measured.
+///
+/// These pin the same two joints SessionUncommittedCountWireTests pins - the mapper and the cache
+/// copy - because a field silently dropped at either one renders as "this session has no history",
+/// which is exactly the defect this feature removes. The other pinned property is that UNKNOWN
+/// survives as unknown: null is what an older Director reports, and it must never arrive at a
+/// client as zero turns or zero idle.
+/// </summary>
+public sealed class SessionSupervisionWireTests
+{
+    [Fact]
+    public void Map_CarriesTurnsAnchorAndIdleOntoTheDto()
+    {
+        using var session = NewSession();
+        var t0 = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var now = t0;
+        session.SupervisionClock = () => now;
+
+        // One full turn (30 seconds of waiting), then a second turn ends and waits.
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        now = t0.AddSeconds(30);
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        now = t0.AddSeconds(90);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+
+        var dto = ControlEndpoints.Map(session, "dir-A");
+
+        Assert.Equal(2, dto.TurnCount);
+        Assert.Equal(t0.AddSeconds(90), dto.WaitingSince);
+        Assert.Equal(30, dto.CumulativeIdleSeconds);
+    }
+
+    [Fact]
+    public void Map_AFreshSessionReportsZeros_NotNulls()
+    {
+        using var session = NewSession();
+
+        var dto = ControlEndpoints.Map(session, "dir-A");
+
+        // A live Director always knows: zero turns and zero idle are measured answers here.
+        // Null is reserved for Directors that predate the fields.
+        Assert.Equal(0, dto.TurnCount);
+        Assert.Null(dto.WaitingSince);
+        Assert.Equal(0, dto.CumulativeIdleSeconds);
+    }
+
+    [Fact]
+    public void PushedSessionStore_ServesTheFactsBackUnchanged()
+    {
+        // The store hands out Clone()d copies; a copy that dropped one of these fields would
+        // render as a session with no history, with no other symptom.
+        var now = new DateTime(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+        var anchor = now.AddMinutes(-5);
+        var store = new PushedSessionStore(() => now);
+        store.RegisterConnection(TenantId.Local, "dir-A", "conn-1");
+
+        store.ApplySnapshot(TenantId.Local, "dir-A", "conn-1", 0, new[]
+        {
+            new SessionDto
+            {
+                SessionId = "s-measured", ActivityState = "WaitingForInput",
+                TurnCount = 14, WaitingSince = anchor, CumulativeIdleSeconds = 2520,
+            },
+            // An older Director that has never heard of the fields: unknown must survive as
+            // unknown, never harden into "zero turns, zero idle".
+            new SessionDto
+            {
+                SessionId = "s-old-director", ActivityState = "Working",
+                TurnCount = null, WaitingSince = null, CumulativeIdleSeconds = null,
+            },
+        });
+
+        var fresh = store.TryGetFresh(TenantId.Local, "dir-A", TimeSpan.FromSeconds(20));
+
+        Assert.NotNull(fresh);
+        var measured = Assert.Single(fresh, s => s.SessionId == "s-measured");
+        Assert.Equal(14, measured.TurnCount);
+        Assert.Equal(anchor, measured.WaitingSince);
+        Assert.Equal(2520, measured.CumulativeIdleSeconds);
+
+        var old = Assert.Single(fresh, s => s.SessionId == "s-old-director");
+        Assert.Null(old.TurnCount);
+        Assert.Null(old.WaitingSince);
+        Assert.Null(old.CumulativeIdleSeconds);
+    }
+
+    private static Session NewSession()
+        => new(Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null, new NullBackend(), SessionBackendType.ConPty);
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public CircularTerminalBuffer? Buffer => null;
+        public int ProcessId => 1;
+        public string Status => "Null";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Kill() { }
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Part of internal#625 (session cards: how old, how long open, how long idle, how many turns). Phase 1 of 4: the Director measures the facts and puts them on the wire.

## What this adds

- **Session.TurnCount** - one flip to WaitingForInput equals one turn, the same rule TurnReviewLogger writes records by. Counted incrementally at the flip, so it works for every agent kind and never re-parses a transcript (the existing ComputeTurnCount is a full JSONL re-parse and Claude-only).
- **Session.WaitingSince** - the absolute anchor of the current waiting-on-the-user stretch (WaitingForInput or WaitingForPerm; the permission-to-input transition keeps one anchor). Null while working.
- **Session.CumulativeIdleSeconds** - the honest idle clock: closed waiting stretches summed. This is NOT the byte-silence IdleSeconds, which resets on any terminal output.

The bookkeeping runs inside SetActivityState before OnActivityStateChanged fires, so the delta push wired to that event always carries the numbers the flip just produced - a subscriber could run after the push and ship values one flip stale. Reporting only, no rulings: hold stays the Gateway's.

All three ride ControlEndpoints.Map onto SessionDto, where null means an older Director and is never rendered as zero. The Gateway passes them through untouched; the display ladder comes in phase 2.

## Proof

- Unit tests drive the same ApplyTerminalActivityState edge production uses, with an injected clock so accumulation is asserted exactly: turn counting (permission prompts and repeated states do not count), anchor lifecycle, closed-stretch summing, exit-while-waiting.
- Wire tests pin the mapper and the pushed-session cache copy, following SessionUncommittedCountWireTests: measured values survive, and an older Director's unknown survives as unknown.
- Full regression: all seven test suites green - 8393 passed, 0 failed (Core 3734, Gateway 4152, Avalonia 309, Engine 62, HostedAgent 86, Launcher 27, Terminal 23).