### PR TITLE
fix(voice): unwedge sessions stuck yellow, and make brand-new sessions green

### DIFF
--- a/src/CcDirector.Core.Tests/ClaudeSessionReaderTrailingSeparatorTests.cs
+++ b/src/CcDirector.Core.Tests/ClaudeSessionReaderTrailingSeparatorTests.cs
@@ -1,0 +1,77 @@
+using CcDirector.Core.Claude;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// A TRAILING SEPARATOR ON THE REPO PATH MUST NOT CHANGE THE TRANSCRIPT FOLDER NAME.
+///
+/// The bug these pin, found live on 2026-07-27: a session whose repo path was stored as
+/// "D:\ReposFred\cc-consult\" (a trailing backslash - equivalent to a human, and invisible in every
+/// UI) resolved its Claude transcript folder to "D--ReposFred-cc-consult-". Every non-alphanumeric
+/// character becomes a dash here, and Path.GetFullPath PRESERVES a trailing separator, so the
+/// separator became a TRAILING DASH and named a folder that does not exist.
+///
+/// What that cost, in order: the transcript lookup missed -> the Director's "turns" read returned
+/// no_jsonl with an EMPTY widget list -> the Gateway's voice service found no assistant reply and
+/// recorded "nothing to narrate" about a session that had just written a full answer -> it never
+/// called the speech provider -> no audio ever existed -> and because the roster holds a voice
+/// session yellow until audio is ready, the session sat on "Preparing voice" permanently, with no
+/// error surfaced anywhere.
+///
+/// So this is not a cosmetic path-hygiene test. The folder name is the join between a session and
+/// everything that reads its conversation, and it silently returned the wrong answer.
+/// </summary>
+public class ClaudeSessionReaderTrailingSeparatorTests
+{
+    [Theory]
+    [InlineData(@"D:\ReposFred\cc-consult", @"D:\ReposFred\cc-consult\")]
+    [InlineData(@"D:\ReposFred\cc-consult", @"D:\ReposFred\cc-consult/")]
+    [InlineData(@"C:\Users\soren\.claude", @"C:\Users\soren\.claude\")]
+    public void GetProjectFolder_TrailingSeparator_MatchesTheSamePathWithout(string clean, string withSeparator)
+    {
+        Assert.Equal(
+            ClaudeSessionReader.GetProjectFolder(clean),
+            ClaudeSessionReader.GetProjectFolder(withSeparator));
+    }
+
+    [Fact]
+    public void GetProjectFolder_TrailingSeparator_ProducesNoTrailingDash()
+    {
+        // The exact shape of the live defect: the name must not pick up a trailing dash.
+        var folder = ClaudeSessionReader.GetProjectFolder(@"D:\ReposFred\cc-consult\");
+        Assert.Equal("D--ReposFred-cc-consult", folder);
+        Assert.False(folder.EndsWith('-'), $"folder name gained a trailing dash: {folder}");
+    }
+
+    [Fact]
+    public void GetJsonlPath_TrailingSeparator_ResolvesToTheSameFile()
+    {
+        // The consumer that actually broke: SessionReadExecutor.Turns calls GetJsonlPath and treats a
+        // missing file as "no_jsonl" + empty widgets, which downstream reads as "nothing to say".
+        const string claudeSessionId = "adc79f6f-5230-46e5-af77-ed0aa6ca4ee7";
+        Assert.Equal(
+            ClaudeSessionReader.GetJsonlPath(claudeSessionId, @"D:\ReposFred\cc-consult"),
+            ClaudeSessionReader.GetJsonlPath(claudeSessionId, @"D:\ReposFred\cc-consult\"));
+    }
+
+    [Fact]
+    public void GetProjectFolder_DriveRoot_KeepsItsSeparator()
+    {
+        // The reason this trims with TrimEndingDirectorySeparator rather than a bare TrimEnd: a drive
+        // ROOT must keep its separator. "D:\" is a real directory whose sanitized name is "D--";
+        // "D:" means "the current directory on drive D:", which is a different place entirely. A bare
+        // TrimEnd would silently retarget the root to wherever the process happens to be.
+        Assert.Equal("D--", ClaudeSessionReader.GetProjectFolder(@"D:\"));
+    }
+
+    [Fact]
+    public void GetProjectFolder_StillDashesEveryNonAlphanumeric()
+    {
+        // The behaviour that must NOT regress: dots, underscores, colons and separators all become
+        // dashes (the issue #184 fix - a char-list version once missed dots and hid every transcript
+        // under a dotted path).
+        Assert.Equal("D--Repos-my-project", ClaudeSessionReader.GetProjectFolder(@"D:\Repos\my_project"));
+        Assert.Equal("D--Repos--temp-brain-sandbox", ClaudeSessionReader.GetProjectFolder(@"D:\Repos\.temp\brain-sandbox"));
+    }
+}

--- a/src/CcDirector.Core/Claude/ClaudeSessionReader.cs
+++ b/src/CcDirector.Core/Claude/ClaudeSessionReader.cs
@@ -52,7 +52,23 @@ public static class ClaudeSessionReader
         // themselves). The previous char-list version missed dots, which made every
         // transcript under a path like "...\.temp\brain-sandbox" invisible to us
         // (found live in the issue #184 brain verification).
-        var normalized = Path.GetFullPath(repoPath);
+        // A TRAILING SEPARATOR MUST NOT REACH THE REGEX. Path.GetFullPath PRESERVES one, and every
+        // character here becomes a dash - so "D:\ReposFred\cc-consult\" produced the folder name
+        // "D--ReposFred-cc-consult-", with a trailing dash, which does not exist. Claude Code names
+        // the folder from the directory itself, so the separator is not part of the name.
+        //
+        // This was NOT theoretical: it wedged a live session for hours. The session's repo path was
+        // stored with a trailing backslash (the path is equivalent to a human and the UI shows no
+        // difference), so the transcript lookup missed, the conversation read back EMPTY, and the
+        // voice service recorded "this session has nothing to say" about a session that had just
+        // written a full answer. With no narration the session could never become playable, so the
+        // roster held it yellow "Preparing voice" permanently. One character, and the whole chain
+        // downstream is silent about it.
+        //
+        // TrimEndingDirectorySeparator (not a bare TrimEnd) because a DRIVE ROOT must keep its
+        // separator: "D:\" is a real path whose name is "D--", while "D:" means "the current
+        // directory on D:", which is a different place entirely.
+        var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(repoPath));
         return System.Text.RegularExpressions.Regex.Replace(normalized, "[^a-zA-Z0-9]", "-");
     }
 

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -144,6 +144,20 @@ public static class SessionOrdering
         // mapping until the user acts". So cooked-red can stand while the raw activity says otherwise.
         // Raw is the authority here - not because the two agree, but because the fold says raw wins.
         if (!IsRawRed(s)) return false;
+        // A BRAND-NEW SESSION IS NEVER "PREPARING VOICE" - it is READY (green), and this arm must not
+        // eat that (owner's ruling, 2026-07-27). A session that has taken no turn has produced no
+        // assistant reply, so there is no turn to narrate: no generation will ever be attempted, no
+        // audio will ever land, and the `|| !VoiceAudioReady` hold below would therefore be permanent.
+        //
+        // The bug this closes: green lives in BaseColor, the LAST arm of EffectiveColor, BELOW the
+        // IsVoicePreparing arm. So with voice mode ON, every freshly-spawned session folded to yellow
+        // "Preparing voice" and STAYED there - the green "Ready" state was unreachable for the entire
+        // voice-mode fleet. "Preparing voice" was also simply false about it: nothing was being prepared.
+        //
+        // Not caught for the same reason it was easy to write: the brand-new-is-green tests build their
+        // session with a helper that leaves VoiceMode at its default false, so green was only ever proven
+        // for the voice-OFF case. The voice-mode variants now live beside them.
+        if (s.IsBrandNew) return false;
         var state = s.AssessedState ?? s.ActivityState;
         var waiting = string.Equals(state, "WaitingForInput", StringComparison.OrdinalIgnoreCase)
                    || string.Equals(state, "WaitingForPerm", StringComparison.OrdinalIgnoreCase);

--- a/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
@@ -429,6 +429,73 @@ public sealed class SessionOrderingTests
         Assert.Equal("blue", SessionOrdering.EffectiveColor(Raw("Working", brandNew: true)));
     }
 
+    // ===================================================================================
+    // A BRAND-NEW SESSION IS GREEN **IN VOICE MODE TOO** (owner's ruling, 2026-07-27).
+    //
+    // The test above proves green only for the voice-OFF case, because the Raw(...) helper
+    // leaves VoiceMode false. That blind spot hid a live defect: green lives in BaseColor,
+    // the LAST arm of EffectiveColor, BELOW IsVoicePreparing - so with voice mode ON every
+    // freshly-spawned session folded to yellow "Preparing voice" instead, and STAYED yellow,
+    // because a session that has taken no turn has no reply to narrate and so never gets
+    // audio. `|| !VoiceAudioReady` then holds forever.
+    //
+    // These are the voice-mode twins. If one goes yellow, the brand-new guard in
+    // IsVoicePreparing was removed or an arm was added above the green.
+    // ===================================================================================
+
+    /// <summary>A brand-new session as it actually arrives with the gateway in voice mode: voice on,
+    /// parked at its first prompt, and (necessarily) with no audio ever generated.</summary>
+    private static SessionDto BrandNewVoiceSession(string activityState = "WaitingForInput")
+    {
+        var s = Raw(activityState, brandNew: true);
+        s.VoiceMode = true;
+        s.VoiceGenerating = false;
+        s.VoiceAudioReady = false;
+        return s;
+    }
+
+    [Fact]
+    public void EffectiveColor_BrandNewInVoiceMode_IsGreen_NotPreparingVoiceYellow()
+    {
+        Assert.Equal("green", SessionOrdering.EffectiveColor(BrandNewVoiceSession()));
+    }
+
+    [Fact]
+    public void StateLabel_BrandNewInVoiceMode_IsReady_NotPreparingVoice()
+    {
+        // The label folds from the same inputs in the same order, so it must move with the dot.
+        Assert.Equal("Ready", SessionOrdering.StateLabel(BrandNewVoiceSession()));
+    }
+
+    [Fact]
+    public void IsVoicePreparing_BrandNew_IsFalse()
+    {
+        // The rule itself: there is no turn to narrate, so nothing is being prepared.
+        Assert.False(SessionOrdering.IsVoicePreparing(BrandNewVoiceSession()));
+    }
+
+    [Fact]
+    public void EffectiveColor_BrandNewInVoiceMode_WhileGenerating_IsStillGreen()
+    {
+        // Even if a generation is somehow marked in flight for a session that has taken no turn,
+        // "brand new" is the truer statement - it has produced nothing to read back.
+        var s = BrandNewVoiceSession();
+        s.VoiceGenerating = true;
+        Assert.Equal("green", SessionOrdering.EffectiveColor(s));
+    }
+
+    [Fact]
+    public void EffectiveColor_VoiceModeAfterFirstTurn_StillHoldsYellow()
+    {
+        // The NEGATIVE control: the brand-new guard must not disarm the voice hold generally.
+        // Once the session has taken a turn (IsBrandNew false), a waiting voice session with no
+        // audio yet is still yellow "Preparing voice" - the behaviour issue #553 asked for.
+        var s = BrandNewVoiceSession();
+        s.IsBrandNew = false;
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(s));
+        Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
+    }
+
     [Fact]
     public void EffectiveColor_BackgroundRunningAtTurnEnd_IsPurple_FromRawFacts()
     {


### PR DESCRIPTION
Two independent causes of a session sitting on yellow "Preparing voice" forever. Two-line production change; the rest is comments and tests.

## 1. A trailing separator renamed the transcript folder

`GetProjectFolder` turns every non-alphanumeric character into a dash, over a path that `Path.GetFullPath` leaves a trailing separator on:

```
D:\ReposFred\cc-consult\  ->  D--ReposFred-cc-consult-   (does not exist)
D:\ReposFred\cc-consult   ->  D--ReposFred-cc-consult    (exists)
```

Proven by running the real production methods with a live wedged session's stored values: same machine, same transcript id, one trailing backslash the only difference between finding the conversation and not finding it.

The chain: lookup misses -> `Turns` returns `no_jsonl` with an empty widget list -> the voice service finds no assistant reply and records "nothing to narrate" about a session that had just written a full answer -> the speech provider is never called -> no audio ever exists -> and since the roster holds a voice session yellow until audio is ready, it stays yellow permanently with no error anywhere.

Uses `TrimEndingDirectorySeparator` rather than a bare `TrimEnd` so a drive root keeps its separator (`D:\` is a directory; `D:` means the current directory on D:). Pinned by a test.

## 2. Brand-new sessions were yellow, never green

Green lives in `BaseColor`, the last arm of `EffectiveColor`, **below** the `IsVoicePreparing` arm. With voice mode on, every freshly-spawned session folded to "Preparing voice" - and stayed there, because a session that has taken no turn has no reply to narrate, so no audio ever arrives and `!VoiceAudioReady` never releases.

`IsVoicePreparing` now answers false for a brand-new session, which is also the truer statement: nothing is being prepared.

The existing brand-new-green tests missed this because their helper leaves `VoiceMode` at false, so green was only ever proven for the voice-off case. The voice-mode twins now sit beside them, with a negative control pinning that a session past its first turn still holds yellow.

## Verification

- Both fixes revert-proven: removing either production line turns its new tests red (4 of 5, and 5 of 7; the survivors are deliberate negative controls).
- `SessionOrderingTests`: 118 passed. `ClaudeSessionReader` tests: 14 passed.
- Full solution suite was green on the brand-new fix earlier (8407 passed, 0 failed).
- Merging ahead of the full 28-minute Gateway suite by owner's instruction; verification continues after merge.

## Known follow-up

`GenerateOnceAsync` still treats "could not read the conversation" and "there is genuinely nothing to say" as the same outcome, so any future read failure wedges silently rather than surfacing an error. `TurnsResponse.Status` already carries what is needed to separate them. Left out of this PR to avoid bundling an under-tested behaviour change.
