### PR TITLE
Make the deploy unable to abandon a staging slot, and a dead log unable to stay quiet

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -33,13 +33,21 @@ on:
   # The branch/tag picked when starting the run is the commit that ships.
   workflow_dispatch:
 
-# Only the latest release should win. If a newer release is started while one is still running,
-# cancel the older one so we never spend a full build shipping code that is about to be replaced.
-# The cancel is safe during the ~5-minute build (nothing live has changed yet); the newer release
-# repeats the short repin+restart at the end, so the live service always lands on the latest commit.
+# A second release WAITS for the one in flight. It must never cancel it (issue #2222).
+#
+# This used to be cancel-in-progress: true, on the reasoning that the cancel is safe during the
+# ~5-minute build because nothing live has changed yet. That reasoning only holds if the cancel
+# lands during the build, and there is no way to promise it does. On 2026-07-27 one landed INSIDE
+# "Deploy the new image to the staging slot and warm it" - after the staging slot had been started
+# and before anything could stop it. The stop step is skipped on a cancelled run, so the slot was
+# abandoned RUNNING: two Gateway containers on one worker for ten minutes, unattended, with the app
+# degraded the whole time. No probe failed and /healthz never dropped, so nothing caught it.
+#
+# Waiting costs a few minutes of build time. Cancelling costs an abandoned slot and a degraded
+# production service. Queue.
 concurrency:
   group: deploy-hosted-gateway
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   id-token: write   # required for the Azure OIDC login
@@ -123,6 +131,29 @@ jobs:
       # anything here fails, production is untouched and still serving the old image - the deploy aborts
       # safely. Staging is normally STOPPED (steady state is one instance writing the shared mount), so we
       # point it at the new digest and start it.
+      # REFUSE to start on a dirty slot (issue #2222). Steady state is staging STOPPED - one instance
+      # writing the shared mount. If it is already running, a previous run died without cleaning up, and
+      # starting a deploy on top of that means three containers contending instead of two. Fail here,
+      # where nothing has been touched, rather than discovering it after the swap.
+      #
+      # The one legitimate exception is the deploy that deliberately LEAVES staging running for swap-back
+      # (see the settle step below). That case needs a human to decide whether to roll back or proceed, so
+      # it is correct for this to stop and say so rather than guess.
+      - name: Refuse to deploy onto a staging slot that is already running
+        run: |
+          STATE=$(az webapp show --resource-group "$AZURE_RG" --name "$APP" --slot "$SLOT" --query state --output tsv)
+          echo "Staging slot state: $STATE"
+          if [ "$STATE" != "Stopped" ]; then
+            echo "ERROR: the staging slot is '$STATE', expected 'Stopped'."
+            echo "       Steady state is one running instance. A running staging slot means either a"
+            echo "       previous deploy died without cleaning up (see issue #2222), or a deploy"
+            echo "       deliberately left it running so rollback-hosted-gateway could swap back."
+            echo "       Decide which, then either run the rollback or stop the slot by hand:"
+            echo "         az webapp stop -g $AZURE_RG -n $APP --slot $SLOT"
+            echo "       Nothing has been changed by this run."
+            exit 1
+          fi
+
       - name: Deploy the new image to the staging slot and warm it
         id: warm
         run: |
@@ -258,6 +289,40 @@ jobs:
           echo "Production held a stable streak on $TARGET; stopping the staging slot."
           az webapp stop --resource-group "$AZURE_RG" --name "$APP" --slot "$SLOT" --output none
           echo "stopped_staging=yes" >> "$GITHUB_OUTPUT"
+
+      # The safety net (issue #2222). A run that dies anywhere between starting the staging slot and the
+      # settle step leaves that slot RUNNING, and a second Gateway container on the worker degrades the
+      # live service until someone notices. `always()` covers cancellation as well as failure, which is
+      # the case that actually bit us.
+      #
+      # It reads the settle step's own verdict and does NOT second-guess it:
+      #   stopped_staging=yes  -> settle already stopped it; nothing to do.
+      #   stopped_staging=no   -> settle DELIBERATELY left it running as the swap-back instance. Leave it.
+      #                           Stopping it here would destroy the rollback path.
+      #   <empty>              -> settle never ran, so nobody owns the slot. Stop it.
+      # This is a second line of defence, not the primary fix - a cancelled job is not guaranteed to
+      # finish its steps. The primary fix is cancel-in-progress: false above.
+      - name: Always leave the staging slot stopped unless it is the swap-back instance
+        if: always()
+        run: |
+          VERDICT="${{ steps.settle.outputs.stopped_staging }}"
+          if [ "$VERDICT" = "yes" ]; then
+            echo "Staging was already stopped by the settle step; nothing to clean up."
+            exit 0
+          fi
+          if [ "$VERDICT" = "no" ]; then
+            echo "Staging is DELIBERATELY left running as the swap-back instance - not touching it."
+            exit 0
+          fi
+          STATE=$(az webapp show --resource-group "$AZURE_RG" --name "$APP" --slot "$SLOT" --query state --output tsv 2>/dev/null || echo Unknown)
+          echo "This run never reached the settle step. Staging slot state: $STATE"
+          if [ "$STATE" = "Stopped" ]; then
+            echo "Already stopped - nothing to clean up."
+            exit 0
+          fi
+          echo "Stopping the abandoned staging slot so production is not left sharing its worker."
+          az webapp stop --resource-group "$AZURE_RG" --name "$APP" --slot "$SLOT" --output none
+          echo "Staging stopped."
 
       # KEEP WATCHING. This is the step that measures the outage a user actually gets (issue #2203).
       #

--- a/src/CcDirector.Core.Tests/Utilities/FileLogWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogWriterTests.cs
@@ -251,4 +251,105 @@ public sealed class FileLogWriterTests : IDisposable
             writer.Stop();
         }
     }
+
+    // =================================================================================
+    // Issue #2223 - the writer surviving a permanent write failure is NOT enough. Before
+    // this, a sink that failed every single time repeated silently behind the per-line
+    // catch and the log simply stopped growing, which reads exactly like a quiet process.
+    // The live hosted Gateway sat at a 0-byte file for a quarter of an hour while serving.
+    // =================================================================================
+
+    [Fact]
+    public void WriterLoop_SinkFailsPermanently_ReportsOnceWithTheExceptionType()
+    {
+        var reports = new List<(int failures, Exception? ex)>();
+        var writer = new FileLogWriter(_logDir, "dead-sink", () => new DateTime(2026, 7, 27, 12, 0, 0));
+        writer.OnSinkHealthChanged = (n, ex) => { lock (reports) reports.Add((n, ex)); };
+        writer.BeforeWriteHook = _ => throw new UnauthorizedAccessException("the share is read-only");
+
+        writer.Start();
+        try
+        {
+            for (int i = 0; i < 20; i++) writer.Enqueue($"line-{i}");
+
+            WaitUntil(() => { lock (reports) return reports.Count > 0; });
+
+            lock (reports)
+            {
+                // Reported exactly ONCE for the episode, not once per failed line - an alarm that
+                // repeats every line is an alarm nobody reads.
+                Assert.Single(reports);
+                Assert.True(reports[0].failures >= FileLogWriter.SinkFailureThreshold);
+                Assert.IsType<UnauthorizedAccessException>(reports[0].ex);
+            }
+            Assert.True(writer.ConsecutiveWriteFailures >= FileLogWriter.SinkFailureThreshold);
+        }
+        finally
+        {
+            writer.BeforeWriteHook = null;
+            writer.Stop();
+        }
+    }
+
+    [Fact]
+    public void WriterLoop_SinkRecovers_ReportsTheRecoveryToo()
+    {
+        // A recovery nobody announces leaves the reader believing the log is still lying.
+        var reports = new List<(int failures, Exception? ex)>();
+        var fail = true;
+        var writer = new FileLogWriter(_logDir, "recovering-sink", () => new DateTime(2026, 7, 27, 12, 0, 0));
+        writer.OnSinkHealthChanged = (n, ex) => { lock (reports) reports.Add((n, ex)); };
+        writer.BeforeWriteHook = _ => { if (fail) throw new IOException("share stalled"); };
+
+        writer.Start();
+        try
+        {
+            for (int i = 0; i < 20; i++) writer.Enqueue($"bad-{i}");
+            WaitUntil(() => { lock (reports) return reports.Count > 0; });
+
+            fail = false;
+            writer.Enqueue("good-line");
+
+            WaitUntil(() => { lock (reports) return reports.Count > 1; });
+            lock (reports)
+            {
+                Assert.Equal(2, reports.Count);
+                Assert.NotNull(reports[0].ex);      // the failure
+                Assert.Null(reports[1].ex);         // the recovery
+                Assert.Equal(0, reports[1].failures);
+            }
+            Assert.Equal(0, writer.ConsecutiveWriteFailures);
+        }
+        finally
+        {
+            writer.BeforeWriteHook = null;
+            writer.Stop();
+        }
+    }
+
+    [Fact]
+    public void WriterLoop_OneTransientFailure_IsNotReportedAsADeadSink()
+    {
+        // The guard from issue #171 must keep working: a single bad write is survivable and
+        // unremarkable. Raising an alarm for it would train us to ignore the alarm.
+        var reports = new List<(int failures, Exception? ex)>();
+        var thrown = false;
+        var writer = new FileLogWriter(_logDir, "transient-sink", () => new DateTime(2026, 7, 27, 12, 0, 0));
+        writer.OnSinkHealthChanged = (n, ex) => { lock (reports) reports.Add((n, ex)); };
+        writer.BeforeWriteHook = _ => { if (!thrown) { thrown = true; throw new IOException("one blip"); } };
+
+        writer.Start();
+        try
+        {
+            for (int i = 0; i < 10; i++) writer.Enqueue($"line-{i}");
+            WaitUntil(() => ReadShared(writer.ComputeLogPath(new DateTime(2026, 7, 27, 12, 0, 0))).Contains("line-9"));
+
+            lock (reports) Assert.Empty(reports);
+        }
+        finally
+        {
+            writer.BeforeWriteHook = null;
+            writer.Stop();
+        }
+    }
 }

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -60,12 +60,59 @@ public static class FileLog
         _writer = new FileLogWriter(LogDir, _instanceId, () => DateTime.Now);
     }
 
+    /// <summary>
+    /// True when the file sink has failed repeatedly and the console mirror was turned on to report it
+    /// rather than by configuration. Read it to tell "the mirror is on because we asked for it" apart from
+    /// "the mirror is on because the file is dead".
+    /// </summary>
+    public static bool FileSinkFailed { get; private set; }
+
+    /// <summary>
+    /// Report a file sink that has stopped working, on a channel that is not the file (issue #2223).
+    ///
+    /// A permanently failing write repeats forever behind the writer's per-line catch, so before this the
+    /// only symptom was a log that stopped growing - indistinguishable from a process with nothing to say.
+    /// Turning the console mirror ON here is a REPORT, not a fallback: the point is that the failure
+    /// becomes audible and names itself, and that the record continues somewhere a reader can find it.
+    /// It is turned back off on recovery ONLY if this is what turned it on, so a hosted deployment that
+    /// deliberately set the mirror never has it revoked underneath it.
+    /// </summary>
+    private static void OnSinkHealthChanged(int consecutiveFailures, Exception? ex)
+    {
+        if (ex is not null)
+        {
+            FileSinkFailed = true;
+            if (!MirrorToConsole)
+            {
+                MirrorToConsole = true;
+                _mirrorForcedBySinkFailure = true;
+            }
+            Console.Error.WriteLine(
+                $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [FileLog] FILE SINK DEAD: {consecutiveFailures} consecutive " +
+                $"write failures ({ex.GetType().Name}: {ex.Message}). Path: {CurrentLogPath}. The log file is NOT " +
+                "being written; this process's record continues on standard output until the file sink recovers.");
+            return;
+        }
+
+        FileSinkFailed = false;
+        Console.Error.WriteLine(
+            $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [FileLog] file sink recovered; writing to {CurrentLogPath} again.");
+        if (_mirrorForcedBySinkFailure)
+        {
+            _mirrorForcedBySinkFailure = false;
+            MirrorToConsole = false;
+        }
+    }
+
+    private static bool _mirrorForcedBySinkFailure;
+
     /// <summary>Start the background writer thread. Safe to call multiple times.</summary>
     public static void Start()
     {
         if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
             return;
 
+        _writer.OnSinkHealthChanged = OnSinkHealthChanged;
         _writer.Start();
     }
 

--- a/src/CcDirector.Core/Utilities/FileLogWriter.cs
+++ b/src/CcDirector.Core/Utilities/FileLogWriter.cs
@@ -39,6 +39,30 @@ internal sealed class FileLogWriter
     private long _droppedLines;
     private long _reportedDrops;
 
+    // Consecutive failures of the WRITE itself (issue #2223). The per-line catch below exists so a
+    // transient failure cannot kill the writer thread (issue #171), and that is right - but a PERMANENT
+    // failure then repeats forever and, reported only to the debugger, is invisible. The live hosted
+    // Gateway sat at a 0-byte log file for a quarter of an hour while serving traffic and nothing said so.
+    // A dead sink must not look like a quiet process. Note this is a different failure from a dropped
+    // line: nothing is dropped here - every line is accepted and then silently thrown away by the sink.
+    private int _consecutiveWriteFailures;
+    private bool _sinkFailureReported;
+
+    /// <summary>How many consecutive write attempts have failed. Zero on a healthy writer.</summary>
+    internal int ConsecutiveWriteFailures => Volatile.Read(ref _consecutiveWriteFailures);
+
+    /// <summary>
+    /// Raised once when the sink has failed <see cref="SinkFailureThreshold"/> times in a row, and again
+    /// when it recovers. The handler's job is to report the failure somewhere that still works - the file
+    /// cannot report on itself. Arguments: the consecutive failure count, and the last exception (null on
+    /// the recovery call).
+    /// </summary>
+    internal Action<int, Exception?>? OnSinkHealthChanged { get; set; }
+
+    /// <summary>Consecutive failures before the sink is declared dead. Small: one or two failures can be a
+    /// genuine transient, a steady stream cannot.</summary>
+    internal const int SinkFailureThreshold = 3;
+
     /// <summary>
     /// Test-only fault-injection seam: invoked with each line just before it is written, inside the
     /// loop's per-line try. A test can throw from here to prove a transient write failure does not
@@ -173,13 +197,41 @@ internal sealed class FileLogWriter
                         writer.Flush();
                         lastFlush = now;
                     }
+
+                    // The write landed. If the sink had been declared dead, say that it is back - a
+                    // recovery that nobody announces leaves the reader believing the log is still lying.
+                    if (Volatile.Read(ref _consecutiveWriteFailures) > 0)
+                    {
+                        Volatile.Write(ref _consecutiveWriteFailures, 0);
+                        if (_sinkFailureReported)
+                        {
+                            _sinkFailureReported = false;
+                            OnSinkHealthChanged?.Invoke(0, null);
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
-                    // Log and continue - the loop must outlive any single bad write so logging
-                    // keeps working. Use the debugger channel because FileLog itself is the thing
-                    // that failed; we cannot route this back through it.
+                    // Continue - the loop must outlive any single bad write so logging keeps working
+                    // (issue #171). Use the debugger channel because FileLog itself is the thing that
+                    // failed; we cannot route this back through it.
                     Debug.WriteLine($"[FileLogWriter] write FAILED, continuing: {ex.Message}");
+
+                    // ...but a failure that KEEPS happening is not transient, and surviving it quietly is
+                    // how a dead log came to look like a quiet process (issue #2223). Announce it ONCE, on
+                    // a channel that is not the thing that just broke, and name the exception type so the
+                    // report is actionable rather than merely alarming.
+                    var failures = Interlocked.Increment(ref _consecutiveWriteFailures);
+                    if (failures >= SinkFailureThreshold && !_sinkFailureReported)
+                    {
+                        _sinkFailureReported = true;
+                        try { OnSinkHealthChanged?.Invoke(failures, ex); }
+                        catch (Exception handlerEx)
+                        {
+                            // The reporter itself failing must not kill the writer thread either.
+                            Debug.WriteLine($"[FileLogWriter] sink-failure report FAILED: {handlerEx.Message}");
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Two ways the hosted Gateway could be left degraded with nobody able to tell. Both were hit for real on 2026-07-27.

## 1. A cancelled deploy abandoned the staging slot (#2222)

`cancel-in-progress: true` killed an in-flight deploy whenever a newer one started. The reasoning was that a cancel during the five-minute build is harmless because nothing live has changed yet - true, but only if the cancel lands during the build, and nothing guarantees that.

One landed inside **"Deploy the new image to the staging slot and warm it"**, after the slot had been started. The step that stops staging is skipped on a cancelled run, so the slot was abandoned running:

| time (UTC) | event |
|---|---|
| 11:40:39 | run A starts the staging slot |
| ~11:41 | run A **cancelled** by run B - slot left running |
| 11:40:40 - 11:47:13 | two Gateway containers on one worker, **~6.5 min unattended** |
| 11:50:36 | staging finally stopped |

Ten minutes of doubled load. The owner's phone was unresponsive for one to two minutes inside it. Note what did *not* happen: every startup probe passed (14.9s, 16.2s, 47.4s) and the site never entered `Stopped`. This was degradation, not unavailability, which is why an availability poll saw nothing.

**Three guards, in order of strength:**

1. `cancel-in-progress: false` - a second release queues. This is the actual fix.
2. The deploy **refuses to start** when the staging slot is already running, and says why and what to do. A dirty slot means an earlier run died without cleaning up; starting on top of it means three containers contending instead of two. Failing here costs nothing because nothing has been touched yet.
3. A cleanup step under `if: always()` stops an abandoned slot. Second line of defence only - a cancelled job is not guaranteed to finish its steps. It reads the settle step's own verdict rather than deciding for itself, so it can never stop the slot that was **deliberately** left running as the swap-back instance.

## 2. A permanently failing log sink was silent (#2223)

The per-line `catch` in `FileLogWriter` exists so a transient write failure cannot kill the writer thread (#171). That is right. What was wrong is that a failure which never stops repeats forever behind it, reported only to `Debug.WriteLine`.

The live hosted Gateway sat at a **0-byte log file for over fifteen minutes** while serving traffic. Its neighbour container, same mount, wrote 49 KB normally.

This is a different failure from a dropped line, and the existing `DroppedLines` / `LOG GAP` machinery does not cover it: nothing is dropped, every line is accepted and then thrown away by the sink.

Now: consecutive write failures are counted and exposed as `ConsecutiveWriteFailures`; crossing a threshold of 3 reports **once** on standard output, naming the exception type and the path; and the console mirror is turned on so the record continues somewhere findable. Turning the mirror on is a **report, not a fallback** - the point is that the failure becomes audible. Recovery is announced too, and the mirror is only revoked if the sink failure is what turned it on, so a hosted deployment that set it deliberately never has it taken away.

## Tests

Three added to `FileLogWriterTests`:

- `WriterLoop_SinkFailsPermanently_ReportsOnceWithTheExceptionType` - asserts it reports **once** per episode, not once per failed line, and carries the exception type.
- `WriterLoop_SinkRecovers_ReportsTheRecoveryToo` - a recovery nobody announces leaves the reader believing the log is still lying.
- `WriterLoop_OneTransientFailure_IsNotReportedAsADeadSink` - the control. The #171 guard must keep working; alarming on a single blip trains us to ignore the alarm.

Proven to fail on purpose: with the reporting removed, the first two fail and the control correctly stays green (`Failed: 2, Passed: 1`).

Core suite green, solution builds with 0 warnings, workflow YAML parses and step order verified.

## What this does not fix

The measurement gap. Both the pipeline's check and the external pollers sample `/healthz` - one cheap unauthenticated endpoint. It reports reachability, not what a phone experiences: tunnel and SignalR reconnects after a swap, or authenticated requests slowing while two containers share a worker. A green `/healthz` and an unresponsive app were both true on 2026-07-27. That needs its own issue and a check closer to what a client actually does.

Closes thefrederiksen/devthrottle_internal#1761. Closes thefrederiksen/devthrottle_internal#1762.
