### PR TITLE
Correct the macOS file-search guidance, and name the path to grant access to

### DIFF
--- a/docs/CC_TOOLS.md
+++ b/docs/CC_TOOLS.md
@@ -1031,16 +1031,28 @@ specific. Use `machine apps` to get the exact name.
 #### On macOS, grant the launcher Full Disk Access before relying on file search
 
 **Without it the file search on a Mac returns close to nothing, and this is not a nice-to-have.**
-macOS guards Documents, Desktop and Downloads behind a privacy consent, and a folder without that
-consent does not refuse the search - it never answers at all. The search gives up on it at the
-deadline and reports the folder as an abandoned root, which is honest but is not results.
+macOS guards Documents, Desktop and Downloads behind a privacy consent, granted per folder
+category. A folder the launcher has no consent for may refuse the search quickly - or it **may hang
+rather than refuse**, never answering at all, and that is the case that costs you. The search gives
+up on such a folder at its deadline and reports it as an abandoned root, which is honest but is not
+results.
 
-It is worse than losing those folders alone. On macOS the search walks a single root (`/`), so
-abandoning it abandons everything not already visited: on a real Mac, hitting the Documents folder
-about 630 directories in returned ZERO files out of the whole machine. On Windows each drive is its
-own root, so the same block would cost you one drive rather than the search.
+Which folders behave which way varies by machine, because the consents are separate: on the Mac this
+was measured on, Desktop and Downloads enumerated normally and only Documents hung. So a search that
+looks fine on one Mac is not evidence about another.
 
-Grant it in System Settings under Privacy & Security, Full Disk Access, adding `cc-launcher`.
+It is worse than losing the guarded folder alone. On macOS the search walks a single root (`/`), so
+abandoning it abandons everything not already visited: on that machine, hitting Documents about 630
+directories in returned ZERO files out of the whole machine. On Windows each drive is its own root,
+so the same block would cost you one drive rather than the search.
+
+Grant it in System Settings under Privacy & Security, Full Disk Access. The launcher is a bare
+binary rather than an application bundle, so the file dialog will not offer it by name - press
+Command-Shift-G and enter the path:
+
+```
+~/Library/Application Support/cc-director/launcher/cc-launcher
+```
 
 ---
 


### PR DESCRIPTION
Follow-up to #2239, from verification on real Apple silicon hardware. Both fixes are about the guidance being wrong rather than merely thin.

## It said the guarded folders never answer

They do not behave alike. The macOS privacy consents are granted per folder category, so a folder the launcher has no consent for may refuse quickly, or may hang and never answer. On the machine this was measured on, Desktop and Downloads enumerated normally and only Documents hung.

Saying they never answer misleads in both directions: it invites someone whose Desktop search works to conclude the feature is broken, and it hides that the dangerous case is the hang rather than the refusal - a refusal is reported and costs one folder, a hang costs everything not yet visited.

Now says "may hang rather than refuse", and adds that a search looking fine on one Mac is not evidence about another.

## It said to add `cc-launcher` to Full Disk Access

The launcher is a bare binary rather than an application bundle, so the file dialog does not offer it by name and a first-timer is left hunting for something that never appears in the list. The concrete path is now given along with the keystroke that makes the dialog accept one:

```
~/Library/Application Support/cc-director/launcher/cc-launcher
```

Verified against the code rather than assumed: `CcStorage.Base()` is `LocalApplicationData` + `"cc-director"`, and .NET maps `LocalApplicationData` to `~/Library/Application Support` on macOS - the same layout as the Windows `%LOCALAPPDATA%\cc-director\launcher\` that holds `cc-launcher.exe`.

## Verification behind this

Merged main (a32538f9) was re-verified end to end on macOS before these corrections were written: 61 launcher tests pass; the file search returns at its deadline with `abandonedRoots=1` rather than hanging; and the launcher REST surface was exercised directly - `GET /apps` unauthenticated is 401, `GET /apps?q=safari` returns Safari from `/Applications`, `GET /files` without a query is 400, and `POST /launch {"app":"Safari"}` started Safari.

Documentation only. No code change.