### PR TITLE
release notes: cover the two changes that landed while v1.8.4 was in review

### DIFF
--- a/docs/public/release-notes/v1.8.4.md
+++ b/docs/public/release-notes/v1.8.4.md
@@ -34,6 +34,28 @@ this version it can act on them.
   fixed, and a launcher that ever fails to find the app again will now say so plainly rather than
   falling back to killing it without a word.
 
+### Skills live on the Gateway now
+
+- **Fixing a skill no longer needs a release, and machines stop drifting apart.** Skills were
+  copied onto every machine by the installer, so correcting a single word meant shipping a new
+  version, and any machine that was not re-installed quietly fell behind the others. They are now
+  held centrally and fetched at the moment an agent uses one, so every machine reads the same
+  skill and a correction takes effect immediately.
+- **You can turn one off, and off means off.** Built-in skills are read-only and customised by
+  cloning. Your on and off choices apply to every read, with no exception that could serve a
+  switched-off skill anyway.
+
+### Moving a session
+
+- **Moving a session now clears the machine it came from.** A move used to leave the original
+  parked but still present, which defeated one of the two reasons to move at all: emptying a
+  computer so it can be shut down and updated. The source is now removed automatically once the
+  destination has demonstrably picked the work up - and if it has not, nothing is deleted, the
+  original keeps running and the failed destination is removed instead.
+- **The handover is written by the session itself.** Since the handover document is now the only
+  thing carried across, it is written deliberately rather than scraped, and it states what the
+  session did *not* check as well as what it did.
+
 ### Setting up a new machine
 
 - **Setup stops asking every computer how often to send one report.** The daily report is a


### PR DESCRIPTION
Documentation only, and it needs to land before the `v1.8.4` tag is created.

The v1.8.4 notes were written against the four commits on main at the time. Two more merged during the release pull request's own continuous-integration run:

- **#2252** - skills held on the Gateway and fetched on use, instead of copied onto every machine by the installer
- **#2256** - moving a session now deletes the source once the destination has verifiably picked the work up

Both are user-facing, and both would have shipped unmentioned.

Notes that omit a change are worse than terse notes: a reader who hits a behaviour they cannot find described concludes it is a fault rather than a feature nobody told them about. Someone whose skills stopped being copied to their machines, or whose moved session vanished from the original computer, would have had no way to know either was intended.

Landing this before the tag so the published notes and the tagged contents agree.