### PR TITLE
Let an account choose how often the daily report arrives (internal 1000)

### DIFF
--- a/packages/client-core/src/settings/DailyReportCard.test.tsx
+++ b/packages/client-core/src/settings/DailyReportCard.test.tsx
@@ -1,0 +1,141 @@
+// The Daily report card (issue #1000), rendered against a fake Gateway.
+//
+// What these prove that a Gateway test cannot: the card SHOWS the account its current answer and SENDS the
+// one it clicked. The Gateway's own tests prove the cadence is stored and that an account holding "off" is
+// dropped from the recipient list; a card that rendered the wrong radio, or sent nothing, would leave both
+// of those green while the person looking at Settings believed the opposite of what is true.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DailyReportCard } from "./NotificationsTab";
+import { SettingsTabPanel } from "./SettingsTabs";
+import { MemoryRouter } from "react-router-dom";
+
+// The per-account snapshot GET /gateway/settings answers with. Only the field under test varies.
+function snapshot(dailyReportCadence: string) {
+  return {
+    snoozeDefaultMinutes: 60,
+    snoozePresets: [15, 60, 240, 480],
+    snoozeMaxPresets: 5,
+    timeZone: "America/Toronto",
+    timeZoneMachineDefault: "America/Toronto",
+    dailyReportCadence,
+  };
+}
+
+// Every request the card makes, recorded, so a test can assert what actually went over the wire rather
+// than what the component says it did.
+let calls: { url: string; method: string; body: unknown }[] = [];
+
+function fakeGateway(cadence: string) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      const body = init?.body === undefined ? undefined : JSON.parse(String(init.body));
+      calls.push({ url, method, body });
+      if (url === "/gateway/settings") {
+        return new Response(JSON.stringify(snapshot(cadence)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url === "/gateway/daily-report") {
+        // The Gateway echoes what it applied; the card must render THAT, not what it sent.
+        return new Response(JSON.stringify({ cadence: (body as { cadence: string }).cadence }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    }),
+  );
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the Daily report card", () => {
+  it("shows an account that never chose as receiving the report", async () => {
+    fakeGateway("daily");
+    render(<DailyReportCard />);
+
+    const on = (await screen.findByLabelText("Send it every morning")) as HTMLInputElement;
+    const off = screen.getByLabelText("Do not send it") as HTMLInputElement;
+    expect(on.checked).toBe(true);
+    expect(off.checked).toBe(false);
+  });
+
+  it("shows an account that turned it off as turned off", async () => {
+    fakeGateway("off");
+    render(<DailyReportCard />);
+
+    const off = (await screen.findByLabelText("Do not send it")) as HTMLInputElement;
+    expect(off.checked).toBe(true);
+    expect((screen.getByLabelText("Send it every morning") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("sends the chosen cadence and confirms in words that the email has stopped", async () => {
+    fakeGateway("daily");
+    render(<DailyReportCard />);
+
+    fireEvent.click(await screen.findByLabelText("Do not send it"));
+
+    await waitFor(() => expect(calls.some((c) => c.url === "/gateway/daily-report")).toBe(true));
+    const write = calls.find((c) => c.url === "/gateway/daily-report")!;
+    expect(write.method).toBe("PUT");
+    expect(write.body).toEqual({ cadence: "off" });
+    // A silent success reads as a button that did nothing, so the card owes a sentence.
+    expect(await screen.findByText(/will not get the daily report email/i)).toBeTruthy();
+    expect((screen.getByLabelText("Do not send it") as HTMLInputElement).checked).toBe(true);
+  });
+
+  // NOTE on what this asserts: the shared settings client wraps a failure in a GatewayError carrying no
+  // serverReason, so the shared message helper answers with its own sentence for the status rather than the
+  // Gateway's words. That is true of every card on this surface, not something this one does; what matters
+  // here is that a refused write SAYS SO and leaves the radio where the Gateway left it.
+  it("reports a refused write rather than pretending the change took", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/gateway/settings") {
+          return new Response(JSON.stringify(snapshot("daily")), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ error: "a tenant could not be resolved for this request" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+    render(<DailyReportCard />);
+
+    fireEvent.click(await screen.findByLabelText("Do not send it"));
+
+    // A real sentence naming the failure, never a bare number and never silence.
+    const failure = await screen.findByText(/could not/i);
+    expect(failure.textContent).toContain("403");
+    // And it must not have moved the radio to a state the Gateway never accepted.
+    expect((screen.getByLabelText("Send it every morning") as HTMLInputElement).checked).toBe(true);
+  });
+
+  // The standing rule is that Settings is one page on two surfaces. The card lives in the shared tab, so
+  // this asserts it through the same panel BOTH shells mount - the phone cannot end up without it.
+  it("is on the Notifications tab that both shells mount", async () => {
+    fakeGateway("daily");
+    render(
+      <MemoryRouter>
+        <SettingsTabPanel tab="notifications" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: /Daily report/ })).toBeTruthy();
+  });
+});

--- a/packages/client-core/src/settings/NotificationsTab.tsx
+++ b/packages/client-core/src/settings/NotificationsTab.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { setSnoozePresets, setTimeZone, type SnoozePresets } from "./settingsClient";
+import {
+  setDailyReportCadence,
+  setSnoozePresets,
+  setTimeZone,
+  type ReportCadence,
+  type SnoozePresets,
+} from "./settingsClient";
 import { formatSnoozeLength, snoozeDraftFrom, snoozeMinutesFrom, type SnoozeUnit } from "./snoozeFormat";
 import { ACCOUNT_SCOPE, CardHead, errText, useGatewaySettings } from "./settingsShared";
 import { disablePush, enablePush, isPushSubscribed, notificationPermission, pushSupported } from "../push/register";
@@ -22,6 +28,7 @@ export function NotificationsTab() {
       <SnoozeCard />
       <TimeZoneCard />
       <NotificationsCard />
+      <DailyReportCard />
     </>
   );
 }
@@ -352,6 +359,75 @@ function NotificationsCard() {
           this on.
         </p>
       )}
+      {msg !== "" && <div className="settings-msg">{msg}</div>}
+    </section>
+  );
+}
+
+// ---- The daily report email (issue #1000) ---------------------------------------------------------
+//
+// How often this ACCOUNT gets the morning report - the last of the "how the fleet reaches you" settings,
+// and the only one that reaches you when you are not in the app at all, so it sits at the end of the tab.
+//
+// This question used to be asked by the first-run wizard, which runs once per director per machine: one
+// person with three machines answered it three times for one email address, and nothing read the answer
+// anyway. It belongs here because the Gateway is the only place the preference is true at - one account,
+// one address, one answer - and it is read by the Gateway itself when the sender asks who to mail.
+//
+// Two choices, not three. The wizard also offered Weekly; the report covers one calendar day, so weekly
+// would mail a Monday and call it a week. It comes back when the report can summarize a range.
+export function DailyReportCard() {
+  const { settings, setSettings, error, busy, msg, runSave } = useGatewaySettings();
+
+  if (error !== null) {
+    return <div className="settings-error">Could not load the daily report setting: {error}</div>;
+  }
+  if (settings === null) {
+    return <p className="settings-loading">Loading...</p>;
+  }
+
+  const choose = (cadence: ReportCadence) => {
+    if (busy || cadence === settings.dailyReportCadence) return;
+    void runSave(async () => {
+      const applied = await setDailyReportCadence(cadence);
+      setSettings({ ...settings, dailyReportCadence: applied });
+      return applied === "off"
+        ? "Off. You will not get the daily report email."
+        : "On. The report arrives every morning at 7:00 Eastern.";
+    });
+  };
+
+  return (
+    <section className="settings-card">
+      <CardHead title="Daily report" scope={ACCOUNT_SCOPE} />
+      <p className="settings-hint">
+        A short email every morning at 7:00 Eastern: what your sessions did yesterday and what is waiting
+        on you. It goes to your account&apos;s email address, so this is one setting for the whole account -
+        every device you sign in on shows the same choice. Read when the email is sent, so a change applies
+        to the next morning.
+      </p>
+      <div className="settings-field">
+        <label className="settings-check">
+          <input
+            type="radio"
+            name="daily-report-cadence"
+            checked={settings.dailyReportCadence === "daily"}
+            disabled={busy}
+            onChange={() => choose("daily")}
+          />
+          Send it every morning
+        </label>
+        <label className="settings-check">
+          <input
+            type="radio"
+            name="daily-report-cadence"
+            checked={settings.dailyReportCadence === "off"}
+            disabled={busy}
+            onChange={() => choose("off")}
+          />
+          Do not send it
+        </label>
+      </div>
       {msg !== "" && <div className="settings-msg">{msg}</div>}
     </section>
   );

--- a/packages/client-core/src/settings/settingsClient.ts
+++ b/packages/client-core/src/settings/settingsClient.ts
@@ -28,7 +28,18 @@ export interface GatewaySettings {
   timeZone: string;
   // What "automatic" resolves to: the Gateway machine's own zone. Lets the page show it and offer a reset.
   timeZoneMachineDefault: string;
+  // How often this account wants the daily report email (issue #1000). One value for the account, not for
+  // this device or this machine: the report is one person and one email, which is exactly why the question
+  // left the first-run wizard, where it was asked once per install.
+  dailyReportCadence: ReportCadence;
 }
+
+/**
+ * How often the daily report email is sent. "weekly" is deliberately absent: the report covers one calendar
+ * day, so a weekly send could only mail one day and call it a week. Add it here when the Gateway can
+ * summarize a range - the wire value is a name precisely so that costs nothing stored.
+ */
+export type ReportCadence = "daily" | "off";
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
   let detail = `${res.status}`;
@@ -88,7 +99,27 @@ export async function getGatewaySettings(signal?: AbortSignal): Promise<GatewayS
       typeof body.timeZoneMachineDefault === "string" && body.timeZoneMachineDefault.length > 0
         ? body.timeZoneMachineDefault
         : "UTC",
+    // Anything this client does not recognize reads as "daily" - the same direction the Gateway takes, and
+    // for the same reason: a card that showed Off because it met a value it did not know would tell the
+    // account its report is stopped when it is not.
+    dailyReportCadence: body.dailyReportCadence === "off" ? "off" : "daily",
   };
+}
+
+// PUT /gateway/daily-report { cadence } - set how often this account gets the daily report email. Read by
+// the Gateway when the sender asks who to mail, so a change applies to the next morning's send. Returns the
+// applied cadence.
+export async function setDailyReportCadence(
+  cadence: ReportCadence,
+  signal?: AbortSignal,
+): Promise<ReportCadence> {
+  const body = await putJson<{ cadence?: string }>(
+    "/gateway/daily-report",
+    "PUT /gateway/daily-report",
+    { cadence },
+    signal,
+  );
+  return body.cadence === "off" ? "off" : "daily";
 }
 
 // PUT /gateway/time-zone { timeZone } - set the display time zone (an IANA id) the private dashboards read

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Settings;
 using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -34,10 +35,10 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// AND IT ASSERTS A POSITIVE FACT PER ROUTE, NOT THE ABSENCE OF THE REFUSAL. "The refusal string is not
 /// in the body" is satisfied by an empty 200, by a single-page-application shell, and by a route that was
-/// deleted - it proves nothing about the route being alive. All twenty-two routes are proved by one of:
-///   - its REAL PAYLOAD, field by field (the eight read routes);
+/// deleted - it proves nothing about the route being alive. All twenty-four routes are proved by one of:
+///   - its REAL PAYLOAD, field by field (the nine read routes);
 ///   - an INDEPENDENTLY RE-READ EFFECT - the value is written over the wire and then read back out of the
-///     configuration store through the Core config class, not out of the response (ten write routes);
+///     configuration store through the Core config class, not out of the response (eleven write routes);
 ///   - a SEEDED TRANSITION off a sentinel the effect cannot produce, where the effect is a RESET rather
 ///     than a stored value (the provider, one route);
 ///   - SERVED-AND-REACHES-A-HANDLER, the deliberately NARROWED claim for the one route that can carry no
@@ -47,7 +48,7 @@ namespace CcDirector.Gateway.Tests;
 ///     day a second mode is added, so the narrowing cannot go stale (one route);
 ///   - a HANDLER-UNIQUE RECEIPT: a status and message only that one handler can produce, where the route
 ///     has no readable effect to assert - the two credential-resolution routes (two routes).
-/// Eight plus ten plus one plus one plus two is twenty-two. No route is left over, and none is proved
+/// Nine plus eleven plus one plus one plus two is twenty-four. No route is left over, and none is proved
 /// only by the absence of the refusal.
 ///
 /// Issue #2022 removed the five machine-scoped routes this control once also covered - brain restart (the
@@ -129,6 +130,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                          {
                              "gateway/settings",
                              "gateway/snooze-default",
+                             "gateway/daily-report",
                              "gateway/injected-text",
                              "gateway/snooze-presets",
                              "gateway/time-zone",
@@ -142,7 +144,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// The eight read routes, each asserted by the REAL PAYLOAD it carries - the fields, and where a field
+    /// The nine read routes, each asserted by the REAL PAYLOAD it carries - the fields, and where a field
     /// has an independently knowable value, that value. Format facts (status, media type) are asserted
     /// BEFORE the body is parsed, on this side too: if a route were gone, the Gateway's single-page
     /// -application fallback would answer with HTML and parsing first would turn that finding into a crash.
@@ -178,8 +180,9 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 Assert.Equal(new[]
                 {
                     "snoozeDefaultMinutes", "snoozePresets",
-                    "snoozeMaxPresets", "timeZone", "timeZoneMachineDefault",
+                    "snoozeMaxPresets", "timeZone", "timeZoneMachineDefault", "dailyReportCadence",
                 }, properties);
+                Assert.Equal(ReportCadences.DailyName, root.GetProperty("dailyReportCadence").GetString());
                 Assert.True(root.GetProperty("snoozePresets").GetArrayLength() > 0);
                 Assert.Equal(SnoozePresetsConfig.MaxPresets, root.GetProperty("snoozeMaxPresets").GetInt32());
                 break;
@@ -187,6 +190,14 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
             case "gateway/snooze-default":
                 Assert.Equal(new[] { "minutes" }, properties);
                 Assert.Equal(SnoozeDefaultConfig.Get(), root.GetProperty("minutes").GetInt32());
+                break;
+
+            case "gateway/daily-report":
+                // The account's report cadence (issue #1000). Its independently knowable value is the
+                // documented default - daily - because a Gateway nobody has configured must still be
+                // mailing everyone who has an address, exactly as it did before the setting existed.
+                Assert.Equal(new[] { "cadence" }, properties);
+                Assert.Equal(ReportCadences.DailyName, root.GetProperty("cadence").GetString());
                 break;
 
             case "gateway/injected-text":
@@ -247,6 +258,9 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 data.Add(hosted, "PUT", "gateway/injected-text", "{\"use_yours\":true,\"yours\":\"words from another tenant\"}", "injected-text", "words from another tenant");
                 data.Add(hosted, "PUT", "gateway/snooze-presets", "{\"presets\":[15,30,60],\"defaultMinutes\":30}", "snooze-presets", "15,30,60");
                 data.Add(hosted, "PUT", "gateway/time-zone", "{\"timeZone\":\"America/New_York\"}", "time-zone", "America/New_York");
+                // "off" is the value that is distinguishable from the default, so the re-read proves a write
+                // rather than a no-op.
+                data.Add(hosted, "PUT", "gateway/daily-report", "{\"cadence\":\"off\"}", "daily-report", "off");
                 // transcription-mode is NOT here - it needs a seeded starting value to be distinguishable
                 // from a no-op, so it has its own test below.
                 data.Add(hosted, "PUT", "gateway/tts-voice", "{\"voice\":\"shimmer\"}", "tts-voice", "shimmer");
@@ -276,6 +290,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         "injected-text" => _gateway.TenantSettingsResolver.InjectedText(TenantId.Local).Yours ?? "",
         "snooze-presets" => string.Join(",", _gateway.TenantSettingsResolver.SnoozePresets(TenantId.Local)),
         "time-zone" => _gateway.TenantSettingsResolver.TimeZone(TenantId.Local),
+        "daily-report" => ReportCadences.Name(_gateway.TenantSettingsResolver.DailyReportCadence(TenantId.Local)),
         "transcription-mode" => TranscriptionModeConfig.Get().ToConfigString(),
         "tts-voice" => _gateway.TenantSettingsResolver.TtsVoice(TenantId.Local, TranscriptionModeConfig.Get()),
         "wingman-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking),
@@ -451,6 +466,33 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
     // receipt. Those endpoints no longer exist, so there is nothing to serve. The brain-restart SEAM
     // (GatewayHost.BrainRestartAction) stays for the automatic recovery path, but it is no longer reachable
     // over HTTP.
+    /// <summary>
+    /// An unknown report cadence is REFUSED and CHANGES NOTHING (issue #1000). The second half is the half
+    /// that matters: a handler that answered 400 after having already written would leave the account on a
+    /// schedule it never asked for while telling it the request failed. The stored value is re-read out of
+    /// the resolver, not out of the response.
+    /// </summary>
+    [Theory]
+    [InlineData("{\"cadence\":\"weekly\"}")]
+    [InlineData("{\"cadence\":\"\"}")]
+    [InlineData("{\"cadence\":null}")]
+    [InlineData("{}")]
+    public async Task An_unknown_report_cadence_is_refused_and_leaves_the_setting_alone(string body)
+    {
+        DeclareSelfHost(null);
+
+        // Start from a value that is NOT the default, so a write that wrongly went through would be visible
+        // either way - as a change to daily, or as a change to the unknown value.
+        (await _http.PutAsync("gateway/daily-report",
+            new StringContent("{\"cadence\":\"off\"}", Encoding.UTF8, "application/json")))
+            .EnsureSuccessStatusCode();
+
+        var refused = await _http.PutAsync("gateway/daily-report",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, refused.StatusCode);
+        Assert.Equal(ReportCadence.Off, _gateway.TenantSettingsResolver.DailyReportCadence(TenantId.Local));
+    }
 }
 
 /// <summary>
@@ -562,4 +604,5 @@ public sealed class HostedOwnerSettingsSelfHostProbeTests : IAsyncLifetime
         }
         finally { http.Dispose(); await app.DisposeAsync(); }
     }
+
 }

--- a/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
@@ -102,8 +102,8 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// The eleven per-account routes that now SERVE on hosted, with a well-formed body for the writes. Reused
-    /// by the serve theory and the unresolved-tenant 403 theory so both drive the identical set.
+    /// The per-account routes that now SERVE on hosted, with a well-formed body for the writes. Reused by the
+    /// serve theory and the unresolved-tenant 403 theory so both drive the identical set.
     /// </summary>
     public static readonly (string Verb, string Path, string? Body)[] ServedRoutes =
     {
@@ -118,6 +118,8 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
         ("PUT", "gateway/ai-provider",              "{\"provider\":\"devthrottle\"}"),
         ("GET", "gateway/tts-voice",                null),
         ("PUT", "gateway/tts-voice",                "{\"voice\":\"shimmer\"}"),
+        ("GET", "gateway/daily-report",             null),
+        ("PUT", "gateway/daily-report",             "{\"cadence\":\"off\"}"),
         ("GET", "gateway/injected-text",            null),
         ("PUT", "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words for one account only\"}"),
         ("PUT", "gateway/ai/wingman-model",         "{\"model\":\"m-think\"}"),
@@ -198,6 +200,21 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
 
         Assert.Equal(45, await ReadInt(_httpA, "gateway/snooze-default", "minutes"));
         Assert.NotEqual(45, await ReadInt(_httpB, "gateway/snooze-default", "minutes"));
+    }
+
+    /// <summary>
+    /// ISOLATED - the daily report cadence (issue #1000). A turns its report off; B still gets one. This is
+    /// the property that matters most on shared infrastructure: one account silencing its own mail must never
+    /// silence anybody else's, and the account that never chose keeps the daily default.
+    /// </summary>
+    [Fact]
+    public async Task Daily_report_turned_off_by_one_tenant_does_not_silence_another_on_hosted()
+    {
+        (await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/daily-report", "{\"cadence\":\"off\"}"))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal("off", await ReadString(_httpA, "gateway/daily-report", "cadence"));
+        Assert.Equal("daily", await ReadString(_httpB, "gateway/daily-report", "cadence"));
     }
 
     /// <summary>ISOLATED - the text-to-speech voice. A picks a distinctive voice; B is unaffected.</summary>

--- a/src/CcDirector.Gateway.Tests/ReportRecipientsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/ReportRecipientsEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Settings;
 using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Tests.Data;
 using Microsoft.AspNetCore.Http;
@@ -38,6 +39,10 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
 
     private TenantRegistry Registry() => new(_h.Open());
 
+    /// <summary>The per-tenant settings over the SAME database as the registry, so a cadence written for a
+    /// minted tenant is the one the endpoint reads back (issue #1000).</summary>
+    private TenantSettingsResolver Settings() => new(new TenantSettingsStore(_h.Open()));
+
     /// <summary>An IResult needs a service provider to execute, exactly as the report endpoint's own
     /// tests build one.</summary>
     private static readonly IServiceProvider Services =
@@ -64,7 +69,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         Environment.SetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar, null);
 
         var ctx = Ctx();
-        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry(), Settings()), ctx);
 
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, status);
     }
@@ -73,7 +78,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
     public async Task WithTheWrongToken_ItRefuses()
     {
         var ctx = Ctx("not-the-token");
-        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry(), Settings()), ctx);
 
         Assert.Equal(StatusCodes.Status401Unauthorized, status);
     }
@@ -82,7 +87,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
     public async Task WithNoAuthorizationHeaderAtAll_ItRefuses()
     {
         var ctx = Ctx(bearer: null);
-        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+        var (status, _) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry(), Settings()), ctx);
 
         Assert.Equal(StatusCodes.Status401Unauthorized, status);
     }
@@ -95,7 +100,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         registry.MintOrLookupBySubject("subject-1", "leaked@example.com");
 
         var ctx = Ctx("wrong");
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
 
         Assert.DoesNotContain("leaked@example.com", body.ToString(), StringComparison.OrdinalIgnoreCase);
     }
@@ -108,7 +113,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         registry.MintOrLookupBySubject("subject-2", "bob@example.com");
 
         var ctx = Ctx();
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
         var emails = body.GetProperty("recipients").EnumerateArray()
             .Select(r => r.GetProperty("email").GetString()).ToList();
 
@@ -125,7 +130,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         registry.MintOrLookupBySubject("subject-with", "real@example.com");
 
         var ctx = Ctx();
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
         var recipients = body.GetProperty("recipients").EnumerateArray().ToList();
 
         Assert.Equal("real@example.com", Assert.Single(recipients).GetProperty("email").GetString());
@@ -141,7 +146,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         registry.MintOrLookupBySubject("subject-2", "SAME@example.com");
 
         var ctx = Ctx();
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
 
         Assert.Single(body.GetProperty("recipients").EnumerateArray());
     }
@@ -150,7 +155,91 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
     public async Task WithNoAccountsAtAll_ItReturnsAnEmptyListRatherThanFailing()
     {
         var ctx = Ctx();
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry()), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, Registry(), Settings()), ctx);
+
+        Assert.Empty(body.GetProperty("recipients").EnumerateArray());
+    }
+
+    // ---- the account's own answer to "do you want this mail" (issue #1000) ---------------------------
+
+    [Fact]
+    public async Task AnAccountThatTurnedTheReportOff_IsNotMailed()
+    {
+        var registry = Registry();
+        var settings = Settings();
+        var quiet = registry.MintOrLookupBySubject("subject-quiet", "quiet@example.com");
+        registry.MintOrLookupBySubject("subject-wants", "wants@example.com");
+        settings.SetDailyReportCadence(quiet, ReportCadence.Off, DateTime.UtcNow);
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, settings), ctx);
+        var emails = body.GetProperty("recipients").EnumerateArray()
+            .Select(r => r.GetProperty("email").GetString()).ToList();
+
+        Assert.Equal(new[] { "wants@example.com" }, emails);
+    }
+
+    [Fact]
+    public async Task AnAccountThatNeverChose_IsStillMailed()
+    {
+        // The default is daily, so switching this setting on cannot silently stop anybody's report. This is
+        // the arm that would catch a filter written the wrong way round - one that mailed only accounts
+        // holding an explicit "daily", which is nobody on the day it ships.
+        var registry = Registry();
+        registry.MintOrLookupBySubject("subject-untouched", "untouched@example.com");
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
+        var emails = body.GetProperty("recipients").EnumerateArray()
+            .Select(r => r.GetProperty("email").GetString()).ToList();
+
+        Assert.Equal(new[] { "untouched@example.com" }, emails);
+    }
+
+    [Fact]
+    public async Task AnAccountThatTurnedTheReportBackOn_IsMailedAgain()
+    {
+        var registry = Registry();
+        var settings = Settings();
+        var tenant = registry.MintOrLookupBySubject("subject-returning", "returning@example.com");
+        settings.SetDailyReportCadence(tenant, ReportCadence.Off, DateTime.UtcNow);
+        settings.SetDailyReportCadence(tenant, ReportCadence.Daily, DateTime.UtcNow);
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, settings), ctx);
+
+        Assert.Equal("returning@example.com",
+            Assert.Single(body.GetProperty("recipients").EnumerateArray()).GetProperty("email").GetString());
+    }
+
+    [Fact]
+    public async Task OneAddressOnTwoAccounts_OneOfWhichWantsIt_IsStillMailedOnce()
+    {
+        // Silence here would be an opt-out the second account never asked for; two copies would be the
+        // duplicate the endpoint already refuses. One copy is the only answer that serves both.
+        var registry = Registry();
+        var settings = Settings();
+        var off = registry.MintOrLookupBySubject("subject-1", "shared@example.com");
+        registry.MintOrLookupBySubject("subject-2", "shared@example.com");
+        settings.SetDailyReportCadence(off, ReportCadence.Off, DateTime.UtcNow);
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, settings), ctx);
+
+        Assert.Equal("shared@example.com",
+            Assert.Single(body.GetProperty("recipients").EnumerateArray()).GetProperty("email").GetString());
+    }
+
+    [Fact]
+    public async Task EveryAccountTurningItOff_LeavesAnEmptyList_NotEveryAccount()
+    {
+        var registry = Registry();
+        var settings = Settings();
+        foreach (var (subject, email) in new[] { ("s1", "a@example.com"), ("s2", "b@example.com") })
+            settings.SetDailyReportCadence(registry.MintOrLookupBySubject(subject, email), ReportCadence.Off, DateTime.UtcNow);
+
+        var ctx = Ctx();
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, settings), ctx);
 
         Assert.Empty(body.GetProperty("recipients").EnumerateArray());
     }
@@ -164,7 +253,7 @@ public sealed class ReportRecipientsEndpointTests : IDisposable
         registry.MintOrLookupBySubject("s2", "bob@example.com");
 
         var ctx = Ctx();
-        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry), ctx);
+        var (_, body) = await ExecuteAsync(ReportRecipientsEndpoint.Handle(ctx, registry, Settings()), ctx);
         var emails = body.GetProperty("recipients").EnumerateArray()
             .Select(r => r.GetProperty("email").GetString()).ToList();
 

--- a/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsResolverTests.cs
@@ -155,4 +155,82 @@ public sealed class TenantSettingsResolverTests
         // The default must be one of the presets - the same invariant the global setter enforces.
         Assert.Throws<ArgumentException>(() => r.SetSnoozePresets(TenantA, new[] { 15, 60 }, 999, Now));
     }
+
+    // ---- the daily report cadence (issue #1000) ------------------------------------------------------
+
+    [Fact]
+    public void DailyReportCadence_NoChoice_IsDaily()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        // What every account received before this setting existed. A different answer here would silently
+        // stop the report for everybody the moment the setting shipped.
+        Assert.Equal(ReportCadence.Daily, r.DailyReportCadence(TenantA));
+    }
+
+    [Fact]
+    public void DailyReportCadence_Off_RoundTrips()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetDailyReportCadence(TenantA, ReportCadence.Off, Now);
+
+        Assert.Equal(ReportCadence.Off, r.DailyReportCadence(TenantA));
+    }
+
+    [Fact]
+    public void DailyReportCadence_OneTenantsChoice_DoesNotSilenceAnother()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetDailyReportCadence(TenantA, ReportCadence.Off, Now);
+
+        Assert.Equal(ReportCadence.Off, r.DailyReportCadence(TenantA));
+        Assert.Equal(ReportCadence.Daily, r.DailyReportCadence(TenantB));
+    }
+
+    [Fact]
+    public void DailyReportCadence_UnreadableValue_ReadsAsDaily_NotAsSilence()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        // Includes the value a NEWER Gateway would write for weekly, read by one that does not know it yet.
+        // Degrading to mail is recoverable and visible; degrading to silence is neither.
+        foreach (var junk in new[] { "", "   ", "true", "never", "weekly" })
+        {
+            store.Set(TenantA, TenantSettingKeys.DailyReportCadence, junk, Now);
+            Assert.Equal(ReportCadence.Daily, r.DailyReportCadence(TenantA));
+        }
+    }
+
+    [Fact]
+    public void DailyReportCadence_IsStoredUnderTheDocumentedKey_AsTheCadenceName()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        r.SetDailyReportCadence(TenantA, ReportCadence.Off, Now);
+
+        // The stored form is the wire name, so the value the recipients endpoint reads and the value the
+        // settings page sends are the same string, not two spellings that could drift apart.
+        Assert.Equal(ReportCadences.OffName, store.Get(TenantA, TenantSettingKeys.DailyReportCadence));
+    }
+
+    [Fact]
+    public void DailyReportCadence_ChoosingDaily_IsStoredRatherThanLeftAbsent()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        r.SetDailyReportCadence(TenantA, ReportCadence.Daily, Now);
+
+        Assert.Equal(ReportCadences.DailyName, store.Get(TenantA, TenantSettingKeys.DailyReportCadence));
+    }
 }

--- a/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/ReportRecipientsEndpoint.cs
@@ -1,4 +1,6 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Settings;
 using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -25,46 +27,64 @@ namespace CcDirector.Gateway.Api;
 /// was at mint time and it is nullable; a recipient with nothing to send to is not a recipient, and
 /// returning an empty address would invite the sender to try anyway.
 ///
-/// WHAT THIS DOES NOT DECIDE: whether a given account WANTS the email. There is no such setting yet,
-/// and it is NOT coming from the first-run wizard - that step was removed (issue #996) because the
-/// wizard runs once per director per machine while this preference is one per ACCOUNT, so it was
-/// asked N times and the answers never reconciled. Until the account-scoped setting exists the report
-/// is simply daily, and the email itself carries the instructions for changing or stopping it.
+/// WHETHER AN ACCOUNT WANTS THE EMAIL IS DECIDED HERE (issue #1000). An account that set its report
+/// cadence to Off is not on this list, so it is not mailed. The filtering is in THIS one place - the
+/// single answer to "who should be mailed" - and not in the sender, so every future channel inherits the
+/// same answer instead of each one re-deriving it. An account that has never touched the setting is
+/// included: the default is daily, which is what everyone received before the setting existed.
 ///
-/// When the setting does exist, the filtering belongs HERE - one place that answers "who should be
-/// mailed" - and not in the sender, so that every future channel inherits the same answer instead of
-/// each one re-deriving it.
+/// The preference is per ACCOUNT and lives on the Gateway because that is the only scope it is true at.
+/// It was once asked by the first-run wizard, which runs once per director per machine - so it was asked
+/// N times for one email address and the answers never reconciled. That step was removed (issue #996);
+/// this is where the question ended up.
 /// </summary>
 internal static class ReportRecipientsEndpoint
 {
     /// <summary>The route. Exact-match public in <c>AuthMiddleware</c>; this endpoint carries its own gate.</summary>
     public const string Path = "/gateway/reports/recipients";
 
-    public static void Map(IEndpointRouteBuilder app, TenantRegistry tenants)
+    public static void Map(IEndpointRouteBuilder app, TenantRegistry tenants, TenantSettingsResolver settings)
     {
         ArgumentNullException.ThrowIfNull(tenants);
+        ArgumentNullException.ThrowIfNull(settings);
 
-        app.MapGet(Path, (HttpContext ctx) => Handle(ctx, tenants));
+        app.MapGet(Path, (HttpContext ctx) => Handle(ctx, tenants, settings));
 
         FileLog.Write($"[ReportRecipientsEndpoint] mapped {Path} (service-token authorized, read-only)");
     }
 
-    internal static IResult Handle(HttpContext ctx, TenantRegistry tenants)
+    internal static IResult Handle(HttpContext ctx, TenantRegistry tenants, TenantSettingsResolver settings)
     {
         // Reuses the report endpoint's gate rather than repeating it: one token, one rule, and no
         // chance of the two drifting so that the recipient list is guarded less well than the reports.
         if (MorningReportEndpoint.ServiceTokenDenial(ctx) is { } denial) return denial;
 
-        var recipients = tenants.ListAll()
+        var addressed = tenants.ListAll()
             .Where(t => !string.IsNullOrWhiteSpace(t.Email))
+            .ToList();
+
+        // The account's own answer to "do you want this mail" (issue #1000), asked per tenant. An account
+        // that never chose is daily, so this removes nobody until somebody deliberately turns it off.
+        var wanted = addressed
+            .Where(t => settings.DailyReportCadence(new TenantId(t.TenantId)) != ReportCadence.Off)
+            .ToList();
+
+        var recipients = wanted
             .Select(t => new { account = t.Email!.Trim(), email = t.Email!.Trim() })
+            // Two accounts may legitimately carry one address, and they may disagree about wanting the
+            // mail. Dropping the duplicate AFTER the filter is what makes "one account still wants it"
+            // win over "the other turned it off" - the address is mailed once, which is the only answer
+            // that serves both, and silence would be an opt-out one account never asked for.
             .DistinctBy(r => r.email, StringComparer.OrdinalIgnoreCase)
             .OrderBy(r => r.email, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        // Count only - the addresses themselves are personally identifying and this log is not the
-        // place for them (the tenants table says the email is never logged).
-        FileLog.Write($"[ReportRecipientsEndpoint] served {recipients.Count} recipient(s)");
+        // Counts only - the addresses themselves are personally identifying and this log is not the
+        // place for them (the tenants table says the email is never logged). The opted-out count is
+        // logged beside the served count so a shrinking list has a stated reason and is never mistaken
+        // for accounts going missing.
+        FileLog.Write($"[ReportRecipientsEndpoint] served {recipients.Count} recipient(s); " +
+                      $"{addressed.Count - wanted.Count} account(s) have the report turned off");
         return Results.Json(new { recipients });
     }
 }

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -22,8 +22,9 @@ namespace CcDirector.Gateway.Api;
 ///
 ///   SERVE ON HOSTED (per-account, resolve the caller tenant, 403 if unresolved):
 ///   GET  /gateway/settings        -> { snoozeDefaultMinutes, snoozePresets, snoozeMaxPresets,
-///                                       timeZone, timeZoneMachineDefault }
+///                                       timeZone, timeZoneMachineDefault, dailyReportCadence }
 ///   GET+PUT /gateway/snooze-default, /gateway/snooze-presets, /gateway/time-zone
+///   GET+PUT /gateway/daily-report               (per-account report cadence; issue #1000)
 ///   GET  /gateway/ai-provider     -> { provider, wingmanModel, wingmanFastModel, carModeModel,
 ///                                       carModeEndPhrase, transcriptionModel, ttsModel, ttsVoice, voices[],
 ///                                       catalogAvailable }
@@ -183,7 +184,54 @@ internal static class SettingsEndpoints
                 // "automatic" resolves to.
                 timeZone = host.TenantSettingsResolver.TimeZone(t.Value),
                 timeZoneMachineDefault = Core.Configuration.TimeZoneConfig.MachineDefault(),
+                // How often this account wants the daily report email (issue #1000): "daily" or "off".
+                // Sent as the cadence NAME, not a boolean, because the question is how often and a third
+                // answer (weekly) is waiting on the report being able to summarize a range.
+                dailyReportCadence = Settings.ReportCadences.Name(
+                    host.TenantSettingsResolver.DailyReportCadence(t.Value)),
             });
+        });
+
+        // How often this account wants the daily report email (issue #1000, follow-up to
+        // devthrottle_internal#996). Per ACCOUNT, because the report is one person and one email: the
+        // first-run wizard used to ask it once per machine, so the same person answered it once per
+        // install and no answer could win. Read by ReportRecipientsEndpoint when the sender asks who to
+        // mail, so a change applies to the next morning's send with no Gateway restart.
+        app.MapGet("/gateway/daily-report", (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
+            return Results.Json(new
+            {
+                cadence = Settings.ReportCadences.Name(host.TenantSettingsResolver.DailyReportCadence(t.Value)),
+            });
+        });
+
+        app.MapPut("/gateway/daily-report", async (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<DailyReportBody>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                // An unknown cadence is REFUSED, never rounded to the nearest one this Gateway knows. A
+                // silent round would answer "saved" and then mail on a schedule the caller did not ask for.
+                if (!Settings.ReportCadences.TryParse(body?.Cadence, out var cadence))
+                    return Results.BadRequest(new
+                    {
+                        error = $"body {{ \"cadence\": \"...\" }} is required, one of: {string.Join(", ", Settings.ReportCadences.AllNames)}",
+                    });
+
+                host.TenantSettingsResolver.SetDailyReportCadence(t.Value, cadence, DateTime.UtcNow);
+                FileLog.Write($"[SettingsEndpoints] daily_report_cadence set to {Settings.ReportCadences.Name(cadence)} for tenant={t.Value.ToLogString()}");
+                return Results.Json(new { cadence = Settings.ReportCadences.Name(cadence) });
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[SettingsEndpoints] PUT /gateway/daily-report bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
         });
 
         // The per-user default snooze length in minutes (Snooze Length mission,
@@ -590,4 +638,5 @@ internal static class SettingsEndpoints
     private sealed record SnoozeDefaultBody(int? Minutes);
     private sealed record SnoozePresetsBody(int[]? Presets, int? DefaultMinutes);
     private sealed record TimeZoneBody(string? TimeZone);
+    private sealed record DailyReportBody(string? Cadence);
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2553,8 +2553,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // (the caller is a server with no device key); it carries its own bearer service token from
         // REPORT_SERVICE_TOKEN and resolves the named account to exactly one tenant. Read-only.
         Api.MorningReportEndpoint.Map(_app, _morningReport, TenantRegistry, _tenantBoundary);
-        // Who that report goes to: every account on this Gateway, behind the same service token.
-        Api.ReportRecipientsEndpoint.Map(_app, TenantRegistry);
+        // Who that report goes to: every account on this Gateway that has an address and has not turned the
+        // report off (issue #1000), behind the same service token.
+        Api.ReportRecipientsEndpoint.Map(_app, TenantRegistry, _tenantSettingsResolver);
 
         // Gateway Centralization Phase 2 (issue #638): GET /account/status answers "is the Gateway
         // signed in to DevThrottle, and as whom?" computed ENTIRELY LOCALLY from the Gateway-hosted

--- a/src/CcDirector.Gateway/Settings/ReportCadence.cs
+++ b/src/CcDirector.Gateway/Settings/ReportCadence.cs
@@ -1,0 +1,71 @@
+namespace CcDirector.Gateway.Settings;
+
+/// <summary>
+/// How often an account wants the daily report email (issue #1000, follow-up to the wizard removal in
+/// devthrottle_internal#996).
+///
+/// WHY THIS IS AN ENUM AND NOT A BOOLEAN. The question is "how often", and it has a third answer already
+/// waiting: weekly, once <c>MorningReportBuilder</c> can summarize a range instead of one calendar day. A
+/// boolean would have to become a name to admit that answer, rewriting every stored row; a name absorbs it.
+/// Weekly is deliberately NOT a member yet - a member here is a promise the sender can keep, and today it
+/// could only mail one day's report on a Monday and call it a week.
+/// </summary>
+public enum ReportCadence
+{
+    /// <summary>One email every morning. The default, and what every account got before this setting existed.</summary>
+    Daily,
+
+    /// <summary>No report email at all. The account said so; it is not the absence of a choice.</summary>
+    Off,
+}
+
+/// <summary>
+/// The stored names for <see cref="ReportCadence"/> and the one place they are parsed and written.
+///
+/// The names are the wire contract in three places at once - the <c>tenant_settings</c> row, the settings
+/// snapshot the cockpit and phone render, and the body of the write - so they are defined once here rather
+/// than spelled out at each end where two of them could drift apart.
+/// </summary>
+public static class ReportCadences
+{
+    /// <summary>The stored/wire name for <see cref="ReportCadence.Daily"/>.</summary>
+    public const string DailyName = "daily";
+
+    /// <summary>The stored/wire name for <see cref="ReportCadence.Off"/>.</summary>
+    public const string OffName = "off";
+
+    /// <summary>
+    /// What an account gets when it has never touched this setting: the report, every day. This is the
+    /// pre-existing behaviour stated as a constant, so turning the setting on for the first time cannot
+    /// silently change what anybody already receives.
+    /// </summary>
+    public const ReportCadence Default = ReportCadence.Daily;
+
+    /// <summary>Every name a caller may write, for validation and for naming them in an error message.</summary>
+    public static readonly IReadOnlyList<string> AllNames = new[] { DailyName, OffName };
+
+    /// <summary>The stored name for a cadence.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">The cadence is not a known member.</exception>
+    public static string Name(ReportCadence cadence) => cadence switch
+    {
+        ReportCadence.Daily => DailyName,
+        ReportCadence.Off => OffName,
+        _ => throw new ArgumentOutOfRangeException(nameof(cadence), cadence, "Unknown report cadence"),
+    };
+
+    /// <summary>
+    /// Parse a stored or submitted name. False for anything unrecognized, so the caller decides what an
+    /// unreadable value means rather than inheriting a lenient parse's guess.
+    /// </summary>
+    public static bool TryParse(string? raw, out ReportCadence cadence)
+    {
+        cadence = Default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case DailyName: cadence = ReportCadence.Daily; return true;
+            case OffName: cadence = ReportCadence.Off; return true;
+            default: return false;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -76,11 +76,24 @@ public static class TenantSettingKeys
     /// </summary>
     public const string DictationEmailCadence = "dictation_email_cadence";
 
+    /// <summary>
+    /// How often this tenant wants the daily report email, stored as the cadence NAME (issue #1000). Like
+    /// <see cref="VoiceModeAll"/> there is no operator global default to fall back to - it is one account's
+    /// choice about one account's mail - and its default is every day, so nothing changes for anyone who
+    /// never opens Settings.
+    ///
+    /// Stored as a NAME rather than a boolean on purpose. The question is "how often", and it already has a
+    /// third answer waiting (weekly, once the report can summarize a range rather than one day). A boolean
+    /// would have to be replaced by a name to admit that third answer, migrating every row already written;
+    /// a name absorbs it as a new value.
+    /// </summary>
+    public const string DailyReportCadence = "daily_report_cadence";
+
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
         WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
-        VoiceModeAll, DictationSuggestionsInDailyEmail, DictationEmailCadence,
+        VoiceModeAll, DictationSuggestionsInDailyEmail, DictationEmailCadence, DailyReportCadence,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -155,6 +155,22 @@ public sealed class TenantSettingsResolver
         }
     }
 
+    /// <summary>
+    /// How often this tenant wants the daily report email (issue #1000). Defaults to
+    /// <see cref="ReportCadences.Default"/> - every day - when the tenant has expressed no choice, which is
+    /// exactly what every account received before the setting existed.
+    ///
+    /// AN UNREADABLE VALUE ALSO READS AS DAILY, and that direction is deliberate. The two ways to be wrong
+    /// are not symmetric: sending a report somebody silenced is visible to them and the mail carries its own
+    /// way out, while silencing a report somebody wants is invisible - they simply stop hearing from the
+    /// product and have nothing to act on. It also makes a Gateway rollback safe: a value written by a newer
+    /// Gateway that this one does not know yet (weekly, when it lands) degrades to mail, not to silence.
+    /// </summary>
+    public ReportCadence DailyReportCadence(TenantId tenant)
+        => ReportCadences.TryParse(_store.Get(tenant, TenantSettingKeys.DailyReportCadence), out var cadence)
+            ? cadence
+            : ReportCadences.Default;
+
     // ---- writes: validate like the global setters, then persist a per-tenant override -------------------
 
     /// <summary>Set the tenant's wingman model for a role.</summary>
@@ -248,6 +264,12 @@ public sealed class TenantSettingsResolver
     /// <summary>Set whether pending suggestions are mentioned in this tenant's daily report email.</summary>
     public void SetSuggestionsInDailyEmail(TenantId tenant, bool include, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.DictationSuggestionsInDailyEmail, include ? "true" : "false", nowUtc);
+
+    /// <summary>Set how often this tenant wants the daily report email. Daily is stored EXPLICITLY rather
+    /// than by clearing the override, so "back to daily" is a choice this account made and reads the same as
+    /// one it never touched - and so a later look at the store can tell the two apart.</summary>
+    public void SetDailyReportCadence(TenantId tenant, ReportCadence cadence, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.DailyReportCadence, ReportCadences.Name(cadence), nowUtc);
 
     /// <summary>Record this tenant's daily-email cadence state after a mention is emitted.</summary>
     public void SetDictationEmailCadence(TenantId tenant, DictationEmailCadenceState state, DateTime nowUtc)


### PR DESCRIPTION
## What this is

The daily report cadence becomes a per-account setting rather than a fixed daily send.

- The Gateway stores the choice (`ReportCadence`, a new tenant setting key) and resolves it per tenant.
- An account that has chosen "off" is dropped from the recipient list.
- Settings gains a **Daily report** card on the Notifications tab.

The card lives in `packages/client-core/src/settings/`, the shared settings, so the Cockpit and the phone both show it. That is the point: a setting added to one shell only would be exactly the drift the settings rule exists to prevent.

## Test coverage

Both halves are covered, and the tests state why each is needed:

- Gateway side - the cadence is stored, resolved per tenant, and an account holding "off" is dropped from recipients.
- Card side - the card shows the account its current answer and sends the one it clicked. A card that rendered the wrong radio, or sent nothing, would leave every Gateway test green while the person looking at Settings believed the opposite of what is true.

## Why it is a draft

Recovered from an uncommitted working tree during a repository hygiene pass, so the work is tracked and continuous integration can judge it rather than sitting on disk where a single clean would end it.

It has not been reviewed and it has not been run. The only signal so far is whatever continuous integration reports on this branch. No database migration is involved.