### PR TITLE
Stop the tunnel backpressure proof failing on a quiet stretch it never promised (internal 910)

### DIFF
--- a/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
@@ -261,8 +261,9 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
         // transport pipe, and the socket buffers fill, then it blocks on its yield - it must NOT run to
         // completion. Frames are at the cap so transport buffers cannot silently absorb the whole stream.
         //
-        // The proof is that the producer's progress STOPS and STAYS stopped below the total while the sink is
-        // held (bounded memory - the Architect's ruling 1), and then drains fully the instant the sink releases.
+        // The proof is that the producer's progress STOPS ramping and STAYS BELOW the total for as long as the
+        // sink is held (bounded memory - the Architect's ruling 1), and then drains fully the instant the sink
+        // releases.
         // (The exact pinning depth is buffer-dependent - on loopback it settles in the low tens because the OS
         // socket and pipe buffers dwarf the 4-deep server channel; over a real slow link it pins far tighter.)
         //
@@ -302,9 +303,21 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
             // stay below total - if backpressure were broken the producer would run to completion (caught here).
             var pinned = await PollUntilStableAsync(() => Volatile.Read(ref yielded), total, testTimeout.Token);
 
-            // Now confirm it STAYS pinned for a further window - blocked on its yield, not slowly draining ahead.
+            // Now sample again after a further window, and assert what backpressure actually promises: the
+            // producer cannot outrun a stalled sink WITHOUT BOUND, so however far it got it is still short of
+            // total. It is deliberately NOT asserted that the count is EXACTLY unchanged over this window.
+            // A producer under backpressure is not frozen - it advances in bursts, each time the socket and
+            // pipe buffers drain enough to admit more - so "did not advance for 800 milliseconds" is a temporal
+            // sample, not a permanent property. On a loaded runner a quiet stretch that long can fall in the
+            // middle of the ramp, and the count then moves inside this window: 35 to 57, and 36 to 58, on the
+            // shared continuous-integration runner, on commits that touched nothing under src at all. Widening
+            // either window does not close that gap, it only lowers the probability, because any fixed quiet
+            // period can be exceeded by a slower machine - the previous attempt here was exactly such a
+            // widening. The bound below holds for as long as the sink is held, so it cannot flake, and it still
+            // fails loudly the moment a regression lets the producer run away from a sink that is not draining.
             await Task.Delay(1000, testTimeout.Token);
-            Assert.Equal(pinned, Volatile.Read(ref yielded));
+            var afterWindow = Volatile.Read(ref yielded);
+            Assert.True(afterWindow < total, $"producer ran to {afterWindow}/{total} with the sink stalled (it was at {pinned} a second earlier) - backpressure is broken");
             Assert.True(pinned < total, $"producer ran to {pinned}/{total} with the sink stalled - backpressure is broken");
             Assert.Equal(0, sink.CompletedWrites); // the first write is in-flight (held by the gate); none have completed
         }


### PR DESCRIPTION
Fixes the recurring false red in `TunnelMechanismProofTests.Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer`, filed and analysed as internal issue 910. One file, one assertion.

## What was wrong

The test stalls the sink, polls until the producer's yield counter has not advanced for about 800 milliseconds, calls that pinned, waits a further second, and then asserted the counter was **exactly** unchanged.

That inference is the defect. A producer under backpressure is not frozen - it advances in bursts, each time the socket and pipe buffers drain enough to admit more. On a loaded runner an 800 millisecond quiet stretch can fall in the middle of the ramp rather than at the end of it, and the counter then moves inside the following second. The shared runner produced exactly that twice, both times on heads that changed nothing under `src` at all: 35 to 57, and 36 to 58.

Widening either window cannot close that gap, only lower the probability, because any fixed quiet period can be exceeded by a slower machine. The previous change to this file was exactly such a widening, which is why the failure came back. So the window is not touched here.

## What changed

The exact-equality sample is replaced by the property backpressure actually promises: the producer cannot outrun a stalled sink **without bound**, so after the further window it is still short of the total. That holds for as long as the sink is held, so it cannot flake.

The assertions that carry the real proof are untouched:

- `cur < total` on every poll sample, inside `PollUntilStableAsync`
- `pinned < total` after the poll
- `sink.CompletedWrites == 0` - nothing drained while the sink was held
- the drain-and-complete assertions after the gate is released

## Proof the test can still fail

A proof test that no longer catches a broken invariant is worse than a flaky one, because it is silently dead and looks like coverage. So backpressure was deliberately broken in the Gateway, twice, in two different ways, and the test was watched going red - then the Gateway was restored and it was watched going green. Neither sabotage was committed; both were applied to `GatewayStreamRegistry.ConsumeAsync`, which is where pull-then-forward lives.

**Sabotage 1 - backpressure removed outright.** `await entry.Sink.WriteFrameAsync(...)` became `_ = entry.Sink.WriteFrameAsync(...)`, so the pump forwards without waiting and the producer is never blocked.

```
Failed CcDirector.Gateway.Tests.TunnelMechanismProofTests.Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer [222 ms]
  producer ran to 100/100 with the sink stalled - backpressure is broken
  at ...TunnelMechanismProofTests.PollUntilStableAsync(...) TunnelMechanismProofTests.cs:line 352
```

Caught by the poll's `cur < total`, one of the two assertions this change deliberately leaves alone.

**Sabotage 2 - aimed at the replaced line specifically.** The first sabotage proves the test as a whole still bites, but not that the *new* assertion is load-bearing. So a second sabotage was written to slip past everything except the new line: a sink that has not completed a write within 1.5 seconds is abandoned and the pump then drains ahead unbounded. The producer therefore pins normally, the poll is satisfied, and it only runs away afterwards - inside the further window. That is precisely the "slowly draining ahead" regression the deleted line claimed to guard.

```
Failed CcDirector.Gateway.Tests.TunnelMechanismProofTests.Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer [2 s]
  producer ran to 100/100 with the sink stalled (it was at 44 a second earlier) - backpressure is broken
  at ...TunnelMechanismProofTests.Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer() TunnelMechanismProofTests.cs:line 320
```

Line 320 is the new assertion. The producer pinned at 44 of 100, so the poll passed and `pinned < total` passed; only the replacement line caught it. The new assertion is not decoration - it is the one that fails.

**Restored.** `GatewayStreamRegistry.cs` was reverted with `git checkout --` and the test goes green again. `git status` shows the test file as the only modification in this branch.

## Runs

| Run | Tree | Result |
| --- | --- | --- |
| The test alone, before the change | main as of `71f90bad` | Passed, 2 s |
| The test alone, with the change | this branch | Passed, 2 s |
| The test alone, sabotage 1 | backpressure removed | **Failed** - ran to 100/100, caught by the poll |
| The test alone, sabotage 2 | stalled sink abandoned after 1.5 s | **Failed** - 44 then 100/100, caught by the new assertion |
| Full `CcDirector.Gateway.Tests` project, restored | this branch | Passed - 4388 passed, 0 failed, 17 skipped, 17 m 55 s |

The 17 skips are the live Postgres tests, which skip when no database is configured; they skip on main too and are unrelated to this change.

Run alone and run in the full assembly both matter here, because the Gateway suite is where contention shows up and contention is the whole subject. Note that this assembly serializes itself per user per machine through `GatewayTestSuiteLock`, so two Gateway runs on one machine cannot overlap; each run below waited its turn for that lock before starting.

## What this does not claim

This does not establish that a red in this test may be waved through in future. It removes one assertion that was stricter than the property under test, and leaves every load-bearing assertion in place. Any future red here is a real finding until shown otherwise.
