### PR TITLE
Moving a session deletes the original, so a Director can actually be emptied

### DIFF
--- a/.claude/skills/move-session/SKILL.md
+++ b/.claude/skills/move-session/SKILL.md
@@ -1,509 +1,260 @@
 ---
 name: move-session
-description: Relocate a live session to another cc-director slot or Director - approval-gated handover through the GATEWAY, the seed identifies itself as a moved session, the TARGET keeps the source's original name, the source is renamed "[MOVED]" and put on hold so the user can close it. Triggers on "/move-session", "move session", "migrate session", "transfer session".
+description: Move a live session to another Director or slot. A move does not migrate a process - it writes a RIGHT-SIZED handover, starts a fresh session on the SAME agent and SAME model, verifies it picked the work up, and then DELETES the original. Triggers on "/move-session", "move session", "migrate session", "transfer session", "move it to the new director".
 ---
 
 # Move Session
 
-Relocate a live Claude Code session from one cc-director slot to another - on the
-same Director or across Directors. The move reads the source session's context,
-creates a fresh target session seeded with a handover SUMMARY (which states it is a
-MOVED session continuing the source), names the TARGET with the source's ORIGINAL
-name, VERIFIES the target picked it up, renames the SOURCE `[MOVED -> ...]`, and PUTS
-THE SOURCE ON HOLD so it stops working while it waits to be closed. This skill never
-kills the source - the user closes it once they see the `[MOVED]` marker.
+Relocate work from one Director to another - a newer build, a different slot, another machine.
 
-## READ FIRST: the control surface is the GATEWAY, not the Director
+**A move does not migrate a running process. It recreates the session, and then it DELETES THE
+ORIGINAL.** The target starts completely fresh: no transcript, no memory, nothing but one document
+you write. The source is destroyed at the end - not parked, not left renamed.
 
-The tunnel-only migration (v1.1.0) REMOVED the per-session control routes from the
-Director's loopback HTTP floor. On any Director port (`:7879`, `:7883`, ...) these
-now return **404** and MUST NOT be used:
+**Deleting the source is the point, not a tidy-up.** A move exists so a Director can be emptied and
+shut down. A move that leaves the source alive has failed: the Director still has open sessions and
+still cannot be updated.
 
-- `POST {director}/handover`
-- `GET {director}/sessions`, `GET {director}/sessions/{id}`
-- `PATCH {director}/sessions/{id}` (rename)
-- `POST {director}/sessions/{id}/hold`, `.../prompt`, `.../context`
+**Verification is the ONLY gate on that deletion.** The source is deleted if and only if the target
+has demonstrably picked the work up (step 4). Nothing else gates it - not the owner, not the clock.
+If verification fails, nothing is deleted and the source keeps running. This is why the move has to
+be good: the handover document is the only thing standing between the work and the bin.
 
-The move/session-control routes you need are NOT on the Director floor. The Director
-loopback still serves `/healthz`, the agent-facing `/fleet/*` verbs, and some agent
-hook routes (e.g. `/sessions/{sid}/claude-hook`, `/sessions/{sid}/fleet-preamble`),
-but not the session-control REST the move needs. Everything this move needs lives on
-the **Gateway** (`http://127.0.0.1:7878`) and on the **`cc-devthrottle`** CLI. If a
-step here tells you to curl a Director port for a session route, the step is stale -
-stop and re-read this section.
+Proven end to end 2026-07-28: a session moved onto a newer Director read its handover, correctly
+restated the work and its constraints, ran the exact next action unprompted, and correctly handled
+the failure that action turned up.
 
-Two surfaces, and when to use each:
+## When NOT to move
 
-- **`cc-devthrottle` CLI (preferred where it covers the step).** Token-free,
-  address-free - it reaches the fleet through your own Director. Use it to list,
-  rename, and hold sessions.
-- **Gateway REST (`http://127.0.0.1:7878`, Bearer token).** The only surface that
-  exposes the handover itself and the composer nudge. Token comes from
-  `%LOCALAPPDATA%\cc-director\config\director\gateway-token.txt` (source of truth:
-  `DirectorAuth.cs`). Send it as `Authorization: Bearer <token>` on every Gateway
-  call - `/sessions` and all mutation routes are token-gated.
+- **Never round-trip.** "Move it to the new Director now and back later" rebuilds the session twice
+  and loses a little each time. Move it where you want it and leave it.
+- **Never move a session that is working.** Wait for its turn to finish.
+- **Every move costs a fresh context window.** Check usage before moving a fleet.
 
-Verify the Gateway is up before you trust any step below:
+## The control surface is the GATEWAY, not the Director
 
-```bash
-curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:7878/healthz
-```
+The tunnel-only cut removed the per-session control routes from the Director's loopback floor. On
+any Director port these now 404 and must not be used: `POST /handover`, `GET/PATCH /sessions`,
+`/sessions/{id}/hold`, `/prompt`, `/context`.
 
-`200` = go. Anything else: the Gateway is down or on another port - find its listen
-port (`Get-NetTCPConnection -State Listen -OwningProcess <pid>`) and confirm the URL
-with the user before proceeding.
+Use the **`cc-devthrottle` command line** wherever it covers the step - it is token-free and
+address-free, reaching the fleet through your own Director. Drop to Gateway REST
+(`http://127.0.0.1:7878`, `Authorization: Bearer <token>` from
+`%LOCALAPPDATA%\cc-director\config\director\gateway-token.txt`) only for the composer nudge and the
+fallback auto-handover.
 
-## WHY a move happens: CONTEXT RELIEF (read this second)
-
-The whole point of a move is **context relief**. You move a session because it is
-LOW ON / OUT OF context. The target MUST start FRESH, with almost its entire context
-window free, seeded only with a compact **handover SUMMARY** of where the work is and
-what is next. The new session then has headroom to keep going.
-
-Two hard consequences:
-
-1. **DEFAULT ROUTE = the handover summary (`POST {gateway}/handover`).** It creates a
-   fresh session and delivers the source's context as a generated summary prompt.
-   This is the only route that achieves context relief. Use it unless the user
-   explicitly asks for the full verbatim transcript.
-2. **NEVER use the resume route for a context-relief move.** `resumeSessionId`
-   re-attaches the ENTIRE original conversation - every turn - so the target comes up
-   already full. That defeats the purpose. The resume route is a clearly-warned
-   opt-in only (see "Resume route"), never the default.
-
-### The target comes up on the configured default agent
-
-The handover does not force a model. The fresh session launches on whatever the
-target Director has configured as its default agent - the code creates the target
-with no model arguments (same-Director `CreateSession` with `userArgs: null`,
-cross-Director `NewSessionRequest` with no `Args`), so the model and window are the
-Director's configured defaults, not a value this skill sets. In the current
-deployment that default is Opus 4.8 with the 1-million-token window (`opus[1m]`), and
-a cross-Director handover was observed landing at `windowTokens: 1,000,000`
-(2026-07-08) - but that is the deployment's configured default, NOT a guarantee the
-handover makes. Do not promise Opus+1M or tell the user to disregard a smaller
-window; if the Director's default ever changes, the target follows it.
-
-(There is no programmatic way for this skill to CONFIRM the window: the Gateway
-exposes no `/context` route, and the old `GET {director}/sessions/{id}/context` check
-is gone with the rest of the Director session floor. If you must verify, read the
-window in the desktop app's session context readout.)
-
-## Session naming convention (applies to EVERY name this skill writes)
-
-Every session name starts with the repo's directory name - the leaf folder of
-`repoPath` (e.g. `cc-consult` for `D:\ReposFred\cc-consult`) - followed by a short
-description:
-
-```
-<repo-dir> - <short description>
-```
-
-Examples: `cc-consult - make-money execution`, `mindzieWeb - fix login MFA loop`.
-
-Rules:
-
-- **Fresh name requested:** compose `<repo-dir> - <short description>` from the
-  target's repo and the work at hand. Propose it in the plan before approval.
-- **Retaining the source's original name (default):** if the source's name already
-  carries the repo prefix, keep it verbatim. If not, prepend the prefix
-  (`<repo-dir> - <original name>`) and mention the normalization in the plan.
-- **The `[MOVED -> ...]` marker** wraps whatever name applies; it never replaces the
-  repo prefix (`[MOVED -> 7886] cc-consult - make-money execution`).
-- Keep the description SHORT - the rail is narrow and truncates.
-
-Lifecycle in one line:
-
-```
-plan -> USER APPROVAL -> Gateway handover -> NAME TARGET (source's original name) -> verify target working -> rename source "[MOVED -> ...]" -> HOLD source -> user closes source
-```
-
-## Quick Reference
-
-All Gateway calls use base `http://127.0.0.1:7878` with `Authorization: Bearer <token>`.
-
-| Action | How |
-|--------|-----|
-| List / number sessions | `cc-devthrottle session list` (fleet-wide) or `GET {gateway}/sessions` (JSON, each entry carries `directorId`, `activityState`, `onHold`) |
-| DEFAULT move (context relief) | `POST {gateway}/handover` with `fromSessionId` + `toRepoPath`. Fresh target, summary seed, Director's default agent. Without `toDirectorId` the target is created on the SOURCE's Director; add `toDirectorId` to place it on a different Director. |
-| Move into an existing empty slot | `toSessionId` instead of `toRepoPath` (send exactly one). SAME Director as the source only - cross-Director `toSessionId` is rejected; use `toRepoPath` + `toDirectorId` instead. |
-| Add a "continue by doing X" note | `extraContext` on the request (MUST open with the moved-session statement) |
-| Name the TARGET (retain the name) | `cc-devthrottle session rename <target-id> "<source's original name>"` right after the handover |
-| Verify target picked up | `cc-devthrottle session list` (state flips to Working) or `GET {gateway}/sessions/{tid}/buffer` (bytes grow) |
-| Unstick a parked seed prompt | `POST {gateway}/sessions/{tid}/prompt` `{"text":"\r","appendEnter":false}` |
-| Mark source as moved | `cc-devthrottle session rename <source-id> "[MOVED -> <target>] <old name>"` |
-| Put the source on hold | `cc-devthrottle session hold <source-id> --minutes 720` |
-| Close the source | THE USER does this, never the skill |
-
-## CRITICAL: the three rules
-
-1. **USER APPROVAL REQUIRED.** `POST /handover` changes live state - it spawns a real
-   session and sends it a prompt. ALWAYS show the move plan (exact source, exact
-   target, what gets seeded) and wait for an explicit go-ahead before the POST. Never
-   fire from a bare slot number without confirmation.
-2. **VERIFY BEFORE MARKING.** The source is renamed `[MOVED]` only after the target
-   has demonstrably picked up the handover (state `Working`, buffer growing, or the
-   seeded prompt visibly submitted). A failed or parked move must never leave a source
-   falsely marked as moved.
-3. **NEVER KILL THE SOURCE.** This skill renames and holds the source so the user can
-   SEE it is safe to close; closing it is the user's call, in the UI, on their own
-   time. No delete, no kill, no process termination.
-
-## What a "slot" means
-
-A slot is one session in a Director. The API does not number slots; it returns a list
-of sessions (GUID, three-digit number, name, repo, state, `directorId`). This skill
-numbers that list 1..N for conversation only. Listing order is NOT the on-screen grid
-order, so never move on a bare slot number - always show the numbered list with names
-and repos and confirm the exact source.
-
-## Workflow
-
-### Step 1: List sessions and number them
-
-```bash
-cc-devthrottle session list
-```
-
-For the machine-readable form (needed to capture `directorId` and GUIDs), read the
-Gateway roster:
-
-```bash
-python - <<'PY'
-import os, json, urllib.request
-tok = open(os.path.join(os.environ['LOCALAPPDATA'],'cc-director','config','director','gateway-token.txt')).read().strip()
-req = urllib.request.Request('http://127.0.0.1:7878/sessions',
-    headers={'Authorization': f'Bearer {tok}', 'Accept': 'application/json'})
-for s in json.load(urllib.request.urlopen(req, timeout=10)):
-    print(s['sessionId'][:8], '|', s.get('directorId','')[:8], '|', s.get('name'), '|', s.get('repoPath'), '|', s.get('activityState'))
-PY
-```
-
-Present a numbered table including which Director each session lives on:
-
-```
-| Slot | Name | Repo | State | Director |
-|------|------|------|-------|----------|
-| 1 | banya-fixes | D:\ReposFred\cc-consult | Idle | a3a971fa |
-```
-
-### Step 2: Identify the source
-
-- "this session" / "move me" -> `$CC_SESSION_ID`.
-- a three-digit number (e.g. "412") -> the session with that number.
-- "slot N" -> the session at position N in your listing - confirm by name.
-- a name or id prefix -> match against `name` / GUID (confirm if ambiguous).
-
-Capture the source `sessionId`, `name`, `repoPath`, `agent`, and its `directorId`.
-The target reuses the source's repo and agent by default.
-
-### Step 3: Identify the target
-
-- **Fresh slot on the SOURCE's Director (simplest):** set `toRepoPath` only. With no
-  `toDirectorId`, the Gateway creates the target on the source session's own Director
-  (it does NOT load-balance across Directors).
-- **Fresh slot on a DIFFERENT Director:** `toRepoPath` + `toDirectorId` (the target
-  Director's id from the roster).
-- **An existing empty session:** `toSessionId` instead of `toRepoPath` (mutually
-  exclusive - send exactly one). SAME Director as the source only: a cross-Director
-  `toSessionId` is rejected (`not supported in v1`) - to reach another Director, use
-  `toRepoPath` + `toDirectorId`.
-
-Set `toAgent` to the source's agent (e.g. `ClaudeCode`).
-
-### Step 4: Optional - gather a continue note
-
-Ask if there is anything the source did not write down that the new session should
-pick up. Put it in `extraContext`; skip if nothing.
-
-Whatever else goes in, `extraContext` MUST OPEN with the moved-session statement so
-the target describes itself correctly to the user and the wingman:
-
-```
-This is a MOVED session: it continues session <source-guid> ("<original name>")
-from Director <source directorId/port>. <then any continue note>
-```
-
-(The auto-generated handover prompt says "picking up an in-progress session", but
-only this line carries WHICH session and WHERE from.)
-
-### Step 5: APPROVAL GATE - confirm the plan
-
-Show the plan in plain language and WAIT for an explicit yes:
-
-```
-Move plan:
-  From:   slot 1 "banya-fixes" (5a4f4929...)  D:\ReposFred\cc-consult  (Idle)  Director a3a971fa
-  To:     NEW session, same repo, agent ClaudeCode, on Director <id or "Gateway picks">
-          named "banya-fixes" (the source's name, retained)
-  Route:  Gateway http://127.0.0.1:7878/handover
-  Seed:   moved-session statement + auto handover summary + note: "continue by wiring the webhook handler"
-  After:  verify target picks up, rename source "[MOVED -> ...] banya-fixes", hold it.
-          Source keeps running - YOU close it when ready.
-
-Proceed?
-```
-
-Do not POST until the user approves. If they adjust anything, re-present and re-confirm.
-
-### Step 6: Fire the handover (Gateway)
-
-Shell quoting of JSON is fragile on Windows; build and send with Python:
-
-```bash
-python - <<'PY'
-import os, json, urllib.request
-tok = open(os.path.join(os.environ['LOCALAPPDATA'],'cc-director','config','director','gateway-token.txt')).read().strip()
-body = {
-    'fromSessionId': os.environ.get('CC_SESSION_ID') or 'PASTE-SOURCE-GUID',
-    'toRepoPath': r'D:\ReposFred\cc-consult',
-    'toAgent': 'ClaudeCode',
-    'archiveToVault': True,
-    # 'toDirectorId': 'TARGET-DIRECTOR-GUID',  # a DIFFERENT Director; omit -> target lands on the source's Director
-    # 'toSessionId': 'GUID',                   # instead of toRepoPath for an existing empty slot
-    # 'extraContext': 'This is a MOVED session: it continues ...  then: continue by ...',
-}
-req = urllib.request.Request('http://127.0.0.1:7878/handover',
-    data=json.dumps(body).encode('utf-8'),
-    headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {tok}'},
-    method='POST')
-with urllib.request.urlopen(req, timeout=60) as r:
-    print(r.status)
-    print(r.read().decode('utf-8'))
-PY
-```
-
-`201` + `accepted: true` means the handover was dispatched. Capture
-`targetSession.sessionId` from the response. `archivedAt` may come back null even with
-`archiveToVault: true` (observed on the Gateway route) - note it in the report rather
-than retrying.
-
-### Step 7: NAME THE TARGET - retain the source's original name
-
-The handover creates the target with `name: null` (renders as "(unnamed)"). Name it
-immediately, BEFORE the verification wait, so the user watching the UI sees the
-familiar name from the first second:
-
-```bash
-cc-devthrottle session rename <TARGET-SESSION-GUID> "banya-fixes"
-```
-
-(The plain name, no markers - the `[MOVED]` marker belongs on the SOURCE only.)
-
-### Step 8: VERIFY the target picked it up
-
-Poll (~10s, up to ~60s):
-
-```bash
-cc-devthrottle session list        # target state should flip to Working
-```
-
-For buffer-level proof:
-
-```bash
-python - <<'PY'
-import os, json, urllib.request
-tok = open(os.path.join(os.environ['LOCALAPPDATA'],'cc-director','config','director','gateway-token.txt')).read().strip()
-tid = 'TARGET-SESSION-GUID'
-req = urllib.request.Request(f'http://127.0.0.1:7878/sessions/{tid}/buffer',
-    headers={'Authorization': f'Bearer {tok}'})
-print(urllib.request.urlopen(req, timeout=10).read().decode('utf-8')[:400])
-PY
-```
-
-Healthy signs: state `Working`, buffer bytes growing, the agent responding.
-
-**KNOWN GOTCHA - parked composer:** the seeded context lands in the target composer
-but the submit Enter never fires. Symptoms: state stuck `WaitingForInput`, buffer
-frozen with the seed visible at the prompt. Fix - send a raw Enter to the TARGET
-through the Gateway:
-
-```bash
-python - <<'PY'
-import os, json, urllib.request
-tok = open(os.path.join(os.environ['LOCALAPPDATA'],'cc-director','config','director','gateway-token.txt')).read().strip()
-tid = 'TARGET-SESSION-GUID'
-body = {'text': '\r', 'appendEnter': False}
-req = urllib.request.Request(f'http://127.0.0.1:7878/sessions/{tid}/prompt',
-    data=json.dumps(body).encode(),
-    headers={'Content-Type': 'application/json', 'Authorization': f'Bearer {tok}'},
-    method='POST')
-print(urllib.request.urlopen(req, timeout=10).status)
-PY
-```
-
-(`{"text":"","appendEnter":true}` is a 400 - the endpoint requires non-empty text,
-so send the literal `\r` with `appendEnter: false`.) Then re-verify: buffer must grow
-and state must reach `Working`.
-
-If verification fails after the nudge, STOP. Report what the target shows. Do NOT mark
-the source as moved.
-
-### Step 9: Mark the SOURCE as moved
-
-Only after Step 8 verification passes:
-
-```bash
-cc-devthrottle session rename <SOURCE-SESSION-GUID> "[MOVED -> <target>] banya-fixes"
-```
-
-Naming: `[MOVED -> <target director id/port or slot>] <original name>`. Keep the
-original name so the user still recognizes it; the marker tells them, in the UI, that
-this session's context lives elsewhere and it is safe to close.
-
-### Step 10: Put the SOURCE on hold
-
-Immediately after the rename (and ONLY after Step 8 passed):
-
-```bash
-cc-devthrottle session hold <SOURCE-SESSION-GUID> --minutes 720
-```
-
-Notes:
-- Hold is a flag, not a kill - it pauses the session's work but does not terminate it.
-- Holding the very session you are driving the move from is safe: a hold asked for
-  mid-turn is DEFERRED and applies when the turn settles (the reply says `pending`).
-- ONLY THE OWNER lifts a hold (by releasing it, typing into the session, or the
-  `--minutes` timer expiring). Another agent messaging it no longer un-holds it.
-
-### Step 11: Report
-
-Tell the user:
-- target session id, repo, Director, its retained name, and that it is verifiably
-  working;
-- the source's new `[MOVED -> ...]` name, WHERE it is, and that it is now ON HOLD;
-- that the source is still running (held, not killed) and THEY close it when ready;
-- the vault archive path if `archivedAt` was returned (or that it came back null).
-
-## API reference
-
-All Gateway calls: base `http://127.0.0.1:7878`, header `Authorization: Bearer <token>`
-(token from `%LOCALAPPDATA%\cc-director\config\director\gateway-token.txt`).
-
-### POST /handover  (GATEWAY - `GatewayEndpoints.cs`, MapPost("/handover"))
-
-Request body (`HandoverRequest`, camelCase):
-
-| Field | Required | Notes |
-|-------|----------|-------|
-| `fromSessionId` | yes | Source session GUID |
-| `toSessionId` | one of two | Existing target session; mutually exclusive with `toRepoPath`. SAME Director as the source only - cross-Director `toSessionId` returns 400 (`not supported in v1`) |
-| `toRepoPath` | one of two | Repo for a brand-new target session |
-| `toDirectorId` | no | Target Director for a new session. Omit -> the target is created on the SOURCE's Director (no load-balancing). Set it to place the target on a different Director |
-| `toAgent` | when `toRepoPath` | `ClaudeCode` (default), `Pi`, `Codex`, `Gemini`, `OpenCode`, `Grok`, `Copilot` |
-| `extraContext` | no | Free text appended to the auto-generated context; MUST open with the moved-session statement |
-| `archiveToVault` | no | Default true. The same-Director path writes the archive and returns its path; the cross-Director path skips it and returns `archivedAt: null` |
-
-Response (`HandoverResponse`): `accepted`, `targetSession` (read `sessionId`),
-`contextSent`, `archivedAt`, `error`.
-
-### Rename, hold, verify - use `cc-devthrottle`
-
-- `cc-devthrottle session rename <target-or-name> "<new name>"` - rename any session
-  (defaults to the current one if the target is omitted).
-- `cc-devthrottle session hold <target> --minutes <n>` - park a session; owner-only
-  release.
-- `cc-devthrottle session list` - fleet-wide roster with state.
-
-The equivalent Gateway REST (if you must script raw HTTP) is `PATCH /sessions/{sid}`
-`{"name":"..."}`, `POST /sessions/{sid}/hold` `{"onHold":true|false}`, and
-`GET /sessions` / `GET /sessions/{sid}/buffer`. Prefer the CLI - it is token-free and
-reaches the fleet through your own Director.
-
-### POST /sessions/{sid}/prompt  (GATEWAY - the unstick nudge)
-
-Body `{"text":"\r","appendEnter":false}` sends a raw Enter to the composer. Non-empty
-`text` is required (empty + `appendEnter:true` = 400).
-
-## Resume route (OPT-IN ONLY - NOT for context relief)
-
-> WARNING: Do NOT use this route for a normal move. A move exists for CONTEXT RELIEF;
-> `resumeSessionId` re-loads the ENTIRE exhausted transcript into the target - it comes
-> up already full, exactly the failure this skill must avoid. Use the default
-> `/handover` summary route instead.
->
-> Use this route ONLY when the user EXPLICITLY asks to carry the full verbatim
-> conversation AND accepts that the target inherits the source's used context.
-
-Create the target with `resumeSessionId`, which re-attaches the entire Claude
-conversation, via the Gateway's spawn-on-a-named-Director route:
-
-```
-POST http://127.0.0.1:7878/directors/{targetDirectorId}/sessions
-Authorization: Bearer <token>
-{
-  "repoPath": "<source's repoPath>",
-  "agent": "ClaudeCode",
-  "resumeSessionId": "<CLAUDE conversation id>",
-  "prePrompt": "This is a MOVED session: it continues <claude-id> ('<name>'). <state + next step>. Confirm to the user the move worked."
-}
-```
-
-Gotchas:
-- `resumeSessionId` is the CLAUDE conversation id (the `.jsonl` filename under
-  `~/.claude/projects/<repo-slug>/`), NOT the Director session GUID. From inside the
-  session being moved it is the current Claude id; otherwise find the newest `.jsonl`
-  that greps for a phrase from that conversation.
-- Resuming forks the transcript at the POST: anything the source says AFTER the fork
-  is not in the target. Put the missing tail in `prePrompt`.
-- The 201 `sessionId` is the new Director session GUID; the naming contract (Step 7,
-  Step 9) applies unchanged.
-- ClaudeCode only; other agents fall back to the `/handover` summary route.
-- Build and send from a single Python stdin script - Windows shell quoting mangles
-  JSON backslashes.
-
-## Troubleshooting
-
-| Symptom | Cause / fix |
-|---------|-------------|
-| Any Director port (`:7879`, `:7883`) returns 404 for `/handover`, `/sessions/{id}`, `PATCH /sessions`, `/hold`, `/prompt` | EXPECTED - those routes moved off the Director loopback in the tunnel-only cut. Use the GATEWAY (`:7878`) and `cc-devthrottle`. |
-| Gateway `:7878` 401 on `/sessions` or a mutation | Missing/blank Bearer token. Read it from `gateway-token.txt` and send `Authorization: Bearer <token>`. |
-| Gateway `:7878` refused | Gateway down or on another port - find its listen port and confirm the URL with the user. |
-| 400 `exactly one of toSessionId or toRepoPath is required` | Send exactly one. |
-| 400 `toRepoPath does not exist` | Re-read the source's `repoPath`. |
-| 400 `unknown agent` | `toAgent` must be a supported agent kind. |
-| 404 source/target not found | Stale GUID. Re-list and re-resolve. |
-| Target stuck `WaitingForInput`, seed parked in composer | Parked-composer gotcha. Send `{"text":"\r","appendEnter":false}` to `{gateway}/sessions/{tid}/prompt`, re-verify. |
-| Target never picks up even after the nudge | Check state/buffer; if the session exited, dispatch was skipped - re-run the handover. Do NOT mark the source. |
-| Target shows "(unnamed)" | Step 7 skipped - the handover creates the target with name null. Rename it with the source's original name. |
-| `archivedAt` null on the Gateway route | Known behavior. Note it; do not retry the whole handover for this. |
-| Marked the source but the move actually failed | Rename it back to the original name and say so plainly. The `[MOVED]` marker must never lie. |
+The Director loopback still serves `/healthz` - which is how you find a target Director's port and
+confirm what it is running.
 
 ---
 
-**Skill Version:** 3.1
-**Last Updated:** 2026-07-16
-**Changes in 3.1:** Corrected four claims that the Gateway code does not back (independent
-review of #1720). (1) Target PLACEMENT: `toRepoPath` with no `toDirectorId` creates the
-target on the SOURCE's Director - the Gateway does NOT load-balance across Directors
-(`GatewayEndpoints.cs` same-Director proxy). (2) `toSessionId` (existing target) is
-SAME-Director only; cross-Director `toSessionId` is rejected with `not supported in v1`
-- use `toRepoPath` + `toDirectorId`. (3) The target comes up on the target Director's
-CONFIGURED DEFAULT agent (the handover passes no model args); Opus+1M is this
-deployment's default, not a guarantee the handover makes - dropped the "do not warn
-about a 200K downgrade" instruction. (4) `archivedAt` is written on the same-Director
-path and null on the cross-Director path (not a generic "may be null"). Also narrowed
-the Director-floor wording (it also serves agent hook routes, not only `/healthz` +
-`/fleet/*`).
-**Changes in 3.0:** Retargeted to the tunnel-only reality (the whole reason the v2.x
-skill broke). The Director loopback no longer serves `/handover`, `GET/PATCH
-/sessions`, `/hold`, or `/prompt` - those moved to the GATEWAY (`:7878`) at the
-tunnel-only cut (v1.1.0), and hitting a Director port for them now 404s. Every step is
-now driven through the Gateway (Bearer token from `gateway-token.txt`) and the
-`cc-devthrottle` CLI (list / rename / hold), which is token- and address-free. Removed:
-the per-Director base URLs, the port-scan topology step, the `GET
-{director}/sessions/{id}/context` window check (no Gateway route; the desktop app shows
-the window), and the force-the-model `POST {director}/sessions {args:"--model"}`
-fallback (depended on removed Director routes; the target follows the Director's default
-agent regardless). Rename
-and hold now use `cc-devthrottle session rename` / `session hold` (issue #1514 - the
-rename 404 - was a wrong-route/stale-Director problem, closed 2026-07-14; the CLI
-verbs work). Added the "control surface is the GATEWAY" preamble and a Gateway health
-precheck. The context-relief philosophy, approval gate, naming contract,
-verify-before-marking, never-kill-the-source, moved-session statement, and the resume
-opt-in are unchanged in substance.
-**Source of truth:** `src/CcDirector.Gateway/Api/GatewayEndpoints.cs` (`POST /handover`,
-`GET /sessions`, `PATCH /sessions/{sid}`, `POST /sessions/{sid}/hold`, `.../prompt`,
-`.../buffer`), `src/CcDirector.Gateway.Contracts/HandoverRequest.cs`,
-`src/CcDirector.ControlApi/DirectorAuth.cs` (token path); `cc-devthrottle session
-list|rename|hold`.
+## Step 1 - Capture what the session IS
+
+```bash
+cc-devthrottle session list --json
+```
+
+Take from the source's record: `sessionId`, `repoPath`, `agent`, `currentModel`, `name`, and its
+`directorId`. **The Director knows all of these. Never ask the agent for them** - it can get them
+wrong, and a fact you can read is never a fact you request.
+
+## Step 2 - Ask the source for a RIGHT-SIZED handover
+
+Message the source asking for a document at a path you choose. Seven headings:
+
+1. **What I am doing** - the goal in my own words, not a restated task title.
+2. **Where I got to** - what is finished and PROVEN, kept separate from what is started or merely
+   believed.
+3. **The exact next action** - specific enough to act on without asking anyone. Commands and paths,
+   not intentions.
+4. **Decisions and why** - what a newcomer would otherwise re-litigate or get wrong.
+5. **Traps** - dead ends already hit, things that look right and are not.
+6. **State** - branch, worktree, uncommitted work, pull requests, issue numbers, running background
+   jobs.
+7. **What I did NOT verify** - suites never run, platforms never tried, claims taken on trust.
+
+**Heading seven is not optional.** A document listing what passed reads as full coverage and the
+reader believes the stronger claim. Learned the hard way: a handover said three test projects
+passed - true - while the wider suite had never been built at all, and continuous integration had
+in fact failed.
+
+Instruct explicitly: **no secrets.** The first handover produced this way came back carrying a
+virtual machine's administrator password.
+
+### Right-sizing - the part that matters most
+
+**A handover is a briefing, not an archive.** Big enough to continue, and nothing more. Aim for
+what the next agent reads in about two minutes - roughly a thousand words. If it is longer than the
+reader's first turn, it is too long.
+
+CUT, without mercy:
+
+- **Work finished, merged and closed.** It is in the repository history. It cannot be acted on and
+  it cannot go wrong.
+- **Superseded decisions.** Only the decision that stands matters; the abandoned ones are noise
+  unless one is a trap.
+- **Exploration that led nowhere** - unless repeating it would waste the next agent's time, in
+  which case it is a trap, not history.
+- **Transcripts, tool output, full file lists.** The biggest source of bloat and almost no signal.
+- **Anything cheaply re-derived.** Do not paste `git status`; name the branch and worktree and let
+  the reader run it.
+
+KEEP, always:
+
+- The live frontier - what is true right now and what happens next.
+- Anything that would be got WRONG rather than merely be unknown. A gap costs a question; a wrong
+  belief costs a day.
+- Pointers, not contents. A path, an issue number, a command.
+
+The test before sending: **for each paragraph, what does the next agent DO differently because it
+is there?** No answer means cut it.
+
+### If the source cannot write one
+
+A session that is unresponsive or out of context cannot answer. Fall back to the Gateway's
+generated summary: `POST {gateway}/handover` with `fromSessionId` + `toRepoPath` (+ `toDirectorId`
+for another Director, `toAgent`, `extraContext` opening with the moved-session statement). It
+returns `targetSession.sessionId`, and creates the target **unnamed** - name it immediately.
+
+Know what you are trading: that route produces a MECHANICAL SCRAPE - last prompt, last reply, files
+touched, commands, to-do items. It carries no intent, no decisions and no traps. Use it when
+nothing better is available, not by preference.
+
+## Step 3 - Start the target on the SAME agent and the SAME model
+
+Sessions are created on whichever Director owns you. To land on a different one, override the API
+base with that Director's Control API port (read it from its `/healthz`):
+
+```bash
+CC_DIRECTOR_API=http://127.0.0.1:<targetPort> cc-devthrottle session spawn "<repoPath>" \
+  --standalone \
+  --agent <sourceAgent> \
+  --name "<the source's ORIGINAL name>" \
+  --purpose "continue <work> after being moved" \
+  --prompt "<seed - below>"
+```
+
+The target keeps the source's original name. That is what makes the move invisible afterwards. Keep
+the naming convention `<repo-dir> - <short description>`; if the source's name lacks the repo
+prefix, add it and say so.
+
+**On the model - do not assume, read back.** With `--args` omitted the session inherits the
+Director's default model and permission mode. That is usually right and is silently wrong whenever
+the source was NOT on the default. Two things to know:
+
+- The reported model (`claude-opus-5`) is **not** the same vocabulary as the `--model` launch flag
+  (`opus[1m]`). You cannot feed one into the other; map it deliberately.
+- `--args` is passed through LITERALLY and applies NO defaults, so if you set it you must supply the
+  permission preset too or the session blocks on a prompt for every action:
+  `--args "--dangerously-skip-permissions --model <id>"`.
+
+Then **verify by reading back**, never by trusting the flags you sent:
+
+```bash
+cc-devthrottle session list --json    # compare the target's agent + currentModel against the source
+```
+
+If they differ, stop. Delete the target and start again. A session continuing on a different model
+is not the same session.
+
+Identity is set at spawn or not at all - if the source carried a role, mission, or workflow seat,
+pass `--role`, `--mission`, `--workflow-run`.
+
+### The seed prompt
+
+Tell it what it is, point it at the document, make it prove it read it:
+
+> YOU ARE A MOVED SESSION. You are the continuation of a session that ran on another Director. You
+> have no transcript and no memory of that work - everything you know is in one document. Read it
+> now and treat it as your own history: `<path>`. Read the WHOLE document before doing anything, and
+> follow its "exact next action" section - including where it tells you to wait and NOT to act. When
+> you have read it, reply with a short summary of what you are working on and what your very next
+> action is, so the move can be verified - then get started on that action and nothing more.
+
+## Step 4 - Verify the pickup BEFORE touching the source
+
+```bash
+CC_DIRECTOR_API=http://127.0.0.1:<targetPort> cc-devthrottle session buffer <targetId>
+```
+
+It **passes** when the target states the work, its constraints and the next action **from the
+document**, then does that action. It **fails** when it guesses, asks what it should be doing, or
+starts something the document assigned to someone else.
+
+**If it fails, stop. Leave the source alone and fix the document.** The source is still alive and
+still holds everything - this is the last moment at which that is true.
+
+Parked-composer gotcha: state stuck `WaitingForInput` with the seed visible at the prompt means the
+submit never fired. Send a raw Enter through the Gateway -
+`POST {gateway}/sessions/{tid}/prompt` `{"text":"\r","appendEnter":false}` - then re-verify. (Empty
+text with `appendEnter:true` is a 400.)
+
+## Step 5 - Delete the source
+
+Step 4 passed, so the work now lives on the target. Destroy the original. **Do not ask - the owner
+asked for the move, and a move includes this.** Asking here is how a Director ends up full of parked
+`[MOVED]` sessions and can never be shut down.
+
+```bash
+cc-devthrottle session rename <sourceId> "[MOVED -> <where>] <original name>"
+cc-devthrottle message send   <sourceId> "Moved and verified. Do nothing further; you are being closed."
+cc-devthrottle session done   <sourceId>     # the Director reaps it shortly
+```
+
+The rename is for the second or two it remains visible, so anyone watching sees why it vanished.
+
+**If step 4 did NOT pass, delete nothing.** Leave the source running and untouched, delete the
+failed TARGET instead, and fix the handover document. A source deleted behind a target that cannot
+continue is the one unrecoverable outcome this skill exists to prevent.
+
+## Step 6 - Report
+
+Give the owner: the target's id, Director, repository, retained name, and the proof it picked up;
+confirmation that the source is deleted and the old Director's session count is one lower; and
+anything the document admitted it had not verified.
+
+When the point of the move was to empty a Director, say how many sessions it has left.
+
+---
+
+## Traps
+
+- **The source cannot tell you what it never checked** unless you ask. That is heading seven.
+- **Background jobs do not survive.** A monitor watching a build dies with the source. The document
+  must say so and give the command to re-check by hand.
+- **Scratchpad files do not survive.** Screenshots and working notes in the source's temporary
+  directory are gone. Name how to regenerate them, or move them somewhere durable first.
+- **`session hold` queues mid-turn.** "still working; it parks when it finishes" is success.
+- **Do not start a Director from your own process.** Use the launcher's `POST /launch` (port 7900,
+  token from `config\launcher\launcher.json`) - it gives clean parentage. A Director started inside
+  an agent's console hosts sessions that die within seconds.
+- **The `[MOVED]` marker must never lie.** If you marked the source and the move actually failed,
+  rename it back and say so plainly.
+- **A parked source is a failed move.** If you find yourself leaving the source alive "to be safe",
+  you have not moved anything - you have duplicated it, and the Director you were emptying is still
+  full. Either verification passed, in which case delete, or it did not, in which case fix the
+  document and try again.
+
+## Note for the future
+
+Written to be lifted into the central Gateway skill library. Keep it self-contained and free of
+machine-specific paths so it can be served unchanged to every agent.
+
+---
+
+**Skill version:** 4.0 · **Updated:** 2026-07-28
+**Changes in 4.0:** A move now DELETES the source automatically, gated on verification and nothing
+else. This reverses 3.1's "never kill the source - the user closes it", which defeated the purpose:
+the reason to move sessions is to empty a Director so it can be shut down and updated, and a parked
+`[MOVED]` session leaves it just as full. Verification is the only gate, which is what makes the
+handover document critical - it is the only thing between the work and the bin.
+The default route is now an AGENT-WRITTEN, right-sized handover with seven headings, proven in a
+real move; the Gateway `POST /handover` auto-summary is demoted to a fallback for a source that
+cannot answer, with its mechanical-scrape limitation stated. Added: the right-sizing rules and the
+per-paragraph test; heading seven (what was not verified) after a real document read as full
+coverage while the wider suite had never run; a no-secrets instruction after one came back carrying
+a password; same-agent and same-model spawn with a READ-BACK check, and the warning that the
+reported model id is not the `--model` flag vocabulary; creating the target on a chosen Director
+with `CC_DIRECTOR_API`; and the launcher launch route.
+Kept from 3.1: the Gateway-is-the-control-surface preamble, the naming convention, and never
+touching the source until the target has demonstrably picked up.


### PR DESCRIPTION
The move skill's third hard rule was "never kill the source - the user closes it". That defeats the reason we now move sessions: emptying a Director so it can be shut down and updated. A parked `[MOVED]` session leaves it just as full, so the update never happens.

A move now deletes the source automatically, gated on verification and nothing else. If the target demonstrably picked the work up, the source goes. If it did not, nothing is deleted - the source keeps running and the failed target is removed instead.

That makes the handover document the only thing between the work and the bin, so it is now written by the agent rather than scraped from the transcript:

- Seven headings, including **what the session did NOT verify**. A real handover listed three passing test projects, which read as full coverage while the wider suite had never been built - and continuous integration had in fact failed.
- Right-sizing rules: a briefing, not an archive. Cut work already merged, superseded decisions, transcripts and file lists. For each paragraph, ask what the next agent does differently because it is there.
- An explicit no-secrets instruction, after the first document came back carrying a virtual machine password.

The Gateway's `POST /handover` generated summary is demoted to a fallback for a source that cannot answer, with its mechanical-scrape limitation stated.

The target is started on the same agent and the same model as the source, verified by **reading the model back** rather than trusting the launch flags - the reported model id (`claude-opus-5`) is not the same vocabulary as the `--model` flag (`opus[1m]`).

Proven end to end on 2026-07-28: a session moved onto a newer Director read its handover, restated the work and its constraints, ran the exact next action unprompted, and correctly handled the failure that action turned up.