### PR TITLE
The screenshots folder you set is the one you see, and an update no longer starts a blank Director

### DIFF
--- a/src/CcDirector.Avalonia.Tests/ScreenshotsFolderConfirmTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ScreenshotsFolderConfirmTests.cs
@@ -1,0 +1,57 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The wizard's Screenshots step must both PERSIST the folder and RE-POINT the live screenshots
+/// panel at it. Persisting alone shipped as a dead end: the panel resolves its folder once at
+/// startup, so a user who set the folder in first-run saw an empty panel until the next restart -
+/// and Refresh could not save them either, because it re-listed the folder resolved at startup.
+///
+/// This drives the production write path (<c>ConfirmScreenshotsFolderAsync</c>, what the step's
+/// primary button invokes) and asserts BOTH halves of the seam: what the panel's own resolver
+/// (<see cref="CcStorage.Screenshots"/>) reports afterwards, and that the reload actually ran.
+///
+/// Constructed headless and never shown. Config is redirected to a temp root via CC_DIRECTOR_ROOT;
+/// the assembly runs sequentially (TestParallelization), so the process-global env var is not raced.
+/// </summary>
+public class ScreenshotsFolderConfirmTests
+{
+    [AvaloniaFact]
+    public async Task ConfirmScreenshotsFolder_PersistsFolder_AndReloadsThePanel()
+    {
+        var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "cc-director-shots-confirm-tests", Guid.NewGuid().ToString("N"));
+        var chosen = Path.Combine(root, "my-screenshots");
+        Directory.CreateDirectory(chosen);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        try
+        {
+            // Before the step runs, the resolver reports the fallback folder - not the user's.
+            Assert.NotEqual(chosen, CcStorage.Screenshots());
+
+            var reloads = 0;
+            var dialog = new FirstRunWizardDialog(new AgentOptions(), () =>
+            {
+                reloads++;
+                return Task.CompletedTask;
+            });
+
+            await dialog.ConfirmScreenshotsFolderAsync(chosen);
+
+            // Persisted: the same resolver the screenshots panel uses now answers with the chosen folder.
+            Assert.Equal(chosen, CcStorage.Screenshots());
+
+            // And the live panel was told, so the payoff lands while the wizard is still open.
+            Assert.Equal(1, reloads);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", old);
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/ScreenshotsStepPreviewTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ScreenshotsStepPreviewTests.cs
@@ -1,0 +1,59 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The Screenshots step shows the newest images from the chosen folder, so the user confirms the
+/// folder by recognising their own screenshots instead of trusting a count. An empty folder shows
+/// no strip at all rather than an empty box.
+/// </summary>
+public class ScreenshotsStepPreviewTests
+{
+    // Smallest valid PNG (1x1) - enough for the decoder, nothing to look at.
+    private const string OnePixelPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+    [AvaloniaFact]
+    public async Task ChoosingAFolderWithImages_ShowsThumbnails()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-director-shots-preview-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var png = Convert.FromBase64String(OnePixelPngBase64);
+            File.WriteAllBytes(Path.Combine(dir, "one.png"), png);
+            File.WriteAllBytes(Path.Combine(dir, "two.png"), png);
+            File.WriteAllText(Path.Combine(dir, "notes.txt"), "not an image");
+
+            var dialog = new FirstRunWizardDialog(new AgentOptions());
+            await dialog.SetScreenshotsFolderAsync(dir, "Chosen by you", imageCount: 2);
+
+            Assert.True(dialog.ShotsPreviewStrip.IsVisible);
+            Assert.Equal(2, dialog.ShotsPreviewRow.Children.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ChoosingAnEmptyFolder_ShowsNoStrip()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-director-shots-preview-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var dialog = new FirstRunWizardDialog(new AgentOptions());
+            await dialog.SetScreenshotsFolderAsync(dir, "Chosen by you", imageCount: 0);
+
+            Assert.False(dialog.ShotsPreviewStrip.IsVisible);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -322,6 +322,18 @@
                     <TextBlock x:Name="ShotsProvenanceText" Classes="hint"
                                HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540" />
 
+                    <!-- Proof you can SEE: the newest images from the chosen folder, drawn as soon as the
+                         folder is picked. Hidden when the folder holds no images. -->
+                    <Border x:Name="ShotsPreviewStrip" IsVisible="False" Background="#FFFFFF"
+                            BorderBrush="#E6E8EC" BorderThickness="1" CornerRadius="12" Padding="14,12">
+                        <StackPanel Spacing="10">
+                            <StackPanel x:Name="ShotsPreviewRow" Orientation="Horizontal" Spacing="10"
+                                        HorizontalAlignment="Center" />
+                            <TextBlock Classes="hint" HorizontalAlignment="Center" TextAlignment="Center"
+                                       Text="Your most recent screenshots. Use this folder and they show up in the Screenshots panel, ready to drag onto an agent." />
+                        </StackPanel>
+                    </Border>
+
                     <!-- The certainty trick: press the normal screenshot shortcut; we watch where it lands. -->
                     <StackPanel x:Name="ShotsWatchIdle" HorizontalAlignment="Center">
                         <Button Classes="quietLink" Content="Not sure? Take a screenshot and we'll find it"

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,6 +70,10 @@ public partial class FirstRunWizardDialog : Window
     private bool _shotsDetectRan;
     private CancellationTokenSource? _shotsWatchCts;
 
+    // Re-points the live screenshots panel after the Screenshots step writes the folder. Null when
+    // no panel is listening (the wizard opened from a context that owns none).
+    private readonly Func<Task>? _reloadScreenshots;
+
     // Tools step: the shipped cc-* toolbelt, read from the embedded manifest catalog. The screen
     // explains that DevThrottle maintains these itself; while any are still installing it polls so
     // rows flip to Ready live - the same state the main window's corner indicator tracks.
@@ -106,10 +111,17 @@ public partial class FirstRunWizardDialog : Window
 
     public FirstRunWizardDialog() : this(new AgentOptions()) { }
 
-    public FirstRunWizardDialog(AgentOptions options)
+    /// <param name="options">The agent options the Agents and Tools steps read.</param>
+    /// <param name="reloadScreenshots">
+    /// Re-points the main window's screenshots panel at the folder just confirmed. Passed in by
+    /// whoever owns that panel (MainWindow, directly or through Settings) so the Screenshots step
+    /// pays off while the wizard is still open instead of only after the next restart.
+    /// </param>
+    public FirstRunWizardDialog(AgentOptions options, Func<Task>? reloadScreenshots = null)
     {
         FileLog.Write("[FirstRunWizardDialog] Constructor: initializing");
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _reloadScreenshots = reloadScreenshots;
 
         // All seven canonical steps are present: the onboarding is one JOURNEY (your workforce ->
         // what we watch over -> show don't type -> with you everywhere -> the payoff -> done), and
@@ -991,7 +1003,7 @@ public partial class FirstRunWizardDialog : Window
             if (best is not null)
             {
                 var count = await Task.Run(() => ScreenshotLocator.CountImages(best.Path));
-                SetScreenshotsFolder(best.Path, best.Provenance, count);
+                await SetScreenshotsFolderAsync(best.Path, best.Provenance, count);
             }
             else
             {
@@ -1008,8 +1020,11 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
-    /// <summary>Adopt a folder as the screenshots choice and render its provenance + proof line.</summary>
-    private void SetScreenshotsFolder(string path, string provenance, int imageCount)
+    /// <summary>
+    /// Adopt a folder as the screenshots choice and render its provenance, proof line, and thumbnails.
+    /// Returns once the thumbnails are drawn (internal so the strip is provable without driving the UI).
+    /// </summary>
+    internal Task SetScreenshotsFolderAsync(string path, string provenance, int imageCount)
     {
         _shotsSelectedPath = path;
         ShotsPathText.Text = path;
@@ -1022,6 +1037,81 @@ public partial class FirstRunWizardDialog : Window
         ShotsProvenanceText.Text = $"{provenance} - {proof}.";
         if (_model.Current == WizardStep.Screenshots)
             PrimaryButton.Content = "Use this folder";
+
+        // A count is a claim; the thumbnails are the evidence. Drawn off the UI thread, so a folder
+        // with hundreds of images does not stall the step.
+        ShotsPreviewStrip.IsVisible = false;
+        return LoadScreenshotPreviewsAsync(path);
+    }
+
+    /// <summary>
+    /// Draw the newest few images from <paramref name="path"/> under the proof line, so confirming the
+    /// folder is a matter of recognising your own screenshots rather than trusting a number. A folder
+    /// with no images simply shows no strip. Late results for a folder the user has already changed
+    /// away from are dropped.
+    /// </summary>
+    private async Task LoadScreenshotPreviewsAsync(string path)
+    {
+        const int MaxPreviews = 4;
+        try
+        {
+            var bitmaps = await Task.Run(() => Directory.EnumerateFiles(path)
+                .Where(ScreenshotLocator.IsImageFile)
+                .OrderByDescending(File.GetLastWriteTime)
+                .Take(MaxPreviews)
+                .Select(LoadPreviewThumbnail)
+                .Where(b => b is not null)
+                .Select(b => b!)
+                .ToList());
+
+            // The user may have browsed to another folder while this was decoding - that folder's own
+            // load owns the strip now.
+            if (!string.Equals(_shotsSelectedPath, path, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            ShotsPreviewRow.Children.Clear();
+            foreach (var bitmap in bitmaps)
+            {
+                ShotsPreviewRow.Children.Add(new Border
+                {
+                    Background = Brush("#F5F6F8"),
+                    BorderBrush = Brush("#E6E8EC"),
+                    BorderThickness = new global::Avalonia.Thickness(1),
+                    CornerRadius = new global::Avalonia.CornerRadius(8),
+                    ClipToBounds = true,
+                    Child = new Image
+                    {
+                        Source = bitmap,
+                        Height = 78,
+                        Stretch = Stretch.Uniform,
+                    },
+                });
+            }
+
+            ShotsPreviewStrip.IsVisible = ShotsPreviewRow.Children.Count > 0;
+            FileLog.Write($"[FirstRunWizardDialog] LoadScreenshotPreviewsAsync: {ShotsPreviewRow.Children.Count} preview(s) from {path}");
+        }
+        catch (Exception ex)
+        {
+            // The folder is the point of this step, not the preview - a folder we cannot read still
+            // reports its path and provenance above, so the step stays usable.
+            FileLog.Write($"[FirstRunWizardDialog] LoadScreenshotPreviewsAsync FAILED for {path}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Decode one thumbnail at preview height. Null for a file that is not a readable image.</summary>
+    private static global::Avalonia.Media.Imaging.Bitmap? LoadPreviewThumbnail(string file)
+    {
+        try
+        {
+            using var stream = File.OpenRead(file);
+            return global::Avalonia.Media.Imaging.Bitmap.DecodeToHeight(stream, 156);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] LoadPreviewThumbnail skipped {file}: {ex.Message}");
+            return null;
+        }
     }
 
     private async void BtnBrowseScreenshots_Click(object? sender, RoutedEventArgs e)
@@ -1039,7 +1129,7 @@ public partial class FirstRunWizardDialog : Window
                 CancelScreenshotWatch();
                 var path = result[0].Path.LocalPath;
                 var count = await Task.Run(() => ScreenshotLocator.CountImages(path));
-                SetScreenshotsFolder(path, "Chosen by you", count);
+                await SetScreenshotsFolderAsync(path, "Chosen by you", count);
             }
         }
         catch (Exception ex)
@@ -1078,7 +1168,7 @@ public partial class FirstRunWizardDialog : Window
             if (landed is not null)
             {
                 var count = await Task.Run(() => ScreenshotLocator.CountImages(landed));
-                SetScreenshotsFolder(landed, "Detected from the screenshot you just took", count);
+                await SetScreenshotsFolderAsync(landed, "Detected from the screenshot you just took", count);
             }
             CancelScreenshotWatch();
         }
@@ -1116,12 +1206,30 @@ public partial class FirstRunWizardDialog : Window
             return;
         }
 
-        var path = _shotsSelectedPath;
+        await ConfirmScreenshotsFolderAsync(_shotsSelectedPath);
+    }
+
+    /// <summary>
+    /// Write the folder to config AND re-point the live screenshots panel at it, in that order.
+    /// Writing alone is not enough: the panel resolved its folder once at startup, so without this
+    /// the user finishes the Screenshots step and the panel still shows the old (on a fresh install,
+    /// empty) folder until the next restart - the step promises immediate value and delivered none.
+    ///
+    /// Internal so the write-then-reload seam is provable without driving the wizard's UI.
+    /// </summary>
+    internal async Task ConfirmScreenshotsFolderAsync(string path)
+    {
         FileLog.Write($"[FirstRunWizardDialog] SaveScreenshotsFolderAsync: {path}");
         await Task.Run(() => CcDirectorConfigService.MergePatch(new JsonObject
         {
             ["screenshots"] = new JsonObject { ["source_directory"] = path },
         }));
+
+        if (_reloadScreenshots is not null)
+        {
+            await _reloadScreenshots();
+            FileLog.Write("[FirstRunWizardDialog] SaveScreenshotsFolderAsync: screenshots panel reloaded");
+        }
     }
 
     // ---- Morning report step (the promise screen) ---------------------------------------------------

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -128,6 +128,11 @@ public partial class MainWindow : Window
     private FileSystemWatcher? _screenshotWatcher;
     private DispatcherTimer? _screenshotDebounceTimer;
     private string? _screenshotsDirectory;
+
+    // Serializes screenshots-panel reloads. A reload tears down the watcher and builds a new one, so two
+    // overlapping reloads (impatient Refresh clicks, or Refresh while the wizard's save reloads) would
+    // leave an orphaned watcher raising events at the panel forever.
+    private readonly SemaphoreSlim _screenshotReloadGate = new(1, 1);
     // The image file types the Screenshots panel loads and clears. Kept in one place so listing
     // (LoadScreenshotViewModels) and Clear All (DeleteAllScreenshots) agree on what a screenshot is.
     private static readonly string[] ScreenshotExtensions = { ".png", ".jpg", ".jpeg", ".bmp", ".gif" };
@@ -394,7 +399,9 @@ public partial class MainWindow : Window
         var app = global::Avalonia.Application.Current as App;
         var options = app?.SessionManager?.Options ?? app?.Options
             ?? throw new InvalidOperationException("AgentOptions not loaded.");
-        var dialog = new FirstRunWizardDialog(options);
+        // The wizard's Screenshots step writes the folder into config; hand it the panel reload so the
+        // thumbnails appear behind the wizard the moment the folder is confirmed.
+        var dialog = new FirstRunWizardDialog(options, ReloadScreenshotsPanelAsync);
         await dialog.ShowDialog<bool?>(this);
         return dialog.WantsNewSession;
     }
@@ -5286,6 +5293,7 @@ public partial class MainWindow : Window
     {
         FileLog.Write("[MainWindow] InitializeScreenshotsPanelAsync: starting");
 
+        await _screenshotReloadGate.WaitAsync();
         try
         {
             // Idempotent: tear down any previous watcher/timer and clear the list so a reload
@@ -5342,6 +5350,10 @@ public partial class MainWindow : Window
         {
             FileLog.Write($"[MainWindow] InitializeScreenshotsPanelAsync FAILED: {ex.Message}");
         }
+        finally
+        {
+            _screenshotReloadGate.Release();
+        }
     }
 
     private static List<ScreenshotViewModel> LoadScreenshotViewModels(string directory)
@@ -5394,10 +5406,17 @@ public partial class MainWindow : Window
             _screenshots.Add(vm);
     }
 
+    /// <summary>
+    /// Refresh re-reads the CONFIGURED folder, not just the files in the folder resolved at startup.
+    /// <see cref="RefreshScreenshots"/> re-lists the cached <c>_screenshotsDirectory</c>, which is the
+    /// right thing for the file watcher but useless after the folder itself changes - a user who set
+    /// the folder in the wizard clicked Refresh and kept getting the old, empty one. This is the
+    /// button the user reaches for when the panel looks wrong, so it re-resolves and re-watches.
+    /// </summary>
     private void BtnRefreshScreenshots_Click(object? sender, RoutedEventArgs e)
     {
         FileLog.Write("[MainWindow] BtnRefreshScreenshots_Click");
-        _ = RefreshScreenshots();
+        _ = ReloadScreenshotsPanelAsync();
     }
 
     private async void BtnClearScreenshots_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Avalonia/Program.cs
+++ b/src/CcDirector.Avalonia/Program.cs
@@ -44,14 +44,15 @@ internal static class Program
 
         // Hidden auto-update relauncher mode, handled BEFORE the single-instance
         // guard: a freshly downloaded build is invoked as
-        //   cc-director --apply-update <installTarget> <parentPid>
+        //   cc-director --apply-update <installTarget> <parentPid> [instanceSlug]
         // to wait for the old process to exit, swap itself into place, and
         // relaunch. It must not acquire the guard or run any normal startup.
+        // The instance slug is optional: a build older than that argument does not send one.
         if (args.Length >= 3 && args[0] == "--apply-update")
         {
             try
             {
-                return UpdateInstaller.ApplyUpdate(args[1], int.Parse(args[2]));
+                return UpdateInstaller.ApplyUpdate(args[1], int.Parse(args[2]), args.Length >= 4 ? args[3] : null);
             }
             catch (Exception ex)
             {
@@ -86,11 +87,11 @@ internal static class Program
             MessageBoxW(IntPtr.Zero, rollbackNotice, "Director - Update rolled back", MB_OK | MB_ICONWARNING | MB_TOPMOST);
             try
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = Environment.ProcessPath ?? "",
-                    UseShellExecute = true,
-                });
+                // Started the same way an update relaunch is: no inherited CC_DIRECTOR_ROOT (which would
+                // make the restored build nest a new, empty data home inside this instance's one) and the
+                // instance carried explicitly.
+                System.Diagnostics.Process.Start(
+                    UpdateInstaller.BuildRelaunchStartInfo(Environment.ProcessPath ?? "", InstanceContext.Slug));
             }
             catch (Exception ex)
             {

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -550,8 +550,13 @@ public partial class SettingsDialog : Window
 
             if (patch.Count == 0 && !alphaChanged && !agentsChanged)
             {
-                // Nothing changed - "Save and Close" just closes, same as Cancel.
-                FileLog.Write("[SettingsDialog] BtnSave_Click: no changes; closing");
+                // Nothing changed on disk - but leaving through Save still has to leave the screenshots
+                // panel pointing at the folder shown in the box. A user whose panel was stale (folder set
+                // elsewhere after the panel resolved it) opened Settings, saw the right folder, pressed
+                // Save, and this early return closed without re-pointing anything.
+                FileLog.Write("[SettingsDialog] BtnSave_Click: no changes; reloading screenshots panel and closing");
+                if (_reloadScreenshots is not null)
+                    await _reloadScreenshots();
                 Close();
                 return;
             }
@@ -714,8 +719,16 @@ public partial class SettingsDialog : Window
         try
         {
             var options = CurrentOptions();
-            var dialog = new FirstRunWizardDialog(options);
+            var dialog = new FirstRunWizardDialog(options, _reloadScreenshots);
             await dialog.ShowDialog<bool?>(this);
+
+            // The wizard writes the screenshots folder straight to config. Re-read it into the box and
+            // the baseline, or Save would write our stale pre-wizard path back over the folder the
+            // user just chose. Only this field is re-read - rebuilding the whole page would recreate
+            // the embedded gateway panel and re-run its LAN scan for nothing.
+            var (screenshots, _, _, _) = await Task.Run(ReadConfigSnapshot);
+            _loadedScreenshots = screenshots;
+            ScreenshotsDirBox.Text = screenshots;
 
             LoadAgentEntries();
             ShowAgentToolsStatus("Setup wizard finished. Your agent list is up to date.", error: false);

--- a/src/CcDirector.Core.Tests/Update/UpdateRelaunchInstanceTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateRelaunchInstanceTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using CcDirector.Core.Update;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Update;
+
+/// <summary>
+/// An update must hand the freshly-installed build a CLEAN environment.
+///
+/// A running Director sets CC_DIRECTOR_ROOT to its own instance home. The relaunched build resolves
+/// the machine-wide root from that same variable, so inheriting it makes the new process treat its
+/// own home as the machine root and settle one level deeper - a brand-new, empty data tree with no
+/// settings, no sessions, and the first-run wizard waiting. To the user that reads as "the update
+/// wiped my Director". The instance therefore travels as an explicit --instance argument.
+///
+/// These assert the decision (<see cref="UpdateInstaller.BuildRelaunchStartInfo"/>), which is what
+/// both the post-update relaunch and the post-rollback relaunch start from.
+/// </summary>
+public class UpdateRelaunchInstanceTests
+{
+    [Fact]
+    public void BuildRelaunchStartInfo_DropsTheInheritedInstanceRoot()
+    {
+        var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", @"C:\Users\someone\AppData\Local\cc-director\instances\default");
+        try
+        {
+            var psi = UpdateInstaller.BuildRelaunchStartInfo(@"C:\install\cc-director.exe", "default");
+
+            Assert.False(psi.Environment.ContainsKey("CC_DIRECTOR_ROOT"));
+
+            // The scrub only works on a direct start - a shell-executed process cannot be given an
+            // edited environment block.
+            Assert.False(psi.UseShellExecute);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", old);
+        }
+    }
+
+    [Fact]
+    public void BuildRelaunchStartInfo_CarriesTheInstanceExplicitly()
+    {
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(@"C:\install\cc-director.exe", "work");
+
+        var args = string.Join(' ', psi.ArgumentList);
+        Assert.Contains("--instance", args);
+        Assert.Contains("work", args);
+    }
+
+    [Fact]
+    public void BuildRelaunchStartInfo_WithNoInstance_PassesNoInstanceArgument()
+    {
+        // An update launched by a build older than the instance argument sends no slug; the new
+        // process then resolves the default instance itself rather than being told a wrong one.
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(@"C:\install\cc-director.exe", null);
+
+        Assert.DoesNotContain("--instance", string.Join(' ', psi.ArgumentList));
+    }
+}

--- a/src/CcDirector.Core/Update/UpdateInstaller.cs
+++ b/src/CcDirector.Core/Update/UpdateInstaller.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
@@ -176,7 +177,8 @@ public static class UpdateInstaller
     /// </summary>
     public static void LaunchRelauncher(string stagedExecutable, string installTarget)
     {
-        FileLog.Write($"[UpdateInstaller] LaunchRelauncher: staged={stagedExecutable}, target={installTarget}");
+        var slug = InstanceContext.Slug;
+        FileLog.Write($"[UpdateInstaller] LaunchRelauncher: staged={stagedExecutable}, target={installTarget}, instance={slug}");
         var psi = new ProcessStartInfo
         {
             FileName = stagedExecutable,
@@ -185,18 +187,29 @@ public static class UpdateInstaller
         psi.ArgumentList.Add("--apply-update");
         psi.ArgumentList.Add(installTarget);
         psi.ArgumentList.Add(Environment.ProcessId.ToString());
+
+        // Which instance is updating, carried as an ARGUMENT rather than left to the inherited
+        // CC_DIRECTOR_ROOT, so the build we finally relaunch can be handed a clean environment and
+        // still come back as this instance. A build older than this argument ignores the extra token.
+        psi.ArgumentList.Add(slug);
+
+        // The relauncher itself KEEPS the inherited override on purpose: it reads and clears this
+        // instance's updater state, which lives in this instance's home.
         Process.Start(psi);
     }
 
     /// <summary>
-    /// Entry point for the hidden "<c>--apply-update &lt;targetPath&gt; &lt;parentPid&gt;</c>"
+    /// Entry point for the hidden "<c>--apply-update &lt;targetPath&gt; &lt;parentPid&gt; [instanceSlug]</c>"
     /// mode. Waits for the parent to exit, replaces the installed build with this
     /// (staged) one, relaunches it, and returns a process exit code.
+    ///
+    /// <paramref name="instanceSlug"/> is absent when the update was launched by a build older than
+    /// the argument; the relaunch then carries no instance and the new process resolves the default.
     /// </summary>
-    public static int ApplyUpdate(string targetPath, int parentPid)
+    public static int ApplyUpdate(string targetPath, int parentPid, string? instanceSlug = null)
     {
         FileLog.Start();
-        FileLog.Write($"[UpdateInstaller] ApplyUpdate: target={targetPath}, parentPid={parentPid}, self={Environment.ProcessPath}");
+        FileLog.Write($"[UpdateInstaller] ApplyUpdate: target={targetPath}, parentPid={parentPid}, instance={instanceSlug ?? "(none)"}, self={Environment.ProcessPath}");
 
         WaitForProcessExit(parentPid, TimeSpan.FromSeconds(30));
 
@@ -218,7 +231,7 @@ public static class UpdateInstaller
         // self-check at the same time (issue #242).
         ClearStagedState();
         ArmHealthCheck(versionBeingInstalled);
-        Relaunch(targetPath);
+        Relaunch(targetPath, instanceSlug);
 
         FileLog.Write("[UpdateInstaller] ApplyUpdate: complete");
         FileLog.Stop();
@@ -470,12 +483,52 @@ public static class UpdateInstaller
         FileLog.Write($"[UpdateInstaller] SwapMac: installed staged bundle at {targetApp}");
     }
 
-    private static void Relaunch(string targetPath)
+    private static void Relaunch(string targetPath, string? instanceSlug)
     {
+        var psi = BuildRelaunchStartInfo(targetPath, instanceSlug);
+        FileLog.Write($"[UpdateInstaller] Relaunch: {psi.FileName} {string.Join(' ', psi.ArgumentList)}");
+        Process.Start(psi);
+    }
+
+    /// <summary>
+    /// How the freshly-installed build is started after an update, and the one place that decides it.
+    ///
+    /// The child must NOT inherit <c>CC_DIRECTOR_ROOT</c>. A running Director sets that variable to its
+    /// own instance home, so a relaunched build that inherited it would read its own home as the
+    /// machine-wide root and settle one level deeper - a brand-new, empty data tree, which reads to the
+    /// user as "the update wiped my Director and started the setup wizard again". The instance travels
+    /// as <c>--instance &lt;slug&gt;</c> instead, so identity is carried deliberately rather than by
+    /// inheritance. Same rule, same reason, as <c>InstanceProcess.Launch</c>.
+    ///
+    /// Pure, so the environment scrub is provable without starting a process.
+    /// </summary>
+    public static ProcessStartInfo BuildRelaunchStartInfo(string targetPath, string? instanceSlug)
+    {
+        // UseShellExecute must stay false: the environment block can only be edited on a direct start.
+        var psi = new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsMacOS() ? "/usr/bin/open" : targetPath,
+            UseShellExecute = false,
+        };
+
         if (OperatingSystem.IsMacOS())
-            Run("/usr/bin/open", targetPath);
-        else
-            Process.Start(new ProcessStartInfo { FileName = targetPath, UseShellExecute = true });
+        {
+            psi.ArgumentList.Add(targetPath);
+            if (!string.IsNullOrWhiteSpace(instanceSlug))
+            {
+                psi.ArgumentList.Add("--args");
+                psi.ArgumentList.Add("--instance");
+                psi.ArgumentList.Add(instanceSlug);
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(instanceSlug))
+        {
+            psi.ArgumentList.Add("--instance");
+            psi.ArgumentList.Add(instanceSlug);
+        }
+
+        psi.Environment.Remove("CC_DIRECTOR_ROOT");
+        return psi;
     }
 
     private static void ClearStagedState()


### PR DESCRIPTION
Two fixes found from one report ("I set the screenshots folder and the panel stays empty"), both on the first-twenty-minutes path. They ship together because the second one decides whether the first one ever reaches the user.

## 1. The screenshots folder you set is the one you see (internal#992)

The Screenshots panel resolved its folder once at startup and never asked again. Every way out was a dead end: the wizard wrote the folder to config and notified nobody, Refresh re-listed the folder resolved at startup, and Settings' Save skipped its one reload hook whenever the value on screen already matched the value on disk.

- The wizard re-points the live panel after writing the folder.
- The Screenshots step draws the newest four images from the chosen folder - a count is a claim, the pictures are the evidence.
- Refresh re-resolves the configured folder and re-watches it.
- Settings hands the reload to the wizard it launches, re-reads the field afterwards, and reloads even on a no-change close.
- Reloads are serialised, so repeated Refresh clicks cannot orphan a folder watcher.

## 2. An update no longer starts a blank Director (internal#993)

A running Director points `CC_DIRECTOR_ROOT` at its own instance home, and the update relaunch chain inherited it - so the freshly installed build read its own home as the machine-wide root and settled one level deeper, in a brand-new empty data tree. Settings gone, sessions gone, first-run wizard again, one level deeper per update. Seen in the wild on 2026-07-28:

    home=...\cc-director\instances\default\instances\default

`UpdateInstaller.BuildRelaunchStartInfo` is now the single place that decides how a post-update or post-rollback build starts: inherited root dropped, instance carried explicitly as `--instance <slug>` through `--apply-update <target> <pid> [slug]`. The slug is optional, so a build older than the argument still updates - it resolves the default instance itself. The relauncher process keeps the inherited root on purpose: it reads and clears the updating instance's own updater state. `InstanceProcess.Launch` has always stripped this variable for exactly this reason; the update path never got the same treatment.

Applying this update on an already-nested install lands it back in its proper home.

## Proof

- 6 new tests: wizard write-then-reload seam, the thumbnail strip (present with images, absent when empty), the relaunch environment scrub, the explicit instance argument, and the no-slug case.
- Full solution suite green on the combined change.