### PR TITLE
Record who started every session, and which session started it (internal#982)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1697,7 +1697,12 @@ public partial class MainWindow : Window
         _lastSessionCreateError = null;
         try
         {
-            var session = _sessionManager.CreateSession(repoPath, agent, userArgs, SessionBackendType.ConPty, resumeSessionId, groupId, groupRole, groupName);
+            // Session origin (devthrottle_internal issue #982): human at the desktop, true BY
+            // CONSTRUCTION - this method only ever runs in response to this machine's own New Session
+            // UI. Stamped pre-launch, because the session's first roster push (which is what creates
+            // the durable history row) can leave before create even returns.
+            var session = _sessionManager.CreateSession(repoPath, agent, userArgs, SessionBackendType.ConPty, resumeSessionId, groupId, groupRole, groupName,
+                beforeLaunch: s => s.StampOrigin(SessionOrigin.DesktopHuman));
             FileLog.Write($"[MainWindow] CreateSession: session created, id={session.Id}, pid={session.ProcessId}");
 
             var vm = new SessionViewModel(session);
@@ -1722,7 +1727,10 @@ public partial class MainWindow : Window
         try
         {
             IAgent agent = CreateAgent(agentKind);
-            var session = _sessionManager.CreateSession(repoPath, agent, claudeArgs, SessionBackendType.ConPty, resumeSessionId, groupId, groupRole, groupName);
+            // Session origin (issue #982): human at the desktop, by construction - see the sibling
+            // overload above.
+            var session = _sessionManager.CreateSession(repoPath, agent, claudeArgs, SessionBackendType.ConPty, resumeSessionId, groupId, groupRole, groupName,
+                beforeLaunch: s => s.StampOrigin(SessionOrigin.DesktopHuman));
             FileLog.Write($"[MainWindow] CreateSession: session created, id={session.Id}, pid={session.ProcessId}");
 
             var vm = new SessionViewModel(session);

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -651,6 +651,16 @@ internal static class ControlEndpoints
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
                 return Results.BadRequest(new { error = "repoPath is required" });
 
+            // Session origin (devthrottle_internal issue #982). This route IS the command line: it is
+            // loopback-only and cc-devthrottle's `session spawn` is what reaches it, so a request that
+            // named no surface came from the CLI and saying so is a measurement, not a guess. The KIND
+            // is left exactly as the caller stated it - only the caller knows whether a session or a
+            // person ran the command (the CLI reads CC_SESSION_ID to decide), and inventing a kind here
+            // would fabricate the one number this field exists to produce. Applied to BOTH legs, since
+            // the remote leg forwards this same request object through the Gateway.
+            if (string.IsNullOrWhiteSpace(req.OriginSurface))
+                req.OriginSurface = SessionOriginSurfaces.Cli;
+
             var machine = req.Machine?.Trim();
             var isLocal = string.IsNullOrEmpty(machine)
                 || string.Equals(machine, "local", StringComparison.OrdinalIgnoreCase)
@@ -1578,6 +1588,13 @@ internal static class ControlEndpoints
             IsBrandNew = s.IsBrandNew,
             IsControlled = s.IsControlled,
             ControllerSessionId = s.ControllerSessionId?.ToString(),
+            // Session origin and lineage (devthrottle_internal issue #982): the birth facts, reported
+            // straight from the Session. They ride every push, not just the first, because the durable
+            // history row is written on FIRST SIGHT and a push that omitted them would be the one that
+            // created the row. Nothing paints from these - they are the record, and the tree.
+            OriginKind = s.OriginKind,
+            OriginSurface = s.OriginSurface,
+            ParentSessionId = s.ParentSessionId?.ToString(),
             // Automatic session roles (chunk 2.5): the sticky explicit role, so the Gateway aggregation can
             // apply the explicit-wins precedence. The RESOLVED SessionRole is computed at the aggregation.
             ExplicitRole = s.ExplicitRole,
@@ -1654,6 +1671,11 @@ internal static class ControlEndpoints
             TurnCount = s.TurnCount,
             WaitingSince = s.WaitingSince,
             CumulativeIdleSeconds = s.CumulativeIdleSeconds,
+            // The interruption COUNT beside the seconds (devthrottle_internal issue #982): how many
+            // times this session started waiting on the user. The pair is what makes the clock
+            // readable - an hour of waiting spread over twelve interruptions is a different session
+            // from one that waited once.
+            WaitingStretchCount = s.WaitingStretchCount,
             // Issue #335: identity fields populated by the Director (not patched by the Gateway).
             MachineName = machineName,
             User = user,

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -434,6 +434,29 @@ internal static class SessionCommandExecutor
         if (req.Role is not null && !SessionRoles.IsValid(req.Role))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown role '{req.Role}'. Valid: {string.Join(", ", SessionRoles.All)}");
 
+        // Session origin and lineage (devthrottle_internal issue #982), validated BEFORE creating the
+        // session on exactly the role check's terms. A mistyped origin is REJECTED rather than recorded
+        // as "unknown", because unknown is also what an honest older caller sends: if a typo landed
+        // there too, the two would be indistinguishable and the field's whole purpose - counting how
+        // many sessions agents start - would quietly absorb every caller's mistakes.
+        if (req.Origin is not null && !SessionOriginKinds.IsValid(req.Origin))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                $"unknown origin '{req.Origin}'. Valid: {string.Join(", ", SessionOriginKinds.All)}");
+        if (req.OriginSurface is not null && !SessionOriginSurfaces.IsValid(req.OriginSurface))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                $"unknown origin surface '{req.OriginSurface}'. Valid: {string.Join(", ", SessionOriginSurfaces.All)}");
+        Guid? parentSessionId = null;
+        if (!string.IsNullOrWhiteSpace(req.ParentSessionId))
+        {
+            if (!Guid.TryParse(req.ParentSessionId, out var parsedParentId))
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                    $"parentSessionId '{req.ParentSessionId}' is not a session id.");
+            parentSessionId = parsedParentId;
+        }
+        // Compose now so the create log records what will actually be stamped, not what was asked for -
+        // the composer drops a parent id that arrived on a non-agent origin.
+        var origin = SessionOrigin.Compose(req.Origin, req.OriginSurface, parentSessionId);
+
         // Workflow seat at spawn (Workflows mission, phase 5b): validated BEFORE creating the session,
         // like the role above. The Director stamps the seat ONLY when the run id arrives with its
         // Gateway-resolved workflow id and pinned version - the Gateway is the source of truth for
@@ -565,6 +588,13 @@ internal static class SessionCommandExecutor
                         s.SetExplicitRole(preLaunchRole);
                     if (seatRequested)
                         s.SeatOnWorkflow(req.WorkflowRunId, req.WorkflowId, req.WorkflowVersion);
+                    // Birth facts (issue #982), stamped in the same pre-launch window as the role and
+                    // the seat. Pre-launch is not cosmetic here: the session's FIRST roster push can
+                    // leave for the Gateway the moment the process starts, and the history recorder
+                    // writes its row from that first sight. A stamp after create returns would race it,
+                    // and the row that lost the race would record "unknown" for a session whose origin
+                    // was known all along - permanently, since first sight only happens once.
+                    s.StampOrigin(origin);
                 });
         }
         catch (Exception ex)

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -547,7 +547,19 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
 
             try
             {
-                target = sessionManager.CreateSession(repo, agent, userArgs: null, SessionBackendType.ConPty, resumeSessionId: null);
+                // Session origin (devthrottle_internal issue #982): a handover's target. The SURFACE
+                // is certain - this is the handover verb, not the command line and not a schedule - so
+                // it is stated, and it matches what the Gateway's CROSS-Director handover records, so
+                // the same act reads the same whichever leg it took. The KIND is left unknown: a
+                // handover is asked for by a person moving work or by a session handing itself over,
+                // and nothing at this point can tell them apart.
+                //
+                // The SOURCE session is deliberately not recorded as the parent. ParentSessionId means
+                // "the session that asked for this one"; in a handover the source is the session being
+                // LEFT, and putting it here would make the lineage tree mean two things at once.
+                target = sessionManager.CreateSession(repo, agent, userArgs: null, SessionBackendType.ConPty, resumeSessionId: null,
+                    beforeLaunch: s => s.StampOrigin(new SessionOrigin(
+                        SessionOriginKinds.Unknown, SessionOriginSurfaces.Api)));
             }
             catch (Exception ex)
             {

--- a/src/CcDirector.Core.Tests/SessionOriginTests.cs
+++ b/src/CcDirector.Core.Tests/SessionOriginTests.cs
@@ -1,0 +1,129 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The session-origin vocabulary and its composer (devthrottle_internal issue #982).
+///
+/// Everything here defends one property: an origin we did not measure must never come out looking like
+/// one we did. The field exists to answer "what share of sessions do agents start", and every way that
+/// number can be quietly wrong runs through this composer - a typo landing in a real bucket, a parent
+/// id surviving on a human origin, a blank normalizing to something plausible.
+/// </summary>
+public class SessionOriginTests
+{
+    [Theory]
+    [InlineData("human", SessionOriginKinds.Human)]
+    [InlineData("AGENT", SessionOriginKinds.Agent)]
+    [InlineData("  Schedule  ", SessionOriginKinds.Schedule)]
+    [InlineData("unknown", SessionOriginKinds.Unknown)]
+    public void Kind_normalizes_case_and_whitespace(string input, string expected)
+        => Assert.Equal(expected, SessionOriginKinds.Normalize(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("humans")]
+    [InlineData("bot")]
+    public void Kind_refuses_anything_it_does_not_know(string? input)
+    {
+        // Null, not "unknown". The API boundary needs to tell "the caller said nothing" from "the
+        // caller said something we do not recognize" so it can reject the second - a mistyped origin
+        // silently becoming "unknown" is indistinguishable from an honest older caller.
+        Assert.Null(SessionOriginKinds.Normalize(input));
+        Assert.False(SessionOriginKinds.IsValid(input));
+    }
+
+    [Theory]
+    [InlineData("desktop", SessionOriginSurfaces.Desktop)]
+    [InlineData("Cockpit", SessionOriginSurfaces.Cockpit)]
+    [InlineData("CLI", SessionOriginSurfaces.Cli)]
+    [InlineData("cron", SessionOriginSurfaces.Cron)]
+    [InlineData("workflow", SessionOriginSurfaces.Workflow)]
+    [InlineData("api", SessionOriginSurfaces.Api)]
+    public void Surface_normalizes_case(string input, string expected)
+        => Assert.Equal(expected, SessionOriginSurfaces.Normalize(input));
+
+    [Theory]
+    [InlineData("phone", SessionOriginSurfaces.Phone)]
+    [InlineData("PHONE", SessionOriginSurfaces.Phone)]
+    [InlineData("browser", SessionOriginSurfaces.Cockpit)]
+    [InlineData("workstation", SessionOriginSurfaces.Unknown)]
+    [InlineData("gateway", SessionOriginSurfaces.Unknown)]
+    [InlineData(null, SessionOriginSurfaces.Unknown)]
+    public void Device_type_maps_only_the_two_surfaces_a_person_holds(string? deviceType, string expected)
+    {
+        // The Gateway spawn relay overwrites the origin ONLY when this returns a real surface, so
+        // "workstation" and "gateway" landing on unknown is what keeps a Director-relayed agent spawn
+        // from being rewritten as a human one. Getting this wrong would erase agent lineage on exactly
+        // the cross-machine spawns that make lineage worth having.
+        Assert.Equal(expected, SessionOriginSurfaces.FromDeviceType(deviceType));
+    }
+
+    [Fact]
+    public void Compose_keeps_a_parent_only_on_an_agent_origin()
+    {
+        var parent = Guid.NewGuid();
+
+        var agent = SessionOrigin.Compose("agent", "cli", parent);
+        Assert.Equal(SessionOriginKinds.Agent, agent.Kind);
+        Assert.Equal(parent, agent.ParentSessionId);
+
+        // A human origin that also names a parent is self-contradictory. The stated kind is what the
+        // caller meant, so the parent goes - storing both would leave a lineage edge hanging off a
+        // session nobody claims started it.
+        Assert.Null(SessionOrigin.Compose("human", "cockpit", parent).ParentSessionId);
+        Assert.Null(SessionOrigin.Compose("schedule", "cron", parent).ParentSessionId);
+        Assert.Null(SessionOrigin.Compose(null, null, parent).ParentSessionId);
+    }
+
+    [Fact]
+    public void Compose_lands_unknown_tokens_on_unknown_not_on_something_plausible()
+    {
+        var composed = SessionOrigin.Compose("robot", "smoke-signal", null);
+        Assert.Equal(SessionOriginKinds.Unknown, composed.Kind);
+        Assert.Equal(SessionOriginSurfaces.Unknown, composed.Surface);
+    }
+
+    [Fact]
+    public void Unknown_is_the_default_shape()
+    {
+        var origin = SessionOrigin.Unknown;
+        Assert.Equal(SessionOriginKinds.Unknown, origin.Kind);
+        Assert.Equal(SessionOriginSurfaces.Unknown, origin.Surface);
+        Assert.Null(origin.ParentSessionId);
+    }
+
+    [Fact]
+    public void The_named_origins_say_what_they_mean()
+    {
+        Assert.Equal((SessionOriginKinds.Human, SessionOriginSurfaces.Desktop),
+            (SessionOrigin.DesktopHuman.Kind, SessionOrigin.DesktopHuman.Surface));
+        Assert.Equal((SessionOriginKinds.Schedule, SessionOriginSurfaces.Cron),
+            (SessionOrigin.Cron.Kind, SessionOrigin.Cron.Surface));
+        Assert.Equal((SessionOriginKinds.Schedule, SessionOriginSurfaces.Workflow),
+            (SessionOrigin.Workflow.Kind, SessionOrigin.Workflow.Surface));
+
+        // A schedule is neither of the two the issue named, and that is the point: a fleet with hourly
+        // jobs would otherwise fold every one of them into "human" or "agent" and move the share.
+        Assert.NotEqual(SessionOriginKinds.Human, SessionOrigin.Cron.Kind);
+        Assert.NotEqual(SessionOriginKinds.Agent, SessionOrigin.Cron.Kind);
+    }
+
+    [Fact]
+    public void Agent_and_human_factories_carry_the_surface_through()
+    {
+        var parent = Guid.NewGuid();
+        var spawned = SessionOrigin.AgentFrom(parent, SessionOriginSurfaces.Cli);
+        Assert.Equal(SessionOriginKinds.Agent, spawned.Kind);
+        Assert.Equal(SessionOriginSurfaces.Cli, spawned.Surface);
+        Assert.Equal(parent, spawned.ParentSessionId);
+
+        var typed = SessionOrigin.HumanFrom(SessionOriginSurfaces.Phone);
+        Assert.Equal(SessionOriginKinds.Human, typed.Kind);
+        Assert.Equal(SessionOriginSurfaces.Phone, typed.Surface);
+        Assert.Null(typed.ParentSessionId);
+    }
+}

--- a/src/CcDirector.Core.Tests/Sessions/SessionSupervisionFactsTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionSupervisionFactsTests.cs
@@ -146,6 +146,73 @@ public sealed class SessionSupervisionFactsTests
         Assert.Null(session.WaitingSince);
     }
 
+    // --- The interruption COUNT beside the clock (devthrottle_internal issue #982) ---
+    // The seconds cannot stand in for the count: one session that needed you once for an hour and one
+    // that needed you twelve times for five minutes read identically on the clock and are nothing alike
+    // to live with. The brain's job is deciding when to interrupt, so this is what it is measured on.
+
+    [Fact]
+    public void WaitingStretchCount_CountsEveryEntryIntoWaiting()
+    {
+        using var session = NewSession();
+
+        Assert.Equal(0, session.WaitingStretchCount);
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(1, session.WaitingStretchCount);
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(2, session.WaitingStretchCount);
+    }
+
+    [Fact]
+    public void WaitingStretchCount_CountsAnOpenWaitImmediately()
+    {
+        // Counted when the stretch OPENS, unlike the seconds, which only land when it closes. A session
+        // sitting on you right now has interrupted you, whatever happens next - and a count that only
+        // moved on release would report zero for exactly the sessions the question is about.
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+
+        Assert.Equal(1, session.WaitingStretchCount);
+        Assert.Equal(0, session.CumulativeIdleSeconds);   // the stretch is still open
+    }
+
+    [Fact]
+    public void WaitingStretchCount_APermissionPromptIsAnInterruptionEvenThoughItIsNotATurn()
+    {
+        // The deliberate difference from TurnCount, which counts only completed turns. A permission
+        // prompt finishes nothing - but it stops and asks you, which is the thing being counted.
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForPerm);
+
+        Assert.Equal(0, session.TurnCount);
+        Assert.Equal(1, session.WaitingStretchCount);
+    }
+
+    [Fact]
+    public void WaitingStretchCount_PermThenInputIsOneUninterruptedWait()
+    {
+        // The wait that changes shape without ending: a permission prompt answered into a turn-end
+        // never returned control to you in between, so it is ONE interruption. The anchor already
+        // survives this transition (one wait, one anchor) and the count must agree with it - two
+        // counters disagreeing about the same stretch is how "how often does this bother me" quietly
+        // doubles.
+        using var session = NewSession();
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForPerm);
+        session.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+
+        Assert.Equal(1, session.WaitingStretchCount);
+    }
+
     private static Session NewSession()
         => new(Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null, new StubSessionBackend(), SessionBackendType.ConPty);
 }

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -168,6 +168,56 @@ public sealed class Session : IDisposable
     public bool IsControlled => ControllerSessionId.HasValue;
 
     /// <summary>
+    /// WHO asked for this session to exist (devthrottle_internal issue #982) - one of the
+    /// <see cref="SessionOriginKinds"/> values. A BIRTH FACT: stamped by the create path and never
+    /// changed, so it keeps describing the create call however the session later behaves. Persisted, so
+    /// a Director restart does not turn a known origin into an unknown one.
+    ///
+    /// Defaults to <see cref="SessionOriginKinds.Unknown"/> rather than to <c>human</c>. The number this
+    /// field exists to produce is the share of sessions AGENTS start; defaulting the unstated case to
+    /// either real value would bias exactly that number, in a way no later reader could detect.
+    /// </summary>
+    public string OriginKind { get; internal set; } = SessionOriginKinds.Unknown;
+
+    /// <summary>WHERE the create call came from (issue #982) - one of the
+    /// <see cref="SessionOriginSurfaces"/> values. A birth fact beside <see cref="OriginKind"/>, on the
+    /// same terms: stamped once, persisted, unknown when unstated.</summary>
+    public string OriginSurface { get; internal set; } = SessionOriginSurfaces.Unknown;
+
+    /// <summary>
+    /// The session that asked for this one (issue #982), or null when nothing did. This is the LINEAGE
+    /// edge: with it a roster of twenty-two sessions resolves into the handful of operations it actually
+    /// is, and delegation depth and runaway-parent detection become answerable at all.
+    ///
+    /// DISTINCT FROM <see cref="ControllerSessionId"/>, which is a live supervision relationship that
+    /// changes how the session is PAINTED (a controlled sub-agent recedes to slate while its controller
+    /// lives). This one is a historical fact about who made the create call and affects no display at
+    /// all. They coincide on the common CLI spawn and diverge whenever a session spawns a deliberate
+    /// peer (<c>--standalone</c>): that peer has no controller and must stay human-facing, but an agent
+    /// still started it, and that is precisely the thing #982 exists to count.
+    /// </summary>
+    public Guid? ParentSessionId { get; internal set; }
+
+    /// <summary>The three birth facts read back together. Stamped through
+    /// <see cref="StampOrigin"/>.</summary>
+    public SessionOrigin Origin => new(OriginKind, OriginSurface, ParentSessionId);
+
+    /// <summary>
+    /// Stamp the birth facts (issue #982). Called once by the create path BEFORE launch, and by the
+    /// restore path carrying the persisted values back. Composed through
+    /// <see cref="SessionOrigin.Compose"/>, so an unknown token lands as unknown rather than as a
+    /// plausible-looking lie, and a parent id never survives on a non-agent origin.
+    /// </summary>
+    public void StampOrigin(SessionOrigin origin)
+    {
+        var composed = SessionOrigin.Compose(origin.Kind, origin.Surface, origin.ParentSessionId);
+        OriginKind = composed.Kind;
+        OriginSurface = composed.Surface;
+        ParentSessionId = composed.ParentSessionId;
+        FileLog.Write($"[Session] {Id} origin stamped: kind={OriginKind} surface={OriginSurface} parent={ParentSessionId?.ToString() ?? "(none)"}");
+    }
+
+    /// <summary>
     /// The sticky EXPLICIT role a human/session declared for this session (automatic session roles), or null
     /// for none. When set it WINS over the Gateway's auto-derivation of the role - the only way to be an
     /// Architect, which cannot be inferred from the spawn graph. Settable at birth (from the create request)
@@ -1080,6 +1130,7 @@ public sealed class Session : IDisposable
     private int _turnCount;
     private DateTime? _waitingSince;
     private double _cumulativeIdleSeconds;
+    private int _waitingStretchCount;
 
     /// <summary>Clock for the supervision facts below. A test seam; production never sets it.</summary>
     internal Func<DateTime> SupervisionClock { private get; set; } = static () => DateTime.UtcNow;
@@ -1112,6 +1163,30 @@ public sealed class Session : IDisposable
     public double CumulativeIdleSeconds => _cumulativeIdleSeconds;
 
     /// <summary>
+    /// How many times this session has STARTED waiting on the user (devthrottle_internal issue #982) -
+    /// one per entry into a waiting state, counted at the same flip that opens the stretch
+    /// <see cref="CumulativeIdleSeconds"/> later closes. The two are a matched pair: seconds waited is
+    /// the total, this is the number of times, and a fleet where the brain is doing its job should move
+    /// one without the other.
+    ///
+    /// The COUNT of interruptions, which the total seconds cannot stand in for: one session that needed
+    /// you once for an hour and one that needed you twelve times for five minutes read identically on
+    /// the clock and are completely different to live with. The brain's whole job is deciding when to
+    /// interrupt, so this is the denominator it gets measured on.
+    ///
+    /// Counts the DIRECTOR's waiting state, which is close to but not identical with the Gateway's red
+    /// verdict: a wait that the wingman is still narrating, or one the owner has snoozed, is counted
+    /// here and is not red yet. That is the honest thing a Director can measure - it cannot see the
+    /// Gateway's overlays - and it is the raw fact a red-event count would have to be built from
+    /// anyway. Reported on <c>SessionDto.WaitingStretchCount</c>.
+    ///
+    /// The stretch that is currently OPEN is already counted (it started), unlike the seconds, which
+    /// are only added when it closes. That is deliberate: a session waiting on you right now has
+    /// interrupted you, whatever happens next.
+    /// </summary>
+    public int WaitingStretchCount => _waitingStretchCount;
+
+    /// <summary>
     /// Supervision bookkeeping (internal#625 Phase 1): the turn counter and the waiting clock.
     /// Runs INSIDE <see cref="SetActivityState"/> before <see cref="OnActivityStateChanged"/> fires,
     /// so the delta push wired to that event always carries the numbers this very flip produced -
@@ -1128,6 +1203,12 @@ public sealed class Session : IDisposable
         if (!wasWaiting && isWaiting)
         {
             _waitingSince = SupervisionClock();
+            // The interruption count (issue #982), incremented at the SAME flip that opens the stretch
+            // the idle clock later closes. Counting it here rather than at the close is what makes an
+            // open wait count: a session sitting on you right now has interrupted you already, and a
+            // count that only moved on release would report zero for the sessions still waiting - the
+            // exact ones the question is about.
+            _waitingStretchCount++;
         }
         else if (wasWaiting && !isWaiting)
         {

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -1173,6 +1173,10 @@ public sealed class SessionManager : IDisposable
                 GroupName = s.GroupName,
                 ControllerSessionId = s.ControllerSessionId,
                 ExplicitRole = s.ExplicitRole,
+                // Birth facts (issue #982): unrecoverable once lost, so they ride every snapshot.
+                OriginKind = s.OriginKind,
+                OriginSurface = s.OriginSurface,
+                ParentSessionId = s.ParentSessionId,
                 IsAutoNamed = s.IsAutoNamed,
                 MissionId = s.MissionId,
                 MissionName = s.MissionName,
@@ -1222,6 +1226,10 @@ public sealed class SessionManager : IDisposable
         session.GroupName = ps.GroupName;
         session.ControllerSessionId = ps.ControllerSessionId;
         session.ExplicitRole = ps.ExplicitRole;
+        // Birth facts (issue #982). Composed, not assigned: a snapshot written before these fields
+        // existed carries nulls, and the composer turns those into the honest "unknown" rather than
+        // leaving the session claiming an origin it never had.
+        session.StampOrigin(SessionOrigin.Compose(ps.OriginKind, ps.OriginSurface, ps.ParentSessionId));
         session.IsAutoNamed = ps.IsAutoNamed;
         session.MissionId = ps.MissionId;
         session.MissionName = ps.MissionName;

--- a/src/CcDirector.Core/Sessions/SessionOrigin.cs
+++ b/src/CcDirector.Core/Sessions/SessionOrigin.cs
@@ -1,0 +1,166 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// WHO asked for a session to exist (devthrottle_internal issue #982). Recorded at birth and never
+/// changed afterwards - it is a fact about the create call, not about what the session went on to do.
+///
+/// The issue asked for two values, <c>human</c> and <c>agent</c>. There are three, because a scheduled
+/// run is neither: nobody typed it and no agent session called for it, and folding it into either one
+/// would corrupt the very number this record exists to produce ("what share of sessions do agents
+/// start"). <see cref="Unknown"/> is the honest answer for a session created through a path that does
+/// not state an origin, or by a Director that predates the field - it is never guessed into a real
+/// value, because a guessed origin is worse than a missing one for exactly the claim this backs.
+/// </summary>
+public static class SessionOriginKinds
+{
+    /// <summary>A person asked for this session - the desktop New Session dialog, the Cockpit, the
+    /// phone, or a human running the CLI outside any session.</summary>
+    public const string Human = "human";
+
+    /// <summary>Another agent session asked for this session. <see cref="Session.ParentSessionId"/>
+    /// names which one.</summary>
+    public const string Agent = "agent";
+
+    /// <summary>Automation asked for this session with no live caller - a cron schedule firing, a work
+    /// list running. Nobody was at a keyboard and no session made the call.</summary>
+    public const string Schedule = "schedule";
+
+    /// <summary>The create path did not say. Recorded as-is; never presented as a real origin.</summary>
+    public const string Unknown = "unknown";
+
+    public static readonly string[] All = { Human, Agent, Schedule, Unknown };
+
+    /// <summary>The canonical lowercase token for a supplied value, or null when the value is blank or
+    /// not one we know. A caller stamps <see cref="Unknown"/> for null; validation at an API boundary
+    /// rejects it instead, so a mistyped origin is never silently swallowed.</summary>
+    public static string? Normalize(string? value)
+    {
+        var v = (value ?? "").Trim().ToLowerInvariant();
+        return Array.IndexOf(All, v) >= 0 ? v : null;
+    }
+
+    /// <summary>True when the value names an origin we know.</summary>
+    public static bool IsValid(string? value) => Normalize(value) is not null;
+}
+
+/// <summary>
+/// WHERE the create call came from (devthrottle_internal issue #982) - the surface axis that sits beside
+/// <see cref="SessionOriginKinds"/>. Recorded at birth and never changed.
+///
+/// Deliberately NOT the same set as <see cref="InputSurface"/>, which describes where a TURN was driven
+/// from. The two answer different questions and share only three of their values; merging them would
+/// force one enum to carry <c>cron</c> (never a place a human types) and the other to carry <c>desktop</c>
+/// (never a place a spawn is relayed from). They are kept apart on purpose.
+/// </summary>
+public static class SessionOriginSurfaces
+{
+    /// <summary>The cc-director desktop app's own New Session flow, on this machine.</summary>
+    public const string Desktop = "desktop";
+
+    /// <summary>The Cockpit web app in a browser.</summary>
+    public const string Cockpit = "cockpit";
+
+    /// <summary>The mobile /m app on a phone.</summary>
+    public const string Phone = "phone";
+
+    /// <summary>The cc-devthrottle command line (<c>session spawn</c>) - whether a human or an agent
+    /// session ran it. Which of those it was is the ORIGIN's job, not this one's.</summary>
+    public const string Cli = "cli";
+
+    /// <summary>A Gateway cron schedule firing a seed run.</summary>
+    public const string Cron = "cron";
+
+    /// <summary>A work-list / workflow runner opening a session for an item.</summary>
+    public const string Workflow = "workflow";
+
+    /// <summary>A direct API call that named no more specific surface.</summary>
+    public const string Api = "api";
+
+    /// <summary>The create path did not say.</summary>
+    public const string Unknown = "unknown";
+
+    public static readonly string[] All = { Desktop, Cockpit, Phone, Cli, Cron, Workflow, Api, Unknown };
+
+    /// <summary>The canonical lowercase token for a supplied value, or null when blank or unknown.</summary>
+    public static string? Normalize(string? value)
+    {
+        var v = (value ?? "").Trim().ToLowerInvariant();
+        return Array.IndexOf(All, v) >= 0 ? v : null;
+    }
+
+    /// <summary>True when the value names a surface we know.</summary>
+    public static bool IsValid(string? value) => Normalize(value) is not null;
+
+    /// <summary>
+    /// Map a device registry <c>DeviceType</c> (resolved from a VERIFIED per-device key) to the surface
+    /// that device is. The Gateway uses this to stamp a spawn relayed from a signed-in phone or browser,
+    /// overwriting whatever the client claimed - the same gateway-authoritative rule
+    /// <c>PromptRequest.Surface</c> already follows for turns. An unrecognized device type is
+    /// <see cref="Unknown"/>, never guessed.
+    /// </summary>
+    public static string FromDeviceType(string? deviceType) =>
+        (deviceType ?? "").Trim().ToLowerInvariant() switch
+        {
+            "phone" => Phone,
+            "browser" => Cockpit,
+            _ => Unknown,
+        };
+}
+
+/// <summary>
+/// The three birth facts issue #982 asked for, carried together so a create path states them in one
+/// place instead of threading three loose parameters: WHO asked (<see cref="Kind"/>), WHERE from
+/// (<see cref="Surface"/>), and - when an agent asked - WHICH session made the call
+/// (<see cref="ParentSessionId"/>).
+///
+/// The issue listed <c>originAgentSessionId</c> and <c>parentSessionId</c> as two fields. They are ONE
+/// fact: the session that made the create call is the parent, and there is no create path where they
+/// could differ. Storing it twice would only create a way for the two copies to disagree, so it is
+/// stored once, here, and the lineage tree is built from it.
+/// </summary>
+/// <param name="Kind">One of <see cref="SessionOriginKinds"/>.</param>
+/// <param name="Surface">One of <see cref="SessionOriginSurfaces"/>.</param>
+/// <param name="ParentSessionId">The session that asked for this one, or null. Only ever set alongside
+/// <see cref="SessionOriginKinds.Agent"/>.</param>
+public readonly record struct SessionOrigin(string Kind, string Surface, Guid? ParentSessionId = null)
+{
+    /// <summary>Nothing was stated. What a create path with no origin information records - honestly.</summary>
+    public static SessionOrigin Unknown =>
+        new(SessionOriginKinds.Unknown, SessionOriginSurfaces.Unknown);
+
+    /// <summary>A person, at the desktop app's own New Session flow. True by construction: this path
+    /// only runs in response to the local UI.</summary>
+    public static SessionOrigin DesktopHuman =>
+        new(SessionOriginKinds.Human, SessionOriginSurfaces.Desktop);
+
+    /// <summary>A Gateway cron schedule firing a seed run.</summary>
+    public static SessionOrigin Cron =>
+        new(SessionOriginKinds.Schedule, SessionOriginSurfaces.Cron);
+
+    /// <summary>A work-list / workflow runner opening a session for an item.</summary>
+    public static SessionOrigin Workflow =>
+        new(SessionOriginKinds.Schedule, SessionOriginSurfaces.Workflow);
+
+    /// <summary>An agent session asked, from the given surface.</summary>
+    public static SessionOrigin AgentFrom(Guid parentSessionId, string surface) =>
+        new(SessionOriginKinds.Agent, surface, parentSessionId);
+
+    /// <summary>A person asked, from the given surface.</summary>
+    public static SessionOrigin HumanFrom(string surface) =>
+        new(SessionOriginKinds.Human, surface);
+
+    /// <summary>
+    /// Build a coherent origin from loose (possibly caller-supplied) values, dropping anything that does
+    /// not hold together. Unknown tokens normalize to the unknown value rather than to a plausible one,
+    /// and a parent id is kept ONLY on an agent origin - an origin that says "a human asked" while also
+    /// naming a parent session is contradictory, and the contradiction is resolved toward the stated
+    /// kind rather than being stored for a later reader to trip over.
+    /// </summary>
+    public static SessionOrigin Compose(string? kind, string? surface, Guid? parentSessionId)
+    {
+        var k = SessionOriginKinds.Normalize(kind) ?? SessionOriginKinds.Unknown;
+        var s = SessionOriginSurfaces.Normalize(surface) ?? SessionOriginSurfaces.Unknown;
+        var parent = k == SessionOriginKinds.Agent ? parentSessionId : null;
+        return new SessionOrigin(k, s, parent);
+    }
+}

--- a/src/CcDirector.Core/Sessions/SessionStateStore.cs
+++ b/src/CcDirector.Core/Sessions/SessionStateStore.cs
@@ -52,6 +52,21 @@ public class PersistedSession
     /// values.</summary>
     public string? ExplicitRole { get; set; }
 
+    /// <summary>WHO asked for this session (issue #982) - one of the SessionOriginKinds values.
+    /// Persisted because it is a birth fact that can never be recovered once lost: nothing about a
+    /// running session says who asked for it. Sessions persisted before this field existed restore as
+    /// null and are stamped "unknown", which is the truth about them.</summary>
+    public string? OriginKind { get; set; }
+
+    /// <summary>WHERE the create call came from (issue #982) - one of the SessionOriginSurfaces values.
+    /// Persisted on the same terms as <see cref="OriginKind"/>.</summary>
+    public string? OriginSurface { get; set; }
+
+    /// <summary>The session that asked for this one (issue #982), or null. Persisted so the lineage tree
+    /// survives a Director restart - an edge lost here is an operation that silently becomes N unrelated
+    /// sessions.</summary>
+    public Guid? ParentSessionId { get; set; }
+
     /// <summary>True when the name was auto-composed at birth (automatic session roles, chunk 3). Persisted
     /// so an explicit human/self rename is never re-auto-named after a restart.</summary>
     public bool IsAutoNamed { get; set; }

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -97,6 +97,49 @@ public sealed class NewSessionRequest
     public string? ControllerSessionId { get; set; }
 
     /// <summary>
+    /// WHO is asking for this session (devthrottle_internal issue #982): one of the
+    /// <c>SessionOriginKinds</c> tokens - "human", "agent", "schedule" - case-insensitive. An unknown
+    /// value is REJECTED as a bad request, the same posture as <see cref="Role"/>: a mistyped origin
+    /// must not silently become "unknown", because unknown is also what an honest older caller sends
+    /// and the two would then be indistinguishable. Null records "unknown", which is the truth about a
+    /// caller that did not say.
+    ///
+    /// STATED BY THE CALLER, AND THAT IS DELIBERATE - but it is not the last word on every path. The
+    /// Gateway's spawn relay OVERWRITES this from the verified per-device key when the caller is a
+    /// signed-in phone or browser (the same gateway-authoritative rule <c>PromptRequest.Surface</c>
+    /// follows), so the one route a stranger could reach cannot forge its own origin. The Director's
+    /// loopback floor is reachable only from this machine, so a caller there is already as trusted as
+    /// the machine itself.
+    /// </summary>
+    public string? Origin { get; set; }
+
+    /// <summary>
+    /// WHERE this create call is coming from (issue #982): one of the <c>SessionOriginSurfaces</c>
+    /// tokens - "desktop", "cockpit", "phone", "cli", "cron", "workflow", "api" - case-insensitive.
+    /// An unknown value is REJECTED, for the same reason as <see cref="Origin"/>. Null records
+    /// "unknown". Overwritten by the Gateway relay for a device-key caller.
+    /// </summary>
+    public string? OriginSurface { get; set; }
+
+    /// <summary>
+    /// The session MAKING this call (issue #982), when an agent session is: the lineage edge that turns
+    /// a flat roster into the tree of operations it actually is. A session id (GUID string); an
+    /// unparseable value is REJECTED rather than dropped, so a broken lineage edge is never mistaken for
+    /// a root session.
+    ///
+    /// This is the issue's <c>originAgentSessionId</c> and its <c>parentSessionId</c>, which are one
+    /// fact under two names - the session that made the create call IS the parent. Kept only alongside
+    /// <see cref="Origin"/> = "agent"; a parent named on a human or scheduled origin is dropped, since
+    /// one of the two statements must be wrong and the stated origin is the one the caller meant.
+    ///
+    /// DISTINCT from <see cref="ControllerSessionId"/>, which asks for a live supervision relationship
+    /// and changes how the new session is painted. The two carry the same id on an ordinary CLI spawn
+    /// and diverge on <c>--standalone</c>, where an agent starts a deliberate human-facing peer: no
+    /// controller, but still an agent-started session.
+    /// </summary>
+    public string? ParentSessionId { get; set; }
+
+    /// <summary>
     /// Optional EXPLICIT role for the new session (automatic session roles). One of the
     /// <see cref="SessionRoles"/> values (Standalone / Manager / Worker / Architect); case-insensitive. An
     /// unknown value is REJECTED as a bad request (so a mistyped --role never silently drops). When set it

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -570,6 +570,41 @@ public sealed class SessionDto
     public string? SessionRole { get; set; }
 
     /// <summary>
+    /// RAW FACT: WHO asked for this session to exist (devthrottle_internal issue #982) - one of the
+    /// <c>SessionOriginKinds</c> tokens ("human" / "agent" / "schedule" / "unknown"). Mirrors
+    /// <c>Session.OriginKind</c>; stamped at birth by the create path and never changed, so it keeps
+    /// describing the create call however the session later behaves. Passes through the Gateway
+    /// aggregation unchanged and is folded into the durable work-history record.
+    ///
+    /// "unknown" is a real answer here and must be rendered as one, never as "human". It is what a
+    /// Director that predates the field reports, and what an honest create path with nothing to say
+    /// records. The whole point of the field is the share of sessions AGENTS start; quietly resolving
+    /// unknown to either real value corrupts that number where no later reader could see it.
+    /// </summary>
+    public string? OriginKind { get; set; }
+
+    /// <summary>
+    /// RAW FACT: WHERE the create call came from (issue #982) - one of the
+    /// <c>SessionOriginSurfaces</c> tokens ("desktop" / "cockpit" / "phone" / "cli" / "cron" /
+    /// "workflow" / "api" / "unknown"). Mirrors <c>Session.OriginSurface</c>, on the same terms as
+    /// <see cref="OriginKind"/>.
+    /// </summary>
+    public string? OriginSurface { get; set; }
+
+    /// <summary>
+    /// RAW FACT: the id of the session that ASKED for this one (issue #982), or null when nothing did.
+    /// Mirrors <c>Session.ParentSessionId</c>. This is the lineage edge: with it, a roster of
+    /// twenty-two sessions resolves into the handful of operations it actually is, and delegation depth
+    /// becomes answerable at all.
+    ///
+    /// DISTINCT from <see cref="ControllerSessionId"/>, which is a live supervision relationship the
+    /// fold reads to recede a sub-agent to slate. This one is history and paints nothing. They carry
+    /// the same id on an ordinary CLI spawn and diverge whenever a session spawns a deliberate peer
+    /// (<c>--standalone</c>) - no controller, but an agent still started it.
+    /// </summary>
+    public string? ParentSessionId { get; set; }
+
+    /// <summary>
     /// RAW FACT: the sticky EXPLICIT role a human/session declared for this session (mirrors
     /// <c>Session.ExplicitRole</c>), or null when none was set. When present it WINS over auto-derivation in
     /// the aggregation's role resolution (so an explicit <see cref="SessionRoles.Architect"/> - which can
@@ -759,6 +794,18 @@ public sealed class SessionDto
     /// an older Director does not report it; unknown, never zero.
     /// </summary>
     public double? CumulativeIdleSeconds { get; set; }
+
+    /// <summary>
+    /// How many times this session has STARTED waiting on the user (devthrottle_internal issue #982),
+    /// as counted by the owning Director at the same activity flip that opens the stretch
+    /// <see cref="CumulativeIdleSeconds"/> later closes. Mirrors <c>Session.WaitingStretchCount</c>.
+    ///
+    /// The matched pair to the idle clock, and not derivable from it: one session that needed you once
+    /// for an hour and one that needed you twelve times for five minutes read the same on the clock and
+    /// are nothing alike to live with. Null when an older Director does not report it - unknown, never
+    /// zero, and zero from a current Director genuinely means it has not needed you yet.
+    /// </summary>
+    public int? WaitingStretchCount { get; set; }
 
     /// <summary>
     /// Issue #1176 (Phase 1a): a copy safe to hand out from the Gateway's pushed-session cache. The

--- a/src/CcDirector.Gateway.Contracts/SessionHistoryDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionHistoryDtos.cs
@@ -73,7 +73,30 @@ public sealed record WorkHistorySessionDto
     [JsonPropertyName("agentKind")] public string? AgentKind { get; init; }
     [JsonPropertyName("model")] public string? Model { get; init; }
     [JsonPropertyName("missionName")] public string? MissionName { get; init; }
+
+    /// <summary>The mission's id (devthrottle_internal issue #982), or null. The name reads well but
+    /// cannot be joined on - missions get renamed, and two can share a name - so reporting a mission as
+    /// a unit of work (sessions taken, elapsed time, cost) needs the key.</summary>
+    [JsonPropertyName("missionId")] public Guid? MissionId { get; init; }
     [JsonPropertyName("sessionRole")] public string? SessionRole { get; init; }
+
+    /// <summary>WHO asked for this session (devthrottle_internal issue #982): one of the
+    /// <c>SessionOriginKinds</c> tokens - "human", "agent", "schedule", "unknown". A birth fact,
+    /// written once and never revised. NULL means the row predates the field - which is not the same
+    /// as "unknown", the answer for a create path that was asked and had nothing to say.</summary>
+    [JsonPropertyName("originKind")] public string? OriginKind { get; init; }
+
+    /// <summary>WHERE the create call came from (issue #982): one of the
+    /// <c>SessionOriginSurfaces</c> tokens - "desktop", "cockpit", "phone", "cli", "cron",
+    /// "workflow", "api", "unknown". Null on rows that predate the field.</summary>
+    [JsonPropertyName("originSurface")] public string? OriginSurface { get; init; }
+
+    /// <summary>The id of the session that ASKED for this one (issue #982), or null when nothing did -
+    /// the lineage edge that turns a flat list of sessions into the operations they belonged to. The id
+    /// keys this same table, so a parent is looked up by its own <see cref="SessionId"/>; it may name a
+    /// row that retention has already pruned, which is a truthful record of a parent we no longer
+    /// keep.</summary>
+    [JsonPropertyName("parentSessionId")] public string? ParentSessionId { get; init; }
 
     [JsonPropertyName("startedAtUtc")] public required DateTime StartedAtUtc { get; init; }
     [JsonPropertyName("lastActivityUtc")] public DateTime? LastActivityUtc { get; init; }
@@ -109,6 +132,37 @@ public sealed record WorkHistorySessionDto
     /// <summary>Total seconds the session spent waiting on the user, summed over closed waiting
     /// stretches. Null when never reported.</summary>
     [JsonPropertyName("idleSeconds")] public double? IdleSeconds { get; init; }
+
+    /// <summary>How many times the session started waiting on the user (devthrottle_internal issue
+    /// #982) - the matched pair to <see cref="IdleSeconds"/>, and not derivable from it. An hour of
+    /// waiting spread over twelve interruptions is a different session to live with from one that
+    /// waited once. Null when the owning Director never reported the counter.</summary>
+    [JsonPropertyName("waitingStretchCount")] public long? WaitingStretchCount { get; init; }
+
+    /// <summary>Character volume of input submitted into the session, operator plus agent-driven
+    /// (issue #982). Turn counts alone flatten a one-word "yes" and a pasted design document into the
+    /// same number. Null when never reported.</summary>
+    [JsonPropertyName("inputCharacterCount")] public long? InputCharacterCount { get; init; }
+
+    /// <summary>Cumulative uncached input tokens for this session (issue #982). Kept apart from the
+    /// cache figures rather than pre-summed, because they are priced differently and one total could
+    /// not be turned back into money. Null when the agent's driver reports no usage.</summary>
+    [JsonPropertyName("inputTokens")] public long? InputTokens { get; init; }
+
+    /// <summary>Cumulative output tokens. See <see cref="InputTokens"/>.</summary>
+    [JsonPropertyName("outputTokens")] public long? OutputTokens { get; init; }
+
+    /// <summary>Cumulative cache-read input tokens. See <see cref="InputTokens"/>.</summary>
+    [JsonPropertyName("cacheReadTokens")] public long? CacheReadTokens { get; init; }
+
+    /// <summary>Cumulative cache-creation input tokens. See <see cref="InputTokens"/>.</summary>
+    [JsonPropertyName("cacheCreationTokens")] public long? CacheCreationTokens { get; init; }
+
+    /// <summary>The fullest the session's context window was observed to be, in tokens (issue #982).
+    /// A GAUGE, so this is a PEAK and never a sum: occupancy rises through a turn and drops on a
+    /// compaction, and adding the readings would produce a number with no unit. Null when the agent's
+    /// driver reports no context reading.</summary>
+    [JsonPropertyName("peakContextTokens")] public long? PeakContextTokens { get; init; }
 
     /// <summary>Null when no summary exists yet; otherwise one of <see cref="SessionHistorySummaryKinds"/>.</summary>
     [JsonPropertyName("summaryKind")] public string? SummaryKind { get; init; }

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727191107_AddSessionOriginColumns.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727191107_AddSessionOriginColumns.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727191107_AddSessionOriginColumns")]
+    partial class AddSessionOriginColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,105 +57,106 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountTrialEntity", b =>
                 {
                     b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("subject");
+                        .HasColumnType("text")
+                        .HasColumnName("subject")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ExpiresAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("expires_at_utc");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("started_at_utc");
 
                     b.HasKey("Subject");
 
                     b.HasIndex("ExpiresAtUtc");
 
-                    b.ToTable("account_trials", (string)null);
+                    b.ToTable("account_trials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -158,108 +168,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", (string)null);
+                    b.ToTable("activity_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -268,108 +278,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", (string)null);
+                    b.ToTable("device_credentials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", (string)null);
+                    b.ToTable("device_import_markers", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("TenantId", "Term");
 
@@ -377,99 +391,100 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", (string)null);
+                    b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", (string)null);
+                    b.ToTable("dictation_suggestion_scans", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", (string)null);
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
@@ -477,43 +492,43 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", (string)null);
+                    b.ToTable("dictation_transcripts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
+                    b.Property<Guid>("Subject")
+                        .HasColumnType("uuid")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", null, t =>
+                    b.ToTable("entitlements", "gateway", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -522,38 +537,38 @@ namespace CcDirector.Gateway.Data.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -566,40 +581,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -612,105 +627,107 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.RepoStateEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BranchesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CollectedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CurrentBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefaultBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDirty")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ReceivedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("WorktreesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "DirectorId", "RepoPath");
 
@@ -718,141 +735,118 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "ReceivedAtUtc");
 
-                    b.ToTable("repo_state", (string)null);
+                    b.ToTable("repo_state", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("AgentTurnCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("BranchesJson")
-                        .HasColumnType("TEXT");
-
-                    b.Property<long?>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("text");
 
                     b.Property<string>("CommitsJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<double?>("CumulativeIdleSeconds")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("EndedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("EndingKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EndingLabel")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FirstPromptLine")
-                        .HasColumnType("TEXT");
-
-                    b.Property<long?>("InputCharacterCount")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("text");
 
                     b.Property<string>("LastActivityState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("LastActivityUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("LastSeenUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LeftUnverifiedJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MissionName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("OriginKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("OriginSurface")
-                        .HasColumnType("TEXT");
-
-                    b.Property<long?>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("text");
 
                     b.Property<string>("ParentSessionId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<long?>("PeakContextTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("text");
 
                     b.Property<string>("PullRequestsJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int?>("SessionNumber")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SessionRole")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("SummaryAttempts")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("SummaryIsPartial")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SummaryKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("TurnCount")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("WaitingStretchCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("WhatWasBuiltJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -862,33 +856,34 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastSeenUtc");
 
-                    b.ToTable("session_history", (string)null);
+                    b.ToTable("session_history", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryRollupEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("RepoKey")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DayUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Attempts")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("ComputedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InputHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "RepoKey", "DayUtc");
 
@@ -896,55 +891,56 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DayUtc");
 
-                    b.ToTable("session_history_rollups", (string)null);
+                    b.ToTable("session_history_rollups", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -952,161 +948,165 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", (string)null);
+                    b.ToTable("tenant_settings", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1114,75 +1114,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1190,71 +1190,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1264,92 +1264,93 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", (string)null);
+                    b.ToTable("workflow_tenant_overrides", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -1358,7 +1359,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1366,28 +1367,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -1398,18 +1399,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -1429,36 +1430,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -1483,35 +1484,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1522,37 +1523,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -1563,23 +1564,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -1599,26 +1600,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1629,34 +1630,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727191107_AddSessionOriginColumns.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727191107_AddSessionOriginColumns.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionOriginColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OriginKind",
+                schema: "gateway",
+                table: "session_history",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OriginSurface",
+                schema: "gateway",
+                table: "session_history",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ParentSessionId",
+                schema: "gateway",
+                table: "session_history",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OriginKind",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "OriginSurface",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "ParentSessionId",
+                schema: "gateway",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727193940_AddSessionCostAndInterruptionColumns.Designer.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727193940_AddSessionCostAndInterruptionColumns.Designer.cs
@@ -3,42 +3,51 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CcDirector.Gateway.Data.Migrations
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727193940_AddSessionCostAndInterruptionColumns")]
+    partial class AddSessionCostAndInterruptionColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
+            modelBuilder
+                .HasDefaultSchema("gateway")
+                .HasAnnotation("ProductVersion", "9.0.2")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountHostedAiSpendEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("AmountMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Kind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("TransactionCreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -48,105 +57,106 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "Kind", "AmountMicros", "TransactionCreatedUtc");
 
-                    b.ToTable("account_hosted_ai_spend", (string)null);
+                    b.ToTable("account_hosted_ai_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.AccountTrialEntity", b =>
                 {
                     b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("subject");
+                        .HasColumnType("text")
+                        .HasColumnName("subject")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ExpiresAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("expires_at_utc");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("started_at_utc");
 
                     b.HasKey("Subject");
 
                     b.HasIndex("ExpiresAtUtc");
 
-                    b.ToTable("account_trials", (string)null);
+                    b.ToTable("account_trials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.ActivityEventEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("EventId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AfterScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BeforeScreenHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BoundedScreenDiff")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Cause")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorMode")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DetectorVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("DirectorSequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InputOrigin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NewState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("OutputByteCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PreviousState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SendSource")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "EventId");
 
@@ -158,108 +168,108 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("activity_events", (string)null);
+                    b.ToTable("activity_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("LastFiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NotifyOn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("NotifyWebhookUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PreventOverlap")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ScheduleKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TimeZoneId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("cron_jobs", (string)null);
+                    b.ToTable("cron_jobs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("FiredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InfraStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("JobId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Machine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ScheduledUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Sequence")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TargetDirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TaskStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -268,108 +278,112 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("JobId", "Sequence");
 
-                    b.ToTable("cron_runs", (string)null);
+                    b.ToTable("cron_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceCredentialEntity", b =>
                 {
                     b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CloudDeviceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceKeyHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DeviceType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("IssuedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("KeyLast4")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("KeyPrefix")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("RevokedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RevokedReason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceId");
 
                     b.HasIndex("DeviceKeyHash");
 
-                    b.ToTable("device_credentials", (string)null);
+                    b.ToTable("device_credentials", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DeviceImportMarkerEntity", b =>
                 {
                     b.Property<string>("SourcePath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("ImportedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("ImportedCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("SourcePath");
 
-                    b.ToTable("device_import_markers", (string)null);
+                    b.ToTable("device_import_markers", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionDismissalEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DismissedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("TotalCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("VariantsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WrongCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.HasKey("TenantId", "Term");
 
@@ -377,99 +391,100 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DismissedAtUtc");
 
-                    b.ToTable("dictation_suggestion_dismissals", (string)null);
+                    b.ToTable("dictation_suggestion_dismissals", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionScanEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<DateTime>("ScannedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ScreeningError")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ScreeningOk")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SuggestionsJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_scans", (string)null);
+                    b.ToTable("dictation_suggestion_scans", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationSuggestionVerdictEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Term")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DisplayTerm")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("JudgedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Reason")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Term");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("dictation_suggestion_verdicts", (string)null);
+                    b.ToTable("dictation_suggestion_verdicts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.DictationTranscriptEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("CleanedText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("CleanupApplied")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("RawText")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("TimestampUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("TurnId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Id");
 
@@ -477,43 +492,43 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "TimestampUtc");
 
-                    b.ToTable("dictation_transcripts", (string)null);
+                    b.ToTable("dictation_transcripts", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.EntitlementEntity", b =>
                 {
-                    b.Property<string>("Subject")
-                        .HasColumnType("TEXT")
+                    b.Property<Guid>("Subject")
+                        .HasColumnType("uuid")
                         .HasColumnName("subject");
 
                     b.Property<DateTime?>("CurrentPeriodEnd")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("current_period_end");
 
                     b.Property<bool?>("Livemode")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasColumnName("livemode");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("status");
 
                     b.Property<string>("StripeSubscriptionId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("stripe_subscription_id");
 
                     b.Property<string>("Tier")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tier");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
                     b.HasKey("Subject");
 
-                    b.ToTable("entitlements", null, t =>
+                    b.ToTable("entitlements", "gateway", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -522,38 +537,38 @@ namespace CcDirector.Gateway.Data.Migrations
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceAuditEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Actor")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Category")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Detail")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -566,40 +581,40 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_audit_events", (string)null);
+                    b.ToTable("governance_audit_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.GovernanceEventEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("OccurredUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("RecordedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("RunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubjectKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
@@ -612,105 +627,107 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "SessionId", "OccurredUtc");
 
-                    b.ToTable("governance_events", (string)null);
+                    b.ToTable("governance_events", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.MissionNoteEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Mission")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Why")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("mission_notes", (string)null);
+                    b.ToTable("mission_notes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.PushSubscriptionEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Endpoint")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("Auth")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("P256dh")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Endpoint");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("push_subscriptions", (string)null);
+                    b.ToTable("push_subscriptions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.RepoStateEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BranchesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CollectedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CurrentBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefaultBranch")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDirty")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("ReceivedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("WorktreesJson")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "DirectorId", "RepoPath");
 
@@ -718,141 +735,142 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "ReceivedAtUtc");
 
-                    b.ToTable("repo_state", (string)null);
+                    b.ToTable("repo_state", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("AgentTurnCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("BranchesJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long?>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("CommitsJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<double?>("CumulativeIdleSeconds")
-                        .HasColumnType("REAL");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("DirectorId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("EndedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("EndingKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EndingLabel")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FirstPromptLine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("InputCharacterCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long?>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("LastActivityState")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("LastActivityUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("LastSeenUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LeftUnverifiedJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("MachineName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("MissionName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("OriginKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("OriginSurface")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("ParentSessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("PeakContextTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PullRequestsJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SessionName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int?>("SessionNumber")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SessionRole")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("StartedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("SummaryAttempts")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("SummaryIsPartial")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SummaryKind")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long?>("TurnCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long?>("WaitingStretchCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("WhatWasBuiltJson")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -862,33 +880,34 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastSeenUtc");
 
-                    b.ToTable("session_history", (string)null);
+                    b.ToTable("session_history", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionHistoryRollupEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("RepoKey")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("DayUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Attempts")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("ComputedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InputHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("SummaryText")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "RepoKey", "DayUtc");
 
@@ -896,55 +915,56 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "DayUtc");
 
-                    b.ToTable("session_history_rollups", (string)null);
+                    b.ToTable("session_history_rollups", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SessionSpendEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AgentKind")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("BillingMode")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<long>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("FirstObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("LastObservedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long?>("MeteredCostMicros")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Model")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TokensCaptured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.HasKey("TenantId", "SessionId");
 
@@ -952,161 +972,165 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("TenantId", "LastObservedUtc");
 
-                    b.ToTable("session_spend", (string)null);
+                    b.ToTable("session_spend", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.SnoozeEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("SessionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("DirectorId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("OwnerTurnBaselineUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("PendingMinutes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("SnoozeUntilUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "SessionId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("snoozes", (string)null);
+                    b.ToTable("snoozes", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantEntity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<string>("AccountSubject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("CreatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AccountSubject")
                         .IsUnique();
 
-                    b.ToTable("tenants", (string)null);
+                    b.ToTable("tenants", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.TenantSettingEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "Key");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("tenant_settings", (string)null);
+                    b.ToTable("tenant_settings", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WingmanInstructionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AckDefaultContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AckDefaultVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActiveVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("wingman_instructions", (string)null);
+                    b.ToTable("wingman_instructions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Consumer")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.HasKey("Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("worklists", (string)null);
+                    b.ToTable("worklists", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkListItemEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Area")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ItemId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("Position")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Source")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("WorkListId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1114,75 +1138,75 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkListId", "Position");
 
-                    b.ToTable("worklist_items", (string)null);
+                    b.ToTable("worklist_items", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Archived")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("Enabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsBuiltIn")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LatestVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("PublishedVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippedContentHash")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("TenantId", "Id");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflows", (string)null);
+                    b.ToTable("workflows", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowFileEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<Guid>("VersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1190,71 +1214,71 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("VersionId");
 
-                    b.ToTable("workflow_files", (string)null);
+                    b.ToTable("workflow_files", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowRunEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AcceptanceStatus")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("AcceptedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("AcceptedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("CompletedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Outcome")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("ParentRunId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("RepoPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("StartedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<int>("WorkflowVersion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("WorkflowVersionId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -1264,92 +1288,93 @@ namespace CcDirector.Gateway.Data.Migrations
 
                     b.HasIndex("WorkflowId");
 
-                    b.ToTable("workflow_runs", (string)null);
+                    b.ToTable("workflow_runs", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowTenantOverrideEntity", b =>
                 {
                     b.Property<string>("TenantId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<string>("WorkflowId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text")
+                        .UseCollation("C");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("UpdatedAtUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UpdatedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("TenantId", "WorkflowId");
 
                     b.HasIndex("TenantId");
 
-                    b.ToTable("workflow_tenant_overrides", (string)null);
+                    b.ToTable("workflow_tenant_overrides", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.WorkflowVersionEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("AuthoredBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChangeNote")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentHash")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("HumanCheckpoint")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("InstructionsMarkdown")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("PublishedUtc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Summary")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("text")
                         .HasColumnName("tenant_id");
 
                     b.Property<int>("Version")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("WhenToUse")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -1358,7 +1383,7 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.HasIndex("TenantId", "WorkflowId", "Version")
                         .IsUnique();
 
-                    b.ToTable("workflow_versions", (string)null);
+                    b.ToTable("workflow_versions", "gateway");
                 });
 
             modelBuilder.Entity("CcDirector.Gateway.Data.Entities.CronJobEntity", b =>
@@ -1366,28 +1391,28 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobAction", "Action", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<bool>("AutoDismiss")
-                                .HasColumnType("INTEGER");
+                                .HasColumnType("boolean");
 
                             b1.Property<string>("RepoPath")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Seed")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("WorkListName")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Action");
 
@@ -1398,18 +1423,18 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsOne("CcDirector.Gateway.Contracts.CronJobTarget", "Target", b1 =>
                         {
                             b1.Property<string>("CronJobEntityTenantId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("CronJobEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("CronJobEntityTenantId", "CronJobEntityId");
 
-                            b1.ToTable("cron_jobs");
+                            b1.ToTable("cron_jobs", "gateway");
 
                             b1.ToJson("Target");
 
@@ -1429,36 +1454,36 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Data.Entities.WingmanInstructionVersionOwned", "Versions", b1 =>
                         {
                             b1.Property<Guid>("WingmanInstructionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Content")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("CreatedAtUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Hash")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Id")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Label")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Source")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WingmanInstructionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("wingman_instructions");
+                            b1.ToTable("wingman_instructions", "gateway");
 
                             b1.ToJson("Versions");
 
@@ -1483,35 +1508,35 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunCriterionResultDto", "CriteriaResults", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime?>("EvaluatedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Evaluator")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Note")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofUrl")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Status")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("CriteriaResults");
 
@@ -1522,37 +1547,37 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunParticipantDto", "Participants", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("AgentKind")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<DateTime>("JoinedUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<DateTime?>("LeftUtc")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Machine")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Role")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("SessionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("Participants");
 
@@ -1563,23 +1588,23 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowRunProofLinkDto", "ProofLinks", b1 =>
                         {
                             b1.Property<Guid>("WorkflowRunEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Label")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowRunEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_runs");
+                            b1.ToTable("workflow_runs", "gateway");
 
                             b1.ToJson("ProofLinks");
 
@@ -1599,26 +1624,26 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowOutcomeCriterionDto", "OutcomeCriteria", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("CriterionId")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("ProofHint")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("OutcomeCriteria");
 
@@ -1629,34 +1654,34 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.OwnsMany("CcDirector.Gateway.Contracts.WorkflowStepDto", "Steps", b1 =>
                         {
                             b1.Property<Guid>("WorkflowVersionEntityId")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("uuid");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAddOrUpdate()
-                                .HasColumnType("INTEGER");
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
 
                             b1.Property<string>("Description")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Doer")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Done")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Name")
                                 .IsRequired()
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.Property<string>("Reviewer")
-                                .HasColumnType("TEXT");
+                                .HasColumnType("text");
 
                             b1.HasKey("WorkflowVersionEntityId", "__synthesizedOrdinal");
 
-                            b1.ToTable("workflow_versions");
+                            b1.ToTable("workflow_versions", "gateway");
 
                             b1.ToJson("Steps");
 

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727193940_AddSessionCostAndInterruptionColumns.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/20260727193940_AddSessionCostAndInterruptionColumns.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Migrations.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionCostAndInterruptionColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "CacheCreationTokens",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "CacheReadTokens",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "InputCharacterCount",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "InputTokens",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "MissionId",
+                schema: "gateway",
+                table: "session_history",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "OutputTokens",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "PeakContextTokens",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "WaitingStretchCount",
+                schema: "gateway",
+                table: "session_history",
+                type: "bigint",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CacheCreationTokens",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "CacheReadTokens",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "InputCharacterCount",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "InputTokens",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "MissionId",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "OutputTokens",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "PeakContextTokens",
+                schema: "gateway",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "WaitingStretchCount",
+                schema: "gateway",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
+++ b/src/CcDirector.Gateway.Migrations.Postgres/Migrations/GatewayDbContextModelSnapshot.cs
@@ -754,6 +754,12 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.Property<string>("BranchesJson")
                         .HasColumnType("text");
 
+                    b.Property<long?>("CacheCreationTokens")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("CacheReadTokens")
+                        .HasColumnType("bigint");
+
                     b.Property<string>("CommitsJson")
                         .HasColumnType("text");
 
@@ -776,6 +782,12 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.Property<string>("FirstPromptLine")
                         .HasColumnType("text");
 
+                    b.Property<long?>("InputCharacterCount")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("InputTokens")
+                        .HasColumnType("bigint");
+
                     b.Property<string>("LastActivityState")
                         .HasColumnType("text");
 
@@ -791,11 +803,29 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                     b.Property<string>("MachineName")
                         .HasColumnType("text");
 
+                    b.Property<Guid?>("MissionId")
+                        .HasColumnType("uuid");
+
                     b.Property<string>("MissionName")
                         .HasColumnType("text");
 
                     b.Property<string>("Model")
                         .HasColumnType("text");
+
+                    b.Property<string>("OriginKind")
+                        .HasColumnType("text");
+
+                    b.Property<string>("OriginSurface")
+                        .HasColumnType("text");
+
+                    b.Property<long?>("OutputTokens")
+                        .HasColumnType("bigint");
+
+                    b.Property<string>("ParentSessionId")
+                        .HasColumnType("text");
+
+                    b.Property<long?>("PeakContextTokens")
+                        .HasColumnType("bigint");
 
                     b.Property<string>("PullRequestsJson")
                         .HasColumnType("text");
@@ -831,6 +861,9 @@ namespace CcDirector.Gateway.Migrations.Postgres.Migrations
                         .HasColumnType("text");
 
                     b.Property<long?>("TurnCount")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("WaitingStretchCount")
                         .HasColumnType("bigint");
 
                     b.Property<string>("WhatWasBuiltJson")

--- a/src/CcDirector.Gateway.Tests/FleetSpawnOriginTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSpawnOriginTests.cs
@@ -1,0 +1,224 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Session origin and lineage at the Director's spawn floor (devthrottle_internal issue #982): a session
+/// records WHO asked for it, from WHERE, and WHICH session made the call, and the record is stamped
+/// before the agent launches.
+///
+/// Drives the REAL Director Control API over a REAL loopback connection, so the whole path runs -
+/// endpoint, validation, create funnel, pre-launch stamp, DTO mapper. The sessions are `cmd /k`, the same
+/// harmless launch the sibling spawn tests use.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class FleetSpawnOriginTests : IAsyncLifetime
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private ControlApiHost _host = null!;
+    private SessionManager _sm = null!;
+    private HttpClient _client = null!;
+    private string _repoDir = null!;
+
+    public FleetSpawnOriginTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-spawnorigin-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _repoDir = Path.Combine(Path.GetTempPath(), "ccd-spawnorigin-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_repoDir);
+
+        _sm = new SessionManager(new AgentOptions());
+        _host = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", DirectorAuth.LoadOrCreateToken());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+        try
+        {
+            var f = Path.Combine(InstanceRegistration.InstancesDirectory, $"{_host.DirectorId}.json");
+            if (File.Exists(f)) File.Delete(f);
+        }
+        catch { /* test cleanup, ignore */ }
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_repoDir)) Directory.Delete(_repoDir, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>A spawn body shaped like the CLI's, launching a harmless shell.</summary>
+    private NewSessionRequest SpawnBody() => new()
+    {
+        RepoPath = _repoDir,
+        Agent = "RawCli",
+        Command = "cmd",
+        CommandArgs = "/k",
+        Name = "origin test session",
+    };
+
+    private async Task<SessionDto> SpawnOkAsync(NewSessionRequest body)
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(dto);
+        return dto!;
+    }
+
+    private async Task CleanUpAsync(SessionDto dto)
+    {
+        if (dto.SessionId is not null) await _client.DeleteAsync($"sessions/{dto.SessionId}");
+    }
+
+    [Fact]
+    public async Task An_agent_spawn_records_who_asked_and_which_session_asked()
+    {
+        // What `cc-devthrottle session spawn` sends from inside a session: CC_SESSION_ID present, so the
+        // CLI states agent + itself as the parent. This is the whole claim the issue is about - the
+        // fleet's sessions are largely started by other sessions, and until now nothing recorded it.
+        var parent = Guid.NewGuid();
+        var body = SpawnBody();
+        body.Origin = SessionOriginKinds.Agent;
+        body.OriginSurface = SessionOriginSurfaces.Cli;
+        body.ParentSessionId = parent.ToString();
+
+        var dto = await SpawnOkAsync(body);
+        try
+        {
+            Assert.Equal(SessionOriginKinds.Agent, dto.OriginKind);
+            Assert.Equal(SessionOriginSurfaces.Cli, dto.OriginSurface);
+            Assert.Equal(parent.ToString(), dto.ParentSessionId);
+
+            // And it is on the SESSION, not just the response - which is what the roster push carries
+            // up to the Gateway and what the durable history row is written from.
+            var session = _sm.GetSession(Guid.Parse(dto.SessionId!));
+            Assert.NotNull(session);
+            Assert.Equal(SessionOriginKinds.Agent, session!.OriginKind);
+            Assert.Equal(parent, session.ParentSessionId);
+        }
+        finally { await CleanUpAsync(dto); }
+    }
+
+    [Fact]
+    public async Task A_spawn_that_names_no_surface_is_recorded_as_the_command_line()
+    {
+        // This route IS the command line - loopback-only, and the CLI is what reaches it - so saying
+        // "cli" is a measurement. The KIND stays unknown, because only the caller can tell a person
+        // running the command from a session running it, and inventing one here would fabricate exactly
+        // the number the field exists to produce.
+        var dto = await SpawnOkAsync(SpawnBody());
+        try
+        {
+            Assert.Equal(SessionOriginSurfaces.Cli, dto.OriginSurface);
+            Assert.Equal(SessionOriginKinds.Unknown, dto.OriginKind);
+            Assert.Null(dto.ParentSessionId);
+        }
+        finally { await CleanUpAsync(dto); }
+    }
+
+    [Fact]
+    public async Task A_parent_named_on_a_human_origin_is_dropped()
+    {
+        // The two statements contradict each other; the stated kind is what the caller meant. Keeping
+        // both would leave a lineage edge hanging off a session nobody claims started it.
+        var body = SpawnBody();
+        body.Origin = SessionOriginKinds.Human;
+        body.OriginSurface = SessionOriginSurfaces.Cli;
+        body.ParentSessionId = Guid.NewGuid().ToString();
+
+        var dto = await SpawnOkAsync(body);
+        try
+        {
+            Assert.Equal(SessionOriginKinds.Human, dto.OriginKind);
+            Assert.Null(dto.ParentSessionId);
+        }
+        finally { await CleanUpAsync(dto); }
+    }
+
+    [Fact]
+    public async Task A_mistyped_origin_is_refused_rather_than_recorded_as_unknown()
+    {
+        // The --type lesson, applied here. If a typo landed in the "unknown" bucket it would be
+        // indistinguishable from an honest older caller, and the share of sessions agents start would
+        // quietly absorb every caller's mistakes with nothing to show for it.
+        var body = SpawnBody();
+        body.Origin = "robot";
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var text = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("unknown origin 'robot'", text);
+        Assert.Contains(SessionOriginKinds.Agent, text);
+    }
+
+    [Fact]
+    public async Task A_mistyped_origin_surface_is_refused()
+    {
+        var body = SpawnBody();
+        body.OriginSurface = "smoke-signal";
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("unknown origin surface", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task A_parent_session_id_that_is_not_an_id_is_refused()
+    {
+        // A broken lineage edge must never be silently dropped: the session would then look like a root,
+        // and a root session is a meaningful thing in the tree this field exists to build.
+        var body = SpawnBody();
+        body.Origin = SessionOriginKinds.Agent;
+        body.ParentSessionId = "the session next to me";
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("is not a session id", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Lineage_is_recorded_even_when_the_new_session_has_no_controller()
+    {
+        // The case that separates lineage from supervision. `session spawn --standalone` deliberately
+        // creates a human-facing PEER with no controller - so nothing recedes it to slate, and nothing
+        // about the running session says an agent made it. It is still an agent-started session, and
+        // that is precisely what is being counted.
+        var parent = Guid.NewGuid();
+        var body = SpawnBody();
+        body.Origin = SessionOriginKinds.Agent;
+        body.OriginSurface = SessionOriginSurfaces.Cli;
+        body.ParentSessionId = parent.ToString();
+        body.ControllerSessionId = null; // --standalone
+
+        var dto = await SpawnOkAsync(body);
+        try
+        {
+            Assert.False(dto.IsControlled);
+            Assert.Null(dto.ControllerSessionId);
+            Assert.Equal(parent.ToString(), dto.ParentSessionId);
+        }
+        finally { await CleanUpAsync(dto); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/History/SessionHistoryOriginTests.cs
+++ b/src/CcDirector.Gateway.Tests/History/SessionHistoryOriginTests.cs
@@ -1,0 +1,300 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
+// CcDirector.Core.Sessions has a SessionHistoryStore of its own (the Director's workspace history,
+// unrelated to the Gateway's durable record). Name the one under test outright.
+using SessionHistoryStore = CcDirector.Gateway.History.SessionHistoryStore;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.History;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.History;
+
+/// <summary>
+/// The birth facts on the durable work-history row (devthrottle_internal issue #982): who asked for a
+/// session, from where, and which session asked. Runs over the real EF store on a throwaway SQLite
+/// file, exactly as the Gateway runs it.
+///
+/// Every test here defends a way the record could be quietly wrong rather than loudly broken - a later
+/// push blanking a known origin, a lineage edge lost across a Gateway restart, a birth-count that
+/// double-counts the long-lived sessions.
+/// </summary>
+public sealed class SessionHistoryOriginTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    private SessionHistoryStore NewStore(ITenantContext? tenant = null)
+        => new(_harness.Open(tenant));
+
+    private static SessionDto Session(string id, DateTime startedAt,
+        string? originKind = null, string? originSurface = null, string? parentSessionId = null) => new()
+    {
+        SessionId = id,
+        Name = "A session",
+        RepoPath = @"D:\repos\devthrottle",
+        RepoName = "thefrederiksen/devthrottle",
+        Agent = "ClaudeCode",
+        MachineName = "SOREN_NORTH",
+        CreatedAt = startedAt,
+        ActivityState = "Working",
+        Status = "Running",
+        OriginKind = originKind,
+        OriginSurface = originSurface,
+        ParentSessionId = parentSessionId,
+    };
+
+    [Fact]
+    public void The_birth_facts_land_on_the_row_and_reach_the_wire()
+    {
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+        var parent = Guid.NewGuid().ToString();
+
+        store.UpsertLive("dir-1", Session("child", now.AddMinutes(-5),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, parent), now);
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(SessionOriginKinds.Agent, row.OriginKind);
+        Assert.Equal(SessionOriginSurfaces.Cli, row.OriginSurface);
+        Assert.Equal(parent, row.ParentSessionId);
+    }
+
+    [Fact]
+    public void A_later_push_that_lost_the_origin_never_blanks_it()
+    {
+        // The failure this exists for: a Director rolling back to an older build, or a second Director
+        // adopting the session, pushes a DTO with no origin fields at all. The row must keep what it
+        // knows. Birth facts cannot be re-derived - once blanked, the answer is gone for good, and
+        // nothing about the running session would ever reveal that it used to be known.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+        var parent = Guid.NewGuid().ToString();
+
+        store.UpsertLive("dir-1", Session("s1", now.AddMinutes(-5),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, parent), now);
+        store.UpsertLive("dir-1", Session("s1", now.AddMinutes(-5)), now.AddMinutes(1));
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(SessionOriginKinds.Agent, row.OriginKind);
+        Assert.Equal(SessionOriginSurfaces.Cli, row.OriginSurface);
+        Assert.Equal(parent, row.ParentSessionId);
+    }
+
+    [Fact]
+    public void A_row_created_without_an_origin_is_filled_in_by_a_later_push_that_has_one()
+    {
+        // The mirror case, and the reason the guard is on the STORED value being empty rather than on
+        // first sight: a session first seen through an old Director creates an origin-less row, and
+        // the moment a current Director reports the same session the facts should land.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        store.UpsertLive("dir-old", Session("s1", now.AddMinutes(-5)), now);
+        store.UpsertLive("dir-new", Session("s1", now.AddMinutes(-5),
+            SessionOriginKinds.Human, SessionOriginSurfaces.Desktop), now.AddMinutes(1));
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(SessionOriginKinds.Human, row.OriginKind);
+        Assert.Equal(SessionOriginSurfaces.Desktop, row.OriginSurface);
+    }
+
+    [Fact]
+    public void A_recorded_unknown_is_a_value_and_is_not_overwritten_later()
+    {
+        // "unknown" is an answer, not an absence. If a later push could replace it, the recorded origin
+        // would depend on which push happened to arrive - the same session reading differently between
+        // two runs of the same fleet.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        store.UpsertLive("dir-1", Session("s1", now.AddMinutes(-5),
+            SessionOriginKinds.Unknown, SessionOriginSurfaces.Unknown), now);
+        store.UpsertLive("dir-1", Session("s1", now.AddMinutes(-5),
+            SessionOriginKinds.Human, SessionOriginSurfaces.Desktop), now.AddMinutes(1));
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(SessionOriginKinds.Unknown, row.OriginKind);
+    }
+
+    [Fact]
+    public void The_lineage_edge_survives_a_gateway_restart()
+    {
+        var now = DateTime.UtcNow;
+        var parent = Guid.NewGuid().ToString();
+        NewStore().UpsertLive("dir-1", Session("child", now.AddMinutes(-5),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, parent), now);
+
+        // A fresh store over the same file - the Gateway coming back up.
+        var reopened = NewStore();
+
+        var row = Assert.Single(reopened.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(parent, row.ParentSessionId);
+    }
+
+    [Fact]
+    public void Origin_totals_count_by_birth_and_keep_not_recorded_apart_from_unknown()
+    {
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        store.UpsertLive("dir-1", Session("a", now.AddHours(-1),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+        store.UpsertLive("dir-1", Session("b", now.AddHours(-1),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+        store.UpsertLive("dir-1", Session("c", now.AddHours(-1),
+            SessionOriginKinds.Human, SessionOriginSurfaces.Desktop), now);
+        store.UpsertLive("dir-1", Session("d", now.AddHours(-1),
+            SessionOriginKinds.Schedule, SessionOriginSurfaces.Cron), now);
+        store.UpsertLive("dir-1", Session("e", now.AddHours(-1),
+            SessionOriginKinds.Unknown, SessionOriginSurfaces.Unknown), now);
+        // A row from before the fields existed: no origin on the wire at all.
+        store.UpsertLive("dir-1", Session("f", now.AddHours(-1)), now);
+
+        var totals = store.OriginTotals(now.AddDays(-1), now.AddDays(1));
+
+        Assert.Equal(6, totals.Sessions);
+        Assert.Equal(2, totals.ByKind[SessionOriginKinds.Agent]);
+        Assert.Equal(1, totals.ByKind[SessionOriginKinds.Human]);
+        Assert.Equal(1, totals.ByKind[SessionOriginKinds.Schedule]);
+        // The two that look alike and are not: one was asked and said nothing, one was never asked.
+        Assert.Equal(1, totals.ByKind[SessionOriginKinds.Unknown]);
+        Assert.Equal(1, totals.ByKind[SessionHistoryStore.NotRecorded]);
+        Assert.Equal(2, totals.BySurface[SessionOriginSurfaces.Cli]);
+        Assert.Equal(2, totals.WithParent);
+        // Where the RECORD begins, which is the oldest birth found and NOT the floor of the query -
+        // the number a caller has to quote beside any "all time" share, because retention prunes from
+        // the front and the fields only began being written the day they shipped.
+        Assert.NotNull(totals.EarliestStartUtc);
+        Assert.True(Math.Abs((totals.EarliestStartUtc!.Value - now.AddHours(-1)).TotalSeconds) < 1);
+    }
+
+    [Fact]
+    public void Origin_totals_over_an_empty_window_report_no_record_rather_than_a_date()
+    {
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        var totals = store.OriginTotals(now.AddDays(-1), now);
+
+        Assert.Equal(0, totals.Sessions);
+        Assert.Null(totals.EarliestStartUtc);
+        Assert.Empty(totals.ByKind);
+    }
+
+    [Fact]
+    public void Origin_totals_count_a_session_in_the_window_it_was_born_in_not_every_window_it_survived()
+    {
+        // The bias this prevents: ReadRange returns any session whose life TOUCHED the window, which is
+        // right for "what was I working on Tuesday" and wrong here. Agent-started sessions tend to be
+        // short and human-started ones long, so counting by overlap would credit the long human session
+        // to every window it ran through and understate the agent share - by more, the wider the window.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+
+        // Born ten days ago, still being observed today.
+        store.UpsertLive("dir-1", Session("long-runner", now.AddDays(-10),
+            SessionOriginKinds.Human, SessionOriginSurfaces.Desktop), now);
+        // Born an hour ago.
+        store.UpsertLive("dir-1", Session("fresh", now.AddHours(-1),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+
+        var lastWeek = store.OriginTotals(now.AddDays(-7), now);
+
+        Assert.Equal(1, lastWeek.Sessions);
+        Assert.Equal(1, lastWeek.ByKind[SessionOriginKinds.Agent]);
+        Assert.False(lastWeek.ByKind.ContainsKey(SessionOriginKinds.Human));
+        // It is still in the record, just not in this week's births.
+        Assert.Equal(2, store.OriginTotals(now.AddDays(-30), now).Sessions);
+    }
+
+    [Fact]
+    public void The_cost_and_interruption_facts_land_and_only_ever_move_forward()
+    {
+        // The rest of what issue #982 asked for per session: what it cost, how much was said to it,
+        // how many times it interrupted the owner, and how full its context got. All on the SAME
+        // high-water-mark rule as the counters that were already here, for the same reason - a
+        // Director restart begins its counters again at zero, and the run's record must not follow.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+        var mission = Guid.NewGuid();
+
+        var measured = Session("s1", now.AddHours(-1));
+        measured.MissionId = mission;
+        measured.WaitingStretchCount = 7;
+        measured.InputStats = new InputStatsDto
+        {
+            Buckets = { new InputStatBucketDto { Modality = "typed", Surface = "desktop", Turns = 3, Characters = 900 } },
+            AgentDrivenTurns = 2,
+            AgentDrivenCharacters = 100,
+        };
+        measured.TokenTotals = new TokenTotalsDto
+        {
+            InputTokens = 5_000,
+            OutputTokens = 1_200,
+            CacheReadTokens = 40_000,
+            CacheCreationTokens = 900,
+            ContextTokens = 88_000,
+        };
+        store.UpsertLive("dir-1", measured, now);
+
+        // The Director came back: every counter starts again at zero, and the context gauge - which
+        // DROPS on a compaction anyway - reads lower.
+        var restarted = Session("s1", now.AddHours(-1));
+        restarted.WaitingStretchCount = 1;
+        restarted.InputStats = new InputStatsDto
+        {
+            Buckets = { new InputStatBucketDto { Modality = "typed", Surface = "desktop", Turns = 1, Characters = 10 } },
+        };
+        restarted.TokenTotals = new TokenTotalsDto
+        {
+            InputTokens = 50, OutputTokens = 10, CacheReadTokens = 0, CacheCreationTokens = 0, ContextTokens = 12_000,
+        };
+        store.UpsertLive("dir-1", restarted, now.AddMinutes(1));
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Equal(mission, row.MissionId);
+        Assert.Equal(7, row.WaitingStretchCount);
+        Assert.Equal(1000, row.InputCharacterCount);   // 900 typed + 100 agent-driven
+        Assert.Equal(5_000, row.InputTokens);
+        Assert.Equal(1_200, row.OutputTokens);
+        Assert.Equal(40_000, row.CacheReadTokens);
+        Assert.Equal(900, row.CacheCreationTokens);
+        // The gauge keeps its PEAK. Summing a gauge would produce a number with no unit; taking the
+        // latest would report a compacted session as one that never filled up.
+        Assert.Equal(88_000, row.PeakContextTokens);
+    }
+
+    [Fact]
+    public void A_director_that_reports_none_of_the_cost_facts_leaves_them_unknown_not_zero()
+    {
+        // An agent whose driver reports no usage (everything but Claude today) must read "we do not
+        // know what this cost", never "this cost nothing" - the second is a claim, and a wrong one.
+        var store = NewStore();
+        var now = DateTime.UtcNow;
+        store.UpsertLive("dir-1", Session("s1", now.AddHours(-1)), now);
+
+        var row = Assert.Single(store.ReadRange(now.AddDays(-1), now.AddDays(1)));
+        Assert.Null(row.InputTokens);
+        Assert.Null(row.OutputTokens);
+        Assert.Null(row.PeakContextTokens);
+        Assert.Null(row.WaitingStretchCount);
+        Assert.Null(row.InputCharacterCount);
+        Assert.Null(row.MissionId);
+    }
+
+    [Fact]
+    public void Origin_totals_are_tenant_scoped()
+    {
+        var alpha = NewStore(new FixedTenantContext(new TenantId("alpha")));
+        var beta = NewStore(new FixedTenantContext(new TenantId("beta")));
+        var now = DateTime.UtcNow;
+
+        alpha.UpsertLive("dir-1", Session("a", now.AddHours(-1),
+            SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+
+        Assert.Equal(1, alpha.OriginTotals(now.AddDays(-1), now.AddDays(1)).Sessions);
+        Assert.Equal(0, beta.OriginTotals(now.AddDays(-1), now.AddDays(1)).Sessions);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
@@ -1,0 +1,143 @@
+using System.Net.Http.Json;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The GATEWAY-AUTHORITATIVE half of session origin (devthrottle_internal issue #982), at
+/// <c>POST /machines/{machine}/sessions</c> - the one spawn route reachable from outside the owner's own
+/// machines, and therefore the one where a client's claim about its own origin cannot be the record.
+///
+/// Two rules, and the second matters more than the first:
+///  - a caller holding a verified PHONE or BROWSER device key is a person, and is recorded as one
+///    whatever the request body said;
+///  - EVERY other caller is left exactly as it arrived. A remote agent spawn reaches this route relayed
+///    by its own Director over the tunnel, carrying that Director's "workstation" key; the Director
+///    already stamped the truth on its loopback floor, and overwriting here would erase agent lineage on
+///    precisely the cross-machine spawns that make lineage worth having.
+///
+/// Boots the real machine routes with a stub spawner that captures the create request, and a middleware
+/// that stamps the device type exactly as <see cref="AuthMiddleware"/> does after verifying a key.
+/// </summary>
+public sealed class MachineSpawnOriginStampTests : IDisposable
+{
+    private readonly string _dir;
+
+    public MachineSpawnOriginStampTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-spawn-origin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>A resolver that always finds a Director, so the relay reaches the create step.</summary>
+    private sealed class AlwaysFound : IDirectorTargetResolver
+    {
+        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+            => Task.FromResult(new DirectorTargetResult("dir-1", null));
+    }
+
+    private async Task<(WebApplication app, HttpClient http, Func<NewSessionRequest?> captured)> StartAsync(string? deviceType)
+    {
+        NewSessionRequest? seen = null;
+        var spawner = new MachineSessionSpawner(new AlwaysFound(), (directorId, req, ct) =>
+        {
+            seen = req;
+            return Task.FromResult<(bool, SessionDto?, string?)>(
+                (true, new SessionDto { SessionId = Guid.NewGuid().ToString() }, null));
+        });
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        // Stand in for AuthMiddleware having verified a key: it stashes the device type under this key,
+        // and that stash is the ONLY thing the stamper reads.
+        app.Use(async (ctx, next) =>
+        {
+            if (deviceType is not null) ctx.Items[AuthMiddleware.DeviceTypeItemKey] = deviceType;
+            await next();
+        });
+
+        MachineEndpoints.Map(app, new LauncherRegistry(), spawner);
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, () => seen);
+    }
+
+    private static NewSessionRequest AgentSpawnBody(string parentSessionId) => new()
+    {
+        RepoPath = @"D:\repos\devthrottle",
+        Agent = "ClaudeCode",
+        Origin = SessionOriginKinds.Agent,
+        OriginSurface = SessionOriginSurfaces.Cli,
+        ParentSessionId = parentSessionId,
+    };
+
+    [Theory]
+    [InlineData("phone", SessionOriginSurfaces.Phone)]
+    [InlineData("browser", SessionOriginSurfaces.Cockpit)]
+    public async Task A_signed_in_device_is_recorded_as_a_person_whatever_the_body_claimed(string deviceType, string expectedSurface)
+    {
+        var (app, http, captured) = await StartAsync(deviceType);
+        try
+        {
+            // The body lies: it claims an agent on the command line. The verified key says otherwise.
+            var resp = await http.PostAsJsonAsync("/machines/SOREN_NORTH/sessions", AgentSpawnBody(Guid.NewGuid().ToString()));
+            resp.EnsureSuccessStatusCode();
+
+            var req = captured();
+            Assert.NotNull(req);
+            Assert.Equal(SessionOriginKinds.Human, req!.Origin);
+            Assert.Equal(expectedSurface, req.OriginSurface);
+            // A phone is nobody's child: the claimed parent goes with the claimed origin.
+            Assert.Null(req.ParentSessionId);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.StopAsync();
+        }
+    }
+
+    [Theory]
+    [InlineData("workstation")]   // what a Director enrols as - the relayed-agent-spawn case
+    [InlineData("gateway")]
+    [InlineData(null)]            // no device key resolved at all
+    public async Task A_relayed_spawn_keeps_the_origin_its_director_already_stamped(string? deviceType)
+    {
+        // THE NEGATIVE CONTROL, and the reason the stamper returns early instead of defaulting. If any
+        // of these overwrote, every cross-machine agent spawn - one session driving work on another
+        // computer, the exact shape the lineage tree is for - would be recorded as a human's doing.
+        var parent = Guid.NewGuid().ToString();
+        var (app, http, captured) = await StartAsync(deviceType);
+        try
+        {
+            var resp = await http.PostAsJsonAsync("/machines/SOREN_NORTH/sessions", AgentSpawnBody(parent));
+            resp.EnsureSuccessStatusCode();
+
+            var req = captured();
+            Assert.NotNull(req);
+            Assert.Equal(SessionOriginKinds.Agent, req!.Origin);
+            Assert.Equal(SessionOriginSurfaces.Cli, req.OriginSurface);
+            Assert.Equal(parent, req.ParentSessionId);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.StopAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/StatsSessionOriginFeedTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsSessionOriginFeedTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using SessionHistoryStore = CcDirector.Gateway.History.SessionHistoryStore;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The session-origin block of <c>GET /stats/data</c> (devthrottle_internal issue #982): how the fleet's
+/// sessions CAME TO EXIST, served beside the turn counts that were already there.
+///
+/// The distinction the block exists to make: the agent-driven numbers already in this feed count TURNS -
+/// who does the talking once a session is running. These count BIRTHS - who decides a session should
+/// exist at all, which is the step that turns one person into a supervisor of twenty-two.
+///
+/// Boots only the stats endpoint over a real work-history store on a throwaway SQLite file.
+/// </summary>
+public sealed class StatsSessionOriginFeedTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    private static SessionDto Born(string id, DateTime startedAt, string kind, string surface, string? parent = null) => new()
+    {
+        SessionId = id,
+        RepoPath = @"D:\repos\devthrottle",
+        Agent = "ClaudeCode",
+        MachineName = "SOREN_NORTH",
+        CreatedAt = startedAt,
+        ActivityState = "Working",
+        Status = "Running",
+        OriginKind = kind,
+        OriginSurface = surface,
+        ParentSessionId = parent,
+    };
+
+    private static async Task<(WebApplication app, HttpClient http)> StartAsync(SessionHistoryStore? history)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+        StatsPageEndpoint.Map(app, new GatewayInputStatsAggregator(), sessionHistory: history);
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });
+    }
+
+    [Fact]
+    public async Task The_feed_reports_how_sessions_came_to_exist()
+    {
+        var store = new SessionHistoryStore(_harness.Open());
+        var now = DateTime.UtcNow;
+        store.UpsertLive("dir-1", Born("a", now.AddHours(-2), SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+        store.UpsertLive("dir-1", Born("b", now.AddHours(-2), SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+        store.UpsertLive("dir-1", Born("c", now.AddHours(-2), SessionOriginKinds.Human, SessionOriginSurfaces.Desktop), now);
+        store.UpsertLive("dir-1", Born("d", now.AddHours(-2), SessionOriginKinds.Schedule, SessionOriginSurfaces.Cron), now);
+
+        var (app, http) = await StartAsync(store);
+        try
+        {
+            using var doc = JsonDocument.Parse(await http.GetStringAsync("/stats/data"));
+            var origins = doc.RootElement.GetProperty("sessionOrigins");
+            var week = origins.GetProperty("last7Days");
+
+            Assert.Equal(4, week.GetProperty("sessions").GetInt32());
+            Assert.Equal(2, week.GetProperty("byKind").GetProperty(SessionOriginKinds.Agent).GetInt32());
+            Assert.Equal(1, week.GetProperty("byKind").GetProperty(SessionOriginKinds.Human).GetInt32());
+            Assert.Equal(1, week.GetProperty("byKind").GetProperty(SessionOriginKinds.Schedule).GetInt32());
+            Assert.Equal(2, week.GetProperty("withParentSession").GetInt32());
+            Assert.Equal(2, week.GetProperty("bySurface").GetProperty(SessionOriginSurfaces.Cli).GetInt32());
+
+            // Both windows are served, and the all-time block reports where the RECORD begins - the
+            // oldest birth actually stored - rather than the floor of the query. Retention prunes from
+            // the front and the fields only began being written the day they shipped, so a share quoted
+            // over "all time" without that date is quoting a denominator the Gateway has not got.
+            var allTime = origins.GetProperty("allTime");
+            Assert.Equal(4, allTime.GetProperty("sessions").GetInt32());
+            var recordBegins = allTime.GetProperty("recordBeginsUtc").GetDateTime();
+            Assert.True(recordBegins > DateTime.UtcNow.AddHours(-3), "the record begins at the oldest stored birth, not at an epoch");
+            Assert.False(allTime.TryGetProperty("sinceUtc", out _));
+
+            // No share is computed. What to do with the unaccounted buckets is the reader's call, and
+            // baking one answer in here would fix that choice for everyone and hide it from all of them.
+            Assert.False(week.TryGetProperty("agentShare", out _));
+        }
+        finally
+        {
+            http.Dispose();
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Sessions_recorded_before_the_fields_existed_are_kept_out_of_the_real_buckets()
+    {
+        var store = new SessionHistoryStore(_harness.Open());
+        var now = DateTime.UtcNow;
+        store.UpsertLive("dir-1", Born("a", now.AddHours(-2), SessionOriginKinds.Agent, SessionOriginSurfaces.Cli, Guid.NewGuid().ToString()), now);
+        // No origin on the wire at all - an older Director, or a row written before this shipped.
+        store.UpsertLive("dir-1", new SessionDto
+        {
+            SessionId = "legacy",
+            RepoPath = @"D:\repos\devthrottle",
+            Agent = "ClaudeCode",
+            CreatedAt = now.AddHours(-2),
+            ActivityState = "Working",
+            Status = "Running",
+        }, now);
+
+        var (app, http) = await StartAsync(store);
+        try
+        {
+            using var doc = JsonDocument.Parse(await http.GetStringAsync("/stats/data"));
+            var week = doc.RootElement.GetProperty("sessionOrigins").GetProperty("last7Days");
+
+            Assert.Equal(2, week.GetProperty("sessions").GetInt32());
+            Assert.Equal(1, week.GetProperty("byKind").GetProperty(SessionOriginKinds.Agent).GetInt32());
+            Assert.Equal(1, week.GetProperty("byKind").GetProperty(SessionHistoryStore.NotRecorded).GetInt32());
+            // The one that matters: it is NOT counted as human, which is what an agent share computed
+            // over a partly-instrumented record would quietly assume.
+            Assert.False(week.GetProperty("byKind").TryGetProperty(SessionOriginKinds.Human, out _));
+
+            // And the feed says in words what the bucket means, so a reader never has to guess whether
+            // "notRecorded" is a kind of session or the absence of a record.
+            Assert.Contains("predates the origin fields",
+                doc.RootElement.GetProperty("sessionOrigins").GetProperty("notRecordedMeans").GetString());
+        }
+        finally
+        {
+            http.Dispose();
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task With_no_history_store_the_block_is_absent_rather_than_zero()
+    {
+        // A zero here would read as "no agent ever started a session" - a different and much more
+        // interesting claim than "this Gateway is not keeping the record".
+        var (app, http) = await StartAsync(history: null);
+        try
+        {
+            using var doc = JsonDocument.Parse(await http.GetStringAsync("/stats/data"));
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("sessionOrigins").ValueKind);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.StopAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1415,6 +1415,12 @@ internal static class GatewayEndpoints
                 RepoPath = row.RepoPath,
                 Agent = row.Agent,
                 PrePrompt = context,
+                // Session origin (devthrottle_internal issue #982). The SURFACE is certain - this is a
+                // direct Gateway API route, not the command line and not a schedule - so it is stated.
+                // The KIND is NOT: restoring an interrupted session can be asked for by a person in the
+                // Cockpit or by an agent cleaning up after a crash, and this handler cannot tell which.
+                // Left unstated, so it records "unknown", which is exactly what we know.
+                OriginSurface = Core.Sessions.SessionOriginSurfaces.Api,
             };
             var createSr = await DirectorCommandRouter.TrySendAsync(sendCommand, target.DirectorId, "create", "", spawnReq, CancellationToken.None, machineName: target.MachineName);
             if (createSr is null)
@@ -2748,6 +2754,16 @@ internal static class GatewayEndpoints
                 RepoPath = req.ToRepoPath,
                 Agent = req.ToAgent,
                 PrePrompt = contextText,
+                // Session origin (devthrottle_internal issue #982): a direct API route, like the
+                // interrupted-session restore above. The kind is left unstated for the same reason - a
+                // handover is asked for by a person moving work or by a session handing itself over,
+                // and this handler cannot tell them apart.
+                //
+                // The SOURCE session is deliberately NOT recorded as the parent. ParentSessionId means
+                // "the session that asked for this one", and in a handover the source is the session
+                // being LEFT, which is a different relationship; putting it here would make the lineage
+                // tree quietly mean two things at once.
+                OriginSurface = Core.Sessions.SessionOriginSurfaces.Api,
             };
             // Gateway Cleanup Phase 2: create the target over the tunnel (create verb, director-level), tunnel-first;
             // the dedicated 20s HTTP client is the fallback pre-cut (the tunnel unary has no 2s aggregate timeout).

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -7,6 +7,7 @@ using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Running;
 using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -236,6 +237,35 @@ internal static class MachineEndpoints
         Results.Json(new { error = "no tenant is bound to this request" }, statusCode: 403);
 
     /// <summary>
+    /// Session origin (devthrottle_internal issue #982), stamped GATEWAY-AUTHORITATIVELY on the spawn
+    /// relay - the same rule <c>PromptRequest.Surface</c> already follows for turns.
+    ///
+    /// This route is the one spawn path a caller outside the owner's machines can reach, so what a
+    /// client CLAIMS about its own origin cannot be the record. When the verified per-device key says
+    /// the caller is a signed-in phone or browser, we know two things by construction - a person is
+    /// holding it, and which surface it is - and both are OVERWRITTEN here, along with any parent
+    /// session the client named (a phone is nobody's child).
+    ///
+    /// Every OTHER caller is left exactly as it arrived, and that is the important half. A remote spawn
+    /// from an agent reaches this route relayed by its own Director over the tunnel, carrying that
+    /// Director's key rather than a device key; the Director already stamped the truth on the loopback
+    /// floor, and overwriting it here would erase the agent lineage on precisely the cross-machine
+    /// spawns - one session driving work on another computer - that make the lineage worth having.
+    /// </summary>
+    private static void StampOriginFromDeviceKey(NewSessionRequest req, HttpContext ctx)
+    {
+        var deviceType = ctx.Items.TryGetValue(AuthMiddleware.DeviceTypeItemKey, out var dt) ? dt as string : null;
+        var surface = Core.Sessions.SessionOriginSurfaces.FromDeviceType(deviceType);
+        if (surface == Core.Sessions.SessionOriginSurfaces.Unknown)
+            return; // not a person's device - keep what the relaying Director stated
+
+        req.Origin = Core.Sessions.SessionOriginKinds.Human;
+        req.OriginSurface = surface;
+        req.ParentSessionId = null;
+        FileLog.Write($"[MachineEndpoints] spawn origin stamped from the verified device key: human/{surface} (deviceType={deviceType})");
+    }
+
+    /// <summary>
     /// The four launcher self-registration routes, mapped relative to <see cref="LauncherPrefix"/> so the full
     /// paths are <c>/launchers</c> and <c>/launchers/{machine}/...</c> exactly as before. Takes the denied
     /// GROUP HANDLE and nothing else: the ungrouped route builder is deliberately out of scope so no route can
@@ -333,11 +363,13 @@ internal static class MachineEndpoints
         // to a Director (auto-launching one via the launcher if none is running) and create the session
         // there through the SAME resolve-then-create path the cron firing engine uses. Fail loud: an
         // off/unreachable machine or a create failure returns 502 with the error - NEVER a local spawn.
-        app.MapPost("/{machine}/sessions", async (string machine, NewSessionRequest req, CancellationToken ct) =>
+        app.MapPost("/{machine}/sessions", async (string machine, NewSessionRequest req, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: repo={req?.RepoPath}, agent={req?.Agent}");
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
                 return Results.BadRequest(new { error = "repoPath is required" });
+
+            StampOriginFromDeviceKey(req, ctx);
 
             // Gateway Cleanup mission (Wave 4b): a mission-scoped spawn is validated against the Gateway's OWN
             // mission store (the source of truth) and the resolved NAME is stamped onto the create request, so

--- a/src/CcDirector.Gateway/Data/Entities/SessionHistoryEntity.cs
+++ b/src/CcDirector.Gateway/Data/Entities/SessionHistoryEntity.cs
@@ -49,8 +49,44 @@ public sealed class SessionHistoryEntity : TenantScopedEntity
     public string? Model { get; set; }
     public string? MissionName { get; set; }
 
+    /// <summary>
+    /// The mission this session was attached to (devthrottle_internal issue #982), or null. The NAME
+    /// was already stored beside it and reads well, but a name is not a key: missions get renamed, two
+    /// can share a name, and reporting a mission as a unit of work - sessions taken, elapsed time, cost
+    /// - needs the id the mission store is keyed by. Written once, like the other attachment facts.
+    /// </summary>
+    public Guid? MissionId { get; set; }
+
     /// <summary>The declared role (Architect/Manager/Worker...), when the session has one.</summary>
     public string? SessionRole { get; set; }
+
+    /// <summary>
+    /// WHO asked for this session (devthrottle_internal issue #982) - one of the
+    /// <c>SessionOriginKinds</c> tokens. A BIRTH FACT: written on first sight and never revised, unlike
+    /// the running facts above, which are refreshed on every observed push. It cannot change, and a
+    /// later push that lost it (an old Director mid-upgrade) must not be allowed to erase it.
+    ///
+    /// Null on rows written before the field existed, and "unknown" on rows whose create path did not
+    /// say. Those are different states and are kept different: the first means the Gateway was not
+    /// asking, the second means it asked and the answer was nothing.
+    /// </summary>
+    public string? OriginKind { get; set; }
+
+    /// <summary>WHERE the create call came from (issue #982) - one of the <c>SessionOriginSurfaces</c>
+    /// tokens. A birth fact on the same terms as <see cref="OriginKind"/>.</summary>
+    public string? OriginSurface { get; set; }
+
+    /// <summary>
+    /// The session that asked for this one (issue #982), or null. THE LINEAGE EDGE, and the reason this
+    /// table can answer questions the live roster never could: a fleet of twenty-two rows resolves into
+    /// the handful of operations it actually was, long after every one of those sessions has exited.
+    ///
+    /// Stored as the session GUID string, matching <see cref="SessionId"/>, so a parent joins to its
+    /// own row in this table. NOT a foreign key: a parent's row can be pruned by the 90-day retention
+    /// while a child's remains, and a dangling id is a truthful record of a parent we no longer keep -
+    /// a constraint here would force the retention sweep to either lie or cascade.
+    /// </summary>
+    public string? ParentSessionId { get; set; }
 
     /// <summary>Director-measured session creation time (SessionDto.CreatedAt) - a real measurement.</summary>
     public DateTime StartedAtUtc { get; set; }
@@ -79,6 +115,57 @@ public sealed class SessionHistoryEntity : TenantScopedEntity
     /// stretches (SessionDto.CumulativeIdleSeconds, internal#625 phase 4), as last pushed. Null when
     /// the owning Director predates the clock.</summary>
     public double? CumulativeIdleSeconds { get; set; }
+
+    /// <summary>
+    /// How many times the session started waiting on the user (devthrottle_internal issue #982) - the
+    /// matched pair to <see cref="CumulativeIdleSeconds"/>. Seconds waited is the total; this is the
+    /// number of times, and the two together are what make either readable. High-water mark, like the
+    /// counters above: a Director restart resets its own counter, and the run's record must not follow
+    /// it down. Null when the owning Director predates the counter.
+    /// </summary>
+    public long? WaitingStretchCount { get; set; }
+
+    /// <summary>
+    /// Character volume of input submitted into this session (issue #982), operator plus agent-driven,
+    /// summed from the pushed input stats. Turn counts alone flatten a one-word "yes" and a pasted
+    /// design document into the same number. High-water mark; null when never reported.
+    /// </summary>
+    public long? InputCharacterCount { get; set; }
+
+    /// <summary>
+    /// This session's cumulative token spend (issue #982), from the pushed
+    /// <c>SessionDto.TokenTotals</c>. Spend existed globally, by hour and by model, but not per
+    /// session - which is what "cost per merged change" needs, joined against the commits and pull
+    /// requests already on this row (the session-to-forge join product strategy decision 27 calls ours).
+    ///
+    /// ADDITIVE tokens only, and all four kept apart rather than pre-summed: cache reads and cache
+    /// creation are priced differently from plain input, so a single total could not be turned back
+    /// into money. High-water marks; null when the agent's driver reports no usage (only Claude's does
+    /// today).
+    /// </summary>
+    public long? InputTokens { get; set; }
+
+    /// <summary>Cumulative output tokens. See <see cref="InputTokens"/>.</summary>
+    public long? OutputTokens { get; set; }
+
+    /// <summary>Cumulative cache-read input tokens. See <see cref="InputTokens"/>.</summary>
+    public long? CacheReadTokens { get; set; }
+
+    /// <summary>Cumulative cache-creation input tokens. See <see cref="InputTokens"/>.</summary>
+    public long? CacheCreationTokens { get; set; }
+
+    /// <summary>
+    /// The FULLEST the session's context window was observed to be (issue #982), in tokens.
+    ///
+    /// A GAUGE, not spend, and that is why it is a peak rather than a sum: context occupancy rises
+    /// through a turn and DROPS when the agent compacts, so adding the readings together would produce
+    /// a number that means nothing. Keeping the maximum is the honest reduction, and it is the fact
+    /// behind "did this session run out of room" - a session whose peak sits near its model's window
+    /// was working under pressure whether or not it visibly compacted.
+    ///
+    /// Null when the agent's driver reports no context reading.
+    /// </summary>
+    public long? PeakContextTokens { get; set; }
 
     /// <summary>The first user prompt, trimmed to one line - description source number two (#1862).
     /// Set once from the prompt-log ingest and never overwritten.</summary>

--- a/src/CcDirector.Gateway/Data/Migrations/20260727191017_AddSessionOriginColumns.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727191017_AddSessionOriginColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727191017_AddSessionOriginColumns")]
+    partial class AddSessionOriginColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");
@@ -739,12 +742,6 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.Property<string>("BranchesJson")
                         .HasColumnType("TEXT");
 
-                    b.Property<long?>("CacheCreationTokens")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("CacheReadTokens")
-                        .HasColumnType("INTEGER");
-
                     b.Property<string>("CommitsJson")
                         .HasColumnType("TEXT");
 
@@ -767,12 +764,6 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.Property<string>("FirstPromptLine")
                         .HasColumnType("TEXT");
 
-                    b.Property<long?>("InputCharacterCount")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("InputTokens")
-                        .HasColumnType("INTEGER");
-
                     b.Property<string>("LastActivityState")
                         .HasColumnType("TEXT");
 
@@ -788,9 +779,6 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.Property<string>("MachineName")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid?>("MissionId")
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("MissionName")
                         .HasColumnType("TEXT");
 
@@ -803,14 +791,8 @@ namespace CcDirector.Gateway.Data.Migrations
                     b.Property<string>("OriginSurface")
                         .HasColumnType("TEXT");
 
-                    b.Property<long?>("OutputTokens")
-                        .HasColumnType("INTEGER");
-
                     b.Property<string>("ParentSessionId")
                         .HasColumnType("TEXT");
-
-                    b.Property<long?>("PeakContextTokens")
-                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PullRequestsJson")
                         .HasColumnType("TEXT");
@@ -846,9 +828,6 @@ namespace CcDirector.Gateway.Data.Migrations
                         .HasColumnType("TEXT");
 
                     b.Property<long?>("TurnCount")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("WaitingStretchCount")
                         .HasColumnType("INTEGER");
 
                     b.Property<string>("WhatWasBuiltJson")

--- a/src/CcDirector.Gateway/Data/Migrations/20260727191017_AddSessionOriginColumns.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727191017_AddSessionOriginColumns.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionOriginColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OriginKind",
+                table: "session_history",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OriginSurface",
+                table: "session_history",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ParentSessionId",
+                table: "session_history",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OriginKind",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "OriginSurface",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "ParentSessionId",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Data/Migrations/20260727193912_AddSessionCostAndInterruptionColumns.Designer.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727193912_AddSessionCostAndInterruptionColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CcDirector.Gateway.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CcDirector.Gateway.Data.Migrations
 {
     [DbContext(typeof(GatewayDbContext))]
-    partial class GatewayDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727193912_AddSessionCostAndInterruptionColumns")]
+    partial class AddSessionCostAndInterruptionColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/src/CcDirector.Gateway/Data/Migrations/20260727193912_AddSessionCostAndInterruptionColumns.cs
+++ b/src/CcDirector.Gateway/Data/Migrations/20260727193912_AddSessionCostAndInterruptionColumns.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CcDirector.Gateway.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionCostAndInterruptionColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "CacheCreationTokens",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "CacheReadTokens",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "InputCharacterCount",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "InputTokens",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "MissionId",
+                table: "session_history",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "OutputTokens",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "PeakContextTokens",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "WaitingStretchCount",
+                table: "session_history",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CacheCreationTokens",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "CacheReadTokens",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "InputCharacterCount",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "InputTokens",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "MissionId",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "OutputTokens",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "PeakContextTokens",
+                table: "session_history");
+
+            migrationBuilder.DropColumn(
+                name: "WaitingStretchCount",
+                table: "session_history");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2728,7 +2728,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // DevThrottle Stats: the always-available private dashboard (/stats) and its JSON (/stats/data).
         // A self-contained embedded page, so it works even on a plain dev build with no React wwwroot.
         // Mapped before the mobile/cockpit catch-alls so the explicit routes win.
-        Stats.StatsPageEndpoint.Map(_app, InputStats, SessionConcurrency, _tenantSettingsResolver, _tenantBoundary);
+        // The work-history store rides along (devthrottle_internal issue #982) as the source of the
+        // session-ORIGIN counts: how sessions came to exist, which only the durable per-session record
+        // can answer - the in-memory aggregates behind the rest of this feed count turns, and a session
+        // is born exactly once.
+        Stats.StatsPageEndpoint.Map(_app, InputStats, SessionConcurrency, _tenantSettingsResolver, _tenantBoundary, _sessionHistory);
 
         // The prompt log (issue #1551): Directors push what they captured to POST /prompts, and anyone
         // wanting history reads GET /prompts. It lives here, not on a Director, because the Gateway is

--- a/src/CcDirector.Gateway/History/SessionHistoryFold.cs
+++ b/src/CcDirector.Gateway/History/SessionHistoryFold.cs
@@ -104,7 +104,14 @@ public static class SessionHistoryFold
         AgentKind = e.AgentKind,
         Model = e.Model,
         MissionName = e.MissionName,
+        MissionId = e.MissionId,
         SessionRole = e.SessionRole,
+        // Birth facts (issue #982). Passed through as stored, INCLUDING null: a row from before the
+        // fields existed is not the same as a session whose origin was asked for and unknown, and the
+        // reader is entitled to tell them apart.
+        OriginKind = e.OriginKind,
+        OriginSurface = e.OriginSurface,
+        ParentSessionId = e.ParentSessionId,
         StartedAtUtc = e.StartedAtUtc,
         LastActivityUtc = e.LastActivityUtc,
         LastSeenUtc = e.LastSeenUtc,
@@ -117,6 +124,13 @@ public static class SessionHistoryFold
         TurnCount = e.TurnCount,
         AgentTurnCount = e.AgentTurnCount,
         IdleSeconds = e.CumulativeIdleSeconds,
+        WaitingStretchCount = e.WaitingStretchCount,
+        InputCharacterCount = e.InputCharacterCount,
+        InputTokens = e.InputTokens,
+        OutputTokens = e.OutputTokens,
+        CacheReadTokens = e.CacheReadTokens,
+        CacheCreationTokens = e.CacheCreationTokens,
+        PeakContextTokens = e.PeakContextTokens,
         SummaryKind = string.IsNullOrEmpty(e.SummaryKind) ? null : e.SummaryKind,
         SummaryIsPartial = e.SummaryIsPartial,
         SummaryText = e.SummaryText,

--- a/src/CcDirector.Gateway/History/SessionHistoryRecorder.cs
+++ b/src/CcDirector.Gateway/History/SessionHistoryRecorder.cs
@@ -219,7 +219,15 @@ public sealed class SessionHistoryRecorder
     /// time are deliberately absent - see the class doc.</summary>
     private static string MaterialSignature(SessionDto s)
         => string.Join('|', s.Name, s.Number?.ToString(), s.MachineName, s.RepoPath, s.RepoName,
-            s.Agent, s.CurrentModel, s.MissionName, s.ExplicitRole);
+            s.Agent, s.CurrentModel, s.MissionName, s.ExplicitRole,
+            // The birth facts (devthrottle_internal issue #982). They are stamped before launch and
+            // never change, so on the normal path they arrive with the first push and this costs
+            // nothing. What it buys is the ONE case where they do not: a session first seen through a
+            // Director too old to report them, then re-reported by a current one mid-upgrade. Without
+            // this the fill-in waits for the five-minute freshness heartbeat; with it the row is
+            // corrected on the next push. The store's write-once guard is what makes adding them here
+            // safe - a change in these can only ever fill a blank, never overwrite a recorded value.
+            s.OriginKind, s.OriginSurface, s.ParentSessionId);
 
     private static string Key(TenantId tenant, string id) => $"{tenant.Value}|{id}";
 }

--- a/src/CcDirector.Gateway/History/SessionHistoryStore.cs
+++ b/src/CcDirector.Gateway/History/SessionHistoryStore.cs
@@ -73,7 +73,27 @@ public sealed class SessionHistoryStore
             entity.AgentKind = string.IsNullOrWhiteSpace(session.Agent) ? entity.AgentKind : session.Agent;
             entity.Model = string.IsNullOrWhiteSpace(session.CurrentModel) ? entity.Model : session.CurrentModel;
             entity.MissionName = string.IsNullOrWhiteSpace(session.MissionName) ? entity.MissionName : session.MissionName;
+            // The mission KEY beside the name (issue #982): a name reads well but cannot be joined on -
+            // missions get renamed, and two can share a name. Unknown never overwrites known.
+            entity.MissionId = session.MissionId ?? entity.MissionId;
             entity.SessionRole = string.IsNullOrWhiteSpace(session.ExplicitRole) ? entity.SessionRole : session.ExplicitRole;
+            // Birth facts (devthrottle_internal issue #982). WRITE-ONCE, unlike everything around them:
+            // these describe the create call, so the first push that carries them is as good as the
+            // last, and a later push that lost them (an older Director taking over mid-upgrade, a
+            // reconnect from a build that predates the fields) must not be able to blank them. The
+            // guard is on the STORED value being empty, not on first-sight, so a row created by an old
+            // Director is still filled in the moment a new one reports the same session.
+            //
+            // "unknown" counts as a value here and is not overwritten later. It is the honest answer for
+            // a create path that did not say, and letting a subsequent push replace it would mean the
+            // recorded origin depended on which push happened to arrive - the same fact reading
+            // differently run to run.
+            if (string.IsNullOrEmpty(entity.OriginKind) && !string.IsNullOrWhiteSpace(session.OriginKind))
+                entity.OriginKind = session.OriginKind;
+            if (string.IsNullOrEmpty(entity.OriginSurface) && !string.IsNullOrWhiteSpace(session.OriginSurface))
+                entity.OriginSurface = session.OriginSurface;
+            if (string.IsNullOrEmpty(entity.ParentSessionId) && !string.IsNullOrWhiteSpace(session.ParentSessionId))
+                entity.ParentSessionId = session.ParentSessionId;
             // CreatedAt is the Director-measured start and is stable; keep the first non-default value.
             if (entity.StartedAtUtc == default && session.CreatedAt != default)
                 entity.StartedAtUtc = Utc(session.CreatedAt);
@@ -90,6 +110,28 @@ public sealed class SessionHistoryStore
                 entity.AgentTurnCount = agentTurns;
             if (session.CumulativeIdleSeconds is { } idle && (entity.CumulativeIdleSeconds is not { } ci || idle > ci))
                 entity.CumulativeIdleSeconds = idle;
+            // The remaining per-session facts issue #982 asked for, all on the SAME high-water-mark
+            // rule as the two above and for the same reason: a Director restart begins its counters
+            // again at zero, and a monotonic record must not follow them down. Null is unknown and
+            // never overwrites a known value.
+            if (session.WaitingStretchCount is { } waits && (entity.WaitingStretchCount is not { } ws || waits > ws))
+                entity.WaitingStretchCount = waits;
+            if (CharacterCountOf(session) is { } chars && (entity.InputCharacterCount is not { } ic || chars > ic))
+                entity.InputCharacterCount = chars;
+            if (session.TokenTotals is { } tokens)
+            {
+                // Cumulative spend, kept per kind rather than pre-summed: cache reads and cache
+                // creation are priced differently from plain input, so one total could never be turned
+                // back into money - which is the whole point of keeping spend per session.
+                if (entity.InputTokens is not { } it || tokens.InputTokens > it) entity.InputTokens = tokens.InputTokens;
+                if (entity.OutputTokens is not { } ot || tokens.OutputTokens > ot) entity.OutputTokens = tokens.OutputTokens;
+                if (entity.CacheReadTokens is not { } crt || tokens.CacheReadTokens > crt) entity.CacheReadTokens = tokens.CacheReadTokens;
+                if (entity.CacheCreationTokens is not { } cct || tokens.CacheCreationTokens > cct) entity.CacheCreationTokens = tokens.CacheCreationTokens;
+                // Context occupancy is a GAUGE - it rises through a turn and DROPS on a compaction -
+                // so the maximum is the only reduction of it that means anything. Summing observations
+                // of a gauge produces a number with no unit.
+                if (entity.PeakContextTokens is not { } pct || tokens.ContextTokens > pct) entity.PeakContextTokens = tokens.ContextTokens;
+            }
             entity.LastSeenUtc = nowUtc;
 
             ctx.SaveChanges();
@@ -102,6 +144,16 @@ public sealed class SessionHistoryStore
         var stats = session.InputStats;
         if (stats is null) return null;
         return stats.Buckets.Sum(b => b.Turns) + stats.AgentDrivenTurns;
+    }
+
+    /// <summary>Total input CHARACTER volume (operator plus agent-driven) off the pushed stats, or
+    /// null (issue #982). Counted on the same population as <see cref="TurnCountOf"/> so the two are
+    /// comparable: a turn count alone cannot tell a one-word "yes" from a pasted design document.</summary>
+    public static long? CharacterCountOf(SessionDto session)
+    {
+        var stats = session.InputStats;
+        if (stats is null) return null;
+        return stats.Buckets.Sum(b => b.Characters) + stats.AgentDrivenCharacters;
     }
 
     /// <summary>
@@ -353,6 +405,55 @@ public sealed class SessionHistoryStore
         }
     }
 
+    /// <summary>
+    /// How the sessions that STARTED in the inclusive UTC window came to exist (devthrottle_internal
+    /// issue #982) - the counts behind "what share of sessions do agents start", plus how many carry a
+    /// lineage edge at all.
+    ///
+    /// Counted by START, not by overlap. <see cref="ReadRange"/> deliberately returns every session
+    /// whose life TOUCHED the window, because "what was I working on Tuesday" includes a session that
+    /// began on Monday. This question is a different one - how sessions come into being - and a session
+    /// is born once. Using the overlap window here would count a long-running session in every window
+    /// it survived into, which for a fleet whose agent-started sessions are typically short and whose
+    /// human-started ones are long would bias the share the wrong way, quietly, and by more the wider
+    /// the window.
+    ///
+    /// A row that predates the origin fields is counted under the null key, kept apart from "unknown":
+    /// one means the Gateway was not asking, the other that it asked and got nothing. A caller
+    /// reporting a share must say what it did with both.
+    /// </summary>
+    public SessionOriginTotals OriginTotals(DateTime fromUtc, DateTime toUtc)
+    {
+        lock (_gate)
+        {
+            using var ctx = _db.CreateContext();
+            var rows = ctx.SessionHistory.AsNoTracking()
+                .Where(e => e.StartedAtUtc >= fromUtc && e.StartedAtUtc <= toUtc)
+                .Select(e => new { e.OriginKind, e.OriginSurface, e.ParentSessionId, e.StartedAtUtc })
+                .ToList();
+
+            var byKind = new Dictionary<string, int>(StringComparer.Ordinal);
+            var bySurface = new Dictionary<string, int>(StringComparer.Ordinal);
+            var withParent = 0;
+            DateTime? earliest = null;
+            foreach (var r in rows)
+            {
+                var kind = string.IsNullOrEmpty(r.OriginKind) ? NotRecorded : r.OriginKind;
+                var surface = string.IsNullOrEmpty(r.OriginSurface) ? NotRecorded : r.OriginSurface;
+                byKind[kind] = byKind.TryGetValue(kind, out var k) ? k + 1 : 1;
+                bySurface[surface] = bySurface.TryGetValue(surface, out var s) ? s + 1 : 1;
+                if (!string.IsNullOrEmpty(r.ParentSessionId)) withParent++;
+                if (earliest is not { } e || r.StartedAtUtc < e) earliest = r.StartedAtUtc;
+            }
+
+            return new SessionOriginTotals(fromUtc, toUtc, earliest, rows.Count, withParent, byKind, bySurface);
+        }
+    }
+
+    /// <summary>The bucket key for a row written before the origin fields existed. Deliberately NOT
+    /// "unknown", which is a recorded answer.</summary>
+    public const string NotRecorded = "notRecorded";
+
     /// <summary>One session's folded record, or null.</summary>
     public WorkHistorySessionDto? Get(string sessionId)
     {
@@ -432,3 +533,35 @@ public sealed class SessionHistoryStore
             _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
         };
 }
+
+/// <summary>
+/// How the sessions born in one window came to exist (devthrottle_internal issue #982), as counted by
+/// <see cref="SessionHistoryStore.OriginTotals"/>.
+///
+/// Counts only - no share, no percentage. The interesting ratio ("agents start X% of sessions") depends
+/// on what its author decides to do with the <see cref="SessionHistoryStore.NotRecorded"/> and
+/// "unknown" buckets, and there is no single right answer: excluding them measures the sessions we can
+/// account for, including them measures the fleet. Computing one here would fix that choice for every
+/// reader and hide it from all of them, which is how a number becomes a claim nobody can check.
+/// </summary>
+/// <param name="FromUtc">Inclusive start of the birth window ASKED FOR - not where the record
+/// actually begins. See <paramref name="EarliestStartUtc"/>.</param>
+/// <param name="ToUtc">Inclusive end of the birth window.</param>
+/// <param name="EarliestStartUtc">The oldest birth actually found, or null when the window is empty.
+/// This is where the RECORD begins, which is rarely where the window does and is never where the fleet
+/// does: retention prunes from the front, and the origin fields only started being written the day they
+/// shipped. A caller quoting a share over "all time" has to say this date out loud, or it is quoting a
+/// denominator it has not got.</param>
+/// <param name="Sessions">How many sessions started in the window - the denominator.</param>
+/// <param name="WithParent">How many of those name a parent session. Never larger than the "agent"
+/// count in <paramref name="ByKind"/>: a parent is only kept on an agent origin.</param>
+/// <param name="ByKind">Session count per origin kind, plus the not-recorded bucket.</param>
+/// <param name="BySurface">Session count per origin surface, plus the not-recorded bucket.</param>
+public sealed record SessionOriginTotals(
+    DateTime FromUtc,
+    DateTime ToUtc,
+    DateTime? EarliestStartUtc,
+    int Sessions,
+    int WithParent,
+    IReadOnlyDictionary<string, int> ByKind,
+    IReadOnlyDictionary<string, int> BySurface);

--- a/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -44,6 +45,14 @@ public sealed class DirectorCronSessionStarter : ICronSessionStarter
             // finishes with nothing needing a human, so an hourly job stops piling leftover sessions into
             // the rail. The job can opt out (AutoDismiss=false) to keep the run open like a normal session.
             AutoDismiss = job.Action.AutoDismiss,
+            // Session origin (devthrottle_internal issue #982). A fired schedule is the third origin:
+            // nobody was at a keyboard and no session made the call, so it is neither "human" nor
+            // "agent". Recording it as either would corrupt the one number the field exists to answer -
+            // what share of sessions agents start - and on a fleet with hourly jobs the error would not
+            // be small. This is a measurement, not a default: this code path only ever runs for a cron
+            // firing, so it knows both facts for certain.
+            Origin = SessionOriginKinds.Schedule,
+            OriginSurface = SessionOriginSurfaces.Cron,
         };
 
         FileLog.Write($"[DirectorCronSessionStarter] start: job={job.Id}, machine={job.Target.Machine}, repo={job.Action.RepoPath}, seed={job.Action.Seed}");

--- a/src/CcDirector.Gateway/Running/DirectorImplSessionDriver.cs
+++ b/src/CcDirector.Gateway/Running/DirectorImplSessionDriver.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
@@ -51,6 +52,12 @@ public sealed class DirectorImplSessionDriver : IImplSessionDriver
             // implementation-loop skill drives the whole DEV->QA loop for this item in its source
             // mode and prints the IMPL-LOOP-TERMINAL sentinel when it terminates.
             PrePrompt = seedPrompt,
+            // Session origin (devthrottle_internal issue #982). A work-list item opening its own
+            // session is automation, like cron: no person asked for this one and no agent session made
+            // the call - the runner did, working its way down a list. Certain on this path, which runs
+            // for nothing else.
+            Origin = SessionOriginKinds.Schedule,
+            OriginSurface = SessionOriginSurfaces.Workflow,
         };
 
         var (ok, body, error) = await _verb.CreateSessionAsync(req, ct);

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -62,6 +62,59 @@ public static class StatsPageEndpoint
             statusCode: StatusCodes.Status403Forbidden);
 
     /// <summary>
+    /// The session-origin block of the feed (devthrottle_internal issue #982): how sessions came to
+    /// exist, over the whole window the work-history table retains and over the last seven days.
+    ///
+    /// TWO WINDOWS, ON PURPOSE. The all-time counts are the ones a claim gets made from, and they are
+    /// the ones that will be wrong first: the record only began the day the fields shipped, so an
+    /// all-time share silently mixes "before we were asking" into the denominator forever. The
+    /// seven-day window is the one that is honestly comparable to itself week over week, and it states
+    /// its own bounds so a reader can see how much record there actually is.
+    ///
+    /// The all-time block reports where the RECORD begins (the oldest birth actually stored), not the
+    /// floor of the query. Those differ by more than a detail: retention prunes from the front, and the
+    /// origin fields only began being written the day they shipped, so quoting a share over "all time"
+    /// without that date is quoting a denominator the Gateway has not got. The floor of the query is
+    /// <see cref="DateTime.MinValue"/> deliberately - anything higher would silently drop a row whose
+    /// start time is missing rather than showing it in the not-recorded bucket where it belongs.
+    /// </summary>
+    private static object OriginBlock(History.SessionHistoryStore sessionHistory)
+    {
+        var now = DateTime.UtcNow;
+        var allTime = sessionHistory.OriginTotals(DateTime.MinValue, now);
+        var week = sessionHistory.OriginTotals(now.AddDays(-7), now);
+        return new
+        {
+            // What each bucket key means, served beside the numbers so a reader never has to guess
+            // whether "notRecorded" is a kind of session or the absence of a record.
+            notRecordedMeans = "the session's row predates the origin fields - the Gateway was not "
+                             + "asking. Distinct from \"unknown\", which is a recorded answer: the "
+                             + "create path was asked and had nothing to say.",
+            allTime = new
+            {
+                // Where the RECORD begins, not where the query floor was set. Null when nothing is
+                // stored at all - honestly empty rather than dated to the epoch.
+                recordBeginsUtc = allTime.EarliestStartUtc,
+                toUtc = allTime.ToUtc,
+                sessions = allTime.Sessions,
+                withParentSession = allTime.WithParent,
+                byKind = allTime.ByKind,
+                bySurface = allTime.BySurface,
+            },
+            last7Days = new
+            {
+                sinceUtc = week.FromUtc,
+                toUtc = week.ToUtc,
+                recordBeginsUtc = week.EarliestStartUtc,
+                sessions = week.Sessions,
+                withParentSession = week.WithParent,
+                byKind = week.ByKind,
+                bySurface = week.BySurface,
+            },
+        };
+    }
+
+    /// <summary>
     /// Maps the two stats routes. Returns the group builder they were mapped through (kept for callers that
     /// compose onto it). The hosted deny is gone: the data route serves the caller's own tenant's totals and
     /// answers 403 when no tenant resolves.
@@ -75,7 +128,12 @@ public static class StatsPageEndpoint
         // The tenant boundary the data route resolves the CALLER's tenant through. Null (self-host, older
         // callers, tests) means the single Local tenant; on hosted it resolves the authenticated device key's
         // tenant and answers 403 when there is none - never falling back to Local.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // The durable work-history store (devthrottle_internal issue #982), source of the session-origin
+        // counts. Null (older callers, tests) omits that block from the feed entirely rather than serving
+        // zeroes - a zero here would read as "no agent ever started a session", which is a different and
+        // much more interesting claim than "this Gateway is not keeping the record".
+        History.SessionHistoryStore? sessionHistory = null)
     {
         FileLog.Write($"[StatsPageEndpoint] mapping /stats (redirect to /your-throttle) and /stats/data; hosted={GatewayHostedMode.IsHosted} - the data route serves the caller's own tenant totals, 403 when unresolved (issue #1848 deny retired)");
 
@@ -142,6 +200,13 @@ public static class StatsPageEndpoint
                 // them is the leverage the owner actually gets per turn they spend.
                 agentDrivenTurns = aggregator.AgentDrivenUsage(tenant).Turns,
                 agentDrivenCharacters = aggregator.AgentDrivenUsage(tenant).Characters,
+                // devthrottle_internal issue #982: how the fleet's sessions CAME TO EXIST, over the
+                // durable work-history window. The agent-driven numbers above count turns - who does
+                // the talking once a session is running. This counts births - who decides a session
+                // should exist at all, which is the step that turns one person into a supervisor of
+                // twenty-two. Null when no history store is wired; see the parameter note above for
+                // why that is not zero.
+                sessionOrigins = sessionHistory is null ? null : OriginBlock(sessionHistory),
                 notCaptured = NotCaptured,
             });
         });

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -586,6 +586,22 @@ def spawn_session(
         body["commandArgs"] = command_args
     if controller_session_id:
         body["controllerSessionId"] = controller_session_id
+    # Session origin and lineage (devthrottle_internal issue #982). This process is the only place
+    # that can tell a session-initiated spawn from a human one: CC_SESSION_ID is injected into a
+    # session's environment at birth and is absent from a human's own shell, so its presence IS the
+    # answer. Stated here rather than inferred at the Director, which sees an identical HTTP request
+    # either way and would have to guess.
+    #
+    # NOT the same as controllerSessionId above, and deliberately sent separately. That one asks for a
+    # live supervision relationship and is dropped by --standalone; this one records who made the call
+    # and survives it. A session spawning a deliberate human-facing peer is exactly the case where the
+    # two must differ - it is still an agent starting a session, which is the thing being counted.
+    if cc_session:
+        body["origin"] = "agent"
+        body["parentSessionId"] = cc_session
+    else:
+        body["origin"] = "human"
+    body["originSurface"] = "cli"
     # Automatic session roles: forward an explicit --role VERBATIM to the Director, which validates it
     # against Standalone/Manager/Worker/Architect and rejects an unknown value (never a silent drop).
     if role:

--- a/tools/cc-devthrottle/tests/test_spawn_ops.py
+++ b/tools/cc-devthrottle/tests/test_spawn_ops.py
@@ -106,3 +106,42 @@ def test_type_option_is_removed(monkeypatch):
     result = runner.invoke(app, ["session", "spawn", "C:/repo", "--type", "Developer"])
     assert result.exit_code != 0
     assert "No such option" in result.output or "--type" in result.output
+
+
+# --- Session origin and lineage (devthrottle_internal issue #982) ---
+# This process is the only place that can tell a session-initiated spawn from a human one:
+# CC_SESSION_ID is injected into a session's environment at birth and is absent from a human's
+# own shell, so its presence IS the answer. The Director sees an identical HTTP request either
+# way and would have to guess, which is why the CLI states it.
+
+
+def test_session_initiated_spawn_records_the_agent_origin_and_its_parent(monkeypatch, captured):
+    _spawn(monkeypatch, cc_session="sess-A")
+    assert captured.get("origin") == "agent"
+    assert captured.get("parentSessionId") == "sess-A"
+    assert captured.get("originSurface") == "cli"
+
+
+def test_human_spawn_records_the_human_origin_and_no_parent(monkeypatch, captured):
+    _spawn(monkeypatch, cc_session=None)
+    assert captured.get("origin") == "human"
+    assert "parentSessionId" not in captured
+    assert captured.get("originSurface") == "cli"
+
+
+def test_standalone_keeps_the_lineage_even_though_it_drops_the_controller(monkeypatch, captured):
+    # The case that separates lineage from supervision. --standalone deliberately creates a
+    # human-facing PEER with no controller, so nothing about the running session says an agent
+    # made it. It is still an agent-started session, and that is exactly what is being counted.
+    _spawn(monkeypatch, cc_session="sess-A", standalone=True)
+    assert "controllerSessionId" not in captured
+    assert captured.get("origin") == "agent"
+    assert captured.get("parentSessionId") == "sess-A"
+
+
+def test_an_explicit_controller_does_not_change_who_made_the_call(monkeypatch, captured):
+    # --controlled-by names who SUPERVISES the new session; the parent is who ASKED for it. A
+    # session seating its worker under a different manager is still the session that spawned it.
+    _spawn(monkeypatch, cc_session="sess-A", controlled_by="explicit-manager-id")
+    assert captured.get("controllerSessionId") == "explicit-manager-id"
+    assert captured.get("parentSessionId") == "sess-A"


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#982 (the P1s and everything else that could be measured honestly; see "Left for later" below).

## Why

Nothing has ever recorded **who asked for a session to exist**. A session the owner opened and a session another agent opened were indistinguishable in the record, which left the product unable to evidence the most interesting thing about itself - agents start agents, and that is how one person ends up supervising twenty-two of them. It was a memory, not a number. And with no record of *which* agent started a session, twenty-two sessions read as twenty-two unrelated things rather than the three or four operations they actually were.

## What lands

Three birth facts on every session, stamped **pre-launch** and kept for the life of the record:

| | |
|---|---|
| `originKind` | who asked - `human` / `agent` / `schedule` / `unknown` |
| `originSurface` | where from - `desktop` / `cockpit` / `phone` / `cli` / `cron` / `workflow` / `api` / `unknown` |
| `parentSessionId` | which session made the call, when an agent did |

They ride the roster push, land on the durable `session_history` row, and are served on the history API and in a new `sessionOrigins` block on `GET /stats/data`.

Pre-launch is not cosmetic: the first roster push can leave before create returns, and the history row is written on first sight. A stamp after create would race it, and the row that lost would say `unknown` forever - first sight happens once.

## Three judgement calls worth reviewing

**A third origin kind.** The issue named `human` and `agent`. A fired cron is neither, and folding it into either corrupts the one number these fields exist to produce - on a fleet with hourly jobs, by a lot. `unknown` is likewise a *recorded answer*, rendered as one and never quietly resolved to `human`. A mistyped origin is **refused**, not landed in the unknown bucket where it would be indistinguishable from an honest older caller.

**Lineage is one field, not the two the issue listed.** `originAgentSessionId` and `parentSessionId` are the same fact - the session that made the create call *is* the parent - and storing it twice would only let the copies disagree.

It is deliberately distinct from the existing `controllerSessionId`, which is a live supervision relationship that changes how a session is painted. The two carry the same id on an ordinary spawn and diverge on `--standalone`, where an agent starts a deliberate human-facing peer: no controller, but an agent still started it, and that is exactly the case being counted.

**Each path states only what it can prove.**

- The **CLI** reads `CC_SESSION_ID` - injected into a session's environment at birth, absent from a human's shell - so its presence *is* the answer. Stated there rather than at the Director, which sees an identical HTTP request either way and would have to guess.
- The **Gateway spawn relay** overwrites from the *verified* per-device key when the caller is a signed-in phone or browser (the rule `PromptRequest.Surface` already follows), and leaves every other caller untouched. That second half is the one that matters: a remote agent spawn arrives relayed by its own Director on a `workstation` key, and overwriting there would erase lineage on precisely the cross-machine spawns that make it worth having. Pinned by a negative-control test.
- **Cron**, the **work-list runner** and the **desktop** are certain by construction and say so.
- **Handover** and **crash-restore** state their surface and leave the kind `unknown` - neither can tell a person moving work from a session handing itself over. The source session is deliberately *not* recorded as the parent: in a handover the source is the session being *left*, and putting it there would make the lineage tree mean two things at once.

## Write-once on the history row

The birth facts describe the create call, so the first push carrying them is as good as the last - and a later push that lost them (an older Director adopting the session mid-upgrade) must not be able to blank them. The guard is on the *stored* value being empty rather than on first sight, so a row an old Director created is filled in the moment a current one reports the same session. Both directions are tested.

## Also closes, from the same issue

- **Interruption count** beside the waiting clock, counted when a wait *opens* so a session sitting on the owner right now is counted. Twelve five-minute waits and one hour-long wait read identically on the clock and are nothing alike to live with.
- **Per-session token spend**, kept per kind rather than pre-summed - cache reads are priced differently, so one total could not be turned back into money. With the commits and pull requests already on the row, this is the cost-per-merged-change join.
- **Peak context occupancy** as a *peak*, never a sum: occupancy is a gauge that drops on compaction, and adding the readings gives a number with no unit.
- **Input character volume**, and **`missionId`** beside the mission name, since a name cannot be joined on.

## The stats block reports counts, never a share

What to do with the `unknown` and `notRecorded` buckets is the reader's call, and computing one answer here would fix that choice for everyone and hide it from all of them. It also reports where the **record** begins - the oldest birth actually stored - rather than the floor of the query, because retention prunes from the front and these fields only start being written now. An "all time" share without that date quotes a denominator we have not got.

## Left for later, deliberately

- **Time-to-first-human-response per red event.** The Gateway holds `NeedsYouSince` in memory and clears it on exit from red; there is no history of transitions to measure against. That is a feature, not a column.
- **An explicit compaction flag.** Needs per-driver transcript instrumentation; peak context is the honest proxy.
- **No UI.** The Cockpit History page and Your Throttle do not render any of this yet.

## Verification

Migration pair for SQLite and Postgres, both snapshots clean, `has-pending-model-changes` reporting none on either - re-checked after rebasing onto v1.8.1.

Full suites green: Gateway 4277, Core 3777, Avalonia/Engine/HostedAgent/Launcher/Terminal 507, plus 115 Python tests for the CLI.

The new tests are written against the ways this can be quietly wrong rather than loudly broken: a later push blanking a known origin, a relayed agent spawn being rewritten as a human one, a lineage edge lost across a Gateway restart, and a birth count that double-counts long-lived sessions because it counted overlap instead of births.
