### PR TITLE
release: v1.8.1 - a clean Windows machine can install, set up, and uninstall

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.8.1.md
+++ b/docs/public/release-notes/v1.8.1.md
@@ -1,0 +1,54 @@
+## v1.8.1 - July 27, 2026
+
+A fix-only release for the first twenty minutes: installing DevThrottle on a clean Windows
+machine, and the setup wizard that runs the first time you open it. Every item below was found
+by running the real installer on a clean Windows 11 machine and judging every screen, and every
+fix was re-verified the same way.
+
+### Installing
+
+- **Re-check now works.** If a required component was missing, installing it and clicking
+  "Re-check" - exactly what the screen told you to do - reported "Not found" forever. The only
+  thing that worked was closing and reopening setup, which nothing mentioned. Setup now finds
+  components installed while it is open.
+- **The final screen tells the truth.** It said "Everything went perfectly. You're ready to go."
+  directly above a warning that no coding agent was installed, so nothing could run. The
+  headline now reflects what actually happened.
+- **DevThrottle can be uninstalled from Windows Settings.** It never registered an entry in
+  Apps & features, so there was no way to remove it through Windows. There is now, and it
+  removes cleanly - with your data kept by default, or deleted if you ask.
+- **A successful uninstall no longer reports failure.** Choosing "Also delete my data" could
+  end with an error message on an uninstall that had actually worked.
+- **Failures explain themselves.** A component that needs an administrator now says so, instead
+  of naming an internal tool and showing an error number.
+- The welcome screen describes the product you downloaded - running Claude Code, Codex, Gemini
+  and others side by side - rather than a Claude Code-only toolkit.
+- One fewer step: the Skills screen is gone. The skills still install and are reported during
+  installation.
+- Descriptions are no longer cut off at the window edge, the prerequisite list scrolls so every
+  item is reachable, and a disabled Next now looks disabled and says what it is waiting for.
+
+### The first time you open it
+
+- **Setup can be finished.** On a 1024x768 screen the last step's buttons sat below the bottom
+  of the window with no way to scroll, so setup could not be completed at all. Every step now
+  scrolls with its buttons pinned in view.
+- **The first screen is calm.** It opened with two red errors, one of which was the tool setup
+  the installer had just described as normal. Setup still finishing is now shown as progress,
+  not failure, and is no longer reported twice.
+- The gateway step no longer tells a brand-new free account that hosted is "included with your
+  subscription"; it names the plan.
+- With no gateway connected, the morning report no longer promises a report that cannot arrive,
+  and the summary no longer marks it done.
+- The closing summary no longer tells you to start an agent on repositories the same screen says
+  you do not have.
+- If you have no code on the machine yet - a new laptop, say - the setup step now has an answer
+  for that instead of only offering to browse for a folder that does not exist.
+- Plain names throughout: the window is "Set up DevThrottle" rather than sharing the installer's
+  name, cards read "Coding agent" and "DevThrottle tools", and every bundled tool is described
+  in words meant for the person reading them.
+
+### Note
+
+The uninstall entry keeps a copy of the installer on disk so Windows has something to run. A
+smaller dedicated uninstaller is planned to recover that space.


### PR DESCRIPTION
Patch release. Version bump plus release notes.

Fix-only, covering the first twenty minutes: the Windows installer (#2229) and the first-run setup wizard (#2230). Every item was found by running the real installer on a clean Windows 11 machine and judging each screen, and every fix was re-verified the same way on a wiped machine.

Six blockers closed:
- Re-check never saw a component installed while setup was open, so following the on-screen instruction could not work.
- The final screen claimed everything went perfectly above a warning that nothing could run.
- DevThrottle registered no Apps & features entry, so it could not be uninstalled from Windows Settings.
- "Also delete my data" could report failure on an uninstall that had succeeded.
- The setup wizard's last step put its finish buttons outside the window at 1024x768, with no scroll - onboarding could not be completed.
- The first frame after install opened with two red errors, one of them describing normal in-progress setup.

Plus honesty and plain-language fixes throughout both surfaces - see docs/public/release-notes/v1.8.1.md.

Once merged, tagging v1.8.1 builds and signs the release artifacts.