### PR TITLE
release: v1.8.2 - the screenshots folder you pick, and an update that keeps your Director

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.8.2.md
+++ b/docs/public/release-notes/v1.8.2.md
@@ -1,0 +1,25 @@
+## v1.8.2 - July 28, 2026
+
+A fix-only release for two things that made a working install look broken.
+
+### Your screenshots
+
+- **The folder you pick is the folder you see.** Choosing your screenshots folder in the setup
+  wizard left the Screenshots panel empty, and nothing you could click fixed it: Refresh kept
+  re-reading the folder DevThrottle had chosen when it started, and saving in Settings did
+  nothing when the folder shown there was already the right one. Pick the folder and your
+  screenshots are there, straight away.
+- **The wizard shows you your screenshots.** The setup step now displays the most recent images
+  from the folder it found, so you can see for yourself it is the right folder instead of taking
+  a number on trust.
+- **Refresh means refresh.** It re-reads the folder from your settings and starts watching it,
+  so it can recover when the folder changes.
+
+### Updating
+
+- **Updating no longer looks like a factory reset.** After an update, DevThrottle could come back
+  with an empty session list, default settings, and the first-run setup wizard - on a machine
+  that had been running for months. Nothing was ever deleted: the app was starting up in a new,
+  empty data folder each time it updated, one level deeper every time. It now stays in the data
+  folder it has always used, and installing this update moves an affected machine back into its
+  own folder, with its settings and sessions.


### PR DESCRIPTION
Version bump and user-facing release notes for v1.8.2. The fixes themselves landed in #2238.

- The Screenshots panel follows the folder you set instead of the one resolved at startup; the wizard shows the pictures it found (internal#992).
- An update no longer starts the Director in a new, empty data home - and applying this one puts an affected machine back in its own (internal#993).

Tagging `v1.8.2` after this merges is what triggers the build-and-publish workflow.