### PR TITLE
fix(gateway): stop telling signed-in hosted users they are not signed in (#984)

### DIFF
--- a/src/CcDirector.Core.Tests/Account/GatewayAccountCreditsClientTests.cs
+++ b/src/CcDirector.Core.Tests/Account/GatewayAccountCreditsClientTests.cs
@@ -34,7 +34,9 @@ public sealed class GatewayAccountCreditsClientTests
     [Fact]
     public async Task GetCreditsAsync_SignedIn_ReadsBalance_AndSendsBearer()
     {
-        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceMicros\":5000000,\"lastDebitMicros\":1200}");
+        // balanceAvailable is what gates the balance since issue #984 - "the caller is signed in" and "a
+        // balance was read" became two fields because on the hosted Gateway they differ.
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceAvailable\":true,\"balanceMicros\":5000000,\"lastDebitMicros\":1200}");
         var client = new GatewayAccountCreditsClient(new HttpClient(handler));
 
         var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl, Token = "tok-123" });
@@ -56,13 +58,47 @@ public sealed class GatewayAccountCreditsClientTests
     {
         // A real zero balance (out of credits) is a KNOWN value the readiness check must gate on -
         // distinct from unknown/null.
-        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceMicros\":0}");
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceAvailable\":true,\"balanceMicros\":0}");
         var client = new GatewayAccountCreditsClient(new HttpClient(handler));
 
         var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
 
         Assert.True(credits.SignedIn);
         Assert.Equal(0, credits.BalanceMicros);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_SignedInButBalanceUnavailable_KeepsTheCallerSignedIn_AndTreatsTheBalanceAsUnknown()
+    {
+        // Issue #984, the hosted shape. The Gateway now says, in one body, that the CALLER is signed in and
+        // that no BALANCE could be read - a combination the old single boolean could not express, which is
+        // why hosted customers were shown "not signed in" on a billing surface. The desktop must carry both
+        // facts through: still signed in, balance UNKNOWN (never a fabricated zero, and never blocking - the
+        // authoritative out-of-credits gate is the runtime 402), and the Gateway's own message preserved.
+        var handler = new CapturingHandler(HttpStatusCode.OK,
+            "{\"signedIn\":true,\"balanceAvailable\":false,\"message\":\"Your account is active and your credit balance is unaffected.\"}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(credits.Reachable);
+        Assert.True(credits.SignedIn);
+        Assert.Null(credits.BalanceMicros);
+        Assert.Equal("Your account is active and your credit balance is unaffected.", credits.Error);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_BalanceNotAvailable_IgnoresAnyBalanceInTheBody()
+    {
+        // Defence in depth for the field that now gates the balance: if a body ever carries a figure while
+        // declaring the balance unavailable, the declaration wins. A stale or partial number on a billing
+        // surface is a worse answer than an honest unknown.
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceAvailable\":false,\"balanceMicros\":123}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.Null(credits.BalanceMicros);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Account/DevThrottleAccountService.cs
+++ b/src/CcDirector.Core/Account/DevThrottleAccountService.cs
@@ -95,6 +95,31 @@ public sealed class DevThrottleAccountService
     }
 
     /// <summary>
+    /// Whether ANY credential is stored at all, regardless of whether it is valid, expired, renewable, or
+    /// even decodable. Read locally with NO network call.
+    ///
+    /// This exists to separate two states that used to collapse into one wrong answer (issue #984). An
+    /// account route that finds <see cref="GetAccessTokenForForwarding"/> empty needs to know WHICH of these
+    /// it is looking at: nothing stored (the user really is signed out, and telling them to sign in is
+    /// useful), or something stored that will not forward (an internal inconsistency, where telling them to
+    /// sign in sends them to redo an action that was already done and cannot help). Only the first is a
+    /// sign-out. <see cref="IsLoggedIn"/> cannot answer this - it folds storage, validity and renewability
+    /// into a single boolean and returns false for both.
+    /// </summary>
+    public bool HasStoredCredential()
+    {
+        DevThrottleTokens? tokens;
+        lock (_gate)
+        {
+            tokens = _store.Load();
+        }
+
+        var stored = tokens is not null;
+        FileLog.Write($"[DevThrottleAccountService] HasStoredCredential: {stored} (no network call)");
+        return stored;
+    }
+
+    /// <summary>
     /// Answers "is this install logged in with a genuinely-usable token?" entirely from the cached
     /// credential, with NO outbound network call. Returns true when a stored access token's signature
     /// verifies AND it either has not expired, or is expired-but-well-formed WHILE the background

--- a/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
@@ -22,9 +22,17 @@ namespace CcDirector.Core.Account;
 /// </summary>
 /// <param name="GatewayConfigured">Whether a Gateway URL is configured at all (config.json gateway.url).</param>
 /// <param name="Reachable">Whether the Gateway answered the credits request.</param>
-/// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
+/// <param name="SignedIn">
+/// Whether the CALLER is signed in to DevThrottle (issue #984). NOT "whether a balance could be read" - on
+/// the hosted Gateway the caller is signed in and no balance is readable, and conflating the two is what put
+/// a false "not signed in" on a billing surface. Read <see cref="BalanceMicros"/> for the balance.
+/// </param>
 /// <param name="BalanceMicros">The balance in micro-dollars when known, else null (unknown - do not block).</param>
-/// <param name="Error">A short human-readable reason when not reachable, or null on success.</param>
+/// <param name="Error">
+/// A short human-readable reason the balance is not available - the Gateway is unreachable, or it answered
+/// but could not read a balance (in which case this is the Gateway's own finished message, rendered
+/// verbatim). Null when a balance was read.
+/// </param>
 public sealed record GatewayAccountCredits(
     bool GatewayConfigured,
     bool Reachable,
@@ -97,12 +105,15 @@ public sealed class GatewayAccountCreditsClient
                 return new GatewayAccountCredits(GatewayConfigured: true, Reachable: false, SignedIn: false,
                     BalanceMicros: null, Error: "The Gateway returned an empty credits response.");
 
-            // Signed out -> balance genuinely unknown (never a fabricated zero). Signed in -> the balance
-            // the readiness check gates on (null when the cloud omitted it, still treated as unknown).
-            var balance = dto.SignedIn ? dto.BalanceMicros : null;
-            FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: signedIn={dto.SignedIn}, balanceMicros={(balance is null ? "unknown" : balance.ToString())}");
+            // Issue #984: gate the balance on BalanceAvailable, not on SignedIn. Those are two different
+            // facts and the Gateway now reports them separately - on hosted the caller is signed in AND no
+            // balance is readable, a combination the old single-boolean read could not express. An
+            // unavailable balance is UNKNOWN, never a fabricated zero, and an unknown balance must not block
+            // (the authoritative gate is the runtime 402).
+            var balance = dto.BalanceAvailable ? dto.BalanceMicros : null;
+            FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: signedIn={dto.SignedIn}, balanceAvailable={dto.BalanceAvailable}, balanceMicros={(balance is null ? "unknown" : balance.ToString())}");
             return new GatewayAccountCredits(GatewayConfigured: true, Reachable: true, SignedIn: dto.SignedIn,
-                BalanceMicros: balance, Error: null);
+                BalanceMicros: balance, Error: dto.BalanceAvailable ? null : dto.Message);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/CcDirector.Gateway.Contracts/AccountCreditsDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AccountCreditsDto.cs
@@ -8,18 +8,47 @@ namespace CcDirector.Gateway.Contracts;
 ///
 /// Amounts are in micro-dollars (1_000_000 = $1), the cloud's native unit, so the client formats the
 /// dollar value without any rounding drift.
+///
+/// Issue #984 split TWO facts this contract used to conflate into <see cref="SignedIn"/> alone: whether the
+/// CALLER is signed in, and whether a BALANCE could be read. On the hosted Gateway those differ - the caller
+/// is signed in and the Gateway holds no credential of theirs to read a balance with - and with only one
+/// boolean the endpoint had to pick one, so it served a false "not signed in" to paying customers on a
+/// billing surface. <see cref="BalanceAvailable"/> and <see cref="Message"/> carry the second fact, so the
+/// client can render the truth without deciding what any of it means (CLAUDE.md rule 7).
 /// </summary>
 public sealed class AccountCreditsDto
 {
-    /// <summary>Whether the Gateway holds a valid DevThrottle credential (computed locally).</summary>
+    /// <summary>
+    /// Whether the CALLER is signed in to DevThrottle. NOT "whether this Gateway can read their balance" -
+    /// see <see cref="BalanceAvailable"/> for that. True on the hosted Gateway for any enrolled tenant, even
+    /// when no balance can be read for them.
+    /// </summary>
     public bool SignedIn { get; set; }
 
-    /// <summary>The current balance in micro-dollars, when signed in. Null when not signed in.</summary>
+    /// <summary>
+    /// Whether <see cref="BalanceMicros"/> carries a real balance read from the cloud. False means the
+    /// balance is UNKNOWN and <see cref="Message"/> says why; it never means the balance is zero, and a
+    /// client must not render it as one.
+    /// </summary>
+    public bool BalanceAvailable { get; set; }
+
+    /// <summary>
+    /// The finished, user-facing sentence to show when <see cref="BalanceAvailable"/> is false, computed on
+    /// the Gateway and rendered verbatim. Null when a balance was read. The client never composes its own -
+    /// composing one locally is exactly how a hosted customer came to be shown "not signed in" on a page
+    /// about their money.
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// The current balance in micro-dollars when <see cref="BalanceAvailable"/> is true. Null otherwise -
+    /// unknown, never a fabricated zero.
+    /// </summary>
     public long? BalanceMicros { get; set; }
 
     /// <summary>
-    /// The magnitude (positive micro-dollars) of the most recent debit, when signed in and the ledger
-    /// has one - used to show the last hosted action's cost inline. Null when there is no recent debit.
+    /// The magnitude (positive micro-dollars) of the most recent debit, when a balance was read and the
+    /// ledger has one - used to show the last hosted action's cost inline. Null when there is no recent debit.
     /// </summary>
     public long? LastDebitMicros { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/Account/AccountActingCredentialSelfHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountActingCredentialSelfHostTests.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Issue #984, the SELF-HOST half - the control for
+/// <see cref="HostedAccountRoutesTellTheTruthTests"/>, and the proof of the two acceptance points that are
+/// not about hosted mode at all.
+///
+/// Self-host is where one Gateway holds one account, so "does this Gateway hold a credential?" genuinely IS
+/// a question about the user, and 401 "not signed in ... sign in from the Gateway tray, then retry" is the
+/// right answer - for exactly ONE of the states the old code lumped together. These tests pin the
+/// separation:
+/// <list type="number">
+/// <item>NOTHING STORED - genuinely signed out. 401, and the sign-in instruction is correct and useful. This
+/// test exists so the fix cannot be mistaken for "never say not signed in": the message is not the problem,
+/// saying it to the wrong person is.</item>
+/// <item>SOMETHING STORED THAT WILL NOT FORWARD - an internal inconsistency, never a sign-out. Reporting it
+/// as one is what sent people to redo a sign-in that was already done and could not help.</item>
+/// <item>THE CREDENTIAL IS RENEWED BEFORE ACTING (acceptance 3): an expired token is renewed and the FRESH
+/// one is what reaches the cloud, a healthy token costs no exchange at all, and an expired token that can
+/// never be renewed is NAMED here rather than forwarded dead for the cloud to reject with a message about
+/// some other cause.</item>
+/// </list>
+///
+/// On where the refresh belongs. The issue asked for a refresh "before failing", and putting it literally
+/// there would have been theatre: <see cref="DevThrottleAccountService.RefreshIfNeededAsync"/> deliberately
+/// declines to spend a refresh on an access token that does not verify - it is not ours to renew - and that
+/// is the ONLY state in which the forwarding read comes back empty. A refresh at that point could not change
+/// the outcome in any reachable case. Moved to before the action it does real work, and these tests assert
+/// the work rather than the call.
+///
+/// A note on the hypothesis these tests do NOT encode. The reported 401 was first assumed to be an expired
+/// access token whose refresh had not run. It was not, and it could not have been:
+/// <see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/> returns an expired-but-well-formed
+/// token quite happily - expiry alone never empties it - so an expired token cannot produce this failure even
+/// in principle. It returns null only when nothing is stored or the token does not verify. The refresh
+/// attempt below is still worth having (a renewable credential should be renewed, not refused), but it is a
+/// robustness measure, not the fix, and the tests are written to say which is which.
+///
+/// Everything here runs over a credential service built on an in-memory token store, so no Windows Data
+/// Protection, no registry, no network - the states are provable cross-platform.
+/// </summary>
+public sealed class AccountActingCredentialSelfHostTests
+{
+    /// <summary>An in-memory store so the credential service can be seeded and cleared off Windows.</summary>
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// A refresher the test drives: it records whether it was asked, and either renews with a token the
+    /// caller supplies or reports the exchange unavailable.
+    /// </summary>
+    private sealed class FakeRefresher : ITokenRefresher
+    {
+        private readonly Func<string?>? _renewWith;
+        private readonly bool _misconfigured;
+        public int Calls;
+
+        /// <param name="renewWith">Supplies the renewed access token, or null to renew nothing.</param>
+        /// <param name="misconfigured">
+        /// True to report the exchange PERSISTENTLY broken (issue #911) rather than merely unavailable. The
+        /// distinction matters: unavailable keeps the cached credential usable, misconfigured condemns it.
+        /// </param>
+        public FakeRefresher(Func<string?>? renewWith = null, bool misconfigured = false)
+        {
+            _renewWith = renewWith;
+            _misconfigured = misconfigured;
+        }
+
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref Calls);
+            var renewed = _renewWith?.Invoke();
+            if (renewed is not null)
+                return Task.FromResult(TokenRefreshResult.Success(new DevThrottleTokens(renewed, refreshToken)));
+            return Task.FromResult(_misconfigured ? TokenRefreshResult.Misconfigured : TokenRefreshResult.Unavailable);
+        }
+    }
+
+    /// <summary>
+    /// A cloud stub for the owner-email egress, so a successful send never leaves the process. It records
+    /// the bearer token it was handed, which is how the "renew before acting" tests prove the RENEWED token
+    /// reached the cloud rather than the stale one.
+    /// </summary>
+    private sealed class CloudStub : HttpMessageHandler
+    {
+        public int Calls;
+        public string? SeenBearer;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref Calls);
+            SeenBearer = request.Headers.Authorization?.Parameter;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"data":{"sent":true,"id":"stub-1"}}""", Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static DevThrottleAccountService MakeAccount(DevThrottleTokens? seed, ITokenRefresher refresher)
+    {
+        var service = new DevThrottleAccountService(
+            new InMemoryTokenStore(),
+            new JwtAccessTokenValidator(GatewayTestJwt.SigningSecret),
+            refresher);
+        if (seed is not null)
+            service.StoreTokens(seed);
+        return service;
+    }
+
+    /// <summary>Boots the email route (and the status route, to prove the pair agrees) on an ephemeral port.</summary>
+    private static async Task<(WebApplication app, HttpClient http, CloudStub cloud)> StartAsync(DevThrottleAccountService? account)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var cloud = new CloudStub();
+        AccountStatusEndpoint.Map(app, account);
+        AccountEmailEndpoint.Map(app, account, new AccountNotifyClient(new HttpClient(cloud)));
+        await app.StartAsync();
+
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, cloud);
+    }
+
+    private static Task<HttpResponseMessage> PostEmail(HttpClient http) =>
+        http.PostAsync("/account/email",
+            new StringContent("""{"subject":"issue 984","bodyText":"body"}""", Encoding.UTF8, "application/json"));
+
+    private static async Task<JsonElement> Json(HttpResponseMessage response)
+    {
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    [Fact]
+    public async Task Nothing_stored_is_the_one_state_that_answers_401_and_tells_the_user_to_sign_in()
+    {
+        // The message is not the bug. Here it is TRUE: this Gateway holds no credential, /account/status
+        // agrees, and signing in from the tray is exactly what fixes it. Removing this answer entirely would
+        // trade one wrong statement for another.
+        var refresher = new FakeRefresher();
+        var account = MakeAccount(seed: null, refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            Assert.False((await Json(await http.GetAsync("/account/status"))).GetProperty("signedIn").GetBoolean());
+
+            var resp = await PostEmail(http);
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+
+            var error = (await Json(resp)).GetProperty("error").GetString() ?? "";
+            Assert.Contains("not signed in", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Sign in from the Gateway tray", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, cloud.Calls);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task A_stored_credential_that_will_not_forward_is_reported_as_that_and_never_as_a_sign_out()
+    {
+        // The state the old single conditional could not see. Something IS stored - the user did sign in -
+        // and it cannot be forwarded. Calling that "not signed in" is what sent people to redo a completed
+        // action; naming it lets them do the thing that actually helps.
+        var refresher = new FakeRefresher();
+        var account = MakeAccount(new DevThrottleTokens("not-a-verifiable-token", "refresh-1"), refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            var resp = await PostEmail(http);
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            var error = (await Json(resp)).GetProperty("error").GetString() ?? "";
+            Assert.False(error.Contains("not signed in", StringComparison.OrdinalIgnoreCase),
+                $"a stored-but-unusable credential was reported as a sign-out. Body: {error}");
+            Assert.Contains("holds a DevThrottle credential", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not in a usable state", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, cloud.Calls);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task An_expired_credential_is_renewed_before_acting_and_the_fresh_token_is_what_reaches_the_cloud()
+    {
+        // Acceptance 3, in the place it can actually do work: BEFORE acting, not after failing. Refreshing
+        // only on the way out of a failure would be theatre - the credential service declines to renew a
+        // token that does not verify, which is the only state that empties the forwarding read, so a refresh
+        // at that point could never change anything. Renewing first is what stops the Gateway attaching a
+        // token it could have renewed. The assertion is on WHICH token the cloud saw, because "a refresh
+        // happened" and "the fresh token was used" are different claims and only the second one helps.
+        var expired = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(-2), "owner@example.com", "github");
+        var renewed = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "owner@example.com", "github");
+        var refresher = new FakeRefresher(() => renewed);
+        var account = MakeAccount(new DevThrottleTokens(expired, "refresh-1"), refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            var resp = await PostEmail(http);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.True((await Json(resp)).GetProperty("sent").GetBoolean());
+            Assert.Equal(1, refresher.Calls);
+            Assert.Equal(renewed, cloud.SeenBearer);
+            Assert.NotEqual(expired, cloud.SeenBearer);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task A_healthy_credential_is_not_refreshed_on_the_request_path()
+    {
+        // The cost control for the test above. Renewing before acting must stay a no-op with no network call
+        // when the token has comfortable life left, or every account request would carry an exchange.
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "owner@example.com", "github");
+        var refresher = new FakeRefresher();
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"), refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            Assert.Equal(HttpStatusCode.OK, (await PostEmail(http)).StatusCode);
+            Assert.Equal(0, refresher.Calls);
+            Assert.Equal(jwt, cloud.SeenBearer);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task An_expired_credential_that_cannot_be_renewed_is_named_rather_than_forwarded_dead()
+    {
+        // Issue #911's state, reached through this route: the access token is expired and renewal is
+        // persistently broken by a client-side misconfiguration, so it can never be renewed. The forwarding
+        // read still hands that token over quite happily, so before this change the Gateway would attach a
+        // certainly-dead credential and the user would receive the CLOUD's rejection - a message about some
+        // other cause, which is the same failure mode issue #984 is about, one layer down.
+        var expired = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(-2), "owner@example.com", "github");
+        var refresher = new FakeRefresher(renewWith: null, misconfigured: true);
+        var account = MakeAccount(new DevThrottleTokens(expired, "refresh-1"), refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            var resp = await PostEmail(http);
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            Assert.Equal(0, cloud.Calls);   // nothing dead was sent upstream
+
+            var error = (await Json(resp)).GetProperty("error").GetString() ?? "";
+            Assert.False(error.Contains("not signed in", StringComparison.OrdinalIgnoreCase),
+                $"an unrenewable credential was reported as a sign-out. Body: {error}");
+            Assert.Contains("failing persistently", error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task An_expired_but_renewable_token_still_sends_which_is_why_expiry_was_never_the_cause()
+    {
+        // Pinning the disproof of the original hypothesis so the next person does not re-derive it from
+        // scratch. The reported 401 was first assumed to be an expired access token whose refresh had not
+        // run. Here the refresh cannot run either - the exchange is merely unavailable, as it would be
+        // offline - and the expired token is STILL forwarded and STILL sends, because
+        // GetAccessTokenForForwarding treats expired-but-well-formed as forwardable. Expiry alone therefore
+        // cannot produce a "not signed in" answer, in principle, and never could. If this goes red, the
+        // reasoning recorded in issue #984 needs revisiting - which is exactly why it is asserted.
+        var expired = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(-2), "owner@example.com", "github");
+        var refresher = new FakeRefresher();   // exchange unavailable: nothing renewed, nothing condemned
+        var account = MakeAccount(new DevThrottleTokens(expired, "refresh-1"), refresher);
+
+        var (app, http, cloud) = await StartAsync(account);
+        try
+        {
+            var resp = await PostEmail(http);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal(1, cloud.Calls);
+            Assert.Equal(expired, cloud.SeenBearer);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Status_and_email_agree_on_self_host_when_signed_in()
+    {
+        // The self-host statement of the same invariant the hosted class proves: the two routes must not
+        // contradict each other about whether the caller is signed in.
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "owner@example.com", "github");
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"), new FakeRefresher());
+
+        var (app, http, _) = await StartAsync(account);
+        try
+        {
+            Assert.True((await Json(await http.GetAsync("/account/status"))).GetProperty("signedIn").GetBoolean());
+
+            var resp = await PostEmail(http);
+            Assert.NotEqual(HttpStatusCode.Unauthorized, resp.StatusCode);
+            Assert.DoesNotContain("not signed in", await resp.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task A_host_with_no_credential_store_says_so_instead_of_blaming_the_user()
+    {
+        // A non-Windows host has no operating system credential store, so no account can live here at all.
+        // That is a property of the HOST, and telling the user to sign in cannot change it.
+        var (app, http, cloud) = await StartAsync(account: null);
+        try
+        {
+            var resp = await PostEmail(http);
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            var error = (await Json(resp)).GetProperty("error").GetString() ?? "";
+            Assert.Contains("no operating system credential store", error, StringComparison.OrdinalIgnoreCase);
+            Assert.False(error.Contains("Sign in from the Gateway tray", StringComparison.OrdinalIgnoreCase),
+                $"a host that cannot hold a credential told the user to sign in. Body: {error}");
+            Assert.Equal(0, cloud.Calls);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountRoutesTellTheTruthTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountRoutesTellTheTruthTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Issue #984, the P0: on the HOSTED Gateway, no <c>/account/*</c> route may tell a signed-in caller that
+/// they are not signed in.
+///
+/// THE DEFECT THESE TESTS CLOSE. Every account route opened with the same three lines - read
+/// <c>GetAccessTokenForForwarding()</c>, and if it is empty answer "not signed in to DevThrottle ... Sign in
+/// from the Gateway tray, then retry." That conditional asks whether THIS GATEWAY holds a credential and
+/// reports the answer as a statement about THE CALLER. The hosted Gateway holds none by design - it is one
+/// shared multi-tenant Gateway, identity arrives per device and is bound to a tenant at enrollment, and the
+/// hosted mint stores neither the access nor the refresh token - so on hosted that token is empty for EVERY
+/// caller, ALWAYS. Two routes were fixed for this before (<c>/account/status</c> in #1856,
+/// <c>/account/devices</c> in #2076) and three were not, which produced this, live, in one minute against
+/// one Gateway with one token:
+/// <code>
+///   GET  /account/status   -> 200 {"signedIn":true,"email":"..."}
+///   GET  /account/devices  -> 200 {"signedIn":true, ...the caller's own devices...}
+///   GET  /account/credits  -> 200 {"signedIn":false,"balanceMicros":null}
+///   POST /account/email    -> 401 "not signed in to DevThrottle ... Sign in from the Gateway tray"
+/// </code>
+///
+/// The missing email was never the damage. The damage is that the product misreports its own state and then
+/// instructs the user to perform the one action they have already performed and that cannot help - it cost
+/// real time twice in a single day, because an agent read the message, believed it, and told the owner to
+/// sign in while his sessions and schedules were running through that same Gateway. Anyone hitting it
+/// concludes either that sign-in is broken or that the software does not know what it is doing, and both are
+/// worse than the feature being honestly unavailable. On <c>/account/credits</c> - a BILLING surface served
+/// to a paying subscriber - "not signed in, no balance" reads as "my account is gone" or "my money is gone".
+///
+/// THE INVARIANT UNDER PROOF, and the reason this is one class and not three:
+/// <b>when <c>/account/status</c> answers <c>signedIn:true</c>, no sibling <c>/account/*</c> route may answer
+/// that the caller is not signed in.</b> It is asserted end to end, in one test per route, by asking BOTH
+/// endpoints with the SAME device key in the same fixture - a per-route test could pass while the pair still
+/// contradicted each other, and it is the contradiction that does the harm.
+///
+/// Note what is NOT claimed: hosted <c>/account/email</c> still does not SEND. The cloud primitive resolves
+/// the recipient from an account access token and hosted holds none, so telling the truth is the whole of
+/// this change; the cloud-side sender is tracked separately in devthrottle_internal. A route that cannot do
+/// the thing must say so accurately - that is the fix - and these tests assert the accuracy, not a send.
+///
+/// Revert-prove: delete the <c>AccountActingCredential</c> call in any one of the three endpoints and put
+/// back <c>if (string.IsNullOrEmpty(account?.GetAccessTokenForForwarding()))</c> with the old message. That
+/// route's test goes RED on the exact string the user was shown, and the other two stay green - so each test
+/// is pinned to its own route rather than to a shared happy accident.
+///
+/// This drives a REAL GatewayHost over REAL HTTP through the REAL auth middleware with the REAL tenant
+/// registry, so the binding under test is the one enrollment actually creates. Self-host behaviour is
+/// unchanged and is covered by <see cref="AccountActingCredentialSelfHostTests"/>, the control for this
+/// change. The assembly runs sequentially, so toggling CC_GATEWAY_HOSTED here is safe; it is restored in
+/// DisposeAsync.
+/// </summary>
+public sealed class HostedAccountRoutesTellTheTruthTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    /// <summary>The message the user was shown, and the one no hosted route may ever produce again.</summary>
+    private const string TheLie = "not signed in";
+
+    // Unique per instance: MintOrLookupBySubject records an email on a fresh mint only and returns the
+    // existing tenant otherwise, so a shared literal subject would let whichever test class ran first decide
+    // this class's answers (issue #1911).
+    private readonly string _subject = "sub-984-" + Guid.NewGuid().ToString("N");
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    /// <summary>An enrolled hosted caller, tenant-bound, with an email on its tenant row.</summary>
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-984-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        // Isolate the storage root so the tenant registry does not mint into the running user's real root,
+        // which is shared with every other class in the assembly (issue #1911's failure shape).
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _instancesDir);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Minted through the REAL registry exactly as hosted enrollment does it, so this is a genuine tenant
+        // row rather than a string invented by the test.
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject(_subject, "owner@example.com");
+        _key = _gateway.Devices.Register("dev-984", "M984").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-984", _subject, tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Status_says_signed_in_so_email_must_never_say_not_signed_in()
+    {
+        // THE HEADLINE INVARIANT, asserted across the pair rather than inside one route: the same caller,
+        // the same key, the same Gateway, in the same test.
+        var status = await Json(await Get("account/status"));
+        Assert.True(status.GetProperty("signedIn").GetBoolean(),
+            "precondition: this fixture's caller must be signed in, or the invariant is untested");
+
+        var resp = await PostEmail();
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.False(resp.StatusCode == HttpStatusCode.Unauthorized,
+            $"POST /account/email answered 401 to a caller /account/status reports as signed in. Body: {body}");
+        AssertDoesNotClaimSignedOut("POST /account/email", body);
+    }
+
+    [Fact]
+    public async Task The_email_refusal_names_the_signed_in_identity_and_the_real_cause()
+    {
+        // A message that merely stops saying the wrong thing is not enough - a user who cannot tell WHY will
+        // still go looking for a sign-in to redo. So the refusal states the identity it can see, and names
+        // the Gateway as the limit. Naming the identity is what makes the sentence impossible to misread.
+        var error = (await Json(await PostEmail())).GetProperty("error").GetString() ?? "";
+
+        Assert.Contains("owner@example.com", error, StringComparison.Ordinal);
+        Assert.Contains("signed in", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hosted", error, StringComparison.OrdinalIgnoreCase);
+        // No email went out, and the message must say so rather than leave the user guessing.
+        Assert.Contains("No email was sent", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Credits_reports_the_caller_signed_in_and_says_the_money_is_untouched()
+    {
+        // The billing surface. This used to answer {"signedIn":false,"balanceMicros":null} to a paying
+        // subscriber, which reads as "my account is gone" or "my money is gone". The honest answer separates
+        // the two facts that were conflated: the caller IS signed in, and no balance is readable HERE.
+        var resp = await Get("account/credits");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var root = await Json(resp);
+        Assert.True(root.GetProperty("signedIn").GetBoolean(),
+            "a hosted enrolled tenant is signed in; a billing surface must never be the place that denies it");
+        Assert.False(root.GetProperty("balanceAvailable").GetBoolean());
+
+        // An unavailable balance must be ABSENT, never a fabricated zero - a zero on a billing page is a
+        // different false statement, not a safer one.
+        var hasBalance = root.TryGetProperty("balanceMicros", out var balance)
+                         && balance.ValueKind != JsonValueKind.Null;
+        Assert.False(hasBalance, $"balanceMicros must be absent when no balance was read, was: {balance}");
+
+        var message = root.GetProperty("message").GetString() ?? "";
+        AssertDoesNotClaimSignedOut("GET /account/credits", message);
+        Assert.Contains("unaffected", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Logout_refuses_instead_of_claiming_a_sign_out_it_did_not_perform()
+    {
+        // On hosted there is no Gateway credential to clear, so the old 200 {"signedIn":false} was a button
+        // reporting success for an action it never performed - next to a /account/status that kept saying
+        // signed in. Refusing is the truthful answer, and it names the mechanism that does work.
+        var resp = await _http.SendAsync(Authed(new HttpRequestMessage(HttpMethod.Post, "account/logout")));
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("\"signedIn\"", body, StringComparison.Ordinal);
+        Assert.Contains("Nothing was signed out", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("remove this device", body, StringComparison.OrdinalIgnoreCase);
+
+        // And it really did not sign anything out: status is unchanged.
+        Assert.True((await Json(await Get("account/status"))).GetProperty("signedIn").GetBoolean());
+    }
+
+    [Fact]
+    public async Task No_account_route_ever_tells_this_caller_to_sign_in_again()
+    {
+        // The sweep, in one assertion over every route in the class. "Sign in from the Gateway tray, then
+        // retry" is the specific instruction that sent people to redo a completed action; on hosted there is
+        // no tray to sign in from at all, so it can never be right here.
+        AssertDoesNotClaimSignedOut("GET /account/status", await (await Get("account/status")).Content.ReadAsStringAsync());
+        AssertDoesNotClaimSignedOut("GET /account/devices", await (await Get("account/devices")).Content.ReadAsStringAsync());
+        AssertDoesNotClaimSignedOut("GET /account/credits", await (await Get("account/credits")).Content.ReadAsStringAsync());
+        AssertDoesNotClaimSignedOut("POST /account/email", await (await PostEmail()).Content.ReadAsStringAsync());
+        AssertDoesNotClaimSignedOut("POST /account/logout",
+            await (await _http.SendAsync(Authed(new HttpRequestMessage(HttpMethod.Post, "account/logout")))).Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task No_refusal_carries_credential_material()
+    {
+        // Control (DT-05): the new messages name an identity, and an identity is not a credential. Neither
+        // the caller's device key nor the Gateway token may appear in any of them.
+        foreach (var body in new[]
+                 {
+                     await (await PostEmail()).Content.ReadAsStringAsync(),
+                     await (await Get("account/credits")).Content.ReadAsStringAsync(),
+                     await (await _http.SendAsync(Authed(new HttpRequestMessage(HttpMethod.Post, "account/logout")))).Content.ReadAsStringAsync(),
+                 })
+        {
+            Assert.DoesNotContain(_key, body, StringComparison.Ordinal);
+            Assert.DoesNotContain(Token, body, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The one assertion this class exists for. It rejects both halves of the reported message: the claim
+    /// itself, and the instruction that followed it. Reporting the offending body is deliberate - an
+    /// assertion that rejects a value should say what the value was.
+    /// </summary>
+    private static void AssertDoesNotClaimSignedOut(string route, string body)
+    {
+        Assert.False(body.Contains(TheLie, StringComparison.OrdinalIgnoreCase),
+            $"{route} told a signed-in hosted caller '{TheLie}'. That is the issue #984 defect. Body: {body}");
+        Assert.False(body.Contains("Sign in from the Gateway tray", StringComparison.OrdinalIgnoreCase),
+            $"{route} told a signed-in hosted caller to sign in from the Gateway tray - the action they have " +
+            $"already performed, and one a hosted Gateway has no tray for. Body: {body}");
+    }
+
+    private HttpRequestMessage Authed(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        return request;
+    }
+
+    private Task<HttpResponseMessage> Get(string path) =>
+        _http.SendAsync(Authed(new HttpRequestMessage(HttpMethod.Get, path)));
+
+    private Task<HttpResponseMessage> PostEmail()
+    {
+        var request = Authed(new HttpRequestMessage(HttpMethod.Post, "account/email"))
+            ;
+        request.Content = new StringContent(
+            """{"subject":"issue 984 invariant","bodyText":"body"}""", Encoding.UTF8, "application/json");
+        return _http.SendAsync(request);
+    }
+
+    private static async Task<JsonElement> Json(HttpResponseMessage response)
+    {
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountActingCredential.cs
+++ b/src/CcDirector.Gateway/Api/AccountActingCredential.cs
@@ -1,0 +1,324 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The ONE place the Gateway rules on "can this Gateway act on the caller's DevThrottle account for this
+/// operation, and if not, what is ACTUALLY wrong?" (issue #984). Per CLAUDE.md rule 7 the verdict is folded
+/// here once - state, finished user-facing message, and HTTP status - and every <c>/account/*</c> route
+/// renders it verbatim. No route re-derives what an absent token means.
+///
+/// WHY THIS EXISTS. Every account route used to open with the same three lines:
+/// <code>
+///   var token = account?.GetAccessTokenForForwarding();
+///   if (string.IsNullOrEmpty(token))
+///       -> "not signed in to DevThrottle ... Sign in from the Gateway tray, then retry."
+/// </code>
+/// That conditional asks whether THIS GATEWAY holds a signed-in credential, and then reports the answer as
+/// a statement about THE CALLER. On the hosted Gateway those are different questions with different
+/// answers: a hosted Gateway holds NO account credential at all, by design - it is one shared multi-tenant
+/// Gateway, identity arrives per device and is bound to a tenant at enrollment, and
+/// <see cref="HostedEnrollmentEndpoint"/> stores neither the account access token nor the refresh token. So
+/// on hosted that token is empty for EVERY caller, ALWAYS, and a correctly signed-in paying subscriber was
+/// told "not signed in - sign in from the Gateway tray, then retry": the one action they had already
+/// performed, and the one action that could never change the outcome.
+///
+/// It cost real time twice in a single day, and it is not merely a bad string. A product that misreports
+/// its own state teaches the user that either their sign-in is broken or the software does not know what it
+/// is doing, and both readings are worse than the feature being honestly unavailable.
+///
+/// THE RULE THAT MATTERS: "this Gateway cannot act on your account" and "you are not signed in" are
+/// DIFFERENT STATEMENTS and must never share a code path. An absent forwarding token is never, on its own,
+/// evidence of a signed-out user.
+///
+/// The states this distinguishes, each with its own message and status:
+/// <list type="bullet">
+/// <item><see cref="AccountActingState.Ready"/> - a forwardable account token is in hand; act.</item>
+/// <item><see cref="AccountActingState.HostedNoGatewayCredential"/> - hosted, the caller's tenant IS
+///   resolved: they are signed in, and this Gateway simply holds no credential of theirs to act with.</item>
+/// <item><see cref="AccountActingState.HostedNoTenant"/> - hosted, nothing bound the request to a tenant:
+///   a deny, not a sign-out.</item>
+/// <item><see cref="AccountActingState.HostedMiswired"/> - hosted mode with no tenant boundary wired: a
+///   deployment fault, refused loudly rather than answered wrongly.</item>
+/// <item><see cref="AccountActingState.NoCredentialStore"/> - self-host on a machine with no operating
+///   system credential store, so no account can be held here at all.</item>
+/// <item><see cref="AccountActingState.SignedOut"/> - self-host with nothing stored: the ONLY state where
+///   "sign in, then retry" is true, and the only one that answers 401.</item>
+/// <item><see cref="AccountActingState.CredentialUnusable"/> - self-host, a credential IS stored but could
+///   not be made forwardable even after a refresh attempt: an internal inconsistency, reported as one.</item>
+/// </list>
+///
+/// Security (carries DT-05): <see cref="AccountActingVerdict.Token"/> is for attaching to an outbound
+/// request only. No token is ever logged here, and no token field reaches any response contract.
+/// </summary>
+internal static class AccountActingCredential
+{
+    /// <summary>
+    /// Resolves the acting verdict for one request. On HOSTED this never touches
+    /// <paramref name="account"/> - the hosted Gateway's own credential is meaningless to the caller, so
+    /// asking about it can only produce a wrong answer. Gated on <see cref="GatewayHostedMode.IsHosted"/>
+    /// itself, NOT on whether a boundary was passed in: selecting the hosted path from the optional argument
+    /// FAILS OPEN, letting a one-word wiring mistake drop a hosted Gateway back onto the self-host answer -
+    /// the exact defect this type exists to stop. A hosted Gateway with no boundary FAILS CLOSED instead.
+    /// </summary>
+    /// <param name="operation">What the calling route is trying to do, for the finished message.</param>
+    /// <param name="ctx">The request, used on hosted to resolve the caller's own tenant.</param>
+    /// <param name="account">The Gateway-hosted credential service; null on a host with no credential store.</param>
+    /// <param name="boundary">The hosted tenant boundary. Required on hosted; ignored off hosted.</param>
+    /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
+    /// <param name="ct">Cancellation for the refresh attempt.</param>
+    public static async Task<AccountActingVerdict> ResolveAsync(
+        AccountOperation operation,
+        HttpContext ctx,
+        DevThrottleAccountService? account,
+        Tenancy.HostedTenantBoundary? boundary,
+        Tenancy.TenantRegistry? tenants,
+        CancellationToken ct = default)
+    {
+        if (operation is null) throw new ArgumentNullException(nameof(operation));
+        if (ctx is null) throw new ArgumentNullException(nameof(ctx));
+
+        if (GatewayHostedMode.IsHosted)
+            return Hosted(operation, ctx, boundary, tenants);
+
+        return await SelfHostAsync(operation, account, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The HOSTED verdict, folded from the CALLER'S OWN authenticated device-key binding and from nothing
+    /// else. signedIn is never false here for an authenticated tenant-bound caller: the two failure answers
+    /// are "I cannot resolve who you are" (a deny) and "I cannot act on your account" (a Gateway limit),
+    /// and neither of them is "you are signed out".
+    /// </summary>
+    private static AccountActingVerdict Hosted(
+        AccountOperation operation, HttpContext ctx,
+        Tenancy.HostedTenantBoundary? boundary, Tenancy.TenantRegistry? tenants)
+    {
+        // A hosted Gateway that cannot tell who is asking has no honest answer to give, and it certainly
+        // does not have a signed-out one. Say the server cannot answer, and say it LOUD - this is a
+        // deployment fault that will not recover on its own.
+        if (boundary is not { IsHosted: true })
+        {
+            FileLog.Write($"[AccountActingCredential] {operation.RouteLabel} (hosted): MISWIRED - hosted mode with no hosted tenant boundary, so the caller's tenant cannot be resolved. Refusing rather than reporting a false signed-out state.");
+            return new AccountActingVerdict(
+                AccountActingState.HostedMiswired, null, null,
+                "This hosted DevThrottle Gateway cannot resolve which account is calling, so it will not answer. "
+                + "This is a fault in the Gateway deployment, not a problem with your account or your sign-in.",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var resolved = boundary.ResolveRequestTenant(ctx);
+        if (resolved is not { } tenant)
+        {
+            FileLog.Write($"[AccountActingCredential] {operation.RouteLabel} (hosted): DENIED - no tenant is bound to this request");
+            return new AccountActingVerdict(
+                AccountActingState.HostedNoTenant, null, null,
+                "No DevThrottle account is bound to this request, so this hosted Gateway will not act on one. "
+                + "The device making this call is not enrolled to an account on this Gateway.",
+                StatusCodes.Status403Forbidden);
+        }
+
+        // The caller IS signed in. The hosted Gateway simply holds nothing it can act WITH on their behalf,
+        // because it never keeps the account token - enrollment validates it, mints a tenant and a device
+        // key, and discards it. Naming the signed-in identity in the message is the point: it makes the
+        // sentence impossible to misread as a sign-out.
+        var email = tenants?.EmailForTenant(tenant);
+        // Carried on the verdict so a route that CAN act for a tenant without a user token has what it needs
+        // already resolved, from the authenticated device key, at the one place that resolves it. See
+        // AccountActingVerdict.Tenant / AccountSubject for why this is on the verdict rather than re-derived.
+        var subject = tenants?.SubjectForTenant(tenant);
+        var who = string.IsNullOrWhiteSpace(email) ? "your DevThrottle account" : email;
+        var message =
+            $"You are signed in to DevThrottle as {who}. This hosted DevThrottle Gateway does not hold a "
+            + $"DevThrottle account credential for your account, so it cannot {operation.Description}. "
+            + "This is a limitation of the shared hosted Gateway - it is not a sign-in problem, and signing "
+            + "in again will not change it.";
+        if (!string.IsNullOrWhiteSpace(operation.HostedReassurance))
+            message += " " + operation.HostedReassurance;
+
+        // The email is user identity and is never written to the log; only whether it resolved.
+        FileLog.Write($"[AccountActingCredential] {operation.RouteLabel} (hosted): caller IS signed in (identity {(email is null ? "unavailable" : "resolved")}); this Gateway holds no account credential to {operation.Description} with -> reporting the Gateway limit, NOT a sign-out");
+        return new AccountActingVerdict(
+            AccountActingState.HostedNoGatewayCredential, null, email, message,
+            StatusCodes.Status503ServiceUnavailable,
+            Tenant: tenant.Value, AccountSubject: subject);   // TenantId.Value is the tenant row id string
+    }
+
+    /// <summary>
+    /// The SELF-HOST verdict, where one Gateway holds one account and the question "does this Gateway hold
+    /// a credential?" really is a question about the user. Renews the credential BEFORE acting (issue #984
+    /// acceptance 3 - see the comment at the refresh call for why "before failing" would have been a no-op),
+    /// and separates "nothing is stored" from "something is stored but is not usable".
+    /// </summary>
+    private static async Task<AccountActingVerdict> SelfHostAsync(
+        AccountOperation operation, DevThrottleAccountService? account, CancellationToken ct)
+    {
+        if (account is null)
+        {
+            FileLog.Write($"[AccountActingCredential] {operation.RouteLabel}: no credential service on this host -> this Gateway can hold no DevThrottle account");
+            return new AccountActingVerdict(
+                AccountActingState.NoCredentialStore, null, null,
+                "This Gateway host has no operating system credential store, so it cannot hold a DevThrottle "
+                + $"account and cannot {operation.Description}.",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+
+        // Issue #984 acceptance 3, renewing BEFORE acting rather than after failing. Refreshing only on the
+        // way out of a failure would be theatre here: the credential service deliberately declines to spend a
+        // refresh on an access token that does not verify (it is not ours to renew), which is the ONLY state
+        // in which the read below comes back empty - so a refresh at that point could never change the
+        // outcome. Renewing first, however, does real work: it stops the Gateway forwarding an access token
+        // it could have renewed, and it turns an expired-and-unrenewable credential into something this
+        // method can NAME rather than something the cloud rejects with a message about a different problem.
+        //
+        // Cheap by construction: a no-op with no network call when the token has comfortable life left, and
+        // single-flight, so concurrent account calls share one exchange rather than racing rotation.
+        await account.RefreshIfNeededAsync(ct).ConfigureAwait(false);
+
+        // BOTH conditions, and they are not the same question. The token read says "is there something to
+        // attach"; IsLoggedIn says "is it genuinely usable" - it is false for an expired token whose refresh
+        // is persistently failing (issue #911), which the token read still hands back happily. Forwarding
+        // that is how a dead credential produces a cloud rejection naming some other cause.
+        var token = account.GetAccessTokenForForwarding();
+        if (!string.IsNullOrEmpty(token) && account.IsLoggedIn())
+            return new AccountActingVerdict(AccountActingState.Ready, token, account.GetIdentity()?.Email, "", StatusCodes.Status200OK);
+
+        // Nothing stored at all is the ONE state where telling the user to sign in is true and useful.
+        if (!account.HasStoredCredential())
+        {
+            FileLog.Write($"[AccountActingCredential] {operation.RouteLabel}: no credential is stored on this Gateway -> genuinely signed out");
+            return new AccountActingVerdict(
+                AccountActingState.SignedOut, null, null,
+                "This Gateway is not signed in to DevThrottle - it holds no account credential, so there is no "
+                + $"account to {operation.Description} with. Sign in from the Gateway tray, then retry.",
+                StatusCodes.Status401Unauthorized);
+        }
+
+        // A credential IS stored and still is not usable. That is an internal inconsistency, and dressing it
+        // up as a sign-out is what sent people to re-run a sign-in that was already done.
+        FileLog.Write($"[AccountActingCredential] {operation.RouteLabel}: a credential IS stored but is not usable after a refresh attempt (persistentRefreshFailure={account.HasPersistentRefreshFailure}) -> reporting an unusable credential, NOT a sign-out");
+        var detail = account.HasPersistentRefreshFailure
+            ? "Renewing it is failing persistently, so retrying alone will not repair it."
+            : "It could not be verified, and renewing it did not produce a usable token.";
+        return new AccountActingVerdict(
+            AccountActingState.CredentialUnusable, null, account.GetIdentity()?.Email,
+            "This Gateway holds a DevThrottle credential for your account, but it is not in a usable state, so "
+            + $"it cannot {operation.Description}. {detail} Signing out and signing in again from the Gateway "
+            + "tray will replace it.",
+            StatusCodes.Status503ServiceUnavailable);
+    }
+}
+
+/// <summary>
+/// What an <c>/account/*</c> route is trying to do, so the folded message names the real operation instead
+/// of a generic one. Defined once per route in <see cref="AccountOperations"/>, so adding a route is one
+/// edit here and never a new conditional in an endpoint.
+/// </summary>
+/// <param name="RouteLabel">The route, for the log line only (never shown to a user).</param>
+/// <param name="Description">
+/// The operation as a verb phrase that completes "it cannot ..." - for example "send an email to the
+/// account owner". Lower case, no trailing punctuation.
+/// </param>
+/// <param name="HostedReassurance">
+/// An optional extra sentence appended on the hosted path, for surfaces where the user's first fear needs
+/// answering directly (a billing surface, above all).
+/// </param>
+internal sealed record AccountOperation(string RouteLabel, string Description, string? HostedReassurance = null);
+
+/// <summary>The operations the account routes perform, one per route.</summary>
+internal static class AccountOperations
+{
+    public static readonly AccountOperation Email = new(
+        "POST /account/email",
+        "send an email to the account owner",
+        "No email was sent.");
+
+    /// <summary>
+    /// The credit balance. This is a BILLING surface, and the old answer here - a bare
+    /// <c>{"signedIn":false,"balanceMicros":null}</c> served to a paying subscriber - reads as "my account is
+    /// gone" or "my money is gone". The reassurance answers exactly that fear, in the response itself.
+    /// </summary>
+    public static readonly AccountOperation Credits = new(
+        "GET /account/credits",
+        "read your credit balance",
+        "Your account is active and your credit balance is unaffected - it simply cannot be read through "
+        + "this hosted Gateway. Check it on the DevThrottle website.");
+
+    public static readonly AccountOperation Logout = new(
+        "POST /account/logout",
+        "sign your account out",
+        "Nothing was signed out and nothing was changed. On the hosted Gateway your access comes from this "
+        + "device's enrollment, so to end it, remove this device under your account's devices.");
+}
+
+/// <summary>The distinct account states an <c>/account/*</c> route can be in. See <see cref="AccountActingCredential"/>.</summary>
+internal enum AccountActingState
+{
+    /// <summary>A forwardable account access token is in hand.</summary>
+    Ready,
+
+    /// <summary>Hosted, caller's tenant resolved: they ARE signed in; this Gateway holds no credential of theirs.</summary>
+    HostedNoGatewayCredential,
+
+    /// <summary>Hosted, no tenant bound to the request: a deny.</summary>
+    HostedNoTenant,
+
+    /// <summary>Hosted mode with no tenant boundary wired: a deployment fault.</summary>
+    HostedMiswired,
+
+    /// <summary>Self-host on a machine with no operating system credential store.</summary>
+    NoCredentialStore,
+
+    /// <summary>Self-host, nothing stored: the only state where "sign in, then retry" is true.</summary>
+    SignedOut,
+
+    /// <summary>Self-host, a credential is stored but is not forwardable even after a refresh attempt.</summary>
+    CredentialUnusable,
+}
+
+/// <summary>
+/// The folded verdict a route renders verbatim. Carries no token field on any response contract - the
+/// <see cref="Token"/> is for attaching to an outbound request only and is never serialized or logged (DT-05).
+/// </summary>
+/// <param name="State">Which of the distinct account states this request is in.</param>
+/// <param name="Token">The forwardable access token; non-null only when <see cref="State"/> is Ready.</param>
+/// <param name="Email">The caller's identity when it resolved, else null. Never fabricated.</param>
+/// <param name="Message">The finished, user-facing sentence. Empty when Ready.</param>
+/// <param name="StatusCode">The HTTP status a route returning an error envelope should use.</param>
+/// <param name="Tenant">
+/// The CALLER's tenant id on the hosted path, resolved from their authenticated device key; null off hosted
+/// and on the deny paths. This is the identifier a cloud route that acts for a tenant WITHOUT a user token
+/// takes (devthrottle_internal #986: the recipient is resolved cloud-side from the tenant, and naming an
+/// address is refused outright). It is carried here rather than re-resolved at each route so there stays
+/// exactly one place that turns a device key into an identity - the property that keeps a caller from ever
+/// naming a tenant that is not its own.
+/// </param>
+/// <param name="AccountSubject">
+/// The verified account subject behind <see cref="Tenant"/>, for use as a CROSS-CHECK on such a call - it
+/// turns a wrong tenant id into a refusal instead of a correctly-delivered message to the wrong person. It
+/// must never be used to RESOLVE a recipient: a subject that selects the target is a subject that can select
+/// somebody else's. Null when unresolvable. Personally identifying - never logged.
+/// </param>
+internal sealed record AccountActingVerdict(
+    AccountActingState State,
+    string? Token,
+    string? Email,
+    string Message,
+    int StatusCode,
+    string? Tenant = null,
+    string? AccountSubject = null)
+{
+    /// <summary>True when the route may go ahead and act on the account.</summary>
+    public bool IsReady => State == AccountActingState.Ready;
+
+    /// <summary>
+    /// Whether THE CALLER is signed in to DevThrottle - which is NOT the same question as whether this
+    /// Gateway can act for them. True on the hosted path whenever a tenant resolved, because an enrolled
+    /// tenant is signed in whatever this Gateway can or cannot do on their behalf. This is the value a
+    /// <c>signedIn</c> field must carry; the old code put "could this Gateway act?" there and that is the
+    /// whole defect (issue #984).
+    /// </summary>
+    public bool CallerIsSignedIn => State is AccountActingState.Ready or AccountActingState.HostedNoGatewayCredential;
+}

--- a/src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs
@@ -16,10 +16,27 @@ namespace CcDirector.Gateway.Api;
 /// already uses for account and device operations), calls the cloud credits endpoint
 /// (<see cref="AccountCreditsClient"/>, JWT-authed), and returns a local, token-free DTO.
 ///
+/// THIS IS A BILLING SURFACE, and that is why issue #984 treats it as at least as serious as the owner-email
+/// route it was found alongside. On the hosted Gateway it used to answer a paying subscriber with a bare
+/// <c>{"signedIn":false,"balanceMicros":null}</c> - because it asked whether THIS GATEWAY held a credential
+/// and then reported the answer as a fact about THE CALLER. A hosted Gateway holds no account credential by
+/// design, so that false was served to every hosted customer, always. A customer reads "not signed in, no
+/// balance" on a billing page as "my account is gone" or "my money is gone". Both are false, both are
+/// alarming, and neither was recoverable by anything the customer could do.
+///
+/// The verdict is now folded once by <see cref="AccountActingCredential"/> and rendered verbatim (CLAUDE.md
+/// rule 7): <c>signedIn</c> carries whether THE CALLER is signed in - which on hosted is true for any
+/// enrolled tenant - and <see cref="AccountCreditsDto.BalanceAvailable"/> plus
+/// <see cref="AccountCreditsDto.Message"/> carry, separately and explicitly, whether a balance could be read
+/// and why not. The old shape had no way to say "you ARE signed in AND I cannot read your balance", so it
+/// said the wrong one of the two.
+///
 /// Behaviour at the edges (no fabricated data):
 /// <list type="bullet">
-/// <item>Signed out / no credential -> an explicit <c>signedIn:false</c> envelope, never a fabricated
-/// zero balance.</item>
+/// <item>Genuinely signed out (self-host, nothing stored) -> <c>signedIn:false</c> with a message, never a
+/// fabricated zero balance.</item>
+/// <item>Hosted (this Gateway cannot read the caller's balance) -> <c>signedIn:true</c>,
+/// <c>balanceAvailable:false</c>, and a message saying the account and balance are unaffected.</item>
 /// <item>Cloud unreachable / erroring -> a clear 502 error (logged), never a fabricated balance.</item>
 /// </list>
 ///
@@ -32,25 +49,49 @@ internal static class AccountCreditsEndpoint
     /// <param name="app">The route builder.</param>
     /// <param name="account">The Gateway-hosted credential service. Null on a host with no credential service.</param>
     /// <param name="credits">The cloud credits client (the injectable cloud egress seam).</param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountCreditsClient credits)
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary (issue #984). On hosted it resolves the CALLER's own tenant so this route
+    /// reports the truth about them. Omitting it on a hosted Gateway does NOT fall back to the self-host
+    /// answer - the hosted path fails closed. Ignored off hosted mode.
+    /// </param>
+    /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountCreditsClient credits,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
     {
         if (credits is null) throw new ArgumentNullException(nameof(credits));
 
         app.MapGet("/account/credits", async (HttpContext ctx) =>
         {
-            // Entry point: the delegate is the boundary, so the only try-catch lives here. A signed-out
-            // Gateway is an expected state answered explicitly; a cloud failure is caught here and
-            // reported as a clear error (never a fabricated balance).
-            var token = account?.GetAccessTokenForForwarding();
-            if (string.IsNullOrEmpty(token))
+            // Entry point: the delegate is the boundary, so the only try-catch lives here. Which account
+            // state this request is in is ruled on once, in the fold, and rendered verbatim - this route
+            // does not decide for itself what an absent token means (issue #984).
+            var verdict = await AccountActingCredential
+                .ResolveAsync(AccountOperations.Credits, ctx, account, tenantBoundary, tenants, ctx.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (!verdict.IsReady)
             {
-                FileLog.Write("[AccountCreditsEndpoint] GET /account/credits: no account credential -> signedIn=false");
-                return Results.Json(new AccountCreditsDto { SignedIn = false });
+                // A deny or a deployment fault is an error, not a balance answer. Every other state is a
+                // truthful 200 that says, in one body, both whether the caller is signed in AND whether a
+                // balance could be read - because on hosted the honest answer is "signed in, no balance here".
+                if (verdict.State is AccountActingState.HostedNoTenant or AccountActingState.HostedMiswired)
+                {
+                    FileLog.Write($"[AccountCreditsEndpoint] GET /account/credits: {verdict.State} -> {verdict.StatusCode}");
+                    return Results.Json(new { error = verdict.Message }, statusCode: verdict.StatusCode);
+                }
+
+                FileLog.Write($"[AccountCreditsEndpoint] GET /account/credits: no balance readable ({verdict.State}); callerSignedIn={verdict.CallerIsSignedIn}");
+                return Results.Json(new AccountCreditsDto
+                {
+                    SignedIn = verdict.CallerIsSignedIn,
+                    BalanceAvailable = false,
+                    Message = verdict.Message,
+                });
             }
 
             try
             {
-                var result = await credits.GetCreditsAsync(token, ctx.RequestAborted).ConfigureAwait(false);
+                var result = await credits.GetCreditsAsync(verdict.Token!, ctx.RequestAborted).ConfigureAwait(false);
 
                 // The most recent debit's magnitude is the last hosted action's cost (a debit's
                 // amount is negative on the ledger); a top-up (credit) is not an action cost.
@@ -68,6 +109,7 @@ internal static class AccountCreditsEndpoint
                 return Results.Json(new AccountCreditsDto
                 {
                     SignedIn = true,
+                    BalanceAvailable = true,
                     BalanceMicros = result.BalanceMicros,
                     LastDebitMicros = lastDebit,
                 });

--- a/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
@@ -20,16 +20,42 @@ namespace CcDirector.Gateway.Api;
 ///   POST /account/email  { "subject": string, "bodyText"?: string, "bodyHtml"?: string,
 ///                          "attachments"?: [ { "filename": string, "content": base64, "contentType"?: string } ] }
 ///        200 -> { "sent": true, "providerId"?: string }
-///        4xx -> { "sent": false, "error": string }   (bad input, forwarded from the cloud)
-///        401 -> { "sent": false, "error": string }   (Gateway not signed in - no account to send from)
+///        400 -> { "sent": false, "error": string }   (bad input, forwarded from the cloud)
+///        401 -> { "sent": false, "error": string }   (GENUINELY signed out - nothing stored on this Gateway)
+///        403 -> { "sent": false, "error": string }   (hosted: no account is bound to this request)
+///        503 -> { "sent": false, "error": string }   (this Gateway cannot act on the caller's account)
 ///        502 -> { "sent": false, "error": string }   (cloud unreachable / send failure - never a fake success)
+///
+/// WHICH of those non-2xx answers applies is NOT decided here. It is folded once by
+/// <see cref="AccountActingCredential"/> and rendered verbatim (CLAUDE.md rule 7). This route used to make
+/// that call itself, with a single <c>if (string.IsNullOrEmpty(token))</c> that answered 401 "not signed in
+/// to DevThrottle - sign in from the Gateway tray, then retry". On the HOSTED Gateway that token is empty
+/// for every caller always - hosted holds no account credential by design - so a signed-in paying user was
+/// told to perform the one action they had already performed and that could not possibly help (issue #984).
+/// The states are now distinct, and 401 is reserved for the one case where it is true.
+///
+/// HOSTED LIMIT, stated plainly: the cloud primitive resolves the recipient from an account access token,
+/// and the hosted Gateway holds none for its tenants. So on hosted this route reports the truth and does NOT
+/// send. Making it send is devthrottle_internal #986 - a tenant-addressed cloud sender authenticated by a
+/// Gateway service credential, with the recipient resolved SERVER-side from the tenant (naming an address is
+/// refused outright, so this Gateway can never address anyone). Its swap point is marked below.
 ///
 /// Inherits the host-wide Gateway token middleware like the other <c>/account/*</c> endpoints (not on the
 /// public-paths allow-list). The account token is never returned or logged (DT-05).
 /// </summary>
 internal static class AccountEmailEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNotifyClient notify)
+    /// <param name="app">The route builder.</param>
+    /// <param name="account">The Gateway-hosted credential service; null on a host with no credential store.</param>
+    /// <param name="notify">The cloud owner-email client (the injectable egress seam).</param>
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary (issue #984). On hosted it resolves the CALLER's own tenant so this route
+    /// can report the truth about them. Omitting it on a hosted Gateway does NOT fall back to the self-host
+    /// answer - the hosted path fails closed. Ignored off hosted mode.
+    /// </param>
+    /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNotifyClient notify,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
     {
         if (notify is null) throw new ArgumentNullException(nameof(notify));
 
@@ -39,16 +65,27 @@ internal static class AccountEmailEndpoint
             if (request is null || string.IsNullOrWhiteSpace(request.Subject))
                 return Results.BadRequest(new AccountEmailResponse(false, "subject is required.", null));
 
-            var token = account?.GetAccessTokenForForwarding();
-            if (string.IsNullOrEmpty(token))
+            // Issue #984: the Gateway rules ONCE on what the caller's account situation actually is, and this
+            // route renders the verdict verbatim. It never re-derives what an empty token means - that
+            // conditional is what turned "this hosted Gateway holds no credential of yours" into "you are not
+            // signed in - sign in from the Gateway tray", told to a user who plainly was signed in.
+            var verdict = await AccountActingCredential
+                .ResolveAsync(AccountOperations.Email, http, account, tenantBoundary, tenants, http.RequestAborted)
+                .ConfigureAwait(false);
+            if (!verdict.IsReady)
             {
-                FileLog.Write("[AccountEmailEndpoint] POST /account/email: no account credential -> not signed in");
-                return Results.Json(
-                    new AccountEmailResponse(false,
-                        "not signed in to DevThrottle - there is no account to email from. Sign in from the Gateway tray, then retry.",
-                        null),
-                    statusCode: StatusCodes.Status401Unauthorized);
+                // THE SWAP POINT for devthrottle_internal #986. When the cloud's tenant-addressed sender
+                // exists, HostedNoGatewayCredential stops being a refusal and becomes a send: the verdict
+                // already carries verdict.Tenant and verdict.AccountSubject, resolved from the caller's own
+                // authenticated device key, which is everything that route takes. It is one branch here and
+                // one client method - deliberately not a rewrite, and deliberately NOT a reason to start
+                // storing user account tokens, which hosted enrollment does not do and must not begin doing.
+                // Every other state stays a refusal, because none of them is a Gateway that could act.
+                FileLog.Write($"[AccountEmailEndpoint] POST /account/email: cannot send ({verdict.State}) -> {verdict.StatusCode}");
+                return Results.Json(new AccountEmailResponse(false, verdict.Message, null), statusCode: verdict.StatusCode);
             }
+
+            var token = verdict.Token!;
 
             try
             {

--- a/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
@@ -20,6 +20,15 @@ namespace CcDirector.Gateway.Api;
 /// (<c>{ "signedIn": false }</c>) so the caller can confirm the gateway is signed out without a
 /// second round-trip; it carries no identity and NO token (security rule DT-05).
 ///
+/// HOSTED (issue #984): everything above describes the SELF-HOST shape, where one Gateway holds one account
+/// and clearing it IS the sign-out. The hosted Gateway holds no account credential at all - identity arrives
+/// per device and is bound to a tenant at enrollment - so there was nothing for this route to clear, and it
+/// answered <c>{"signedIn":false}</c> anyway. That is a button reporting success for an action it did not
+/// perform, next to a <c>/account/status</c> that keeps saying signed in: the same lie as the credits and
+/// owner-email routes, in the form the user is most likely to act on. On hosted it now REFUSES, says so, and
+/// names the mechanism that does work (removing the device under the account's devices, which is already
+/// tenant-scoped and functioning). Refusing is not a denial of the capability - it points at the working one.
+///
 /// When Gateway auth is enabled, this endpoint inherits the host-wide Gateway token middleware exactly
 /// like the other Gateway endpoints (it is not on the public-paths allow-list), so a call with no token
 /// is answered 401 by that middleware before this delegate runs.
@@ -41,10 +50,30 @@ internal static class AccountLogoutEndpoint
     /// auto-minted inference key while the account token is still available to authenticate the revoke).
     /// It has its own boundary try/catch here, so a slow or failed revoke never blocks or fails logout.
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, Func<CancellationToken, Task>? onBeforeLogout = null)
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary (issue #984). On hosted it resolves the CALLER's own tenant so this route
+    /// can refuse truthfully instead of reporting a sign-out it did not perform. Omitting it on a hosted
+    /// Gateway does NOT fall back to the self-host answer - the hosted path fails closed. Ignored off hosted.
+    /// </param>
+    /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, Func<CancellationToken, Task>? onBeforeLogout = null,
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
     {
         app.MapPost("/account/logout", async (HttpContext ctx) =>
         {
+            // Issue #984: on HOSTED there is no Gateway credential to clear, so clearing one and reporting
+            // signedIn=false claims an action that did not happen. Ruled on once in the fold and rendered
+            // verbatim; gated on hosted MODE, not on the boundary argument, so a hosted Gateway can never
+            // silently take the self-host path.
+            if (GatewayHostedMode.IsHosted)
+            {
+                var hostedVerdict = await AccountActingCredential
+                    .ResolveAsync(AccountOperations.Logout, ctx, account, tenantBoundary, tenants, ctx.RequestAborted)
+                    .ConfigureAwait(false);
+                FileLog.Write($"[AccountLogoutEndpoint] POST /account/logout (hosted): refusing ({hostedVerdict.State}) -> {hostedVerdict.StatusCode}; nothing was cleared and nothing is claimed to have been");
+                return Results.Json(new { error = hostedVerdict.Message }, statusCode: hostedVerdict.StatusCode);
+            }
+
             // No credential service on this host (a non-Windows host where the operating-system
             // credential store is not yet implemented): there is no credential to clear, so the truthful
             // post-logout answer is simply not-signed-in.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2552,8 +2552,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #881: revoke the auto-minted inference key on sign-out (before the credential is cleared),
         // so a signed-out install leaves no live key behind. A manually-pasted key has no recorded id and
         // is left untouched. Best-effort - never blocks logout.
+        // Issue #984: on hosted there is no Gateway credential to clear, so the tenant boundary is passed in
+        // and the route refuses truthfully instead of reporting a sign-out that never happened.
         AccountLogoutEndpoint.Map(_app, Account,
-            onBeforeLogout: _transcriptionKeyProvisioner is null ? null : ct => _transcriptionKeyProvisioner.RevokeMintedKeyAsync(ct));
+            onBeforeLogout: _transcriptionKeyProvisioner is null ? null : ct => _transcriptionKeyProvisioner.RevokeMintedKeyAsync(ct),
+            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
 
         // Account device list + revoke proxy (issue #854): GET /account/devices and
         // DELETE /account/devices/{id}. The Cockpit Account page needs the account-wide device list with
@@ -2573,17 +2576,25 @@ public sealed class GatewayHost : IAsyncDisposable
         // Account credit-balance proxy (issue #884): GET /account/credits. Same proxy shape as the device
         // list - the Gateway reads the balance from the cloud with its own stored account token (JWT) and
         // returns a token-free DTO, so the Settings account section shows the balance without the Cockpit
-        // ever holding the token. Signed-out -> explicit signedIn:false; unreachable cloud -> clear 502.
-        AccountCreditsEndpoint.Map(_app, Account, new Core.Account.AccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }));
+        // ever holding the token. Genuinely signed out -> explicit signedIn:false; unreachable cloud -> clear
+        // 502. Issue #984: this is a BILLING surface and it was telling hosted customers they were not signed
+        // in, because it reported "this Gateway holds no credential" as a fact about the caller. The tenant
+        // boundary is passed in so the hosted path answers about the CALLER: signed in, balance unreadable
+        // here, account and balance unaffected.
+        AccountCreditsEndpoint.Map(_app, Account, new Core.Account.AccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
+            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
 
         // "DevThrottle emails me" relay (issue #1318 consumer): POST /account/email. A session or scheduled
         // run passes a subject + body (+ optional attachments); the Gateway injects its own stored account
         // token and forwards to the cloud primitive (POST /api/v1/account/notify-owner, devthrottle_internal
         // #338), which resolves the recipient from the token and sends via Resend. The Gateway holds NO
         // Resend key and runs no email code - it only relays the account's own token. Single-recipient by
-        // construction (no recipient field). Signed-out -> 401; cloud failure -> clear 502. Inherits the
-        // host-wide token middleware above like the other /account routes.
-        AccountEmailEndpoint.Map(_app, Account, new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }));
+        // construction (no recipient field). Genuinely signed out -> 401; cloud failure -> clear 502. Inherits
+        // the host-wide token middleware above like the other /account routes. Issue #984: the tenant boundary
+        // is passed in so the hosted path reports the truth - the caller IS signed in and this shared Gateway
+        // holds no credential of theirs to send with - instead of the old 401 "sign in from the Gateway tray".
+        AccountEmailEndpoint.Map(_app, Account, new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }),
+            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
 
 
         // The credential-free cloud sign-in START front door (epic #1069, issue #1076): GET + POST


### PR DESCRIPTION
## The bug

On the hosted Gateway, in one minute, with one token, against one Gateway:

```
GET  /account/status   -> 200 {"signedIn":true,"email":"soren@centerconsulting.com"}
GET  /account/devices  -> 200 {"signedIn":true, ...the caller's own devices...}
GET  /account/credits  -> 200 {"signedIn":false,"balanceMicros":null}
POST /account/email    -> 401 "not signed in to DevThrottle - there is no account to email
                               from. Sign in from the Gateway tray, then retry."
```

The product reported that a signed-in user was not signed in, and then instructed them to
perform the one action they had already performed. It cost real time twice in a single day:
an agent read the message, believed it, and told the owner to sign in - while his sessions and
schedules were running through that same Gateway.

On `/account/credits` it is worse, not better. That is a billing surface, and "not signed in,
no balance" served to a paying subscriber reads as "my account is gone" or "my money is gone".

## Root cause - and it is not an expired token

The first hypothesis was an expired access token whose refresh had not run. **It was not, and it
could not have been.** Recording that here because the next person will otherwise re-derive it:

`DevThrottleAccountService.GetAccessTokenForForwarding()` returns a token when the validation is
`IsValid` **or** `IsExpiredButWellFormed`. An expired access token is forwarded quite happily.
Expiry alone can therefore never empty that read, so it cannot produce a "not signed in" answer
even in principle. The read returns null only when nothing is stored, or when the token does not
verify at all.

The actual cause is hosted mode. A hosted Gateway holds **no** DevThrottle account credential, by
design: it is one shared multi-tenant Gateway, identity arrives per device, and hosted enrollment
validates the account token, mints a tenant and a device key, and stores **neither** token. So on
hosted that forwarding read is empty for every caller, always.

Every account route then opened with the same three lines:

```csharp
var token = account?.GetAccessTokenForForwarding();
if (string.IsNullOrEmpty(token))
    -> "not signed in to DevThrottle ... Sign in from the Gateway tray, then retry."
```

That conditional asks whether **this Gateway** holds a credential, and reports the answer as a
statement about **the caller**. Two routes had already been given a hosted per-caller path -
`/account/status` (#1856) and `/account/devices` (#2076). Three had not. Those three are the bug.

## The fix

One Gateway-side fold, `AccountActingCredential`, rules once on what the caller's account
situation actually is and stamps a finished verdict - state, user-facing message, HTTP status.
Every `/account/*` route renders it verbatim (CLAUDE.md rule 7). No route decides for itself what
an absent token means.

Seven distinct states, each with its own message and status, where there was previously one:

| State | Meaning | Answer |
|---|---|---|
| `Ready` | a forwardable token is in hand | act |
| `HostedNoGatewayCredential` | hosted, tenant resolved: the caller **is** signed in; this Gateway holds no credential of theirs | 503, names the identity |
| `HostedNoTenant` | hosted, nothing bound the request to a tenant | 403 deny |
| `HostedMiswired` | hosted mode with no tenant boundary wired | 503, fails closed |
| `NoCredentialStore` | self-host, no operating system credential store on this machine | 503 |
| `SignedOut` | self-host, nothing stored | **401, and "sign in from the tray" is correct here** |
| `CredentialUnusable` | self-host, stored but not usable after a renewal attempt | 503, never a sign-out |

Applied to `/account/email`, `/account/credits` and `/account/logout`. Gated on
`GatewayHostedMode.IsHosted` itself rather than on the optional boundary argument, because
selecting on the argument fails **open** - a one-word wiring mistake would restore the exact lie.

Route by route:

- **`/account/email`** - hosted now reports the truth, naming the signed-in identity so the
  sentence cannot be misread as a sign-out. It still does not send; see below.
- **`/account/credits`** - `AccountCreditsDto` gains `balanceAvailable` and `message`. The old
  contract had no way to say "you are signed in **and** I cannot read your balance", so it said
  the wrong one of the two. `signedIn` now carries whether the **caller** is signed in.
  `GatewayAccountCreditsClient` gates the balance on `balanceAvailable`, not on `signedIn`.
- **`/account/logout`** - on hosted it used to clear a credential that was not there and answer
  `{"signedIn":false}`: a button reporting success for an action it never performed, next to a
  status endpoint that kept saying signed in. It now refuses and names the mechanism that does
  work (remove the device under the account's devices, which is already tenant-scoped).

Also, in the same fold: the credential is renewed **before acting** rather than before failing.
Renewing on the way out of a failure would have been theatre - the credential service declines to
spend a refresh on a token that does not verify, which is the only state that empties the
forwarding read. Renewing first does real work: an expired token is renewed and the **fresh** one
reaches the cloud, and an expired-and-unrenewable credential (#911) is named here rather than
forwarded dead for the cloud to reject with a message about some other cause.

## Checked and NOT affected

`MobileDeviceEnrollmentService` takes the same `DevThrottleAccountService?` and has the same
`GetAccessTokenForForwarding()` shape, but is **not** affected on hosted:
`MobileEnrollmentEndpoint` branches to the hosted mint on `GatewayHostedMode.IsHosted` before
reaching it, and throws at map time if a hosted Gateway is wired without its mint dependencies.
`/account/status` and `/account/devices` were verified already correct against the live Gateway.

## Scope, stated plainly

**Hosted `/account/email` now tells the truth and still does not send.** The cloud primitive
resolves the recipient from an account access token and the hosted Gateway holds none. The
cloud-side sender is devthrottle_internal #986 (`POST /api/v1/account/notify-owner-by-tenant`,
service-credential auth, recipient resolved server-side from tenant identity), whose wire contract
is agreed and locked. This change is built so that swap is small: the hosted verdict already
carries `Tenant` and `AccountSubject`, resolved from the caller's authenticated device key, and
the swap point is one marked branch in `AccountEmailEndpoint`. No user account token is stored to
achieve it - hosted enrollment stores neither token and that stays true.

## Tests

- `HostedAccountRoutesTellTheTruthTests` - a real `GatewayHost` in hosted mode over real HTTP
  through the real auth middleware and the real tenant registry. Asserts the invariant **across
  the pair**: with `/account/status` reporting `signedIn:true`, no sibling route may say the caller
  is not signed in, and none may tell them to sign in from the tray. One test per route, plus a
  sweep and a credential-material control.
- `AccountActingCredentialSelfHostTests` - the control. Self-host still answers 401 with the
  sign-in instruction when it is **true**; a stored-but-unusable credential is never reported as a
  sign-out; an expired credential is renewed before acting and the fresh token is what reaches the
  cloud; a healthy credential costs no exchange; and the expired-token disproof above is pinned as
  an executable assertion.

Revert-proven: restoring the old conditional in `AccountEmailEndpoint` turns the headline test red
on the exact string the user was shown -

```
POST /account/email answered 401 to a caller /account/status reports as signed in.
Body: {"sent":false,"error":"not signed in to DevThrottle - there is no account to email from.
Sign in from the Gateway tray, then retry."}
```

- while the credits and logout tests stay green, so each test is pinned to its own route rather
than to a shared happy accident.

Tracked by devthrottle_internal #984. Paired with devthrottle_internal #986 for the cloud sender.
