### PR TITLE
release: v1.8.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.2</Version>
+    <Version>1.8.3</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Version bump only.

## Since v1.8.2

- **Installer offers Git** (#2242). A clean Windows machine has no git, yet the Director shells out to it in six production paths. Without it every repository feature is silently dead - the change count degrades to unknown and the reason only reaches a log file. Verified on a clean VM: five rows, list scrolls, all five install buttons reachable.
- macOS file-search guidance names the path to grant (#2243)
- Search and start applications on another machine (#2239)

Tagging `v1.8.3` after this merges publishes the signed installer to `releases/latest/download`.

The published artifact will then be verified on a clean Hyper-V VM - version assertion (so the redirect cannot silently serve the previous release), signature, and the Git row read out of the shipped binary.