### PR TITLE
feat(gateway): send hosted owner email by naming the tenant (internal #986)

### DIFF
--- a/src/CcDirector.Core/Account/AccountNotifyByTenantClient.cs
+++ b/src/CcDirector.Core/Account/AccountNotifyByTenantClient.cs
@@ -1,0 +1,229 @@
+using CcDirector.Core.Network;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The outcome of a TENANT-ADDRESSED owner-email send (devthrottle_internal #986).
+/// </summary>
+/// <param name="Sent">True only when the cloud accepted and sent. Never inferred from a status alone.</param>
+/// <param name="ProviderId">The provider message id when the cloud returned one; may be null even on a send.</param>
+/// <param name="Error">The cloud's own human-readable message, to be surfaced VERBATIM. Null on success.</param>
+/// <param name="StatusCode">The cloud HTTP status (0 when the request never got a response).</param>
+/// <param name="ErrorCode">
+/// The cloud's machine-readable code (<c>tenant_not_found</c>, <c>owner_not_resolvable</c>,
+/// <c>subject_mismatch</c>, <c>notify_rate_limited</c>, <c>tenant_lookup_not_installed</c>, ...). Used for
+/// LOGGING and for the retry rule only - never for composing a user-facing sentence, which is what
+/// <see cref="Error"/> already is.
+/// </param>
+/// <param name="RetryAfterSeconds">
+/// The cloud's <c>Retry-After</c> in seconds on a 429. Authoritative: the caller waits at least this long and
+/// applies no backoff of its own, because the cloud computes it from when the oldest hit in the window
+/// actually expires.
+/// </param>
+public sealed record TenantNotifyResult(
+    bool Sent, string? ProviderId, string? Error, int StatusCode, string? ErrorCode, int? RetryAfterSeconds);
+
+/// <summary>
+/// The Gateway's client for the TENANT-ADDRESSED owner-email primitive
+/// (<c>POST /api/v1/account/notify-owner-by-tenant</c>, devthrottle_internal #986). It exists because the
+/// hosted Gateway holds NO account access token for its tenants and must never start holding one: hosted
+/// enrollment validates the account token, mints a tenant and a device key, and stores neither. So the
+/// existing JWT-authenticated <see cref="AccountNotifyClient"/> cannot be used on hosted at all - that gap is
+/// what made <c>POST /account/email</c> report a signed-in user as signed out (issue #984).
+///
+/// THE SAFETY PROPERTY THIS TYPE IS BUILT AROUND: <b>this client cannot address anyone.</b> There is no
+/// recipient parameter, no recipient field on the wire, and no code path that could add one. The Gateway
+/// names a TENANT; the cloud resolves that tenant to its account subject and then to the owner's address
+/// through the same authority the JWT route uses. A recipient field in the body is refused by the cloud with
+/// a hard 400 rather than ignored, so neither side can quietly believe it addressed someone. That is belt
+/// and braces on purpose - the braces are here (no field can be constructed), the belt is there (a field
+/// would be rejected).
+///
+/// <see cref="AccountSubject"/> is sent as a CROSS-CHECK ONLY. The cloud compares it byte-for-byte against
+/// the subject stored on that tenant row and answers 403 <c>subject_mismatch</c> when it differs. It is never
+/// used to RESOLVE the recipient, and it must not be: a subject that selects the target is a subject that
+/// could select somebody else's. Sending it turns a wrong tenant id into a refusal instead of a
+/// correctly-delivered message to the wrong person.
+///
+/// Auth is a single shared secret in the <c>X-DevThrottle-Gateway-Token</c> header and NO Authorization
+/// header - presenting both is refused with a 400, because a route whose auth mode depends on which header
+/// happened to arrive is a route that will eventually pick the wrong one. The secret is read from
+/// <see cref="ServiceTokenEnvVar"/> and is NEVER logged, echoed, or placed in any response (DT-05).
+///
+/// The base URL resolves the same way the rest of the account egress does
+/// (<see cref="DevThrottleApi.BaseUrlEnvVar"/> override, else the production default), so this introduces no
+/// new hard-coded host and a preview deployment can be targeted by environment variable without a rebuild.
+/// </summary>
+public sealed class AccountNotifyByTenantClient
+{
+    /// <summary>The tenant-addressed send path (devthrottle_internal #986). Separate from the JWT route,
+    /// which is unchanged and still serves the self-host path.</summary>
+    public const string NotifyOwnerByTenantPath = "/api/v1/account/notify-owner-by-tenant";
+
+    /// <summary>The header carrying the Gateway service credential. Deliberately NOT <c>Authorization</c>.</summary>
+    public const string ServiceTokenHeader = "X-DevThrottle-Gateway-Token";
+
+    /// <summary>
+    /// The app setting holding the shared service secret. Its ABSENCE is meaningful: the Gateway must fail
+    /// closed rather than call unauthenticated, so that a 401 from the cloud always means the secret is
+    /// WRONG and never that it was missing. That distinction is what makes a misconfiguration diagnosable
+    /// from one end.
+    /// </summary>
+    public const string ServiceTokenEnvVar = "NOTIFY_OWNER_SERVICE_TOKEN";
+
+    private readonly HttpClient _client;
+    private readonly string _baseUrl;
+
+    public AccountNotifyByTenantClient(HttpClient? client = null, string? baseUrl = null)
+    {
+        _client = client ?? new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(30) };
+        _baseUrl = DevThrottleApi.ResolveBaseUrl(baseUrl);
+    }
+
+    /// <summary>The configured service secret, or null when unset. Never logged.</summary>
+    public static string? ResolveServiceToken()
+    {
+        var token = Environment.GetEnvironmentVariable(ServiceTokenEnvVar);
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    /// <summary>
+    /// Sends the owner of <paramref name="tenantId"/> an email, with the recipient resolved entirely
+    /// cloud-side. Returns a result: <see cref="TenantNotifyResult.Sent"/> is true only on an explicit
+    /// success envelope, never inferred from a status code. Throws only on a transport failure, which the
+    /// caller reports as unreachable. No token, subject, body, or attachment content is logged.
+    /// </summary>
+    /// <param name="serviceToken">The shared service secret. Never logged.</param>
+    /// <param name="tenantId">The caller tenant's id, exactly as stored. Compared byte-for-byte cloud-side.</param>
+    /// <param name="accountSubject">The subject on that tenant row, sent as a cross-check. Optional.</param>
+    public async Task<TenantNotifyResult> SendOwnerForTenantAsync(
+        string serviceToken, string tenantId, string? accountSubject,
+        string subject, string? text, string? html,
+        IReadOnlyList<NotifyAttachment>? attachments, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(serviceToken))
+            throw new ArgumentException("A Gateway service token is required", nameof(serviceToken));
+        if (string.IsNullOrWhiteSpace(tenantId))
+            throw new ArgumentException("A tenant id is required", nameof(tenantId));
+
+        var endpoint = $"{_baseUrl}{NotifyOwnerByTenantPath}";
+        var json = BuildBody(tenantId, accountSubject, subject, text, html, attachments);
+        // The tenant id and account subject are account-identifying and are NOT logged; only the shape is.
+        FileLog.Write($"[AccountNotifyByTenantClient] SendOwnerForTenantAsync: POST {endpoint} (attachments={attachments?.Count ?? 0}, crossCheck={(accountSubject is null ? "absent" : "present")})");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        // The service credential goes in its OWN header. No Authorization header is set here, ever -
+        // presenting both modes is a 400 by contract, and this client must not be the thing that does it.
+        request.Headers.Add(ServiceTokenHeader, serviceToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        var status = (int)response.StatusCode;
+
+        if (response.IsSuccessStatusCode)
+        {
+            var success = ParseSuccess(body, status);
+            FileLog.Write($"[AccountNotifyByTenantClient] SendOwnerForTenantAsync: status={status}, sent={success.Sent}");
+            return success;
+        }
+
+        int? retryAfter = null;
+        if (response.Headers.RetryAfter?.Delta is { } delta)
+            retryAfter = (int)Math.Ceiling(delta.TotalSeconds);
+        else if (response.Headers.TryGetValues("Retry-After", out var values)
+                 && int.TryParse(values.FirstOrDefault(), out var seconds))
+            retryAfter = seconds;
+
+        var (message, code) = ParseError(body, status);
+        FileLog.Write($"[AccountNotifyByTenantClient] SendOwnerForTenantAsync: NOT sent, status={status}, code={code ?? "<none>"}, retryAfter={(retryAfter is null ? "<none>" : retryAfter.ToString())}");
+        return new TenantNotifyResult(false, null, message, status, code, retryAfter);
+    }
+
+    /// <summary>
+    /// Builds the request body. Internal so a test can assert the wire shape - specifically that NO
+    /// recipient-shaped key can appear, which is the property the whole design rests on.
+    /// </summary>
+    internal static string BuildBody(
+        string tenantId, string? accountSubject, string subject, string? text, string? html,
+        IReadOnlyList<NotifyAttachment>? attachments)
+    {
+        var payload = new JsonObject
+        {
+            ["tenant_id"] = tenantId,
+            ["subject"] = subject,
+        };
+        // Cross-check only. Omitted rather than sent empty when unresolvable - a blank subject would be
+        // compared byte-for-byte and refused, turning a missing cross-check into a failed send.
+        if (!string.IsNullOrWhiteSpace(accountSubject))
+            payload["account_subject"] = accountSubject;
+        if (!string.IsNullOrEmpty(text)) payload["text"] = text;
+        if (!string.IsNullOrEmpty(html)) payload["html"] = html;
+        if (attachments is { Count: > 0 })
+        {
+            var arr = new JsonArray();
+            foreach (var a in attachments)
+            {
+                var obj = new JsonObject { ["filename"] = a.Filename, ["content"] = a.ContentBase64 };
+                if (!string.IsNullOrEmpty(a.ContentType)) obj["contentType"] = a.ContentType;
+                arr.Add(obj);
+            }
+            payload["attachments"] = arr;
+        }
+        return payload.ToJsonString();
+    }
+
+    /// <summary>
+    /// Parses the <c>{ "data": { "sent": true, "id": ... } }</c> success envelope. A 2xx whose body does NOT
+    /// say sent is reported as NOT sent - a status code is not a delivery receipt, and reporting a send that
+    /// did not happen is the one failure this whole change exists to prevent.
+    /// </summary>
+    internal static TenantNotifyResult ParseSuccess(string json, int status)
+    {
+        JsonObject? data = null;
+        try { data = (JsonNode.Parse(json) as JsonObject)?["data"] as JsonObject; }
+        catch (JsonException) { /* handled as not-sent below */ }
+
+        var sent = (data?["sent"] as JsonValue)?.TryGetValue<bool>(out var s) == true && s;
+        if (!sent)
+        {
+            return new TenantNotifyResult(false, null,
+                "The DevThrottle account service answered without confirming the email was sent.",
+                status, null, null);
+        }
+
+        var providerId = (data?["id"] as JsonValue)?.TryGetValue<string>(out var id) == true ? id : null;
+        return new TenantNotifyResult(true, providerId, null, status, null, null);
+    }
+
+    /// <summary>
+    /// Extracts the human message and machine code from the cloud's
+    /// <c>{ "error": { "type", "code", "message" } }</c> envelope. The message is written to be read by a
+    /// human and is surfaced VERBATIM; only the code is for us.
+    /// </summary>
+    internal static (string Message, string? Code) ParseError(string json, int statusCode)
+    {
+        try
+        {
+            var error = (JsonNode.Parse(json) as JsonObject)?["error"] as JsonObject;
+            var message = (error?["message"] as JsonValue)?.TryGetValue<string>(out var m) == true ? m : null;
+            var code = (error?["code"] as JsonValue)?.TryGetValue<string>(out var c) == true ? c : null;
+            if (!string.IsNullOrWhiteSpace(message))
+                return (message!, code);
+            if (!string.IsNullOrWhiteSpace(code))
+                return ($"the DevThrottle account service refused the send ({code}).", code);
+        }
+        catch (JsonException)
+        {
+            // fall through to the generic message below
+        }
+        return ($"the DevThrottle account service returned {statusCode}.", null);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Account/HostedOwnerEmailByTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedOwnerEmailByTenantTests.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Account;
+using CcDirector.Gateway;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// The hosted owner-email SEND (devthrottle_internal #986 consumer, closing the half of issue #984 that the
+/// truthful-state fold could not).
+///
+/// Issue #984 stopped <c>POST /account/email</c> lying to a signed-in hosted user, but it still could not
+/// send: the original cloud primitive resolves the recipient from an account access token, and the hosted
+/// Gateway holds none - hosted enrollment validates the account token, mints a tenant and a device key, and
+/// stores NEITHER. #986 adds a tenant-addressed cloud route so the Gateway names a TENANT and the cloud
+/// resolves the recipient server-side. This class proves the Gateway's half of that wire against a stub
+/// implementing the agreed contract exactly, so the wiring is verified before either side's credentialed
+/// configuration step exists.
+///
+/// WHY A STUB AND NOT THE REAL ROUTE, stated so nobody reads more into these greens than they cover. The
+/// cloud preview sits behind Vercel deployment protection, the tenant-resolution migration is not applied
+/// yet, and the service secret was deliberately destroyed after being set (a credential that can mail any
+/// tenant owner from a verified domain does not belong in a message log). So a live call is impossible until
+/// a human applies two configuration steps. These tests prove REQUEST SHAPE, AUTH DISCIPLINE, RESPONSE
+/// HANDLING and FAIL-CLOSED BEHAVIOUR - everything on this side of the wire. They do NOT prove that the
+/// cloud resolves a real tenant; only a live run against production can, and it is deliberately outstanding.
+///
+/// THE PROPERTIES UNDER PROOF, in the order they matter:
+/// <list type="number">
+/// <item>The Gateway CANNOT ADDRESS ANYONE. There is no recipient field on the wire, and none can be
+/// constructed - the safety property the whole design rests on.</item>
+/// <item>An unconfigured Gateway FAILS CLOSED rather than calling unauthenticated, which is what keeps a
+/// cloud 401 meaning "wrong secret" and never "no secret".</item>
+/// <item>The service credential travels in its own header and NEVER as an Authorization header, because a
+/// route whose auth mode depends on which header arrived will eventually pick the wrong one.</item>
+/// <item>A refusal is never rendered as a success, and the cloud's human-readable message is surfaced
+/// verbatim rather than reworded into something less true.</item>
+/// </list>
+/// </summary>
+public sealed class HostedOwnerEmailByTenantTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+    private const string ServiceSecret = "test-service-secret-for-986";
+
+    private readonly string _subject = "sub-986-" + Guid.NewGuid().ToString("N");
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-986-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+    private string _tenantId = "";
+    private string? _priorHosted;
+    private string? _priorRoot;
+    private string? _priorSecret;
+    private string? _priorApiUrl;
+
+    /// <summary>
+    /// A stub of the cloud route, run as a REAL HTTP server the Gateway reaches through
+    /// <c>DEVTHROTTLE_API_URL</c>. Deliberately a server rather than an injected message handler: the
+    /// Gateway builds its own client, and going over the wire exercises the real header names, the real JSON
+    /// serialization and the real Retry-After parsing rather than a hand-fed object graph. The whole point is
+    /// to catch a wire mismatch before a credentialed run can, so the wire has to be real.
+    /// </summary>
+    private sealed class CloudStub : IAsyncDisposable
+    {
+        private readonly Microsoft.AspNetCore.Builder.WebApplication _app;
+
+        public int Status = 200;
+        public string Body = """{"data":{"sent":true,"id":"resend-986"}}""";
+        public string? RetryAfter;
+
+        public int Calls;
+        public string? SeenPath;
+        public string? SeenServiceToken;
+        public string? SeenAuthorization;
+        public string? SeenBody;
+
+        public string BaseUrl { get; private set; } = "";
+
+        private CloudStub(Microsoft.AspNetCore.Builder.WebApplication app) => _app = app;
+
+        public static async Task<CloudStub> StartAsync()
+        {
+            var builder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            var stub = new CloudStub(app);
+
+            app.MapPost(AccountNotifyByTenantClient.NotifyOwnerByTenantPath, async (Microsoft.AspNetCore.Http.HttpContext ctx) =>
+            {
+                Interlocked.Increment(ref stub.Calls);
+                stub.SeenPath = ctx.Request.Path.Value;
+                stub.SeenServiceToken = ctx.Request.Headers[AccountNotifyByTenantClient.ServiceTokenHeader].FirstOrDefault();
+                stub.SeenAuthorization = ctx.Request.Headers.Authorization.FirstOrDefault();
+                using var reader = new StreamReader(ctx.Request.Body);
+                stub.SeenBody = await reader.ReadToEndAsync();
+
+                ctx.Response.StatusCode = stub.Status;
+                if (stub.RetryAfter is not null)
+                    ctx.Response.Headers["Retry-After"] = stub.RetryAfter;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(stub.Body);
+            });
+
+            await app.StartAsync();
+            stub.BaseUrl = app.Urls.First();
+            return stub;
+        }
+
+        public async ValueTask DisposeAsync() => await _app.DisposeAsync();
+    }
+
+    private CloudStub _cloud = null!;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _priorSecret = Environment.GetEnvironmentVariable(AccountNotifyByTenantClient.ServiceTokenEnvVar);
+        _priorApiUrl = Environment.GetEnvironmentVariable(DevThrottleApi.BaseUrlEnvVar);
+
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _instancesDir);
+        Environment.SetEnvironmentVariable(AccountNotifyByTenantClient.ServiceTokenEnvVar, ServiceSecret);
+
+        // Start the stub BEFORE the Gateway: the Gateway's egress client resolves its base URL at
+        // construction, so the environment variable has to be pointing at the stub by then.
+        _cloud = await CloudStub.StartAsync();
+        Environment.SetEnvironmentVariable(DevThrottleApi.BaseUrlEnvVar, _cloud.BaseUrl.TrimEnd('/'));
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject(_subject, "owner@example.com");
+        _tenantId = tenant.Value;
+        _key = _gateway.Devices.Register("dev-986", "M986").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-986", _subject, _tenantId);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        await _cloud.DisposeAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        Environment.SetEnvironmentVariable(AccountNotifyByTenantClient.ServiceTokenEnvVar, _priorSecret);
+        Environment.SetEnvironmentVariable(DevThrottleApi.BaseUrlEnvVar, _priorApiUrl);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    // ---- the client's wire shape, proven directly (no Gateway needed) -------------------------------
+
+    [Fact]
+    public void The_request_body_can_never_carry_a_recipient()
+    {
+        // PROPERTY 1, and the one that must never regress. The cloud refuses a recipient field with a hard
+        // 400 rather than ignoring it; this asserts the Gateway could not send one in the first place. Belt
+        // (their refusal) and braces (this) - and the braces are what stop a bad request ever being formed.
+        var body = AccountNotifyByTenantClient.BuildBody(
+            "tenant-1", "subject-1", "Subject line", "text", "<p>html</p>",
+            new List<NotifyAttachment> { new("report.html", "YWJj", "text/html") });
+
+        using var doc = JsonDocument.Parse(body);
+        var keys = doc.RootElement.EnumerateObject().Select(p => p.Name).ToList();
+
+        foreach (var forbidden in new[]
+                 {
+                     "to", "cc", "bcc", "email", "recipient", "recipients",
+                     "owner_email", "to_email", "address", "from", "reply_to",
+                 })
+        {
+            Assert.False(keys.Contains(forbidden, StringComparer.OrdinalIgnoreCase),
+                $"the tenant-addressed body carried a recipient-shaped key '{forbidden}'. The Gateway must " +
+                $"name a TENANT and nothing else - the recipient is resolved cloud-side. Body: {body}");
+        }
+
+        Assert.Equal("tenant-1", doc.RootElement.GetProperty("tenant_id").GetString());
+        Assert.Equal("subject-1", doc.RootElement.GetProperty("account_subject").GetString());
+    }
+
+    [Fact]
+    public void An_unresolvable_account_subject_is_omitted_rather_than_sent_blank()
+    {
+        // The cross-check is compared byte-for-byte cloud-side, so a blank would be a guaranteed 403
+        // subject_mismatch - turning a missing cross-check into a failed send. Omission keeps it optional,
+        // which is what the contract says it is.
+        var body = AccountNotifyByTenantClient.BuildBody("tenant-1", null, "Subject", "text", null, null);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.False(doc.RootElement.TryGetProperty("account_subject", out _));
+        Assert.Equal("tenant-1", doc.RootElement.GetProperty("tenant_id").GetString());
+    }
+
+    [Fact]
+    public void A_two_hundred_that_does_not_confirm_a_send_is_not_reported_as_sent()
+    {
+        // A status code is not a delivery receipt. Reporting a send that did not happen is the exact failure
+        // this whole line of work exists to prevent, so the success envelope must SAY sent.
+        var result = AccountNotifyByTenantClient.ParseSuccess("""{"data":{"id":"x"}}""", 200);
+
+        Assert.False(result.Sent);
+        Assert.NotNull(result.Error);
+    }
+
+    [Theory]
+    [InlineData("tenant_not_found")]
+    [InlineData("owner_not_resolvable")]
+    [InlineData("subject_mismatch")]
+    [InlineData("notify_rate_limited")]
+    [InlineData("tenant_lookup_not_installed")]
+    [InlineData("gateway_auth_failed")]
+    [InlineData("recipient_not_accepted")]
+    public void Every_agreed_error_code_keeps_its_message_and_its_code(string code)
+    {
+        // The cloud's messages are written to be read by a human, so they are surfaced verbatim. The code is
+        // for our logs and the retry rule only. Parsing every agreed code here means a contract change on
+        // their side shows up as a red test rather than as a generic message in front of a user.
+        var body = "{\"error\":{\"type\":\"t\",\"code\":\"" + code
+                   + "\",\"message\":\"the human sentence for " + code + "\"}}";
+
+        var (message, parsed) = AccountNotifyByTenantClient.ParseError(body, 400);
+
+        Assert.Equal($"the human sentence for {code}", message);
+        Assert.Equal(code, parsed);
+    }
+
+    // ---- end to end through the real hosted route ---------------------------------------------------
+
+    [Fact]
+    public async Task A_hosted_caller_sends_by_naming_its_own_tenant_and_never_a_recipient()
+    {
+        var resp = await PostEmail();
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(body);
+        Assert.True(doc.RootElement.GetProperty("sent").GetBoolean());
+        Assert.Equal("resend-986", doc.RootElement.GetProperty("providerId").GetString());
+
+        Assert.Equal(1, _cloud.Calls);
+        Assert.Equal(AccountNotifyByTenantClient.NotifyOwnerByTenantPath, _cloud.SeenPath);
+
+        // The tenant it named is the caller's OWN, resolved from their authenticated device key - never
+        // anything the caller put in the request.
+        using var sent = JsonDocument.Parse(_cloud.SeenBody!);
+        Assert.Equal(_tenantId, sent.RootElement.GetProperty("tenant_id").GetString());
+        Assert.Equal(_subject, sent.RootElement.GetProperty("account_subject").GetString());
+    }
+
+    [Fact]
+    public async Task The_service_credential_travels_in_its_own_header_and_never_as_authorization()
+    {
+        // Presenting both modes is a hard 400 by contract. The Gateway must not be the thing that does it,
+        // and it must never leak the CALLER's device key upstream either.
+        await PostEmail();
+
+        Assert.Equal(ServiceSecret, _cloud.SeenServiceToken);
+        Assert.True(string.IsNullOrEmpty(_cloud.SeenAuthorization), $"an Authorization header was sent alongside the service token, which the contract refuses with a 400: {_cloud.SeenAuthorization}");
+        Assert.DoesNotContain(_key, _cloud.SeenBody ?? "", StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_unconfigured_gateway_refuses_rather_than_calling_unauthenticated()
+    {
+        // PROPERTY 2. If an unconfigured Gateway called anyway, a cloud 401 would mean either "wrong secret"
+        // or "no secret" and neither end could tell which. Refusing here keeps that 401 diagnostic. It is
+        // also the moment most likely to be reported as a sign-out by a future edit, so the message is
+        // asserted, not just the status.
+        Environment.SetEnvironmentVariable(AccountNotifyByTenantClient.ServiceTokenEnvVar, null);
+        try
+        {
+            var resp = await PostEmail();
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+            Assert.Equal(0, _cloud.Calls);
+
+            var error = await ErrorOf(resp);
+            Assert.Contains(AccountNotifyByTenantClient.ServiceTokenEnvVar, error, StringComparison.Ordinal);
+            Assert.Contains("You are signed in", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no email was sent", error, StringComparison.OrdinalIgnoreCase);
+            Assert.False(error.Contains("not signed in", StringComparison.OrdinalIgnoreCase),
+                $"an unconfigured Gateway reported a configuration gap as a sign-out. Body: {error}");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AccountNotifyByTenantClient.ServiceTokenEnvVar, ServiceSecret);
+        }
+    }
+
+    [Fact]
+    public async Task The_missing_migration_is_reported_in_the_cloud_own_words_and_never_as_a_send()
+    {
+        // The state the pair is actually in until a human applies the migration. The cloud answers 503
+        // tenant_lookup_not_installed - deliberately not a 404, which would have claimed the tenant was
+        // unknown and sent someone hunting a tenant problem that does not exist.
+        _cloud.Status = 503;
+        _cloud.Body = """{"error":{"type":"server_error","code":"tenant_lookup_not_installed","message":"The tenant lookup function is not installed on this deployment."}}""";
+
+        var resp = await PostEmail();
+
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.False(doc.RootElement.GetProperty("sent").GetBoolean());
+        Assert.Equal("The tenant lookup function is not installed on this deployment.",
+            doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task A_rate_limit_keeps_its_status_and_passes_the_cloud_wait_through_untouched()
+    {
+        // The cloud computes Retry-After from when the oldest hit in its window actually expires, so
+        // honouring it is sufficient and a backoff of our own would only fight it. Rewriting 429 to a generic
+        // 400 would also strip the caller's ability to wait correctly.
+        _cloud.Status = 429;
+        _cloud.RetryAfter = "137";
+        _cloud.Body = """{"error":{"type":"rate_limited","code":"notify_rate_limited","message":"Too many owner emails from this account recently. Try again shortly."}}""";
+
+        var resp = await PostEmail();
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        Assert.Equal("137", resp.Headers.TryGetValues("Retry-After", out var v) ? v.FirstOrDefault() : null);
+        Assert.Contains("Too many owner emails", await ErrorOf(resp), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_subject_mismatch_is_surfaced_as_the_refusal_it_is()
+    {
+        // The cross-check doing its job: a wrong tenant id becomes a refusal instead of a correctly-delivered
+        // email to the wrong person. It must never be softened into a success or a retry.
+        _cloud.Status = 403;
+        _cloud.Body = """{"error":{"type":"forbidden","code":"subject_mismatch","message":"The account subject does not match the tenant."}}""";
+
+        var resp = await PostEmail();
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("does not match the tenant", await ErrorOf(resp), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_caller_cannot_name_a_tenant_that_is_not_its_own()
+    {
+        // The isolation property, asserted from this side too. The tenant is taken from the authenticated
+        // device key; anything tenant-shaped in the request body is ignored entirely.
+        var request = new HttpRequestMessage(HttpMethod.Post, "account/email");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        request.Content = new StringContent(
+            """{"subject":"s","bodyText":"b","tenant_id":"11111111-1111-1111-1111-111111111111","to":"someone@elsewhere.example"}""",
+            Encoding.UTF8, "application/json");
+
+        var resp = await _http.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var sent = JsonDocument.Parse(_cloud.SeenBody!);
+        Assert.Equal(_tenantId, sent.RootElement.GetProperty("tenant_id").GetString());
+        Assert.DoesNotContain("someone@elsewhere.example", _cloud.SeenBody!, StringComparison.Ordinal);
+        Assert.DoesNotContain("11111111-1111-1111-1111-111111111111", _cloud.SeenBody!, StringComparison.Ordinal);
+    }
+
+    private Task<HttpResponseMessage> PostEmail()
+    {
+        // Point the client's egress at the stub by handing the Gateway host a client over it. The route is
+        // mapped by the real GatewayHost, so this replaces only the outermost network hop.
+        var request = new HttpRequestMessage(HttpMethod.Post, "account/email");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        request.Content = new StringContent("""{"subject":"issue 986","bodyText":"body"}""",
+            Encoding.UTF8, "application/json");
+        return _http.SendAsync(request);
+    }
+
+    private static async Task<string> ErrorOf(HttpResponseMessage response)
+    {
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("error").GetString() ?? "";
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
@@ -54,8 +54,14 @@ internal static class AccountEmailEndpoint
     /// answer - the hosted path fails closed. Ignored off hosted mode.
     /// </param>
     /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
+    /// <param name="byTenant">
+    /// The TENANT-ADDRESSED cloud sender (devthrottle_internal #986), used on the hosted path where no
+    /// account token exists. Null disables the hosted send, and the route then reports the truthful refusal
+    /// - never a fabricated success and never a fabricated sign-out.
+    /// </param>
     public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNotifyClient notify,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
+        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null,
+        AccountNotifyByTenantClient? byTenant = null)
     {
         if (notify is null) throw new ArgumentNullException(nameof(notify));
 
@@ -72,15 +78,25 @@ internal static class AccountEmailEndpoint
             var verdict = await AccountActingCredential
                 .ResolveAsync(AccountOperations.Email, http, account, tenantBoundary, tenants, http.RequestAborted)
                 .ConfigureAwait(false);
+            // HOSTED SEND (devthrottle_internal #986). The caller IS signed in and this Gateway holds no
+            // account token for them - and now does not need one. It names their TENANT, resolved from their
+            // own authenticated device key, and the cloud resolves the recipient. Note what is NOT happening:
+            // no user account token is stored, read, or forwarded on this path, so the property that hosted
+            // enrollment keeps neither token stays true.
+            if (verdict.State == AccountActingState.HostedNoGatewayCredential && byTenant is not null && verdict.Tenant is { } tenant)
+            {
+                var result = await SendForTenantAsync(byTenant, tenant, verdict, request, http).ConfigureAwait(false);
+                if (result is not null)
+                    return result;
+                // Null means this Gateway is not configured to make that call. Fall through to the verdict,
+                // which reports the truth for the state we are actually in.
+            }
+
             if (!verdict.IsReady)
             {
-                // THE SWAP POINT for devthrottle_internal #986. When the cloud's tenant-addressed sender
-                // exists, HostedNoGatewayCredential stops being a refusal and becomes a send: the verdict
-                // already carries verdict.Tenant and verdict.AccountSubject, resolved from the caller's own
-                // authenticated device key, which is everything that route takes. It is one branch here and
-                // one client method - deliberately not a rewrite, and deliberately NOT a reason to start
-                // storing user account tokens, which hosted enrollment does not do and must not begin doing.
-                // Every other state stays a refusal, because none of them is a Gateway that could act.
+                // Every remaining state is a refusal, because none of them is a Gateway that could act:
+                // genuinely signed out, no credential store, an unusable credential, a caller bound to no
+                // tenant, or a miswired hosted deployment.
                 FileLog.Write($"[AccountEmailEndpoint] POST /account/email: cannot send ({verdict.State}) -> {verdict.StatusCode}");
                 return Results.Json(new AccountEmailResponse(false, verdict.Message, null), statusCode: verdict.StatusCode);
             }
@@ -120,6 +136,93 @@ internal static class AccountEmailEndpoint
                     statusCode: StatusCodes.Status502BadGateway);
             }
         });
+    }
+
+    /// <summary>
+    /// The HOSTED send (devthrottle_internal #986): name the caller's own tenant and let the cloud resolve
+    /// the recipient. Returns null when this Gateway holds no service secret, so the caller falls through to
+    /// the truthful refusal - it does NOT call unauthenticated.
+    ///
+    /// FAILING CLOSED ON A MISSING SECRET IS LOAD-BEARING, not tidiness. If an unconfigured Gateway called
+    /// anyway, the cloud's 401 would mean either "your secret is wrong" or "you have no secret", and nobody
+    /// could tell which from either end. Refusing here keeps that 401 diagnostic: it can only ever mean
+    /// WRONG. The message says which of the two configuration steps is outstanding, because "unauthorized"
+    /// on a route nobody has configured yet is exactly the sort of true-but-useless answer this whole issue
+    /// is about.
+    ///
+    /// This is the one try-catch for this path (the delegate boundary rule): a transport failure is caught
+    /// and reported as unreachable, never as a send.
+    /// </summary>
+    private static async Task<IResult?> SendForTenantAsync(
+        AccountNotifyByTenantClient byTenant, string tenant, AccountActingVerdict verdict,
+        AccountEmailRequest request, HttpContext http)
+    {
+        var serviceToken = AccountNotifyByTenantClient.ResolveServiceToken();
+        if (serviceToken is null)
+        {
+            FileLog.Write($"[AccountEmailEndpoint] POST /account/email (hosted): {AccountNotifyByTenantClient.ServiceTokenEnvVar} is not set on this Gateway -> refusing to call the owner-email service unauthenticated");
+            // NAME THE SIGNED-IN IDENTITY HERE TOO. This message replaces the fold's refusal on the hosted
+            // path, and the fold names the identity for a reason: it is what makes the sentence impossible to
+            // read as a sign-out. A configuration gap that forgot to say who you are would quietly reintroduce
+            // the ambiguity issue #984 exists to remove - which is exactly how this was caught, by that issue's
+            // own test going red when this path was added.
+            var who = string.IsNullOrWhiteSpace(verdict.Email) ? "your DevThrottle account" : verdict.Email;
+            return Results.Json(
+                new AccountEmailResponse(false,
+                    $"You are signed in to DevThrottle as {who}. This hosted Gateway is not yet configured to "
+                    + $"send owner email - its {AccountNotifyByTenantClient.ServiceTokenEnvVar} setting is "
+                    + "missing. This is a Gateway configuration step, not a sign-in problem, and signing in "
+                    + "again will not change it. No email was sent.",
+                    null),
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        try
+        {
+            var attachments = request.Attachments?
+                .Select(a => new NotifyAttachment(a.Filename ?? "", a.Content ?? "", a.ContentType))
+                .ToList();
+
+            var result = await byTenant
+                .SendOwnerForTenantAsync(serviceToken, tenant, verdict.AccountSubject, request.Subject!,
+                    request.BodyText, request.BodyHtml, attachments, http.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (result.Sent)
+            {
+                FileLog.Write("[AccountEmailEndpoint] POST /account/email (hosted): sent to the tenant's owner.");
+                return Results.Json(new AccountEmailResponse(true, null, result.ProviderId));
+            }
+
+            // The cloud's message is written to be read by a human, so it is surfaced VERBATIM rather than
+            // reworded here. A 4xx is a caller/config problem forwarded as-is; 429 keeps its own status so a
+            // caller can honour Retry-After; anything else is an upstream failure. Never a fabricated success.
+            var status = result.StatusCode switch
+            {
+                StatusCodes.Status429TooManyRequests => StatusCodes.Status429TooManyRequests,
+                >= 400 and < 500 => StatusCodes.Status400BadRequest,
+                _ => StatusCodes.Status502BadGateway,
+            };
+            FileLog.Write($"[AccountEmailEndpoint] POST /account/email (hosted): not sent (cloud status {result.StatusCode}, code {result.ErrorCode ?? "<none>"})");
+
+            var response = Results.Json(new AccountEmailResponse(false, result.Error, null), statusCode: status);
+            if (result.RetryAfterSeconds is { } retryAfter)
+            {
+                // Pass the cloud's own wait through untouched. It is computed from when the oldest hit in the
+                // window actually expires, so honouring it is sufficient and a backoff of our own would only
+                // fight it.
+                http.Response.Headers["Retry-After"] = retryAfter.ToString();
+            }
+            return response;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[AccountEmailEndpoint] POST /account/email (hosted) FAILED: {ex.Message}");
+            return Results.Json(
+                new AccountEmailResponse(false,
+                    "Could not reach the DevThrottle account service to send the email. Try again shortly.", null),
+                statusCode: StatusCodes.Status502BadGateway);
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2593,8 +2593,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // the host-wide token middleware above like the other /account routes. Issue #984: the tenant boundary
         // is passed in so the hosted path reports the truth - the caller IS signed in and this shared Gateway
         // holds no credential of theirs to send with - instead of the old 401 "sign in from the Gateway tray".
+        // devthrottle_internal #986: on hosted there is no account token to forward, so the send names the
+        // caller's TENANT and the cloud resolves the recipient. Wired unconditionally - the route decides by
+        // hosted state, and the client itself fails closed when NOTIFY_OWNER_SERVICE_TOKEN is unset rather
+        // than calling the service unauthenticated.
         AccountEmailEndpoint.Map(_app, Account, new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }),
-            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
+            tenantBoundary: _tenantBoundary, tenants: TenantRegistry,
+            byTenant: new Core.Account.AccountNotifyByTenantClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }));
 
 
         // The credential-free cloud sign-in START front door (epic #1069, issue #1076): GET + POST


### PR DESCRIPTION
Stacked on #2233 (issue #984). Review that one first; this targets its branch, so the diff here is only the new work.

## What this closes

#2233 stopped `POST /account/email` telling a signed-in hosted user they were not signed in. It could not make it **send**: the original cloud primitive resolves the recipient from an account access token, and a hosted Gateway holds none - hosted enrollment validates the account token, mints a tenant and a device key, and stores neither.

devthrottle_internal #986 adds a tenant-addressed cloud route. The Gateway names a **tenant**; the cloud resolves the recipient server-side from that tenant's account subject, through the same authority the JWT route uses.

## The safety properties, and how each is held

**The Gateway cannot address anyone.** No recipient parameter, no recipient field on the wire, no code path that could add one. The cloud refuses a recipient field with a hard 400 rather than ignoring it - braces here, belt there. A test asserts eleven recipient-shaped key names can never appear in a constructed body.

**The account subject is a cross-check only.** Compared byte-for-byte cloud-side, so a wrong tenant id becomes a refusal instead of a correctly-delivered email to the wrong person. It never resolves the recipient: a subject that selects the target is a subject that could select someone else's.

**No user account token is stored, read, or forwarded** on this path. The property that hosted enrollment keeps neither token stays true - that was a hard constraint from the cloud side and it is preserved by construction, not by discipline.

**An unconfigured Gateway fails closed** rather than calling unauthenticated. This is load-bearing: if it called anyway, the cloud's 401 would mean either "wrong secret" or "no secret", and neither end could tell which. Refusing keeps that 401 diagnostic.

**The refusal names the signed-in identity**, exactly as the #984 fold does. That was missed on the first cut and caught by #984's own test going red when this path was added - the invariant test doing precisely the job it was written for.

**Rate limits keep their 429** and the cloud's `Retry-After` passes through untouched. It is computed from when the oldest hit in the window actually expires, so a backoff of our own would only fight it. No retry on any 4xx.

## Verification

Committed tests run a real HTTP stub of the contract, so they stay hermetic and CI-safe.

Separately - and this is the part worth knowing - the real client was driven against **the cloud side's own contract server**, which runs their production decision code (`api/_lib/notify-tenant.js`) and fakes only the tenant lookup, the owner lookup and the send. 24 checks passed, including:

- both directions of the cross-tenant refusal (tenant A id with tenant B subject, and the reverse) -> 403 `subject_mismatch`
- unknown tenant -> 404 `tenant_not_found`
- tenant exists but owner unresolvable -> 404 `owner_not_resolvable`
- `simulate-lookup-not-installed` -> 503 `tenant_lookup_not_installed`, the state production is actually in today
- a wrong service token -> 401 `gateway_auth_failed`
- the recipient resolved cloud-side matching the fixture owner
- all eleven recipient-shaped field names refused with `recipient_not_accepted`

Neither side's reading of the contract was the referee - their code was. A stub encodes the contract as its author read it; this does not.

301 account tests pass; the full Gateway suite was green at 4265/0/17 on the parent branch.

## What this does NOT prove

**Not end-to-end.** The contract server fakes the lookup and the send, and the tenant-resolution migration is not applied on any environment. Two manual configuration steps remain, both needing credentials no automated session holds:

1. **Supabase SQL editor** - apply the migration creating the tenant-resolution function and its grant. Until this lands the cloud route authenticates and then answers 503 `tenant_lookup_not_installed`.
2. **Azure App Service** - add `NOTIFY_OWNER_SERVICE_TOKEN` to the hosted Gateway, matching the Vercel value. Until this lands the Gateway will not call the route at all.

Neither side misbehaves half-configured: the Gateway fails closed without its secret, and the route refuses to resolve without the function. There is no window where something is half-wired and doing something odd.

Pairs with devthrottle_internal #987.
