### PR TITLE
History carries the supervision facts: agent turns and idle seconds on the work-history record (internal#625 phase 4)

### DIFF
--- a/apps/cockpit/src/history/HistoryView.tsx
+++ b/apps/cockpit/src/history/HistoryView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { durationFromMs } from "@devthrottle/client-core/sessions/waiting";
 import {
   getWorkHistoryReport,
   type WorkHistoryReport,
@@ -63,7 +64,12 @@ function SessionEntry({ session }: { session: WorkHistorySession }) {
   if (session.agentKind) meta.push(session.agentKind);
   if (session.model) meta.push(session.model);
   meta.push(`started ${timeOf(session.startedAtUtc)}`);
-  if (session.turnCount != null && session.turnCount > 0) meta.push(`${session.turnCount} turns`);
+  // Agent turns (completed turns, internal#625) are the sharper fact when the Director reports
+  // them; the input-turn count stays as the fallback for records from older Directors.
+  if (session.agentTurnCount != null && session.agentTurnCount > 0) meta.push(`${session.agentTurnCount} turns`);
+  else if (session.turnCount != null && session.turnCount > 0) meta.push(`${session.turnCount} turns`);
+  if (session.idleSeconds != null && session.idleSeconds >= 60)
+    meta.push(`idle ${durationFromMs(session.idleSeconds * 1000)}`);
 
   const hasDetail =
     (session.summaryText != null && session.summaryText.length > 0) ||

--- a/packages/client-core/src/history/historyClient.ts
+++ b/packages/client-core/src/history/historyClient.ts
@@ -34,6 +34,10 @@ export interface WorkHistorySession {
   /** Gateway-folded one-liner; never empty. */
   descriptionLine: string;
   turnCount?: number | null;
+  /** Completed agent turns (one flip to waiting-for-input equals one turn). Null when never reported. */
+  agentTurnCount?: number | null;
+  /** Total seconds spent waiting on the user, closed stretches only. Null when never reported. */
+  idleSeconds?: number | null;
   /** null until a summary exists; "sealed" | "generated" | "none" | "unavailable". */
   summaryKind?: string | null;
   summaryIsPartial: boolean;

--- a/src/CcDirector.Gateway.Contracts/SessionHistoryDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionHistoryDtos.cs
@@ -102,6 +102,14 @@ public sealed record WorkHistorySessionDto
     /// <summary>Total input turns observed (operator plus agent-driven). Null when never reported.</summary>
     [JsonPropertyName("turnCount")] public long? TurnCount { get; init; }
 
+    /// <summary>Completed agent turns - one flip to waiting-for-input equals one turn, counted on the
+    /// Director (internal#625). Null when the owning Director never reported the counter.</summary>
+    [JsonPropertyName("agentTurnCount")] public long? AgentTurnCount { get; init; }
+
+    /// <summary>Total seconds the session spent waiting on the user, summed over closed waiting
+    /// stretches. Null when never reported.</summary>
+    [JsonPropertyName("idleSeconds")] public double? IdleSeconds { get; init; }
+
     /// <summary>Null when no summary exists yet; otherwise one of <see cref="SessionHistorySummaryKinds"/>.</summary>
     [JsonPropertyName("summaryKind")] public string? SummaryKind { get; init; }
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727053525_AddSessionSupervisionColumns.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727053525_AddSessionSupervisionColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727053525_AddSessionSupervisionColumns")]
+    partial class AddSessionSupervisionColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727053525_AddSessionSupervisionColumns.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727053525_AddSessionSupervisionColumns.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionSupervisionColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "AgentTurnCount",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "CumulativeIdleSeconds",
+                schema: "gateway",
+                table: "session_history",
+                type: "double precision",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AgentTurnCount",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "CumulativeIdleSeconds",
+                schema: "gateway",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/History/SessionHistoryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/History/SessionHistoryStoreTests.cs
@@ -45,6 +45,46 @@ public sealed class SessionHistoryStoreTests : IDisposable
     };
 
     [Fact]
+    public void Supervision_facts_land_and_unknown_never_erases_them()
+    {
+        // internal#625 phase 4: the agent turn count and the cumulative idle clock ride the pushed
+        // session onto the history row. The cases that are silent when wrong: an older Director's
+        // null must not erase a known value, and a Director restart (whose counters start again at
+        // zero) must not lower the run's high-water mark.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        var measured = Session();
+        measured.TurnCount = 14;
+        measured.CumulativeIdleSeconds = 2520;
+        store.UpsertLive("dir-1", measured, now);
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(14, row.AgentTurnCount);
+        Assert.Equal(2520, row.IdleSeconds);
+
+        // An older Director pushes the same session with no supervision facts: nothing is erased.
+        var silent = Session();
+        silent.TurnCount = null;
+        silent.CumulativeIdleSeconds = null;
+        store.UpsertLive("dir-1", silent, now.AddMinutes(6));
+
+        row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(14, row.AgentTurnCount);
+        Assert.Equal(2520, row.IdleSeconds);
+
+        // A restarted Director reports lower counters: the high-water mark stands.
+        var restarted = Session();
+        restarted.TurnCount = 2;
+        restarted.CumulativeIdleSeconds = 30;
+        store.UpsertLive("dir-1", restarted, now.AddMinutes(12));
+
+        row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(14, row.AgentTurnCount);
+        Assert.Equal(2520, row.IdleSeconds);
+    }
+
+    [Fact]
     public void First_sight_creates_an_open_row_carrying_the_director_measured_start()
     {
         var store = NewStore();

--- a/src/CcDirector.Gateway/Data/Entities/SessionHistoryEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/SessionHistoryEntity.cs
@@ -69,6 +69,17 @@ public sealed class SessionHistoryEntity : TenantScopedEntity
     /// <summary>Total input turns observed (operator plus agent-driven), from the pushed input stats.</summary>
     public long? TurnCount { get; set; }
 
+    /// <summary>Completed AGENT turns (SessionDto.TurnCount, internal#625 phase 4): one flip to
+    /// waiting-for-input equals one turn, counted incrementally on the Director. Distinct from
+    /// <see cref="TurnCount"/>, which counts turns SUBMITTED to the session. Null when the owning
+    /// Director predates the counter; a known value is never overwritten by null.</summary>
+    public long? AgentTurnCount { get; set; }
+
+    /// <summary>Total seconds the session spent waiting on the user, summed over CLOSED waiting
+    /// stretches (SessionDto.CumulativeIdleSeconds, internal#625 phase 4), as last pushed. Null when
+    /// the owning Director predates the clock.</summary>
+    public double? CumulativeIdleSeconds { get; set; }
+
     /// <summary>The first user prompt, trimmed to one line - description source number two (#1862).
     /// Set once from the prompt-log ingest and never overwritten.</summary>
     public string? FirstPromptLine { get; set; }

--- a/src/CcDirector.Gateway/Data/Migrations/20260727053454_AddSessionSupervisionColumns.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727053454_AddSessionSupervisionColumns.Designer.cs
@@ -3,48 +3,45 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727053454_AddSessionSupervisionColumns")]
+    partial class AddSessionSupervisionColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasDefaultSchema("gateway")
-                .HasAnnotation("ProductVersion", "9.0.2")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -54,106 +51,105 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", "gateway");
+                    b.ToTable("account_hosted_ai_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountTrialEntity", b =>
                 {
                     b.Property<string>("Subject")
-                        .HasColumnType("text")
-                        .HasColumnName("subject")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT")
+                        .HasColumnName("subject");
 
                     b.Property<DateTime>("ExpiresAtUtc")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("expires_at_utc");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("started_at_utc");
 
                     b.HasKey("Subject");
 
                     b.HasIndex("ExpiresAtUtc");
 
-                    b.ToTable("account_trials", "gateway");
+                    b.ToTable("account_trials", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -165,108 +161,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", "gateway");
+                    b.ToTable("activity_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", "gateway");
+                    b.ToTable("cron_jobs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -275,112 +271,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", "gateway");
+                    b.ToTable("cron_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", "gateway");
+                    b.ToTable("device_credentials", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", "gateway");
+                    b.ToTable("device_import_markers", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("TenantId", "Term");
 
@@ -388,100 +380,99 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", "gateway");
+                    b.ToTable("dictation_suggestion_dismissals", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", "gateway");
+                    b.ToTable("dictation_suggestion_scans", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", "gateway");
+                    b.ToTable("dictation_suggestion_verdicts", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
@@ -489,43 +480,43 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", "gateway");
+                    b.ToTable("dictation_transcripts", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<Guid>("Subject")
-                        .HasColumnType("uuid")
+                    b.Property<string>("Subject")
+                        .HasColumnType("TEXT")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("TEXT")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", "gateway", t =>
+                    b.ToTable("entitlements", null, t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -534,38 +525,38 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -578,40 +569,40 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", "gateway");
+                    b.ToTable("governance_audit_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -624,107 +615,105 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", "gateway");
+                    b.ToTable("governance_events", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", "gateway");
+                    b.ToTable("mission_notes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", "gateway");
+                    b.ToTable("push_subscriptions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.RepoStateEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BranchesJson")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CollectedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CurrentBranch")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DefaultBranch")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsDirty")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ReceivedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorktreesJson")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "DirectorId", "RepoPath");
 
@@ -732,109 +721,108 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "ReceivedAtUtc");
 
-                    b.ToTable("repo_state", "gateway");
+                    b.ToTable("repo_state", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("AgentTurnCount")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("BranchesJson")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CommitsJson")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<double?>("CumulativeIdleSeconds")
-                        .HasColumnType("double precision");
+                        .HasColumnType("REAL");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("EndedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EndingKind")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EndingLabel")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FirstPromptLine")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastActivityState")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("LastActivityUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("LastSeenUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LeftUnverifiedJson")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MachineName")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MissionName")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Model")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PullRequestsJson")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoName")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionName")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("SessionNumber")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SessionRole")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SummaryAttempts")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("SummaryIsPartial")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SummaryKind")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("TurnCount")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("WhatWasBuiltJson")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -844,34 +832,33 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "LastSeenUtc");
 
-                    b.ToTable("session_history", "gateway");
+                    b.ToTable("session_history", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryRollupEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("RepoKey")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DayUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Attempts")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("ComputedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InputHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "RepoKey", "DayUtc");
 
@@ -879,56 +866,55 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "DayUtc");
 
-                    b.ToTable("session_history_rollups", "gateway");
+                    b.ToTable("session_history_rollups", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Model")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -936,165 +922,161 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", "gateway");
+                    b.ToTable("session_spend", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", "gateway");
+                    b.ToTable("snoozes", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", "gateway");
+                    b.ToTable("tenants", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", "gateway");
+                    b.ToTable("tenant_settings", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", "gateway");
+                    b.ToTable("wingman_instructions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", "gateway");
+                    b.ToTable("worklists", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Area")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Position")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -1102,75 +1084,75 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", "gateway");
+                    b.ToTable("worklist_items", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", "gateway");
+                    b.ToTable("workflows", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -1178,71 +1160,71 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", "gateway");
+                    b.ToTable("workflow_files", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -1252,93 +1234,92 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", "gateway");
+                    b.ToTable("workflow_runs", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("text")
-                        .UseCollation("C");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", "gateway");
+                    b.ToTable("workflow_tenant_overrides", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("text")
+                        .HasColumnType("TEXT")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -1347,7 +1328,7 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", "gateway");
+                    b.ToTable("workflow_versions", (string)null);
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1355,28 +1336,28 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("boolean");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Action");
 
@@ -1387,18 +1368,18 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs", "gateway");
+                            b1.ToTable("cron_jobs");
 
                             b1.ToJson("Target");
 
@@ -1418,36 +1399,36 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions", "gateway");
+                            b1.ToTable("wingman_instructions");
 
                             b1.ToJson("Versions");
 
@@ -1472,35 +1453,35 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1511,37 +1492,37 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("timestamp with time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("Participants");
 
@@ -1552,23 +1533,23 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs", "gateway");
+                            b1.ToTable("workflow_runs");
 
                             b1.ToJson("ProofLinks");
 
@@ -1588,26 +1569,26 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1618,34 +1599,34 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("uuid");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
+                                .ValueGeneratedOnAddOrUpdate()
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions", "gateway");
+                            b1.ToTable("workflow_versions");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway/Data/Migrations/20260727053454_AddSessionSupervisionColumns.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727053454_AddSessionSupervisionColumns.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionSupervisionColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "AgentTurnCount",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "CumulativeIdleSeconds",
+                table: "session_history",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AgentTurnCount",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "CumulativeIdleSeconds",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/GatewayDbContextModelSnapshot.cs
@@ -733,11 +733,17 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.Property<string>("AgentKind")
                         .HasColumnType("TEXT");
 
+                    b.Property<long?>("AgentTurnCount")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("BranchesJson")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("CommitsJson")
                         .HasColumnType("TEXT");
+
+                    b.Property<double?>("CumulativeIdleSeconds")
+                        .HasColumnType("REAL");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()

--- a/src/CcDirector.Gateway/History/SessionHistoryFold.cs
+++ b/src/CcDirector.Gateway/History/SessionHistoryFold.cs
@@ -115,6 +115,8 @@ public static class SessionHistoryFold
         DescriptionLine = DescriptionLine(e.MissionName, e.SessionRole, e.FirstPromptLine,
             e.SessionName, e.RepoName, e.RepoPath),
         TurnCount = e.TurnCount,
+        AgentTurnCount = e.AgentTurnCount,
+        IdleSeconds = e.CumulativeIdleSeconds,
         SummaryKind = string.IsNullOrEmpty(e.SummaryKind) ? null : e.SummaryKind,
         SummaryIsPartial = e.SummaryIsPartial,
         SummaryText = e.SummaryText,

--- a/src/CcDirector.Gateway/History/SessionHistoryStore.cs
+++ b/src/CcDirector.Gateway/History/SessionHistoryStore.cs
@@ -83,6 +83,13 @@ public sealed class SessionHistoryStore
             var turns = TurnCountOf(session);
             if (turns is { } t && (entity.TurnCount is not { } existing || t > existing))
                 entity.TurnCount = t;
+            // The supervision facts (internal#625 phase 4). Null means an older Director - unknown
+            // never overwrites a known value - and both only move forward, so a Director restart
+            // (whose counters start again at zero) cannot erase the run's high-water mark.
+            if (session.TurnCount is { } agentTurns && (entity.AgentTurnCount is not { } at || agentTurns > at))
+                entity.AgentTurnCount = agentTurns;
+            if (session.CumulativeIdleSeconds is { } idle && (entity.CumulativeIdleSeconds is not { } ci || idle > ci))
+                entity.CumulativeIdleSeconds = idle;
             entity.LastSeenUtc = nowUtc;
 
             ctx.SaveChanges();


### PR DESCRIPTION
Part of internal#625, the final phase. The durable work-history record (#2217) now keeps the two facts the session cards already show live.

## What this adds

- **SessionHistoryEntity.AgentTurnCount** - completed agent turns from SessionDto.TurnCount (one flip to waiting-for-input equals one turn). Deliberately distinct from the existing TurnCount, which counts turns SUBMITTED to the session from the input statistics.
- **SessionHistoryEntity.CumulativeIdleSeconds** - total waiting-on-the-user seconds over closed stretches.
- Sourced inside the recorder's existing write cadence: activity flips remain non-material, so this adds zero extra database writes - the five-minute freshness pass picks the numbers up.
- **Unknown never erases known**: an older Director's null leaves the stored value, and both facts only move forward, so a restarted Director's reset counters cannot lower a run's high-water mark.
- Served on the history API as agentTurnCount / idleSeconds; the History page prefers agent turns over input turns and shows idle from one minute up, via the one shared duration ladder.
- Migration pair (SQLite and Postgres) in the same pull request, per the standing rule; both snapshots verified clean with has-pending-model-changes.

## Proof

- The store tests run over the real Entity Framework store on a throwaway SQLite file, exactly as the Gateway runs it - the new pin drives three pushes (measured, older-Director null, restarted-Director lower values) and asserts the row keeps the high-water marks. All 54 session-history tests green.
- The wire these columns read from (Director to Gateway) was proven live on a real rig in phases 1 and 2 (docs/proofs/session-supervision-cards-2026-07-27/).
- Web typechecks and the full cockpit suite green; full Gateway suite running alongside the pull request checks.