### PR TITLE
Refuse a Gateway that answers a skill request with its own web page

### DIFF
--- a/packages/client-core/src/skills/skillsClient.test.ts
+++ b/packages/client-core/src/skills/skillsClient.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getSkillBody, getSkills } from "./skillsClient";
+
+// The Gateway serves the Cockpit at "/" and falls UNKNOWN page paths back to index.html, so a Gateway
+// running a build from before the skill library answers /gateway/skills with HTTP 200, Content-Type
+// text/html, and the app's own shell - never a 404. Every machine whose Gateway has not been upgraded
+// is in exactly that state.
+//
+// The danger is not the failure, it is being BELIEVED: without asserting the content type, the Skills
+// preview would render a web page as a skill's instructions and look like it worked. These tests hold
+// that line, and the last one holds the other side of it - the guard must not cost the real thing.
+
+const APP_SHELL =
+  '<!doctype html><html><head><title>DevThrottle Cockpit</title></head><body><div id="root"></div></body></html>';
+
+function respond(body: string, contentType: string, status = 200): Response {
+  return new Response(body, { status, headers: { "Content-Type": contentType } });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("the skills client against a Gateway that does not serve the library yet", () => {
+  it("refuses the app shell instead of returning it as a skill body", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond(APP_SHELL, "text/html; charset=utf-8")));
+
+    await expect(getSkillBody("move-session", 5)).rejects.toThrow(
+      /does not serve the skill library yet/,
+    );
+  });
+
+  it("names the cause in words a person can act on", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond(APP_SHELL, "text/html")));
+
+    // Not "content type mismatch": the person reading this needs to know their Gateway is behind.
+    await expect(getSkills()).rejects.toThrow(/Upgrade or redeploy the Gateway/);
+  });
+
+  it("refuses an unlabelled body rather than guessing it is JSON", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{}", { status: 200 })));
+
+    await expect(getSkills()).rejects.toThrow(/does not serve the skill library yet/);
+  });
+
+  it("still returns a real register and a real body untouched", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        respond(JSON.stringify({ skills: [{ id: "move-session", name: "Move", summary: "s", triggers: [] }] }),
+          "application/json"),
+      ),
+    );
+    const skills = await getSkills();
+    expect(skills.map((s) => s.id)).toEqual(["move-session"]);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(respond("# Move Session\n\nRelocate.", "text/markdown")));
+    expect(await getSkillBody("move-session", 5)).toBe("# Move Session\n\nRelocate.");
+  });
+});

--- a/packages/client-core/src/skills/skillsClient.ts
+++ b/packages/client-core/src/skills/skillsClient.ts
@@ -58,6 +58,24 @@ export interface SkillVersionInfo {
   publishedUtc: string | null;
 }
 
+// A 2XX IS NOT PROOF THE GATEWAY UNDERSTOOD THE REQUEST. The Gateway serves this app at "/" and
+// falls UNKNOWN page paths back to index.html, so a Gateway from before the skill library answers
+// /gateway/skills with 200 and the app's own HTML shell - not a 404. Believed at face value, the
+// preview would render a web page as a skill's instructions. Every read here asserts the content
+// type it was promised, and an app-shell answer is reported as what it actually means.
+function notTheSkillLibrary(saw: string): GatewayError {
+  return new GatewayError(
+    502,
+    `This Gateway does not serve the skill library yet - it answered with ${saw} instead of skill ` +
+      "data, which happens when it is running a build from before the library existed. Upgrade or " +
+      "redeploy the Gateway.",
+  );
+}
+
+function contentType(res: Response): string {
+  return (res.headers.get("Content-Type") ?? "").split(";")[0].trim().toLowerCase();
+}
+
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
   let detail = `${res.status}`;
   try {
@@ -85,6 +103,7 @@ export async function getSkills(signal?: AbortSignal): Promise<SkillDefinition[]
     signal,
   });
   if (!res.ok) throw await gatewayErrorFrom(res, "GET /gateway/skills");
+  if (contentType(res) !== "application/json") throw notTheSkillLibrary(contentType(res) || "an unlabelled body");
   const body = (await res.json()) as { skills?: SkillDefinition[] } | null;
   const skills = body?.skills;
   if (skills === undefined) throw new GatewayError(res.status, "GET /gateway/skills returned no skills field");
@@ -99,6 +118,7 @@ export async function getSkill(id: string, signal?: AbortSignal): Promise<SkillD
     signal,
   });
   if (!res.ok) throw await gatewayErrorFrom(res, `GET /gateway/skills/${id}`);
+  if (contentType(res) !== "application/json") throw notTheSkillLibrary(contentType(res) || "an unlabelled body");
   return (await res.json()) as SkillDefinition;
 }
 
@@ -114,6 +134,9 @@ export async function getSkillBody(id: string, version?: number, signal?: AbortS
     signal,
   });
   if (!res.ok) throw await gatewayErrorFrom(res, `GET /gateway/skills/${id}/body`);
+  // The one that matters most: without this, the preview renders the app's own HTML shell as the
+  // skill's instructions, and it looks like it worked.
+  if (contentType(res) === "text/html") throw notTheSkillLibrary("its own web app page");
   return await res.text();
 }
 
@@ -125,6 +148,7 @@ export async function getSkillVersions(id: string, signal?: AbortSignal): Promis
     signal,
   });
   if (!res.ok) throw await gatewayErrorFrom(res, `GET /gateway/skills/${id}/versions`);
+  if (contentType(res) !== "application/json") throw notTheSkillLibrary(contentType(res) || "an unlabelled body");
   const body = (await res.json()) as { versions?: SkillVersionInfo[] } | null;
   return body?.versions ?? [];
 }

--- a/tools/cc-devthrottle/src/skill_ops.py
+++ b/tools/cc-devthrottle/src/skill_ops.py
@@ -152,15 +152,51 @@ class SkillClient:
         text = (resp.text or "").strip()
         return text if text else f"Gateway returned HTTP {resp.status_code}"
 
+    # A 2XX IS NOT PROOF THE GATEWAY UNDERSTOOD THE REQUEST. The Gateway serves the Cockpit
+    # single-page app at "/" and falls UNKNOWN page paths back to index.html, so a Gateway that has
+    # never heard of skills answers GET /gateway/skills with HTTP 200, Content-Type text/html, and
+    # ~800 bytes of the app shell - not a 404. That is the live state of every machine whose Gateway
+    # has not been upgraded yet, which is precisely the window this command has to survive.
+    #
+    # Believed at face value it is worse than an error: `skill get` would print the HTML shell into
+    # an agent's context AS THE SKILL'S INSTRUCTIONS, and `skill list` would raise a raw ValueError
+    # traceback. So both read paths assert the content type they were PROMISED, and an app-shell
+    # answer is reported as "this Gateway does not serve the skill library yet" - which is the true
+    # statement, and the one that tells the user what to do about it.
+    def _not_the_skill_library(self, saw: str) -> GatewayError:
+        return GatewayError(
+            f"the Gateway at {self.base_url} answered with {saw} instead of skill data, which means "
+            "it does not serve the skill library yet - it is running a build from before the library "
+            "existed, and the request fell through to its web app. Upgrade or redeploy that Gateway. "
+            "Do NOT treat what it returned as a skill."
+        )
+
+    @staticmethod
+    def _content_type(resp: requests.Response) -> str:
+        return (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+
     def _json_or_raise(self, resp: requests.Response) -> Dict[str, Any]:
         if 200 <= resp.status_code < 300:
             if not resp.content:
                 return {}
-            return resp.json()
+            if self._content_type(resp) != "application/json":
+                raise self._not_the_skill_library(self._content_type(resp) or "an unlabelled body")
+            try:
+                return resp.json()
+            except ValueError as exc:
+                # Labelled JSON that is not JSON: a proxy or error page, never something to act on.
+                raise GatewayError(
+                    f"the Gateway at {self.base_url} returned a body labelled JSON that could not be "
+                    f"parsed: {exc}"
+                ) from exc
         raise GatewayError(self._gateway_message(resp))
 
     def _text_or_raise(self, resp: requests.Response) -> str:
         if 200 <= resp.status_code < 300:
+            # The body and file routes promise markdown and plain text. HTML here is the app shell,
+            # and printing it would put a web page into an agent's context dressed as instructions.
+            if self._content_type(resp) == "text/html":
+                raise self._not_the_skill_library("its web app page")
             return resp.text
         raise GatewayError(self._gateway_message(resp))
 

--- a/tools/cc-devthrottle/tests/test_skill_ops.py
+++ b/tools/cc-devthrottle/tests/test_skill_ops.py
@@ -37,10 +37,14 @@ def _flat(text: str) -> str:
 
 
 def _fake_response(status_code: int, json_body=None, text: str = "") -> MagicMock:
+    """A stand-in for a real response, INCLUDING its Content-Type. The header is not decoration: the
+    client asserts it, because a Gateway from before the skill library answers 200 with its web app
+    page and a fake without headers would let that slip through untested."""
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.content = b"x" if (json_body is not None or text) else b""
     resp.text = text
+    resp.headers = {"Content-Type": "text/markdown" if (text and json_body is None) else "application/json"}
     if json_body is not None:
         resp.json.return_value = json_body
     else:
@@ -294,3 +298,82 @@ class TestList:
             result = runner.invoke(app, ["skill", "list", "--json"])
 
         assert json.loads(result.output)["skills"][0]["id"] == "move-session"
+
+
+class TestAPreLibraryGatewayIsNotBelieved:
+    """The Gateway serves the Cockpit at "/" and falls unknown page paths back to index.html, so a
+    Gateway from before the skill library answers /gateway/skills with HTTP 200, Content-Type
+    text/html and the app shell - never a 404. That is the live state of every machine whose Gateway
+    has not been upgraded, so these are the rollout window's tests.
+
+    The dangerous direction is not the error: it is being BELIEVED. Without the content-type
+    assertion, `skill get` prints a web page into an agent's context as the literal text of a skill,
+    and it looks like it worked.
+    """
+
+    APP_SHELL = '<!doctype html><html><head><title>DevThrottle Cockpit</title></head><body><div id="root"></div></body></html>'
+
+    @staticmethod
+    def _shell_response() -> MagicMock:
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 200
+        resp.content = TestAPreLibraryGatewayIsNotBelieved.APP_SHELL.encode()
+        resp.text = TestAPreLibraryGatewayIsNotBelieved.APP_SHELL
+        resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        resp.json.side_effect = ValueError("not json")
+        return resp
+
+    def test_skill_get_refuses_the_app_shell_instead_of_printing_it_as_instructions(self, capsys):
+        with patch.object(skill_ops.SkillClient, "_request") as request:
+            request.return_value = self._shell_response()
+            result = runner.invoke(app, ["skill", "get", "move-session"])
+
+        assert result.exit_code == 1
+        combined = _flat(result.output + capsys.readouterr().err)
+        # Nothing of the page reached standard output as a skill.
+        assert "<!doctype html" not in combined
+        assert "DevThrottle Cockpit</title>" not in combined
+        # And the reason is stated the way the agent hitting it needs to read it.
+        assert "does not serve the skill library yet" in combined
+        assert "Do NOT treat what it returned as a skill" in combined
+
+    def test_skill_list_says_the_gateway_is_not_deployed_rather_than_raising_a_traceback(self):
+        with patch.object(skill_ops.SkillClient, "_request") as request:
+            request.return_value = self._shell_response()
+            result = runner.invoke(app, ["skill", "list"])
+
+        assert result.exit_code == 1
+        assert "does not serve the skill library yet" in _flat(result.output)
+
+    def test_a_body_labelled_json_that_is_not_json_is_reported_not_raised(self):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 200
+        resp.content = b"{ truncated"
+        resp.text = "{ truncated"
+        resp.headers = {"Content-Type": "application/json"}
+        resp.json.side_effect = ValueError("Expecting property name")
+        with patch.object(skill_ops.SkillClient, "_request") as request:
+            request.return_value = resp
+            result = runner.invoke(app, ["skill", "list"])
+
+        assert result.exit_code == 1
+        assert "could not be parsed" in _flat(result.output)
+
+    def test_a_real_markdown_body_still_passes_through_untouched(self, capsys):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 200
+        resp.content = BODY.encode()
+        resp.text = BODY
+        resp.headers = {"Content-Type": "text/markdown; charset=utf-8"}
+        head = MagicMock(spec=requests.Response)
+        head.status_code = 200
+        head.content = b"{}"
+        head.headers = {"Content-Type": "application/json"}
+        head.json.return_value = HEAD
+
+        with patch.object(skill_ops.SkillClient, "_request") as request:
+            request.side_effect = [head, resp]
+            skill_ops.get_skill("move-session", None)
+
+        # The guard must not cost the thing it protects: a real body is still byte for byte.
+        assert capsys.readouterr().out == BODY


### PR DESCRIPTION
The Gateway serves the Cockpit at `/` and falls unknown page paths back to `index.html`. So a Gateway running a build from before the skill library answers `GET /gateway/skills` with **HTTP 200, `Content-Type: text/html`, and about 800 bytes of the app shell** - not a 404. That is the live state of every machine whose Gateway has not been upgraded, which is every machine until the hosted Gateway is deployed.

## Why this is worse than an error

It fails in the direction that looks like success.

- `cc-devthrottle skill get <id>` returned any 2xx body verbatim, so an agent would have had **a web page printed into its context as the literal text of a skill**. That is context poisoning, not a usability problem.
- `cc-devthrottle skill list` raised a bare `ValueError` traceback.
- The Cockpit had the same assumption in a different shape: the Skills preview would have rendered the app's own HTML as a skill's instructions.

## The fix

Both read paths - the command line and the Cockpit client - assert the content type they were promised, and an app-shell answer is reported as what it actually means: *this Gateway does not serve the skill library yet, upgrade or redeploy it*. The wording names the cause rather than the symptom, because whoever hits this is an agent trying to do its job, not someone debugging an endpoint.

## Proof

- Four new command line tests and four new client-core tests, driving a fake Gateway that returns the app shell with 200.
- **Both new groups confirmed to fail with the guards removed**, then pass with them restored.
- The command line test fake gained real headers. Without them a fake response could never have exercised this, which is exactly why the gap survived the first round of tests.
- One test on each side holds the other direction: a real markdown body and a real register still pass through untouched, so the guard does not cost the thing it protects.
- Full command line suite 148, client-core 812, Cockpit 236, every workspace typechecked.

## Where it came from

Found by the session retiring the skill installer, while measuring the **before-state** of the live hosted Gateway ahead of the deploy - the check it ran to prove the library was not yet live is the check that would have passed against a Gateway that had never heard of skills.

devthrottle_internal #995
