### PR TITLE
First-run wizard: make onboarding completable, and stop the first frame opening in red

### DIFF
--- a/src/CcDirector.Avalonia/Controls/HomeView.axaml
+++ b/src/CcDirector.Avalonia/Controls/HomeView.axaml
@@ -43,7 +43,7 @@
 
             <!-- Problem: needs-attention header + only the failing rows. Hidden when healthy. -->
             <StackPanel x:Name="HomeProblems" IsVisible="False" Spacing="0">
-                <TextBlock Text="NEEDS ATTENTION"
+                <TextBlock x:Name="HomeProblemsHeading" Text="NEEDS ATTENTION"
                            Foreground="#F0B848"
                            FontSize="12" FontWeight="Bold" LetterSpacing="1.5"
                            HorizontalAlignment="Center"

--- a/src/CcDirector.Avalonia/Controls/HomeView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/HomeView.axaml.cs
@@ -69,6 +69,14 @@ public partial class HomeView : UserControl
         HomeAllClear.IsVisible = false;
         HomeProblems.IsVisible = true;
 
+        // The heading must match what is actually listed. When the only thing not green is setup
+        // still running, "NEEDS ATTENTION" is false and alarming - nothing needs the user at all.
+        var onlyInProgress = !gatewayError
+            && status.Checks.Any(c => c.Level == HomeCheckLevel.Busy)
+            && status.Checks.All(c => c.Level is HomeCheckLevel.Ok or HomeCheckLevel.Busy);
+        HomeProblemsHeading.Text = onlyInProgress ? "FINISHING SETUP" : "NEEDS ATTENTION";
+        HomeProblemsHeading.Foreground = Brush.Parse(onlyInProgress ? "#7FB2E5" : "#F0B848");
+
         // Gateway trouble is surfaced here too (its glanceable light is in the rail), so the
         // status screen is a single place to see and fix everything that is wrong.
         if (gatewayError)
@@ -90,14 +98,19 @@ public partial class HomeView : UserControl
             };
             HomeStatusRows.Children.Add(BuildProblemRow(
                 check.Title, check.Detail, fix is null ? null : "Fix", fix,
-                warn: check.Level == HomeCheckLevel.Warn));
+                warn: check.Level == HomeCheckLevel.Warn,
+                busy: check.Level == HomeCheckLevel.Busy));
         }
     }
 
-    /// <summary>A single failing-check card: icon + title + detail, with an optional fix button.</summary>
-    private Control BuildProblemRow(string title, string detail, string? fixLabel, Action? onFix, bool warn = false)
+    /// <summary>
+    /// A single check card: icon + title + detail, with an optional fix button. Three looks - red for
+    /// a failure, amber for a warning, and calm blue with a progress glyph for work still running
+    /// (<paramref name="busy"/>), which is not a problem and never offers a fix.
+    /// </summary>
+    private Control BuildProblemRow(string title, string detail, string? fixLabel, Action? onFix, bool warn = false, bool busy = false)
     {
-        var accent = warn ? "#F0B848" : "#E05656";
+        var accent = busy ? "#7FB2E5" : warn ? "#F0B848" : "#E05656";
 
         var dock = new DockPanel();
 
@@ -123,7 +136,7 @@ public partial class HomeView : UserControl
 
         var icon = new TextBlock
         {
-            Text = warn ? "!" : "X",
+            Text = busy ? "..." : warn ? "!" : "X",
             Foreground = Brush.Parse(accent),
             FontWeight = FontWeight.Bold,
             FontSize = 13,
@@ -152,8 +165,8 @@ public partial class HomeView : UserControl
 
         return new Border
         {
-            Background = Brush.Parse(warn ? "#241f17" : "#241a1a"),
-            BorderBrush = Brush.Parse(warn ? "#4a3f22" : "#4a2a2a"),
+            Background = Brush.Parse(busy ? "#171d24" : warn ? "#241f17" : "#241a1a"),
+            BorderBrush = Brush.Parse(busy ? "#26384a" : warn ? "#4a3f22" : "#4a2a2a"),
             BorderThickness = new global::Avalonia.Thickness(1),
             CornerRadius = new global::Avalonia.CornerRadius(7),
             Padding = new global::Avalonia.Thickness(14, 12),
@@ -162,17 +175,22 @@ public partial class HomeView : UserControl
     }
 
     /// <summary>
-    /// Show the cc-* tools check in a "repairing" state while the one-click Fix rebuild runs.
-    /// MainWindow pushes live progress text here; a normal status refresh restores the screen
-    /// when it finishes. Reuses the problem-card style with no fix button (the repair is running).
+    /// Show the tools check in a working state while a rebuild runs - either the one-click Fix or the
+    /// automatic first-launch setup (<paramref name="firstRunSetup"/>), which is the expected state on
+    /// a new machine and must never read as a failure. MainWindow pushes live progress text here; a
+    /// normal status refresh restores the screen when it finishes. No fix button: it is already running.
     /// </summary>
-    public void SetToolsRepairing(string detail)
+    public void SetToolsRepairing(string detail, bool firstRunSetup = false)
     {
         HomeBusyText.IsVisible = false;
         HomeAllClear.IsVisible = false;
         HomeProblems.IsVisible = true;
+        HomeProblemsHeading.Text = firstRunSetup ? "FINISHING SETUP" : "NEEDS ATTENTION";
+        HomeProblemsHeading.Foreground = Brush.Parse(firstRunSetup ? "#7FB2E5" : "#F0B848");
         HomeStatusRows.Children.Clear();
         HomeStatusRows.Children.Add(BuildProblemRow(
-            "cc-* tools", $"Repairing... {detail}", null, null, warn: true));
+            HomeStatusBuilder.ToolsRowTitle,
+            firstRunSetup ? $"Finishing setup - {detail}" : $"Repairing - {detail}",
+            null, null, busy: true));
     }
 }

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -1,4 +1,4 @@
-<Window xmlns="https://github.com/avaloniaui"
+﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="CcDirector.Avalonia.FirstRunWizardDialog"
         Title="Set up DevThrottle"
@@ -138,7 +138,8 @@
                  expanded used to push "Set me up" off the bottom of the window. -->
             <Grid x:Name="WelcomePanel" IsVisible="False" RowDefinitions="*,Auto">
                 <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="580" HorizontalAlignment="Center">
                     <StackPanel Spacing="16" VerticalAlignment="Center">
                         <TextBlock Classes="wtitle" Text="Welcome to DevThrottle" />
                         <TextBlock Classes="wsub"
@@ -185,7 +186,8 @@
                 <TextBlock Grid.Row="2" x:Name="AgentsStatusText" Classes="wsub"
                            Text="Scanning this machine for coding agents..." Margin="0,0,0,20" />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="600" HorizontalAlignment="Center">
                     <StackPanel x:Name="AgentsListPanel" Spacing="8" MaxWidth="560"
                                 HorizontalAlignment="Stretch" />
                 </ScrollViewer>
@@ -229,7 +231,8 @@
                            Foreground="#1A7F37" HorizontalAlignment="Center" TextAlignment="Center"
                            Margin="0,0,0,14" Text="" />
                 <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel x:Name="ToolsListPanel" Spacing="6" MaxWidth="600"
                                 HorizontalAlignment="Stretch" />
                 </ScrollViewer>
@@ -245,7 +248,8 @@
                 <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,22"
                            Text="Pick the folder (or folders) where you keep your repositories. This is what DevThrottle keeps the books on - branches, unmerged work, what is waiting on you - and where it offers you repositories when you start an agent." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel MaxWidth="600" HorizontalAlignment="Stretch" Spacing="8">
                         <StackPanel x:Name="CodeSuggestionsPanel" Spacing="8" />
                         <TextBlock x:Name="CodeScanStatusText" Classes="hint"
@@ -295,7 +299,8 @@
                 <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,26"
                            Text="Snap a screen, then drag the screenshot straight onto an agent - the fastest way to show it exactly what you mean. DevThrottle watches one folder for new screenshots." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="640" HorizontalAlignment="Center">
                 <StackPanel MaxWidth="600" Spacing="14" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
 
@@ -345,7 +350,8 @@
                     <!-- Choice view: one dominant hosted card (pre-selected), two quiet alternatives.
                          Scrolls so the cards stay reachable on a short window. -->
                     <ScrollViewer x:Name="GatewayChoiceView" VerticalScrollBarVisibility="Auto"
-                                  HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                                  HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                                  MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel MaxWidth="600" Spacing="14"
                                 VerticalAlignment="Top" HorizontalAlignment="Stretch">
                         <Border x:Name="GatewayHostedCard" Cursor="Hand"
@@ -447,7 +453,8 @@
                 <TextBlock Grid.Row="2" x:Name="ReportSubText" Classes="wsub" Margin="0,0,0,24"
                            Text="Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="560" HorizontalAlignment="Center">
                 <StackPanel MaxWidth="520" Spacing="10" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
                     <Border x:Name="ReportDailyCard" Cursor="Hand"
@@ -492,7 +499,8 @@
                  close button as the only way out of the wizard. -->
             <Grid x:Name="DonePanel" IsVisible="False" RowDefinitions="*,Auto">
                 <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              MaxWidth="560" HorizontalAlignment="Center">
                     <StackPanel Spacing="18" VerticalAlignment="Center">
                         <TextBlock Classes="wtitle" Text="You are ready" />
                         <TextBlock x:Name="DoneSubText" Classes="wsub"

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -1,7 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="CcDirector.Avalonia.FirstRunWizardDialog"
-        Title="DevThrottle Setup"
+        Title="Set up DevThrottle"
         Width="900" Height="640"
         MinWidth="760" MinHeight="560"
         WindowStartupLocation="CenterOwner"
@@ -134,34 +134,40 @@
         <Grid Grid.Row="1">
 
             <!-- ===================== WELCOME ===================== -->
-            <StackPanel x:Name="WelcomePanel" IsVisible="False" Spacing="16"
-                        VerticalAlignment="Center">
-                <TextBlock Classes="wtitle" Text="Welcome to DevThrottle" />
-                <TextBlock Classes="wsub"
-                           Text="You are about three minutes from running your first coding agent. We will show you what comes included - your agents, your code, your morning report - and every step is a take-it-or-leave-it offer. Use what helps, breeze past what doesn't." />
+            <!-- Body scrolls, actions are pinned: on a small screen (1024x768) the founder note
+                 expanded used to push "Set me up" off the bottom of the window. -->
+            <Grid x:Name="WelcomePanel" IsVisible="False" RowDefinitions="*,Auto">
+                <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                    <StackPanel Spacing="16" VerticalAlignment="Center">
+                        <TextBlock Classes="wtitle" Text="Welcome to DevThrottle" />
+                        <TextBlock Classes="wsub"
+                                   Text="You are about three minutes from running your first coding agent. We will show you what comes included - your agents, your code, your morning report - and every step is a take-it-or-leave-it offer. Use what helps, breeze past what doesn't." />
 
-                <!-- Founder note: two sentences collapsed, one quiet Read more. It must never
-                     delay the "Set me up" click - short by design. -->
-                <Border Background="#F5F6F8" BorderBrush="#E6E8EC" BorderThickness="1"
-                        CornerRadius="12" Padding="20,16" MaxWidth="540"
-                        HorizontalAlignment="Center" Margin="0,6,0,0">
-                    <StackPanel Spacing="8">
-                        <TextBlock FontSize="13.5" Foreground="#5A616B" TextWrapping="Wrap"
-                                   LineHeight="21"
-                                   Text="I built DevThrottle because running agents was never the hard part. The hard part was getting to Friday and realizing the week went to the wrong things. DevThrottle keeps the books - so that stops happening." />
-                        <TextBlock x:Name="FounderMoreText" FontSize="13.5" Foreground="#5A616B"
-                                   TextWrapping="Wrap" LineHeight="21" IsVisible="False"
-                                   Text="Agents multiply what you can build, and they multiply the bookkeeping with it: branches, worktrees, half-finished work, sessions waiting on you. DevThrottle carries that administration for you and reports back every morning with what happened and what needs your attention. Give it one small task today, then read tomorrow's report. That is the whole loop." />
-                        <Grid ColumnDefinitions="*,Auto">
-                            <TextBlock Grid.Column="0" FontSize="12.5" Foreground="#8A909A"
-                                       Text="- Soren, founder" VerticalAlignment="Center" />
-                            <Button Grid.Column="1" x:Name="FounderMoreLink" Classes="quietLink"
-                                    Content="Read more" Click="BtnFounderMore_Click" />
-                        </Grid>
+                        <!-- Founder note: two sentences collapsed, one quiet Read more. It must never
+                             delay the "Set me up" click - short by design. -->
+                        <Border Background="#F5F6F8" BorderBrush="#E6E8EC" BorderThickness="1"
+                                CornerRadius="12" Padding="20,16" MaxWidth="540"
+                                HorizontalAlignment="Center" Margin="0,6,0,0">
+                            <StackPanel Spacing="8">
+                                <TextBlock FontSize="13.5" Foreground="#5A616B" TextWrapping="Wrap"
+                                           LineHeight="21"
+                                           Text="I built DevThrottle because running agents was never the hard part. The hard part was getting to Friday and realizing the week went to the wrong things. DevThrottle keeps the books - so that stops happening." />
+                                <TextBlock x:Name="FounderMoreText" FontSize="13.5" Foreground="#5A616B"
+                                           TextWrapping="Wrap" LineHeight="21" IsVisible="False"
+                                           Text="Agents multiply what you can build, and they multiply the bookkeeping with it: branches, worktrees, half-finished work, sessions waiting on you. DevThrottle carries that administration for you and reports back every morning with what happened and what needs your attention. Give it one small task today, then read tomorrow's report. That is the whole loop." />
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Grid.Column="0" FontSize="12.5" Foreground="#8A909A"
+                                               Text="- Soren, founder" VerticalAlignment="Center" />
+                                    <Button Grid.Column="1" x:Name="FounderMoreLink" Classes="quietLink"
+                                            Content="Read more" Click="BtnFounderMore_Click" />
+                                </Grid>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
-                </Border>
+                </ScrollViewer>
 
-                <StackPanel Spacing="16" HorizontalAlignment="Center" Margin="0,10,0,0">
+                <StackPanel Grid.Row="1" Spacing="16" HorizontalAlignment="Center" Margin="0,16,0,0">
                     <Button x:Name="WelcomeSetupButton" Classes="primaryButton"
                             Content="Set me up" HorizontalAlignment="Center"
                             Click="BtnPrimary_Click" />
@@ -169,7 +175,7 @@
                             Content="Skip setup and figure it out myself"
                             HorizontalAlignment="Center" Click="BtnWholeWizardSkip_Click" />
                 </StackPanel>
-            </StackPanel>
+            </Grid>
 
             <!-- ===================== AGENTS ===================== -->
             <Grid x:Name="AgentsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
@@ -237,7 +243,7 @@
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="WHAT WE WATCH OVER" />
                 <TextBlock Grid.Row="1" Classes="wtitle" Text="Where does your code live?" Margin="0,0,0,10" />
                 <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,22"
-                           Text="Pick the folder (or folders) where you keep your repositories. This is what DevThrottle keeps the books on - branches, worktrees, unmerged work - and where it offers you repos when you start an agent." />
+                           Text="Pick the folder (or folders) where you keep your repositories. This is what DevThrottle keeps the books on - branches, unmerged work, what is waiting on you - and where it offers you repositories when you start an agent." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
                     <StackPanel MaxWidth="600" HorizontalAlignment="Stretch" Spacing="8">
@@ -250,15 +256,26 @@
                                 CornerRadius="10" Padding="16,13">
                             <Grid ColumnDefinitions="*,Auto">
                                 <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
-                                    <TextBlock Text="Somewhere else" FontSize="14" FontWeight="SemiBold"
+                                    <TextBlock Text="Choose a folder" FontSize="14" FontWeight="SemiBold"
                                                Foreground="#16181D" />
-                                    <TextBlock Text="Add another base folder" FontSize="11"
-                                               Foreground="#8A909A" />
+                                    <TextBlock Text="Point DevThrottle at where you keep your code"
+                                               FontSize="11" Foreground="#8A909A" />
                                 </StackPanel>
                                 <Button Grid.Column="1" Classes="dialogButton" Content="Browse..."
                                         Click="BtnBrowseCodeFolder_Click" VerticalAlignment="Center" />
                             </Grid>
                         </Border>
+
+                        <!-- The clean-machine path. A new laptop has no repositories at all, and a
+                             lone "Browse..." to a folder that does not exist reads as a dead end.
+                             This acknowledges the state and moves on; it does not create anything. -->
+                        <Button x:Name="CodeNoneLink" Classes="quietLink"
+                                Content="I don't have code on this machine yet"
+                                HorizontalAlignment="Center" Margin="0,4,0,0"
+                                Click="BtnNoCodeYet_Click" />
+                        <TextBlock x:Name="CodeNoneAckText" Classes="hint" IsVisible="False"
+                                   HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="480"
+                                   Text="No problem - nothing here is required. When you clone or create your first repository, add its folder from the Repositories view and DevThrottle picks it up." />
                     </StackPanel>
                 </ScrollViewer>
                 <!-- The proof number: how many repositories the added folders will surface. -->
@@ -277,7 +294,9 @@
                 <TextBlock Grid.Row="1" Classes="wtitle" Text="Where do your screenshots go?" Margin="0,0,0,10" />
                 <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,26"
                            Text="Snap a screen, then drag the screenshot straight onto an agent - the fastest way to show it exactly what you mean. DevThrottle watches one folder for new screenshots." />
-                <StackPanel Grid.Row="3" MaxWidth="600" Spacing="14" VerticalAlignment="Top"
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                <StackPanel MaxWidth="600" Spacing="14" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
 
                     <!-- The chosen folder, with a Change (browse) escape hatch. -->
@@ -312,6 +331,7 @@
                                 Click="BtnCancelWatchScreenshot_Click" />
                     </StackPanel>
                 </StackPanel>
+                </ScrollViewer>
             </Grid>
 
             <!-- ===================== GATEWAY (native, hosted-first per the mockup) ===================== -->
@@ -322,8 +342,11 @@
                            Text="The gateway is what lets you check on your agents from your phone, use voice, and get your morning report. Signing in takes seconds." />
                 <Grid Grid.Row="3">
 
-                    <!-- Choice view: one dominant hosted card (pre-selected), two quiet alternatives. -->
-                    <StackPanel x:Name="GatewayChoiceView" MaxWidth="600" Spacing="14"
+                    <!-- Choice view: one dominant hosted card (pre-selected), two quiet alternatives.
+                         Scrolls so the cards stay reachable on a short window. -->
+                    <ScrollViewer x:Name="GatewayChoiceView" VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                    <StackPanel MaxWidth="600" Spacing="14"
                                 VerticalAlignment="Top" HorizontalAlignment="Stretch">
                         <Border x:Name="GatewayHostedCard" Cursor="Hand"
                                 Background="#F2F8FD" BorderBrush="#0066B8" BorderThickness="2"
@@ -341,8 +364,10 @@
                                 </StackPanel>
                                 <TextBlock TextWrapping="Wrap" FontSize="13.5" Foreground="#5A616B"
                                            Text="We run it for you. Sign in and this machine is enrolled - phone access, voice, and the morning report work immediately." />
+                                <!-- State the plan, never assert what this user already owns: on a
+                                     brand-new free account "included with your subscription" is false. -->
                                 <TextBlock FontSize="12.5" Foreground="#8A909A"
-                                           Text="Included with your subscription" />
+                                           Text="Part of Pro" />
                             </StackPanel>
                         </Border>
 
@@ -371,6 +396,7 @@
                             </Border>
                         </Grid>
                     </StackPanel>
+                    </ScrollViewer>
 
                     <!-- Connecting view: browser sign-in is in flight. -->
                     <StackPanel x:Name="GatewayConnectingView" IsVisible="False" Spacing="12"
@@ -416,10 +442,13 @@
             <!-- ===================== MORNING REPORT (the promise screen) ===================== -->
             <Grid x:Name="ReportPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="THE PAYOFF" />
-                <TextBlock Grid.Row="1" Classes="wtitle" Text="Tomorrow morning, we report back" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,24"
+                <TextBlock Grid.Row="1" x:Name="ReportTitle" Classes="wtitle"
+                           Text="Tomorrow morning, we report back" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" x:Name="ReportSubText" Classes="wsub" Margin="0,0,0,24"
                            Text="Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you." />
-                <StackPanel Grid.Row="3" MaxWidth="520" Spacing="10" VerticalAlignment="Top"
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                <StackPanel MaxWidth="520" Spacing="10" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
                     <Border x:Name="ReportDailyCard" Cursor="Hand"
                             Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
@@ -453,20 +482,29 @@
                                Margin="0,6,0,0"
                                Text="The report travels through your gateway. Connect one on the previous step - or any time in Settings - and it starts arriving." />
                 </StackPanel>
+                </ScrollViewer>
             </Grid>
 
-            <!-- ===================== DONE ===================== -->
-            <StackPanel x:Name="DonePanel" IsVisible="False" Spacing="18"
-                        VerticalAlignment="Center">
-                <TextBlock Classes="wtitle" Text="You are ready" />
-                <TextBlock Classes="wsub"
-                           Text="Start an agent on one of your repos - give it a small task and watch the card, not the terminal. Tomorrow morning, DevThrottle reports back on how it went." />
-                <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                        CornerRadius="12" Padding="4" MaxWidth="520" HorizontalAlignment="Center"
-                        Margin="0,6,0,0">
-                    <StackPanel x:Name="DoneReceiptPanel" />
-                </Border>
-                <StackPanel Spacing="16" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <!-- ===================== DONE =====================
+                 The receipt grows with the number of things it reports, so it scrolls and the two
+                 finish buttons are pinned to the bottom row. Before this they lived inside the
+                 scrolling content and fell off the bottom of a 1024x768 screen, leaving the window
+                 close button as the only way out of the wizard. -->
+            <Grid x:Name="DonePanel" IsVisible="False" RowDefinitions="*,Auto">
+                <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0">
+                    <StackPanel Spacing="18" VerticalAlignment="Center">
+                        <TextBlock Classes="wtitle" Text="You are ready" />
+                        <TextBlock x:Name="DoneSubText" Classes="wsub"
+                                   Text="Start an agent on one of your repos - give it a small task and watch the card, not the terminal. Tomorrow morning, DevThrottle reports back on how it went." />
+                        <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                                CornerRadius="12" Padding="4" MaxWidth="520" HorizontalAlignment="Center"
+                                Margin="0,6,0,0">
+                            <StackPanel x:Name="DoneReceiptPanel" />
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+                <StackPanel Grid.Row="1" Spacing="16" HorizontalAlignment="Center" Margin="0,16,0,0">
                     <Button x:Name="DoneStartButton" Classes="primaryButton"
                             Content="Start my first agent" HorizontalAlignment="Center"
                             Click="BtnStartFirstAgent_Click" />
@@ -474,7 +512,7 @@
                             Content="Take me to the board" HorizontalAlignment="Center"
                             Click="BtnPrimary_Click" />
                 </StackPanel>
-            </StackPanel>
+            </Grid>
         </Grid>
 
         <!-- Footer: Back link (bottom-left), a faint note, a per-step skip link, and the primary CTA. -->

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -84,6 +84,10 @@ public partial class FirstRunWizardDialog : Window
     private bool _codeScanRan;
     private CancellationTokenSource? _codeScanCts;
 
+    // Set when the user says there is no code on this machine yet (a new laptop). It changes nothing
+    // on disk - it only stops the step, and the Done receipt, from reading as a failure.
+    private bool _codeNoneOnThisMachine;
+
     // Morning report step: the chosen cadence. Daily is the default - the report is the payoff the
     // whole onboarding story builds to, so it arrives unless the user says otherwise.
     private enum ReportCadence { Daily, Weekly, Off }
@@ -238,8 +242,17 @@ public partial class FirstRunWizardDialog : Window
                 PrimaryButton.IsVisible = true;
                 PrimaryButton.IsEnabled = true;
                 RefreshReportCards();
-                // The report travels through the gateway; say so plainly when none is connected.
-                ReportGatewayNote.IsVisible = !_gatewayConnected && string.IsNullOrWhiteSpace(GatewayConfig.Load().Url);
+                // The report travels through the gateway. With none connected nothing can arrive
+                // tomorrow morning, so the headline says what is actually true instead of making a
+                // promise the previous step already ruled out.
+                var hasGateway = HasGateway();
+                ReportGatewayNote.IsVisible = !hasGateway;
+                ReportTitle.Text = hasGateway
+                    ? "Tomorrow morning, we report back"
+                    : "Your morning report is ready when your gateway is";
+                ReportSubText.Text = hasGateway
+                    ? "Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you."
+                    : "The report tells you every morning what happened, what needs your attention, and what DevThrottle recommends. Choose how often you want it - it starts arriving as soon as a gateway is connected.";
                 break;
 
             case WizardStep.Done:
@@ -247,6 +260,11 @@ public partial class FirstRunWizardDialog : Window
                 // the carried to-do leads: the button routes back to the Agents step and its installer
                 // instead of promising a session that cannot start.
                 DoneStartButton.Content = _model.AgentsFound ? "Start my first agent" : "Install an agent";
+                // Never close with an instruction the same screen says cannot be followed: with no code
+                // folder there is nothing to start an agent on, so adding one is the closing step.
+                DoneSubText.Text = _codeAddedRoots.Values.Sum() > 0
+                    ? "Start an agent on one of your repositories - give it a small task and watch the card, not the terminal. Tomorrow morning, DevThrottle reports back on how it went."
+                    : "Add a code folder first - the Repositories view in the left rail - and DevThrottle can start an agent on it. Everything else here is already set up.";
                 FooterNote.Text = "Everything here can be changed in Settings.";
                 FooterNote.IsVisible = true;
                 BuildDoneReceipt();
@@ -942,6 +960,20 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
+    /// <summary>
+    /// "I don't have code on this machine yet": acknowledge the clean-machine case and move on. It
+    /// writes nothing and creates nothing - a genuinely empty machine is a normal state, not a step
+    /// the user failed.
+    /// </summary>
+    private void BtnNoCodeYet_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnNoCodeYet_Click");
+        _codeNoneOnThisMachine = true;
+        CodeNoneLink.IsVisible = false;
+        CodeNoneAckText.IsVisible = true;
+        Advance();
+    }
+
     // ---- Screenshots step --------------------------------------------------------------------------
 
     /// <summary>
@@ -1141,6 +1173,14 @@ public partial class FirstRunWizardDialog : Window
 
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
 
+    /// <summary>
+    /// True when a gateway is reachable for this machine - connected during this run, or already
+    /// configured before it. Everything that travels through the gateway (the morning report) reads
+    /// this one answer rather than deciding for itself.
+    /// </summary>
+    private bool HasGateway() =>
+        _gatewayConnected || !string.IsNullOrWhiteSpace(GatewayConfig.Load().Url);
+
     /// <summary>Paint the three choice cards and the primary CTA from the current selection.</summary>
     private void RefreshGatewayChoiceUi()
     {
@@ -1331,7 +1371,11 @@ public partial class FirstRunWizardDialog : Window
                 string.Join(", ", _codeAddedRoots.Keys), done: true));
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
-                "No code folders yet", "Add them from the Repositories view to get repo suggestions", done: false));
+                "No code folders yet",
+                _codeNoneOnThisMachine
+                    ? "Add a folder from the Repositories view once you have code on this machine"
+                    : "Add them from the Repositories view to get repository suggestions",
+                done: false));
 
         // Screenshots row.
         if (_shotsSelectedPath is not null)
@@ -1361,16 +1405,24 @@ public partial class FirstRunWizardDialog : Window
         DoneReceiptPanel.Children.Add(ReceiptRow(
             "Browsers", "Give agents a signed-in browser any time - the Browsers group in the left rail", done: false));
 
-        // Morning report row - the promise, restated on the receipt.
-        DoneReceiptPanel.Children.Add(_reportCadence switch
+        // Morning report row - the promise, restated on the receipt. With no gateway the report
+        // cannot arrive, so this row must not claim it is Done two rows under "No gateway".
+        var gatewayReady = !string.IsNullOrWhiteSpace(gatewayUrl);
+        DoneReceiptPanel.Children.Add((_reportCadence, gatewayReady) switch
         {
-            ReportCadence.Daily => ReceiptRow("Morning report", "Every morning at 7:00, your time", done: true),
-            ReportCadence.Weekly => ReceiptRow("Morning report", "Monday mornings", done: true),
-            _ => ReceiptRow("Morning report off", "Turn it on any time in Settings", done: false),
+            (ReportCadence.Off, _) => ReceiptRow("Morning report off", "Turn it on any time in Settings", done: false),
+            (ReportCadence.Daily, true) => ReceiptRow("Morning report", "Every morning at 7:00, your time", done: true),
+            (ReportCadence.Weekly, true) => ReceiptRow("Morning report", "Monday mornings", done: true),
+            (ReportCadence.Daily, false) => ReceiptRow(
+                "Morning report", "Every morning at 7:00 - once a gateway is connected",
+                done: false, pillText: "Waiting for a gateway"),
+            _ => ReceiptRow(
+                "Morning report", "Monday mornings - once a gateway is connected",
+                done: false, pillText: "Waiting for a gateway"),
         });
     }
 
-    private static Border ReceiptRow(string name, string sub, bool done)
+    private static Border ReceiptRow(string name, string sub, bool done, string? pillText = null)
     {
         var pill = new Border
         {
@@ -1380,7 +1432,7 @@ public partial class FirstRunWizardDialog : Window
             VerticalAlignment = VerticalAlignment.Center,
             Child = new TextBlock
             {
-                Text = done ? "Done" : "Later",
+                Text = pillText ?? (done ? "Done" : "Later"),
                 Foreground = Brush(done ? "#1A7F37" : "#8A909A"),
                 FontSize = 11,
                 FontWeight = FontWeight.SemiBold,

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -992,7 +992,15 @@ public partial class MainWindow : Window
 
             _lastClis = facts.clis;
             _lastBuildFacts = (facts.built, facts.total, facts.missing);
-            _lastHomeStatus = HomeStatusBuilder.Build(facts.clis, facts.built, facts.total, facts.missing, _lastToolHealth, _lastBasePythonBroken);
+            // Tools that are missing on the very first launch are the setup the installer promised
+            // ("your tools finish setting up the first time you open DevThrottle"), and the automatic
+            // self-heal below is about to run. Rule it as in-progress BEFORE painting, so the first
+            // frame never shows the expected state as a red failure.
+            _toolsSetupInProgress = _repairingTools
+                || (facts.missing.Count > 0 && !_autoRepairAttempted);
+            _lastHomeStatus = HomeStatusBuilder.Build(
+                facts.clis, facts.built, facts.total, facts.missing, _lastToolHealth, _lastBasePythonBroken,
+                _toolsSetupInProgress);
 
             ApplyHomeHealth();
 
@@ -1033,12 +1041,13 @@ public partial class MainWindow : Window
     {
         if (_repairingTools) return;
         _repairingTools = true;
+        _toolsSetupInProgress = true;
         FileLog.Write(auto ? "[MainWindow] Tools auto self-heal started" : "[MainWindow] Tools repair requested from Home");
         try
         {
-            HomeView.SetToolsRepairing(auto ? "auto-repairing..." : "starting...");
+            HomeView.SetToolsRepairing(auto ? "starting" : "starting...", firstRunSetup: auto);
             var layout = CcDirector.Setup.Engine.InstallLayout.Default();
-            var progress = new Progress<string>(msg => HomeView.SetToolsRepairing(msg));
+            var progress = new Progress<string>(msg => HomeView.SetToolsRepairing(msg, firstRunSetup: auto));
             var result = await Task.Run(() =>
                 new CcDirector.Setup.Engine.ToolUpdater(layout).RepairPythonToolsAsync(progress));
             FileLog.Write($"[MainWindow] Tools repair done: success={result.Success}, count={result.ToolCount}, msg={result.Message}");
@@ -1063,6 +1072,9 @@ public partial class MainWindow : Window
     // in RefreshHomeAsync reflects a known-broken runtime without re-launching the probe on the fast path.
     private bool _lastBasePythonBroken;
     private bool _toolHealthRunning;
+    // True while the tools are still being set up (first-launch provisioning or a repair in flight).
+    // The status screen renders this as progress instead of a failure - see HomeCheckLevel.Busy.
+    private bool _toolsSetupInProgress;
 
     // ---- Active cc-* tools indicator state machine (issue #829) ----
     // The rail badge is no longer a passive "fix me" warning: when drift is detected and
@@ -1121,9 +1133,14 @@ public partial class MainWindow : Window
             _lastBasePythonBroken = basePythonBroken;
             FileLog.Write($"[MainWindow] tool health: pass={summary.Pass}, fail={summary.Fail}, notBuilt={summary.NotBuilt}, broken={summary.Broken}, basePythonBroken={basePythonBroken}");
 
+            // Same rule as the fast path: a broken runtime that the automatic self-heal below is about
+            // to repair is unfinished setup, not a fault, and is painted as progress rather than red.
+            _toolsSetupInProgress = _repairingTools || (basePythonBroken && !_autoRepairAttempted);
+
             if (_lastClis is { } clis && _lastBuildFacts is { } bf)
             {
-                _lastHomeStatus = HomeStatusBuilder.Build(clis, bf.built, bf.total, bf.missing, summary, basePythonBroken);
+                _lastHomeStatus = HomeStatusBuilder.Build(
+                    clis, bf.built, bf.total, bf.missing, summary, basePythonBroken, _toolsSetupInProgress);
                 ApplyHomeHealth();
             }
 
@@ -1165,7 +1182,7 @@ public partial class MainWindow : Window
     /// </summary>
     private async Task DriveToolsSyncAsync()
     {
-        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == "cc-* tools");
+        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
         var healthDrift = toolsCheck is not null && toolsCheck.Level != HomeCheckLevel.Ok;
         var enabled = ToolAutoUpdateSetting.Get();
 
@@ -1242,7 +1259,7 @@ public partial class MainWindow : Window
         _lastToolHealth = null;
         await RefreshToolHealthAsync(force: true, driveSync: false);
 
-        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == "cc-* tools");
+        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
         var healthDrift = toolsCheck is not null && toolsCheck.Level != HomeCheckLevel.Ok;
         var reconcilerDrift = await Task.Run(() =>
             new CcDirector.Setup.Engine.ToolReconciler(CcDirector.Setup.Engine.InstallLayout.Default()).HasDrift());
@@ -1349,8 +1366,18 @@ public partial class MainWindow : Window
     /// </summary>
     private void UpdateToolsIndicator()
     {
-        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == "cc-* tools");
+        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
         var detail = toolsCheck?.Detail ?? "";
+
+        // Never say the same thing twice. When the status screen is up it already carries the tools
+        // row, so a rail badge repeating it is the same problem reported in two places at once - which
+        // is how the very first frame came to show one Python failure as two red alarms.
+        if (HomeView.IsVisible)
+        {
+            ToolsIndicator.IsVisible = false;
+            ToolsIndicatorSpinner.IsVisible = false;
+            return;
+        }
 
         switch (_toolsSync.State)
         {
@@ -1363,10 +1390,10 @@ public partial class MainWindow : Window
                 ToolsIndicatorGlyph.IsVisible = false;
                 ToolsIndicatorLabel.Text = "Syncing tools...";
                 ToolsIndicatorLabel.Foreground = SyncOrangeText;
-                ToolsIndicatorSub.Text = "reconciling cc-* tools";
+                ToolsIndicatorSub.Text = "updating the DevThrottle tools";
                 ToolsIndicatorSub.Foreground = SyncOrangeSub;
                 ToolsIndicatorSpinner.IsVisible = true;
-                ToolTip.SetTip(ToolsIndicator, "Bringing the cc-* tools back in sync...");
+                ToolTip.SetTip(ToolsIndicator, "Bringing the DevThrottle tools back in sync...");
                 break;
 
             case ToolsIndicatorState.NeedsAttention:
@@ -1392,13 +1419,13 @@ public partial class MainWindow : Window
                 ToolsIndicator.Cursor = new Cursor(StandardCursorType.Hand);
                 ToolsIndicatorDot.Fill = WarnAmberBorder;
                 ToolsIndicatorGlyph.IsVisible = true;
-                ToolsIndicatorLabel.Text = "cc-* tools";
+                ToolsIndicatorLabel.Text = HomeStatusBuilder.ToolsRowTitle;
                 ToolsIndicatorLabel.Foreground = WarnAmberText;
                 ToolsIndicatorSub.Text = detail;
                 ToolsIndicatorSub.Foreground = WarnAmberSub;
                 ToolsIndicatorSpinner.IsVisible = false;
                 ToolTip.SetTip(ToolsIndicator,
-                    $"Some cc-* tools are missing or failing ({detail}).\nClick to open Settings and download/repair the tools.");
+                    $"Some DevThrottle tools are missing or failing ({detail}).\nClick to open Settings and download/repair the tools.");
                 break;
 
             case ToolsIndicatorState.InSync:

--- a/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using CcDirector.Core.Home;
@@ -43,10 +43,10 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", false), Cli("Codex", false), Cli("Pi", false) },
             toolsBuilt: 31, toolsTotal: 31);
 
-        var clis = Row(status, "Agent CLIs");
+        var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Bad, clis.Level);
         Assert.Equal(HomeCheckAction.OpenSettings, clis.Action);
-        Assert.Contains("No agent CLI found", clis.Detail);
+        Assert.Contains("No coding agent found", clis.Detail);
         Assert.False(status.AllReady);
         Assert.Equal(1, status.ReadyCount);
     }
@@ -58,7 +58,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Codex", true, "0.21.0"), Cli("Claude Code", false) },
             toolsBuilt: 31, toolsTotal: 31);
 
-        var clis = Row(status, "Agent CLIs");
+        var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
         Assert.Equal("Codex 0.21.0 - on PATH", clis.Detail);
         Assert.Equal(HomeCheckAction.None, clis.Action);
@@ -71,7 +71,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.177"), Cli("Codex", true), Cli("Gemini", false) },
             toolsBuilt: 31, toolsTotal: 31);
 
-        var clis = Row(status, "Agent CLIs");
+        var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
         Assert.Equal("Claude Code 2.1.177, Codex - on PATH", clis.Detail);
     }
@@ -84,7 +84,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.177 (Claude Code)") },
             toolsBuilt: 31, toolsTotal: 31);
 
-        Assert.Equal("Claude Code 2.1.177 - on PATH", Row(status, "Agent CLIs").Detail);
+        Assert.Equal("Claude Code 2.1.177 - on PATH", Row(status, HomeStatusBuilder.AgentRowTitle).Detail);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true) },
             toolsBuilt: 1, toolsTotal: 1);
 
-        var clis = Row(status, "Agent CLIs");
+        var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
         Assert.Equal("Claude Code - on PATH", clis.Detail);
     }
@@ -106,7 +106,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.168") },
             toolsBuilt: 12, toolsTotal: 31);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Equal("12 of 31 working", tools.Detail);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action);
@@ -122,7 +122,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.168") },
             toolsBuilt: 25, toolsTotal: 25);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, tools.Level);
         Assert.Equal(HomeCheckAction.None, tools.Action);
         Assert.Equal("25 installed, all working", tools.Detail);
@@ -135,7 +135,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.168") },
             toolsBuilt: 0, toolsTotal: 0);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, tools.Level);
         Assert.Equal(HomeCheckAction.None, tools.Action);
     }
@@ -148,7 +148,7 @@ public class HomeStatusBuilderTests
             toolsBuilt: 29, toolsTotal: 32,
             brokenTools: new[] { "cc-html", "cc-pdf", "cc-word" });
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action);
         Assert.Contains("cc-html", tools.Detail);
@@ -164,7 +164,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.168") },
             toolsBuilt: 26, toolsTotal: 32, brokenTools: missing);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Contains("+2 more", tools.Detail);
     }
 
@@ -175,7 +175,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.168") },
             toolsBuilt: 0, toolsTotal: 31);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Bad, tools.Level);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action);
     }
@@ -188,7 +188,7 @@ public class HomeStatusBuilderTests
         var health = new ToolHealthSummary(24, 1, 4,0, new[] { "cc-foo" });
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Contains("24 pass", tools.Detail);
         Assert.Contains("1 fail", tools.Detail);
@@ -206,7 +206,7 @@ public class HomeStatusBuilderTests
         var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<string>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Contains("4 not built", tools.Detail);
         Assert.Equal(HomeCheckAction.OpenTools, tools.Action); // not broken -> route to the Tools page
@@ -218,7 +218,7 @@ public class HomeStatusBuilderTests
         var health = new ToolHealthSummary(28, 0, 0, 0, Array.Empty<string>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, tools.Level);   // green ONLY when every tool passes
         Assert.Equal(HomeCheckAction.None, tools.Action);
     }
@@ -229,7 +229,7 @@ public class HomeStatusBuilderTests
         var health = new ToolHealthSummary(24, 0, 1,1, Array.Empty<string>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action); // broken -> one-click Fix
     }
@@ -244,10 +244,10 @@ public class HomeStatusBuilderTests
         var status = HomeStatusBuilder.Build(
             new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health, basePythonBroken: true);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckLevel.Bad, tools.Level);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action);
-        Assert.Contains("runtime broken", tools.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cannot start", tools.Detail, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class HomeStatusBuilderTests
         var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<string>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
-        var tools = Row(status, "cc-* tools");
+        var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
         Assert.Equal(HomeCheckAction.OpenTools, tools.Action);
     }
 

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -1,4 +1,4 @@
-namespace CcDirector.Core.Home;
+﻿namespace CcDirector.Core.Home;
 
 /// <summary>Severity of a single readiness row on the home page.</summary>
 public enum HomeCheckLevel
@@ -6,6 +6,14 @@ public enum HomeCheckLevel
     Ok,
     Warn,
     Bad,
+
+    /// <summary>
+    /// Work that has not finished yet, and has not failed. Setup still running is NOT an error: on a
+    /// brand-new machine the installer tells the user the tools finish installing the first time the
+    /// app opens, and reporting that expected state as a red failure alarms them about the product
+    /// working as designed. Rendered as calm progress, never as a problem to fix.
+    /// </summary>
+    Busy,
 }
 
 /// <summary>Where a row's "fix it" affordance should take the user, if anywhere.</summary>
@@ -57,22 +65,39 @@ public sealed record HomeStatus(
 /// </summary>
 public static class HomeStatusBuilder
 {
+    /// <summary>
+    /// The row titles the user reads. Plain product words, not internal vocabulary - these are among
+    /// the first things a new customer ever sees. Every lookup of a row goes through these constants
+    /// so a rename is one edit, never a scatter of string literals.
+    /// </summary>
+    public const string AgentRowTitle = "Coding agent";
+
+    public const string ToolsRowTitle = "DevThrottle tools";
+
     public static HomeStatus Build(
         IReadOnlyList<AgentCliFact> agentClis,
         int toolsBuilt,
         int toolsTotal,
         IReadOnlyList<string>? brokenTools = null,
         Tools.ToolHealthSummary? toolHealth = null,
-        bool basePythonBroken = false)
+        bool basePythonBroken = false,
+        bool toolsSetupInProgress = false)
     {
+        // Tool setup that is still running is progress, not a fault - it outranks every failure signal
+        // below, because on first launch those signals ARE the unfinished setup. It goes red only once
+        // setup has finished and the tools are still not working.
+        HomeCheck toolsCheck;
+        if (toolsSetupInProgress)
+            toolsCheck = new HomeCheck(ToolsRowTitle, HomeCheckLevel.Busy,
+                "Finishing setup - this completes on its own, you can start working",
+                HomeCheckAction.None);
         // The shared base Python being hollow (present but unable to import its standard library) takes down
         // EVERY Python cc-* tool at once (issue #995). It is a distinct, repairable runtime failure, so it
         // short-circuits the per-tool breakdown with a clear message and a one-click repair - the repair
         // re-provisions the base Python.
-        HomeCheck toolsCheck;
-        if (basePythonBroken)
-            toolsCheck = new HomeCheck("cc-* tools", HomeCheckLevel.Bad,
-                "Python runtime broken - the shared Python cannot start; one-click repair reinstalls it",
+        else if (basePythonBroken)
+            toolsCheck = new HomeCheck(ToolsRowTitle, HomeCheckLevel.Bad,
+                "The shared runtime the tools need cannot start; one-click repair reinstalls it",
                 HomeCheckAction.RepairTools);
         // When tool tests have run (toolHealth supplied) the tools row reflects pass/fail/not-built;
         // before that it falls back to the cheap build-status check so the home renders immediately.
@@ -103,7 +128,7 @@ public static class HomeStatusBuilder
     private static HomeCheck BuildToolsFromHealth(Tools.ToolHealthSummary h)
     {
         if (h.Total == 0)
-            return new HomeCheck("cc-* tools", HomeCheckLevel.Ok, "no tools installed", HomeCheckAction.None);
+            return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Ok, "no tools installed", HomeCheckAction.None);
 
         var parts = new List<string> { $"{h.Pass} pass" };
         if (h.Fail > 0) parts.Add($"{h.Fail} fail");
@@ -111,7 +136,7 @@ public static class HomeStatusBuilder
         var detail = string.Join(" · ", parts);
 
         if (!h.HasProblem)
-            return new HomeCheck("cc-* tools", HomeCheckLevel.Ok, detail, HomeCheckAction.None);
+            return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Ok, detail, HomeCheckAction.None);
 
         if (h.Failing.Count > 0)
         {
@@ -121,7 +146,7 @@ public static class HomeStatusBuilder
         }
 
         var action = (h.Broken > 0 || h.Fail > 0) ? HomeCheckAction.RepairTools : HomeCheckAction.OpenTools;
-        return new HomeCheck("cc-* tools", HomeCheckLevel.Warn, detail, action);
+        return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Warn, detail, action);
     }
 
     /// <summary>
@@ -132,12 +157,12 @@ public static class HomeStatusBuilder
     {
         var installed = agentClis.Where(c => c.Found).ToList();
         if (installed.Count == 0)
-            return new HomeCheck("Agent CLIs", HomeCheckLevel.Bad,
-                "No agent CLI found - install Claude Code, Codex, Pi, Gemini, or OpenCode",
+            return new HomeCheck(AgentRowTitle, HomeCheckLevel.Bad,
+                "No coding agent found - install Claude Code, Codex, Pi, Gemini, or OpenCode",
                 HomeCheckAction.OpenSettings);
 
         var names = installed.Select(CliLabel);
-        return new HomeCheck("Agent CLIs", HomeCheckLevel.Ok,
+        return new HomeCheck(AgentRowTitle, HomeCheckLevel.Ok,
             $"{string.Join(", ", names)} - on PATH", HomeCheckAction.None);
     }
 
@@ -168,9 +193,9 @@ public static class HomeStatusBuilder
     private static HomeCheck BuildTools(int built, int total, IReadOnlyList<string> broken)
     {
         if (total == 0)
-            return new HomeCheck("cc-* tools", HomeCheckLevel.Ok, "no tools installed", HomeCheckAction.None);
+            return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Ok, "no tools installed", HomeCheckAction.None);
         if (built == total)
-            return new HomeCheck("cc-* tools", HomeCheckLevel.Ok, $"{total} installed, all working", HomeCheckAction.None);
+            return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Ok, $"{total} installed, all working", HomeCheckAction.None);
 
         string detail;
         if (broken.Count > 0)
@@ -185,6 +210,6 @@ public static class HomeStatusBuilder
         }
 
         var level = built == 0 ? HomeCheckLevel.Bad : HomeCheckLevel.Warn;
-        return new HomeCheck("cc-* tools", level, detail, HomeCheckAction.RepairTools);
+        return new HomeCheck(ToolsRowTitle, level, detail, HomeCheckAction.RepairTools);
     }
 }

--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -4,63 +4,63 @@
     {
       "name": "cc-html",
       "category": "Documents",
-      "description": "Convert between Markdown and HTML with themes.",
+      "description": "Turn plain notes into a styled web page you can share, with a choice of looks.",
       "smoke": { "args": ["--themes"], "expectContains": null },
       "note": null
     },
     {
       "name": "cc-pdf",
       "category": "Documents",
-      "description": "Convert between Markdown and PDF with themes.",
+      "description": "Turn plain notes into a finished PDF you can send, with a choice of looks.",
       "smoke": { "args": ["--themes"], "expectContains": null },
       "note": null
     },
     {
       "name": "cc-word",
       "category": "Documents",
-      "description": "Convert between Markdown and Word (.docx) with themes.",
+      "description": "Turn plain notes into a Word document you can edit and send, with a choice of looks.",
       "smoke": { "args": ["--themes"], "expectContains": null },
       "note": null
     },
     {
       "name": "cc-vault",
       "category": "Data",
-      "description": "Personal contacts/secrets vault CLI. The only sanctioned way to query the vault.",
+      "description": "A private store on this machine for your contacts and credentials, so an agent can look one up instead of you pasting it into a chat.",
       "smoke": { "args": ["stats"], "expectContains": "Vault Statistics" },
       "note": null
     },
     {
       "name": "cc-image",
       "category": "Media",
-      "description": "Image analysis, OCR, and batch folder cataloging via the DevThrottle API vision model.",
+      "description": "Read the text out of a picture, describe what an image shows, and catalogue a whole folder of them.",
       "smoke": null,
       "note": "Auth-gated (needs DEVTHROTTLE_API_KEY). No zero-auth command. Presence + version only."
     },
     {
       "name": "cc-gmail",
       "category": "Email",
-      "description": "Gmail CLI: read, send, search and manage email.",
+      "description": "Read, search, and send your Gmail from the command line, so an agent can handle email for you.",
       "smoke": null,
       "note": "Auth-gated (OAuth). No zero-auth read-only command. Presence + version only."
     },
     {
       "name": "cc-outlook",
       "category": "Email",
-      "description": "Outlook/Microsoft 365 CLI: read, send, search email.",
+      "description": "Read, search, and send your Outlook or Microsoft 365 email from the command line.",
       "smoke": null,
       "note": "Auth-gated (device code). No zero-auth read-only command. Presence + version only."
     },
     {
       "name": "cc-playwright",
       "category": "Web",
-      "description": "Trusted-event browser automation via Playwright CDP with named, isolated connections.",
+      "description": "Drive a real web browser - click, type, and fill in pages - with separate signed-in profiles that stay out of each other's way.",
       "smoke": { "args": ["list"], "expectContains": null },
       "note": null
     },
     {
       "name": "cc-devthrottle",
       "category": "Fleet",
-      "description": "Unified DevThrottle command surface for fleet, sessions, messages, settings, Gateway schedules, and setup.",
+      "description": "Run DevThrottle itself from the command line: your sessions, messages between them, schedules, and settings.",
       "smoke": { "args": ["actions", "--json"], "expectContains": "settings-get" },
       "note": null
     }


### PR DESCRIPTION
Findings from a clean-Windows-VM QA pass (run 1), fixed and re-verified on a clean machine.

## Blockers

- **Onboarding could not be completed.** On a 1024x768 screen the Done step's receipt overflowed and BOTH finish buttons sat outside the window - "Start my first agent" 47px below the bottom edge, "Take me to the board" 107px - with no scrollbar. The only way out was the close button, which suppresses the wizard permanently. Every step was checked, not just the last: Welcome, Screenshots, Gateway and Morning report could overflow too. All now scroll with their actions pinned.
- **The first frame opened with two red errors**, one of which ("Python runtime broken") was the tool setup the installer had just described as normal - while the wizard's own tools step said all nine were Ready. Setup still in progress is now a calm in-progress card, the duplicate left-rail badge is suppressed, and the cards read "Coding agent" and "DevThrottle tools" instead of "Agent CLIs" and "cc-* tools".

## Honesty fixes

- The gateway step told a brand-new free user the hosted option was "Included with your subscription". Now "Part of Pro".
- With no gateway connected, the morning-report headline promised a report that could never arrive, and the receipt marked it "Done". Now "Your morning report is ready when your gateway is" and "Waiting for a gateway".
- The receipt told users to "start an agent on one of your repos" when the same screen said they had none. Now it says to add a code folder first.

## Smaller

- Window title "Set up DevThrottle" - it was "DevThrottle Setup", identical to the installer's, so the two were indistinguishable in the taskbar.
- Code step: "Choose a folder" (was "Somewhere else"), "worktrees" dropped, and an "I don't have code on this machine yet" option for anyone setting up a new laptop.
- All nine cc-* tool descriptions rewritten for a customer; cc-vault no longer says "the only sanctioned way to query the vault".
- Scrollbars sit beside their content rather than at the window edge.

## Verification

Clean Windows 11 VM, standard non-admin user, 1024x768. Both finish buttons now inside the window (ending y=603 and y=641 against a bottom edge of y=720). The in-progress card was confirmed to appear AND to clear once provisioning finished. The morning-report choice was tested with Weekly rather than Daily - Daily is the default, so confirming it would prove nothing - and the receipt read "Monday mornings", proving the selection took.