### PR TITLE
Installer: offer Git, which the app needs to read repositories at all

### DIFF
--- a/tools/cc-director-setup-engine/CapabilityNotice.cs
+++ b/tools/cc-director-setup-engine/CapabilityNotice.cs
@@ -9,12 +9,13 @@ public static class PrerequisiteNames
 {
     public const string DotNetRuntime = ".NET 10 Runtime";
     public const string ClaudeCode = "Claude Code";
+    public const string Git = "Git";
     public const string Python = "Python";
     public const string NodeJs = "Node.js";
     public const string Tailscale = "Tailscale";
 
     /// <summary>The rows that are recommended - checked and offered, but never gating.</summary>
-    public static readonly IReadOnlyList<string> Recommended = [ClaudeCode, Python, NodeJs];
+    public static readonly IReadOnlyList<string> Recommended = [ClaudeCode, Git, Python, NodeJs];
 }
 
 /// <summary>One recommended prerequisite and whether the checker accepted it.</summary>
@@ -52,6 +53,8 @@ public static class CapabilityNotice
             "the Claude agent is unavailable - your other coding agent still works",
         PrerequisiteNames.ClaudeCode =>
             "no coding agent is set up yet, so your board has nothing to run",
+        PrerequisiteNames.Git =>
+            "DevThrottle cannot read your repositories, so branch and change counts stay blank",
         PrerequisiteNames.Python =>
             "your own Python scripts will not run (the cc-* tools bring their own Python)",
         PrerequisiteNames.NodeJs =>

--- a/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
+++ b/tools/cc-director-setup.Tests/PrerequisiteClassificationTests.cs
@@ -86,12 +86,30 @@ public class PrerequisiteClassificationTests
     }
 
     [Fact]
-    public void CreateChecklist_RecommendedRowsAreExactlyTheThree()
+    public void CreateChecklist_RecommendedRowsAreExactlyTheRecommendedNames()
     {
         var recommended = PrerequisiteChecker.CreateChecklist(InstallRole.Gateway)
             .Where(p => p.IsRecommended).Select(p => p.Name).ToList();
 
         Assert.Equal(PrerequisiteNames.Recommended, recommended);
+    }
+
+    [Fact]
+    public void CreateChecklist_GitIsRecommendedAndAutoInstallable()
+    {
+        // The Director shells out to git in six production paths (repository status, sync state,
+        // write operations, the Wingman). A clean Windows machine has no git, and the failure is
+        // SILENT - the count degrades to unknown and the reason goes to a log file only. So the
+        // one place a user can be told is the Prerequisites screen, where it can also be installed.
+        var git = PrerequisiteChecker.CreateChecklist(InstallRole.Workstation)
+            .Single(p => p.Name == PrerequisiteNames.Git);
+
+        Assert.False(git.IsRequired);          // DevThrottle starts and runs without it
+        Assert.True(git.IsRecommended);        // but a user who skips it has a real, named gap
+        Assert.Equal("Recommended", git.ImportanceLabel);
+        Assert.True(git.CanAutoInstall);
+        Assert.Equal("Git.Git", git.WingetId);
+        Assert.False(string.IsNullOrWhiteSpace(git.InstallUrl));
     }
 
     [Fact]

--- a/tools/cc-director-setup/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup/Services/PrerequisiteChecker.cs
@@ -47,6 +47,17 @@ public static class PrerequisiteChecker
             },
             new PrerequisiteInfo
             {
+                Name = CcDirector.Setup.Engine.PrerequisiteNames.Git,
+                IsRecommended = true,
+                Description = "Recommended: DevThrottle reads your repositories with git - branch, "
+                    + "changed-file counts and the Repositories view. Without it those stay blank.",
+                IsRequired = false,
+                CanAutoInstall = true,
+                WingetId = "Git.Git",
+                InstallUrl = "https://git-scm.com/download/win"
+            },
+            new PrerequisiteInfo
+            {
                 Name = CcDirector.Setup.Engine.PrerequisiteNames.Python,
                 IsRecommended = true,
                 Description = "Recommended: Python 3.11 or higher, for your own scripts. The cc-* tools "
@@ -131,6 +142,9 @@ public static class PrerequisiteChecker
                     break;
                 case "Claude Code":
                     CheckExecutable(item, "claude", "--version");
+                    break;
+                case "Git":
+                    CheckExecutable(item, "git", "--version");
                     break;
                 case "Python":
                     CheckPython(item);


### PR DESCRIPTION
## The defect

A clean Windows machine has no git. DevThrottle installs and onboards **completely** without it, and then every repository feature is silently dead.

Verified on a freshly installed clean VM - install and onboarding both completed, Director running:

```
git on PATH : NOT FOUND
git dirs    : no Git install dir
director up : True
```

The Director shells out to `git` in six production paths - `GitCommandRunner`, `GitStatusProvider`, `GitSyncStatusProvider`, `GitWriteService`, `GitHubUrls`, `WingmanService` - yet git appeared in **neither** the prerequisite checklist nor the tools manifest.

And the failure is silent: `GitStatusProvider` degrades the change count to unknown and writes the reason to a log file, `GitSyncStatusProvider` swallows the error outright, and there is no user-facing message anywhere. Same class as the six original blockers - not a crash, but a dead end that never says what is wrong.

## The change

Git becomes a **Recommended** row, the same class as Claude Code. Not Required: DevThrottle genuinely starts and runs without it, so gating the install would be dishonest in the other direction. But a user who skips it has a real, named gap, and the Complete screen now says what it costs.

- `CapabilityNotice.cs` - canonical `Git` name, added to `Recommended`, plus an explicit consequence line. That switch has a vague `_ =>` fallback, so without a case the Complete screen would have said "some features are unavailable".
- `PrerequisiteChecker.cs` - the row, with winget id `Git.Git` so auto-install genuinely works. Placed **after Claude Code rather than last**, because burying it below the fold is what made blocker #6 hurt.
- Detection via `CheckExecutable(item, "git", "--version")`, which goes through `ExecutableResolver` and so does not repeat the stale-PATH bug.
- Renamed `CreateChecklist_RecommendedRowsAreExactlyTheThree`, and added a test pinning git as recommended and auto-installable, with the six call sites recorded in the comment.

## Proof on a clean machine

The screen now has **five** rows. Blocker #6 was that the list did not scroll and the *fourth* card was unreachable at 1024x768 - and that fix was proved across thirteen runs against a **four-row** screen. So the scroll was re-proved against five, with the locally built installer on a wiped VM:

| Check | Result |
|---|---|
| Clean machine has no git before we start | PASS |
| All five rows present | PASS |
| No gateway-only Tailscale row on a workstation | PASS |
| List scrolls to 100% | PASS |
| All 5 "Install automatically" buttons `IsOffscreen=false` | PASS |

Buttons at y=49, 177, 305, 433, 546. Present in the accessibility tree is not the same as usable - that difference *was* blocker #6.

## Tests

- `cc-director-setup.Tests` 46 passed
- `cc-director-setup-engine.Tests` 409 passed
- `cc-director.sln` 8594 passed, 0 failed

Note: the setup test projects are **not in `cc-director.sln`**, so CI's single `dotnet test cc-director.sln` does not run them. They were run directly. Worth fixing separately.

macOS unaffected - the Avalonia installer builds its own list and does not read `Recommended`.