### PR TITLE
History shows the shape the work had, not a flat list (internal#989)

### DIFF
--- a/apps/cockpit/src/history/HistoryLineage.test.tsx
+++ b/apps/cockpit/src/history/HistoryLineage.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, within, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// The History page renders the SHAPE the work actually had (internal#989), not a flat list.
+//
+// The lineage rules themselves are tested in client-core; this file exists because passing those is
+// not the same as the screen changing. It asserts what a person looking at the page can see: three
+// roots instead of twenty-two rows, a child nested under the session that started it, a
+// cross-repository parent named rather than moved, and a share that never quietly counts the rows
+// that cannot say who started them.
+
+const { getWorkHistoryReport } = vi.hoisted(() => ({ getWorkHistoryReport: vi.fn() }));
+
+vi.mock("@devthrottle/client-core/history/historyClient", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getWorkHistoryReport };
+});
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  authHeaders: () => ({}),
+  gatewayErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+import { HistoryView } from "./HistoryView";
+import type { WorkHistoryReport, WorkHistorySession } from "@devthrottle/client-core/history/historyClient";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function session(id: string, over: Partial<WorkHistorySession> = {}): WorkHistorySession {
+  return {
+    sessionId: id,
+    startedAtUtc: "2026-07-27T10:00:00Z",
+    lastSeenUtc: "2026-07-27T11:00:00Z",
+    endingTone: "neutral",
+    endingKind: "closed",
+    endingLabel: "Closed",
+    descriptionLine: `work ${id}`,
+    summaryIsPartial: false,
+    ...over,
+  };
+}
+
+function reportOf(repos: Array<{ key: string; sessions: WorkHistorySession[] }>): WorkHistoryReport {
+  return {
+    fromDay: "2026-07-27",
+    toDay: "2026-07-27",
+    repos: repos.map((r) => ({
+      repoKey: r.key,
+      displayName: r.key,
+      days: [{ day: "2026-07-27", summaryText: "A day.", summaryPending: false, sessions: r.sessions }],
+    })),
+  };
+}
+
+async function renderWith(report: WorkHistoryReport) {
+  getWorkHistoryReport.mockResolvedValue(report);
+  render(
+    <MemoryRouter>
+      <HistoryView />
+    </MemoryRouter>,
+  );
+  // findAll, not find: a two-repository report renders the day heading once per repository, and a
+  // single-match query would fail on exactly the cross-repo cases this file is here to check.
+  await screen.findAllByText("A day.");
+}
+
+describe("History shows the shape of the work", () => {
+  it("nests the sessions an agent started under it, and says how many", async () => {
+    await renderWith(
+      reportOf([
+        {
+          key: "devthrottle",
+          sessions: [
+            session("boss", { descriptionLine: "Release manager" }),
+            session("w1", { parentSessionId: "boss", descriptionLine: "Worker one", originKind: "agent" }),
+            session("w2", { parentSessionId: "boss", descriptionLine: "Worker two", originKind: "agent" }),
+          ],
+        },
+      ]),
+    );
+
+    // The parent owns its children: they render INSIDE its list item, not beside it.
+    const toggle = screen.getByRole("button", { name: /2 sessions this one started/i });
+    expect(toggle).toBeTruthy();
+
+    const parentItem = screen.getByText("Release manager").closest("li")!;
+    expect(within(parentItem).getByText("Worker one")).toBeTruthy();
+    expect(within(parentItem).getByText("Worker two")).toBeTruthy();
+  });
+
+  it("shows the children expanded, and lets them be hidden", async () => {
+    // Collapsed-by-default would hide the answer behind a click on every row that has one.
+    await renderWith(
+      reportOf([
+        {
+          key: "devthrottle",
+          sessions: [session("boss"), session("w1", { parentSessionId: "boss", descriptionLine: "Worker one" })],
+        },
+      ]),
+    );
+
+    expect(screen.getByText("Worker one")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /1 session this one started/i }));
+    expect(screen.queryByText("Worker one")).toBeNull();
+  });
+
+  it("names a parent in another repository instead of moving the row there", async () => {
+    // The fleet's most ordinary move is `session spawn <other-repo>`. Nesting the child under its
+    // parent would file that work against a repository it never touched.
+    await renderWith(
+      reportOf([
+        { key: "repo-a", sessions: [session("boss", { sessionName: "Release manager" })] },
+        { key: "repo-b", sessions: [session("child", { parentSessionId: "boss", descriptionLine: "Other repo work" })] },
+      ]),
+    );
+
+    const childItem = screen.getByText("Other repo work").closest("li")!;
+    expect(within(childItem).getByText(/started by Release manager, elsewhere in this range/i)).toBeTruthy();
+
+    // And it is still filed under its OWN repository.
+    expect(screen.getByText("repo-b")).toBeTruthy();
+  });
+
+  it("says so when the parent is outside the range entirely", async () => {
+    // Pruned by retention, or older than the window. Silently promoting it to a root would invent a
+    // root, and roots are the thing being counted.
+    await renderWith(
+      reportOf([
+        { key: "repo-a", sessions: [session("orphan", { parentSessionId: "long-gone", descriptionLine: "Orphaned work" })] },
+      ]),
+    );
+
+    const item = screen.getByText("Orphaned work").closest("li")!;
+    expect(within(item).getByText(/started by a session outside this range/i)).toBeTruthy();
+  });
+
+  it("states the agent share over what it can account for, and names what it cannot", async () => {
+    // THE number this whole feature exists to produce - and the one way to get it wrong. These
+    // fields only start being written on 2026-07-27, so a window reaching back further is mostly
+    // rows that predate them; dividing by the total would report a share far below the truth.
+    await renderWith(
+      reportOf([
+        {
+          key: "devthrottle",
+          sessions: [
+            session("a", { originKind: "agent" }),
+            session("b", { originKind: "agent" }),
+            session("c", { originKind: "human" }),
+            session("old1"), // predates the field
+            session("old2"),
+          ],
+        },
+      ]),
+    );
+
+    expect(screen.getByText(/2 of 3 started by agents/)).toBeTruthy();
+    expect(screen.getByText(/2 older sessions do not record who started them/)).toBeTruthy();
+    // Never "2 of 5": the unrecorded rows are not silently counted as human.
+    expect(screen.queryByText(/2 of 5/)).toBeNull();
+  });
+
+  it("omits the share entirely when nothing can say who started it", async () => {
+    await renderWith(
+      reportOf([{ key: "devthrottle", sessions: [session("old1"), session("old2")] }]),
+    );
+
+    expect(screen.queryByText(/started by agents/)).toBeNull();
+  });
+
+  it("marks who started a session in plain words, without claiming which person", async () => {
+    await renderWith(
+      reportOf([
+        {
+          key: "devthrottle",
+          sessions: [
+            session("h", { originKind: "human", descriptionLine: "By hand" }),
+            session("s", { originKind: "schedule", descriptionLine: "By schedule" }),
+            session("u", { originKind: "unknown", descriptionLine: "Unrecorded" }),
+          ],
+        },
+      ]),
+    );
+
+    expect(within(screen.getByText("By hand").closest("li")!).getByText(/started by hand/)).toBeTruthy();
+    expect(within(screen.getByText("By schedule").closest("li")!).getByText(/started by a schedule/)).toBeTruthy();
+    // A row that cannot say shows nothing rather than a hedge.
+    const unknownItem = screen.getByText("Unrecorded").closest("li")!;
+    expect(within(unknownItem).queryByText(/started by/)).toBeNull();
+  });
+
+  it("shows the interruption count beside the idle clock", async () => {
+    await renderWith(
+      reportOf([
+        {
+          key: "devthrottle",
+          sessions: [session("a", { descriptionLine: "Needy", waitingStretchCount: 7 })],
+        },
+      ]),
+    );
+
+    expect(within(screen.getByText("Needy").closest("li")!).getByText(/needed you 7x/)).toBeTruthy();
+  });
+});

--- a/apps/cockpit/src/history/HistoryView.tsx
+++ b/apps/cockpit/src/history/HistoryView.tsx
@@ -7,6 +7,15 @@ import {
   type WorkHistoryReport,
   type WorkHistorySession,
 } from "@devthrottle/client-core/history/historyClient";
+import {
+  accountedFor,
+  buildLineage,
+  indexReport,
+  nodeCount,
+  originLabel,
+  tallyOrigins,
+  type LineageNode,
+} from "@devthrottle/client-core/history/lineage";
 import { ErrorBanner, LoadingState, PageHeader } from "../components";
 
 // The History page (issue #2194): "what have I been working on?" answered from the Gateway's durable
@@ -54,9 +63,14 @@ function timeOf(iso: string | null | undefined): string {
   return parsed.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
 }
 
-function SessionEntry({ session }: { session: WorkHistorySession }) {
+function SessionEntry({ node, depth = 0 }: { node: LineageNode; depth?: number }) {
+  const session = node.session;
   const [open, setOpen] = useState(false);
+  // Children start EXPANDED. The whole point of nesting is that you can see what a session set off;
+  // collapsed-by-default would hide the answer behind a click on every row that has one.
+  const [childrenOpen, setChildrenOpen] = useState(true);
   const live = session.endingKind == null;
+  const descendants = nodeCount(node) - 1;
   const meta: string[] = [];
   if (session.sessionName) meta.push(session.sessionNumber != null ? `${session.sessionName} (#${session.sessionNumber})` : session.sessionName);
   else if (session.sessionNumber != null) meta.push(`#${session.sessionNumber}`);
@@ -70,6 +84,14 @@ function SessionEntry({ session }: { session: WorkHistorySession }) {
   else if (session.turnCount != null && session.turnCount > 0) meta.push(`${session.turnCount} turns`);
   if (session.idleSeconds != null && session.idleSeconds >= 60)
     meta.push(`idle ${durationFromMs(session.idleSeconds * 1000)}`);
+  // The interruption COUNT beside the clock (internal#982). Twelve five-minute waits and one
+  // hour-long wait read identically on the clock and are nothing alike to live with.
+  if (session.waitingStretchCount != null && session.waitingStretchCount > 0)
+    meta.push(`needed you ${session.waitingStretchCount}x`);
+  // Who started it (internal#982). Null for "unknown" and for rows that predate the field - a row
+  // that cannot say shows nothing rather than a hedge.
+  const origin = originLabel(session);
+  if (origin !== null) meta.push(origin);
 
   const hasDetail =
     (session.summaryText != null && session.summaryText.length > 0) ||
@@ -80,7 +102,7 @@ function SessionEntry({ session }: { session: WorkHistorySession }) {
     (session.commits?.length ?? 0) > 0;
 
   return (
-    <li className={`wh-session wh-tone-${session.endingTone}`}>
+    <li className={`wh-session wh-tone-${session.endingTone}${depth > 0 ? " wh-session-child" : ""}`}>
       <button
         type="button"
         className="wh-session-row"
@@ -92,6 +114,18 @@ function SessionEntry({ session }: { session: WorkHistorySession }) {
         <span className="wh-session-main">
           <span className="wh-session-desc">{session.descriptionLine}</span>
           <span className="wh-session-meta">{meta.join(" · ")}</span>
+          {/* The parent is real but not in this group - almost always because it spawned work in
+              another repository, which is the fleet's most ordinary move. Nesting the row here
+              would file that work under a repository it never touched, so it stays put and says
+              who started it instead. A null label means the parent is outside the report
+              altogether (pruned, or older than the window) - which is worth saying, not hiding. */}
+          {node.parentElsewhere && (
+            <span className="wh-parent-note">
+              {node.parentElsewhere.label !== null
+                ? `started by ${node.parentElsewhere.label}, elsewhere in this range`
+                : "started by a session outside this range"}
+            </span>
+          )}
         </span>
         <span className="wh-ending">
           {live ? "Running now" : session.endingLabel ?? session.endingKind}
@@ -111,6 +145,26 @@ function SessionEntry({ session }: { session: WorkHistorySession }) {
           <DetailList title="Pull requests" items={session.pullRequests} />
           <DetailList title="Commits" items={session.commits} />
         </div>
+      )}
+      {node.children.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="wh-children-toggle"
+            onClick={() => setChildrenOpen((v) => !v)}
+            aria-expanded={childrenOpen}
+          >
+            {childrenOpen ? "Hide" : "Show"} {descendants} session
+            {descendants === 1 ? "" : "s"} this one started
+          </button>
+          {childrenOpen && (
+            <ul className="wh-sessions wh-sessions-nested">
+              {node.children.map((child) => (
+                <SessionEntry key={child.session.sessionId} node={child} depth={depth + 1} />
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </li>
   );
@@ -153,18 +207,29 @@ export function HistoryView() {
     return () => controller.abort();
   }, [load, days]);
 
+  // Every session in the report, keyed by id - what a cross-group parent is resolved against, so a
+  // child can name its parent even when that parent is filed under another repository or day.
+  const reportIndex = useMemo(() => (report === null ? null : indexReport(report)), [report]);
+
   const totals = useMemo(() => {
-    if (report === null) return null;
-    const sessions = new Set<string>();
+    if (report === null || reportIndex === null) return null;
+    const unique = new Map<string, WorkHistorySession>();
     let running = 0;
     for (const repo of report.repos)
       for (const day of repo.days)
         for (const s of day.sessions) {
-          if (!sessions.has(s.sessionId) && s.endingKind == null) running++;
-          sessions.add(s.sessionId);
+          if (!unique.has(s.sessionId) && s.endingKind == null) running++;
+          if (!unique.has(s.sessionId)) unique.set(s.sessionId, s);
         }
-    return { repos: report.repos.length, sessions: sessions.size, running };
-  }, [report]);
+    const origins = tallyOrigins(unique.values());
+    return {
+      repos: report.repos.length,
+      sessions: unique.size,
+      running,
+      origins,
+      known: accountedFor(origins),
+    };
+  }, [report, reportIndex]);
 
   return (
     <div className="page wh">
@@ -189,6 +254,26 @@ export function HistoryView() {
             {totals.sessions} session{totals.sessions === 1 ? "" : "s"} across {totals.repos}{" "}
             repositor{totals.repos === 1 ? "y" : "ies"}
             {totals.running > 0 ? ` · ${totals.running} running now` : ""}
+            {/* The agent share, stated over the sessions we can actually ACCOUNT FOR rather than
+                over all of them. These fields only start being written on 2026-07-27, so a window
+                reaching back further is mostly rows that predate them - and dividing by the total
+                would report a share far lower than the truth. When some rows cannot say, the
+                denominator says so out loud rather than quietly absorbing them. */}
+            {totals.known > 0 && (
+              <>
+                {" · "}
+                {totals.origins.agent} of {totals.known} started by agents
+                {totals.known < totals.sessions && (
+                  <span className="wh-totals-caveat">
+                    {" "}
+                    ({totals.sessions - totals.known} older session
+                    {totals.sessions - totals.known === 1 ? "" : "s"} do
+                    {totals.sessions - totals.known === 1 ? "es" : ""} not record who started
+                    {totals.sessions - totals.known === 1 ? " it" : " them"})
+                  </span>
+                )}
+              </>
+            )}
           </span>
         )}
       </div>
@@ -224,9 +309,14 @@ export function HistoryView() {
                     The day&apos;s summary has not been written yet.
                   </p>
                 )}
+                {/* The day's sessions as the shape they actually had (internal#989): a day where
+                    three things were started and they spawned nineteen helpers is a list of
+                    twenty-two rows and a tree of three roots - identical data, completely
+                    different stories. Built per group, resolving parents against the whole report
+                    so a child can still name a parent filed under another repository. */}
                 <ul className="wh-sessions">
-                  {day.sessions.map((s) => (
-                    <SessionEntry key={s.sessionId} session={s} />
+                  {buildLineage(day.sessions, reportIndex ?? undefined).map((node) => (
+                    <SessionEntry key={node.session.sessionId} node={node} />
                   ))}
                 </ul>
               </div>

--- a/apps/cockpit/src/history/history.css
+++ b/apps/cockpit/src/history/history.css
@@ -150,6 +150,56 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Lineage (internal#989). ---------------------------------------------------------------------
+   Children are INDENTED with a rail rather than boxed: the rail says "these came from the row
+   above" while keeping every row on the same reading line, so a parent with six children still
+   scans as one thing. A box per level turns three roots into three cards and undoes the point. */
+.wh-sessions-nested {
+  margin: 0 0 6px 22px;
+  border-left: 2px solid var(--border);
+  padding-left: 10px;
+}
+/* A nested row's top border would double up with the rail; drop it on the first child. */
+.wh-sessions-nested > .wh-session:first-child {
+  border-top: none;
+}
+.wh-session-child > .wh-session-row {
+  font-size: 12.5px;
+}
+
+/* "Hide/Show N sessions this one started" - quiet by default; this is orientation, not an action. */
+.wh-children-toggle {
+  display: block;
+  margin: 0 0 2px 22px;
+  padding: 2px 0;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-size: 11.5px;
+  text-align: left;
+  cursor: pointer;
+}
+.wh-children-toggle:hover {
+  color: var(--accent);
+}
+
+/* The parent that is not in this group - a real fact about the row, so it reads as one rather
+   than as a warning. */
+.wh-parent-note {
+  color: var(--text-dim);
+  font-size: 11.5px;
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The "some rows cannot say who started them" caveat on the totals line. Deliberately not hidden
+   behind a tooltip: a share whose denominator needs explaining must carry the explanation. */
+.wh-totals-caveat {
+  opacity: 0.75;
+}
 .wh-ending {
   flex: 0 0 auto;
   font-size: 12px;

--- a/packages/client-core/src/history/historyClient.ts
+++ b/packages/client-core/src/history/historyClient.ts
@@ -20,7 +20,20 @@ export interface WorkHistorySession {
   agentKind?: string | null;
   model?: string | null;
   missionName?: string | null;
+  missionId?: string | null;
   sessionRole?: string | null;
+  /**
+   * Who asked for this session (internal#982): "human" | "agent" | "schedule" | "unknown".
+   * NULL means the row predates the field - which is NOT the same as "unknown", the answer for a
+   * create path that was asked and had nothing to say. Never render either as "human".
+   */
+  originKind?: string | null;
+  /** Where the create call came from: "desktop" | "cockpit" | "phone" | "cli" | "cron" |
+   * "workflow" | "api" | "unknown". Null on rows that predate the field. */
+  originSurface?: string | null;
+  /** The session that ASKED for this one, or null. Keys the same table, so it resolves against
+   * other records in the report - and may name a row retention has already pruned. */
+  parentSessionId?: string | null;
   startedAtUtc: string;
   lastActivityUtc?: string | null;
   lastSeenUtc: string;
@@ -38,6 +51,20 @@ export interface WorkHistorySession {
   agentTurnCount?: number | null;
   /** Total seconds spent waiting on the user, closed stretches only. Null when never reported. */
   idleSeconds?: number | null;
+  /** How many times the session started waiting on the user (internal#982) - the matched pair to
+   * idleSeconds, and not derivable from it. Null when never reported. */
+  waitingStretchCount?: number | null;
+  /** Character volume of input submitted, operator plus agent-driven. Null when never reported. */
+  inputCharacterCount?: number | null;
+  /** Cumulative token spend, kept per kind because they are priced differently. Null when the
+   * agent's driver reports no usage. */
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheReadTokens?: number | null;
+  cacheCreationTokens?: number | null;
+  /** The fullest the context window was observed to be. A PEAK, never a sum - occupancy is a gauge
+   * that drops on compaction. Null when the driver reports no reading. */
+  peakContextTokens?: number | null;
   /** null until a summary exists; "sealed" | "generated" | "none" | "unavailable". */
   summaryKind?: string | null;
   summaryIsPartial: boolean;

--- a/packages/client-core/src/history/lineage.test.ts
+++ b/packages/client-core/src/history/lineage.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  accountedFor,
+  buildLineage,
+  indexReport,
+  nodeCount,
+  originLabel,
+  sessionLabel,
+  tallyOrigins,
+  type LineageNode,
+} from "./lineage";
+import type { WorkHistoryReport, WorkHistorySession } from "./historyClient";
+
+// The lineage rules (internal#989). Almost every test here is about a parent that ISN'T in the
+// group, because that is the normal case on this fleet - `session spawn <other-repo>` puts the child
+// under a different repository - and each way of getting it wrong is its own quiet lie.
+
+function session(id: string, over: Partial<WorkHistorySession> = {}): WorkHistorySession {
+  return {
+    sessionId: id,
+    startedAtUtc: "2026-07-27T10:00:00Z",
+    lastSeenUtc: "2026-07-27T11:00:00Z",
+    endingTone: "neutral",
+    descriptionLine: `session ${id}`,
+    summaryIsPartial: false,
+    ...over,
+  };
+}
+
+function report(sessions: WorkHistorySession[]): WorkHistoryReport {
+  return {
+    fromDay: "2026-07-27",
+    toDay: "2026-07-27",
+    repos: [
+      {
+        repoKey: "r",
+        displayName: "r",
+        days: [{ day: "2026-07-27", summaryPending: false, sessions }],
+      },
+    ],
+  };
+}
+
+const ids = (nodes: LineageNode[]) => nodes.map((n) => n.session.sessionId);
+
+describe("buildLineage", () => {
+  it("nests a child under a parent in the same group", () => {
+    const parent = session("p");
+    const child = session("c", { parentSessionId: "p" });
+
+    const roots = buildLineage([parent, child]);
+
+    expect(ids(roots)).toEqual(["p"]);
+    expect(ids(roots[0].children)).toEqual(["c"]);
+  });
+
+  it("turns twenty-two rows into the three things that were actually started", () => {
+    // The whole point of the feature, in one assertion.
+    const sessions: WorkHistorySession[] = [];
+    for (const root of ["a", "b", "c"]) {
+      sessions.push(session(root));
+      for (let i = 0; i < 6; i++) sessions.push(session(`${root}${i}`, { parentSessionId: root }));
+    }
+    sessions.push(session("d"));
+
+    const roots = buildLineage(sessions);
+
+    expect(roots).toHaveLength(4);
+    expect(sessions).toHaveLength(22);
+    expect(roots.reduce((sum, r) => sum + nodeCount(r), 0)).toBe(22);
+  });
+
+  it("nests grandchildren, so delegation depth survives", () => {
+    const roots = buildLineage([
+      session("a"),
+      session("b", { parentSessionId: "a" }),
+      session("c", { parentSessionId: "b" }),
+    ]);
+
+    expect(ids(roots)).toEqual(["a"]);
+    expect(ids(roots[0].children)).toEqual(["b"]);
+    expect(ids(roots[0].children[0].children)).toEqual(["c"]);
+    expect(nodeCount(roots[0])).toBe(3);
+  });
+
+  it("orders children oldest first, so a parent reads as the sequence it set off", () => {
+    const roots = buildLineage([
+      session("p"),
+      session("late", { parentSessionId: "p", startedAtUtc: "2026-07-27T12:00:00Z" }),
+      session("early", { parentSessionId: "p", startedAtUtc: "2026-07-27T09:00:00Z" }),
+    ]);
+
+    expect(ids(roots[0].children)).toEqual(["early", "late"]);
+  });
+
+  it("keeps a child at top level when its parent is in another group, and says who", () => {
+    // The common case: an agent in one repository spawned work in another. Nesting it here would
+    // file that work under a repository it never touched; dropping the note would make it look like
+    // nobody started it.
+    const elsewhere = session("p", { sessionName: "Release manager" });
+    const child = session("c", { parentSessionId: "p" });
+    const index = indexReport(report([elsewhere, child]));
+
+    const roots = buildLineage([child], index);
+
+    expect(ids(roots)).toEqual(["c"]);
+    expect(roots[0].parentElsewhere).toEqual({ sessionId: "p", label: "Release manager" });
+  });
+
+  it("distinguishes a parent outside the report from one merely in another group", () => {
+    // Pruned by retention, or started before the window. A null label is not a missing value to
+    // hide - "started by a session we no longer keep" is true and worth showing.
+    const child = session("c", { parentSessionId: "gone" });
+
+    const roots = buildLineage([child], indexReport(report([child])));
+
+    expect(roots[0].parentElsewhere).toEqual({ sessionId: "gone", label: null });
+  });
+
+  it("never invents a root: a child with an absent parent is still marked", () => {
+    // Roots are the thing being counted. A child quietly promoted to root would add one to
+    // "things you started" for a session you did not start.
+    const roots = buildLineage([session("c", { parentSessionId: "gone" })]);
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].parentElsewhere?.sessionId).toBe("gone");
+  });
+
+  it("treats a session claiming itself as a root, without a note", () => {
+    // The id is minted on another machine and arrives over the wire. A node that is its own child
+    // would hang the render rather than show a wrong number.
+    const roots = buildLineage([session("a", { parentSessionId: "a" })]);
+
+    expect(ids(roots)).toEqual(["a"]);
+    expect(roots[0].parentElsewhere).toBeUndefined();
+    expect(roots[0].children).toHaveLength(0);
+  });
+
+  it("survives a two-session cycle instead of looping forever", () => {
+    const roots = buildLineage([
+      session("a", { parentSessionId: "b" }),
+      session("b", { parentSessionId: "a" }),
+    ]);
+
+    // Neither can attach without closing the loop, so both stay at top level carrying their notes.
+    // Corrupt data renders FLAT. The failure this pins is not cosmetic: the first version walked the
+    // half-built tree, so at the moment each was examined the other had no children yet, both
+    // attached, the forest came out with ZERO roots, and the first thing to walk it looped forever.
+    expect(roots).toHaveLength(2);
+    expect(roots.every((r) => r.children.length === 0)).toBe(true);
+    expect(roots.every((r) => r.parentElsewhere != null)).toBe(true);
+    const total = roots.reduce((sum, r) => sum + nodeCount(r), 0);
+    expect(total).toBe(2);
+  });
+
+  it("survives a three-session cycle", () => {
+    const roots = buildLineage([
+      session("a", { parentSessionId: "c" }),
+      session("b", { parentSessionId: "a" }),
+      session("c", { parentSessionId: "b" }),
+    ]);
+
+    // Every session appears exactly once, and nothing loops.
+    expect(roots.reduce((sum, r) => sum + nodeCount(r), 0)).toBe(3);
+  });
+
+  it("a long legitimate chain still nests", () => {
+    // The cycle guard must not mistake depth for corruption.
+    const sessions = [session("s0")];
+    for (let i = 1; i < 20; i++) sessions.push(session(`s${i}`, { parentSessionId: `s${i - 1}` }));
+
+    const roots = buildLineage(sessions);
+
+    expect(ids(roots)).toEqual(["s0"]);
+    expect(nodeCount(roots[0])).toBe(20);
+  });
+
+  it("keeps every session exactly once", () => {
+    // The invariant that matters for any count drawn off this tree.
+    const sessions = [
+      session("a"),
+      session("b", { parentSessionId: "a" }),
+      session("c", { parentSessionId: "missing" }),
+      session("d", { parentSessionId: "b" }),
+    ];
+
+    const roots = buildLineage(sessions);
+    const seen: string[] = [];
+    const walk = (n: LineageNode) => {
+      seen.push(n.session.sessionId);
+      n.children.forEach(walk);
+    };
+    roots.forEach(walk);
+
+    expect(seen.sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("ignores a duplicate row for the same session", () => {
+    const roots = buildLineage([session("a"), session("a")]);
+    expect(roots).toHaveLength(1);
+  });
+
+  it("handles an empty group", () => {
+    expect(buildLineage([])).toEqual([]);
+  });
+});
+
+describe("tallyOrigins", () => {
+  it("keeps unrecorded apart from unknown, and neither becomes human", () => {
+    // THE fold this feature exists to prevent. These fields only start being written on
+    // 2026-07-27, so for any window reaching back further the unrecorded rows are the majority -
+    // counting them as human would report the exact opposite of the truth.
+    const tally = tallyOrigins([
+      session("1", { originKind: "human" }),
+      session("2", { originKind: "agent" }),
+      session("3", { originKind: "agent" }),
+      session("4", { originKind: "schedule" }),
+      session("5", { originKind: "unknown" }),
+      session("6"), // predates the field
+    ]);
+
+    expect(tally).toEqual({ human: 1, agent: 2, schedule: 1, unknown: 1, notRecorded: 1, total: 6 });
+    expect(accountedFor(tally)).toBe(4);
+    expect(tally.total).not.toBe(accountedFor(tally));
+  });
+
+  it("counts an all-unrecorded set as nothing accounted for", () => {
+    const tally = tallyOrigins([session("1"), session("2")]);
+    expect(accountedFor(tally)).toBe(0);
+    expect(tally.notRecorded).toBe(2);
+  });
+});
+
+describe("originLabel", () => {
+  it("says a person without claiming which person", () => {
+    // The Gateway is multi-tenant and the record does not store WHICH human, so "you" would be
+    // inventing a fact to make a nicer sentence.
+    expect(originLabel(session("1", { originKind: "human" }))).toBe("started by hand");
+    expect(originLabel(session("1", { originKind: "human" }))).not.toContain("you");
+  });
+
+  it("shows nothing rather than a hedge when the record cannot say", () => {
+    expect(originLabel(session("1", { originKind: "unknown" }))).toBeNull();
+    expect(originLabel(session("1"))).toBeNull();
+  });
+
+  it("labels agents and schedules", () => {
+    expect(originLabel(session("1", { originKind: "agent" }))).toBe("started by an agent");
+    expect(originLabel(session("1", { originKind: "schedule" }))).toBe("started by a schedule");
+  });
+});
+
+describe("sessionLabel", () => {
+  it("prefers the name, then the number, then a short id", () => {
+    expect(sessionLabel(session("abcdef123456", { sessionName: "Wingman" }))).toBe("Wingman");
+    expect(sessionLabel(session("abcdef123456", { sessionNumber: 104 }))).toBe("#104");
+    expect(sessionLabel(session("abcdef123456"))).toBe("abcdef12");
+  });
+});

--- a/packages/client-core/src/history/lineage.ts
+++ b/packages/client-core/src/history/lineage.ts
@@ -1,0 +1,212 @@
+// Turning the flat work-history list into the shape it actually had (internal#989, on the record
+// internal#982 laid down).
+//
+// A day where you started three things and they spawned nineteen helpers is a list of twenty-two
+// rows and a tree of three roots. Both contain identical data and they tell completely different
+// stories; only one of them answers "what did I set in motion".
+//
+// THE HARD PART IS NOT THE TREE, IT IS THE PARENTS THAT ARE NOT THERE. The History page groups by
+// repository and then by day, and lineage cuts straight across both: `session spawn <other-repo>`
+// is the fleet's most ordinary move, so a child very often sits in a different group from its
+// parent - and a parent can also have been pruned by the 90-day retention, or simply started before
+// the window the page is showing. Three genuinely different situations, and collapsing them would
+// each be its own small lie:
+//
+//   - parent in this group      -> nest it. The tree does its job.
+//   - parent elsewhere in the report -> keep it at top level and SAY who started it, with the id so
+//                                  the page can link. Moving the row into the parent's group would
+//                                  file work under a repository it never touched.
+//   - parent nowhere in the report -> keep it at top level and say the parent is outside this view.
+//                                  Silently treating it as a root would invent a root, and roots are
+//                                  the thing being counted.
+//
+// Pure functions over plain data, no React, so the rules above are testable on their own.
+import type { WorkHistoryReport, WorkHistorySession } from "./historyClient";
+
+/** One session in the tree, with its children and an honest note about a parent that is not here. */
+export interface LineageNode {
+  session: WorkHistorySession;
+  /** Nested children, oldest first. Empty for a leaf. */
+  children: LineageNode[];
+  /**
+   * Set when this session names a parent that is NOT in the same group. `label` is the parent's
+   * display name when the report contains it, or null when the parent is outside the report
+   * entirely (pruned, or started before the window). A null label is not a missing value to hide:
+   * "started by a session we no longer keep" is a true and useful thing to show.
+   */
+  parentElsewhere?: { sessionId: string; label: string | null };
+}
+
+/** How many sessions sit under a node, itself included. */
+export function nodeCount(node: LineageNode): number {
+  let total = 1;
+  for (const child of node.children) total += nodeCount(child);
+  return total;
+}
+
+/** A short human label for a session row: its name, else its number, else a short id. */
+export function sessionLabel(session: WorkHistorySession): string {
+  if (session.sessionName != null && session.sessionName.length > 0) return session.sessionName;
+  if (session.sessionNumber != null) return `#${session.sessionNumber}`;
+  return session.sessionId.slice(0, 8);
+}
+
+/** Every session in the report, keyed by id - the index a cross-group parent is resolved against. */
+export function indexReport(report: WorkHistoryReport): Map<string, WorkHistorySession> {
+  const index = new Map<string, WorkHistorySession>();
+  for (const repo of report.repos)
+    for (const day of repo.days)
+      for (const session of day.sessions)
+        if (!index.has(session.sessionId)) index.set(session.sessionId, session);
+  return index;
+}
+
+/**
+ * Build the forest for ONE group's sessions (one repository, one day), resolving cross-group parents
+ * against `reportIndex` - the whole report - so a child can name its parent even when that parent is
+ * filed under another repository or another day.
+ *
+ * Order is preserved: roots come out in the order they arrived (the page sorts them already), and
+ * children are ordered oldest-first, because a parent's children read as the sequence of things it
+ * set off.
+ */
+export function buildLineage(
+  sessions: readonly WorkHistorySession[],
+  reportIndex?: ReadonlyMap<string, WorkHistorySession>,
+): LineageNode[] {
+  const inGroup = new Map<string, WorkHistorySession>();
+  for (const s of sessions) if (!inGroup.has(s.sessionId)) inGroup.set(s.sessionId, s);
+
+  const nodes = new Map<string, LineageNode>();
+  for (const s of inGroup.values()) nodes.set(s.sessionId, { session: s, children: [] });
+
+  const roots: LineageNode[] = [];
+  for (const s of inGroup.values()) {
+    const node = nodes.get(s.sessionId)!;
+    const parentId = s.parentSessionId ?? null;
+
+    if (parentId === null || parentId === s.sessionId) {
+      // No parent, or a session claiming itself. The self-parent case is not paranoia for its own
+      // sake: the id is minted on another machine and arrives over the wire, and a node that is its
+      // own child would hang the render rather than show a wrong number.
+      roots.push(node);
+      continue;
+    }
+
+    const parentHere = nodes.get(parentId);
+    if (parentHere !== undefined && !wouldCycle(parentId, s.sessionId, inGroup)) {
+      parentHere.children.push(node);
+      continue;
+    }
+
+    // Either the parent is not in this group, or attaching would close a cycle. Both end up at top
+    // level carrying the note; a cycle is corrupt data and the honest render is the flat one.
+    //
+    // Mutated in place rather than copied. A child may be attached to this same node either before
+    // or after we get here - the iteration order is the map's, not the tree's - and a copy would
+    // leave two objects that have to be kept in step for the rest of the function.
+    const known = reportIndex?.get(parentId);
+    node.parentElsewhere = { sessionId: parentId, label: known ? sessionLabel(known) : null };
+    roots.push(node);
+  }
+
+  const byStart = (a: LineageNode, b: LineageNode) =>
+    a.session.startedAtUtc < b.session.startedAtUtc ? -1 : a.session.startedAtUtc > b.session.startedAtUtc ? 1 : 0;
+  const sortChildren = (node: LineageNode, depth: number) => {
+    if (depth > 64) return; // corrupt data cannot make this loop forever
+    node.children.sort(byStart);
+    for (const child of node.children) sortChildren(child, depth + 1);
+  };
+  for (const root of roots) sortChildren(root, 0);
+
+  return roots;
+}
+
+/**
+ * Would attaching `childId` under `parentId` close a loop? Walks the PARENT-POINTER chain upward
+ * from the prospective parent, not the half-built tree.
+ *
+ * That distinction is the whole of it, and the first version got it wrong. Walking the tree asks
+ * "is the child already underneath the parent right now", which depends on how far construction has
+ * got: for a two-session cycle (a names b, b names a) neither node has children at the moment it is
+ * examined, so both attach, the forest comes out with NO roots at all, and the first thing to walk
+ * the result loops forever. The parent chain is in the data from the start, so the answer does not
+ * depend on iteration order.
+ *
+ * A chain that leaves the group is not a cycle - it just ends. A chain that revisits any id, or runs
+ * implausibly long, is refused.
+ */
+function wouldCycle(
+  parentId: string,
+  childId: string,
+  inGroup: ReadonlyMap<string, WorkHistorySession>,
+): boolean {
+  const seen = new Set<string>();
+  let current: string | undefined = parentId;
+  for (let hops = 0; current !== undefined && hops < 256; hops++) {
+    if (current === childId) return true;
+    if (seen.has(current)) return true;
+    seen.add(current);
+    const parent = inGroup.get(current);
+    if (parent === undefined) return false; // the chain leaves this group; nothing to close
+    current = parent.parentSessionId ?? undefined;
+  }
+  return current !== undefined; // ran out of hops with more chain to go: refuse
+}
+
+/** What the origin markers add up to over a set of sessions. Counts only - see originTotals. */
+export interface OriginTally {
+  human: number;
+  agent: number;
+  schedule: number;
+  /** The create path was asked and had nothing to say. */
+  unknown: number;
+  /** The row predates the field entirely. A different thing from `unknown`. */
+  notRecorded: number;
+  total: number;
+}
+
+/**
+ * Tally how a set of sessions came to exist.
+ *
+ * `unknown` and `notRecorded` are kept apart, and neither is folded into `human`. That fold is the
+ * one mistake this whole feature exists to prevent: these fields only started being written on
+ * 2026-07-27, so for any window reaching back before that the unrecorded rows are the MAJORITY, and
+ * quietly counting them as human would report the exact opposite of the truth.
+ */
+export function tallyOrigins(sessions: Iterable<WorkHistorySession>): OriginTally {
+  const tally: OriginTally = { human: 0, agent: 0, schedule: 0, unknown: 0, notRecorded: 0, total: 0 };
+  for (const s of sessions) {
+    tally.total++;
+    switch (s.originKind ?? null) {
+      case "human": tally.human++; break;
+      case "agent": tally.agent++; break;
+      case "schedule": tally.schedule++; break;
+      case "unknown": tally.unknown++; break;
+      default: tally.notRecorded++; break;
+    }
+  }
+  return tally;
+}
+
+/** How many sessions in the tally we can actually account for - the only honest denominator. */
+export function accountedFor(tally: OriginTally): number {
+  return tally.human + tally.agent + tally.schedule;
+}
+
+/**
+ * The plain-language marker for a row: who started this session.
+ *
+ * Deliberately not "you". The Gateway is multi-tenant and "a person" is all the record says - which
+ * human is not stored, so claiming it would be inventing a fact to make a nicer sentence. Returns
+ * null for unknown and for unrecorded, because a row that cannot say who started it should show
+ * nothing rather than a hedge.
+ */
+export function originLabel(session: WorkHistorySession): string | null {
+  switch (session.originKind ?? null) {
+    case "human": return "started by hand";
+    case "agent": return "started by an agent";
+    case "schedule": return "started by a schedule";
+    default: return null;
+  }
+}


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#989 (the History half; the Your Throttle share is still open - see below).

## Why

Origin and lineage landed on the record in #2232 and **nothing rendered a single field of it**. Answering "what did I set in motion this week" still meant querying the API by hand, which is the situation the original issue was filed about.

## What changes

The History page nests each session under the one that started it. A day where three things were started and they spawned nineteen helpers was twenty-two rows; it is now three roots. Identical data, completely different story - and only one of them is an answer.

## The hard part is the parents that are not there

The page groups by repository and then by day, and lineage cuts straight across both. `session spawn <other-repo>` is the fleet's most ordinary move, so a child very often sits in a different group from its parent - and a parent can also have been pruned by the 90-day retention, or simply started before the window on screen.

Three genuinely different situations, and each has its own way of quietly lying:

| Situation | What it does | Why not the obvious thing |
|---|---|---|
| Parent in this group | Nest it | - |
| Parent elsewhere in the report | Keep the row where it is, **name** who started it, note it is elsewhere | Moving the row to its parent would file that work under a repository it never touched |
| Parent outside the report | Keep it, say the parent is outside this range | Silently promoting it to a root would **invent a root**, and roots are the thing being counted |

## A real bug its own test caught

The cycle guard originally walked the half-built tree, asking "is this child already underneath the prospective parent". That answer depends on how far construction has got. For a two-session cycle (`a` names `b`, `b` names `a`) neither node has children at the moment it is examined, so **both attached**, the forest came out with **zero roots**, and the first thing to walk the result looped forever.

It now walks the parent-pointer chain, which is in the data from the start and does not depend on iteration order. Corrupt data renders flat, with both rows carrying their note. Pinned by tests for two-session and three-session cycles, plus a twenty-deep legitimate chain so the guard cannot mistake depth for corruption.

## Honesty in the numbers

**The share is stated over what can be accounted for, and names what cannot:**

> 2 of 3 started by agents *(2 older sessions do not record who started them)*

These fields only start being written today, so any window reaching further back is mostly rows that predate them. Dividing by the total would report a share far below the truth - and the whole point of #982 was to be able to make this claim honestly. The share is omitted entirely when nothing can say.

**The per-row marker reads "started by hand", not "started by you."** The Gateway is multi-tenant and *which* human is not stored, so "you" would be inventing a fact to make a nicer sentence. A row whose origin is `unknown` or unrecorded shows nothing at all rather than a hedge.

**Children render expanded.** Collapsed-by-default would hide the answer behind a click on every row that has one.

## Also

Interruption count beside the idle clock ("needed you 7x"), and the rest of the #982 record - per-session spend, peak context, character volume, mission id - carried on the client types for the readers that follow.

## Still open on #989

The **Your Throttle** page does not yet show the fleet-wide agent-started share from the `sessionOrigins` block. Separate surface, separate change; I have left the issue open for it.

## Verification

28 new tests - 20 on the lineage rules in client-core (pure functions, no React) and 8 on the page itself, because passing the first is not the same as the screen changing. The page tests assert what a person can see: children inside the parent's list item, a cross-repository parent named rather than moved, an out-of-range parent stated, and that the share never reads "2 of 5" when only 3 rows can say.

Typecheck clean across all three packages. client-core 808 passed, cockpit 227 passed.

The 3 eslint errors in the workspace are pre-existing (missing rule definitions in `sw.test.ts`, `Recorder.tsx`, `VoiceMode.tsx` - none of them touched here), and CI does not run lint.
