### PR TITLE
Let the launcher find a 1.8 Director's registration, so a remote stop is graceful

### DIFF
--- a/src/CcDirector.Launcher.Tests/DirectorSupervisorInstanceDiscoveryTests.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorSupervisorInstanceDiscoveryTests.cs
@@ -1,0 +1,181 @@
+using CcDirector.Launcher;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// The launcher has to find a running Director's instance registration, and from 1.8 that registration is not
+/// where it used to be.
+///
+/// THE DEFECT THESE PIN. The launcher runs at the storage ROOT, so it read
+/// <c>&lt;root&gt;/config/director/instances</c>. A Director started for a named instance keeps its whole
+/// storage under <c>&lt;root&gt;/instances/&lt;slug&gt;/</c> and registers THERE instead, and from 1.8 the
+/// installed Director boots as instance "default". So on a normal machine the directory the launcher read was
+/// empty and every live registration sat one level in.
+///
+/// It failed differently on each platform, which is how it survived. On macOS the running check walks these
+/// files, so the launcher reported the Director as not running while it was up. On Windows the running check
+/// enumerates processes and was CORRECT - the damage was one level down, where the Control API port is looked
+/// up: no registration meant port 0, the graceful shutdown was skipped, and every remote stop and restart
+/// force-killed while appearing to succeed.
+///
+/// These tests are written against the ROOT rather than against either symptom, because one lookup feeds both.
+/// </summary>
+public sealed class DirectorSupervisorInstanceDiscoveryTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+    private readonly string? _previousInstancesDir;
+
+    public DirectorSupervisorInstanceDiscoveryTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        // This override pins the flat directory on its own. Left set, it would mask exactly what these tests
+        // are about, so it is cleared for the duration and restored afterwards.
+        _previousInstancesDir = Environment.GetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", null);
+
+        _root = Path.Combine(Path.GetTempPath(), "cc-supervisor-discovery-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", _previousInstancesDir);
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a temporary directory that outlives the run is not a failure */ }
+    }
+
+    /// <summary>The flat directory a pre-1.8 Director registers in.</summary>
+    private string FlatDirectory => Path.Combine(_root, "config", "director", "instances");
+
+    /// <summary>The directory a Director running as <paramref name="slug"/> registers in.</summary>
+    private string InstanceDirectory(string slug) =>
+        Path.Combine(_root, "instances", slug, "config", "director", "instances");
+
+    /// <summary>
+    /// Write a registration exactly as a Director writes one. The pid is this test process by default, so the
+    /// entry describes a process that is genuinely alive - a registration for a dead pid is meaningless to
+    /// every caller of this code.
+    /// </summary>
+    private static void WriteRegistration(string directory, string directorId, int port, int? pid = null)
+    {
+        Directory.CreateDirectory(directory);
+        var json = $$"""
+        {
+          "DirectorId": "{{directorId}}",
+          "Pid": {{pid ?? Environment.ProcessId}},
+          "ControlEndpoint": "http://127.0.0.1:{{port}}",
+          "Version": "1.8.3"
+        }
+        """;
+        File.WriteAllText(Path.Combine(directory, directorId + ".json"), json);
+    }
+
+    [Fact]
+    public void InstanceRegistrationDirectories_IncludesTheFlatPath()
+    {
+        Directory.CreateDirectory(FlatDirectory);
+
+        var directories = DirectorSupervisor.InstanceRegistrationDirectories().ToList();
+
+        Assert.Contains(FlatDirectory, directories);
+    }
+
+    /// <summary>The regression itself: the per-instance home must be scanned, not only the root's own.</summary>
+    [Fact]
+    public void InstanceRegistrationDirectories_IncludesEveryPerInstanceHome()
+    {
+        Directory.CreateDirectory(InstanceDirectory("default"));
+        Directory.CreateDirectory(InstanceDirectory("work"));
+
+        var directories = DirectorSupervisor.InstanceRegistrationDirectories().ToList();
+
+        Assert.Contains(InstanceDirectory("default"), directories);
+        Assert.Contains(InstanceDirectory("work"), directories);
+    }
+
+    [Fact]
+    public void InstanceRegistrationDirectories_WithNoInstancesRoot_StillYieldsTheFlatPath()
+    {
+        // A machine that has never run a named instance has no instances/ directory at all. Enumerating must
+        // not throw or come back empty - the pre-1.8 layout is still a supported machine.
+        var directories = DirectorSupervisor.InstanceRegistrationDirectories().ToList();
+
+        Assert.Contains(FlatDirectory, directories);
+    }
+
+    /// <summary>
+    /// THE ONE THAT MATTERS. A 1.8 Director's registration lives in the per-instance home; the launcher must
+    /// read it. Before the fix this returned nothing, which is what made the port lookup fail and the stop
+    /// force-kill.
+    /// </summary>
+    [Fact]
+    public void ReadInstanceRegistrations_FindsARegistrationInAPerInstanceHome()
+    {
+        WriteRegistration(InstanceDirectory("default"), "c6db060e-0000-0000-0000-000000000001", port: 7879);
+
+        var registrations = DirectorSupervisor.ReadInstanceRegistrations();
+
+        var found = Assert.Single(registrations);
+        Assert.Equal(Environment.ProcessId, found.Pid);
+        Assert.Equal(7879, found.Port);
+    }
+
+    /// <summary>
+    /// A pre-1.8 Director still registers flat, and must still be found. Replacing the old path rather than
+    /// adding to it would have broken those machines the way the old launcher breaks 1.8 ones.
+    /// </summary>
+    [Fact]
+    public void ReadInstanceRegistrations_StillFindsAFlatRegistration()
+    {
+        WriteRegistration(FlatDirectory, "5edf0787-0000-0000-0000-000000000002", port: 7880);
+
+        var registrations = DirectorSupervisor.ReadInstanceRegistrations();
+
+        var found = Assert.Single(registrations);
+        Assert.Equal(7880, found.Port);
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_FindsBothLayoutsAtOnce()
+    {
+        WriteRegistration(FlatDirectory, "5edf0787-0000-0000-0000-000000000003", port: 7880);
+        WriteRegistration(InstanceDirectory("default"), "c6db060e-0000-0000-0000-000000000004", port: 7879);
+
+        var ports = DirectorSupervisor.ReadInstanceRegistrations().Select(r => r.Port).OrderBy(p => p).ToList();
+
+        Assert.Equal(new[] { 7879, 7880 }, ports);
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_FindsRegistrationsAcrossSeveralInstances()
+    {
+        WriteRegistration(InstanceDirectory("default"), "c6db060e-0000-0000-0000-000000000005", port: 7879);
+        WriteRegistration(InstanceDirectory("work"), "c6db060e-0000-0000-0000-000000000006", port: 7881);
+
+        var ports = DirectorSupervisor.ReadInstanceRegistrations().Select(r => r.Port).OrderBy(p => p).ToList();
+
+        Assert.Equal(new[] { 7879, 7881 }, ports);
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_MalformedFile_IsSkippedRatherThanFailingTheScan()
+    {
+        Directory.CreateDirectory(InstanceDirectory("default"));
+        File.WriteAllText(Path.Combine(InstanceDirectory("default"), "broken.json"), "{ this is not json");
+        WriteRegistration(InstanceDirectory("default"), "c6db060e-0000-0000-0000-000000000007", port: 7879);
+
+        var registrations = DirectorSupervisor.ReadInstanceRegistrations();
+
+        Assert.Equal(7879, Assert.Single(registrations).Port);
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_NothingRegistered_IsEmptyRatherThanThrowing()
+    {
+        Assert.Empty(DirectorSupervisor.ReadInstanceRegistrations());
+    }
+}

--- a/src/CcDirector.Launcher/CcDirector.Launcher.csproj
+++ b/src/CcDirector.Launcher/CcDirector.Launcher.csproj
@@ -13,6 +13,14 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!-- The registration-directory scan is the seam a test has to reach: it is a pure function of the storage
+       layout, and the defect it fixes was entirely about WHICH directories get looked in. Exposing it through
+       the public surface would put an implementation detail on the supervisor's contract, so the test assembly
+       is admitted to internals instead. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="CcDirector.Launcher.Tests" />
+  </ItemGroup>
+
   <!-- Windows-only executable dressing: the Win32 icon resource and the app manifest
        only apply to the Windows apphost. -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -22,10 +22,17 @@ namespace CcDirector.Launcher;
 ///
 /// Stop strategy: POST /shutdown to the Director's Control API (graceful, portable).
 /// The running Director and its Control API port are discovered through the instance
-/// registration files every Director writes to config/director/instances/{id}.json
-/// (see CcStorage.DirectorInstances). A registration counts only when its process is
-/// alive AND that process's executable is the installed Director - a stale file or a
-/// development-slot Director never matches.
+/// registration files every Director writes to config/director/instances/{id}.json.
+/// A registration counts only when its process is alive AND that process's executable
+/// is the installed Director - a stale file or a development-slot Director never matches.
+///
+/// THOSE FILES LIVE IN MORE THAN ONE PLACE, which is easy to get wrong and was.
+/// CcStorage.DirectorInstances resolves relative to the CALLER'S home, and the launcher
+/// runs at the storage root - but a Director started for a named instance keeps its whole
+/// storage under &lt;root&gt;/instances/&lt;slug&gt;/ and registers there. From 1.8 the
+/// installed Director boots as instance "default", so on a normal machine the root's own
+/// directory is empty and every live registration sits one level in. Both layouts are
+/// scanned; see InstanceRegistrationDirectories.
 /// </summary>
 public sealed class DirectorSupervisor
 {
@@ -127,7 +134,23 @@ public sealed class DirectorSupervisor
         }
 
         // Try graceful shutdown via Control API.
+        //
+        // A port of 0 means no registration was found for this pid, and that is NOT a normal condition - the
+        // Director is demonstrably running, so it registered somewhere. It is logged loudly because the silent
+        // version of this cost real damage: when the launcher looked in only one of the registration
+        // directories, every 1.8 Director came back with port 0, the graceful shutdown below was skipped
+        // without a word, and every remote stop and restart force-killed instead. A force-kill gives the
+        // Director no chance to clean up and leaves a phantom interrupted entry in its crash journal, so the
+        // failure degraded the very signal used to tell a real crash from a clean stop - while looking like it
+        // worked every time. The kill remains the fallback, because a Director that cannot be stopped at all
+        // would be worse; what changes is that it can no longer happen quietly.
         var port = FindDirectorPort(proc.Id);
+        if (port <= 0)
+            FileLog.Write($"[DirectorSupervisor] StopAsync: NO registration found for pid={proc.Id} - cannot reach "
+                          + "the Control API, so this stop will FORCE-KILL instead of shutting down gracefully. "
+                          + "The Director is running but its instance registration was not found in any known "
+                          + "directory; expect a phantom crash-journal entry.");
+
         if (port > 0)
         {
             try
@@ -239,39 +262,92 @@ public sealed class DirectorSupervisor
         return 0;
     }
 
+    /// <summary>
+    /// The folder under the storage root that holds per-instance homes. A Director started for a named
+    /// instance keeps its whole storage under &lt;root&gt;/instances/&lt;slug&gt;/ and registers there rather
+    /// than in the root's own config directory - which from 1.8 is where the installed Director lives, as
+    /// instance "default".
+    /// </summary>
+    private const string InstancesFolderName = "instances";
+
     /// <summary>One parsed instance registration file: config/director/instances/{id}.json.</summary>
-    private readonly record struct InstanceRegistration(int Pid, int Port);
+    internal readonly record struct InstanceRegistration(int Pid, int Port);
 
     /// <summary>
     /// Read every Director instance registration file (CcStorage.DirectorInstances).
     /// Each running Director writes {DirectorId, Pid, ControlEndpoint, ...}; files of
     /// dead Directors may linger, so callers must verify the Pid is alive.
     /// </summary>
-    private static List<InstanceRegistration> ReadInstanceRegistrations()
+    internal static IEnumerable<string> InstanceRegistrationDirectories()
+    {
+        // The launcher's own home. Also the path CC_DIRECTOR_INSTANCES_DIR pins, which is how a test aims this
+        // whole scan at a throwaway directory.
+        yield return CcStorage.DirectorInstances();
+
+        var instancesRoot = Path.Combine(CcStorage.Root(), InstancesFolderName);
+        string[] instanceHomes;
+        try
+        {
+            if (!Directory.Exists(instancesRoot)) yield break;
+            instanceHomes = Directory.GetDirectories(instancesRoot);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorSupervisor] InstanceRegistrationDirectories: cannot list {instancesRoot}: {ex.Message}");
+            yield break;
+        }
+
+        foreach (var home in instanceHomes)
+            yield return Path.Combine(home, "config", "director", "instances");
+    }
+
+    /// <summary>
+    /// Read every Director instance registration file, across the launcher's own home AND every per-instance
+    /// home (see <see cref="InstanceRegistrationDirectories"/>).
+    ///
+    /// Each running Director writes {DirectorId, Pid, ControlEndpoint, ...}; files of dead Directors may
+    /// linger, so callers must verify the Pid is alive.
+    /// </summary>
+    internal static List<InstanceRegistration> ReadInstanceRegistrations()
     {
         var result = new List<InstanceRegistration>();
-        var dir = CcStorage.DirectorInstances();
-        if (!Directory.Exists(dir)) return result;
 
-        foreach (var file in Directory.GetFiles(dir, "*.json"))
+        foreach (var dir in InstanceRegistrationDirectories())
         {
+            if (!Directory.Exists(dir)) continue;
+
+            string[] files;
             try
             {
-                using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(file));
-                var root = doc.RootElement;
-                if (!root.TryGetProperty("Pid", out var pidEl) || !pidEl.TryGetInt32(out var pid))
-                    continue;
-                var port = 0;
-                if (root.TryGetProperty("ControlEndpoint", out var epEl)
-                    && Uri.TryCreate(epEl.GetString(), UriKind.Absolute, out var ep))
-                    port = ep.Port;
-                result.Add(new InstanceRegistration(pid, port));
+                files = Directory.GetFiles(dir, "*.json");
             }
-            catch
+            catch (Exception ex)
             {
-                // Skip malformed files.
+                FileLog.Write($"[DirectorSupervisor] ReadInstanceRegistrations: cannot list {dir}: {ex.Message}");
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(file));
+                    var root = doc.RootElement;
+                    if (!root.TryGetProperty("Pid", out var pidEl) || !pidEl.TryGetInt32(out var pid))
+                        continue;
+                    var port = 0;
+                    if (root.TryGetProperty("ControlEndpoint", out var epEl)
+                        && Uri.TryCreate(epEl.GetString(), UriKind.Absolute, out var ep))
+                        port = ep.Port;
+                    result.Add(new InstanceRegistration(pid, port));
+                }
+                catch
+                {
+                    // Skip malformed files.
+                }
             }
         }
+
         return result;
     }
 


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1763. Found on macOS during v1.8.3 field verification, then reproduced on Windows, where it fails differently and more quietly.

## The disagreement

`DirectorSupervisor` reads instance registrations from `CcStorage.DirectorInstances()`, which resolves relative to the **caller's** home - and the launcher runs at the storage root:

```
<root>/config/director/instances/{id}.json
```

A Director started for a named instance keeps its whole storage under `<root>/instances/<slug>/` and registers **there**. From 1.8 the installed Director boots as instance `default`, so on a normal machine the directory the launcher read is empty and every live registration sits one level in.

Confirmed on Windows: the flat directory is empty, while `instances/default/config/director/instances/b8b51eea….json` holds `Pid=29996`, `ControlEndpoint=http://127.0.0.1:7879` - matching the running `cc-director.exe`.

## Two failures, and the Windows one is the dangerous one

`FindDirectorProcess` is platform-split, which is why this survived a release.

**macOS** walks the registration files, so it finds nothing: `/status` reports `running:false` against a healthy Director, `stop` and `restart` find no process, and `Start`'s already-running guard never fires.

**Windows** enumerates processes and is **correct** - `/status` says `running:true`. The damage is one level down:

```csharp
var port = FindDirectorPort(proc.Id);   // matches a registration by pid -> none found -> 0
if (port > 0) { ...POST /shutdown...; return; }
// falls through to proc.Kill()
```

Every remote stop and restart **force-killed** the Director and looked like it worked. A force-kill leaves a phantom "interrupted" entry in the crash journal (#960), so the bug quietly degraded the very signal used to tell a real crash from a clean stop.

## The fix

The reader is instance-aware: it scans the launcher's own home **and** every per-instance home. The flat path stays **first** rather than being replaced - a pre-1.8 Director still registers there, and a launcher that saw only the new layout would break those exactly as the old launcher breaks 1.8 ones.

The silent fall-through is treated as its own defect rather than fixed by accident. A port of 0 against a demonstrably running Director is not a normal condition, and it is now logged loudly, naming the force-kill and the phantom journal entry it will cause. The kill remains the fallback - a Director that cannot be stopped at all would be worse - but it can no longer happen quietly, and the next lookup failure will announce itself instead of hiding behind a working-looking stop.

## Verified by mutation, not just by passing

Nine tests in `DirectorSupervisorInstanceDiscoveryTests`, driven through `CC_DIRECTOR_ROOT` against a temporary layout.

Pointing the per-instance scan at a folder that does not exist - the pre-fix behaviour - reddens the five discovery tests and leaves the flat-path and empty-machine controls green. So they are load-bearing on the change rather than passing because the defect is absent.

Launcher suite: **70 passed** on both `net10.0` and `net10.0-windows`.

`InternalsVisibleTo` admits the test assembly rather than widening the supervisor's public surface: the scan is an implementation detail, and the defect was entirely about which directories it looks in.

## Note on delivery

This is launcher-side, so it reaches machines in a **release**, not in a Gateway redeploy - unlike thefrederiksen/devthrottle#2251, which is Gateway-side. They are independent and can ship together, but they arrive by different routes, and a release cut without this leaves every machine on a launcher that still force-kills.