### PR TITLE
Onboarding: stop asking every machine how often to send one account's report

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -457,53 +457,6 @@
                 </Grid>
             </Grid>
 
-            <!-- ===================== MORNING REPORT (the promise screen) ===================== -->
-            <Grid x:Name="ReportPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
-                <TextBlock Grid.Row="0" Classes="eyebrow" Text="THE PAYOFF" />
-                <TextBlock Grid.Row="1" x:Name="ReportTitle" Classes="wtitle"
-                           Text="Tomorrow morning, we report back" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" x:Name="ReportSubText" Classes="wsub" Margin="0,0,0,24"
-                           Text="Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you." />
-                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
-                              MaxWidth="560" HorizontalAlignment="Center">
-                <StackPanel MaxWidth="520" Spacing="10" VerticalAlignment="Top"
-                            HorizontalAlignment="Stretch">
-                    <Border x:Name="ReportDailyCard" Cursor="Hand"
-                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                            CornerRadius="10" Padding="16,13"
-                            PointerPressed="ReportDailyCard_Pressed">
-                        <StackPanel Spacing="2">
-                            <TextBlock Text="Daily" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
-                            <TextBlock Text="Every morning at 7:00, your time" FontSize="11" Foreground="#8A909A" />
-                        </StackPanel>
-                    </Border>
-                    <Border x:Name="ReportWeeklyCard" Cursor="Hand"
-                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                            CornerRadius="10" Padding="16,13"
-                            PointerPressed="ReportWeeklyCard_Pressed">
-                        <StackPanel Spacing="2">
-                            <TextBlock Text="Weekly" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
-                            <TextBlock Text="Monday mornings only" FontSize="11" Foreground="#8A909A" />
-                        </StackPanel>
-                    </Border>
-                    <Border x:Name="ReportOffCard" Cursor="Hand"
-                            Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                            CornerRadius="10" Padding="16,13"
-                            PointerPressed="ReportOffCard_Pressed">
-                        <StackPanel Spacing="2">
-                            <TextBlock Text="No report" FontSize="14" FontWeight="SemiBold" Foreground="#16181D" />
-                            <TextBlock Text="You can turn it on later in Settings" FontSize="11" Foreground="#8A909A" />
-                        </StackPanel>
-                    </Border>
-                    <TextBlock x:Name="ReportGatewayNote" Classes="hint" IsVisible="False"
-                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="480"
-                               Margin="0,6,0,0"
-                               Text="The report travels through your gateway. Connect one on the previous step - or any time in Settings - and it starts arriving." />
-                </StackPanel>
-                </ScrollViewer>
-            </Grid>
-
             <!-- ===================== DONE =====================
                  The receipt grows with the number of things it reports, so it scrolls and the two
                  finish buttons are pinned to the bottom row. Before this they lived inside the

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -93,12 +93,6 @@ public partial class FirstRunWizardDialog : Window
     // on disk - it only stops the step, and the Done receipt, from reading as a failure.
     private bool _codeNoneOnThisMachine;
 
-    // Morning report step: the chosen cadence. Daily is the default - the report is the payoff the
-    // whole onboarding story builds to, so it arrives unless the user says otherwise.
-    private enum ReportCadence { Daily, Weekly, Off }
-
-    private ReportCadence _reportCadence = ReportCadence.Daily;
-
     // True once the completion marker has been written, so OnClosed does not write it twice.
     private bool _marked;
 
@@ -181,7 +175,6 @@ public partial class FirstRunWizardDialog : Window
         CodePanel.IsVisible = step == WizardStep.Code;
         ScreenshotsPanel.IsVisible = step == WizardStep.Screenshots;
         GatewayPanel.IsVisible = step == WizardStep.Gateway;
-        ReportPanel.IsVisible = step == WizardStep.MorningReport;
         DonePanel.IsVisible = step == WizardStep.Done;
 
         // Leaving the Screenshots step ends any take-a-screenshot watch; leaving Tools stops the
@@ -249,24 +242,6 @@ public partial class FirstRunWizardDialog : Window
                 RefreshGatewayChoiceUi();
                 break;
 
-            case WizardStep.MorningReport:
-                PrimaryButton.Content = "Sounds good";
-                PrimaryButton.IsVisible = true;
-                PrimaryButton.IsEnabled = true;
-                RefreshReportCards();
-                // The report travels through the gateway. With none connected nothing can arrive
-                // tomorrow morning, so the headline says what is actually true instead of making a
-                // promise the previous step already ruled out.
-                var hasGateway = HasGateway();
-                ReportGatewayNote.IsVisible = !hasGateway;
-                ReportTitle.Text = hasGateway
-                    ? "Tomorrow morning, we report back"
-                    : "Your morning report is ready when your gateway is";
-                ReportSubText.Text = hasGateway
-                    ? "Every morning DevThrottle emails you what happened, what needs your attention, and what it recommends - stale worktrees, unmerged branches, sessions waiting on you. So Friday never surprises you."
-                    : "The report tells you every morning what happened, what needs your attention, and what DevThrottle recommends. Choose how often you want it - it starts arriving as soon as a gateway is connected.";
-                break;
-
             case WizardStep.Done:
                 // Primary and the board link live in the content panel. With no agent on the machine
                 // the carried to-do leads: the button routes back to the Agents step and its installer
@@ -302,11 +277,6 @@ public partial class FirstRunWizardDialog : Window
 
                 case WizardStep.Screenshots:
                     await SaveScreenshotsFolderAsync();
-                    Advance();
-                    break;
-
-                case WizardStep.MorningReport:
-                    await SaveReportCadenceAsync();
                     Advance();
                     break;
 
@@ -1232,45 +1202,6 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
-    // ---- Morning report step (the promise screen) ---------------------------------------------------
-
-    private void RefreshReportCards()
-    {
-        StyleGatewayCard(ReportDailyCard, _reportCadence == ReportCadence.Daily, emphasized: false);
-        StyleGatewayCard(ReportWeeklyCard, _reportCadence == ReportCadence.Weekly, emphasized: false);
-        StyleGatewayCard(ReportOffCard, _reportCadence == ReportCadence.Off, emphasized: false);
-    }
-
-    private void SelectReportCadence(ReportCadence cadence)
-    {
-        FileLog.Write($"[FirstRunWizardDialog] SelectReportCadence: {cadence}");
-        _reportCadence = cadence;
-        RefreshReportCards();
-    }
-
-    private void ReportDailyCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Daily);
-    private void ReportWeeklyCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Weekly);
-    private void ReportOffCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectReportCadence(ReportCadence.Off);
-
-    /// <summary>
-    /// Persist the cadence choice to config so the morning-report sender reads the user's answer
-    /// when it ships. Skipping the step writes nothing - only an explicit "Sounds good" commits.
-    /// </summary>
-    private async Task SaveReportCadenceAsync()
-    {
-        var cadence = _reportCadence switch
-        {
-            ReportCadence.Daily => "daily",
-            ReportCadence.Weekly => "weekly",
-            _ => "off",
-        };
-        FileLog.Write($"[FirstRunWizardDialog] SaveReportCadenceAsync: {cadence}");
-        await Task.Run(() => CcDirectorConfigService.MergePatch(new JsonObject
-        {
-            ["morning_report"] = new JsonObject { ["cadence"] = cadence, ["hour"] = 7 },
-        }));
-    }
-
     // ---- Welcome: founder note ----------------------------------------------------------------------
 
     private void BtnFounderMore_Click(object? sender, RoutedEventArgs e)
@@ -1280,14 +1211,6 @@ public partial class FirstRunWizardDialog : Window
     }
 
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
-
-    /// <summary>
-    /// True when a gateway is reachable for this machine - connected during this run, or already
-    /// configured before it. Everything that travels through the gateway (the morning report) reads
-    /// this one answer rather than deciding for itself.
-    /// </summary>
-    private bool HasGateway() =>
-        _gatewayConnected || !string.IsNullOrWhiteSpace(GatewayConfig.Load().Url);
 
     /// <summary>Paint the three choice cards and the primary CTA from the current selection.</summary>
     private void RefreshGatewayChoiceUi()
@@ -1513,21 +1436,20 @@ public partial class FirstRunWizardDialog : Window
         DoneReceiptPanel.Children.Add(ReceiptRow(
             "Browsers", "Give agents a signed-in browser any time - the Browsers group in the left rail", done: false));
 
-        // Morning report row - the promise, restated on the receipt. With no gateway the report
-        // cannot arrive, so this row must not claim it is Done two rows under "No gateway".
-        var gatewayReady = !string.IsNullOrWhiteSpace(gatewayUrl);
-        DoneReceiptPanel.Children.Add((_reportCadence, gatewayReady) switch
-        {
-            (ReportCadence.Off, _) => ReceiptRow("Morning report off", "Turn it on any time in Settings", done: false),
-            (ReportCadence.Daily, true) => ReceiptRow("Morning report", "Every morning at 7:00, your time", done: true),
-            (ReportCadence.Weekly, true) => ReceiptRow("Morning report", "Monday mornings", done: true),
-            (ReportCadence.Daily, false) => ReceiptRow(
-                "Morning report", "Every morning at 7:00 - once a gateway is connected",
-                done: false, pillText: "Waiting for a gateway"),
-            _ => ReceiptRow(
-                "Morning report", "Monday mornings - once a gateway is connected",
-                done: false, pillText: "Waiting for a gateway"),
-        });
+        // Morning report row. There is no longer a frequency question in the wizard - the report is
+        // one person, one email, and asking about it once per machine could never reconcile (issue
+        // #996) - so this row states the ONE default rather than reporting a choice back. It is now
+        // also the only place onboarding says the email is coming at all, which is why the row stays.
+        //
+        // Two claims here have to be true and stay true. The report travels through the gateway, so
+        // with none connected it must not read Done two rows under "No gateway". And the time is
+        // 7:00 EASTERN, not "your time" - that is when the sender runs, and a receipt that invents a
+        // local hour is wrong for everyone outside one timezone.
+        DoneReceiptPanel.Children.Add(!string.IsNullOrWhiteSpace(gatewayUrl)
+            ? ReceiptRow("Morning report", "Every morning at 7:00 Eastern - the email says how to change or stop it", done: true)
+            : ReceiptRow(
+                "Morning report", "Every morning at 7:00 Eastern - once a gateway is connected",
+                done: false, pillText: "Waiting for a gateway"));
     }
 
     private static Border ReceiptRow(string name, string sub, bool done, string? pillText = null)

--- a/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
@@ -123,14 +123,37 @@ public class FirstRunWizardModelTests
     }
 
     [Fact]
-    public void CreateFull_HasAllEightStepsInCanonicalOrder()
+    public void CreateFull_HasAllSevenStepsInCanonicalOrder()
     {
         var model = FirstRunWizardModel.CreateFull();
         Assert.Equal(FirstRunWizardModel.CanonicalOrder, model.Steps);
-        Assert.Equal(8, model.Count);
+        Assert.Equal(7, model.Count);
 
         // Tools sits right after Agents: workforce first, then their toolbelt.
         Assert.Equal(WizardStep.Tools, model.Steps[2]);
+
+        // Gateway is the last step before Done. It used to be followed by a daily-report frequency
+        // question, which is an ACCOUNT setting and so was asked once per machine with no way to
+        // reconcile the answers (issue #996). The number here is also the number of progress dots,
+        // so a step creeping back in is a failing assertion rather than a silently longer wizard.
+        Assert.Equal(WizardStep.Gateway, model.Steps[^2]);
+    }
+
+    [Fact]
+    public void CanonicalOrder_HasNoStepAskingForAnAccountLevelSetting()
+    {
+        // The guard for issue #996, stated as the rule rather than as one banned name: the wizard
+        // runs per director per machine, so every step it presents must be answerable about THIS
+        // machine. Enum.GetValues is the source, so adding a step to WizardStep without adding it
+        // to this list fails here and forces the question to be asked deliberately.
+        var machineScoped = new[]
+        {
+            WizardStep.Welcome, WizardStep.Agents, WizardStep.Tools, WizardStep.Code,
+            WizardStep.Screenshots, WizardStep.Gateway, WizardStep.Done,
+        };
+
+        Assert.Equal(machineScoped, Enum.GetValues<WizardStep>());
+        Assert.Equal(machineScoped, FirstRunWizardModel.CanonicalOrder);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
+++ b/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
@@ -3,11 +3,18 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.Onboarding;
 
 /// <summary>
-/// The seven first-run wizard screens in their canonical order (issue #2100 mockup). A given
+/// The first-run wizard screens in their canonical order (issue #2100 mockup). A given
 /// release presents a subsequence of these: the bookends (<see cref="Welcome"/> and
 /// <see cref="Done"/>) always ship, the middle steps slot in as their own issues land. Absent
 /// steps are simply not part of the present-step list a <see cref="FirstRunWizardModel"/> is built
 /// with, so the wizard tolerates a configurable step list without re-ordering logic.
+///
+/// EVERY STEP HERE MUST BE ABOUT THIS MACHINE. The wizard runs once per director, per machine, so a
+/// question whose answer belongs to the ACCOUNT gets asked once per machine and the copies never
+/// reconcile. That is why there is no daily-report step (issue #996): the report is one person, one
+/// email, delivered through the gateway, so asking about it on machine two was asking the same
+/// person the same question again and writing the answer somewhere machine one could not see. The
+/// gateway step stays, because enrolling THIS machine to a gateway genuinely is about this machine.
 /// </summary>
 public enum WizardStep
 {
@@ -17,7 +24,6 @@ public enum WizardStep
     Code,
     Screenshots,
     Gateway,
-    MorningReport,
     Done,
 }
 
@@ -60,7 +66,6 @@ public sealed class FirstRunWizardModel
         WizardStep.Code,
         WizardStep.Screenshots,
         WizardStep.Gateway,
-        WizardStep.MorningReport,
         WizardStep.Done,
     };
 
@@ -96,7 +101,7 @@ public sealed class FirstRunWizardModel
         FileLog.Write($"[FirstRunWizardModel] Constructor: steps=[{string.Join(",", _steps)}]");
     }
 
-    /// <summary>Build a wizard over all seven canonical steps (the full mockup flow).</summary>
+    /// <summary>Build a wizard over every canonical step (the full mockup flow).</summary>
     public static FirstRunWizardModel CreateFull() => new(CanonicalOrder);
 
     /// <summary>The present steps, in canonical order. Its length is the number of progress dots.</summary>

--- a/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
@@ -25,10 +25,15 @@ namespace CcDirector.Gateway.Api;
 /// was at mint time and it is nullable; a recipient with nothing to send to is not a recipient, and
 /// returning an empty address would invite the sender to try anyway.
 ///
-/// WHAT THIS DOES NOT DECIDE: whether a given account WANTS the email. There is no such setting yet
-/// (the wizard cadence step is issue #2107). When it exists, the filtering belongs HERE - one place
-/// that answers "who should be mailed" - and not in the sender, so that every future channel inherits
-/// the same answer instead of each one re-deriving it.
+/// WHAT THIS DOES NOT DECIDE: whether a given account WANTS the email. There is no such setting yet,
+/// and it is NOT coming from the first-run wizard - that step was removed (issue #996) because the
+/// wizard runs once per director per machine while this preference is one per ACCOUNT, so it was
+/// asked N times and the answers never reconciled. Until the account-scoped setting exists the report
+/// is simply daily, and the email itself carries the instructions for changing or stopping it.
+///
+/// When the setting does exist, the filtering belongs HERE - one place that answers "who should be
+/// mailed" - and not in the sender, so that every future channel inherits the same answer instead of
+/// each one re-deriving it.
 /// </summary>
 internal static class ReportRecipientsEndpoint
 {


### PR DESCRIPTION
Closes the code half of devthrottle_internal#996.

## The problem

The first-run wizard asked how often you want the daily report - Daily, Weekly, or
No report. The report is one person, one email, delivered through the gateway. The
wizard runs once per director, per machine. So a person with three machines was
asked three times and the three answers had nowhere to reconcile.

The step's own footnote gave it away: "The report travels through your gateway."
And the storage confirmed it - `SaveReportCadenceAsync` wrote `morning_report.cadence`
into the machine's `config.json`.

**Worth knowing before reviewing:** that key had no readers at all. Nothing in this
repository, and nothing in the sender that actually mails the report, ever read
`morning_report`. The question cost a screen on every machine and changed nothing.

## What changed

- The step is gone: the `MorningReport` panel, its three cards, the `ReportCadence`
  state, and the config write.
- The report is simply daily. No prompt.
- The done receipt no longer reports a choice nobody was offered. Two of its claims
  also had to become true: it said "7:00, your time" when the sender runs at 7:00
  Eastern for everybody, and it could report a frequency that was never asked. It
  now states the one default - and still refuses to mark the report Done when there
  is no gateway to carry it.
- `ReportRecipientsEndpoint`'s comment pointed the next reader at the wizard cadence
  step as the future home of the opt-out. It now points at account scope instead of
  at a screen that no longer exists.

The change/stop instructions move into the email itself. That is a separate pull
request on the internal repository, where the sender lives.

## Where the setting actually belongs

Account/gateway scope, not this machine - and that is deliberately NOT in here. It
needs a per-tenant column and an EF migration, a read/write endpoint, the filter in
`ReportRecipientsEndpoint` (whose comment already says the filtering belongs there),
and a settings card in `packages/client-core` so the cockpit and the phone stay in
sync. That is a feature, not this bug fix. Written up on the issue rather than left
implied.

The per-machine key is not left behind as a half-measure: the write is deleted. A
machine that already ran the old wizard keeps an inert `morning_report` block in its
config; nothing reads it, and stripping a key with no readers did not seem worth a
migration.

## Proof

Unit: `FirstRunWizardModelTests` asserts the step list against `Enum.GetValues`, so a
step cannot creep back in without that assertion going red, and the count assertion
doubles as the progress-dot count. **Both were verified to fail** by putting the step
back and re-running.

Full solution green: 3783 + 4344 passing, 0 failures.

Onboarding is not something a unit test can prove, so it was also walked on a clean
Windows virtual machine restored to its CLEAN-BASE snapshot, in two arms on the same
runtime with only the code differing: v1.8.3 as the control (the walker must fail on
the report checks) and this branch as the treatment. Harness, screenshots and both
logs are in the internal repository under `docs/qa/runs/2026-07-28-996/`.