### PR TITLE
release: v1.8.4 - your other computers are reachable, and a remote restart is graceful

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.8.4.md
+++ b/docs/public/release-notes/v1.8.4.md
@@ -1,0 +1,47 @@
+## v1.8.4 - July 28, 2026
+
+The release that makes your other computers reachable. DevThrottle could already see them; from
+this version it can act on them.
+
+### Your other computers
+
+- **Start, stop and restart DevThrottle on a computer you are not sitting at.** This is what the
+  launcher on each machine has always been for, and on a hosted account it has never worked: the
+  launcher announced itself, appeared correctly in your machine list, and could not be told to do
+  anything. It was left retrying a closed connection thousands of times a day while looking
+  perfectly healthy. The connection is now open, so the machine list is a list of computers you
+  can actually use rather than a list of computers you own.
+- **Only ever your own computers.** A machine belongs to the account that registered it. Naming
+  someone else's machine reaches nothing, even if it has the same name as one of yours - two
+  accounts can each have a "DESKTOP" and neither can see, displace, or send anything to the
+  other's.
+- **Search and start applications remotely, for real.** v1.8.3 added asking a machine what is
+  installed, finding a file anywhere on its drives, and starting a program there by name. On a
+  hosted account those requests reached the Gateway and stopped, because the same closed
+  connection was the only way through to the machine. They work now.
+
+### Restarting a remote computer no longer force-kills it
+
+- **A remote restart shuts DevThrottle down properly instead of killing it.** The launcher could
+  not find the running app's registration - it looked in the folder used before 1.8, while the
+  app now registers one level in - so it gave up on the polite shutdown and killed the process
+  every time. On a Mac this was loud: the launcher reported the app as not running while it was
+  plainly running, and stop and restart did nothing at all. On Windows it was silent and worse:
+  everything looked like it worked, while each restart terminated the app outright.
+- **Why that mattered beyond tidiness.** A killed app has no chance to tidy up, and leaves a
+  crash marker behind. So every remote restart quietly filed itself as a crash, and the record
+  that tells a genuine crash from an ordinary stop was being filled with false ones. Both are
+  fixed, and a launcher that ever fails to find the app again will now say so plainly rather than
+  falling back to killing it without a word.
+
+### Setting up a new machine
+
+- **Setup stops asking every computer how often to send one report.** The daily report is a
+  setting for your account, not for each machine, so being asked again on every install was a
+  question with no useful answer. It is asked once.
+
+### Upgrading from 1.8.1 or earlier
+
+If a machine still shows an empty session list and the first-run wizard after updating, it is
+running from a data folder created by the update bug fixed in v1.8.2. Updating to this version
+moves it back into the folder it has always used, with its settings and sessions intact.


### PR DESCRIPTION
Version bump to 1.8.4 and the public release notes. Tag `v1.8.4` follows on merge, which is what triggers the release build.

## What is in it

Four commits since v1.8.3, two of them user-facing.

**Cross-machine control becomes usable on hosted accounts** (#2251). The launcher command channel was closed on hosted, so a launcher registered, heartbeated, appeared correctly in the machine list, and could never receive a single command - found in the field retrying thousands of times a day while looking healthy. It is open now, scoped so an account reaches every machine it registered and none that it did not, proved by tests that redden both when the gate is restored and when the tenant key is removed.

This also switches on the application and file search that shipped in v1.8.3: those requests reached the Gateway and stopped there on hosted, because the same closed channel was the only route to the machine.

**A remote restart shuts down gracefully instead of force-killing** (#2253, closes thefrederiksen/devthrottle_internal#1763). The launcher looked for the running app's registration in the pre-1.8 location while the app registers one level in. Loud on macOS - the launcher reported the app as not running while it plainly was. Silent on Windows - everything looked like it worked while every restart killed the process, and each one then filed itself as a crash, degrading the record used to tell a real crash from a clean stop.

**Setup stops asking every machine about the daily report frequency** (#2249) - an account setting, asked once.

Also included but not user-facing: the installer's tests now run in continuous integration (#2250).

## Delivery note

These two changes travel by different routes, which is why both need to happen:

- thefrederiksen/devthrottle#2251 is Gateway-side and reaches an account through a **hosted Gateway redeploy**
- thefrederiksen/devthrottle#2253 is launcher-side and reaches machines through **this release**

A redeploy without this release leaves every machine on a launcher that still force-kills. This release without a redeploy leaves the command channel closed, so nothing can be sent at all.

## Verification behind the two launcher changes

- Gateway suite green on both, 4349 passed on thefrederiksen/devthrottle#2251
- Launcher suite 70 passed on both target frameworks
- Both were checked by mutation rather than by passing alone: restoring the hosted gate reddens the five capability tests; re-keying the connection registry on the bare machine name reddens exactly the three isolation tests; pointing the registration scan at a folder that does not exist reddens the five discovery tests. In each case the controls stay green.
- v1.8.3 was verified end to end on real Apple silicon hardware before these landed, including the launcher's REST surface