### PR TITLE
release: v1.8.0 - session supervision, work history, first-run wizard

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.8.0.md
+++ b/docs/public/release-notes/v1.8.0.md
@@ -1,0 +1,58 @@
+## v1.8.0 - July 27, 2026
+
+Every session now tells you its story: when it started, how long it has been open, how long it
+has been waiting on you, and what it did - live on the session cards, and kept in a durable
+work history you can read back across all your repositories.
+
+### Highlights
+
+- Session cards answer the supervision questions: every card in the Cockpit and on the phone
+  now shows when the session started, how long it has been open, how long it has spent waiting
+  on you, and how many turns the agent has completed - ticking live. Waiting time turns amber
+  after an hour and red after four, so a neglected session looks neglected.
+- Work history: DevThrottle keeps a durable record of every session as it runs - what it was
+  asked to do, how it ended, and a summary of what it built. The new History page shows your
+  work across all repositories, grouped by repository and day, and survives crashes and power
+  cuts because the record is written while the session runs, never at the end.
+- First-run wizard: setting up a new machine is now one guided journey instead of a chain of
+  dialogs - it finds your coding agents, offers to install what is missing, locates your
+  repositories and screenshots, and explains each step as an offer, never a demand.
+- Fleet Assistant: ask questions about your whole fleet in plain language - by chat or voice,
+  from the Cockpit or the phone - without being tied to any one session.
+- Trustworthy voice input: test your microphone and test transcription from Settings on both
+  surfaces, and DevThrottle now measures every dictation's microphone quality in the background
+  and shows the detail in a Transcription Health view, so a bad microphone gets caught before
+  it ruins a day of dictation.
+- One Settings page: the phone and the Cockpit now show the same Settings - same tabs, same
+  names, same cards - so a setting you find on one surface is where you expect it on the other.
+- Every new hosted account starts with a 14-day Pro trial.
+
+### Also in this release
+
+- Voice mode is a real switch with the way out on every screen, and the voice queue plays the
+  waiting sessions first-in-first-out with big buttons on top.
+- The phone's voice recorder is back, with durable segments that survive interruptions and
+  transcripts on both surfaces.
+- The mobile Snooze button lets you pick a length, and a session returning from an expired
+  snooze is labeled so you know to go see why it went quiet.
+- Repositories are a first-class subsystem: an always-current monitor, safe worktree and branch
+  cleanup with an orphaned-worktree reaper, and a worktree that an open session is using is
+  never touched.
+- The shared workflow library: browse the built-in workflows, switch them on or off per
+  account, and clone one to customize it.
+- Each session's uncommitted file count shows in the roster, so you can see who is sitting on
+  unpushed work.
+- The session roster puts Sessions first in the rail, and the Needs-you group is a waiting
+  line: the session that has waited longest is on top.
+- The phone says nothing about the network unless something is actually wrong.
+- No user is ever shown a bare status code: errors now arrive as plain sentences, and browser
+  errors also land in the Gateway log so they can be diagnosed after the fact.
+- The About page reports the Gateway, Cockpit, and mobile app versions, so you can tell at a
+  glance whether everything is up to date.
+- One Director executable can run several named profiles, and a staged update applies itself
+  automatically when no sessions are running.
+- Scheduled runs name their sessions after the schedule and fire time, and asking an agent to
+  clear a session's context now asks you first.
+- Many reliability improvements to the hosted service, including safer deploys with a warmed
+  standby, honest network verdicts, and per-account serving of settings, statistics, and
+  transcripts.


### PR DESCRIPTION
The v1.8.0 release: bumps Directory.Build.props from 1.7.4 to 1.8.0 and adds docs/public/release-notes/v1.8.0.md, the canonical notes for the tag body and the internal changelog. 124 commits since v1.7.4. Owner approved the notes wording and the release in chat, 2026-07-27.