### PR TITLE
sessions.json stops lying: the desktop persists through the one complete builder (internal#625 phase 3)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2508,21 +2508,15 @@ public partial class MainWindow : Window
         try
         {
             var app = (App)global::Avalonia.Application.Current!;
-            var persisted = _sessions.Select((vm, i) => new PersistedSession
-            {
-                Id = vm.Session.Id,
-                RepoPath = vm.Session.RepoPath,
-                ClaudeArgs = vm.Session.ClaudeArgs,
-                CustomName = vm.Session.CustomName,
-                CustomColor = vm.Session.CustomColor,
-                ClaudeSessionId = vm.Session.ClaudeSessionId,
-                ActivityState = vm.Session.ActivityState,
-                BackendType = vm.Session.BackendType,
-                PendingPromptText = vm.Session.PendingPromptText,
-                WingmanEnabled = vm.Session.WingmanEnabled,
-                SortOrder = i,
-            });
-            app.SessionStateStore.Save(persisted);
+            // ONE builder, the SessionManager's (internal#625 phase 3). A hand-rolled initializer
+            // used to live here and silently dropped every field it did not name - CreatedAt,
+            // Number, HistoryEntryId, WorkingDirectory, mission and workflow attachment, the
+            // prompt queue and a dozen more - which is why every row in sessions.json read
+            // 0001-01-01 while the crash journal two lines below carried the real timestamp.
+            // The rail order still wins: SyncPromptTextToSessions stamps Session.SortOrder from
+            // the list index on the UI thread before the debounce, and SaveCurrentState orders
+            // by it.
+            _sessionManager.SaveCurrentState(app.SessionStateStore);
 
             // Mirror the live roster into the durable crash journal (issue #212 L5). Same
             // snapshot, but keyed per-Director and preserved across an abnormal death so the

--- a/src/CcDirector.Core.Tests/SessionPersistenceTests.cs
+++ b/src/CcDirector.Core.Tests/SessionPersistenceTests.cs
@@ -53,6 +53,29 @@ public class SessionPersistenceTests : IDisposable
     // which is the entire reason the state moved. The coverage lives in SnoozeRegistryTests.
 
     [Fact]
+    public void SaveCurrentState_PreservesCreatedAtNumberAndHistoryLink()
+    {
+        // internal#625 phase 3: the desktop used to write sessions.json through a second,
+        // hand-rolled builder that dropped these fields, so every persisted row read
+        // 0001-01-01 and the roster-to-history link did not survive a restart. The desktop now
+        // saves through THIS builder; these three fields are the ones whose loss went unnoticed
+        // the longest, so they are pinned by name.
+        var store = CreateTempStore();
+        var session = _manager.CreateSession(Path.GetTempPath());
+        session.Number = 102;
+        session.HistoryEntryId = Guid.NewGuid();
+
+        _manager.SaveCurrentState(store);
+
+        var loaded = store.Load().Sessions;
+        Assert.Single(loaded);
+        Assert.Equal(session.CreatedAt, loaded[0].CreatedAt);
+        Assert.NotEqual(default, loaded[0].CreatedAt);
+        Assert.Equal(102, loaded[0].Number);
+        Assert.Equal(session.HistoryEntryId, loaded[0].HistoryEntryId);
+    }
+
+    [Fact]
     public void SaveCurrentState_PreservesExpectedFirstPrompt()
     {
         var store = CreateTempStore();


### PR DESCRIPTION
Part of internal#625. Phase 3 of 4: the roster file on disk carries what the session actually is.

## The defect

Every row in config/director/sessions.json read CreatedAt 0001-01-01. MainWindow.PersistSessionStateCore built PersistedSession by hand and named only eleven fields - silently dropping CreatedAt, Number, HistoryEntryId, WorkingDirectory, the mission and workflow attachment, the prompt queue and about a dozen more - while the complete, tested builder (SessionManager.BuildPersistedSessions) sat unused by production code. Two builders for one file is how they came to disagree; the crash journal two lines below carried the correct timestamp the whole time.

## The fix

The desktop saves through SessionManager.SaveCurrentState. The hand-rolled builder is deleted, so there is exactly one way sessions.json gets written and it cannot drift from the tested path again.

Deliberate behavior notes:
- The rail order is unchanged: SyncPromptTextToSessions stamps Session.SortOrder from the list index on the interface thread before the debounce, and SaveCurrentState orders by it.
- The store now applies its own documented filter - rows are sessions that can be resumed (running, or holding a claude session id). Dead unresumable rows are no longer written, which matches the store's stated purpose.

## Proof

- Live: a slot-18 Director built from this branch under an isolated storage root spawned a session; its sessions.json row carried the real CreatedAt to the tick of the spawn response, the session Number, the HistoryEntryId link and the working directory.
- Pinned: a new SessionPersistenceTests case names CreatedAt, Number and HistoryEntryId - the three fields whose loss went unnoticed longest. All 17 persistence tests and all 309 desktop tests green; full Core suite run in progress locally alongside the pull request checks.