### PR TITLE
docs: the design records that were only ever on one disk

### DIFF
--- a/docs/HANDOVER-driver-activity-ledger-and-semantic-working-2026-07-24.md
+++ b/docs/HANDOVER-driver-activity-ledger-and-semantic-working-2026-07-24.md
@@ -1,0 +1,534 @@
+# Handover — Gateway activity ledger and trustworthy agent `Working` state (2026-07-24)
+
+## Status
+
+Design and incident investigation only. No product code, tests, migrations, or deployment were
+changed in the originating session.
+
+The next agent owns implementation. Start from a fresh worktree at the latest `origin/main`; this
+shared checkout contains unrelated user work and must not be cleaned or reset.
+
+## Read this first
+
+This feature started with a false snooze interruption. The eight-hour timer was correct. A
+background terminal-output event was classified as real agent work, and the Gateway deliberately
+deleted the armed snooze because its current rule is “work ends a snooze.”
+
+Do not change snooze arithmetic, add another timer, or special-case Claude Code. The owner’s
+decisions are:
+
+1. DevThrottle supports multiple agents. Agent-specific interpretation belongs behind the driver
+   abstraction, never in shared code as `if Claude`, `if Codex`, and so on.
+2. Avoid a broad or clever state-machine rewrite. Prove a narrower activity rule before making it
+   authoritative.
+3. The hosted Gateway owns durable fleet history. Store the activity/turn audit there, tenant
+   scoped, with unbounded retention for now. A purge policy can be decided later.
+4. Preserve a safe fallback for any driver that has not been verified.
+5. The first production increment must be observational only: persist the evidence and run the new
+   classification in shadow mode without changing `ActivityState`, Cockpit, voice, or snooze
+   behavior.
+
+## Incident and established root cause
+
+Affected session:
+
+- Director session: `abddd91b-5faf-4450-9e54-db0ec4293bca`
+- Director: `a4f518a4-ea96-4827-a9a6-796c462b3cc9`
+- Machine: `SOREN`
+- Session number/name in Cockpit: `108`, `cc-consult - clickfunnels new`
+- Screenshot: `D:\Personal\OneDrive\Pictures\Screenshots\Screenshot 2026-07-24 090201.png`
+
+All times below are 24 July 2026 in Toronto/EDT:
+
+1. At 7:41:50 a.m. Cockpit submitted an armed snooze for `480` minutes.
+2. Gateway stored the correct deadline: 3:41:50 p.m.
+3. At 7:56:12 a.m. the Director reported `Working`.
+4. `SnoozeLandingObserver` called `ClearIfArmed`; the snooze entry was deleted.
+5. At 7:56:46 a.m. the session returned to `Needs you`.
+6. At 9:02 a.m. Cockpit showed `waiting 1h 5m`. That was the age of the red state since
+   7:56:46, not the snooze duration.
+
+The same session had armed snoozes cleared by `Working` at 6:56:49, 7:26:49, and 7:56:12—almost
+exactly a 30-minute cadence. The screenshot showed one background shell still running. There was
+no new owner turn, transcript message, or token activity at the final transition. This strongly
+identifies periodic output from the background watcher or the agent TUI’s status/footer for that
+watcher.
+
+Be precise in future reporting: bytes were emitted **out of** the ConPTY. Nothing proves that bytes
+were injected into the terminal. The Gateway log did not retain the exact ANSI payload, so the
+precise repaint text cannot be reconstructed from the Gateway record. That missing evidence is one
+reason for this feature.
+
+The relevant diagnostic copy from the investigation is:
+
+```text
+.temp/gateway-director-2026-07-24-live.log
+```
+
+Important lines:
+
+- `32981`: armed snooze stored until `2026-07-24T19:41:50.8969981Z`
+- `32987`: `POST /sessions/{sid}/hold -> 200`
+- `39692-39693`: armed snooze deleted because the session was reported working
+- `39697-39698`: blue/Working display fold
+- `39908`: red clock started at `2026-07-24T11:56:46.4961600Z`
+
+The temporary log is investigation evidence, not a source file to commit.
+
+## Current code path
+
+### The false `Working` start
+
+`src/CcDirector.Core/Wingman/TerminalStateDetector.cs`
+
+- Its default rule is: any ConPTY output byte means `Working`.
+- Ten seconds with no output means `WaitingForInput`.
+- It contains a screen-body comparison path for drivers that declare
+  `EmitsContinuousIdleOutput`, but the shared rule remains raw-byte based for most drivers.
+- A Director-induced resize repaint has a short suppression window, but arbitrary TUI/background
+  repaint does not.
+
+### Real submissions are already observable
+
+`src/CcDirector.Core/Sessions/Session.cs`
+
+- `SendInput` detects CR/LF and sets `ActivityState.Working`.
+- `SendTextAsync` sets `ActivityState.Working` after the shared submit protocol succeeds.
+- Those paths cover desktop typing, Cockpit, voice, queue/framework sends, and agent-to-agent
+  prompts when their call sites are correctly tagged.
+- `LastOwnerTurnAtUtc` separately records whether the owner drove the turn. Do not conflate owner
+  identity with whether a turn exists.
+
+`src/CcDirector.Core/Backends/GitHubActionsBackend.cs`
+
+- Remote backends can already report explicit activity through `ActivitySink`.
+
+These facts support the hypothesis that terminal output should maintain an already-open turn but
+should not automatically create a new turn from a settled state for a verified driver.
+
+### Driver boundary
+
+`src/CcDirector.Core/Drivers/IAgentDriver.cs`
+
+- Drivers are stateless, shared behavior bundles.
+- `EmitsContinuousIdleOutput` is an existing terminal-behavior trait, but it is too narrow to be
+  the final semantic contract.
+- Any stateful activity classifier must be instantiated per session; do not put mutable per-session
+  state on the shared driver singleton.
+
+`src/CcDirector.Core/Drivers/AgentDrivers.cs`
+
+- This is the registry for Claude, Codex, Gemini, Pi, Cursor, Copilot, OpenCode, Grok, and generic
+  drivers.
+- No shared detector should switch on `AgentKind`. The registry/driver supplies the behavior.
+
+### Snooze cancellation
+
+`src/CcDirector.Gateway/Snooze/SnoozeLandingObserver.cs`
+
+- `Working` or `Starting` calls `ClearIfArmed`.
+- The source comments explicitly acknowledge that another agent’s message or a bare terminal
+  repaint can be misread as work, but the current policy still deletes an armed snooze.
+
+`src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs`
+
+- `ClearIfArmed` removes the durable snooze entry. This is not timer expiry.
+
+`src/CcDirector.Gateway.Tests/SnoozeLandingObserverTests.cs` and
+`src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs`
+
+- Tests currently require an armed snooze to be deleted on `Working`.
+- The end-to-end test also requires `SnoozeExpired=false`, so Cockpit shows no “Snooze ended”
+  badge for activity cancellation.
+
+Do not change this Gateway policy in the first implementation. First make the upstream `Working`
+fact trustworthy and prove it.
+
+### Existing durable Gateway history
+
+`src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs`
+
+- The Gateway already owns the fleet-wide prompt/reply history.
+- It is tenant partitioned and intentionally retained forever.
+- The Director captures and pushes; the Gateway keeps the single durable copy.
+
+`src/CcDirector.Core/Storage/ConversationIngestor.cs`,
+`src/CcDirector.ControlApi/GatewayPromptSink.cs`, and
+`src/CcDirector.Gateway/Prompts/PromptEndpoints.cs`
+
+- These are the reference pattern for Director capture, authenticated Gateway ingestion,
+  acknowledgement, retry, and tenant-scoped storage.
+
+Do not overload `PromptRecord` with state transitions. Conversation history and activity evidence
+have different lifecycles and cardinality. Link them when possible, but keep a separate activity
+ledger.
+
+## Feature objective
+
+Build a durable, tenant-scoped Gateway activity ledger that can answer:
+
+- What caused each session to enter or leave `Working`?
+- Was there a submitted turn, an explicit backend event, or only terminal output?
+- Which driver and detector version made the decision?
+- Did a transcript/reply later prove that a real turn occurred?
+- Was a snooze active, and why did the Gateway end it?
+- What bounded terminal evidence changed during an output-only anomaly?
+
+Use that ledger to shadow-test a submission-gated activity-start rule. Only after a driver passes
+the acceptance gates should it opt into the new authoritative behavior.
+
+## Required implementation sequence
+
+### Increment 1 — Gateway activity ledger and shadow evidence only
+
+This increment must not change any current state transition.
+
+#### Contracts
+
+Add a dedicated contract in `CcDirector.Gateway.Contracts`, for example:
+
+```csharp
+public sealed record ActivityEventRecord
+{
+    public required Guid EventId { get; init; }
+    public required long DirectorSequence { get; init; }
+    public required DateTime OccurredUtc { get; init; }
+    public required string DirectorId { get; init; }
+    public required string SessionId { get; init; }
+    public string? Machine { get; init; }
+    public string? AgentKind { get; init; }
+    public string? ContextId { get; init; }
+    public required string EventType { get; init; }
+    public string? PreviousState { get; init; }
+    public string? NewState { get; init; }
+    public required string Cause { get; init; }
+    public string? InputOrigin { get; init; }
+    public string? SendSource { get; init; }
+    public string? DetectorMode { get; init; }
+    public string? DetectorVersion { get; init; }
+    public long? TranscriptGeneration { get; init; }
+    public long? OutputByteCount { get; init; }
+    public string? BeforeScreenHash { get; init; }
+    public string? AfterScreenHash { get; init; }
+    public string? BoundedScreenDiff { get; init; }
+}
+```
+
+Names may improve during implementation, but preserve the facts. Use closed constants/enums for
+event type and cause rather than arbitrary strings where the wire format permits it.
+
+Minimum event types:
+
+- `turn-submitted`
+- `backend-activity-started`
+- `terminal-output-while-settled`
+- `activity-transition`
+- `turn-observed-in-transcript`
+- `turn-completed`
+- `session-exited`
+- `snooze-created`
+- `snooze-landed`
+- `snooze-ended`
+
+Minimum causes:
+
+- `owner-submit`
+- `agent-submit`
+- `framework-submit`
+- `backend-signal`
+- `terminal-output-only`
+- `quiet-threshold`
+- `driver-completion`
+- `owner-turn`
+- `manual-release`
+- `timer-expired`
+- `session-exit`
+- `working-observation`
+
+#### Durable store
+
+Create a new tenant-scoped `activity_events` table through `GatewayDatabase`/EF Core rather than an
+in-memory ring.
+
+Requirements:
+
+- Derive the entity from `TenantScopedEntity`.
+- Add it to `GatewayDbContext` and `ApplyTenantScope`.
+- Add matching SQLite and PostgreSQL migrations/snapshots.
+- Primary key: code-generated `EventId`.
+- Enforce idempotency per tenant. A retried batch must not duplicate events.
+- Index `(tenant_id, session_id, occurred_utc)`.
+- Index `(tenant_id, director_id, director_sequence)`.
+- Index `(tenant_id, event_type, occurred_utc)` for shadow analysis.
+- Retention is unbounded in this increment. Add no sweeper or cap.
+
+Do not reuse `DirectorEventLog`; that is an in-memory, capped diagnostic ring. Do not reuse the
+governance event ledger; agent activity is a different domain and volume.
+
+#### Ingestion
+
+Add an authenticated batch endpoint, for example:
+
+```text
+POST /activity-events/batch
+```
+
+Requirements:
+
+- Resolve the tenant at the authenticated Gateway boundary.
+- Hosted unresolved tenant: 403, never Local.
+- Self-host: `TenantId.Local`.
+- Validate bounded field lengths and batch size.
+- Return the number accepted plus enough acknowledgement for the Director to drop acknowledged
+  outbox records.
+- Duplicate event IDs are successful idempotent replays, not errors.
+- Add hostile two-tenant tests: tenant A cannot read, overwrite, or collide with tenant B.
+
+Add a tenant-scoped read endpoint for diagnosis, filtered by session and UTC range. It is not
+necessary to build a Cockpit page in the first increment.
+
+#### Director producer and retry
+
+The Director sees the raw facts and must emit them:
+
+- submission events at the existing input choke points;
+- backend activity events;
+- terminal-output-only candidate starts;
+- actual `ActivityState` transitions;
+- transcript observations at conversation ingest.
+
+Use a temporary durable outbox until the Gateway acknowledges each event. The Gateway remains the
+only durable history; the outbox is delivery state and deletes acknowledged records. Activity
+events cannot always be reconstructed from an agent transcript, so an in-memory-only retry is not
+sufficient if “keep the history” is the contract.
+
+Event IDs and Director sequence values must be minted once before entering the outbox and preserved
+across retries.
+
+#### Gateway-produced snooze events
+
+The Gateway itself owns snooze decisions, so it must append its own events to the same ledger:
+
+- request accepted/deferred/armed, including requested minutes and deadline;
+- deferred snooze landed;
+- owner turn superseded it;
+- manual release;
+- timer expiry;
+- session exit;
+- deletion caused by a `Working` observation.
+
+Include the prior snooze state, resulting state, deadline, and end reason. This would have made the
+July 24 incident self-explanatory without reconstructing it from free-text logs.
+
+#### Bounded terminal evidence
+
+Do not upload or retain every PTY byte.
+
+For `terminal-output-while-settled`, retain:
+
+- byte count;
+- before/after normalized screen hashes;
+- a bounded normalized changed-row diff or snapshot;
+- whether the cursor/body changed;
+- whether the event was inside a Director resize-suppression window.
+
+Prompt text is already tenant-scoped customer history, but terminal evidence can contain secrets.
+Keep it tenant scoped, bounded, and absent from ordinary process logs. Do not log raw tenant IDs or
+terminal content to hosted application logs.
+
+### Increment 2 — Shadow activity-start classification
+
+Still do not change authoritative `ActivityState`.
+
+For every current transition into `Working`, compute a shadow cause:
+
+1. A successful submission was observed.
+2. An explicit backend activity start was observed.
+3. Only terminal output was observed while the session was settled.
+4. The driver cannot decide (`unknown`).
+
+Recommended driver-facing shape:
+
+```csharp
+public enum AgentActivityEvidence
+{
+    Unknown,
+    Working,
+    Settled,
+}
+```
+
+If stateful interpretation is required, add a per-session tracker created by the driver, for
+example `IAgentDriver.CreateActivityTracker(...)`. Drivers are shared singletons; mutable tracker
+state must not live on `IAgentDriver` itself.
+
+The shared detector consumes evidence. It must not switch on `AgentKind`.
+
+Shadow output belongs in the Gateway activity ledger, not only `FileLog`. Include detector version
+and driver kind so results remain interpretable after upgrades.
+
+### Increment 3 — Live and replay verification
+
+Do not enable new behavior based only on unit tests.
+
+#### Replay
+
+Use `TerminalSessionRecorder` captures and `TurnReviewLog` records as replay inputs. Add the July 24
+incident capture if it can be recovered from the `SOREN` machine.
+
+For each replay, compare:
+
+- current raw-byte decision;
+- shadow driver decision;
+- known submission events;
+- transcript generation/reply evidence;
+- final prompt-ready state.
+
+The incident replay must classify the periodic watcher/footer output as
+`terminal-output-while-settled`, not a submitted turn.
+
+#### Live driver harness
+
+Run the same contract against every installed driver intended to opt in:
+
+1. Normal typed prompt.
+2. Cockpit prompt.
+3. Voice/dictation prompt.
+4. Queue/framework prompt.
+5. Agent-to-agent prompt.
+6. A 45–60 second silent reasoning/tool interval.
+7. Continuous streaming output.
+8. Permission request.
+9. Cancel and interrupt.
+10. Process exit and restart.
+11. Terminal resize/reconnect/full repaint.
+12. An idle background shell printing periodically for at least one hour.
+
+Independent ground truth is required:
+
+- successful submission timestamps establish turn start;
+- agent transcript/rollout completion records establish completion where available;
+- controlled helpers create external `started` and `finished` markers around long silent work;
+- the activity classifier’s own answer is never its test oracle.
+
+#### Acceptance gates per driver
+
+A driver may opt into new authoritative behavior only when:
+
+- every observed real turn has a recognized start before its first reply;
+- every transcript-generation increment has a preceding shadow `Working`;
+- no controlled silent turn becomes settled before its external `finished` marker;
+- idle footer/background/resize output creates zero shadow turns;
+- permission, cancel, exit, and restart scenarios match the expected lifecycle;
+- reconnect and Gateway retry do not duplicate or reorder its durable ledger.
+
+Any unexplained `current=Working, shadow=Settled` disagreement blocks that driver.
+
+### Increment 4 — Per-driver authoritative opt-in
+
+Only after a driver passes Increment 3:
+
+- Expose a driver activity-start policy such as `TerminalOutputFallback` versus
+  `SubmissionGated`.
+- Default remains `TerminalOutputFallback`. Unverified and generic drivers keep today’s behavior.
+- For `SubmissionGated`, terminal bytes may maintain an already-open turn and refresh the existing
+  quiet observation, but terminal output alone may not create a turn from a settled state.
+- A successful submission or explicit backend/driver signal starts `Working`.
+- `Unknown` during an open turn must preserve `Working`; uncertainty must not hide active work.
+
+Keep the current quiet/end behavior in the first authoritative cut unless a driver has independently
+verified positive completion evidence. Do not combine the snooze incident fix with a fleet-wide
+completion-classifier rewrite.
+
+### Increment 5 — Snooze regression proof
+
+Add end-to-end coverage:
+
+1. Arm an eight-hour snooze.
+2. Emit periodic background/footer terminal output.
+3. Assert the session remains snoozed and the ledger records ignored output evidence.
+4. Submit a genuine new turn through a verified driver.
+5. Assert the session enters `Working`.
+6. Under the current Gateway policy, assert the armed snooze ends with the durable reason
+   `working-observation`.
+7. Separately prove normal deadline expiry and manual release.
+
+The test must assert the Gateway ledger, registry state, session DTO, and Cockpit-facing fields agree.
+
+## Secondary bug discovered during the incident
+
+The first snooze attempt at 6:40 a.m. exposed a separate `/hold` race:
+
+- the hold endpoint used a stale pushed-session owner-turn baseline;
+- the observer removed the snooze 172 ms after it was written;
+- the endpoint still returned HTTP 200 from its local `decided` value;
+- a second click was required.
+
+This is real but is not the cause of the 7:41 snooze cancellation. Do not bundle its fix into the
+activity-ledger feature. The ledger should make the race visible; fix it in a separately reviewed
+change by re-reading authoritative snooze state before responding or making baseline/write
+validation atomic.
+
+## Explicit non-goals
+
+- No Claude-specific condition in shared code.
+- No immediate fleet-wide switch away from raw-byte fallback.
+- No snooze-duration or clock changes.
+- No new Cockpit activity-history page in the first increment.
+- No storage of every raw PTY byte.
+- No retention/purge policy in the first increment.
+- No attempt to infer owner identity from output.
+- No bundling of the `/hold` response race.
+
+## Minimum test suites
+
+At minimum, add or extend:
+
+- Core activity tracker/detector unit tests.
+- One contract suite exercised by every registered driver/tracker.
+- Session submission-origin tests for raw Enter and `SendTextAsync`.
+- Director outbox retry/idempotency tests.
+- Gateway activity store tests on SQLite.
+- PostgreSQL migration/model tests.
+- Hosted two-tenant isolation tests.
+- Endpoint authentication and batch validation tests.
+- Snooze observer/end-to-end tests.
+- Recorded terminal replay tests.
+- Live harness instructions and captured results for each opted-in driver.
+
+Run the full Core and Gateway test suites before merge. Treat a driver opt-in as a separate reviewable
+change from the ledger/shadow infrastructure.
+
+## Delivery order
+
+Prefer separate PRs:
+
+1. Contracts, tenant-scoped Gateway ledger, migrations, endpoints, and isolation tests.
+2. Director activity producer, durable outbox, Gateway acknowledgement, and shadow events.
+3. Replay/live harness and per-driver verification evidence.
+4. First verified driver opt-in plus snooze regression test.
+5. Additional driver opt-ins, one or a small compatible group at a time.
+
+Deploy the ledger/shadow increments before any behavior change and collect hosted evidence across
+normal work. The behavior PR must cite that evidence and list which driver acceptance gates passed.
+
+## Definition of done
+
+The feature is done only when:
+
+- the hosted Gateway durably retains tenant-scoped activity and snooze lifecycle events;
+- retry/reconnect cannot lose or duplicate events;
+- the July 24 failure is diagnosable from structured history without free-text log archaeology;
+- at least one driver has passed replay and live acceptance gates;
+- that driver ignores idle background/footer output without missing any controlled real turn;
+- unverified drivers retain the safe current fallback;
+- snooze timer behavior remains unchanged and covered;
+- the deployed hosted version is verified against the merged commit.
+
+## Hard rules
+
+- Preserve unrelated work in the shared checkout.
+- Use a fresh worktree from current `origin/main`.
+- Verify current source and deployed behavior; this handover records the July 24 state and may age.
+- Keep all hosted reads/writes tenant scoped and deny unresolved hosted tenants.
+- Do not add authorship or generation attribution.

--- a/docs/MISSION-cockpit-fix-2026-07-23.md
+++ b/docs/MISSION-cockpit-fix-2026-07-23.md
@@ -1,0 +1,71 @@
+# Mission: Cockpit Fix (2026-07-23)
+
+## Why (the point of this mission)
+We are relaunching the hosted, multi-tenant Gateway. The Cockpit web app is broken on several
+pages in that hosted environment. Two pages are confirmed broken and are the priority: the
+**Settings** page and the **Your Throttle** (Stats) page. Your job is to get the ENTIRE cockpit
+fully working per-tenant on the hosted Gateway, with the code MERGED to origin/main so it can be
+tested against the live hosted Gateway.
+
+## Definition of done
+- Merged to origin/main is the ONLY done. Committed, pushed, or an open pull request are all still
+  in progress. Each page you fix drives all the way to a merged pull request on origin/main.
+- Every page you touch must be built AND tested green before it merges. Merge on green; QA on main.
+- You are allowed to deploy the hosted Gateway as often as you want to verify against it.
+
+## Order of work
+1. **Settings** (first)
+2. **Your Throttle / Stats** (second)
+3. Then sweep every other cockpit page and confirm it works per-tenant on hosted.
+
+## Settings - the implementation already exists, land it
+- The full implementation is on branch **`settings-unify`**, worktree **`D:\ReposFred\devthrottle-unify`**,
+  tip `967e5bfa`. It is a 10-commit stack implementing GitHub issues #2017 + #2022: a per-tenant
+  settings store + resolver + migrations, the collapsed one-per-account Settings page, machine
+  settings moved off the web to the CLI, and retirement of the hosted deny so the routes serve
+  per-tenant. It builds clean and has hostile two-tenant isolation tests.
+- It is built on `settings-per-tenant` (on origin) + a cherry-pick of `mtr/settings-runtime-threading`.
+  It is roughly 16 commits behind current origin/main and NOT pushed.
+- On CURRENT origin/main the whole owner-settings group is DENIED on hosted (#1898) - that is why the
+  Settings page is broken/empty on hosted. This stack is the fix.
+- Task: cut a fresh worktree from origin/main, land the settings-unify work onto it (rebase or
+  re-apply), re-run the gates, open a pull request, merge. Read the full handover first:
+  `docs/HANDOVER-issue-2022-settings-unify-2026-07-22.md` and the auto-memory
+  `issue-2022-settings-unify-mission.md`.
+
+## Your Throttle / Stats - write the fix fresh on origin/main
+- On current origin/main the Stats / Your Throttle page is intentionally DENIED (404) on hosted:
+  `src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs`, method `DenyOnHosted()`, gated on
+  `GatewayHostedMode.IsHosted`.
+- The stats aggregator is ALREADY fully tenant-aware on main: every read takes a `TenantId`
+  (`aggregator.CurrentTotals(tenant)`, `HourlyTurns(tenant)`, `RepoTotals(tenant)`, etc.). The
+  self-host path hardcodes `TenantId.Local`.
+- The fix: on hosted, stop denying; resolve the CALLER's tenant, return 403 if the tenant cannot be
+  resolved (never fall back to Local), and serve that tenant's totals. This mirrors EXACTLY what
+  settings-unify did for the settings routes - use the same tenant-boundary pattern.
+- DO NOT resurrect either of these - both are traps:
+  - branch/worktree `throttle-on` (`4c6ada91`, "demo: serve Your Throttle... override the deny"):
+    a demo hack that rips out the deny and knowingly leaks COMBINED all-tenant totals. Unsafe.
+  - `wip/1848-stats-tenant-partition-not-for-merge`: a stale earlier attempt, ~113 commits behind,
+    superseded by main's own #1848 work. Marked not-for-merge.
+- Write the fix fresh on a worktree cut from current origin/main, with hostile two-tenant tests that
+  prove one tenant cannot read another's throttle.
+
+## Hard rules
+- NEVER work in the shared checkout `D:\ReposFred\devthrottle` (it is ~117 commits behind and other
+  sessions use it). Cut a worktree from origin/main for every piece of work:
+  `git fetch origin` then `git worktree add ../devthrottle-<task> -b <branch> origin/main`.
+- To READ shipped code, read origin/main directly (`git show origin/main:path`), never the stale tree.
+- NO Claude / AI / assistant attribution anywhere - commits, pull requests, issues, comments, docs.
+  The code is the owner's; write commits and pull requests as the owner.
+- A branch lives less than a day; split work so each piece merges the same day.
+- Deploy mechanics for the hosted Gateway are in the auto-memory files
+  `hosted-gateway-azure-deploy-mechanics.md`, `hosted-deploy-by-digest-not-tag.md`, and
+  `hosted-gateway-verify-running-commit.md` (the /healthz version can lie on direct pushes; verify
+  the actual running commit via the ACR digest / live Postgres / file-share logs).
+
+## Coordination
+- A separate session ("repo cleanup", id 40ed) is landing `mtr/g3-paywall-reader-gate` and purging
+  stale branches/worktrees. Do NOT touch the g3-paywall branch or the cleanup branches. If you need
+  something from that work, ask it: `cc-devthrottle message ask 40ed "<question>"`.
+- Ping at milestones (each page merged, each hosted deploy verified).

--- a/docs/MISSION-source-control-tab-2026-07-23.md
+++ b/docs/MISSION-source-control-tab-2026-07-23.md
@@ -1,0 +1,64 @@
+# Mission: Source Control tab + orphaned-worktree reaper in the Director (2026-07-23)
+
+## Why (the point of this mission)
+Worktrees and stranded branches pile up because a merge is a GitHub event and a worktree is a
+local disk artifact, and nothing links the two - so nobody knows what is safe to delete without
+digging by hand. A recent cleanup went from 82 worktrees to 8, all by hand. We want the Director
+to make this visible and one-click safe: a Source Control tab with a red-dot badge and a single
+"Remove N orphaned worktrees" button that only ever removes worktrees whose work is provably on
+origin/main.
+
+## The specification - READ IT FIRST
+The full, build-ready design is GitHub issue **thefrederiksen/devthrottle_internal#503**. Read it
+before writing anything:
+```
+gh issue view 503 --repo thefrederiksen/devthrottle_internal
+```
+Everything below is a pointer to that spec, not a replacement for it. If the spec and this brief
+ever disagree, the issue wins - and tell the owner.
+
+## Where the code lives
+- The Director is the Avalonia desktop app in this repo (`src/CcDirector.Avalonia`), binary
+  `cc-director.exe`. The Source Control tab is a new view there.
+- The worktree/branch detection and the safe-to-reap verdict belong in a testable service (Core or
+  a Gateway-adjacent service), NOT in the view - the view renders what the service decides. Follow
+  the "dumb client" rule in this repo's CLAUDE.md: the verdict is computed once in one place and the
+  view only renders it.
+- The reaper runs git commands (`git worktree list --porcelain`, `git worktree remove`,
+  `git worktree prune`, `git fetch --prune`, `git cherry`, `git ls-remote`).
+
+## Phased plan - prove each phase before the next, each phase merges to origin/main on its own
+1. **Detector service** (no UI): enumerate every worktree for a repo and compute the fail-closed
+   safe-to-reap verdict EXACTLY as the spec defines it (not primary checkout; clean tree; work
+   proven merged by pull-request-merged OR origin-branch-gone OR `git cherry` clean; detached HEAD
+   is an ancestor of origin/main). Unit tests are the heart of this phase: plant a worktree with
+   uncommitted work and prove it is NEVER safe; plant a squash-merged-then-deleted branch and prove
+   it IS safe. This phase carries the two must-pass acceptance tests from the issue.
+2. **Read-only UI**: the Source Control tab with the red-dot badge + count and the two-group listing
+   (safe-to-reap vs needs-attention), plus the copy-to-clipboard report. No delete button yet.
+   Comply with `docs/VisualStyle.md` - all UI changes must.
+3. **The reaper**: the "Remove N orphaned worktrees" button. Re-check safety immediately before
+   acting; remove only the safe set; run `git worktree prune`; and HANDLE the Windows locked-file
+   case (a `git worktree remove` that deregisters the worktree but fails to delete the folder with
+   "Directory not empty" because bin/obj DLLs are locked) - report which folders remain rather than
+   claim success. Log every removal with its proof-of-safety.
+
+## Hard rules
+- Merged to origin/main is the ONLY done. Each phase drives to a merged pull request.
+- NEVER work in the shared checkout `D:\ReposFred\devthrottle`. Cut a worktree from origin/main per
+  piece of work: `git fetch origin` then `git worktree add ../devthrottle-<task> -b <branch> origin/main`.
+- Every phase builds AND tests green before it merges. Merge on green.
+- NO Claude / AI / assistant attribution anywhere - commits, pull requests, issues, comments, docs.
+  Write everything as the owner.
+- Follow this repo's CLAUDE.md: responsive UI (immediate feedback), enterprise logging on public
+  methods, tests for public methods and every bug fix, try-catch at entry points only, no fallback
+  programming (fail closed with a clear message).
+- To TEST the Director UI without killing the owner's running Directors: build to slot 5+
+  (`scripts\local-build-avalonia.ps1 -Slot 5`) and launch via the `cc-director-launch` Windows
+  scheduled task, per CLAUDE.md rule 0b. NEVER taskkill or Stop-Process the owner's Directors.
+
+## Coordination
+- Two other sessions are live on this repo: "repo cleanup" (id 40ed) and "Cockpit Fix". Do NOT touch
+  their branches (anything settings-*, land/settings-*, mtr/*, the open pull requests). Ask if unsure:
+  `cc-devthrottle message ask 40ed "<question>"`.
+- Ping the owner (and 40ed) at each phase merged.

--- a/docs/architecture/gateway-skill-library-mockups-2026-07-28.html
+++ b/docs/architecture/gateway-skill-library-mockups-2026-07-28.html
@@ -1,0 +1,470 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Gateway skill library - mockup screens</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #171a21;
+    --panel-2: #1d222b;
+    --line: #2b313d;
+    --ink: #e6e9ef;
+    --ink-dim: #99a1b0;
+    --ink-faint: #6b7382;
+    --accent: #4d8bf0;
+    --good: #35b37e;
+    --warn: #d9a441;
+    --bad: #e05561;
+    --mono: "Cascadia Mono", "Consolas", "Courier New", monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 15px/1.6 "Segoe UI", system-ui, sans-serif;
+    padding: 40px 24px 80px;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; }
+  h1 { font-size: 30px; margin: 0 0 6px; letter-spacing: -0.01em; }
+  .sub { color: var(--ink-dim); margin: 0 0 8px; }
+  .meta { color: var(--ink-faint); font-size: 13px; margin: 0 0 40px; }
+  h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: 0.12em;
+    color: var(--ink-faint); margin: 56px 0 6px; font-weight: 600;
+  }
+  h2 .num { color: var(--accent); }
+  .lead { color: var(--ink-dim); margin: 0 0 18px; max-width: 78ch; }
+  .note {
+    border-left: 3px solid var(--accent); background: rgba(77,139,240,0.07);
+    padding: 12px 16px; margin: 18px 0; color: var(--ink-dim); max-width: 82ch;
+  }
+  .note b { color: var(--ink); }
+
+  /* window chrome */
+  .win { border: 1px solid var(--line); border-radius: 8px; overflow: hidden; background: var(--panel); }
+  .titlebar {
+    background: var(--panel-2); border-bottom: 1px solid var(--line);
+    padding: 9px 14px; font-size: 13px; color: var(--ink-dim);
+    display: flex; align-items: center; gap: 10px;
+  }
+  .dots { display: flex; gap: 6px; }
+  .dot { width: 10px; height: 10px; border-radius: 50%; background: #3a4150; }
+  .crumb { color: var(--ink-faint); }
+  .crumb b { color: var(--ink); font-weight: 600; }
+
+  .body { display: flex; min-height: 380px; }
+  .rail { width: 190px; border-right: 1px solid var(--line); padding: 14px 0; background: #13161c; flex: none; }
+  .rail div { padding: 8px 18px; color: var(--ink-dim); font-size: 14px; }
+  .rail div.on { color: var(--ink); background: rgba(77,139,240,0.12); border-left: 2px solid var(--accent); padding-left: 16px; }
+  .main { flex: 1; padding: 22px 26px; min-width: 0; }
+
+  .head-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 4px; }
+  .screen-h { font-size: 20px; font-weight: 600; margin: 0; }
+  .screen-p { color: var(--ink-dim); font-size: 14px; margin: 4px 0 20px; max-width: 62ch; }
+
+  .btn {
+    background: var(--accent); color: #fff; border: 0; border-radius: 5px;
+    padding: 8px 14px; font-size: 13px; font-weight: 600; white-space: nowrap;
+  }
+  .btn.ghost { background: transparent; border: 1px solid var(--line); color: var(--ink-dim); }
+  .btn.sm { padding: 5px 10px; font-size: 12px; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  th {
+    text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.09em;
+    color: var(--ink-faint); font-weight: 600; padding: 0 12px 9px 0; border-bottom: 1px solid var(--line);
+  }
+  td { padding: 12px 12px 12px 0; border-bottom: 1px solid #21262f; vertical-align: top; }
+  td.name { color: var(--ink); font-weight: 600; white-space: nowrap; }
+  td.desc { color: var(--ink-dim); }
+  .tag {
+    display: inline-block; font-size: 11px; padding: 2px 7px; border-radius: 3px;
+    border: 1px solid var(--line); color: var(--ink-faint); margin-left: 8px; font-weight: 500;
+  }
+  .tag.yours { border-color: rgba(77,139,240,0.5); color: #7fb0ff; }
+  .tag.edited { border-color: rgba(217,164,65,0.5); color: var(--warn); }
+  .sw { font-size: 12px; font-weight: 600; white-space: nowrap; }
+  .sw.on { color: var(--good); }
+  .sw.off { color: var(--ink-faint); }
+  .ver { font-family: var(--mono); font-size: 12px; color: var(--ink-faint); white-space: nowrap; }
+
+  .banner {
+    border: 1px solid rgba(217,164,65,0.45); background: rgba(217,164,65,0.09);
+    border-radius: 6px; padding: 12px 15px; margin-bottom: 18px;
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  }
+  .banner p { margin: 0; font-size: 13px; color: #e8cd97; }
+  .banner p b { color: #f5e3bd; }
+
+  .field { margin-bottom: 16px; }
+  .lbl { font-size: 11px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--ink-faint); margin-bottom: 5px; font-weight: 600; }
+  .inp {
+    border: 1px solid var(--line); background: #12151a; border-radius: 5px;
+    padding: 9px 12px; font-size: 14px; color: var(--ink);
+  }
+  .inp.mono { font-family: var(--mono); font-size: 13px; }
+  .editor {
+    border: 1px solid var(--line); background: #0d1015; border-radius: 5px;
+    padding: 14px; font-family: var(--mono); font-size: 12.5px; line-height: 1.65;
+    color: #c8cedb; white-space: pre-wrap; min-height: 190px;
+  }
+  .editor .h { color: #7fb0ff; }
+  .editor .c { color: var(--ink-faint); }
+
+  .two { display: flex; gap: 22px; align-items: flex-start; }
+  .two .left { flex: 1; min-width: 0; }
+  .two .right { width: 270px; flex: none; }
+  .vhist { border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+  .vhist .vh { background: var(--panel-2); padding: 8px 13px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--ink-faint); font-weight: 600; }
+  .vrow { padding: 10px 13px; border-top: 1px solid #21262f; font-size: 13px; }
+  .vrow.cur { background: rgba(53,179,126,0.07); }
+  .vrow .vn { font-family: var(--mono); font-size: 12px; color: var(--ink); }
+  .vrow .vd { color: var(--ink-faint); font-size: 12px; }
+  .vrow .vcur { color: var(--good); font-size: 11px; font-weight: 600; }
+
+  .term {
+    background: #0a0c10; border: 1px solid var(--line); border-radius: 8px;
+    padding: 18px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.7;
+    color: #c8cedb; white-space: pre-wrap; overflow-x: auto;
+  }
+  .term .dim { color: var(--ink-faint); }
+  .term .ok { color: var(--good); }
+  .term .k { color: #7fb0ff; }
+  .term .w { color: var(--warn); }
+
+  .cmp { display: flex; gap: 18px; }
+  .cmp > div { flex: 1; border: 1px solid var(--line); border-radius: 8px; padding: 16px 18px; background: var(--panel); min-width: 0; }
+  .cmp h4 { margin: 0 0 4px; font-size: 14px; }
+  .cmp .tagline { font-size: 12px; color: var(--ink-faint); margin: 0 0 12px; }
+  .cmp ul { margin: 0; padding-left: 18px; color: var(--ink-dim); font-size: 13.5px; }
+  .cmp li { margin-bottom: 7px; }
+  .cmp.before h4 { color: var(--bad); }
+  .cmp.after h4 { color: var(--good); }
+
+  .q { border: 1px solid var(--line); border-radius: 8px; padding: 18px 20px; background: var(--panel); }
+  .q ol { margin: 0; padding-left: 20px; color: var(--ink-dim); }
+  .q li { margin-bottom: 11px; }
+  .q li b { color: var(--ink); }
+  footer { margin-top: 60px; padding-top: 20px; border-top: 1px solid var(--line); color: var(--ink-faint); font-size: 13px; }
+  @media (max-width: 860px) {
+    .body { flex-direction: column; }
+    .rail { width: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+    .two, .cmp { flex-direction: column; }
+    .two .right { width: auto; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Skills live on the Gateway</h1>
+  <p class="sub">Mockup screens for devthrottle_internal issue 995.</p>
+  <p class="meta">2026-07-28 &middot; these are pictures to argue with, not a specification &middot; nothing here is built</p>
+
+  <div class="note">
+    <b>The idea in one line.</b> The Gateway holds every skill and serves it over a REST interface.
+    An agent arrives knowing only that the library exists. Nothing is installed on any machine,
+    so fixing a skill is an edit on the server that is live everywhere at once - no release, no
+    re-install, no drift between machines.
+  </div>
+
+  <!-- ============================ SCREEN 1 ============================ -->
+  <h2><span class="num">Screen one</span> &nbsp;/&nbsp; The skills register</h2>
+  <p class="lead">
+    Settings gets a Skills page, sitting beside Workflows. Same shelf, separate list: a workflow
+    governs how a whole mission is run, a skill is a capability an agent reaches for mid-task.
+  </p>
+
+  <div class="win">
+    <div class="titlebar">
+      <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+      <span class="crumb">DevThrottle &nbsp;/&nbsp; Settings &nbsp;/&nbsp; <b>Skills</b></span>
+    </div>
+    <div class="body">
+      <div class="rail">
+        <div>General</div>
+        <div>Notifications</div>
+        <div>Voice and dictation</div>
+        <div>Agents</div>
+        <div>Workflows</div>
+        <div class="on">Skills</div>
+        <div>Instructions</div>
+        <div>Account</div>
+      </div>
+      <div class="main">
+        <div class="head-row">
+          <div>
+            <p class="screen-h">Skills</p>
+            <p class="screen-p">
+              Capabilities every agent on every machine can reach. Edit one here and it is live
+              immediately - nothing is installed locally and nothing needs a release.
+            </p>
+          </div>
+          <button class="btn">New skill</button>
+        </div>
+
+        <table>
+          <tr>
+            <th style="width:24%">Name</th>
+            <th>What it does</th>
+            <th style="width:12%">Version</th>
+            <th style="width:10%">Status</th>
+          </tr>
+          <tr>
+            <td class="name">dev-throttle<span class="tag">built in</span></td>
+            <td class="desc">The product itself - the app, the command line tools, how an agent drives the fleet.</td>
+            <td class="ver">v7</td>
+            <td><span class="sw on">On</span></td>
+          </tr>
+          <tr>
+            <td class="name">fleet-comms<span class="tag">built in</span></td>
+            <td class="desc">Talk to other sessions: list, rename, message, ask, spawn.</td>
+            <td class="ver">v3</td>
+            <td><span class="sw on">On</span></td>
+          </tr>
+          <tr>
+            <td class="name">move-session<span class="tag">built in</span><span class="tag edited">edited</span></td>
+            <td class="desc">Relocate a live session to another Director through the Gateway, with an approval gate.</td>
+            <td class="ver">v5</td>
+            <td><span class="sw on">On</span></td>
+          </tr>
+          <tr>
+            <td class="name">handover<span class="tag">built in</span></td>
+            <td class="desc">Write down where a session stood so a fresh session can pick the work up.</td>
+            <td class="ver">v2</td>
+            <td><span class="sw on">On</span></td>
+          </tr>
+          <tr>
+            <td class="name">repo-hygiene<span class="tag">built in</span></td>
+            <td class="desc">Drive a repository to its target state: everything merged, nothing left lying around.</td>
+            <td class="ver">v4</td>
+            <td><span class="sw off">Off</span></td>
+          </tr>
+          <tr>
+            <td class="name">deploy-gateway<span class="tag yours">yours</span></td>
+            <td class="desc">Release the hosted Gateway and confirm the live service comes back healthy.</td>
+            <td class="ver">v2</td>
+            <td><span class="sw on">On</span></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="note">
+    <b>Why the tags matter.</b> <i>built in</i> means the Gateway shipped it. <i>edited</i> means you
+    changed it, which is what stops an upgrade from silently overwriting your wording - exactly the
+    ours-versus-theirs trade the workflow register already makes. <i>Off</i> keeps everything but
+    hides the skill from every agent.
+  </div>
+
+  <!-- ============================ SCREEN 2 ============================ -->
+  <h2><span class="num">Screen two</span> &nbsp;/&nbsp; Editing a skill</h2>
+  <p class="lead">
+    One document, versioned. Saving makes a draft; publishing makes it live on every machine
+    instantly. Every previous version stays, so a bad edit is one click from undone.
+  </p>
+
+  <div class="win">
+    <div class="titlebar">
+      <div class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+      <span class="crumb">DevThrottle &nbsp;/&nbsp; Settings &nbsp;/&nbsp; Skills &nbsp;/&nbsp; <b>move-session</b></span>
+    </div>
+    <div class="body">
+      <div class="main">
+
+        <div class="banner">
+          <p><b>The shipped version of this skill has changed.</b> You edited move-session, so we
+             left your wording alone. Compare yours with the new default before taking it.</p>
+          <span style="display:flex;gap:8px">
+            <button class="btn ghost sm">Compare</button>
+            <button class="btn sm">Take the new one</button>
+          </span>
+        </div>
+
+        <div class="two">
+          <div class="left">
+            <div class="field">
+              <div class="lbl">Name</div>
+              <div class="inp mono">move-session</div>
+            </div>
+            <div class="field">
+              <div class="lbl">One line - this is all an agent sees until it opens the skill</div>
+              <div class="inp">Relocate a live session to another Director through the Gateway, with an approval gate.</div>
+            </div>
+            <div class="field">
+              <div class="lbl">Triggers</div>
+              <div class="inp mono">move session, migrate session, transfer session</div>
+            </div>
+            <div class="field">
+              <div class="lbl">Body</div>
+              <div class="editor"><span class="h"># move-session</span>
+
+Relocate a live session to another slot or Director. The handover
+goes through the <span class="h">GATEWAY</span>, never machine to machine.
+
+<span class="h">## Before you start</span>
+
+<span class="c">- The target Director must be online and reachable.</span>
+<span class="c">- The source session must not be working.</span>
+<span class="c">- The owner approves the move. Never move a session unasked.</span>
+
+<span class="h">## The steps</span>
+
+1. Ask the Gateway which Directors can accept a session.
+2. Request the move; the seed identifies itself as a moved session.
+3. The target keeps the source's original name...</div>
+            </div>
+            <span style="display:flex;gap:10px;margin-top:4px">
+              <button class="btn">Publish to every machine</button>
+              <button class="btn ghost">Save as draft</button>
+            </span>
+          </div>
+
+          <div class="right">
+            <div class="vhist">
+              <div class="vh">Version history</div>
+              <div class="vrow cur">
+                <div><span class="vn">v5</span> &nbsp; <span class="vcur">LIVE</span></div>
+                <div class="vd">yours &middot; 2026-07-24 &middot; "spell out the approval gate"</div>
+              </div>
+              <div class="vrow">
+                <div><span class="vn">v4</span></div>
+                <div class="vd">shipped &middot; 2026-07-19</div>
+              </div>
+              <div class="vrow">
+                <div><span class="vn">v3</span></div>
+                <div class="vd">yours &middot; 2026-07-11</div>
+              </div>
+              <div class="vrow">
+                <div><span class="vn">v2</span></div>
+                <div class="vd">shipped &middot; 2026-07-02</div>
+              </div>
+            </div>
+            <div class="vhist" style="margin-top:16px">
+              <div class="vh">Reached by</div>
+              <div class="vrow"><div class="vd">14 sessions &middot; 3 machines &middot; 5 agent types</div></div>
+              <div class="vrow"><div class="vd">Last fetched 4 minutes ago</div></div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================ SCREEN 3 ============================ -->
+  <h2><span class="num">Screen three</span> &nbsp;/&nbsp; What the agent side actually looks like</h2>
+  <p class="lead">
+    This is the screen that decides whether the feature works. Today an agent reads whole skill
+    files off disk. Once the library is central, the agent must learn what exists without pulling
+    the whole library into its context.
+  </p>
+
+  <p class="lead" style="color:var(--ink-faint);font-size:13.5px">
+    Injected into every session's launch briefing, next to the workflow paragraph that is already there:
+  </p>
+
+  <div class="term"><span class="dim">[Skills] Capabilities this fleet gives you. The list below is all you get for free -
+fetch the full instructions only when you are about to use one:</span>
+
+  <span class="k">cc-devthrottle skill list</span>              <span class="dim">every skill, one line each</span>
+  <span class="k">cc-devthrottle skill get &lt;name&gt;</span>       <span class="dim">the full instructions - read before you act</span>
+
+  <span class="dim">dev-throttle</span>   the app, the command line tools, how to drive the fleet
+  <span class="dim">fleet-comms</span>    talk to other sessions: list, rename, message, ask, spawn
+  <span class="dim">move-session</span>   relocate a live session to another Director
+  <span class="dim">handover</span>       write down where a session stood so a fresh one can continue
+
+<span class="dim">Skills are held centrally and can change at any time. Fetch, never remember.</span></div>
+
+  <p class="lead" style="margin-top:24px;color:var(--ink-faint);font-size:13.5px">
+    And when the agent actually reaches for one:
+  </p>
+
+  <div class="term"><span class="dim">$</span> cc-devthrottle skill get move-session
+<span class="ok">ok</span> <span class="dim">fetched from gateway &middot; v5 &middot; 2.1 KB &middot; cached 15 min</span>
+
+<span class="k"># move-session</span>
+
+Relocate a live session to another slot or Director. The handover goes
+through the GATEWAY, never machine to machine.
+<span class="dim">...</span></div>
+
+  <div class="note">
+    <b>The one number that decides this feature.</b> The register listing above is roughly 60 words.
+    The four skill bodies behind it are several thousand. If discovery costs the listing and only
+    the used skill costs its body, the library is cheaper than the files it replaces. If an agent
+    ends up pulling everything, it is worse. Every design choice should be checked against that.
+  </div>
+
+  <div class="note" style="border-left-color:var(--warn);background:rgba(217,164,65,0.07)">
+    <b>The unresolved one.</b> What happens when the Gateway is unreachable? A cached copy on the
+    machine is the obvious answer - and it quietly reintroduces the drift this whole feature exists
+    to remove. Whatever the caching rule is, it has to be a decision, not an accident.
+  </div>
+
+  <!-- ============================ SCREEN 4 ============================ -->
+  <h2><span class="num">Screen four</span> &nbsp;/&nbsp; What comes out of the installer</h2>
+  <p class="lead">
+    The point of doing this before the release: ship with no local skill deployment at all, rather
+    than shipping a mechanism we already intend to delete.
+  </p>
+
+  <div class="cmp">
+    <div class="before">
+      <h4>Today</h4>
+      <p class="tagline">tools/cc-director-setup/Services/SkillInstaller.cs</p>
+      <ul>
+        <li>Three skill names hard-coded in an array. A fourth is a code change.</li>
+        <li>Each downloaded from the public repository's raw content at install time.</li>
+        <li>Written to <span style="font-family:var(--mono);font-size:12.5px">%USERPROFILE%\.claude\skills\</span> on every machine.</li>
+        <li>A manifest recorded so uninstall removes exactly ours and not the user's own.</li>
+        <li>Fixing a typo needs a release, then every user has to update to receive it.</li>
+        <li>Only one agent family ever sees them. The rest get nothing.</li>
+      </ul>
+    </div>
+    <div class="after">
+      <h4>After</h4>
+      <p class="tagline">the Gateway serves them</p>
+      <ul>
+        <li>The installer places no skills at all. SkillInstaller is deleted.</li>
+        <li>The skill manifest is deleted. Uninstall has nothing of ours to remove.</li>
+        <li>Adding a skill is a row in a register, not a release.</li>
+        <li>A fix is live on every machine the moment it is published.</li>
+        <li>Every agent gets the same library, not just one family.</li>
+        <li>One paragraph in the launch briefing replaces the whole deployment.</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ============================ QUESTIONS ============================ -->
+  <h2><span class="num">Before any code</span> &nbsp;/&nbsp; What the next session has to settle</h2>
+
+  <div class="q">
+    <ol>
+      <li><b>How does an agent find a skill without reading them all?</b> Screen three proposes a
+          short register in the briefing plus fetch-on-use. It is a proposal, not a decision, and it
+          is the whole feature.</li>
+      <li><b>One markdown document, or a skill with supporting files?</b> The workflow store already
+          has a file entity, so multi-file is available if it earns its place.</li>
+      <li><b>Offline behaviour.</b> Cache and drift, or fail loudly and stay honest. Pick one on
+          purpose.</li>
+      <li><b>Do we copy the workflow register, or extend it?</b> Separate register sharing the
+          storage shape is the recommendation - a skill and a way of working are different things
+          and should not share a list.</li>
+      <li><b>What happens to the skills that stay local?</b> A repository can have its own skills in
+          its own tree. Central and local have to coexist without one shadowing the other silently.</li>
+    </ol>
+  </div>
+
+  <footer>
+    Mockups only. Nothing here is built. Issue: devthrottle_internal 995.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/architecture/hosted-settings-redesign-2026-07-22.html
+++ b/docs/architecture/hosted-settings-redesign-2026-07-22.html
@@ -1,0 +1,692 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The DevThrottle Settings Page - What It Should Be on a Hosted Gateway</title>
+<style>
+  :root {
+    --ink: #14304a;
+    --ink-soft: #3d5570;
+    --paper: #faf9f6;
+    --card: #ffffff;
+    --line: #d9d4c8;
+    --accent: #0e6a8a;
+    --gold: #a87b23;
+    --danger: #a33b2e;
+    --good: #2e7d54;
+    --warn-bg: #fdf6ec;
+    --danger-bg: #fbf0ee;
+    --good-bg: #eef7f1;
+    --mono: "Consolas", "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body { background: var(--paper); color: var(--ink); font: 16px/1.65 "Segoe UI", -apple-system, "Helvetica Neue", Arial, sans-serif; }
+  .page { max-width: 1080px; margin: 0 auto; padding: 0 28px 120px; }
+  h1, h2, h3, h4 { font-family: Georgia, "Iowan Old Style", "Times New Roman", serif; font-weight: 600; color: var(--ink); }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.86em; background: #f0ede5; padding: 1px 5px; border-radius: 3px; color: #24425f; }
+  p { margin: 0 0 14px; }
+  ul, ol { margin: 0 0 14px 24px; }
+  li { margin-bottom: 6px; }
+
+  .masthead { border-bottom: 3px double var(--line); padding: 64px 0 36px; margin-bottom: 8px; }
+  .masthead .kicker { font-family: var(--mono); font-size: 12px; letter-spacing: 2.5px; text-transform: uppercase; color: var(--gold); margin-bottom: 18px; }
+  .masthead h1 { font-size: 42px; line-height: 1.15; margin-bottom: 16px; max-width: 900px; }
+  .masthead .sub { font-size: 19px; color: var(--ink-soft); max-width: 820px; margin-bottom: 28px; }
+  .factline { display: flex; flex-wrap: wrap; gap: 10px 26px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); border-top: 1px solid var(--line); padding-top: 16px; }
+  .factline b { color: var(--ink); font-weight: 600; }
+
+  .chips { display: grid; grid-template-columns: repeat(auto-fit, minmax(215px, 1fr)); gap: 14px; margin: 30px 0 8px; }
+  .chip { background: var(--card); border: 1px solid var(--line); border-top: 3px solid var(--accent); border-radius: 6px; padding: 16px 18px; }
+  .chip .num { font-family: Georgia, serif; font-size: 30px; line-height: 1.1; }
+  .chip .lbl { font-size: 13px; color: var(--ink-soft); margin-top: 4px; }
+  .chip.gold { border-top-color: var(--gold); }
+  .chip.red { border-top-color: var(--danger); }
+  .chip.green { border-top-color: var(--good); }
+
+  .toc { background: var(--card); border: 1px solid var(--line); border-radius: 6px; padding: 24px 28px; margin: 34px 0 10px; columns: 2; column-gap: 44px; }
+  .toc div { break-inside: avoid; margin-bottom: 7px; font-size: 15px; }
+  .toc .n { font-family: var(--mono); font-size: 12px; color: var(--gold); margin-right: 8px; }
+  @media (max-width: 760px) { .toc { columns: 1; } }
+
+  section { margin-top: 74px; }
+  .sec-head { display: flex; align-items: baseline; gap: 18px; border-bottom: 2px solid var(--ink); padding-bottom: 10px; margin-bottom: 24px; }
+  .sec-head .n { font-family: Georgia, serif; font-size: 46px; color: var(--line); line-height: 1; }
+  .sec-head h2 { font-size: 29px; }
+  h3 { font-size: 21px; margin: 34px 0 12px; }
+  h4 { font-size: 16.5px; margin: 24px 0 8px; color: var(--ink-soft); }
+  .lede { font-size: 18px; color: var(--ink-soft); }
+
+  .rule-box { border-left: 4px solid var(--accent); background: #eef4f7; padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .rule-box b { color: var(--accent); }
+  .warn-box { border-left: 4px solid var(--gold); background: var(--warn-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .danger-box { border-left: 4px solid var(--danger); background: var(--danger-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .good-box { border-left: 4px solid var(--good); background: var(--good-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+
+  table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 14.5px; background: var(--card); }
+  th { text-align: left; font-size: 12.5px; text-transform: uppercase; letter-spacing: 1px; color: var(--ink-soft); border-bottom: 2px solid var(--ink); padding: 9px 12px; }
+  td { border-bottom: 1px solid var(--line); padding: 10px 12px; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 6px; }
+
+  .st { font-family: var(--mono); font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: 9px; white-space: nowrap; }
+  .st.keep { background: var(--good-bg); color: var(--good); border: 1px solid var(--good); }
+  .st.drop { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger); }
+  .st.selfhost { background: var(--warn-bg); color: var(--gold); border: 1px solid var(--gold); }
+  .st.device { background: #eef4f7; color: var(--accent); border: 1px solid var(--accent); }
+
+  footer { margin-top: 90px; border-top: 3px double var(--line); padding-top: 22px; font-size: 13px; color: var(--ink-soft); }
+  footer code { font-size: 12px; }
+
+  /* ---------- mockup: the full-width desktop Cockpit, rendered in DevThrottle's own dark skin ---------- */
+  .screen { background: #0e1820; border: 1px solid #24384a; border-radius: 10px; overflow: hidden; box-shadow: 0 10px 30px rgba(10,20,30,0.22); margin: 20px 0 8px; }
+  .screen .bar { background: #0a121a; border-bottom: 1px solid #1d2f40; padding: 9px 14px; display: flex; align-items: center; gap: 7px; }
+  .screen .dot { width: 11px; height: 11px; border-radius: 50%; background: #2a3f52; }
+  .screen .dot.r { background: #c0554a; } .screen .dot.y { background: #c99a3f; } .screen .dot.g { background: #3f9d6a; }
+  .screen .url { font-family: var(--mono); font-size: 11.5px; color: #6f8598; margin-left: 12px; }
+  .screen .app { display: flex; min-height: 360px; }
+
+  /* left navigation rail */
+  .rail { width: 210px; flex: 0 0 210px; background: #0b141c; border-right: 1px solid #1a2a38; padding: 16px 0 18px; color: #93a7b8; }
+  @media (max-width: 720px) { .rail { display: none; } }
+  .rail .brand { font-family: Georgia, serif; font-size: 18px; color: #f2f6f9; font-weight: 700; padding: 0 18px 14px; }
+  .rail .net { margin: 0 14px 12px; font-size: 11px; color: #9fb2c2; background: #101d27; border: 1px solid #22323f; border-radius: 20px; padding: 5px 12px; display: inline-flex; align-items: center; gap: 7px; }
+  .rail .net .nd { width: 8px; height: 8px; border-radius: 50%; background: #7a8a97; }
+  .rail .net.on .nd { background: #3f9d6a; }
+  .rail .nav { list-style: none; margin: 6px 0 0; padding: 0; }
+  .rail .nav li { font-size: 13px; padding: 9px 18px; display: flex; align-items: center; gap: 10px; }
+  .rail .nav li .ic { width: 15px; color: #5f7486; font-family: var(--mono); font-size: 12px; }
+  .rail .nav li.on { background: #14222e; color: #eaf1f6; border-left: 2px solid #2f9fce; padding-left: 16px; }
+  .rail .nav li.on .ic { color: #7cc6e6; }
+
+  /* main settings surface */
+  .main { flex: 1 1 auto; padding: 26px 34px 30px; color: #d6e2ec; min-width: 0; }
+  .main h5 { font-family: Georgia, serif; font-size: 26px; color: #f2f6f9; margin: 0 0 5px; font-weight: 600; }
+  .main .lede2 { font-size: 13px; color: #8ba0b2; margin: 0 0 4px; }
+  .main .relo { font-size: 12px; color: #6f8598; margin: 0 0 18px; }
+  .main .relo a { color: #6cb6d6; }
+  .main .tabs { display: flex; gap: 6px; border-bottom: 1px solid #22364a; margin-bottom: 20px; flex-wrap: wrap; }
+  .main .tabx { font-size: 13px; padding: 9px 14px 11px; color: #8ba0b2; border-bottom: 2px solid transparent; }
+  .main .tabx.on { color: #7cc6e6; border-bottom-color: #2f9fce; font-weight: 600; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  @media (max-width: 640px) { .grid2 { grid-template-columns: 1fr; } }
+  .setcard { background: #13212d; border: 1px solid #223648; border-radius: 8px; padding: 14px 16px; }
+  .setcard .top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .setcard .name { font-size: 14px; color: #eaf1f6; font-weight: 600; }
+  .setcard .desc { font-size: 12px; color: #7f96a8; margin-top: 3px; }
+  .pill { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.6px; text-transform: uppercase; padding: 2px 8px; border-radius: 9px; white-space: nowrap; }
+  .pill.acct { background: rgba(47,159,206,0.16); color: #7cc6e6; border: 1px solid #2f6f8a; }
+  .pill.gw { background: rgba(168,123,35,0.16); color: #d3aa5a; border: 1px solid #8a6f2a; }
+  .pill.dev { background: rgba(46,125,84,0.16); color: #7fce9f; border: 1px solid #2a7d54; }
+  .ctrl { margin-top: 11px; display: inline-flex; align-items: center; gap: 8px; font-size: 12.5px; color: #cbd8e2; background: #0c1720; border: 1px solid #263c4f; border-radius: 6px; padding: 7px 11px; }
+  .ctrl .car { color: #6f8598; }
+  .absent { font-size: 12.5px; color: #7f96a8; font-style: italic; padding: 13px 15px; border: 1px dashed #2a3f52; border-radius: 8px; margin-top: 12px; background: #0f1a23; }
+  .mock-cap { font-size: 13px; color: var(--ink-soft); margin: 4px 0 30px; }
+  .mock-cap b { color: var(--ink); }
+  .legend { display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 12.5px; color: var(--ink-soft); margin: 6px 0 20px; }
+  .legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .swatch { width: 11px; height: 11px; border-radius: 3px; display: inline-block; }
+</style>
+</head>
+<body>
+<div class="page">
+
+<!-- ================= MASTHEAD ================= -->
+<div class="masthead">
+  <div class="kicker">DevThrottle &middot; Settings Design Proposal</div>
+  <h1>The Settings page: what belongs on a hosted Gateway, and what does not</h1>
+  <p class="sub">
+    Today the Cockpit Settings page paints a red error on the hosted Gateway because every setting it
+    reads is deliberately refused there. This document decides what the page should be instead - which
+    tabs stay, which are removed, and which settings become tenant-aware - and shows it as a mockup, so a
+    single well-defined issue can be written from it. No code is changed here; this is the design.
+  </p>
+  <div class="factline">
+    <span>Date <b>2026-07-22</b></span>
+    <span>Source of truth <b>origin/main @ d67a3d1c</b></span>
+    <span>Status <b>proposal for review - not implemented</b></span>
+    <span>Companion to <b>multi-tenant-gateway-architecture-2026-07-21</b></span>
+  </div>
+</div>
+
+<div class="chips">
+  <div class="chip red"><div class="num">404</div><div class="lbl">the error the page shows today: the hosted Gateway refuses the whole owner-settings group (issue #1863)</div></div>
+  <div class="chip green"><div class="num">3</div><div class="lbl">tabs that stay on hosted, made tenant-aware: Notifications, AI, Car Mode</div></div>
+  <div class="chip gold"><div class="num">1</div><div class="lbl">tab removed from BOTH surfaces (settings go to the About page + installer/CLI, or are dropped): This machine</div></div>
+  <div class="chip"><div class="num">1</div><div class="lbl">tab deleted entirely, both surfaces: Privacy</div></div>
+</div>
+
+<!-- ================= REVISED: CURRENT PLAN ================= -->
+<section id="now" style="margin-top:40px;">
+  <div class="rule-box" style="border-left-width:6px;background:#eef4f7;">
+    <div style="font-family:var(--mono);font-size:11px;letter-spacing:2px;text-transform:uppercase;color:var(--gold);margin-bottom:8px;">Revised 2026-07-22 &middot; read this first</div>
+    <h3 style="margin:0 0 10px;">Where this stands, and the model we settled on</h3>
+    <p style="margin-bottom:10px;">
+      <b>Built already (issue #2017), and verified working on a live Gateway:</b> the per-tenant settings
+      store and typed resolver, the settings-page endpoints reading and writing per tenant, the snooze-default
+      and time-zone runtime consumers, the Gateway-owned hosted signal, and the Cockpit page. On self-host
+      every setting persists per the single local tenant today.
+    </p>
+    <p style="margin-bottom:10px;">
+      <b>The model we settled on (issue #2022 - unification):</b> self-host <i>is</i> the hosted Gateway with
+      exactly one tenant (<code>Local</code>, SQLite behind it). One code path, one page. The machine-scoped
+      settings <b>leave the web page entirely</b>: read-only diagnostics go to the <b>About page</b> (web, both
+      surfaces); start-at-login moves to <b>the installer plus a CLI command</b> - the one home that works on
+      every platform including a headless Linux server (a tray/menu-bar toggle is an optional convenience only
+      where a desktop exists); network addressing is <b>dropped</b> (auto-resolved, shown read-only on About);
+      and brain restart / config is <b>removed entirely</b> (restart is automatic; the model it set is now the
+      per-account AI tab). So the web Settings page becomes <b>identical on both
+      surfaces</b>: per-account, <b>no "This machine" tab on either</b>, scope pills always read
+      <b>"your account"</b>. Time zone stays on the page (it is a per-tenant display preference, not a machine
+      fact). Privacy is gone.
+    </p>
+    <p style="margin-bottom:0;">
+      <b>The last step, landed as one:</b> the deep runtime consumers (wingman models, text-to-speech, narration,
+      car mode) are being threaded per tenant by the multi-tenant (MTR) mission; the hosted deny is retired
+      <b>together with</b> that integration, so no setting is ever settable-but-not-consumed. The
+      snooze/time-zone consumers are already threaded.
+    </p>
+  </div>
+  <div class="warn-box" style="margin-top:14px;">
+    <b>Note on the sections below.</b> Sections 02-05 were written for an INTERIM step - "hosted drops the
+    machine tab, self-host keeps it, pills differ per surface." That is superseded by the unified model above:
+    after #2022 <b>neither surface shows a machine tab on the web, and the pills are always "your account".</b>
+    The reasoning in those sections (why the deny existed, one-code-path, the matrix of what is per-tenant)
+    still holds - only the "self-host keeps a machine tab" framing changes.
+  </div>
+</section>
+
+<div class="toc">
+  <div><span class="n">00</span><a href="#now">Where this stands (revised) - read first</a></div>
+  <div><span class="n">01</span><a href="#why">Why the page is broken on hosted</a></div>
+  <div><span class="n">02</span><a href="#decisions">The decisions, stated plainly</a></div>
+  <div><span class="n">03</span><a href="#crux">The crux: global becomes tenant-aware</a></div>
+  <div><span class="n">04</span><a href="#matrix">Every setting, and where it lives</a></div>
+  <div><span class="n">05</span><a href="#mockups">What the page looks like</a></div>
+  <div><span class="n">06</span><a href="#open">Open questions to settle first</a></div>
+  <div><span class="n">07</span><a href="#issue">The issue this design produces</a></div>
+</div>
+
+<!-- ================= 01 WHY ================= -->
+<section id="why">
+  <div class="sec-head"><span class="n">01</span><h2>Why the page is broken on hosted</h2></div>
+
+  <p class="lede">
+    On <code>gateway.devthrottle.com/settings</code> the page loads its tabs, calls the Gateway for the
+    values, and is told <b>404 - not found</b>. It renders that verbatim as a red banner: "Could not load
+    settings from the Gateway: The Gateway rejected the request (error 404)." Nothing is malfunctioning.
+    The 404 is on purpose.
+  </p>
+
+  <p>
+    The Cockpit Settings page is, by its own header comment, "a pure client of existing Gateway
+    endpoints." Its five tabs read one owner-settings surface - <code>GET /gateway/settings</code> plus a
+    family of sibling routes for AI models, snooze, addressing, and so on. On the hosted Gateway that
+    entire family is refused as a group (issue #1863). The refusal is a single primitive over 22 routes,
+    and it answers 404, not 403, deliberately - the code says so:
+  </p>
+
+  <div class="rule-box">
+    <b>From <code>SettingsEndpoints.cs</code>:</b> "the owner settings are process-global
+    <code>config.json</code> values with no tenant dimension anywhere - not in the file, the store or the
+    routes - and the host-wide auth gate admits any enrolled device key from any account, so one
+    subscriber would repoint or read the whole fleet's settings." 404 rather than 403 because on hosted
+    "the owner's settings" does not exist as a concept; "not here" is the truthful answer.
+  </div>
+
+  <p>
+    So the real defect is not in the Gateway - it is that the <b>Cockpit page was never taught that it is
+    running against a hosted Gateway.</b> It still shows machine-scoped tabs, still fetches denied
+    endpoints, and paints the refusal. On a self-hosted Gateway (your own machine, single tenant) the
+    same page works completely. The fix is a page that knows which surface it is on and, underneath it,
+    settings that have somewhere per-tenant to live.
+  </p>
+</section>
+
+<!-- ================= 02 DECISIONS ================= -->
+<section id="decisions">
+  <div class="sec-head"><span class="n">02</span><h2>The decisions, stated plainly</h2></div>
+
+  <p class="lede">Five tabs today: This machine, Notifications, AI, Car Mode, Privacy. Here is the ruling on each.</p>
+
+  <div class="tbl-wrap">
+  <table>
+    <thead><tr><th>Tab</th><th>Decision</th><th>Reasoning</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><b>This machine</b></td>
+        <td><span class="st drop">off the web page</span></td>
+        <td>These configure a physical Gateway host, which a shared hosted Gateway does not have. Under the
+            unified model they leave the web Settings page entirely: read-only diagnostics go to the About
+            page; start-at-login goes to the installer plus a CLI command (the universal home - a headless
+            Linux server has no tray or window, so the CLI is the only thing that works everywhere; a
+            tray/menu-bar toggle is an optional convenience on Windows/macOS); network addressing is dropped
+            (auto-resolved, shown read-only on About); and brain restart / config is removed outright. So there
+            is no "This machine" tab on either surface. (Time zone is the one that STAYS on the page - it is a
+            per-tenant display preference, not a machine fact.)</td>
+      </tr>
+      <tr>
+        <td><b>Notifications</b></td>
+        <td><span class="st keep">keep - tenant-aware</span></td>
+        <td>Snooze lengths and the default become per-account on hosted. Browser notifications are already
+            device-scoped and work everywhere.</td>
+      </tr>
+      <tr>
+        <td><b>AI</b></td>
+        <td><span class="st keep">keep - tenant-aware</span></td>
+        <td>Thinking model, fast model, speech model, voice, transcription - each becomes a per-account
+            choice. This is a headline feature of the hosted product, not an owner-only knob.</td>
+      </tr>
+      <tr>
+        <td><b>Car Mode</b></td>
+        <td><span class="st keep">keep - tenant-aware</span></td>
+        <td>Model and end phrase become per-account. Hands-free fleet control is a per-user experience.</td>
+      </tr>
+      <tr>
+        <td><b>Privacy</b></td>
+        <td><span class="st drop">delete entirely</span></td>
+        <td>Telemetry consent is already being removed (fleet session "remove telemetry"). Wingman training
+            capture goes with it. The tab disappears on both surfaces.</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="warn-box">
+    <b>Net result (unified model, #2022).</b> BOTH surfaces show the same three tabs - Notifications, AI,
+    Car Mode - all scoped to "your account." The "This machine" settings leave the web page entirely: on
+    self-host they live in the tray app + the About page; on hosted they do not exist. Neither surface has a
+    Privacy tab, and neither has a "This machine" tab. (The earlier "self-host keeps four tabs" line was the
+    interim step - see the revised note at the top.)
+  </div>
+</section>
+
+<!-- ================= 03 CRUX ================= -->
+<section id="crux">
+  <div class="sec-head"><span class="n">03</span><h2>The crux: global becomes tenant-aware</h2></div>
+
+  <p class="lede">
+    "Keep it, but make it tenant-aware" is not a UI tweak. It is the exact thing the deny was put there to
+    force. The settings that stay are global today - and that is precisely why they are refused on hosted.
+  </p>
+
+  <p>
+    Look at the AI and Car Mode cards in the current page: each carries a scope pill reading <b>"whole
+    fleet."</b> That pill is honest. The values are written to a single process-global <code>config.json</code>
+    with no tenant column anywhere. On a shared Gateway, one subscriber changing "the thinking model"
+    would change it for <i>every</i> tenant. The deny is what stops that.
+  </p>
+
+  <div class="danger-box">
+    <b>You cannot simply lift the deny.</b> The code carries its own un-deny instruction: "do NOT simply
+    remove this deny: give each of these settings a per-tenant home (<code>config.json</code> has none
+    today), migrate any global value already written, and only then restore a tenant-scoped route." The
+    design below assumes that work is the substance of the issue.
+  </div>
+
+  <p>The clean target - and the recommendation of this document - is <b>one code path, not two:</b></p>
+  <ul>
+    <li><b>Every kept setting gets a per-tenant home.</b> On hosted (Postgres) that is a row per tenant.
+        On self-host (SQLite) it is the single "Local" tenant's row. The reader keys by the caller's
+        tenant in both cases.</li>
+    <li><b>The route becomes tenant-scoped and therefore safe,</b> so the hosted deny for these families
+        is retired - not bypassed - because the reason for it (no tenant dimension) is gone.</li>
+    <li><b>The scope pill flips</b> from "whole fleet" to "your account" on hosted, and reads "this
+        Gateway" on self-host, where there is genuinely one tenant.</li>
+  </ul>
+
+  <div class="good-box">
+    <b>Why one path beats a hosted fork.</b> If self-host stayed on global <code>config.json</code> and
+    only hosted got per-tenant storage, we would maintain two readers, two writers, and a deny that
+    applies to one surface but not the other - the exact split that made the current page fragile. A
+    single per-tenant store where self-host is "the tenant count is one" removes the deny as a concept
+    instead of routing around it.
+  </div>
+</section>
+
+<!-- ================= 04 MATRIX ================= -->
+<section id="matrix">
+  <div class="sec-head"><span class="n">04</span><h2>Every setting, and where it lives</h2></div>
+
+  <p class="lede">
+    The full inventory, read from the current page. Each row says what the setting is, whether it survives,
+    and its home on each surface. This table is the specification the issue is built from.
+  </p>
+
+  <div class="legend">
+    <span><i class="swatch" style="background:#2e7d54"></i> per-account (per-tenant) on hosted</span>
+    <span><i class="swatch" style="background:#a87b23"></i> this Gateway / this machine (self-host)</span>
+    <span><i class="swatch" style="background:#0e6a8a"></i> per-device / per-browser</span>
+    <span><i class="swatch" style="background:#a33b2e"></i> removed</span>
+  </div>
+
+  <div class="tbl-wrap">
+  <table>
+    <thead><tr><th>Tab / setting</th><th>What it is</th><th>On hosted</th><th>On self-host</th></tr></thead>
+    <tbody>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">This machine - NOT on the web page; moved to the About page / installer + CLI (self-host only)</td></tr>
+      <tr><td>Diagnostics (+ address/IP)</td><td>version, address, uptime, director count, mode - read-only</td><td><span class="st keep">About page</span></td><td><span class="st keep">About page</span></td></tr>
+      <tr><td>Network addressing</td><td>Tailscale front door vs raw LAN IP</td><td><span class="st drop">dropped</span></td><td><span class="st drop">dropped - auto-resolved, shown on About; config/CLI if ever overridden</span></td></tr>
+      <tr><td>Autostart (start at login)</td><td>launch the Gateway at login</td><td><span class="st drop">absent</span></td><td><span class="st selfhost">installer + CLI (tray/menu-bar optional)</span></td></tr>
+      <tr><td>Brain restart / config</td><td>advanced process controls - restart is automatic; the model it set is now the per-account AI tab</td><td><span class="st drop">removed</span></td><td><span class="st drop">removed</span></td></tr>
+      <tr><td>Display time zone <b>(stays on the web page)</b></td><td>IANA zone the dashboards read local hours in - a per-tenant display preference, not a machine fact</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Notifications (web page, both surfaces)</td></tr>
+      <tr><td>Snooze lengths + default</td><td>the lengths every Snooze menu offers, and which is default</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>Browser notifications</td><td>enable push to this browser (VAPID, <code>/push/*</code>)</td><td><span class="st device">this browser</span></td><td><span class="st device">this browser</span></td></tr>
+
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">AI (web page, both surfaces)</td></tr>
+      <tr><td>Provider</td><td>DevThrottle-hosted inference (only option today)</td><td><span class="st keep">included **</span></td><td><span class="st keep">included **</span></td></tr>
+      <tr><td>Thinking model</td><td>the wingman's main reasoning model</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>Fast model</td><td>the wingman's quick-turn model</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>Speech model</td><td>text-to-speech engine</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>Voice</td><td>which voice the speech model uses</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>Transcription model</td><td>speech-to-text engine</td><td><span class="st keep">included **</span></td><td><span class="st keep">included **</span></td></tr>
+
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Car Mode (web page, both surfaces)</td></tr>
+      <tr><td>Model</td><td>the conversational model Car Mode drives</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+      <tr><td>End phrase</td><td>the spoken phrase that ends a turn</td><td><span class="st keep">per-account</span></td><td><span class="st keep">per local tenant</span></td></tr>
+
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Privacy</td></tr>
+      <tr><td>Usage telemetry consent</td><td>opt-in analytics</td><td><span class="st drop">removed</span></td><td><span class="st drop">removed</span></td></tr>
+      <tr><td>Wingman training capture</td><td>save wingman turns for training</td><td><span class="st drop">removed</span></td><td><span class="st drop">removed</span></td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <p style="font-size:13px;color:var(--ink-soft);">
+    <b>*</b> Time zone is a display preference, not a machine fact - see open question 3. It is proposed to
+    survive on hosted as a per-account setting rather than vanish with the This machine tab.<br>
+    <b>**</b> Provider and transcription currently have exactly one hosted option. Shown as informational
+    on hosted, or as a real selector only if more than one option exists - see open question 5.
+  </p>
+</section>
+
+<!-- ================= 05 MOCKUPS ================= -->
+<section id="mockups">
+  <div class="sec-head"><span class="n">05</span><h2>What the page looks like</h2></div>
+
+  <p class="lede">
+    The same page, two surfaces. Hosted shows three account-scoped tabs; self-host shows four
+    Gateway-scoped tabs. Every card carries a scope pill so the reach of a change is readable without
+    reading the hint text - the convention the current page already uses.
+  </p>
+
+  <div class="legend">
+    <span><i class="swatch" style="background:#2f9fce"></i> your account (per-tenant)</span>
+    <span><i class="swatch" style="background:#d3aa5a"></i> this Gateway</span>
+    <span><i class="swatch" style="background:#7fce9f"></i> this browser / device</span>
+  </div>
+
+  <h3>Hosted - <code>gateway.devthrottle.com/settings</code></h3>
+  <div class="screen">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">gateway.devthrottle.com/settings</span></div>
+    <div class="app">
+      <nav class="rail">
+        <div class="brand">DevThrottle</div>
+        <div class="net on"><span class="nd"></span>Network: Online</div>
+        <ul class="nav">
+          <li><span class="ic">[#]</span>Fleet Map</li>
+          <li><span class="ic">[=]</span>Sessions</li>
+          <li><span class="ic">[o]</span>Directors</li>
+          <li><span class="ic">[t]</span>Schedule</li>
+          <li><span class="ic">[w]</span>Workflows</li>
+          <li><span class="ic">[b]</span>Dictionary</li>
+          <li><span class="ic">[v]</span>Voice Recorder</li>
+          <li><span class="ic">[~]</span>Transcription</li>
+          <li><span class="ic">[@]</span>Network</li>
+          <li class="on"><span class="ic">[*]</span>Settings</li>
+        </ul>
+      </nav>
+      <div class="main">
+        <h5>Settings</h5>
+        <p class="lede2">Your DevThrottle account settings.</p>
+        <p class="relo">Looking for something else? Your <a>DevThrottle account</a> and <a>Gateway diagnostics</a> each have their own page.</p>
+        <div class="tabs">
+          <span class="tabx on">Notifications</span>
+          <span class="tabx">AI</span>
+          <span class="tabx">Car Mode</span>
+        </div>
+        <div class="grid2">
+          <div class="setcard">
+            <div class="top"><span class="name">Snooze lengths</span><span class="pill acct">your account</span></div>
+            <div class="desc">The lengths every Snooze menu offers you, on every device.</div>
+            <div class="ctrl">15m &middot; 1h &middot; <b style="color:#7cc6e6">4h (default)</b> &middot; 8h</div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Browser notifications</span><span class="pill dev">this browser</span></div>
+            <div class="desc">Get notified in this browser when a session needs you.</div>
+            <div class="ctrl"><span class="car">[ x ]</span> Enabled on this browser</div>
+          </div>
+        </div>
+        <div class="absent">The "This machine" and "Privacy" tabs are not shown on the hosted Gateway.</div>
+      </div>
+    </div>
+  </div>
+  <p class="mock-cap"><b>Hosted.</b> Three tabs, every setting scoped to "your account." No machine tab (there is no machine of yours to configure on the shared Gateway) and no Privacy tab. The red 404 banner is gone because the page no longer asks for settings the hosted Gateway refuses.</p>
+
+  <h3>Self-host - the SAME web page; machine settings on the About page + installer/CLI</h3>
+  <div class="screen">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">localhost:8770/settings</span></div>
+    <div class="app">
+      <nav class="rail">
+        <div class="brand">DevThrottle</div>
+        <div class="net on"><span class="nd"></span>Network: Online</div>
+        <ul class="nav">
+          <li><span class="ic">[#]</span>Fleet Map</li>
+          <li><span class="ic">[=]</span>Sessions</li>
+          <li><span class="ic">[o]</span>Directors</li>
+          <li><span class="ic">[t]</span>Schedule</li>
+          <li><span class="ic">[w]</span>Workflows</li>
+          <li><span class="ic">[b]</span>Dictionary</li>
+          <li><span class="ic">[v]</span>Voice Recorder</li>
+          <li><span class="ic">[~]</span>Transcription</li>
+          <li><span class="ic">[@]</span>Network</li>
+          <li class="on"><span class="ic">[*]</span>Settings</li>
+        </ul>
+      </nav>
+      <div class="main">
+        <h5>Settings</h5>
+        <p class="lede2">Your DevThrottle account settings.</p>
+        <p class="relo">Looking for something else? Your <a>DevThrottle account</a> and <a>Gateway diagnostics</a> each have their own page.</p>
+        <div class="tabs">
+          <span class="tabx on">Notifications</span>
+          <span class="tabx">AI</span>
+          <span class="tabx">Car Mode</span>
+        </div>
+        <div class="grid2">
+          <div class="setcard">
+            <div class="top"><span class="name">Snooze lengths</span><span class="pill acct">your account</span></div>
+            <div class="desc">The lengths every Snooze menu offers you, on every device.</div>
+            <div class="ctrl">15m &middot; 1h &middot; <b style="color:#7cc6e6">4h (default)</b> &middot; 8h</div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Display time zone</span><span class="pill acct">your account</span></div>
+            <div class="desc">Which local hours your dashboards read in.</div>
+            <div class="ctrl">America/Chicago <span class="car">v</span></div>
+          </div>
+        </div>
+        <div class="absent">Same page as the hosted Gateway. No "This machine" tab, no Privacy tab.</div>
+      </div>
+    </div>
+  </div>
+  <p class="mock-cap"><b>Self-host web page = the hosted page.</b> Same three tabs, same "your account" pills - a self-hosted Gateway is just the hosted Gateway with one tenant. The machine settings are not here. Their homes:</p>
+
+  <div class="good-box" style="margin:8px 0 16px;">
+    <b>The rule: the CLI + a config file is the universal home; a GUI is only a convenience.</b> A headless
+    Linux server has no tray AND no window, so no GUI can be the home for a host setting. The one thing that
+    works on every platform is a <b>CLI command</b> (DevThrottle already ships <code>cc-devthrottle</code>)
+    backed by a <b>config file</b>. On Windows and macOS, where a desktop exists, the tray / menu bar offers
+    the same toggle as a shortcut - never the source of truth. Read-only facts (version, address, uptime) need
+    no platform home at all: they live on the web <b>About page</b>, which works everywhere and on both
+    surfaces. Nothing host-specific ever touches the Cockpit Settings page.
+  </div>
+
+  <div class="tbl-wrap"><table>
+    <thead><tr><th>Setting</th><th>Universal home (all platforms, incl. headless)</th><th>Windows</th><th>macOS</th><th>Linux</th></tr></thead>
+    <tbody>
+      <tr><td>Diagnostics + address/IP + version</td><td>web <b>About page</b> (read-only, both surfaces)</td><td colspan="3" style="text-align:center;color:var(--ink-soft)">same page everywhere</td></tr>
+      <tr><td>Start at login (autostart)</td><td><code>devthrottle autostart on|off</code> (installer sets the default)</td><td>Registry Run key; tray toggle optional</td><td>LaunchAgent plist; menu-bar toggle optional</td><td><code>systemd --user</code> unit; CLI only (no reliable tray)</td></tr>
+      <tr><td>Network addressing (mode)</td><td><b>dropped</b> - auto-resolved; shown read-only on About. A config-file / CLI override only if ever genuinely needed.</td><td colspan="3" style="text-align:center;color:var(--ink-soft)">no UI on any platform</td></tr>
+      <tr><td>Brain restart / config</td><td><b>removed</b> - restart is automatic; the model it set is the per-account AI tab</td><td colspan="3" style="text-align:center;color:var(--ink-soft)">gone</td></tr>
+    </tbody>
+  </table></div>
+  <p class="cap" style="margin-top:4px;"><b>Why not the tray.</b> The Gateway tray works on Windows and (as a menu-bar item) macOS, but a Linux server install has no desktop at all. Making the tray the home would strand headless Linux; making the CLI the home covers every case, with the tray as a Windows/macOS nicety on top. None of this exists on the hosted Gateway - DevThrottle operates that host.</p>
+
+  <h3>The AI tab on hosted - the headline case</h3>
+  <div class="screen">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">gateway.devthrottle.com/settings?tab=ai</span></div>
+    <div class="app">
+      <nav class="rail">
+        <div class="brand">DevThrottle</div>
+        <div class="net on"><span class="nd"></span>Network: Online</div>
+        <ul class="nav">
+          <li><span class="ic">[#]</span>Fleet Map</li>
+          <li><span class="ic">[=]</span>Sessions</li>
+          <li><span class="ic">[o]</span>Directors</li>
+          <li><span class="ic">[t]</span>Schedule</li>
+          <li><span class="ic">[w]</span>Workflows</li>
+          <li><span class="ic">[b]</span>Dictionary</li>
+          <li><span class="ic">[v]</span>Voice Recorder</li>
+          <li><span class="ic">[~]</span>Transcription</li>
+          <li><span class="ic">[@]</span>Network</li>
+          <li class="on"><span class="ic">[*]</span>Settings</li>
+        </ul>
+      </nav>
+      <div class="main">
+        <h5>Settings</h5>
+        <p class="lede2">Your DevThrottle account settings.</p>
+        <p class="relo">Looking for something else? Your <a>DevThrottle account</a> and <a>Gateway diagnostics</a> each have their own page.</p>
+        <div class="tabs">
+          <span class="tabx">Notifications</span>
+          <span class="tabx on">AI</span>
+          <span class="tabx">Car Mode</span>
+        </div>
+        <div class="grid2">
+          <div class="setcard">
+            <div class="top"><span class="name">Provider</span><span class="pill dev">included</span></div>
+            <div class="desc">DevThrottle-hosted AI. No key to manage.</div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Transcription</span><span class="pill dev">included</span></div>
+            <div class="desc">DevThrottle-hosted speech-to-text.</div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Thinking model</span><span class="pill acct">your account</span></div>
+            <div class="ctrl">Opus 4.8 (1M) <span class="car">v</span></div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Fast model</span><span class="pill acct">your account</span></div>
+            <div class="ctrl">Haiku 4.5 <span class="car">v</span></div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Speech model</span><span class="pill acct">your account</span></div>
+            <div class="ctrl">Cartesia Sonic <span class="car">v</span></div>
+          </div>
+          <div class="setcard">
+            <div class="top"><span class="name">Voice</span><span class="pill acct">your account</span></div>
+            <div class="ctrl">Shimmer <span class="car">v</span> &middot; <span class="car">[ play sample ]</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="good-box">
+    <b>Note the two pill kinds.</b> "Your account" is a real per-tenant choice that writes to your tenant's
+    row - change it and only your fleet is affected. "Included" marks something the hosted plan fixes for
+    everyone: shown for honesty, not editable, because there is only one option. On self-host these same
+    rows read "this Gateway", and the provider row becomes a real selector if a self-hoster wires their own key.
+  </div>
+</section>
+
+<!-- ================= 06 OPEN ================= -->
+<section id="open">
+  <div class="sec-head"><span class="n">06</span><h2>Open questions to settle first</h2></div>
+
+  <p class="lede">These are the decisions that must be nailed before the issue is written, not during it.</p>
+
+  <h3>1. Where does per-tenant settings storage live?</h3>
+  <p>
+    <code>config.json</code> has no tenant dimension - that is the entire reason for the deny. The kept
+    settings need a tenant-keyed home: a table row per tenant on hosted Postgres, a single row on
+    self-host SQLite. This is the bulk of the work. <b>Proposed:</b> one small per-tenant settings table,
+    read by the caller's tenant id, defaulting to today's global values on first read.
+  </p>
+
+  <h3>2. One code path, or a hosted fork?</h3>
+  <p>
+    <b>Proposed: one path.</b> Self-host is "tenant count is one." The same reader/writer serves both,
+    and the hosted deny for these families is retired because its precondition is gone. A fork keeps the
+    deny alive on one surface and doubles the code that must stay in step.
+  </p>
+
+  <h3>3. Is time zone a machine setting or a per-account preference?</h3>
+  <p>
+    It currently lives under This machine, but it is a display preference - which local hours the
+    dashboards render in - not a fact about the host. <b>Proposed:</b> treat it as per-account so it
+    survives on hosted rather than disappearing with the machine tab. If it must stay machine-scoped,
+    hosted simply loses it; decide explicitly.
+  </p>
+
+  <h3>4. Confirm full removal of the two Privacy settings.</h3>
+  <p>
+    Telemetry consent is being removed by another fleet session already. <b>Wingman training capture</b>
+    must be confirmed as removed, not merely hidden - capturing wingman turns on a shared Gateway is a
+    cross-tenant data question in its own right. If it is ever wanted back, it returns as a per-tenant
+    setting, never a global one.
+  </p>
+
+  <h3>5. Provider and transcription on hosted: selector or informational?</h3>
+  <p>
+    Both have exactly one hosted option today. <b>Proposed:</b> render them as "included" informational
+    rows on hosted (no false choice), and as real selectors only where more than one option exists (e.g.
+    a self-hoster who supplies their own key). This keeps the dumb-client rule - the page shows what the
+    Gateway says is available, and never invents a choice.
+  </p>
+
+  <h3>6. How does the page know which surface it is on?</h3>
+  <p>
+    The page must render the right tab set without first failing a fetch. <b>Proposed:</b> the Gateway
+    already knows it is hosted (<code>GatewayHostedMode.IsHosted</code>); expose that on a public,
+    always-available snapshot the page reads before choosing tabs, so tab selection is Gateway-owned
+    (project rule 7), not guessed by the client.
+  </p>
+</section>
+
+<!-- ================= 07 ISSUE ================= -->
+<section id="issue">
+  <div class="sec-head"><span class="n">07</span><h2>The issue this design produces</h2></div>
+
+  <p class="lede">Once the six questions above are answered, the work item writes itself. A scaffold:</p>
+
+  <div class="rule-box">
+    <p style="margin-bottom:8px"><b>Title.</b> Make the Cockpit Settings page hosted-aware and its settings tenant-scoped</p>
+    <p style="margin-bottom:8px"><b>Why.</b> The hosted Settings page shows a 404 error banner because the whole owner-settings group is refused on hosted (issue #1863). The settings we want to keep are process-global, which is exactly why they are refused. Give them a per-tenant home and the page can serve them.</p>
+    <p style="margin-bottom:8px"><b>In scope.</b> Per-tenant storage for the kept settings; retire the hosted deny for those families once the route is tenant-scoped; a Gateway-owned "which tabs" signal; remove the This machine tab on hosted; delete the Privacy tab on both surfaces; flip the scope pills.</p>
+    <p style="margin-bottom:8px"><b>Out of scope.</b> Telemetry removal (already in flight, separate session); any new AI provider or voice; changes to self-host machine settings beyond the storage unification.</p>
+    <p style="margin-bottom:0"><b>Acceptance.</b> On hosted, <code>/settings</code> shows Notifications, AI, Car Mode with no error banner, each setting saved per account and isolated from other tenants. On self-host, the page is unchanged except the Privacy tab is gone. The specification is the matrix in section 4.</p>
+  </div>
+
+  <div class="warn-box">
+    <b>Sequencing note.</b> The per-tenant storage (question 1) is the gate. The tab-visibility and
+    pill-copy changes are cheap and could ship first as a pure UX fix - hiding the machine and Privacy
+    tabs on hosted removes the red error immediately - but that only hides the problem until the kept
+    settings actually persist per tenant. Decide whether to split into a "stop the error" step and a
+    "make them work" step, or land them together.
+  </div>
+</section>
+
+<footer>
+  <p><b>DevThrottle - Settings Design Proposal.</b> Read from <code>origin/main @ d67a3d1c</code> on 2026-07-22.
+  Not implemented; this is the design to review and turn into a work item. Companion to
+  <code>docs/architecture/multi-tenant-gateway-architecture-2026-07-21.html</code>. Sources:
+  <code>apps/cockpit/src/settings/SettingsView.tsx</code>, <code>packages/client-core/src/settings/settingsClient.ts</code>,
+  <code>src/CcDirector.Gateway/Api/SettingsEndpoints.cs</code>, <code>HostedOwnerSettingsDenyTests.cs</code> (issue #1863).</p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/architecture/multi-tenant-gateway-architecture-2026-07-21.html
+++ b/docs/architecture/multi-tenant-gateway-architecture-2026-07-21.html
@@ -1,0 +1,934 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The DevThrottle Gateway - Architecture of a Multi-Tenant Fleet Coordinator</title>
+<style>
+  :root {
+    --ink: #14304a;
+    --ink-soft: #3d5570;
+    --paper: #faf9f6;
+    --card: #ffffff;
+    --line: #d9d4c8;
+    --accent: #0e6a8a;
+    --gold: #a87b23;
+    --danger: #a33b2e;
+    --good: #2e7d54;
+    --warn-bg: #fdf6ec;
+    --danger-bg: #fbf0ee;
+    --good-bg: #eef7f1;
+    --mono: "Consolas", "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font: 16px/1.65 "Segoe UI", -apple-system, "Helvetica Neue", Arial, sans-serif;
+  }
+  .page { max-width: 1080px; margin: 0 auto; padding: 0 28px 120px; }
+  h1, h2, h3, h4 { font-family: Georgia, "Iowan Old Style", "Times New Roman", serif; font-weight: 600; color: var(--ink); }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.86em; background: #f0ede5; padding: 1px 5px; border-radius: 3px; color: #24425f; }
+  p { margin: 0 0 14px; }
+  ul, ol { margin: 0 0 14px 24px; }
+  li { margin-bottom: 6px; }
+
+  /* ---------- masthead ---------- */
+  .masthead {
+    border-bottom: 3px double var(--line);
+    padding: 64px 0 36px;
+    margin-bottom: 8px;
+  }
+  .masthead .kicker {
+    font-family: var(--mono); font-size: 12px; letter-spacing: 2.5px;
+    text-transform: uppercase; color: var(--gold); margin-bottom: 18px;
+  }
+  .masthead h1 { font-size: 44px; line-height: 1.15; margin-bottom: 16px; max-width: 900px; }
+  .masthead .sub { font-size: 19px; color: var(--ink-soft); max-width: 820px; margin-bottom: 28px; }
+  .factline {
+    display: flex; flex-wrap: wrap; gap: 10px 26px;
+    font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft);
+    border-top: 1px solid var(--line); padding-top: 16px;
+  }
+  .factline b { color: var(--ink); font-weight: 600; }
+
+  /* ---------- verdict chips ---------- */
+  .chips { display: grid; grid-template-columns: repeat(auto-fit, minmax(215px, 1fr)); gap: 14px; margin: 30px 0 8px; }
+  .chip {
+    background: var(--card); border: 1px solid var(--line); border-top: 3px solid var(--accent);
+    border-radius: 6px; padding: 16px 18px;
+  }
+  .chip .num { font-family: Georgia, serif; font-size: 30px; line-height: 1.1; }
+  .chip .lbl { font-size: 13px; color: var(--ink-soft); margin-top: 4px; }
+  .chip.gold { border-top-color: var(--gold); }
+  .chip.red { border-top-color: var(--danger); }
+  .chip.green { border-top-color: var(--good); }
+
+  /* ---------- table of contents ---------- */
+  .toc {
+    background: var(--card); border: 1px solid var(--line); border-radius: 6px;
+    padding: 24px 28px; margin: 34px 0 10px;
+    columns: 2; column-gap: 44px;
+  }
+  .toc div { break-inside: avoid; margin-bottom: 7px; font-size: 15px; }
+  .toc .n { font-family: var(--mono); font-size: 12px; color: var(--gold); margin-right: 8px; }
+  @media (max-width: 760px) { .toc { columns: 1; } }
+
+  /* ---------- sections ---------- */
+  section { margin-top: 74px; }
+  .sec-head { display: flex; align-items: baseline; gap: 18px; border-bottom: 2px solid var(--ink); padding-bottom: 10px; margin-bottom: 24px; }
+  .sec-head .n { font-family: Georgia, serif; font-size: 46px; color: var(--line); line-height: 1; }
+  .sec-head h2 { font-size: 29px; }
+  h3 { font-size: 21px; margin: 34px 0 12px; }
+  h4 { font-size: 16.5px; margin: 24px 0 8px; color: var(--ink-soft); }
+  .lede { font-size: 18px; color: var(--ink-soft); }
+
+  /* ---------- callouts ---------- */
+  .rule-box {
+    border-left: 4px solid var(--accent); background: #eef4f7;
+    padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0;
+  }
+  .rule-box b { color: var(--accent); }
+  .warn-box { border-left: 4px solid var(--gold); background: var(--warn-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .danger-box { border-left: 4px solid var(--danger); background: var(--danger-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .good-box { border-left: 4px solid var(--good); background: var(--good-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+
+  /* ---------- tables ---------- */
+  table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 14.5px; background: var(--card); }
+  th { text-align: left; font-size: 12.5px; text-transform: uppercase; letter-spacing: 1px; color: var(--ink-soft); border-bottom: 2px solid var(--ink); padding: 9px 12px; }
+  td { border-bottom: 1px solid var(--line); padding: 10px 12px; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 6px; }
+
+  /* ---------- feature cards ---------- */
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; margin: 18px 0; }
+  .fcard { background: var(--card); border: 1px solid var(--line); border-radius: 6px; padding: 16px 18px; }
+  .fcard h4 { margin: 0 0 6px; color: var(--ink); font-size: 15.5px; font-family: "Segoe UI", sans-serif; font-weight: 700; }
+  .fcard .tag { font-family: var(--mono); font-size: 10.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--gold); display: block; margin-bottom: 6px; }
+  .fcard p { font-size: 13.8px; color: var(--ink-soft); margin-bottom: 6px; }
+  .fcard .anchor { font-family: var(--mono); font-size: 11px; color: #8b8577; }
+
+  /* ---------- findings ---------- */
+  .finding { background: var(--card); border: 1px solid var(--line); border-radius: 6px; margin: 14px 0; padding: 16px 20px; }
+  .finding .fhead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; }
+  .finding .sev { font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: 1px; padding: 2px 9px; border-radius: 10px; white-space: nowrap; }
+  .sev.s0 { background: var(--danger); color: #fff; }
+  .sev.s1 { background: var(--gold); color: #fff; }
+  .sev.s2 { background: #6b7d90; color: #fff; }
+  .finding h4 { margin: 0; font-size: 16px; color: var(--ink); font-family: "Segoe UI", sans-serif; font-weight: 700; }
+  .finding p { font-size: 14.5px; margin-bottom: 6px; }
+  .finding .ev { font-family: var(--mono); font-size: 11.5px; color: #8b8577; }
+
+  /* ---------- diagrams ---------- */
+  figure { margin: 26px 0 32px; }
+  .diagram { background: var(--card); border: 1px solid var(--line); border-radius: 6px; padding: 18px; overflow-x: auto; }
+  .diagram svg { display: block; min-width: 640px; width: 100%; height: auto; }
+  figcaption { font-size: 13.5px; color: var(--ink-soft); margin-top: 10px; padding-left: 4px; }
+  figcaption b { color: var(--ink); }
+
+  /* status pills in tables */
+  .st { font-family: var(--mono); font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: 9px; white-space: nowrap; }
+  .st.done { background: var(--good-bg); color: var(--good); border: 1px solid var(--good); }
+  .st.open { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger); }
+  .st.part { background: var(--warn-bg); color: var(--gold); border: 1px solid var(--gold); }
+
+  footer { margin-top: 90px; border-top: 3px double var(--line); padding-top: 22px; font-size: 13px; color: var(--ink-soft); }
+  footer code { font-size: 12px; }
+
+  @media print {
+    body { font-size: 12px; }
+    .masthead { padding-top: 20px; }
+    section { margin-top: 40px; page-break-inside: avoid; }
+    .diagram svg { min-width: 0; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+<!-- ================= MASTHEAD ================= -->
+<div class="masthead">
+  <div class="kicker">DevThrottle &middot; Architecture Design Document</div>
+  <h1>The Gateway: one always-on hub that turns many coding agents on many machines into one supervised fleet</h1>
+  <p class="sub">
+    How the multi-tenant hosted Gateway works, why it exists, how tenants are kept apart on shared
+    infrastructure, what it can already do for agentic development - and, with equal honesty, what is
+    still wrong and still missing. Written to be argued over at a blackboard and decided from.
+  </p>
+  <div class="factline">
+    <span>Date <b>2026-07-21</b></span>
+    <span>Source of truth <b>origin/main @ 0dc22714</b></span>
+    <span>Read from a pinned worktree, never a stale checkout</span>
+    <span>Altitude <b>structure and guarantees, not methods</b></span>
+  </div>
+</div>
+
+<div class="chips">
+  <div class="chip"><div class="num">1</div><div class="lbl">shared hosted Gateway instance serving every tenant (Azure, Postgres); the same binary self-hosts on SQLite</div></div>
+  <div class="chip green"><div class="num">6</div><div class="lbl">independent enforcement layers between one tenant and another's data</div></div>
+  <div class="chip gold"><div class="num">94</div><div class="lbl">retained-state rows in the finite isolation census (July 20); 40 were actively unsafe at that snapshot</div></div>
+  <div class="chip red"><div class="num">4</div><div class="lbl">open, exploitable cross-tenant or remote-execution issues that gate go-live (section 8)</div></div>
+</div>
+
+<div class="toc">
+  <div><span class="n">01</span><a href="#why">Why the Gateway exists</a></div>
+  <div><span class="n">02</span><a href="#shape">The shape of the system</a></div>
+  <div><span class="n">03</span><a href="#features">What the Gateway does</a></div>
+  <div><span class="n">04</span><a href="#flow">How commands and truth flow</a></div>
+  <div><span class="n">05</span><a href="#tenant">What a tenant is, and how one is born</a></div>
+  <div><span class="n">06</span><a href="#isolation">How isolation is enforced</a></div>
+  <div><span class="n">07</span><a href="#data">The data layer</a></div>
+  <div><span class="n">08</span><a href="#wrong">What is wrong today</a></div>
+  <div><span class="n">09</span><a href="#missing">What is missing</a></div>
+  <div><span class="n">10</span><a href="#blackboard">The blackboard: decisions to make</a></div>
+  <div><span class="n">11</span><a href="#sources">Sources and method</a></div>
+</div>
+
+<!-- ================= 01 WHY ================= -->
+<section id="why">
+  <div class="sec-head"><span class="n">01</span><h2>Why the Gateway exists</h2></div>
+
+  <p class="lede">
+    DevThrottle runs fleets of coding agents - Claude Code and its peers - inside desktop
+    <b>Directors</b> on developers' machines. A Director sees exactly one machine. The moment you have
+    two machines, or a phone, or a question like "is this worker's manager still alive?", you need a
+    place that sees everything. The Gateway is that place.
+  </p>
+
+  <p>
+    The codebase justifies Gateway ownership of a fact with one recurring argument, stated in the code
+    itself: a session's role (Manager, Worker, Architect) depends on whether its controller is alive -
+    and the controller may be a session on another machine entirely. <i>Unanswerable from one Director.</i>
+    Everything with that property migrated to the Gateway:
+  </p>
+
+  <ul>
+    <li><b>Fleet-wide truth.</b> The aggregated roster of every session on every machine, each session's
+        color, label, role, and triage bucket - computed once, served to every screen.</li>
+    <li><b>Remote control across networks.</b> Phones and browsers command sessions on desktops that sit
+        behind NAT and firewalls, because Directors dial out and hold a tunnel open.</li>
+    <li><b>State that outlives a dead Director.</b> Snoozes, mission intent, schedules, governance
+        ledgers, prompt history, turn briefs - durable on the Gateway, so a desktop reboot loses nothing.</li>
+    <li><b>The keys.</b> The account credential, hosted inference keys, and the voice and transcription
+        brains live only here. Clients never hold provider secrets.</li>
+    <li><b>The business.</b> Sign-in, subscriptions, entitlements, credits, and metered spend - the
+        Gateway is where DevThrottle's open-source desktop meets its paid cloud service.</li>
+  </ul>
+
+  <div class="rule-box">
+    <b>The prime directive (project rule 7): the client is dumb; the Gateway owns all ruling.</b>
+    Every display verdict - colors, labels, triage buckets, the voice screen's badge and offered actions -
+    is folded once on the Gateway and stamped onto the data the client reads. A client renders verbatim
+    and never re-derives meaning. This is why one architectural document can describe the whole system's
+    behavior: the behavior lives in one place.
+  </div>
+
+  <p>
+    Hosting it multi-tenant is what turns this from a personal tool into a product: one shared Gateway
+    in the cloud, where creating an account makes you a <b>tenant</b>, your machines enroll with per-device
+    keys, and everything above happens for you without running a server - which is exactly why tenant
+    isolation (sections 5-6) is the load-bearing wall of the whole business.
+  </p>
+</section>
+
+<!-- ================= 02 SHAPE ================= -->
+<section id="shape">
+  <div class="sec-head"><span class="n">02</span><h2>The shape of the system</h2></div>
+
+  <p class="lede">
+    One cardinal transport rule explains the whole topology: <b>the Gateway never dials anyone.
+    Every participant dials out to the Gateway and holds the connection open.</b> The old
+    Gateway-to-Director reverse path was deliberately deleted; there is no fallback.
+  </p>
+
+  <figure>
+    <div class="diagram">
+    <svg viewBox="0 0 1000 620" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Arial, sans-serif">
+      <defs>
+        <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#3d5570"/>
+        </marker>
+        <marker id="arrg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#a87b23"/>
+        </marker>
+      </defs>
+
+      <!-- Humans / client devices (left) -->
+      <text x="30" y="34" font-size="12" fill="#a87b23" letter-spacing="2">HUMANS AND THEIR DEVICES</text>
+      <g>
+        <rect x="30" y="50" width="190" height="58" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="125" y="74" font-size="14" font-weight="700" fill="#14304a" text-anchor="middle">Phone (PWA)</text>
+        <text x="125" y="93" font-size="11.5" fill="#3d5570" text-anchor="middle">served at /mobile</text>
+
+        <rect x="30" y="122" width="190" height="58" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="125" y="146" font-size="14" font-weight="700" fill="#14304a" text-anchor="middle">Browser Cockpit</text>
+        <text x="125" y="165" font-size="11.5" fill="#3d5570" text-anchor="middle">React, served at /cockpit</text>
+
+        <rect x="30" y="194" width="190" height="58" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="125" y="218" font-size="14" font-weight="700" fill="#14304a" text-anchor="middle">Car Mode voice</text>
+        <text x="125" y="237" font-size="11.5" fill="#3d5570" text-anchor="middle">hands-free fleet control</text>
+
+        <rect x="30" y="266" width="190" height="58" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="125" y="290" font-size="14" font-weight="700" fill="#14304a" text-anchor="middle">Command-line tools</text>
+        <text x="125" y="309" font-size="11.5" fill="#3d5570" text-anchor="middle">cc-devthrottle, installers</text>
+      </g>
+
+      <!-- arrows clients -> gateway -->
+      <line x1="220" y1="79" x2="330" y2="150" stroke="#3d5570" stroke-width="1.6" marker-end="url(#arr)"/>
+      <line x1="220" y1="151" x2="330" y2="185" stroke="#3d5570" stroke-width="1.6" marker-end="url(#arr)"/>
+      <line x1="220" y1="223" x2="330" y2="225" stroke="#3d5570" stroke-width="1.6" marker-end="url(#arr)"/>
+      <line x1="220" y1="295" x2="330" y2="262" stroke="#3d5570" stroke-width="1.6" marker-end="url(#arr)"/>
+      <text x="252" y="128" font-size="10.5" fill="#3d5570" transform="rotate(23 252 128)">REST + WebSocket</text>
+      <text x="240" y="218" font-size="10.5" fill="#3d5570">per-device key</text>
+
+      <!-- THE GATEWAY (center) -->
+      <rect x="335" y="45" width="330" height="420" rx="10" fill="#eef4f7" stroke="#14304a" stroke-width="2.2"/>
+      <text x="500" y="76" font-size="17" font-weight="700" fill="#14304a" text-anchor="middle">THE GATEWAY</text>
+      <text x="500" y="94" font-size="11" fill="#3d5570" text-anchor="middle">one shared multi-tenant instance (hosted)</text>
+      <text x="500" y="108" font-size="11" fill="#3d5570" text-anchor="middle">or one private instance (self-host)</text>
+
+      <g font-size="11.5" fill="#14304a">
+        <rect x="352" y="122" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="422" y="139" text-anchor="middle" font-weight="600">Auth edge</text>
+        <text x="422" y="153" text-anchor="middle" fill="#3d5570" font-size="10.5">deny-by-default</text>
+
+        <rect x="508" y="122" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="578" y="139" text-anchor="middle" font-weight="600">Tenant boundary</text>
+        <text x="578" y="153" text-anchor="middle" fill="#3d5570" font-size="10.5">key -&gt; tenant, once</text>
+
+        <rect x="352" y="172" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="422" y="189" text-anchor="middle" font-weight="600">Fleet truth</text>
+        <text x="422" y="203" text-anchor="middle" fill="#3d5570" font-size="10.5">roster, roles, folds</text>
+
+        <rect x="508" y="172" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="578" y="189" text-anchor="middle" font-weight="600">Command router</text>
+        <text x="578" y="203" text-anchor="middle" fill="#3d5570" font-size="10.5">one chokepoint down</text>
+
+        <rect x="352" y="222" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="422" y="239" text-anchor="middle" font-weight="600">Autonomy</text>
+        <text x="422" y="253" text-anchor="middle" fill="#3d5570" font-size="10.5">cron, work lists, spawn</text>
+
+        <rect x="508" y="222" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="578" y="239" text-anchor="middle" font-weight="600">Voice + speech</text>
+        <text x="578" y="253" text-anchor="middle" fill="#3d5570" font-size="10.5">wingman, dictation</text>
+
+        <rect x="352" y="272" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="422" y="289" text-anchor="middle" font-weight="600">Governance</text>
+        <text x="422" y="303" text-anchor="middle" fill="#3d5570" font-size="10.5">ledgers, spend, 402</text>
+
+        <rect x="508" y="272" width="140" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="578" y="289" text-anchor="middle" font-weight="600">Account + billing</text>
+        <text x="578" y="303" text-anchor="middle" fill="#3d5570" font-size="10.5">entitlement, credits</text>
+
+        <rect x="352" y="322" width="296" height="40" rx="4" fill="#fff" stroke="#8fa5b8"/>
+        <text x="500" y="339" text-anchor="middle" font-weight="600">Tenant-partitioned live state</text>
+        <text x="500" y="353" text-anchor="middle" fill="#3d5570" font-size="10.5">pushed sessions, director registry, streams</text>
+      </g>
+
+      <!-- durable stores under gateway -->
+      <g>
+        <path d="M 380 385 h 110 a8 8 0 0 1 8 8 v 40 a8 8 0 0 1 -8 8 h -110 a8 8 0 0 1 -8 -8 v -40 a8 8 0 0 1 8 -8 z" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="435" y="409" font-size="12" font-weight="700" fill="#14304a" text-anchor="middle">Postgres</text>
+        <text x="435" y="425" font-size="10.5" fill="#3d5570" text-anchor="middle">hosted, schema "gateway"</text>
+        <path d="M 512 385 h 110 a8 8 0 0 1 8 8 v 40 a8 8 0 0 1 -8 8 h -110 a8 8 0 0 1 -8 -8 v -40 a8 8 0 0 1 8 -8 z" fill="#fff" stroke="#14304a" stroke-width="1.4"/>
+        <text x="567" y="409" font-size="12" font-weight="700" fill="#14304a" text-anchor="middle">SQLite</text>
+        <text x="567" y="425" font-size="10.5" fill="#3d5570" text-anchor="middle">self-host, one file</text>
+      </g>
+      <text x="500" y="452" font-size="10.5" fill="#3d5570" text-anchor="middle">same model, either provider - chosen by config, fail-loud</text>
+
+      <!-- User machines (right) -->
+      <text x="730" y="34" font-size="12" fill="#a87b23" letter-spacing="2">USER MACHINES (ANY NUMBER)</text>
+      <g>
+        <rect x="730" y="50" width="240" height="150" rx="8" fill="#fff" stroke="#14304a" stroke-width="1.6"/>
+        <text x="850" y="74" font-size="13.5" font-weight="700" fill="#14304a" text-anchor="middle">Machine A</text>
+        <rect x="748" y="88" width="204" height="42" rx="4" fill="#eef4f7" stroke="#8fa5b8"/>
+        <text x="850" y="105" font-size="12" font-weight="600" fill="#14304a" text-anchor="middle">Director (cc-director)</text>
+        <text x="850" y="121" font-size="10.5" fill="#3d5570" text-anchor="middle">runs N agent sessions</text>
+        <rect x="748" y="140" width="204" height="42" rx="4" fill="#eef4f7" stroke="#8fa5b8"/>
+        <text x="850" y="157" font-size="12" font-weight="600" fill="#14304a" text-anchor="middle">Launcher (cc-launcher)</text>
+        <text x="850" y="173" font-size="10.5" fill="#3d5570" text-anchor="middle">starts and stops Directors</text>
+
+        <rect x="730" y="222" width="240" height="120" rx="8" fill="#fff" stroke="#14304a" stroke-width="1.6" stroke-dasharray="5 4"/>
+        <text x="850" y="248" font-size="13.5" font-weight="700" fill="#14304a" text-anchor="middle">Machine B, C, ...</text>
+        <text x="850" y="270" font-size="11.5" fill="#3d5570" text-anchor="middle">every machine dials out;</text>
+        <text x="850" y="287" font-size="11.5" fill="#3d5570" text-anchor="middle">no inbound ports, works</text>
+        <text x="850" y="304" font-size="11.5" fill="#3d5570" text-anchor="middle">behind NAT and firewalls</text>
+      </g>
+
+      <!-- arrows machines -> gateway -->
+      <line x1="730" y1="109" x2="668" y2="150" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr)"/>
+      <line x1="730" y1="161" x2="668" y2="185" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr)"/>
+      <text x="676" y="120" font-size="10.5" fill="#3d5570" transform="rotate(-24 676 120)">SignalR /director-stream</text>
+      <text x="684" y="182" font-size="10.5" fill="#3d5570" transform="rotate(-14 684 182)">/launcher-stream</text>
+
+      <!-- Cloud services (bottom) -->
+      <text x="30" y="512" font-size="12" fill="#a87b23" letter-spacing="2">DEVTHROTTLE CLOUD + PROVIDERS</text>
+      <rect x="30" y="526" width="280" height="64" rx="6" fill="#fff" stroke="#a87b23" stroke-width="1.4"/>
+      <text x="170" y="550" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">Account service (Supabase)</text>
+      <text x="170" y="568" font-size="11" fill="#3d5570" text-anchor="middle">sign-in tokens, entitlements, credits</text>
+
+      <rect x="340" y="526" width="280" height="64" rx="6" fill="#fff" stroke="#a87b23" stroke-width="1.4"/>
+      <text x="480" y="550" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">Hosted model endpoints</text>
+      <text x="480" y="568" font-size="11" fill="#3d5570" text-anchor="middle">transcription, speech, car-mode brain</text>
+
+      <rect x="650" y="526" width="320" height="64" rx="6" fill="#fff" stroke="#a87b23" stroke-width="1.4"/>
+      <text x="810" y="550" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">Azure front end</text>
+      <text x="810" y="568" font-size="11" fill="#3d5570" text-anchor="middle">TLS at gateway.devthrottle.com; container inside</text>
+
+      <line x1="440" y1="465" x2="240" y2="526" stroke="#a87b23" stroke-width="1.5" marker-end="url(#arrg)"/>
+      <line x1="500" y1="465" x2="490" y2="526" stroke="#a87b23" stroke-width="1.5" marker-end="url(#arrg)"/>
+      <text x="352" y="498" font-size="10.5" fill="#a87b23">only the Gateway holds cloud credentials</text>
+    </svg>
+    </div>
+    <figcaption><b>Diagram 1 - system context.</b> All arrows point AT the Gateway: phones, browsers,
+    command-line tools, Directors, and launchers all dial out to it and authenticate with per-device keys.
+    The Gateway alone talks onward to the account service and the hosted model endpoints. Hosted and
+    self-host run the same binary against Postgres or SQLite respectively.</figcaption>
+  </figure>
+
+  <h3>Who connects, and with what</h3>
+  <div class="tbl-wrap"><table>
+    <tr><th>Participant</th><th>Transport</th><th>Direction</th><th>Credential</th></tr>
+    <tr><td><b>Director</b> (desktop app running agent sessions)</td><td>SignalR hub <code>/director-stream</code> (MessagePack), plus streamed terminal bytes with backpressure</td><td>Director dials Gateway, holds open</td><td>Per-device key as Bearer on the handshake</td></tr>
+    <tr><td><b>Launcher</b> (always-on machine agent)</td><td>SignalR hub <code>/launcher-stream</code>, one-way command channel</td><td>Launcher dials Gateway, holds open</td><td>Per-device key</td></tr>
+    <tr><td><b>Browser Cockpit</b> (React, desktop screens)</td><td>REST plus WebSocket per-session terminal stream</td><td>Browser dials Gateway (same origin)</td><td>Device key mirrored into a Secure cookie</td></tr>
+    <tr><td><b>Phone app</b> (progressive web app + native client)</td><td>REST plus WebSocket; web push for wake-up</td><td>Phone dials Gateway</td><td>Per-device key from enrollment (QR sign-in; the QR carries a URL, never a secret)</td></tr>
+    <tr><td><b>Command-line tools and installers</b></td><td>REST; <code>/healthz</code> probe for address selection</td><td>Tool dials Gateway</td><td>Per-device key</td></tr>
+  </table></div>
+
+  <h3>Finding the Gateway</h3>
+  <p>
+    <b>Hosted:</b> there is nothing to discover. One public base URL (<code>gateway.devthrottle.com</code>)
+    with the Cockpit and the phone app as paths under it. An account does not get a Gateway; it becomes a
+    tenant of the shared one. <b>Self-host:</b> the Gateway fronts itself through Tailscale, and a joining
+    client walks an ordered candidate list - machine name, then Tailscale address, then raw address -
+    probing <code>/healthz</code> and keeping the first that answers.
+  </p>
+</section>
+
+<!-- ================= 03 FEATURES ================= -->
+<section id="features">
+  <div class="sec-head"><span class="n">03</span><h2>What the Gateway does</h2></div>
+
+  <p class="lede">
+    Nineteen subsystems, but they cluster into five jobs: know the fleet, control the fleet,
+    speak and listen, run work unattended, and keep the honest books. Each card names the capability a
+    user actually experiences and the classes a reader should open first.
+  </p>
+
+  <h3>Know the fleet</h3>
+  <div class="cards">
+    <div class="fcard"><span class="tag">Discovery</span><h4>Live roster and short addresses</h4>
+      <p>The in-memory registry of every live Director and launcher, plus the fleet-wide allocator of the three-digit session numbers humans and agents use instead of GUIDs - a number names exactly one session across all machines.</p>
+      <div class="anchor">DirectorRegistry, FleetSessionNumberAllocator, FleetRosterCache</div></div>
+    <div class="fcard"><span class="tag">Fleet</span><h4>One verdict for role and color</h4>
+      <p>Resolves each session's role (Manager, Worker, Architect, solo) from the whole-fleet view - controller liveness is a cross-machine fact - and pushes the folded verdict down so desktop, phone, and Cockpit can never disagree.</p>
+      <div class="anchor">FleetRoleResolver, FleetRoleObserver, FleetDisplayStateObserver</div></div>
+    <div class="fcard"><span class="tag">Briefing</span><h4>Turn boundaries and waiting-time</h4>
+      <p>Detects the real end of an agent's turn (not a startup catch-up), stamps when a session started needing its human, and stores the turn briefs that power spoken summaries and post-mortem recovery.</p>
+      <div class="anchor">TurnEndWatcher, NeedsYouClock, GatewayTurnBriefStore</div></div>
+    <div class="fcard"><span class="tag">Stats / Events</span><h4>Counters and lifecycle proof</h4>
+      <p>Fleet statistics (activity counters, concurrency peaks) in a schema-versioned store, and a per-Director event ring that proves from outside that the Gateway received a Director's lifecycle events.</p>
+      <div class="anchor">GatewayStatsDatabase, GatewayInputStatsAggregator, DirectorEventLog</div></div>
+  </div>
+
+  <h3>Control the fleet</h3>
+  <div class="cards">
+    <div class="fcard"><span class="tag">Streaming</span><h4>The tunnel</h4>
+      <p>The transport backbone: Directors push session state up their held-open connection; commands and live terminal bytes ride the same tunnel down and up with end-to-end backpressure. First message must be an identity binding.</p>
+      <div class="anchor">DirectorHub, LauncherHub, GatewayStreamRegistry, PushedSessionStore</div></div>
+    <div class="fcard"><span class="tag">Cockpit / Mobile</span><h4>The two front doors</h4>
+      <p>The React Cockpit (full mission-control in a browser) and the phone app (supervise, message, approve from anywhere) are both served by the Gateway itself, same-origin, so one URL is the whole product surface.</p>
+      <div class="anchor">CockpitReactApp, MobileApp</div></div>
+    <div class="fcard"><span class="tag">Push</span><h4>Wake the phone</h4>
+      <p>Standards-based web push (VAPID-signed) lights the phone's app icon when a session starts needing its human, even with the app closed - sent on the rising edge, re-asserted periodically.</p>
+      <div class="anchor">WebPushNeedsYouNotifier, VapidWebPushSender</div></div>
+    <div class="fcard"><span class="tag">Snooze / Recovery</span><h4>Holds and resurrection</h4>
+      <p>Snoozes are Gateway-durable so a hold has a guaranteed return even if the Director dies. A dead session is restored as a continuation: a fresh session seeded from surviving turn briefs that ends by re-asking the user.</p>
+      <div class="anchor">SnoozeRegistry, RestoreContextBuilder</div></div>
+  </div>
+
+  <h3>Speak and listen</h3>
+  <div class="cards">
+    <div class="fcard"><span class="tag">Transcription</span><h4>One owner of speech-to-text</h4>
+      <p>Every module that turns audio into text goes through one service - one key, one mode resolution, one dictionary correction - behind resumable, restart-surviving upload staging for dictation and voice notes.</p>
+      <div class="anchor">GatewayTranscriptionService, VoiceUploadStore</div></div>
+    <div class="fcard"><span class="tag">Wingman voice</span><h4>Spoken turn summaries</h4>
+      <p>Narrates session state: turn-end briefings synthesized and cached per session, with the voice screen's entire verdict (badge, message, offered actions) folded on the Gateway per the dumb-client rule.</p>
+      <div class="anchor">GatewayWingmanVoiceEndpoint, VoiceDisplayFold</div></div>
+    <div class="fcard"><span class="tag">Car Mode</span><h4>Hands-free fleet management</h4>
+      <p>A server-side tool-calling loop against the hosted model: the driver talks, the Gateway executes fleet tools (list, start, message, approve, delete) and speaks back, keeping conversation context per device so follow-ups resolve.</p>
+      <div class="anchor">CarModeBrain, CarModeConversationStore</div></div>
+  </div>
+
+  <h3>Run work unattended</h3>
+  <div class="cards">
+    <div class="fcard"><span class="tag">Running</span><h4>Cron for agents</h4>
+      <p>Scheduled jobs with a real cron grammar (timezone- and daylight-saving-correct), durable definitions, run history, and recomputed next-runs after downtime - overnight fleets that fire on time.</p>
+      <div class="anchor">CronEngine, CronJobStore, CronSchedule</div></div>
+    <div class="fcard"><span class="tag">Running</span><h4>Work-queue orchestration</h4>
+      <p>Claims a named work list (GitHub or DevOps backed), drains it one item at a time - spawning an implementation session per item, watching its transcript for the terminal sentinel, recording the outcome, advancing. The Director stays dumb; orchestration lives here.</p>
+      <div class="anchor">WorkListRunner, WorkListRunnerManager</div></div>
+    <div class="fcard"><span class="tag">Running</span><h4>Cross-machine spawn</h4>
+      <p>One resolve-then-create path starts a session on another computer, launching a Director through the launcher channel if none is running. Fail-loud: never silently local.</p>
+      <div class="anchor">MachineSessionSpawner</div></div>
+    <div class="fcard"><span class="tag">Missions / Prompts</span><h4>Shared intent and shared history</h4>
+      <p>Every mission's WHY is durable and shown to everyone (a missing WHY is a loud flag), and the fleet's whole prompt history is queryable in one place because Directors push and keep no copy.</p>
+      <div class="anchor">MissionNoteStore, PromptEndpoints</div></div>
+  </div>
+
+  <h3>Keep the honest books</h3>
+  <div class="cards">
+    <div class="fcard"><span class="tag">Governance</span><h4>An append-only outcome ledger</h4>
+      <p>Every session and run state transition (active, idle, waiting-on-human, waiting-on-permission, blocked, recovered) in an immutable timeline - "a ledger you can rewrite is not a ledger" - powering weekly attention-burden and duration reports.</p>
+      <div class="anchor">GovernanceEventLedger, OutcomeLedgerReporter, GovernanceAuditLog</div></div>
+    <div class="fcard"><span class="tag">Account</span><h4>Sign in once, fleet inherits</h4>
+      <p>The Gateway holds the account token (sole holder), registers itself as a device, mints hosted inference keys, and enrolls child devices - so hosted AI works without anyone pasting a provider key anywhere.</p>
+      <div class="anchor">GatewaySignInService, AccountInferenceKeyProvisioner, DeviceRegistry</div></div>
+    <div class="fcard"><span class="tag">Hosted AI + billing</span><h4>Meter, gate, tally</h4>
+      <p>Enrollment is gated on a paid entitlement (three-state: entitled, not entitled, unknown - never minting on ignorance). Paid endpoints answer 402 with a top-up path when credits run dry; a background sweep mirrors the cloud debit ledger into per-account spend.</p>
+      <div class="anchor">EntitlementRegistry, HostedAiHttp, HostedAiSpendSweep, SessionSpendStore</div></div>
+  </div>
+
+  <div class="rule-box">
+    <b>The multi-agent thesis in one line:</b> the Gateway supplies the four things a pod of cooperating
+    agents cannot supply for itself - a shared address space (numbers, roster), a shared purpose
+    (missions and their WHYs), a shared supervisor channel (roles, messaging, approval from any device),
+    and a shared clock (schedules, turn boundaries, ledgers). That is why it is the center of gravity for
+    agentic development rather than a mere relay.
+  </div>
+</section>
+
+<!-- ================= 04 FLOW ================= -->
+<section id="flow">
+  <div class="sec-head"><span class="n">04</span><h2>How commands and truth flow</h2></div>
+
+  <p class="lede">
+    Two one-way rivers. State flows up from Directors and is folded into verdicts; commands flow down
+    through a single router. Nothing polls, and no client computes meaning.
+  </p>
+
+  <figure>
+    <div class="diagram">
+    <svg viewBox="0 0 1000 560" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Arial, sans-serif">
+      <defs>
+        <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#0e6a8a"/>
+        </marker>
+        <marker id="arr3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#a33b2e"/>
+        </marker>
+      </defs>
+
+      <!-- lanes -->
+      <text x="115" y="36" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">PHONE / COCKPIT</text>
+      <text x="500" y="36" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">GATEWAY</text>
+      <text x="880" y="36" font-size="13" font-weight="700" fill="#14304a" text-anchor="middle">DIRECTOR + SESSION</text>
+      <line x1="115" y1="48" x2="115" y2="530" stroke="#d9d4c8" stroke-width="2"/>
+      <line x1="500" y1="48" x2="500" y2="530" stroke="#d9d4c8" stroke-width="2"/>
+      <line x1="880" y1="48" x2="880" y2="530" stroke="#d9d4c8" stroke-width="2"/>
+
+      <!-- UP: state -->
+      <rect x="70" y="60" width="530" height="20" fill="none"/>
+      <text x="70" y="74" font-size="12" fill="#0e6a8a" font-weight="700" letter-spacing="1.5">TRUTH FLOWS UP (continuous)</text>
+
+      <line x1="880" y1="100" x2="505" y2="100" stroke="#0e6a8a" stroke-width="2" marker-end="url(#arr2)"/>
+      <text x="690" y="92" font-size="11.5" fill="#14304a" text-anchor="middle">Hello: bind identity; tenant resolved from the authenticated key</text>
+
+      <line x1="880" y1="140" x2="505" y2="140" stroke="#0e6a8a" stroke-width="2" marker-end="url(#arr2)"/>
+      <text x="690" y="132" font-size="11.5" fill="#14304a" text-anchor="middle">push snapshot, then deltas (monotonic sequence; stale pushes rejected)</text>
+
+      <rect x="380" y="162" width="240" height="96" rx="6" fill="#eef4f7" stroke="#0e6a8a" stroke-width="1.6"/>
+      <text x="500" y="182" font-size="12" font-weight="700" fill="#14304a" text-anchor="middle">THE FOLD (rule 7)</text>
+      <text x="500" y="200" font-size="11" fill="#3d5570" text-anchor="middle">color + label + triage (SessionOrdering)</text>
+      <text x="500" y="216" font-size="11" fill="#3d5570" text-anchor="middle">role verdict (FleetRoleResolver)</text>
+      <text x="500" y="232" font-size="11" fill="#3d5570" text-anchor="middle">voice screen verdict (VoiceDisplayFold)</text>
+      <text x="500" y="248" font-size="11" fill="#3d5570" text-anchor="middle">5-second sweep as a backstop</text>
+
+      <line x1="495" y1="286" x2="120" y2="286" stroke="#0e6a8a" stroke-width="2" marker-end="url(#arr2)"/>
+      <text x="305" y="278" font-size="11.5" fill="#14304a" text-anchor="middle">finished verdicts stamped on the session data</text>
+      <text x="305" y="302" font-size="11" fill="#3d5570" text-anchor="middle">client renders verbatim - never re-derives meaning</text>
+
+      <line x1="495" y1="330" x2="885" y2="330" stroke="#0e6a8a" stroke-width="2" marker-end="url(#arr2)"/>
+      <text x="690" y="322" font-size="11.5" fill="#14304a" text-anchor="middle">same verdicts pushed DOWN to the owning desktop rail</text>
+
+      <!-- DOWN: commands -->
+      <text x="70" y="382" font-size="12" fill="#a33b2e" font-weight="700" letter-spacing="1.5">COMMANDS FLOW DOWN (on demand)</text>
+
+      <line x1="120" y1="410" x2="495" y2="410" stroke="#a33b2e" stroke-width="2" marker-end="url(#arr3)"/>
+      <text x="305" y="402" font-size="11.5" fill="#14304a" text-anchor="middle">verb: prompt / hold / interrupt / approve / spawn ...</text>
+
+      <rect x="380" y="428" width="240" height="58" rx="6" fill="#fbf0ee" stroke="#a33b2e" stroke-width="1.6"/>
+      <text x="500" y="448" font-size="12" font-weight="700" fill="#14304a" text-anchor="middle">DirectorCommandRouter</text>
+      <text x="500" y="464" font-size="11" fill="#3d5570" text-anchor="middle">resolves owner from pushed state only;</text>
+      <text x="500" y="478" font-size="11" fill="#3d5570" text-anchor="middle">untethered Director = 502, no fallback</text>
+
+      <line x1="620" y1="457" x2="875" y2="457" stroke="#a33b2e" stroke-width="2" marker-end="url(#arr3)"/>
+      <text x="748" y="449" font-size="11.5" fill="#14304a" text-anchor="middle">invoked down the held-open tunnel</text>
+
+      <line x1="880" y1="505" x2="120" y2="505" stroke="#0e6a8a" stroke-width="1.6" stroke-dasharray="6 4" marker-end="url(#arr2)"/>
+      <text x="500" y="497" font-size="11.5" fill="#14304a" text-anchor="middle">result / live terminal bytes stream back (WebSocket leg, backpressure end to end)</text>
+    </svg>
+    </div>
+    <figcaption><b>Diagram 2 - the two rivers.</b> Directors push state up; the Gateway folds every
+    display verdict once and stamps it; clients render verbatim. Commands go down one router with a
+    bounded wait (30 seconds for ordinary verbs, 3 minutes for language-model verbs like recap and
+    handover) and fail loud with 502 when the target Director is not tethered.</figcaption>
+  </figure>
+
+  <p>
+    The architectural payoff of this shape is worth stating plainly. Because state is pushed and cached,
+    the read path (<code>/sessions</code>) is a memory read - no fan-out polling storm as fleets grow.
+    Because commands ride a connection the Director itself opened, remote control needs no inbound
+    firewall rule anywhere. And because every verdict folds in one place, adding a new session state is
+    one edit on the Gateway - never a new conditional in three clients. The known cost is equally plain:
+    the Gateway is a stateful single point of coordination (section 10, decision 6).
+  </p>
+</section>
+
+<!-- ================= 05 TENANT ================= -->
+<section id="tenant">
+  <div class="sec-head"><span class="n">05</span><h2>What a tenant is, and how one is born</h2></div>
+
+  <p class="lede">
+    A tenant is an account's private universe on the shared Gateway: its Directors, sessions, devices,
+    schedules, ledgers, and voice - keyed everywhere by one minted identifier. The design has a single
+    repeated shape: <b>resolve the tenant once, at an authentication boundary, from a server-verified
+    credential - then carry it ambiently and refuse to ever guess it.</b>
+  </p>
+
+  <h3>The identity chain</h3>
+  <ul>
+    <li><b><code>TenantId</code> is a validated type, not a string.</b> An invalid or empty value cannot
+      be constructed; <code>default</code> is invalid rather than a fallback. Two well-known values exist:
+      <code>Local</code> (the self-host single tenant) and <code>System</code> (hosted-side seed and
+      startup writes). Real tenants are minted GUIDs. Logs render account tenants only as a one-way
+      short hash - raw tenant identifiers are a privacy contract.</li>
+    <li><b>An account maps to exactly one tenant, by subject.</b> The account service's stable subject
+      claim - never the email - is the idempotency key: same account, same tenant, forever; new subject,
+      fresh mint. A unique database index is the backstop against a racing double-mint.</li>
+    <li><b>Devices are the credential.</b> Every phone, browser, Director, and launcher enrolls and
+      receives its own 256-bit key - individually revocable, hashed at rest (SHA-256, constant-time
+      compare), shown in plaintext exactly once at mint, rotated in place on re-enrollment. The device
+      record carries the account subject and the tenant; from then on, presenting the key IS presenting
+      the tenant.</li>
+  </ul>
+
+  <figure>
+    <div class="diagram">
+    <svg viewBox="0 0 1000 330" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Arial, sans-serif">
+      <defs>
+        <marker id="arr4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#3d5570"/>
+        </marker>
+      </defs>
+      <!-- steps -->
+      <rect x="20" y="60" width="170" height="88" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+      <text x="105" y="84" font-size="12.5" font-weight="700" fill="#14304a" text-anchor="middle">1. Account token</text>
+      <text x="105" y="103" font-size="10.8" fill="#3d5570" text-anchor="middle">caller presents a signed</text>
+      <text x="105" y="118" font-size="10.8" fill="#3d5570" text-anchor="middle">sign-in token; signature,</text>
+      <text x="105" y="133" font-size="10.8" fill="#3d5570" text-anchor="middle">audience, expiry verified</text>
+
+      <rect x="225" y="60" width="170" height="88" rx="6" fill="#fff" stroke="#a87b23" stroke-width="1.5"/>
+      <text x="310" y="84" font-size="12.5" font-weight="700" fill="#14304a" text-anchor="middle">2. Entitlement gate</text>
+      <text x="310" y="103" font-size="10.8" fill="#3d5570" text-anchor="middle">three outcomes:</text>
+      <text x="310" y="118" font-size="10.8" fill="#3d5570" text-anchor="middle">entitled -&gt; continue; unpaid -&gt; 402;</text>
+      <text x="310" y="133" font-size="10.8" fill="#3d5570" text-anchor="middle">unknown -&gt; 503, never mint</text>
+
+      <rect x="430" y="60" width="170" height="88" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+      <text x="515" y="84" font-size="12.5" font-weight="700" fill="#14304a" text-anchor="middle">3. Tenant mint</text>
+      <text x="515" y="103" font-size="10.8" fill="#3d5570" text-anchor="middle">subject -&gt; tenant, idempotent;</text>
+      <text x="515" y="118" font-size="10.8" fill="#3d5570" text-anchor="middle">unique index backstops</text>
+      <text x="515" y="133" font-size="10.8" fill="#3d5570" text-anchor="middle">the mint race</text>
+
+      <rect x="635" y="60" width="170" height="88" rx="6" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+      <text x="720" y="84" font-size="12.5" font-weight="700" fill="#14304a" text-anchor="middle">4. Device key issue</text>
+      <text x="720" y="103" font-size="10.8" fill="#3d5570" text-anchor="middle">256-bit key, hashed at rest,</text>
+      <text x="720" y="118" font-size="10.8" fill="#3d5570" text-anchor="middle">bound to subject + tenant;</text>
+      <text x="720" y="133" font-size="10.8" fill="#3d5570" text-anchor="middle">device id namespaced by tenant</text>
+
+      <rect x="840" y="60" width="140" height="88" rx="6" fill="#eef4f7" stroke="#0e6a8a" stroke-width="1.8"/>
+      <text x="910" y="84" font-size="12.5" font-weight="700" fill="#14304a" text-anchor="middle">5. Forever after</text>
+      <text x="910" y="103" font-size="10.8" fill="#3d5570" text-anchor="middle">every call presents</text>
+      <text x="910" y="118" font-size="10.8" fill="#3d5570" text-anchor="middle">the key; the key</text>
+      <text x="910" y="133" font-size="10.8" fill="#3d5570" text-anchor="middle">IS the tenant</text>
+
+      <line x1="190" y1="104" x2="220" y2="104" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr4)"/>
+      <line x1="395" y1="104" x2="425" y2="104" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr4)"/>
+      <line x1="600" y1="104" x2="630" y2="104" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr4)"/>
+      <line x1="805" y1="104" x2="835" y2="104" stroke="#3d5570" stroke-width="1.8" marker-end="url(#arr4)"/>
+
+      <!-- bottom notes -->
+      <rect x="20" y="190" width="465" height="106" rx="6" fill="#fdf6ec" stroke="#a87b23" stroke-width="1.2"/>
+      <text x="40" y="216" font-size="12" font-weight="700" fill="#14304a">Where the tenant is bound afterwards</text>
+      <text x="40" y="238" font-size="11.3" fill="#3d5570">HTTP: middleware authenticates the key; the route resolves the</text>
+      <text x="40" y="255" font-size="11.3" fill="#3d5570">caller's tenant from that key - never from the payload.</text>
+      <text x="40" y="272" font-size="11.3" fill="#3d5570">Tunnel: resolved once at Hello; a key with no bound tenant means</text>
+      <text x="40" y="289" font-size="11.3" fill="#3d5570">the connection is aborted, not defaulted.</text>
+
+      <rect x="515" y="190" width="465" height="106" rx="6" fill="#eef4f7" stroke="#0e6a8a" stroke-width="1.2"/>
+      <text x="535" y="216" font-size="12" font-weight="700" fill="#14304a">The one absolute rule</text>
+      <text x="535" y="238" font-size="11.3" fill="#3d5570">On the hosted Gateway, "no tenant resolved" is ALWAYS a denial</text>
+      <text x="535" y="255" font-size="11.3" fill="#3d5570">(403, abort, or empty result) - never a quiet fall-through to the</text>
+      <text x="535" y="272" font-size="11.3" fill="#3d5570">Local tenant. Defaulting is the one sin the design refuses,</text>
+      <text x="535" y="289" font-size="11.3" fill="#3d5570">because a silent default is a silent merge of two customers.</text>
+    </svg>
+    </div>
+    <figcaption><b>Diagram 3 - how a tenant is born and carried.</b> Enrollment verifies the account,
+    gates on payment (never minting on ignorance), mints the tenant idempotently, and issues a hashed
+    per-device key that carries the tenant on every subsequent call.</figcaption>
+  </figure>
+
+  <h3>Hosted and self-host are the same code, split by one contract</h3>
+  <div class="tbl-wrap"><table>
+    <tr><th></th><th>Self-host (open source)</th><th>Hosted (the product)</th></tr>
+    <tr><td>Tenancy</td><td>Exactly one tenant, <code>Local</code>; tenant context is inert</td><td>Per-account tenants; async ambient context that throws when unresolved</td></tr>
+    <tr><td>Credentials</td><td>Per-device keys, plus a shared machine token for the box owner</td><td>Per-device keys only; the shared machine token is rejected, break-glass login disabled, cookies Secure</td></tr>
+    <tr><td>Storage</td><td>SQLite file next to the app</td><td>Postgres, schema <code>gateway</code>, same model and migrations discipline</td></tr>
+    <tr><td>Billing</td><td>None; entitlement gate absent</td><td>Enrollment requires a paid entitlement; hosted AI meters credits and answers 402</td></tr>
+    <tr><td>Mode integrity</td><td>-</td><td>The hosted image identity is compiled in; at boot the startup contract refuses to run unless hosted mode, auth, an HTTPS public URL, and Postgres are all present - a hosted box cannot silently downgrade to single-tenant semantics</td></tr>
+    <tr><td>Self-host-only surfaces</td><td>Available (key vault, stats dashboard, owner settings, machine-local discovery)</td><td>Denied wholesale by a shared refusal primitive that covers every verb and malformed-request shape</td></tr>
+  </table></div>
+</section>
+
+<!-- ================= 06 ISOLATION ================= -->
+<section id="isolation">
+  <div class="sec-head"><span class="n">06</span><h2>How isolation is enforced</h2></div>
+
+  <p class="lede">
+    There is no single wall; there are six, each fail-closed, each of a different kind - so one missed
+    call site does not become a breach. That is the strength. The honest weakness (section 8) is that
+    the layers between the edge and the database are still applied per call site rather than imposed
+    by one chokepoint.
+  </p>
+
+  <figure>
+    <div class="diagram">
+    <svg viewBox="0 0 1000 470" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Arial, sans-serif">
+      <!-- attacker on left -->
+      <text x="60" y="46" font-size="12.5" font-weight="700" fill="#a33b2e">A hostile or buggy</text>
+      <text x="60" y="63" font-size="12.5" font-weight="700" fill="#a33b2e">tenant's request</text>
+      <line x1="70" y1="80" x2="70" y2="420" stroke="#a33b2e" stroke-width="2" stroke-dasharray="7 5"/>
+      <text x="60" y="445" font-size="11" fill="#a33b2e">must survive all six to touch foreign data</text>
+
+      <!-- layers -->
+      <g font-size="11.5">
+        <rect x="130" y="72" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="93" font-size="12.5" font-weight="700" fill="#14304a">1. Edge authentication - deny by default</text>
+        <text x="150" y="111" fill="#3d5570">Every route except health and sign-in demands a valid device key; hashed at rest, constant-time compare; revocable per device.</text>
+
+        <rect x="130" y="132" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="153" font-size="12.5" font-weight="700" fill="#14304a">2. Tenant binding - once, from the credential</text>
+        <text x="150" y="171" fill="#3d5570">HTTP routes and the tunnel's Hello resolve the tenant from the authenticated key; unresolved means 403 or connection abort, never a default.</text>
+
+        <rect x="130" y="192" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="213" font-size="12.5" font-weight="700" fill="#14304a">3. Object ownership - authentication is not authorization</text>
+        <text x="150" y="231" fill="#3d5570">Owning THIS object is proved separately: per-Director routes answer 404 for a foreign identifier; stream ownership is re-checked on every frame.</text>
+
+        <rect x="130" y="252" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="273" font-size="12.5" font-weight="700" fill="#14304a">4. Partitioned live state - tenant is half of every key</text>
+        <text x="150" y="291" fill="#3d5570">The session cache and Director registry are keyed by (tenant, identifier); a guessed foreign identifier simply is not in the caller's partition.</text>
+
+        <rect x="130" y="312" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="333" font-size="12.5" font-weight="700" fill="#14304a">5. The data layer - structural, not conventional</text>
+        <text x="150" y="351" fill="#3d5570">Every scoped table carries tenant_id with a global query filter bound to the ambient tenant; collision-prone tables use composite (tenant, id) keys.</text>
+
+        <rect x="130" y="372" width="840" height="52" rx="5" fill="#fff" stroke="#14304a" stroke-width="1.5"/>
+        <text x="150" y="393" font-size="12.5" font-weight="700" fill="#14304a">6. Refusal and boot integrity - what has no tenant model is denied</text>
+        <text x="150" y="411" fill="#3d5570">Self-host-only route families are refused wholesale on hosted; the compiled-in image identity refuses to boot without the full hosted contract.</text>
+      </g>
+
+      <!-- right margin: who enforces -->
+      <g font-size="10" fill="#8b8577" font-family="Consolas, monospace">
+        <text x="962" y="103" text-anchor="end">AuthMiddleware, DeviceRegistry</text>
+        <text x="962" y="163" text-anchor="end">HostedTenantBoundary, DirectorHub.Hello</text>
+        <text x="962" y="223" text-anchor="end">StreamOwner, TryResolveOwnedDirector</text>
+        <text x="962" y="283" text-anchor="end">PushedSessionStore, DirectorRegistry</text>
+        <text x="962" y="343" text-anchor="end">GatewayDbContext, GatewayDatabase</text>
+        <text x="962" y="403" text-anchor="end">HostedRouteDeny, HostedStartupContract</text>
+      </g>
+    </svg>
+    </div>
+    <figcaption><b>Diagram 4 - defense in depth.</b> Six layers of different kinds: credential, binding,
+    ownership, partition, schema, refusal. A cross-tenant read requires a hole in several at once; most
+    single-call-site mistakes are caught by the layer beneath them.</figcaption>
+  </figure>
+
+  <h3>The guarantees, stated as a security engineer would</h3>
+  <ul>
+    <li><b>Guessing an identifier gets you nothing.</b> Tenant is half of every lookup key for live state,
+      so tenant A asking for tenant B's Director yields 404 - indistinguishable from "does not exist."
+      Registration happens under the resolved tenant, not the claimed identifier, so naming another
+      account's Director is structurally impossible regardless of what the client sends.</li>
+    <li><b>Authentication and authorization are kept distinct, on purpose.</b> The code says it in so many
+      words: binding proves WHO is calling, not that the caller owns THIS stream. Stream ownership
+      (tenant plus owning Director, both server-resolved) is recorded at open and re-verified on every
+      frame; a mismatch is a loud refusal, not a dropped frame.</li>
+    <li><b>The database cannot forget the tenant.</b> Scoping is inherited by construction: any entity
+      deriving from the scoped base gets the column, the index, and the query filter automatically. The
+      deliberate escape hatch (for the two global tables) sets the ambient tenant to null, so misusing
+      it against a scoped table returns nothing rather than everything.</li>
+    <li><b>Unpaid means unminted.</b> The entitlement gate has three outcomes, and only a confirmed
+      "entitled" mints a tenant. A billing-database hiccup neither locks a paying customer out forever
+      (503, retry) nor gives the product away (no mint on unknown).</li>
+    <li><b>Background work runs as somebody.</b> Sweeps and loops iterate live tenants one scope at a
+      time; on hosted there is no ambient "nobody" whose work silently lands in a shared bucket - the
+      historical hard-coded Local passes are exactly what the current program is eliminating.</li>
+  </ul>
+
+  <div class="good-box">
+    <b>What is genuinely senior here.</b> The typed <code>TenantId</code> that cannot be empty; deny
+    instead of default at every resolution site; three-state entitlement instead of a boolean; hashing
+    device keys like passwords; refusing whole route families rather than pretending single-tenant
+    surfaces have a tenant model; and a boot contract that makes the hosted image refuse to run
+    mis-configured rather than silently collapse into single-tenant behavior. These are the patterns
+    reviewers keep flagging as the right shape.
+  </div>
+</section>
+
+<!-- ================= 07 DATA ================= -->
+<section id="data">
+  <div class="sec-head"><span class="n">07</span><h2>The data layer</h2></div>
+
+  <p class="lede">
+    One entity model, two interchangeable engines, three storage tiers. The durable tier is where the
+    isolation guarantee is strongest - it is structural. The file and in-memory tiers enforce tenancy
+    in code, which is exactly where the remaining census work lives.
+  </p>
+
+  <figure>
+    <div class="diagram">
+    <svg viewBox="0 0 1000 540" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Arial, sans-serif">
+      <!-- Tier 1: relational -->
+      <rect x="20" y="40" width="960" height="230" rx="8" fill="#eef7f1" stroke="#2e7d54" stroke-width="1.8"/>
+      <text x="40" y="66" font-size="13.5" font-weight="700" fill="#14304a">TIER 1 - RELATIONAL, TENANT-SCOPED BY CONSTRUCTION (survives everything)</text>
+      <text x="40" y="84" font-size="11" fill="#3d5570">every table carries tenant_id + a global query filter; ambient tenant stamped by one context factory; migrations applied at boot, SQLite and Postgres in lockstep</text>
+
+      <g font-size="11.5" fill="#14304a">
+        <rect x="40" y="100" width="215" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="147" y="120" text-anchor="middle" font-weight="700">Scheduling</text>
+        <text x="147" y="137" text-anchor="middle" fill="#3d5570" font-size="10.8">cron_jobs (tenant+id key)</text>
+        <text x="147" y="152" text-anchor="middle" fill="#3d5570" font-size="10.8">cron_runs, worklists + items</text>
+
+        <rect x="270" y="100" width="215" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="377" y="120" text-anchor="middle" font-weight="700">Workflows</text>
+        <text x="377" y="137" text-anchor="middle" fill="#3d5570" font-size="10.8">workflows (tenant+id key)</text>
+        <text x="377" y="152" text-anchor="middle" fill="#3d5570" font-size="10.8">versions, files, runs (pinned)</text>
+
+        <rect x="500" y="100" width="215" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="607" y="120" text-anchor="middle" font-weight="700">Governance ledgers</text>
+        <text x="607" y="137" text-anchor="middle" fill="#3d5570" font-size="10.8">governance_events (append-only)</text>
+        <text x="607" y="152" text-anchor="middle" fill="#3d5570" font-size="10.8">governance_audit_events</text>
+
+        <rect x="730" y="100" width="230" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="845" y="120" text-anchor="middle" font-weight="700">Spend</text>
+        <text x="845" y="137" text-anchor="middle" fill="#3d5570" font-size="10.8">session_spend (micro-dollars)</text>
+        <text x="845" y="152" text-anchor="middle" fill="#3d5570" font-size="10.8">account_hosted_ai_spend</text>
+
+        <rect x="40" y="180" width="215" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="147" y="200" text-anchor="middle" font-weight="700">Session control</text>
+        <text x="147" y="217" text-anchor="middle" fill="#3d5570" font-size="10.8">snoozes, push_subscriptions</text>
+        <text x="147" y="232" text-anchor="middle" fill="#3d5570" font-size="10.8">wingman_instructions</text>
+
+        <rect x="270" y="180" width="215" height="66" rx="5" fill="#fff" stroke="#2e7d54"/>
+        <text x="377" y="200" text-anchor="middle" font-weight="700">Missions</text>
+        <text x="377" y="217" text-anchor="middle" fill="#3d5570" font-size="10.8">mission_notes (tenant+key)</text>
+        <text x="377" y="232" text-anchor="middle" fill="#3d5570" font-size="10.8">the durable WHY</text>
+
+        <rect x="500" y="180" width="460" height="66" rx="5" fill="#fdf6ec" stroke="#a87b23" stroke-width="1.5"/>
+        <text x="730" y="200" text-anchor="middle" font-weight="700">GLOBAL BY DESIGN (the only two)</text>
+        <text x="730" y="217" text-anchor="middle" fill="#3d5570" font-size="10.8">tenants: the account-to-tenant map itself &middot; entitlements: read-only, owned by the payment side</text>
+        <text x="730" y="232" text-anchor="middle" fill="#3d5570" font-size="10.8">reached only through an unscoped context that fails closed against every scoped table</text>
+      </g>
+
+      <!-- Tier 2 -->
+      <rect x="20" y="290" width="960" height="110" rx="8" fill="#fdf6ec" stroke="#a87b23" stroke-width="1.8"/>
+      <text x="40" y="316" font-size="13.5" font-weight="700" fill="#14304a">TIER 2 - FILES AND JSON, TENANT-PARTITIONED IN CODE (survives restart)</text>
+      <g font-size="11" fill="#3d5570">
+        <text x="40" y="340">devices.json - enrolled devices and hashed keys &middot; the Gateway's own cloud device key &middot; voice upload staging + delivery tombstones</text>
+        <text x="40" y="358">turn-brief history (what recovery reads after a Director dies) &middot; recording and transcript archives &middot; the stats database</text>
+        <text x="40" y="382" font-style="italic">isolation here depends on code discipline, not schema - this tier holds the recordings and transcripts, the product's most sensitive data (see section 8)</text>
+      </g>
+
+      <!-- Tier 3 -->
+      <rect x="20" y="420" width="960" height="100" rx="8" fill="#eef4f7" stroke="#0e6a8a" stroke-width="1.8"/>
+      <text x="40" y="446" font-size="13.5" font-weight="700" fill="#14304a">TIER 3 - IN-MEMORY, REBUILT FROM PUSHES ON RESTART (live fleet truth)</text>
+      <g font-size="11" fill="#3d5570">
+        <text x="40" y="470">pushed session cache and Director registry - keyed by (tenant, identifier) &middot; stream registry with per-stream ownership &middot; launcher connections</text>
+        <text x="40" y="488">plus the long tail of small singleton maps the census audited - the tier where 40 rows were actively unsafe on July 20 and where the remaining work is</text>
+        <text x="40" y="506" font-style="italic">nothing here is precious: a Gateway restart loses no durable state; Directors re-push and the world reassembles</text>
+      </g>
+    </svg>
+    </div>
+    <figcaption><b>Diagram 5 - three storage tiers.</b> The guarantee weakens as you go down: tier 1 is
+    structural (schema-enforced), tier 2 is code-enforced on files, tier 3 is code-enforced in memory.
+    The isolation program's remaining work is almost entirely in tiers 2 and 3.</figcaption>
+  </figure>
+
+  <p>Facts worth carrying to the blackboard:</p>
+  <ul>
+    <li><b>Provider selection is fail-loud.</b> Connection string present means Postgres; absent means
+      SQLite; blank or broken means refuse to boot. There is no fallback between them - a
+      mis-configured hosted box never quietly becomes a local one.</li>
+    <li><b>The model enforces a strict common subset</b> so both engines behave identically: UTC-forced
+      timestamps, money as integer micro-units (bare decimals are banned), code-generated GUID keys,
+      matching string collation for natural keys.</li>
+    <li><b>Composite keys where identifiers collide.</b> Cron jobs, workflows, and mission notes use
+      (tenant, identifier) primary keys because their identifiers are short, seeded, or human-chosen -
+      two tenants can legitimately hold the same one.</li>
+    <li><b>Ledgers reference by value, not foreign key.</b> Governance events and spend rows point at
+      session identifiers without database-level foreign keys - deliberately, because ledgers must
+      outlive the sessions they record.</li>
+  </ul>
+</section>
+
+<!-- ================= 08 WRONG ================= -->
+<section id="wrong">
+  <div class="sec-head"><span class="n">08</span><h2>What is wrong today</h2></div>
+
+  <p class="lede">
+    This section is deliberately unsparing; decisions get made here. The good news first: the team ran
+    a finite census of every piece of retained state (94 rows, not a sample) and published a remedy map
+    - the defect surface is <i>known and bounded</i>, and a large wave of fixes has landed since the
+    census snapshot. The bad news: the highest-risk items open today are not exotic - they are reachable
+    by any authenticated tenant on a Gateway with open signup.
+  </p>
+
+  <h3>8.1 The structural defect underneath everything else</h3>
+  <div class="finding">
+    <div class="fhead"><span class="sev s0">STRUCTURAL</span><h4>Tenancy is enforced per call site; a forgotten call site fails toward sharing, not toward denial</h4></div>
+    <p>Every route and background loop must individually resolve its tenant. The recurring code idiom
+    resolves to the Local tenant when no hosted boundary is present - correct for self-host, but it means
+    the failure mode of a <i>missed</i> hosted call site is silent state-sharing, not a loud error. The
+    proof that this is the real defect class is the commit history itself: the cockpit read path, the
+    display push seam, the role push seam, the voice path, the per-Director routes, the input statistics
+    aggregator, and the device listing were each made tenant-aware in separate fixes, one surface at a
+    time. Every one of those was the same bug wearing a different coat.</p>
+    <p class="ev">Evidence: the eleven-unit remedy map's conclusion that no single prefix boundary exists; the fix stream on origin/main through 0dc22714.</p>
+  </div>
+
+  <h3>8.2 Open, exploitable issues that gate go-live</h3>
+
+  <div class="finding">
+    <div class="fhead"><span class="sev s0">SECURITY</span><h4>Machine control and process control reachable across tenants</h4></div>
+    <p>The launcher and machine-control family is still tenant-blind: open issues cover cross-machine
+    code execution and outbound request forgery by an authenticated subscriber (#1917), a brain-restart
+    route that lets any authenticated caller respawn the shared brain process and rewrite fleet-injected
+    text (#1863), and a diagnostic route that force-kills an arbitrary process tree by caller-chosen
+    process identifier (#1913). On a box with open signup, "authenticated" is not a meaningful barrier.</p>
+    <p class="ev">Open issues #1917, #1863, #1913. Interim denies for several owner surfaces exist; these three name routes that remain live.</p>
+  </div>
+
+  <div class="finding">
+    <div class="fhead"><span class="sev s0">SECURITY</span><h4>Any enrolled tenant can spend the operator's model key</h4></div>
+    <p>The AI-model routes still allow an enrolled tenant to drive inference billed to the operator's
+    provider key (#1921). Combined with the absence of any rate limiting (section 9), this is an
+    unmetered cost hole as well as an authorization one.</p>
+    <p class="ev">Open issue #1921.</p>
+  </div>
+
+  <div class="finding">
+    <div class="fhead"><span class="sev s0">SECURITY</span><h4>Speech - the product's most sensitive data - is not yet partitioned at

--- a/docs/architecture/multi-tenant-gateway-architecture-reference-2026-07-21.html
+++ b/docs/architecture/multi-tenant-gateway-architecture-reference-2026-07-21.html
@@ -1,0 +1,770 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The DevThrottle Gateway - Architecture Reference</title>
+</head>
+<body>
+<style>
+  :root{
+    --paper:#F3F4F3; --panel:#FFFFFF; --panel-2:#FAFBFA;
+    --ink:#16201F; --ink-soft:#48524F; --ink-faint:#6E7874;
+    --line:#DCE1DE; --line-soft:#E8ECE9;
+    --accent:#0B6E6A; --accent-ink:#095E5A; --accent-tint:#E4EFED;
+    --working:#2E6BB0; --needsyou:#BE3A2C; --waiting:#B4801A; --idle:#6E7C86; --good:#2C7A57;
+    --working-tint:#E7EEF6; --needsyou-tint:#F6E7E4; --waiting-tint:#F5EEDD; --idle-tint:#ECEFF1; --good-tint:#E4F0EA;
+    --shadow:0 1px 2px rgba(20,30,28,.04), 0 8px 28px rgba(20,30,28,.06);
+    --radius:14px; --radius-sm:9px;
+    --font-display:"Segoe UI Variable Display","Segoe UI Semibold","Segoe UI",system-ui,-apple-system,"Helvetica Neue",Arial,sans-serif;
+    --font-body:Georgia,"Iowan Old Style","Palatino Linotype","Times New Roman",serif;
+    --font-mono:"Cascadia Code","JetBrains Mono",ui-monospace,"SFMono-Regular",Consolas,"Liberation Mono",monospace;
+    --measure:68ch;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{
+      --paper:#0E1413; --panel:#151D1C; --panel-2:#111817;
+      --ink:#E9EDEB; --ink-soft:#A6B1AD; --ink-faint:#7E8985;
+      --line:#26302E; --line-soft:#1E2726;
+      --accent:#33B4A9; --accent-ink:#57C6BC; --accent-tint:#12302D;
+      --working:#5E9BE0; --needsyou:#E4695A; --waiting:#E4B24C; --idle:#93A2AC; --good:#4CB07E;
+      --working-tint:#12222F; --needsyou-tint:#2A1613; --waiting-tint:#271F0E; --idle-tint:#182022; --good-tint:#0F241B;
+      --shadow:0 1px 2px rgba(0,0,0,.3), 0 10px 34px rgba(0,0,0,.4);
+    }
+  }
+  :root[data-theme="light"]{
+    --paper:#F3F4F3; --panel:#FFFFFF; --panel-2:#FAFBFA;
+    --ink:#16201F; --ink-soft:#48524F; --ink-faint:#6E7874;
+    --line:#DCE1DE; --line-soft:#E8ECE9;
+    --accent:#0B6E6A; --accent-ink:#095E5A; --accent-tint:#E4EFED;
+    --working:#2E6BB0; --needsyou:#BE3A2C; --waiting:#B4801A; --idle:#6E7C86; --good:#2C7A57;
+    --working-tint:#E7EEF6; --needsyou-tint:#F6E7E4; --waiting-tint:#F5EEDD; --idle-tint:#ECEFF1; --good-tint:#E4F0EA;
+    --shadow:0 1px 2px rgba(20,30,28,.04), 0 8px 28px rgba(20,30,28,.06);
+  }
+  :root[data-theme="dark"]{
+    --paper:#0E1413; --panel:#151D1C; --panel-2:#111817;
+    --ink:#E9EDEB; --ink-soft:#A6B1AD; --ink-faint:#7E8985;
+    --line:#26302E; --line-soft:#1E2726;
+    --accent:#33B4A9; --accent-ink:#57C6BC; --accent-tint:#12302D;
+    --working:#5E9BE0; --needsyou:#E4695A; --waiting:#E4B24C; --idle:#93A2AC; --good:#4CB07E;
+    --working-tint:#12222F; --needsyou-tint:#2A1613; --waiting-tint:#271F0E; --idle-tint:#182022; --good-tint:#0F241B;
+    --shadow:0 1px 2px rgba(0,0,0,.3), 0 10px 34px rgba(0,0,0,.4);
+  }
+
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  @media (prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
+  body{
+    margin:0; background:var(--paper); color:var(--ink);
+    font-family:var(--font-body); font-size:1.06rem; line-height:1.66;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  }
+
+  /* ---------- reading progress ---------- */
+  .progress{position:fixed; top:0; left:0; height:3px; width:0%; z-index:60;
+    background:linear-gradient(90deg,var(--accent),var(--accent-ink));}
+
+  /* ---------- top bar ---------- */
+  .topbar{position:sticky; top:0; z-index:50; backdrop-filter:saturate(1.2) blur(8px);
+    background:color-mix(in srgb, var(--paper) 82%, transparent);
+    border-bottom:1px solid var(--line-soft);}
+  .topbar-in{max-width:1180px; margin:0 auto; padding:.55rem clamp(1rem,4vw,2rem);
+    display:flex; align-items:center; justify-content:space-between; gap:1rem;}
+  .brand{font-family:var(--font-mono); font-size:.72rem; letter-spacing:.14em; text-transform:uppercase;
+    color:var(--ink-soft); display:flex; align-items:center; gap:.6rem;}
+  .brand .dot{width:8px; height:8px; border-radius:50%; background:var(--accent); box-shadow:0 0 0 3px var(--accent-tint);}
+  .brand b{color:var(--ink); font-weight:600}
+  .topmeta{font-family:var(--font-mono); font-size:.68rem; color:var(--ink-faint); letter-spacing:.04em}
+
+  /* ---------- layout ---------- */
+  .wrap{max-width:1180px; margin:0 auto; padding:0 clamp(1rem,4vw,2rem);}
+  .col{max-width:720px; margin-left:auto; margin-right:auto;}
+  .bleed{max-width:1080px; margin-left:auto; margin-right:auto;}
+  section{padding:clamp(2.4rem,5vw,4rem) 0; border-bottom:1px solid var(--line-soft);}
+
+  /* ---------- hero ---------- */
+  .hero{padding:clamp(3rem,7vw,6rem) 0 clamp(2.2rem,5vw,3.4rem);}
+  .kicker{font-family:var(--font-mono); font-size:.74rem; letter-spacing:.2em; text-transform:uppercase;
+    color:var(--accent-ink); display:inline-flex; align-items:center; gap:.6rem;}
+  .kicker::before{content:""; width:26px; height:1px; background:var(--accent); display:inline-block;}
+  h1{font-family:var(--font-display); font-weight:800; letter-spacing:-.02em; line-height:1.02;
+    font-size:clamp(2.5rem,6vw,4.3rem); margin:1.1rem 0 0; text-wrap:balance;
+    color:var(--ink);}
+  h1 .thin{color:var(--ink-soft); font-weight:600;}
+  .thesis{font-family:var(--font-body); font-size:clamp(1.16rem,2.3vw,1.5rem); line-height:1.5;
+    color:var(--ink-soft); max-width:40ch; margin:1.5rem 0 0; text-wrap:pretty;}
+  .thesis b{color:var(--ink); font-weight:400; font-style:italic;}
+  .provenance{margin-top:2.2rem; display:flex; flex-wrap:wrap; gap:.5rem .5rem;}
+  .tag{font-family:var(--font-mono); font-size:.7rem; letter-spacing:.03em; color:var(--ink-soft);
+    border:1px solid var(--line); background:var(--panel); padding:.32rem .6rem; border-radius:999px;}
+  .tag b{color:var(--ink)}
+
+  /* ---------- orientation strip ---------- */
+  .facts{display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:1px;
+    background:var(--line); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; margin-top:2.4rem;}
+  .fact{background:var(--panel); padding:1.15rem 1.2rem;}
+  .fact .n{font-family:var(--font-display); font-weight:800; font-size:1.7rem; letter-spacing:-.01em; color:var(--accent-ink);}
+  .fact .l{font-family:var(--font-mono); font-size:.68rem; text-transform:uppercase; letter-spacing:.09em; color:var(--ink-faint); margin-top:.3rem;}
+  .fact .d{font-size:.92rem; color:var(--ink-soft); margin-top:.5rem; line-height:1.5; font-family:var(--font-body);}
+
+  /* ---------- table of contents ---------- */
+  .toc{display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:.7rem; margin-top:1.6rem;}
+  .toc a{display:flex; gap:.85rem; align-items:baseline; text-decoration:none; color:var(--ink);
+    border:1px solid var(--line); background:var(--panel); border-radius:var(--radius-sm);
+    padding:.85rem 1rem; transition:border-color .18s, transform .18s, box-shadow .18s;}
+  .toc a:hover{border-color:var(--accent); transform:translateY(-2px); box-shadow:var(--shadow);}
+  .toc .idx{font-family:var(--font-mono); font-size:.8rem; color:var(--accent-ink); font-weight:600;}
+  .toc .tt{font-family:var(--font-display); font-weight:600; font-size:.98rem; line-height:1.2;}
+  .toc .ts{display:block; font-family:var(--font-body); font-size:.82rem; color:var(--ink-faint); margin-top:.15rem;}
+
+  /* ---------- section headings ---------- */
+  .eyebrow{font-family:var(--font-mono); font-size:.72rem; letter-spacing:.18em; text-transform:uppercase; color:var(--accent-ink);}
+  h2{font-family:var(--font-display); font-weight:800; letter-spacing:-.015em; line-height:1.08;
+    font-size:clamp(1.7rem,3.3vw,2.35rem); margin:.7rem 0 0; text-wrap:balance;}
+  h3{font-family:var(--font-display); font-weight:700; font-size:1.2rem; letter-spacing:-.01em; margin:2.4rem 0 .2rem;}
+  h4{font-family:var(--font-mono); font-weight:600; font-size:.78rem; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--ink-soft); margin:1.8rem 0 .6rem;}
+  .lead{font-size:1.14rem; line-height:1.6; color:var(--ink-soft); margin:1.1rem 0 0; max-width:var(--measure);}
+  p{max-width:var(--measure); margin:1.05rem 0;}
+  p b{font-weight:400; color:var(--ink); background:linear-gradient(transparent 62%, var(--accent-tint) 62%);}
+  a{color:var(--accent-ink);}
+  code{font-family:var(--font-mono); font-size:.86em; background:var(--panel-2); border:1px solid var(--line-soft);
+    padding:.06em .38em; border-radius:5px; color:var(--ink); white-space:nowrap;}
+  .mono{font-family:var(--font-mono);}
+  ul.clean{max-width:var(--measure); padding-left:1.1rem; margin:1rem 0;}
+  ul.clean li{margin:.5rem 0;}
+  ul.clean li::marker{color:var(--accent);}
+
+  /* ---------- callouts ---------- */
+  .callout{max-width:var(--measure); border-left:3px solid var(--accent); background:var(--accent-tint);
+    padding:1rem 1.2rem; border-radius:0 var(--radius-sm) var(--radius-sm) 0; margin:1.6rem auto 1.6rem 0;}
+  .callout .h{font-family:var(--font-mono); font-size:.72rem; letter-spacing:.1em; text-transform:uppercase; color:var(--accent-ink); margin-bottom:.35rem;}
+  .callout p{margin:.35rem 0; max-width:none;}
+  .pull{font-family:var(--font-body); font-style:italic; font-size:clamp(1.25rem,2.6vw,1.7rem); line-height:1.4;
+    color:var(--ink); max-width:26ch; margin:2.2rem auto 2.2rem 0; text-wrap:balance;}
+  .pull::before{content:""; display:block; width:40px; height:3px; background:var(--accent); margin-bottom:1rem;}
+
+  /* ---------- diagram panels ---------- */
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:var(--radius);
+    padding:clamp(1.2rem,3vw,2rem); box-shadow:var(--shadow); margin:2rem 0;}
+  .panel-scroll{overflow-x:auto;}
+  .panel-cap{display:flex; align-items:baseline; gap:.7rem; margin-bottom:1.4rem; flex-wrap:wrap;}
+  .panel-cap .fig{font-family:var(--font-mono); font-size:.7rem; letter-spacing:.12em; text-transform:uppercase; color:var(--accent-ink);
+    border:1px solid var(--accent); border-radius:999px; padding:.2rem .55rem;}
+  .panel-cap .ct{font-family:var(--font-display); font-weight:700; font-size:1.05rem;}
+  .panel-note{font-family:var(--font-body); font-size:.9rem; color:var(--ink-faint); margin-top:1.2rem; max-width:70ch;}
+
+  /* nodes */
+  .node{border:1px solid var(--line); background:var(--panel-2); border-radius:10px; padding:.75rem .85rem; min-width:0;}
+  .node .nk{font-family:var(--font-mono); font-size:.62rem; letter-spacing:.09em; text-transform:uppercase; color:var(--ink-faint);}
+  .node .nt{font-family:var(--font-display); font-weight:700; font-size:.95rem; line-height:1.15; margin-top:.15rem;}
+  .node .ns{font-family:var(--font-body); font-size:.82rem; color:var(--ink-soft); margin-top:.25rem; line-height:1.4;}
+  .node.accent{border-color:var(--accent); background:var(--accent-tint);}
+  .node.working{border-color:var(--working); background:var(--working-tint);}
+  .node.needsyou{border-color:var(--needsyou); background:var(--needsyou-tint);}
+  .node.waiting{border-color:var(--waiting); background:var(--waiting-tint);}
+  .node.idle{border-color:var(--idle); background:var(--idle-tint);}
+  .node.good{border-color:var(--good); background:var(--good-tint);}
+
+  .band-label{font-family:var(--font-mono); font-size:.66rem; letter-spacing:.13em; text-transform:uppercase; color:var(--ink-faint); margin-bottom:.6rem;}
+  .row{display:flex; gap:.7rem; flex-wrap:wrap;}
+  .row > *{flex:1 1 0; min-width:150px;}
+  .grid3{display:grid; grid-template-columns:repeat(3,1fr); gap:.7rem;}
+  .grid2{display:grid; grid-template-columns:repeat(2,1fr); gap:.9rem;}
+  @media (max-width:640px){.grid3,.grid2{grid-template-columns:1fr}}
+
+  /* connectors */
+  .connzone{display:flex; align-items:center; justify-content:center; gap:.6rem; padding:.5rem 0; color:var(--ink-faint);}
+  .connlabel{font-family:var(--font-mono); font-size:.64rem; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-faint);}
+  .rail-v{width:2px; height:26px; background:var(--line); margin:0 auto; position:relative;}
+  .rail-v.up::before,.rail-v.down::after{content:""; position:absolute; left:50%; transform:translateX(-50%); width:0; height:0;}
+  .rail-v.down::after{bottom:-1px; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid var(--accent);}
+  .rail-v.up::before{top:-1px; border-left:5px solid transparent; border-right:5px solid transparent; border-bottom:7px solid var(--accent);}
+  .rail-v.accent{background:var(--accent);}
+
+  /* enforcement ladder */
+  .ladder{display:flex; flex-direction:column; gap:.55rem;}
+  .rung{display:grid; grid-template-columns:auto 1fr auto; gap:1rem; align-items:center;
+    border:1px solid var(--line); border-radius:10px; padding:.8rem 1rem; background:var(--panel-2);
+    border-left:3px solid var(--accent);}
+  .rung .lv{font-family:var(--font-mono); font-size:.68rem; color:var(--accent-ink); font-weight:600;}
+  .rung .nm{font-family:var(--font-display); font-weight:700; font-size:.98rem;}
+  .rung .gu{font-family:var(--font-body); font-size:.86rem; color:var(--ink-soft); margin-top:.15rem;}
+  .rung .an{font-family:var(--font-mono); font-size:.66rem; color:var(--ink-faint); white-space:nowrap;}
+  @media (max-width:640px){.rung{grid-template-columns:1fr}.rung .an{white-space:normal}}
+
+  /* pipeline steps */
+  .pipe{display:flex; gap:.5rem; align-items:stretch; min-width:640px;}
+  .step{flex:1; border:1px solid var(--line); border-radius:10px; padding:.8rem .8rem; background:var(--panel-2); position:relative;}
+  .step .sn{font-family:var(--font-mono); font-size:.62rem; color:var(--accent-ink); letter-spacing:.08em;}
+  .step .st{font-family:var(--font-display); font-weight:700; font-size:.9rem; margin-top:.2rem; line-height:1.15;}
+  .step .sd{font-family:var(--font-body); font-size:.8rem; color:var(--ink-soft); margin-top:.3rem; line-height:1.4;}
+  .step .arr{position:absolute; right:-11px; top:50%; transform:translateY(-50%); z-index:2;
+    width:0; height:0; border-top:6px solid transparent; border-bottom:6px solid transparent; border-left:9px solid var(--accent);}
+  .step:last-child .arr{display:none}
+  .step.deny{border-color:var(--needsyou); background:var(--needsyou-tint);}
+
+  /* tables */
+  .tbl-scroll{overflow-x:auto; margin:1.4rem 0;}
+  table{border-collapse:collapse; width:100%; font-size:.92rem; min-width:560px;}
+  caption{caption-side:top; text-align:left; font-family:var(--font-mono); font-size:.7rem;
+    letter-spacing:.1em; text-transform:uppercase; color:var(--ink-faint); padding-bottom:.7rem;}
+  th{font-family:var(--font-mono); font-size:.66rem; letter-spacing:.07em; text-transform:uppercase;
+    text-align:left; color:var(--ink-soft); font-weight:600; padding:.6rem .8rem; border-bottom:1.5px solid var(--line);}
+  td{padding:.7rem .8rem; border-bottom:1px solid var(--line-soft); vertical-align:top; font-family:var(--font-body);}
+  td b{font-weight:700}
+  tbody tr:hover{background:var(--panel-2);}
+  td .mono, th .mono{font-family:var(--font-mono); font-size:.82em;}
+  .num{font-variant-numeric:tabular-nums; text-align:right;}
+
+  /* chips */
+  .chip{display:inline-flex; align-items:center; gap:.35rem; font-family:var(--font-mono);
+    font-size:.64rem; letter-spacing:.05em; text-transform:uppercase; font-weight:600;
+    padding:.2rem .5rem; border-radius:999px; border:1px solid; white-space:nowrap;}
+  .chip.crit{color:var(--needsyou); border-color:var(--needsyou); background:var(--needsyou-tint);}
+  .chip.high{color:var(--waiting); border-color:var(--waiting); background:var(--waiting-tint);}
+  .chip.med{color:var(--idle); border-color:var(--idle); background:var(--idle-tint);}
+  .chip.ok{color:var(--good); border-color:var(--good); background:var(--good-tint);}
+  .chip.dot::before{content:""; width:6px; height:6px; border-radius:50%; background:currentColor;}
+
+  /* census bar */
+  .census{margin:1.6rem 0;}
+  .census-bar{display:flex; height:44px; border-radius:9px; overflow:hidden; border:1px solid var(--line);}
+  .census-bar > div{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:.72rem; font-weight:600; color:#fff;}
+  .seg-clean{background:var(--good);} .seg-latent{background:var(--idle);}
+  .seg-unsafe{background:var(--needsyou);} .seg-policy{background:var(--waiting);}
+  .census-legend{display:flex; flex-wrap:wrap; gap:1rem; margin-top:.8rem; font-family:var(--font-mono); font-size:.72rem; color:var(--ink-soft);}
+  .census-legend span{display:inline-flex; align-items:center; gap:.4rem;}
+  .swatch{width:11px; height:11px; border-radius:3px; display:inline-block;}
+
+  /* remedy list */
+  .remedy{display:flex; flex-direction:column; gap:.5rem; margin:1.4rem 0;}
+  .runit{display:grid; grid-template-columns:1fr auto; gap:.6rem 1rem; align-items:center;
+    border:1px solid var(--line); border-radius:9px; padding:.7rem .95rem; background:var(--panel-2);}
+  .runit .u{font-family:var(--font-display); font-weight:600; font-size:.92rem;}
+  .runit .m{font-family:var(--font-body); font-size:.8rem; color:var(--ink-soft); margin-top:.1rem;}
+
+  /* right/wrong split */
+  .split{display:grid; grid-template-columns:1fr 1fr; gap:1rem;}
+  @media (max-width:720px){.split{grid-template-columns:1fr}}
+  .card{border:1px solid var(--line); border-radius:var(--radius); padding:1.2rem 1.3rem; background:var(--panel);}
+  .card.right{border-top:3px solid var(--good);}
+  .card.risk{border-top:3px solid var(--needsyou);}
+  .card h5{font-family:var(--font-mono); font-size:.72rem; letter-spacing:.1em; text-transform:uppercase; margin:0 0 .8rem;}
+  .card.right h5{color:var(--good);} .card.risk h5{color:var(--needsyou);}
+  .card ul{margin:0; padding-left:1.1rem;}
+  .card li{margin:.55rem 0; font-family:var(--font-body); font-size:.92rem; line-height:1.5;}
+  .card li b{font-weight:700}
+
+  /* footer */
+  footer{padding:3rem 0 4rem;}
+  .foot-grid{display:grid; grid-template-columns:1.2fr 1fr; gap:2rem;}
+  @media (max-width:720px){.foot-grid{grid-template-columns:1fr}}
+  .foot-grid h4{margin-top:0}
+  .srcs{font-family:var(--font-mono); font-size:.76rem; color:var(--ink-soft); line-height:1.9;}
+  .srcs .p{color:var(--ink)}
+
+  .reveal{opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease;}
+  .reveal.in{opacity:1; transform:none;}
+  @media (prefers-reduced-motion:reduce){.reveal{opacity:1; transform:none; transition:none;}}
+</style>
+
+<div class="progress" id="progress"></div>
+
+<div class="topbar">
+  <div class="topbar-in">
+    <div class="brand"><span class="dot"></span> The DevThrottle Gateway <b>&nbsp;/ Architecture</b></div>
+    <div class="topmeta">origin/main @ 0dc22714 &nbsp;|&nbsp; 2026-07-21</div>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <!-- HERO -->
+  <header class="hero col">
+    <span class="kicker">Architecture reference &nbsp;/&nbsp; systems altitude</span>
+    <h1>A control plane for <span class="thin">fleets of coding agents.</span></h1>
+    <p class="thesis">One always-on hub sits between the phones and browsers you supervise from, and the many desktop machines where your agents actually run. <b>It exists because a single machine cannot see the fleet</b> - and now that it is hosted and shared, it has to keep every customer's fleet in a sealed lane of its own.</p>
+
+    <div class="provenance">
+      <span class="tag">Source of truth: <b>origin/main</b></span>
+      <span class="tag">HEAD <b>0dc22714</b></span>
+      <span class="tag">Read <b>2026-07-21</b></span>
+      <span class="tag">Altitude: <b>structural, not code</b></span>
+    </div>
+
+    <div class="facts">
+      <div class="fact"><div class="n">1</div><div class="l">Always-on hub</div><div class="d">A single shared, multi-tenant instance. It never dials out - everyone dials in to it.</div></div>
+      <div class="fact"><div class="n">N</div><div class="l">Desktop Directors</div><div class="d">Each runs coding-agent sessions on one machine and holds a tunnel open to the hub.</div></div>
+      <div class="fact"><div class="n">4</div><div class="l">Client surfaces</div><div class="d">Desktop cockpit, phone app, car voice, and command-line - all served from one origin.</div></div>
+      <div class="fact"><div class="n">1:1</div><div class="l">Account to tenant</div><div class="d">An account does not get its own server. It becomes an isolated tenant on the shared one.</div></div>
+    </div>
+  </header>
+
+  <!-- TOC -->
+  <section class="col" style="border-bottom:none; padding-top:2.2rem;">
+    <span class="eyebrow">What is in this document</span>
+    <h2 style="font-size:clamp(1.3rem,2.6vw,1.7rem)">Seven parts, read in order</h2>
+    <p class="lead" style="font-size:1.02rem">Written to be argued at a blackboard: why the thing exists, what it does, how it is wired, how the isolation is actually enforced, what it stores - and an honest register of what is still wrong or missing before it can carry paying customers at scale.</p>
+    <nav class="toc">
+      <a href="#p1"><span class="idx">01</span><span><span class="tt">Why it exists</span><span class="ts">The one argument that justifies a hub</span></span></a>
+      <a href="#p2"><span class="idx">02</span><span><span class="tt">What it does</span><span class="ts">The capability catalog for multi-agent work</span></span></a>
+      <a href="#p3"><span class="idx">03</span><span><span class="tt">How it is wired</span><span class="ts">Connection topology and the dumb-client seam</span></span></a>
+      <a href="#p4"><span class="idx">04</span><span><span class="tt">How tenancy is secured</span><span class="ts">The isolation model, layer by layer</span></span></a>
+      <a href="#p5"><span class="idx">05</span><span><span class="tt">What it stores</span><span class="ts">The data model and its scoping guarantee</span></span></a>
+      <a href="#p6"><span class="idx">06</span><span><span class="tt">What is wrong</span><span class="ts">The retrofit debt, ranked and evidenced</span></span></a>
+      <a href="#p7"><span class="idx">07</span><span><span class="tt">The decision surface</span><span class="ts">What is settled, what is bet, what must hold</span></span></a>
+    </nav>
+  </section>
+
+  <!-- PART 1 -->
+  <section id="p1">
+    <div class="col">
+      <span class="eyebrow">Part 01 &nbsp;/&nbsp; Purpose</span>
+      <h2>Why a hub has to exist at all</h2>
+      <p class="lead">A desktop Director sees exactly one machine: its own. Every interesting question about a fleet of agents - and every piece of state that must outlive a crash - lives above any single machine. That gap is the entire reason the Gateway exists.</p>
+      <p>Ask a single Director a simple question: <em>is this session's controller still alive?</em> It cannot answer - the controlling session may be running on a different computer entirely. Ask it to keep a snooze timer, or a mission's stated purpose, or a week of spend history: it cannot promise those survive its own reboot. The Gateway is the authority for everything that must be true <b>fleet-wide</b> or must <b>outlive a dead Director</b>.</p>
+      <p>So the shape is a hub-and-spoke control plane. The humans supervise from lightweight surfaces - a phone on cellular, a browser, a voice session in a car. The agents run on heavyweight desktops behind home and office NATs. The Gateway is the fixed point in the middle that both sides can always reach, holding the durable truth and relaying control across the network boundary.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel panel-scroll reveal">
+        <div class="panel-cap"><span class="fig">Figure A</span><span class="ct">The altitude view: everyone dials the hub</span></div>
+        <div style="min-width:600px">
+          <div class="band-label">Supervisors &nbsp;-&nbsp; lightweight, often remote</div>
+          <div class="grid3">
+            <div class="node"><div class="nk">Browser</div><div class="nt">Desktop cockpit</div><div class="ns">Full mission-control web UI at /cockpit</div></div>
+            <div class="node"><div class="nk">Phone</div><div class="nt">Mobile app + car voice</div><div class="ns">Supervise, approve, and talk to the fleet at /mobile</div></div>
+            <div class="node"><div class="nk">Shell</div><div class="nt">Command-line tools</div><div class="ns">cc-devthrottle drives the fleet as an agent would</div></div>
+          </div>
+
+          <div class="connzone"><span class="connlabel">dial in &nbsp;/&nbsp; REST + WebSocket</span></div>
+          <div style="display:flex; justify-content:center; gap:6rem;"><div class="rail-v down accent"></div></div>
+
+          <div class="node accent" style="text-align:center; padding:1.3rem;">
+            <div class="nk" style="color:var(--accent-ink)">The Gateway &nbsp;-&nbsp; one shared, always-on, multi-tenant instance</div>
+            <div class="nt" style="font-size:1.15rem; margin-top:.3rem">Fleet authority &nbsp;|&nbsp; durable state &nbsp;|&nbsp; identity and billing &nbsp;|&nbsp; voice and AI brain</div>
+            <div class="ns" style="margin-top:.4rem">It never dials out. It holds every open connection and pushes commands down through them.</div>
+          </div>
+
+          <div style="display:flex; justify-content:center; gap:6rem;"><div class="rail-v up accent"></div></div>
+          <div class="connzone"><span class="connlabel">dial out &nbsp;/&nbsp; SignalR tunnel held open through NAT</span></div>
+
+          <div class="band-label">The fleet &nbsp;-&nbsp; heavyweight desktops behind firewalls</div>
+          <div class="grid2">
+            <div class="node working"><div class="nk">Machine A</div><div class="nt">Director + launcher</div><div class="ns">Runs agent sessions; pushes their live state up; obeys commands pushed down</div></div>
+            <div class="node working"><div class="nk">Machine B</div><div class="nt">Director + launcher</div><div class="ns">Same tunnel; the Gateway can even start or restart the Director here on demand</div></div>
+          </div>
+        </div>
+        <p class="panel-note">The single most load-bearing fact in the whole system: the direction of every arrow is <em>toward</em> the Gateway. Because both the supervisors and the fleet open the connection, the Gateway can serve a phone on cellular and command a desktop behind a home router without ever needing a public address on either of them.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- PART 2 -->
+  <section id="p2">
+    <div class="col">
+      <span class="eyebrow">Part 02 &nbsp;/&nbsp; Capability</span>
+      <h2>What the hub actually does</h2>
+      <p class="lead">The Gateway is not a proxy. It is where fleet coordination, durable memory, voice, identity, and billing all live - the parts of the product that have no home on any single machine.</p>
+      <p>Grouped by the job they do, the subsystems fall into five families. Each one exists on the Gateway for the same reason: it needs the whole-fleet view, or it needs to survive a Director's death, or it holds a secret (the account token, the inference key) that must never sit on a client.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel reveal">
+        <div class="panel-cap"><span class="fig">Figure B</span><span class="ct">Five capability families</span></div>
+        <div class="grid2" style="gap:1rem">
+          <div class="node"><div class="nk">Coordinate the fleet</div><div class="nt">Fleet roster, roles, missions</div><div class="ns">One unified list of every Director and session across machines; each session gets a fleet-unique short number so people and agents address one another by number, not a raw identifier. Roles (architect / manager / worker) are resolved from the whole-fleet view and pushed down. Missions bind a pod of sessions to one shared goal and its stated purpose.</div></div>
+          <div class="node"><div class="nk">Supervise and be alerted</div><div class="nt">Live state, needs-you, push, car voice</div><div class="ns">The aggregated live roster and streaming terminals feed every screen. A turn-boundary engine stamps when a session started waiting on you; web-push lights your phone when it needs you even with the app closed; car mode narrates and voice-controls the fleet hands-free.</div></div>
+          <div class="node"><div class="nk">Persist what must survive</div><div class="nt">Snoozes, cron, work-lists, governance, prompts</div><div class="ns">Snoozes and mission purpose survive a dead Director because their timers live here, not on the machine. A cron engine and a work-list runner drive unattended, overnight, multi-item agent execution. An append-only governance ledger records every state transition for weekly outcome reports.</div></div>
+          <div class="node"><div class="nk">Run voice and AI</div><div class="nt">Transcription, wingman, hosted brain</div><div class="ns">One transcription path turns all audio into text; wingman speaks a briefing exactly when a turn ends; the car-mode brain runs a tool-calling loop against the hosted model. These live here because the Gateway is the only holder of the account token and inference keys.</div></div>
+          <div class="node accent" style="grid-column:1 / -1"><div class="nk" style="color:var(--accent-ink)">Own identity, subscription, and isolation</div><div class="nt">Sign-in, per-device keys, entitlement, credits, tenancy</div><div class="ns">Sign in once on the Gateway and the whole fleet plus every phone inherits the account. Each device gets its own revocable key. A paid entitlement gates hosted enrollment; credits meter hosted-AI use and a 402 stops you cleanly when they run out. On the hosted instance, the authenticated device key also resolves which tenant every request belongs to.</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>The part that makes it a multi-agent platform</h3>
+      <p>Several of those capabilities exist specifically so that many agents, on many machines, can be driven as one coordinated team rather than as scattered terminals.</p>
+    </div>
+    <div class="bleed">
+      <div class="tbl-scroll reveal">
+        <table>
+          <caption>Multi-agent coordination surface</caption>
+          <thead><tr><th>Capability</th><th>What it enables</th></tr></thead>
+          <tbody>
+            <tr><td><b>Roster and addressing</b></td><td>One list of every session across every machine; a short fleet-unique number names exactly one session everywhere.</td></tr>
+            <tr><td><b>Cross-machine spawn</b></td><td>Start a session on another computer on demand or on a schedule; if no Director is running there, the launcher is told to start one first.</td></tr>
+            <tr><td><b>Agent-to-agent messaging</b></td><td>Sessions message each other across machines through the hub; a phone can see and drive pending message drafts.</td></tr>
+            <tr><td><b>Role coordination</b></td><td>Manager / worker / architect roles computed from cross-machine liveness and pushed to every surface so they never disagree.</td></tr>
+            <tr><td><b>Autonomous work queues</b></td><td>Drain a named GitHub or DevOps work-list one item at a time, spawning an implementation session per item and watching for its terminal signal.</td></tr>
+            <tr><td><b>Scheduling</b></td><td>Cron and one-off runs that fire at the correct wall-clock time and survive restarts - the basis for overnight fleets.</td></tr>
+            <tr><td><b>Oversight</b></td><td>An immutable transition ledger across all sessions becomes a weekly report of attention burden, durations, and spend.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- PART 3 -->
+  <section id="p3">
+    <div class="col">
+      <span class="eyebrow">Part 03 &nbsp;/&nbsp; Topology</span>
+      <h2>How it is wired</h2>
+      <p class="lead">Two persistent tunnels carry the fleet; a set of request/stream routes serve the clients; and one firm rule governs who computes meaning - the Gateway rules, the client renders.</p>
+      <p>Directors and launchers hold SignalR tunnels open to the hub. The Gateway pushes commands <em>down</em> those tunnels - there is no reverse HTTP path left; the old dial-back was deliberately removed. Session state flows <em>up</em> the same tunnels as a snapshot plus deltas, cached so that a phone asking "what is running" is answered from memory, not by polling a desktop.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel panel-scroll reveal">
+        <div class="panel-cap"><span class="fig">Figure C</span><span class="ct">Command down, state up - and where meaning is computed</span></div>
+        <div style="min-width:660px; display:grid; grid-template-columns:1fr 1fr; gap:1.4rem;">
+          <div>
+            <div class="band-label" style="color:var(--accent-ink)">Command path &nbsp;-&nbsp; downstream</div>
+            <div class="ladder">
+              <div class="rung" style="grid-template-columns:1fr"><div><div class="nm">Client issues a verb</div><div class="gu">Phone or cockpit: "send this prompt to session 342"</div></div></div>
+              <div class="connzone"><div class="rail-v down accent"></div></div>
+              <div class="rung" style="grid-template-columns:1fr"><div><div class="nm">Resolve the owning Director</div><div class="gu">From the live push cache - only a tunnel-connected, fresh Director qualifies</div></div></div>
+              <div class="connzone"><div class="rail-v down accent"></div></div>
+              <div class="rung" style="grid-template-columns:1fr"><div><div class="nm">One command chokepoint</div><div class="gu">Routed down the Director's tunnel; an untethered Director yields a clean 502, never a silent fallback</div></div></div>
+            </div>
+          </div>
+          <div>
+            <div class="band-label" style="color:var(--accent-ink)">State path &nbsp;-&nbsp; upstream, then folded</div>
+            <div class="ladder">
+              <div class="rung" style="grid-template-columns:1fr"><div><div class="nm">Director pushes up</div><div class="gu">Snapshot then deltas into the tenant-partitioned live store</div></div></div>
+              <div class="connzone"><div class="rail-v up accent"></div></div>
+              <div class="rung" style="grid-template-columns:1fr; border-left-color:var(--needsyou)"><div><div class="nm">The Gateway folds the verdict</div><div class="gu">Color, label, role, and the voice-screen state are computed here - once, server-side</div></div></div>
+              <div class="connzone"><div class="rail-v up accent"></div></div>
+              <div class="rung" style="grid-template-columns:1fr; border-left-color:var(--good)"><div><div class="nm">Client renders verbatim</div><div class="gu">The phone and desktop read the same stamped answer; neither re-derives it</div></div></div>
+            </div>
+          </div>
+        </div>
+        <p class="panel-note">This is the project's firmest architectural law: <em>the client is dumb; the Gateway owns all ruling.</em> A client that decides for itself what a state means will, the moment it meets something unexpected, render something plausible instead of something true. So the verdict is folded exactly once, on the Gateway, and stamped onto the data the client reads. Adding a new state is one edit in the fold, never a new branch in every client.</p>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>The API surface, by area</h3>
+      <p>The routes group into a dozen families. At altitude they matter only as capability areas - the detail is that every non-public route is credential-gated, and on the hosted instance that same credential also fixes the caller's tenant.</p>
+    </div>
+    <div class="bleed">
+      <div class="tbl-scroll reveal">
+        <table>
+          <caption>Endpoint families</caption>
+          <thead><tr><th>Area</th><th>Serves</th></tr></thead>
+          <tbody>
+            <tr><td><b>Cockpit read path</b></td><td>The aggregated session and Director roster, served from the push cache; the React shell</td></tr>
+            <tr><td><b>Per-session legs</b></td><td>Live terminal stream, files, screenshots, prompt, hold, interrupt, recap, handover - all riding the tunnel</td></tr>
+            <tr><td><b>Pairing, enrollment, account</b></td><td>Device enrollment (signed-in, hosted), account status, credits, QR sign-in</td></tr>
+            <tr><td><b>Transcription, voice, recordings</b></td><td>Phone note ingest, dictation upload, spoken turn summaries</td></tr>
+            <tr><td><b>Wingman and hosted AI</b></td><td>Ask-the-model, text-to-speech, the warm brain</td></tr>
+            <tr><td><b>Governance</b></td><td>Append-only event ledger, session and hosted-AI spend, outcome reports</td></tr>
+            <tr><td><b>Machine lifecycle</b></td><td>Start / stop / restart a Director on a named machine; launcher control</td></tr>
+            <tr><td><b>Cron, workflows, work-lists</b></td><td>Scheduled and automated fleet work</td></tr>
+            <tr><td><b>Push, diagnostics, car mode, missions</b></td><td>Web-push subscriptions, reachability rollups, car voice, mission notes and turn briefs</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="col">
+      <h4>Finding the hub</h4>
+      <p>Two worlds. On <b>hosted</b>, there is nothing to discover: one public front door at <code>gateway.devthrottle.com</code> (with <code>/cockpit</code> and <code>/mobile</code> as paths under it), backed by a single Azure App Service container. On <b>self-host</b>, the Gateway is reached over a Tailscale tailnet, and a joining client walks an ordered list of candidate addresses - machine name, then tailnet address, then raw IP - probing each until one answers.</p>
+    </div>
+  </section>
+
+  <!-- PART 4 -->
+  <section id="p4">
+    <div class="col">
+      <span class="eyebrow">Part 04 &nbsp;/&nbsp; Isolation</span>
+      <h2>How multi-tenancy is secured</h2>
+      <p class="lead">The whole design has one repeated shape. A tenant is resolved once, at an authentication boundary, from a server-verified credential - never from anything the client claims - then carried ambiently and enforced deny-by-default, so an unresolved tenant is refused, never defaulted.</p>
+    </div>
+
+    <div class="col">
+      <p class="pull">A tenant is an account. The credential proves who is calling; it never lets the caller name someone else's world.</p>
+      <p>A <b>tenant</b> is an account, identified by its stable sign-in subject and mapped one-to-one to a minted identifier. Self-host is simply the degenerate case where there is exactly one tenant, and the code runs byte-identical to its pre-tenancy self. The reserved local and system scopes are well-known singletons - crucially, they are never the answer to "no tenant could be resolved." That answer is always: deny.</p>
+
+      <h3>How a request gets its tenant</h3>
+      <p>There is exactly one credential in the hosted trust model: a per-device key. Each enrolled device - a desktop, a phone, a browser - gets its own distinct, individually revocable key. The key is stored only as a hash at rest (a recent hardening: the raw secret is disclosed once at enrollment and never again). The tenant is read from that key's server-side binding, and from nothing the caller sends in a payload.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel panel-scroll reveal">
+        <div class="panel-cap"><span class="fig">Figure D</span><span class="ct">Credential to tenant - resolved once, fail-closed</span></div>
+        <div class="pipe">
+          <div class="step"><div class="sn">step 1</div><div class="st">Credential presented</div><div class="sd">A per-device key on the request, or a Director's key on the tunnel handshake</div><span class="arr"></span></div>
+          <div class="step"><div class="sn">step 2</div><div class="st">Authenticated</div><div class="sd">The auth layer verifies the key and stashes it; every non-public route is gated</div><span class="arr"></span></div>
+          <div class="step"><div class="sn">step 3</div><div class="st">Tenant resolved</div><div class="sd">One boundary maps the verified key to its bound tenant - from the binding, never the payload</div><span class="arr"></span></div>
+          <div class="step"><div class="sn">step 4</div><div class="st">Ambient scope</div><div class="sd">The tenant flows down the async call chain; asking for it with no scope in effect throws</div><span class="arr"></span></div>
+          <div class="step deny"><div class="sn">on failure</div><div class="st">Deny, never default</div><div class="sd">An unresolved tenant on hosted is refused - it is never folded into the local tenant</div></div>
+        </div>
+        <p class="panel-note">Every entry class funnels through this: a Director's tunnel resolves its tenant at the first handshake message; a phone or browser resolves it from the same device key that authenticates the call; the one-time account sign-in that bootstraps enrollment is validated locally and then gated on a paid entitlement before any tenant is minted.</p>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>Where isolation is actually enforced</h3>
+      <p>Not at one chokepoint, but as a layered stack - the same deny-by-default discipline repeated at each layer, so that a mistake at one layer meets a second one below it.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel reveal">
+        <div class="panel-cap"><span class="fig">Figure E</span><span class="ct">The enforcement stack, top to bottom</span></div>
+        <div class="ladder">
+          <div class="rung"><span class="lv">L1</span><div><div class="nm">Database global query filter</div><div class="gu">Every tenant-scoped table carries a tenant column and an automatic filter; a query can only see the active tenant's rows</div></div><span class="an">the primary data chokepoint</span></div>
+          <div class="rung"><span class="lv">L2</span><div><div class="nm">Composite primary keys</div><div class="gu">Tables whose identifiers are client- or seed-supplied put the tenant into the key itself, so two tenants can hold the same id without colliding</div></div><span class="an">collision-proof by design</span></div>
+          <div class="rung"><span class="lv">L3</span><div><div class="nm">Scoped context factory</div><div class="gu">Hands out a database context only after stamping the ambient tenant; fails loud on an invalid one; the global tables are reached through a separate factory that fails closed</div></div><span class="an">fail-loud / fail-closed</span></div>
+          <div class="rung"><span class="lv">L4</span><div><div class="nm">Ambient tenant context</div><div class="gu">Flows the tenant down async chains and throws when no scope is set - deny-by-default at the language level</div></div><span class="an">throws when unset</span></div>
+          <div class="rung"><span class="lv">L5</span><div><div class="nm">Tenant-keyed live stores</div><div class="gu">The in-memory registries of live Directors and sessions are keyed by tenant; client-serving lookups answer from one partition only</div></div><span class="an">partitioned in code</span></div>
+          <div class="rung"><span class="lv">L6</span><div><div class="nm">Per-endpoint resolution</div><div class="gu">Client routes resolve the request tenant and return 403 with no tenant, 404 for an identifier that belongs to another tenant</div></div><span class="an">403 no-tenant / 404 foreign</span></div>
+          <div class="rung"><span class="lv">L7</span><div><div class="nm">Per-tenant background passes</div><div class="gu">Sweeps and loops run once per live tenant inside that tenant's scope, replacing the old single hard-coded pass</div></div><span class="an">one pass per tenant</span></div>
+          <div class="rung"><span class="lv">L8</span><div><div class="nm">Hosted route refusal</div><div class="gu">Whole families of self-host-only routes are refused outright on hosted - for every request shape, valid or malformed</div></div><span class="an">deny by whole route group</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>Guessing another tenant's identifier does not help</h3>
+      <p>The design separates <b>authentication</b> (proving who you are) from <b>authorization</b> (proving you own <em>this</em> object) - and never conflates them.</p>
+      <ul class="clean">
+        <li>The tenant is half of every lookup key. There is no bare-identifier accessor for Directors: a guessed foreign identifier is simply not in the caller's partition, so the answer is 404, not somebody else's Director.</li>
+        <li>A Director is registered under its <em>resolved</em> tenant, not the identifier it claims - so naming another account's Director is structurally inexpressible, whatever the client sends.</li>
+        <li>Terminal streams record a server-resolved owner pair when they open and re-check it on every frame: an account that guessed a live stream identifier is refused, not silently allowed to write into or tear down another account's terminal.</li>
+        <li>Enrollment device identifiers are namespaced by a hash of the tenant, so two accounts presenting the same device identifier cannot collide on one registry entry.</li>
+      </ul>
+
+      <h3>Hosted and self-host differ where it counts</h3>
+      <div class="split reveal">
+        <div class="card">
+          <h5>Hosted</h5>
+          <ul>
+            <li><b>Identity is compiled in.</b> The hosted image carries a baked marker, so a lost or edited environment flag cannot silently downgrade it to single-tenant.</li>
+            <li><b>Boot is fail-closed.</b> The process refuses to start unless hosted mode, real auth, an HTTPS public URL, and a Postgres connection all hold together.</li>
+            <li><b>Shared machine token is rejected.</b> It authenticates a host with no device, hence no tenant. Only per-device keys are accepted.</li>
+            <li><b>Entitlement gates the mint.</b> An unpaid account gets no tenant and no key; the gate is three-state, so a database hiccup never locks out a payer or gives the product away.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h5>Self-host</h5>
+          <ul>
+            <li><b>One tenant, the local singleton.</b> The tenant context is inert; behavior matches the original single-tenant product exactly.</li>
+            <li><b>Local file storage.</b> A SQLite file rather than shared Postgres, same model, same schema.</li>
+            <li><b>Reached over the tailnet.</b> No public front door; a Tailscale address fronts the loopback server.</li>
+            <li><b>Shared machine token allowed.</b> There is only one owner to authenticate, and the account token is encrypted at rest with the OS key store.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PART 5 -->
+  <section id="p5">
+    <div class="col">
+      <span class="eyebrow">Part 05 &nbsp;/&nbsp; Data</span>
+      <h2>What it stores, and the one guarantee that scopes it</h2>
+      <p class="lead">One data model runs over two interchangeable backends - a local file for self-host, shared Postgres for hosted - with a single deny-by-default filter that scopes every durable row to its tenant by construction, not by a developer remembering to add a clause.</p>
+      <p>The durable state divides into a handful of entity families, all but two of them tenant-scoped. Any new store inherits scoping simply by deriving from the tenant-scoped base type: it gets the tenant column, the index, and the automatic query filter for free. The two deliberately-global tables - the account-to-tenant map and the read-only entitlement table owned by the payment side - are the source of the filter's values, so scoping them would be circular; they are reached only through a factory that fails closed if misused.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel panel-scroll reveal">
+        <div class="panel-cap"><span class="fig">Figure F</span><span class="ct">Entity families and the scoping membrane</span></div>
+        <div style="min-width:640px">
+          <div class="band-label">Global &nbsp;-&nbsp; unscoped by design, the source of every tenant value</div>
+          <div class="row" style="margin-bottom:1.2rem">
+            <div class="node idle"><div class="nk">identity</div><div class="nt">Tenants</div><div class="ns">Account subject to tenant, the unique backstop against a split account</div></div>
+            <div class="node idle"><div class="nk">read-only</div><div class="nt">Entitlements</div><div class="ns">Paid-subscription status, owned by the payment side; the Gateway only reads it</div></div>
+          </div>
+
+          <div class="node accent" style="text-align:center; padding:.7rem; margin-bottom:1.2rem;">
+            <div class="nk" style="color:var(--accent-ink)">The scoping membrane</div>
+            <div class="ns" style="margin-top:.2rem">Every family below carries a tenant column and an automatic filter: a query sees only the active tenant's rows. Three collision-prone tables put the tenant into the primary key itself.</div>
+          </div>
+
+          <div class="band-label">Tenant-scoped durable families &nbsp;-&nbsp; sealed per account</div>
+          <div class="grid3" style="margin-bottom:1rem">
+            <div class="node"><div class="nk">automation</div><div class="nt">Cron jobs and runs</div><div class="ns">Scheduled and one-off fleet work; tenant in the key</div></div>
+            <div class="node"><div class="nk">automation</div><div class="nt">Workflows and versions</div><div class="ns">Immutable version snapshots; tenant in the key</div></div>
+            <div class="node"><div class="nk">automation</div><div class="nt">Work-lists and items</div><div class="ns">Named queues drained one item at a time</div></div>
+            <div class="node"><div class="nk">oversight</div><div class="nt">Governance ledgers</div><div class="ns">Append-only transition and audit timelines</div></div>
+            <div class="node"><div class="nk">billing</div><div class="nt">Session and account spend</div><div class="ns">Metered cost in integer micro-units, never bare money</div></div>
+            <div class="node"><div class="nk">control</div><div class="nt">Snoozes, push, mission notes</div><div class="ns">Holds and intent that outlive a dead Director</div></div>
+          </div>
+
+          <div class="band-label">Not in the database &nbsp;-&nbsp; tenant-partitioned in code</div>
+          <div class="row">
+            <div class="node working"><div class="nk">in-memory, rebuilt on restart</div><div class="nt">Live registries</div><div class="ns">The pushed-session store and Director registry - keyed by tenant, gone on restart and rebuilt from the tunnels</div></div>
+            <div class="node waiting"><div class="nk">files on disk</div><div class="nt">Device keys, audio staging, turn briefs</div><div class="ns">Hashed device keys and resumable uploads - partitioned by code, not by the database filter</div></div>
+          </div>
+        </div>
+        <p class="panel-note">The membrane is the guarantee worth arguing about: because scoping is structural, the risk is never "did this query forget its tenant clause" for anything in the database. The risk that remains lives entirely in the two zones the membrane does not cover - the in-memory registries and file stores that must enforce their own partitioning in code. That is exactly where Part 06 concentrates.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- PART 6 -->
+  <section id="p6">
+    <div class="col">
+      <span class="eyebrow">Part 06 &nbsp;/&nbsp; The register of what is wrong</span>
+      <h2>An honest account of the debt</h2>
+      <p class="lead">The isolation is careful and deny-by-default where it is installed. The danger is not sloppy code - it is that isolation is still being retrofitted, one call site at a time, onto a system that was architected single-tenant. The database layer is sealed. The in-memory and file layers are not yet.</p>
+      <p>This is the frame to hold: the team has already <b>enumerated its own attack surface</b> - a finite census of every piece of retained process state, dispositioned as clean, latent, or actively cross-tenant unsafe. That census is unusual discipline. What follows is drawn from it, reconciled against the code on today's main.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="panel reveal">
+        <div class="panel-cap"><span class="fig">Figure G</span><span class="ct">The self-declared census: 94 addressable pieces of retained state</span></div>
+        <div class="census">
+          <div class="census-bar">
+            <div class="seg-clean" style="width:49%">46 clean</div>
+            <div class="seg-unsafe" style="width:42.5%">40 unsafe</div>
+            <div class="seg-latent" style="width:7.5%">7 latent</div>
+            <div class="seg-policy" style="width:1%">1</div>
+          </div>
+          <div class="census-legend">
+            <span><span class="swatch" style="background:var(--good)"></span> Clean - tenant discriminator present or no tenant state</span>
+            <span><span class="swatch" style="background:var(--needsyou)"></span> Active unsafe - a hosted path can cross tenants today</span>
+            <span><span class="swatch" style="background:var(--idle)"></span> Latent - unsafe shape, no completing path yet</span>
+            <span><span class="swatch" style="background:var(--waiting)"></span> Policy - authorization object is mint-able</span>
+          </div>
+        </div>
+        <p class="panel-note">The forty active-unsafe rows reduce to eleven remedy units. The database work has largely landed; the remaining units live in the in-memory and file layers, and the single largest one - the session-identifier family - has the tenant-safe types built but <em>zero</em> production adoption. On today's main the typed tenant-session collection exists and is tested, yet the live stores it was built to fix still key on a bare session string. A type that looks finished while the collision it prevents is still present is the most deceptive state in the whole program.</p>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>The risk register, ranked</h3>
+      <p>Severity weighs exploitability on an open-signup box against structural weight. The top two are the ones that should govern any go-live decision.</p>
+    </div>
+    <div class="bleed">
+      <div class="tbl-scroll reveal">
+        <table>
+          <caption>Ranked risks - hosted multi-tenant Gateway</caption>
+          <thead><tr><th>Severity</th><th>Risk</th><th>Why it matters</th><th>Evidence</th></tr></thead>
+          <tbody>
+            <tr><td><span class="chip crit dot">Critical</span></td><td><b>Owner-power routes reachable by any authenticated tenant</b></td><td>On an open-signup box, launcher and machine control, brain restart, arbitrary process kill, and spending the operator's model key are side doors that rewrite another account's world. Interim fix is a blanket deny on hosted, not a real tenant model.</td><td class="mono">#1917 #1863 #1913 #1921</td></tr>
+            <tr><td><span class="chip crit dot">Critical</span></td><td><b>Forty process-global collections still cross-tenant unsafe</b></td><td>Two accounts that present the same raw session identifier can overwrite, suppress, or read one another's live state. No single enforcement chokepoint exists for the in-memory layer; each store must be converted by hand.</td><td class="mono">census + remedy map</td></tr>
+            <tr><td><span class="chip crit dot">Critical</span></td><td><b>Session-identifier family has zero adoption</b></td><td>The tenant-safe collection type is designed and tested but wired into nothing. The needs-you clock, transcribing marks, turn-end watcher, and governance emitter still collide across tenants. The largest single remedy unit; verified still open on today's main.</td><td class="mono">#1934, 14 rows</td></tr>
+            <tr><td><span class="chip high dot">High</span></td><td><b>Speech and dictation paths still local-pinned</b></td><td>Voice state is partitioned but the routes and background loops that drive it still read and write the local partition, so hosted voice is dead or wrong; dictation upload maps are unpartitioned, and a replayed idempotency key could hand one account another's transcript. This is the highest-value data the product holds.</td><td class="mono">#1890 #1893 #1884 #1896</td></tr>
+            <tr><td><span class="chip high dot">High</span></td><td><b>Isolation hinges on one mutable flag</b></td><td>Losing the hosted-mode environment variable collapses every tenant into one shared partition - a silent failure, not a loud crash. Partly mitigated by the baked image marker and fail-closed boot, but the runtime still reads the flag in many places.</td><td class="mono">#1868</td></tr>
+            <tr><td><span class="chip high dot">High</span></td><td><b>Half-fixed removal fallout</b></td><td>Director-removal now carries its tenant, but the session-number allocator, hosted snooze clear, and removal logs still drop or leak it - duplicated rail numbers and durable tombstones across accounts. Dangerous precisely because the code looks multi-tenant.</td><td class="mono">#1942 residue</td></tr>
+            <tr><td><span class="chip med dot">Medium</span></td><td><b>No general rate limiting or per-tenant quotas</b></td><td>There is no request rate limiter at the API surface and no per-tenant cap on sessions, storage, or concurrency. On a shared box this compounds the owner-power routes above.</td><td class="mono">verified absent</td></tr>
+            <tr><td><span class="chip med dot">Medium</span></td><td><b>At-rest encryption is partial</b></td><td>Account tokens use the OS key store and device keys are hashed, but that key store is a self-host mechanism; there is no evidence of application-level encryption of the hosted Postgres store, and raw recordings sit unencrypted and unpartitioned on shared infrastructure.</td><td class="mono">#1897</td></tr>
+            <tr><td><span class="chip med dot">Medium</span></td><td><b>Operability blind spots</b></td><td>The health endpoint does not report which image is running, so "is the fix deployed" is unanswerable; a stats database sits on a shared file mount guarded only by an in-process lock; some background sweeps discard errors silently.</td><td class="mono">#1882 #1861 #1925</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="col">
+      <h3>The half-fixes deserve their own line</h3>
+      <p>These are more dangerous than plainly missing work, because the code reads as multi-tenant while a single seam still is not. A reviewer skimming for "is this tenant-aware" sees the partitioned store and moves on, never reaching the route that still passes the local tenant.</p>
+      <div class="remedy reveal">
+        <div class="runit"><div><div class="u">Voice state</div><div class="m">Store partitioned by tenant - routes and loops still pass the local tenant</div></div><span class="chip crit">seam open</span></div>
+        <div class="runit"><div><div class="u">Director removal</div><div class="m">Event carries the tenant - number allocator, snoozes, and logs still drop it</div></div><span class="chip crit">seam open</span></div>
+        <div class="runit"><div><div class="u">Session-key types</div><div class="m">Designed and tested - zero production call sites</div></div><span class="chip crit">unadopted</span></div>
+        <div class="runit"><div><div class="u">Per-session routes</div><div class="m">Most resolve the request tenant - a residual bare-identifier Director family remains</div></div><span class="chip high">partial</span></div>
+        <div class="runit"><div><div class="u">Statistics aggregation</div><div class="m">Dashboard denied on hosted - push-time aggregation still mixes tenants in memory</div></div><span class="chip high">partial</span></div>
+      </div>
+
+      <div class="callout">
+        <div class="h">What is genuinely missing, verified</div>
+        <p>Before claiming absence, each was checked. <b>Billing scaffolding exists</b> - entitlement, credits, spend accounting, and a clean 402 are all present, though limited to hosted-AI spend rather than general usage quotas. <b>A governance audit trail exists</b>, but it is a safety log over interventions, not a security log of cross-tenant API activity. <b>Genuinely absent:</b> API rate limiting, per-tenant resource quotas, application-level encryption of the hosted store, and an access-audit across tenants.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- PART 7 -->
+  <section id="p7">
+    <div class="col">
+      <span class="eyebrow">Part 07 &nbsp;/&nbsp; The decision surface</span>
+      <h2>For the blackboard</h2>
+      <p class="lead">Three things to settle: what is already right and should not be re-litigated, the one structural bet worth debating, and the gates that must hold before this box can charge customers at scale.</p>
+    </div>
+
+    <div class="bleed">
+      <div class="split reveal">
+        <div class="card right">
+          <h5>Settled - this is senior work, keep it</h5>
+          <ul>
+            <li><b>Deny-by-default everywhere.</b> Unresolved tenant is refused, never defaulted; boot is fail-closed; whole route groups are refused rather than half-guarded.</li>
+            <li><b>Typed partition keys.</b> A tenant-safe key cannot be constructed without a resolved tenant - a missing tenant fails at compile time, not at runtime after a silent collision.</li>
+            <li><b>The structural database membrane.</b> Global query filter plus composite keys means the durable layer cannot forget its tenant clause.</li>
+            <li><b>Three-state entitlement.</b> Entitled, not entitled, and unknown are separated, so an outage neither locks out a payer nor gives the product away.</li>
+            <li><b>They mapped their own attack surface.</b> A finite census and remedy map is the rare discipline that makes the rest of this decidable.</li>
+          </ul>
+        </div>
+        <div class="card risk">
+          <h5>The bet - and the gates before go-live</h5>
+          <ul>
+            <li><b>The bet:</b> retrofit isolation call-site by call-site, versus install one required-tenant boundary and a single derivation helper adopted across the fourteen live stores at once. The per-call-site path is why the same class of bug keeps resurfacing.</li>
+            <li><b>Gate 1:</b> close the owner-power side doors - keep them denied on hosted until each has a real tenant model or a permanent design.</li>
+            <li><b>Gate 2:</b> adopt the session-key type into the fourteen colliding stores, with a two-tenant collision test per store.</li>
+            <li><b>Gate 3:</b> do not put the voice synthesis key in the vault until voice and dictation are proven tenant-correct with two live accounts.</li>
+            <li><b>Gate 4:</b> keep the self-host provisioning card disabled until a real-machine proof passes; a half-provision is worse than a disabled button.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="col">
+      <p class="pull">The database is sealed. The seal on the layers above it is drawn on the map but not yet fully installed. That gap is the whole decision.</p>
+      <p>The honest one-line verdict: the architecture is right and the hard primitives are built; the remaining work is adoption and enforcement in the two layers the database membrane does not cover. Merge the isolation work already written and green, then close the in-memory and file gaps before the box carries paying customers or turns synthesis on.</p>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="col">
+    <div class="foot-grid">
+      <div>
+        <h4>How this document was built</h4>
+        <p style="font-size:.95rem">Every claim is read from <code>origin/main</code> at commit <code>0dc22714</code>, in a worktree cut for the purpose - never from a working tree that might lag behind. Where the July 20 census and today's code disagree, the code on main wins: several rows it flagged have since been fixed, and the session-identifier family it names as open was re-verified still open here.</p>
+        <p style="font-size:.95rem">It lives at architectural altitude on purpose. It names the load-bearing subsystems and the guarantees they make or miss; it does not describe methods, and it barely mentions the technology. It is meant to be argued.</p>
+      </div>
+      <div>
+        <h4>Primary sources on main</h4>
+        <div class="srcs">
+          <div class="p">Self-declared census</div>
+          hosted-gateway process-global collection census<br>
+          hosted-gateway unsafe-collection ingestion map<br>
+          <div class="p" style="margin-top:.8rem">Standing reviews</div>
+          multi-tenant gateway code review - 07-20<br>
+          multi-tenant gateway code review - 07-21<br>
+          <div class="p" style="margin-top:.8rem">Design record</div>
+          docs/new_architecture - session-state, fleet identity, mission-as-unit-of-work
+        </div>
+      </div>
+    </div>
+  </footer>
+
+</div>
+
+<script>
+  (function(){
+    var prog=document.getElementById('progress');
+    function onScroll(){
+      var h=document.documentElement, b=document.body;
+      var st=h.scrollTop||b.scrollTop;
+      var sh=(h.scrollHeight||b.scrollHeight)-h.clientHeight;
+      prog.style.width=(sh>0?(st/sh*100):0)+'%';
+    }
+    document.addEventListener('scroll',onScroll,{passive:true}); onScroll();
+
+    var reduce=window.matchMedia&&window.matchMedia('(prefers-reduced-motion:reduce)').matches;
+    var els=document.querySelectorAll('.reveal');
+    if(reduce||!('IntersectionObserver'in window)){
+      els.forEach(function(e){e.classList.add('in');});
+    }else{
+      var io=new IntersectionObserver(function(entries){
+        entries.forEach(function(en){ if(en.isIntersecting){ en.target.classList.add('in'); io.unobserve(en.target); } });
+      },{threshold:.12});
+      els.forEach(function(e){io.observe(e);});
+    }
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/architecture/shared-workflow-library-plan-2026-07-24.html
+++ b/docs/architecture/shared-workflow-library-plan-2026-07-24.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shared Workflow Library - Architecture and Implementation Plan</title>
+<style>
+  :root {
+    --ink: #1a2332;
+    --muted: #5a6a7e;
+    --line: #d8dee8;
+    --paper: #f7f8fa;
+    --card: #ffffff;
+    --accent: #1f4e79;
+    --accent-soft: #e8eff7;
+    --good: #206040;
+    --good-soft: #e6f2ea;
+    --bad: #8a2a2a;
+    --bad-soft: #f7e9e9;
+    --warn-soft: #fdf3e0;
+    --warn: #8a6010;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 0;
+    font-family: Georgia, "Times New Roman", serif;
+    color: var(--ink);
+    background: var(--paper);
+    line-height: 1.55;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 0 28px 80px; }
+  header {
+    background: var(--accent);
+    color: #fff;
+    padding: 40px 0 34px;
+    margin-bottom: 36px;
+  }
+  header .wrap { padding-bottom: 0; }
+  header h1 { margin: 0 0 8px; font-size: 30px; font-weight: normal; letter-spacing: 0.3px; }
+  header .sub { color: #cfe0f0; font-size: 15px; }
+  header .meta { margin-top: 14px; font-size: 13px; color: #a9c4dd; font-family: "Segoe UI", Arial, sans-serif; }
+  h2 {
+    font-size: 21px; font-weight: normal; color: var(--accent);
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 6px; margin: 44px 0 16px;
+  }
+  h3 { font-size: 16px; margin: 26px 0 10px; color: var(--ink); }
+  p { margin: 10px 0; }
+  .lede { font-size: 17px; color: var(--ink); }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 6px;
+    padding: 18px 22px; margin: 16px 0;
+  }
+  .callout {
+    border-left: 4px solid var(--accent); background: var(--accent-soft);
+    padding: 14px 18px; margin: 16px 0; border-radius: 0 6px 6px 0;
+  }
+  .callout.bad { border-left-color: var(--bad); background: var(--bad-soft); }
+  .callout.good { border-left-color: var(--good); background: var(--good-soft); }
+  .callout.warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  code, .mono {
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13px;
+    background: #eef1f5; padding: 1px 5px; border-radius: 3px;
+  }
+  pre {
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13px; line-height: 1.5;
+    background: #232b36; color: #dde5ee;
+    padding: 16px 20px; border-radius: 6px;
+    overflow-x: auto;
+  }
+  pre .c { color: #7fa3c4; }
+  table {
+    width: 100%; border-collapse: collapse; margin: 16px 0;
+    background: var(--card); font-size: 14px;
+    font-family: "Segoe UI", Arial, sans-serif;
+  }
+  th {
+    text-align: left; background: var(--accent); color: #fff;
+    padding: 9px 12px; font-weight: 600; font-size: 13px;
+  }
+  td { padding: 9px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .pill {
+    display: inline-block; font-family: "Segoe UI", Arial, sans-serif;
+    font-size: 11px; font-weight: 700; letter-spacing: 0.5px;
+    padding: 2px 9px; border-radius: 10px; text-transform: uppercase;
+  }
+  .pill.p1 { background: var(--accent-soft); color: var(--accent); }
+  .pill.done-crit { background: var(--good-soft); color: var(--good); }
+  .phase {
+    background: var(--card); border: 1px solid var(--line); border-radius: 6px;
+    margin: 22px 0; overflow: hidden;
+  }
+  .phase .head {
+    background: var(--accent); color: #fff; padding: 12px 22px;
+    font-family: "Segoe UI", Arial, sans-serif;
+  }
+  .phase .head .num { font-size: 12px; letter-spacing: 1.5px; text-transform: uppercase; color: #a9c4dd; }
+  .phase .head .name { font-size: 18px; margin-top: 2px; }
+  .phase .body { padding: 6px 22px 18px; }
+  .kv { font-family: "Segoe UI", Arial, sans-serif; font-size: 14px; }
+  .kv dt { font-weight: 700; margin-top: 12px; color: var(--accent); font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .kv dd { margin: 4px 0 0 0; }
+  ul { margin: 8px 0; padding-left: 24px; }
+  li { margin: 5px 0; }
+  .diagram {
+    background: var(--card); border: 1px solid var(--line); border-radius: 6px;
+    padding: 22px; margin: 16px 0; overflow-x: auto;
+  }
+  .diagram pre {
+    background: transparent; color: var(--ink); padding: 0; margin: 0;
+    font-size: 13px;
+  }
+  footer {
+    margin-top: 60px; padding-top: 16px; border-top: 1px solid var(--line);
+    color: var(--muted); font-size: 13px; font-family: "Segoe UI", Arial, sans-serif;
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <h1>Shared Workflow Library</h1>
+    <div class="sub">DevThrottle-maintained workflows served to every tenant on the hosted Gateway - architecture and implementation plan</div>
+    <div class="meta">DevThrottle &middot; 2026-07-24 &middot; Status: PLAN, awaiting owner approval before implementation</div>
+  </div>
+</header>
+
+<div class="wrap">
+
+<h2>Why</h2>
+<p class="lede">
+When DevThrottle moved from the local Gateway to the hosted multi-tenant Gateway, the out-of-the-box
+workflows - Mission, Standalone, and Standalone with review - disappeared from every tenant's catalog.
+Nobody deleted them. The built-in workflows are seeded once at Gateway boot into the reserved
+<span class="mono">System</span> partition, while every signed-in tenant reads its own partition.
+The two never meet, so every hosted tenant sees an empty workflow catalog: no mission workflow to seat
+sessions on, no workflow index line in any session's launch briefing.
+</p>
+
+<div class="callout bad">
+<strong>Root cause, precisely.</strong> <span class="mono">WorkflowStore</span>'s constructor is the only
+caller of <span class="mono">BuiltInWorkflowSeeder.Seed()</span>. It runs once at host startup inside
+the startup <span class="mono">System</span> tenant scope (<span class="mono">GatewayHost.cs</span>).
+Every built-in row is stamped <span class="mono">TenantId = System</span>. At request time the catalog
+read scopes to the authenticated caller's tenant through the Entity Framework global query filter
+(<span class="mono">TenantId == ActiveTenant</span>), which returns nothing. New tenants are minted in
+<span class="mono">TenantRegistry.MintOrLookupBySubject()</span> with no seeding at all. On the local
+install this never showed because the single-tenant context answers <span class="mono">Local</span> for
+both the seed write and every read.
+</div>
+
+<h2>The product decision (owner ruling, 2026-07-24)</h2>
+<div class="card">
+<ul>
+<li><strong>Built-in workflows are DevThrottle's.</strong> Shipped in the binary, maintained and updated
+    by DevThrottle, always present in every tenant's catalog, and never editable or deletable by a tenant.
+    They are the start of a growing library of DevThrottle-maintained workflows.</li>
+<li><strong>Tenants customize by cloning, not editing.</strong> A tenant who wants a different conduct
+    clones a built-in into a tenant-owned, fully editable copy, or authors one from scratch.</li>
+<li><strong>Tenants can turn a built-in off</strong> for their own fleet. Off hides it from launch
+    briefings and refuses new seats; it never removes it, and the switch is per tenant.</li>
+<li><strong>Shared central library, not copy-per-tenant.</strong> The built-ins live once, centrally,
+    read-only, shared by every tenant. DevThrottle ships an update, seeds it in one place, and every
+    tenant sees the new version immediately. No fan-out, no per-tenant drift. The only per-tenant state
+    is the on/off choice and the tenant's own workflows and clones.</li>
+</ul>
+</div>
+<p>
+This ruling <strong>reverses</strong> the earlier ruling of 2026-07-17 ("built-ins are editable with
+reset-to-shipped"). The seeder's customized-content branch and the reset-to-shipped path exist to serve
+that older ruling and are retired by this plan.
+</p>
+
+<h2>Target architecture</h2>
+
+<div class="diagram">
+<pre>
+                        THE HOSTED GATEWAY DATABASE (PostgreSQL)
+  +---------------------------------------------------------------------------+
+  |                                                                           |
+  |   SHARED LIBRARY PARTITION (TenantId = System)                            |
+  |   +--------------------------------------------------------------+       |
+  |   |  workflows / workflow_versions / workflow_files               |       |
+  |   |  - mission                (built-in, read-only)               |       |
+  |   |  - standalone             (built-in, read-only)               |       |
+  |   |  - standalone-with-review (built-in, read-only)               |       |
+  |   |  Seeded and upgraded ONLY by the boot-time seeder             |       |
+  |   |  from what the running binary ships.                          |       |
+  |   +--------------------------------------------------------------+       |
+  |                          |  read-only union                              |
+  |                          v                                               |
+  |   TENANT A PARTITION                      TENANT B PARTITION             |
+  |   +---------------------------+          +---------------------------+   |
+  |   |  own workflows and clones |          |  own workflows and clones |   |
+  |   |  built-in on/off choices  |          |  built-in on/off choices  |   |
+  |   +---------------------------+          +---------------------------+   |
+  |                                                                           |
+  +---------------------------------------------------------------------------+
+
+  What tenant A's catalog serves  =  shared built-ins (minus the ones A turned off,
+                                     shown with their off state)
+                                     UNION  tenant A's own workflows
+</pre>
+</div>
+
+<h3>Key properties</h3>
+<table>
+<tr><th style="width:30%">Property</th><th>How the architecture delivers it</th></tr>
+<tr><td>Always present for every tenant, including brand-new ones</td>
+    <td>No per-tenant seeding exists at all. A new tenant's catalog read unions the shared partition
+        from its first request. There is nothing to forget to run.</td></tr>
+<tr><td>DevThrottle updates reach everyone at once</td>
+    <td>The existing boot-time seeder keeps maintaining the shared partition: when a new binary ships
+        different content, it publishes the next version there, once. Every tenant's next read serves it.</td></tr>
+<tr><td>Built-ins cannot be changed by tenants</td>
+    <td>Every authoring write path (draft, publish, archive) refuses built-in ids. The only writer of
+        built-in content is the seeder.</td></tr>
+<tr><td>Per-tenant off switch</td>
+    <td>A small per-tenant override table (tenant, workflow id, enabled). The shared row is never
+        touched; the read folds the override in.</td></tr>
+<tr><td>Customization path</td>
+    <td>Clone: copies a built-in's published content into a new tenant-owned, editable workflow under
+        the tenant's own id.</td></tr>
+<tr><td>Self-host unchanged in behavior</td>
+    <td>On the local install the single-tenant context makes the shared partition and the tenant
+        partition the same partition; the union is a no-op and everything behaves as today, except
+        built-ins also become read-only there (one uniform rule everywhere).</td></tr>
+<tr><td>Pinned runs always resolve</td>
+    <td>A session seated on a run pins a workflow version. Version reads resolve against the shared
+        partition for built-ins, so a seated run's conduct never disappears - even mid-upgrade, the
+        superseded version row remains readable.</td></tr>
+</table>
+
+<div class="callout good">
+<strong>Why this is the small change, not the big one.</strong> The built-ins are already sitting in the
+shared System partition on the hosted Gateway today - the boot seeder put them there. Phase 1 is a
+read-path change: teach the reads to look in the shared partition for built-ins. No data migration, no
+backfill, no per-tenant copies.
+</div>
+
+<h2>What has to change, file by file</h2>
+<table>
+<tr><th style="width:38%">Surface</th><th>Change</th></tr>
+<tr><td><span class="mono">Gateway/Workflows/WorkflowStore.cs</span></td>
+    <td>The heart of the work. Reads (catalog list, get by id, instructions, versions, version detail,
+        files) resolve built-ins from the shared partition and union them with the ambient tenant's own
+        rows. Writes (create draft, update draft, publish, archive) refuse built-in ids. New clone
+        operation. The enable switch writes the per-tenant override for built-ins.</td></tr>
+<tr><td><span class="mono">Gateway/Workflows/BuiltInWorkflowSeeder.cs</span></td>
+    <td>Simplified: built-ins can no longer be customized, so the customized-content branch goes away -
+        on a shipped-hash change it always publishes the shipped content as the next version in the
+        shared partition. Runs exactly where it runs today (boot, System scope).</td></tr>
+<tr><td><span class="mono">Gateway/Api/WorkflowEndpoints.cs</span></td>
+    <td>Reset-to-shipped route retired (built-ins cannot diverge, so there is nothing to reset).
+        Clone route added. Enable/disable unchanged on the surface, rerouted underneath for built-ins.</td></tr>
+<tr><td><span class="mono">Gateway/Workflows/WorkflowRunStore.cs</span></td>
+    <td>Run creation and seat validation resolve the workflow through the same shared-aware read, so a
+        tenant can seat sessions on the mission workflow.</td></tr>
+<tr><td>Database schema (both providers)</td>
+    <td>One new table for the per-tenant built-in on/off override. One Entity Framework migration in
+        each migration assembly (SQLite and PostgreSQL), in the same pull request as the model change,
+        serialized with any other in-flight migration work.</td></tr>
+<tr><td>Cockpit workflows page</td>
+    <td>Built-ins render with a "Built-in - maintained by DevThrottle" badge, no edit affordances, a
+        clone action, and the per-tenant on/off toggle. The Gateway computes what is editable and
+        stamps it on the DTO; the client renders the verdict (rule 7 - the client is dumb).</td></tr>
+<tr><td><span class="mono">cc-devthrottle</span> command line</td>
+    <td>New verb: <span class="mono">workflow clone &lt;id&gt; &lt;new-id&gt;</span>. Existing verbs
+        (list, instructions, enable, disable) keep working and now see built-ins on hosted.</td></tr>
+</table>
+
+<h2>Implementation phases</h2>
+<p>
+Each phase is built in its own worktree cut from origin/main, delivered as one merged pull request,
+proven before the next phase starts. Merged to origin/main is the only done. The mission ends with an
+independent quality-assurance report.
+</p>
+
+<div class="phase">
+  <div class="head"><div class="num">Phase 1</div><div class="name">Serve the shared library to every tenant</div></div>
+  <div class="body kv">
+    <dt>What</dt>
+    <dd>All workflow read paths resolve built-ins from the shared System partition and union them with
+        the caller's own tenant rows: the catalog list, get by id, instructions (head and pinned
+        version), version history, version detail, helper files, run creation and seat validation, and
+        the workflow index block that rides every session's launch briefing. Built-ins are always-on in
+        this phase; the off switch arrives in phase 2.</dd>
+    <dt>Why first</dt>
+    <dd>This alone restores the mission workflow for the owner's tenant and every current and future
+        tenant. It is pure read-path work: no schema change, no data movement.</dd>
+    <dt>Proof</dt>
+    <dd>Gateway tests that run the store hosted-style with two distinct tenants: both list all three
+        built-ins; each sees only its own user workflows; a tenant can read mission instructions and
+        create a run seated on mission; a pinned version read resolves after the seeder publishes a
+        newer shipped version. A failing-first test reproducing today's empty catalog.</dd>
+    <dt>Done</dt>
+    <dd>Pull request merged to origin/main with the proof suite green.</dd>
+  </div>
+</div>
+
+<div class="phase">
+  <div class="head"><div class="num">Phase 2</div><div class="name">Per-tenant on/off for built-ins</div></div>
+  <div class="body kv">
+    <dt>What</dt>
+    <dd>A per-tenant override table (tenant, workflow id, enabled, who flipped it, when). The
+        enable/disable operations write the override when the target is a built-in (a tenant must never
+        write the shared row); user-owned workflows keep the head-row switch they have today. Reads fold
+        the override into the served DTO and the workflow index. Off refuses default conduct reads and
+        new seats for that tenant only, exactly as the switch behaves today.</dd>
+    <dt>Schema</dt>
+    <dd>One migration in each provider assembly (SQLite and PostgreSQL), in the same pull request as the
+        model change, serialized with any other in-flight migration work fleet-wide.</dd>
+    <dt>Proof</dt>
+    <dd>Tenant A turns mission off: A's catalog shows it off, A's briefings drop it, A cannot seat on
+        it; tenant B is completely unaffected; A turns it back on and everything returns. The actor is
+        recorded. Self-host behavior unchanged by the tests that already cover the switch.</dd>
+    <dt>Done</dt>
+    <dd>Pull request merged to origin/main with the proof suite green.</dd>
+  </div>
+</div>
+
+<div class="phase">
+  <div class="head"><div class="num">Phase 3</div><div class="name">Built-ins become read-only</div></div>
+  <div class="body kv">
+    <dt>What</dt>
+    <dd>Every authoring write refuses built-in ids with a clear message pointing at clone: create draft
+        over a built-in id, update draft, publish, archive. The reset-to-shipped route is retired. The
+        seeder drops its customized-content branch and always publishes shipped content on a hash
+        change. The Gateway stamps an "editable" verdict on the workflow DTO so the Cockpit renders
+        built-ins without edit affordances (the client renders the verdict, never derives it).</dd>
+    <dt>Upgrade note</dt>
+    <dd>A self-host install that customized a built-in under the old ruling keeps its edit in the
+        version history (superseded, readable forever); the shipped content is republished over it on
+        first boot of the new binary. This is stated in the release notes, not silently done.</dd>
+    <dt>Proof</dt>
+    <dd>Each refused write returns the clear refusal with the clone pointer; the seeder upgrade test
+        shows a previously-customized built-in republished to shipped with history intact; the DTO
+        carries the editable verdict and the Cockpit renders from it.</dd>
+    <dt>Done</dt>
+    <dd>Pull request merged to origin/main with the proof suite green.</dd>
+  </div>
+</div>
+
+<div class="phase">
+  <div class="head"><div class="num">Phase 4</div><div class="name">Clone - the customization path</div></div>
+  <div class="body kv">
+    <dt>What</dt>
+    <dd>Clone copies a workflow's published content (steps, instructions, helper files, everything) into
+        a new tenant-owned workflow under a new id chosen by the caller, born as version 1, editable,
+        recorded as cloned-from (id and version) for provenance. Works on built-ins and on the tenant's
+        own workflows. Surfaced as a Gateway route, a <span class="mono">cc-devthrottle workflow
+        clone</span> verb, and a Cockpit action on the workflow page.</dd>
+    <dt>Proof</dt>
+    <dd>Clone mission, edit the clone, publish it: the clone serves the edited conduct while the
+        built-in serves the shipped conduct untouched; the clone records what it was cloned from; the
+        id-collision and validation refusals are exact.</dd>
+    <dt>Done</dt>
+    <dd>Pull request merged to origin/main with the proof suite green.</dd>
+  </div>
+</div>
+
+<div class="phase">
+  <div class="head"><div class="num">Phase 5</div><div class="name">Hosted deploy and independent quality-assurance report</div></div>
+  <div class="body kv">
+    <dt>What</dt>
+    <dd>Deploy the merged work to the live hosted Gateway (the manual release path), verify the actual
+        running commit, then an independent verification pass - a different agent than the ones that
+        built the phases - exercises every phase against the LIVE hosted Gateway with a real signed-in
+        tenant: catalog shows the three built-ins, a session's briefing carries the workflow index, a
+        session seats on mission, the off switch isolates per tenant, edits are refused, clone works
+        end to end. Also a fresh-tenant check: a newly minted tenant sees the full library on first
+        read with no seeding step.</dd>
+    <dt>Deliverable</dt>
+    <dd>An HTML quality-assurance report in <span class="mono">docs/reviews/</span> recording each
+        phase, its merged pull request, the live-gateway evidence for each claim, and any defects found
+        and fixed. The report reaches the owner - the one planned interruption.</dd>
+    <dt>Done</dt>
+    <dd>Report delivered; every phase merged to origin/main; live hosted Gateway verified serving the
+        library.</dd>
+  </div>
+</div>
+
+<h2>Decisions locked by this plan</h2>
+<table>
+<tr><th style="width:44%">Decision</th><th>Ruling</th></tr>
+<tr><td>Library storage model</td><td>Shared central library in the System partition; never copy-per-tenant. Owner ruling 2026-07-24.</td></tr>
+<tr><td>Built-in editability</td><td>Read-only everywhere (hosted and self-host). Reverses the 2026-07-17 ruling; reset-to-shipped is retired.</td></tr>
+<tr><td>Customization path</td><td>Clone into a tenant-owned copy, provenance recorded.</td></tr>
+<tr><td>Per-tenant off switch</td><td>Kept, moved to a per-tenant override for built-ins. Off hides and refuses seats; never deletes.</td></tr>
+<tr><td>Historical backfill</td><td>Not needed. The shared-library read makes existing System-partition rows visible to everyone; no per-tenant data is created for built-ins at all.</td></tr>
+<tr><td>New-tenant provisioning</td><td>Nothing to provision. First read serves the library.</td></tr>
+</table>
+
+<h2>Risks and how the plan holds them</h2>
+<div class="card">
+<ul>
+<li><strong>Cross-tenant leakage through the union read.</strong> The union deliberately reaches outside
+    the ambient tenant - exactly once, for the System partition, for built-in rows only, read-only. The
+    proof suite includes a negative: tenant A's user workflows never appear in tenant B's catalog, and
+    nothing tenant-owned is ever read from or written to the System partition by request paths.</li>
+<li><strong>Id collision between a tenant workflow and a built-in.</strong> A tenant must not be able to
+    create a workflow named <span class="mono">mission</span> and shadow the library. Create refuses
+    ids that collide with a built-in (clear message: clone instead). Phase 1 defines the resolution
+    order; phase 3 adds the refusal.</li>
+<li><strong>Migration serialization.</strong> Phase 2 carries the only schema change, in both provider
+    assemblies, in the same pull request as the model change, coordinated with any other in-flight
+    migration fleet-wide.</li>
+<li><strong>Deploying main ships everyone's work.</strong> The hosted deploy in phase 5 ships whatever
+    else has merged to main; the deploy follows the standard verify-the-running-commit discipline.</li>
+</ul>
+</div>
+
+<footer>
+DevThrottle - Shared Workflow Library plan - 2026-07-24. Companion GitHub issue lives in the
+devthrottle_internal tracker. Implementation starts only after owner approval of this plan.
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/reviews/hosted-settings-per-tenant-qa-2026-07-22.html
+++ b/docs/reviews/hosted-settings-per-tenant-qa-2026-07-22.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Per-Tenant Gateway Settings - QA Report (issue #2017)</title>
+<style>
+  :root {
+    --ink: #14304a; --ink-soft: #3d5570; --paper: #faf9f6; --card: #ffffff; --line: #d9d4c8;
+    --accent: #0e6a8a; --gold: #a87b23; --danger: #a33b2e; --good: #2e7d54;
+    --warn-bg: #fdf6ec; --danger-bg: #fbf0ee; --good-bg: #eef7f1; --mono: "Consolas", "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body { background: var(--paper); color: var(--ink); font: 16px/1.65 "Segoe UI", -apple-system, "Helvetica Neue", Arial, sans-serif; }
+  .page { max-width: 1080px; margin: 0 auto; padding: 0 28px 120px; }
+  h1, h2, h3, h4 { font-family: Georgia, "Iowan Old Style", "Times New Roman", serif; font-weight: 600; color: var(--ink); }
+  a { color: var(--accent); text-decoration: none; } a:hover { text-decoration: underline; }
+  code { font-family: var(--mono); font-size: 0.85em; background: #f0ede5; padding: 1px 5px; border-radius: 3px; color: #24425f; }
+  p { margin: 0 0 14px; } ul, ol { margin: 0 0 14px 24px; } li { margin-bottom: 6px; }
+  .masthead { border-bottom: 3px double var(--line); padding: 60px 0 32px; }
+  .masthead .kicker { font-family: var(--mono); font-size: 12px; letter-spacing: 2.5px; text-transform: uppercase; color: var(--gold); margin-bottom: 16px; }
+  .masthead h1 { font-size: 40px; line-height: 1.15; margin-bottom: 14px; max-width: 900px; }
+  .masthead .sub { font-size: 18px; color: var(--ink-soft); max-width: 820px; margin-bottom: 26px; }
+  .factline { display: flex; flex-wrap: wrap; gap: 10px 26px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); border-top: 1px solid var(--line); padding-top: 16px; }
+  .factline b { color: var(--ink); font-weight: 600; }
+  .chips { display: grid; grid-template-columns: repeat(auto-fit, minmax(215px, 1fr)); gap: 14px; margin: 30px 0 8px; }
+  .chip { background: var(--card); border: 1px solid var(--line); border-top: 3px solid var(--accent); border-radius: 6px; padding: 16px 18px; }
+  .chip .num { font-family: Georgia, serif; font-size: 28px; line-height: 1.1; } .chip .lbl { font-size: 13px; color: var(--ink-soft); margin-top: 4px; }
+  .chip.gold { border-top-color: var(--gold); } .chip.green { border-top-color: var(--good); } .chip.red { border-top-color: var(--danger); }
+  section { margin-top: 66px; }
+  .sec-head { display: flex; align-items: baseline; gap: 18px; border-bottom: 2px solid var(--ink); padding-bottom: 10px; margin-bottom: 22px; }
+  .sec-head .n { font-family: Georgia, serif; font-size: 42px; color: var(--line); line-height: 1; } .sec-head h2 { font-size: 27px; }
+  h3 { font-size: 20px; margin: 30px 0 10px; } .lede { font-size: 17px; color: var(--ink-soft); }
+  .rule-box { border-left: 4px solid var(--accent); background: #eef4f7; padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; } .rule-box b { color: var(--accent); }
+  .warn-box { border-left: 4px solid var(--gold); background: var(--warn-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  .good-box { border-left: 4px solid var(--good); background: var(--good-bg); padding: 14px 20px; border-radius: 0 6px 6px 0; margin: 18px 0; }
+  table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 14px; background: var(--card); }
+  th { text-align: left; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: var(--ink-soft); border-bottom: 2px solid var(--ink); padding: 9px 11px; }
+  td { border-bottom: 1px solid var(--line); padding: 9px 11px; vertical-align: top; } tr:last-child td { border-bottom: none; }
+  .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 6px; }
+  .st { font-family: var(--mono); font-size: 10.5px; font-weight: 700; padding: 1px 7px; border-radius: 9px; white-space: nowrap; }
+  .st.pass { background: var(--good-bg); color: var(--good); border: 1px solid var(--good); }
+  .st.gate { background: var(--warn-bg); color: var(--gold); border: 1px solid var(--gold); }
+  .st.drop { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger); }
+  .st.acct { background: #eef4f7; color: var(--accent); border: 1px solid var(--accent); }
+  pre { background: #0f1a24; color: #d6e2ec; border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; margin: 14px 0; }
+  pre .k { color: #7cc6e6; } pre .g { color: #7fce9f; } pre .c { color: #7f96a8; }
+  footer { margin-top: 80px; border-top: 3px double var(--line); padding-top: 22px; font-size: 13px; color: var(--ink-soft); }
+
+  /* desktop cockpit mockup */
+  .screen { background: #0e1820; border: 1px solid #24384a; border-radius: 10px; overflow: hidden; box-shadow: 0 10px 30px rgba(10,20,30,0.22); margin: 18px 0 6px; }
+  .screen .bar { background: #0a121a; border-bottom: 1px solid #1d2f40; padding: 9px 14px; display: flex; align-items: center; gap: 7px; }
+  .screen .dot { width: 11px; height: 11px; border-radius: 50%; } .dot.r{background:#c0554a}.dot.y{background:#c99a3f}.dot.g{background:#3f9d6a}
+  .screen .url { font-family: var(--mono); font-size: 11.5px; color: #6f8598; margin-left: 12px; }
+  .screen .app { display: flex; min-height: 320px; }
+  .rail { width: 200px; flex: 0 0 200px; background: #0b141c; border-right: 1px solid #1a2a38; padding: 15px 0 16px; color: #93a7b8; }
+  @media (max-width: 720px){ .rail{display:none} }
+  .rail .brand { font-family: Georgia, serif; font-size: 17px; color: #f2f6f9; font-weight: 700; padding: 0 18px 12px; }
+  .rail .nav { list-style: none; margin: 4px 0 0; padding: 0; } .rail .nav li { font-size: 12.5px; padding: 8px 18px; color: #93a7b8; }
+  .rail .nav li.on { background: #14222e; color: #eaf1f6; border-left: 2px solid #2f9fce; padding-left: 16px; }
+  .main { flex: 1 1 auto; padding: 22px 30px 26px; color: #d6e2ec; min-width: 0; }
+  .main h5 { font-family: Georgia, serif; font-size: 24px; color: #f2f6f9; margin: 0 0 4px; font-weight: 600; }
+  .main .lede2 { font-size: 12.5px; color: #8ba0b2; margin: 0 0 16px; }
+  .main .tabs { display: flex; gap: 6px; border-bottom: 1px solid #22364a; margin-bottom: 18px; flex-wrap: wrap; }
+  .tabx { font-size: 12.5px; padding: 8px 13px 10px; color: #8ba0b2; border-bottom: 2px solid transparent; }
+  .tabx.on { color: #7cc6e6; border-bottom-color: #2f9fce; font-weight: 600; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 11px; } @media (max-width:640px){ .grid2{grid-template-columns:1fr} }
+  .setcard { background: #13212d; border: 1px solid #223648; border-radius: 8px; padding: 13px 15px; }
+  .setcard .top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .setcard .name { font-size: 13.5px; color: #eaf1f6; font-weight: 600; } .setcard .desc { font-size: 11.5px; color: #7f96a8; margin-top: 3px; }
+  .pill { font-family: var(--mono); font-size: 9.5px; letter-spacing: .6px; text-transform: uppercase; padding: 2px 8px; border-radius: 9px; white-space: nowrap; }
+  .pill.acct { background: rgba(47,159,206,.16); color: #7cc6e6; border: 1px solid #2f6f8a; }
+  .pill.gw { background: rgba(168,123,35,.16); color: #d3aa5a; border: 1px solid #8a6f2a; }
+  .pill.dev { background: rgba(46,125,84,.16); color: #7fce9f; border: 1px solid #2a7d54; }
+  .ctrl { margin-top: 10px; display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: #cbd8e2; background: #0c1720; border: 1px solid #263c4f; border-radius: 6px; padding: 6px 10px; } .ctrl .car { color: #6f8598; }
+  .absent { font-size: 12px; color: #7f96a8; font-style: italic; padding: 11px 14px; border: 1px dashed #2a3f52; border-radius: 8px; margin-top: 12px; background: #0f1a23; }
+  .cap { font-size: 13px; color: var(--ink-soft); margin: 4px 0 26px; } .cap b { color: var(--ink); }
+</style>
+</head>
+<body>
+<div class="page">
+
+<div class="masthead">
+  <div class="kicker">DevThrottle &middot; QA Report &middot; Issue #2017</div>
+  <h1>Per-tenant Gateway settings: the store, the resolver, the page - verified</h1>
+  <p class="sub">
+    The Settings page no longer 404s on the hosted Gateway because the settings it keeps now have a
+    per-tenant home. This report records what was built, where it lives, how it was proven on a live
+    Gateway, and exactly what is deferred to the multi-tenant runtime mission before it can ship.
+  </p>
+  <div class="factline">
+    <span>Date <b>2026-07-22</b></span>
+    <span>Branch <b>settings-per-tenant @ 9bfdb76b</b></span>
+    <span>Base <b>origin/main @ d67a3d1c</b></span>
+    <span>Verified on a live self-host Gateway (port 8791)</span>
+  </div>
+</div>
+
+<div class="chips">
+  <div class="chip green"><div class="num">410+</div><div class="lbl">Gateway tests green, incl. 26 hostile two-tenant isolation tests + 7 cockpit tab tests</div></div>
+  <div class="chip"><div class="num">6</div><div class="lbl">commits: store &amp; resolver, migrations, endpoints, consumers, about signal, cockpit page</div></div>
+  <div class="chip gold"><div class="num">2</div><div class="lbl">items deferred to the MTR mission: the deep runtime consumers and the hosted deny-retirement (stacked, unmerged)</div></div>
+  <div class="chip red"><div class="num">0</div><div class="lbl">cross-tenant leaks found - a tenant with no override gets the operator default, never another tenant's value</div></div>
+</div>
+
+<!-- 01 -->
+<section id="what">
+  <div class="sec-head"><span class="n">01</span><h2>What shipped, and the split with the MTR mission</h2></div>
+  <p class="lede">
+    Making a setting per-tenant is a paired change: its WRITE (the settings page) and its READ (the runtime
+    that consumes it) must move together, or self-host regresses. This branch owns the store, the resolver,
+    the page, and the two consumers that are plain HTTP endpoints. The deep runtime consumers stay with the
+    multi-tenant (MTR) mission, which is threading them from this branch's base commit in parallel.
+  </p>
+  <div class="tbl-wrap"><table>
+    <thead><tr><th>Piece</th><th>Owner</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td>Per-tenant store <code>tenant_settings</code> + typed resolver + dual-provider migrations</td><td>this branch</td><td><span class="st pass">done + tested</span></td></tr>
+      <tr><td>Settings-page endpoints on the resolver (snooze, time zone, TTS voice, AI models, provider snapshot)</td><td>this branch</td><td><span class="st pass">done + tested</span></td></tr>
+      <tr><td>Two plain-endpoint consumers threaded: snooze default at hold-creation, time zone in stats</td><td>this branch</td><td><span class="st pass">done, end-to-end</span></td></tr>
+      <tr><td><code>/gateway/about</code> hosted flag for Gateway-owned tab selection</td><td>this branch</td><td><span class="st pass">done</span></td></tr>
+      <tr><td>Cockpit: hosted-aware tabs, Privacy removed, per-tenant scope pills</td><td>this branch</td><td><span class="st pass">done, builds</span></td></tr>
+      <tr><td>Deep runtime consumers: wingman models, TTS voice/model, narration, car mode</td><td>MTR mission</td><td><span class="st gate">in progress (parallel)</span></td></tr>
+      <tr><td>Hosted deny-retirement (serve the per-tenant routes on hosted)</td><td>stacked</td><td><span class="st gate">unmerged until MTR integration + hostile runtime tests</span></td></tr>
+    </tbody>
+  </table></div>
+  <div class="rule-box">
+    <b>The security invariant, held everywhere.</b> Every read and write takes an EXPLICIT <code>TenantId</code> -
+    no ambient inference. On hosted a blank/unresolved tenant fails closed (403) and never becomes
+    <code>TenantId.Local</code>; self-host resolves to <code>Local</code> explicitly. An absent override falls
+    back only to the operator global default (config.json), never another tenant's value.
+  </div>
+</section>
+
+<!-- 02 -->
+<section id="matrix">
+  <div class="sec-head"><span class="n">02</span><h2>The matrix: localhost / self-host vs. hosted</h2></div>
+  <p class="lede">Where each setting lives and how it behaves on each surface. This is the specification, verified below.</p>
+  <div class="tbl-wrap"><table>
+    <thead><tr><th>Setting</th><th>Localhost / self-host</th><th>Hosted Gateway</th><th>Runtime consumer</th></tr></thead>
+    <tbody>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">This machine tab (self-host only)</td></tr>
+      <tr><td>Diagnostics, network addressing, autostart, brain</td><td><span class="st gw" style="border:none;background:none;color:var(--gold)">this machine</span></td><td><span class="st drop">absent (tab hidden)</span></td><td>Gateway process</td></tr>
+      <tr><td>Display time zone</td><td><span class="st acct">per local tenant</span></td><td><span class="st acct">per account *</span></td><td><b>this branch</b> (stats page)</td></tr>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Notifications</td></tr>
+      <tr><td>Snooze default + presets</td><td><span class="st acct">per local tenant</span></td><td><span class="st acct">per account</span></td><td><b>this branch</b> (hold creation)</td></tr>
+      <tr><td>Browser notifications</td><td><span class="st acct" style="border-color:#2a7d54;color:var(--good)">this browser</span></td><td><span class="st acct" style="border-color:#2a7d54;color:var(--good)">this browser</span></td><td>device (unchanged)</td></tr>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">AI</td></tr>
+      <tr><td>Provider / transcription</td><td>this Gateway</td><td><span class="st acct" style="border-color:#2a7d54;color:var(--good)">included (one option)</span></td><td>provider-level</td></tr>
+      <tr><td>Thinking model, fast model, speech model, voice</td><td><span class="st acct">per local tenant</span></td><td><span class="st acct">per account</span></td><td><span class="st gate">MTR (wingman / TTS)</span></td></tr>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Car Mode</td></tr>
+      <tr><td>Model, end phrase</td><td><span class="st acct">per local tenant</span></td><td><span class="st acct">per account</span></td><td><span class="st gate">MTR (car mode)</span></td></tr>
+      <tr><td colspan="4" style="background:#f4f1ea;font-weight:700;">Privacy</td></tr>
+      <tr><td>Usage telemetry, wingman training capture</td><td><span class="st drop">removed</span></td><td><span class="st drop">removed</span></td><td>&mdash;</td></tr>
+    </tbody>
+  </table></div>
+  <p style="font-size:13px;color:var(--ink-soft)"><b>*</b> Time zone is a display preference, treated as per-account so it survives on hosted rather than vanishing with the machine tab.
+  Rows marked <span class="st gate" style="font-size:9.5px">MTR</span> persist per-tenant on the settings page now (written and read back through the resolver); the runtime that CONSUMES them at turn time is being threaded by the MTR mission before the hosted deny is retired.</p>
+</section>
+
+<!-- 03 -->
+<section id="impl">
+  <div class="sec-head"><span class="n">03</span><h2>How it works, and where it is implemented</h2></div>
+  <p class="lede">The data path for a per-tenant setting, and the files that make it.</p>
+  <div class="tbl-wrap"><table>
+    <thead><tr><th>Layer</th><th>File</th><th>What it does</th></tr></thead>
+    <tbody>
+      <tr><td>Entity</td><td><code>Data/Entities/TenantSettingEntity.cs</code></td><td>One <code>(tenant_id, Key)</code> composite-key row in <code>tenant_settings</code>, mirroring <code>mission_notes</code>.</td></tr>
+      <tr><td>Context</td><td><code>Data/GatewayDbContext.cs</code></td><td>DbSet + <code>ApplyTenantScope</code> (deny-by-default query filter) + Postgres <code>"C"</code> collation on the key.</td></tr>
+      <tr><td>Explicit-tenant context</td><td><code>Data/GatewayDatabase.cs</code></td><td><code>CreateContext(TenantId)</code> - scopes to an EXPLICIT tenant, fails loud on an invalid one. No ambient inference.</td></tr>
+      <tr><td>Store</td><td><code>Settings/TenantSettingsStore.cs</code></td><td>Explicit-tenant Get / GetAll / Set / Remove; query-filter isolated so a tenant cannot read another's row.</td></tr>
+      <tr><td>Resolver (the seam)</td><td><code>Settings/TenantSettingsResolver.cs</code></td><td>The one typed resolver: tenant override else operator default, never another tenant's value; validates writes.</td></tr>
+      <tr><td>Migrations</td><td><code>Data/Migrations/*</code> + <code>Gateway.Migrations.Postgres/*</code></td><td>SQLite + Postgres, both snapshots in sync, no model drift.</td></tr>
+      <tr><td>Settings endpoints</td><td><code>Api/SettingsEndpoints.cs</code></td><td>Snooze / time-zone / TTS-voice read+write via the resolver; per-tenant AI-provider snapshot; routes stay denied on hosted.</td></tr>
+      <tr><td>AI model endpoints</td><td><code>Api/AiModelsEndpoint.cs</code></td><td>Wingman / car-mode / speech model writes via the resolver, tenant-resolved.</td></tr>
+      <tr><td>Consumer: snooze</td><td><code>Api/GatewayEndpoints.cs</code> (hold route)</td><td>The snooze default at hold-creation reads the caller tenant's value, not global config.</td></tr>
+      <tr><td>Consumer: time zone</td><td><code>Stats/StatsPageEndpoint.cs</code></td><td>The dashboard time zone reads the (self-host local) tenant's value.</td></tr>
+      <tr><td>Hosted signal</td><td><code>Gateway.Contracts/AboutDto.cs</code>, <code>about/aboutClient.ts</code></td><td>A public <code>hosted</code> flag on <code>/gateway/about</code> the page reads to pick its tabs.</td></tr>
+      <tr><td>Cockpit page</td><td><code>settings/SettingsView.tsx</code>, <code>settings/settingsTabs.ts</code></td><td>Surface-aware tabs, Privacy removed, per-tenant scope pills.</td></tr>
+    </tbody>
+  </table></div>
+</section>
+
+<!-- 04 -->
+<section id="evidence">
+  <div class="sec-head"><span class="n">04</span><h2>Live evidence (a running Gateway, not a mock)</h2></div>
+  <p class="lede">
+    The branch was built with the cockpit embedded and run as a self-host Gateway on port 8791. The API was
+    exercised with the machine token. These are verbatim responses.
+  </p>
+  <h3>The hosted flag that drives tab selection</h3>
+<pre><span class="c"># GET /gateway/about</span>
+<span class="k">hosted</span> = <span class="g">False</span>   <span class="c"># self-host -> the "This machine" tab shows, pills read "this Gateway"</span></pre>
+  <h3>Settings read per the local tenant</h3>
+<pre><span class="c"># GET /gateway/settings</span>
+{'snoozeDefaultMinutes': <span class="g">60</span>, 'snoozePresets': [15, 60, 240, 480], 'timeZone': 'America/New_York'}
+<span class="c"># GET /gateway/ai-provider</span>
+{'provider': 'devthrottle', 'wingmanModel': 'zai-org/GLM-5.2', 'ttsVoice': 'af_bella', 'carModeModel': 'Qwen/Qwen2.5-72B-Instruct'}</pre>
+  <h3>A per-tenant write round-trips through the store (not config.json)</h3>
+<pre><span class="k">PUT</span> /gateway/snooze-default {"minutes":30}   -> {"minutes":30}
+<span class="k">PUT</span> /gateway/tts-voice     {"voice":"shimmer"} -> {"voice":"shimmer"}
+<span class="c"># re-GET, proving persistence to the tenant store:</span>
+snoozeDefaultMinutes = <span class="g">30</span>
+ttsVoice = <span class="g">shimmer</span></pre>
+  <div class="good-box"><b>Result.</b> The settings the page keeps are read and written per the caller's tenant on a live Gateway. On self-host that tenant is <code>Local</code>; the same code path serves hosted tenants once the deny is retired.</div>
+</section>
+
+<!-- 05 -->
+<section id="page">
+  <div class="sec-head"><span class="n">05</span><h2>The page, on each surface</h2></div>
+  <p class="lede">
+    The desktop Cockpit Settings page. (Pixel screenshots of the live page were blocked by local browser
+    tooling - Brave uninstalled, Chrome remote-debugging off - so these are faithful renderings of the exact
+    tab set and pills the code produces; the live self-host page is clickable at the URL in the handover.)
+  </p>
+
+  <h3>Self-host - <code>localhost/c/settings</code></h3>
+  <div class="screen">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">127.0.0.1:8791/c/settings</span></div>
+    <div class="app">
+      <nav class="rail"><div class="brand">DevThrottle</div><ul class="nav">
+        <li>Fleet Map</li><li>Sessions</li><li>Directors</li><li>Schedule</li><li>Workflows</li><li>Dictionary</li><li>Voice Recorder</li><li>Transcription</li><li>Network</li><li class="on">Settings</li>
+      </ul></nav>
+      <div class="main">
+        <h5>Settings</h5><p class="lede2">Gateway and fleet configuration for this machine.</p>
+        <div class="tabs"><span class="tabx on">This machine</span><span class="tabx">Notifications</span><span class="tabx">AI</span><span class="tabx">Car Mode</span></div>
+        <div class="grid2">
+          <div class="setcard"><div class="top"><span class="name">Network addressing</span><span class="pill gw">this machine</span></div><div class="desc">How other devices reach this Gateway.</div><div class="ctrl"><b style="color:#d3aa5a">Tailscale</b> &middot; <span class="car">LAN IP</span></div></div>
+          <div class="setcard"><div class="top"><span class="name">Display time zone</span><span class="pill gw">this machine</span></div><div class="ctrl">America/New_York <span class="car">v</span></div></div>
+        </div>
+        <div class="absent">No Privacy tab (removed on both surfaces).</div>
+      </div>
+    </div>
+  </div>
+  <p class="cap"><b>Self-host.</b> Four tabs incl. This machine; pills read "this machine / this Gateway". No Privacy tab.</p>
+
+  <h3>Hosted - <code>gateway.devthrottle.com/settings</code></h3>
+  <div class="screen">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">gateway.devthrottle.com/settings?tab=ai</span></div>
+    <div class="app">
+      <nav class="rail"><div class="brand">DevThrottle</div><ul class="nav">
+        <li>Fleet Map</li><li>Sessions</li><li>Directors</li><li>Schedule</li><li>Workflows</li><li>Dictionary</li><li>Voice Recorder</li><li>Transcription</li><li>Network</li><li class="on">Settings</li>
+      </ul></nav>
+      <div class="main">
+        <h5>Settings</h5><p class="lede2">Your DevThrottle account settings.</p>
+        <div class="tabs"><span class="tabx">Notifications</span><span class="tabx on">AI</span><span class="tabx">Car Mode</span></div>
+        <div class="grid2">
+          <div class="setcard"><div class="top"><span class="name">Provider</span><span class="pill dev">included</span></div><div class="desc">DevThrottle-hosted AI.</div></div>
+          <div class="setcard"><div class="top"><span class="name">Thinking model</span><span class="pill acct">your account</span></div><div class="ctrl">Opus 4.8 (1M) <span class="car">v</span></div></div>
+          <div class="setcard"><div class="top"><span class="name">Voice</span><span class="pill acct">your account</span></div><div class="ctrl">Shimmer <span class="car">v</span></div></div>
+          <div class="setcard"><div class="top"><span class="name">Transcription</span><span class="pill dev">included</span></div><div class="desc">DevThrottle-hosted speech-to-text.</div></div>
+        </div>
+        <div class="absent">No This machine tab and no Privacy tab on the hosted Gateway.</div>
+      </div>
+    </div>
+  </div>
+  <p class="cap"><b>Hosted.</b> Three tabs (no machine tab); models/voice pills read "your account"; provider/transcription read "included".</p>
+</section>
+
+<!-- 06 -->
+<section id="tests">
+  <div class="sec-head"><span class="n">06</span><h2>Test evidence</h2></div>
+  <div class="tbl-wrap"><table>
+    <thead><tr><th>Suite</th><th>Proves</th><th>Result</th></tr></thead>
+    <tbody>
+      <tr><td><code>TenantSettingsStoreTests</code> (12)</td><td>Round-trip, cross-tenant read/write isolation, upsert, remove-clears-only-that-tenant, restart persistence, unknown-key + invalid-tenant guards.</td><td><span class="st pass">green</span></td></tr>
+      <tr><td><code>TenantSettingsResolverTests</code> (11)</td><td>Override-else-operator-default; a leak never crosses tenants; corrupt override degrades to default; write validation.</td><td><span class="st pass">green</span></td></tr>
+      <tr><td><code>TenantSettingsConsumerIsolationTests</code> (3)</td><td>The snooze-default and time-zone consumers read only the caller's tenant; another tenant gets the operator default.</td><td><span class="st pass">green</span></td></tr>
+      <tr><td><code>HostedOwnerSettingsDenyTests</code></td><td>Every owner-settings + model route is STILL refused on hosted (deny not retired).</td><td><span class="st pass">green</span></td></tr>
+      <tr><td><code>HostedOwnerSettingsSelfHostControlTests</code> (65)</td><td>Every route serves on self-host; the write re-reads from the tenant store (updated from the old config.json read-back).</td><td><span class="st pass">green</span></td></tr>
+      <tr><td><code>SnoozeEndToEndTests</code>, <code>AiModelsEndpointTests</code>, <code>Stats*</code></td><td>End-to-end: set via endpoint, consumed/reflected per tenant.</td><td><span class="st pass">green</span></td></tr>
+      <tr><td>Cockpit <code>settingsTabs.test.ts</code> (7)</td><td>visibleTabs drops the machine tab on hosted; no Privacy tab; retired ids fall to the default.</td><td><span class="st pass">green</span></td></tr>
+    </tbody>
+  </table></div>
+  <p style="font-size:13px;color:var(--ink-soft)">Full targeted Gateway set: <b>410+ green, 0 failing</b>. Cockpit typechecks and builds. The stale tests that asserted the old "writes land in config.json" contract were updated to read the per-tenant store - a genuine store re-read, not a handler echo.</p>
+</section>
+
+<!-- 07 -->
+<section id="gated">
+  <div class="sec-head"><span class="n">07</span><h2>What is deferred, and the merge gate</h2></div>
+  <div class="warn-box">
+    <b>Not merged yet - by design.</b> The hosted deny-retirement (serving these routes on the hosted Gateway)
+    is a stacked, unmerged change. It lands only after the MTR mission threads the deep runtime consumers
+    (wingman models, TTS voice/model, narration, car mode) through this resolver and adds hostile
+    two-tenant runtime tests. Until then the routes stay refused on hosted, so no half-threaded setting can be
+    served there. The MTR architect has the resolver interface and is basing that work on this branch's base
+    commit <code>9386d9e8</code>.
+  </div>
+  <p><b>Also deferred (separate mission):</b> removal of the telemetry backend (the Privacy tab UI is gone here; the telemetry consent endpoint/config is retired by the "remove telemetry" session).</p>
+</section>
+
+<!-- 08 -->
+<section id="codex">
+  <div class="sec-head"><span class="n">08</span><h2>Independent Codex review</h2></div>
+  <p class="lede">A fresh Codex session reviewed this branch against origin/main, focused on cross-tenant isolation, the explicit-tenant seam, the hosted deny, and no-fallback compliance.</p>
+  <div class="rule-box"><b>Status:</b> review running at the time of writing - this section is filled with the verdict and how each finding was dispositioned once it completes. (See the handover note.)</div>
+</section>
+
+<footer>
+  <p><b>DevThrottle - Per-Tenant Gateway Settings QA Report.</b> Issue #2017. Branch <code>settings-per-tenant @ 9bfdb76b</code>,
+  base <code>origin/main @ d67a3d1c</code>, verified 2026-07-22 on a live self-host Gateway. Companion to
+  <code>docs/architecture/hosted-settings-redesign-2026-07-22.html</code>. Not merged - the hosted deny-retirement is gated on the MTR runtime integration.</p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/reviews/multi-tenant-gateway-code-review-2026-07-20.html
+++ b/docs/reviews/multi-tenant-gateway-code-review-2026-07-20.html
@@ -1,0 +1,868 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Multi-tenant Gateway Code Review - 2026-07-20</title>
+<style>
+  :root {
+    --ink: #1a1d21;
+    --muted: #5c6570;
+    --line: #d8dde3;
+    --paper: #f7f8fa;
+    --card: #ffffff;
+    --p0: #8b1a1a;
+    --p0-bg: #fdecec;
+    --p1: #9a3412;
+    --p1-bg: #fff4ed;
+    --p2: #854d0e;
+    --p2-bg: #fef9c3;
+    --p3: #1e3a5f;
+    --p3-bg: #eef4fb;
+    --good: #14532d;
+    --good-bg: #ecfdf3;
+    --accent: #0f3d5c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: var(--ink);
+    background: var(--paper);
+    line-height: 1.55;
+    font-size: 15px;
+  }
+  header {
+    background: linear-gradient(135deg, #0f3d5c 0%, #1a5276 55%, #234e70 100%);
+    color: #fff;
+    padding: 2.25rem 1.5rem 2rem;
+  }
+  header .wrap, main, footer .wrap { max-width: 980px; margin: 0 auto; }
+  header h1 {
+    margin: 0 0 0.4rem;
+    font-size: 1.75rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+  header p { margin: 0.35rem 0; opacity: 0.92; max-width: 52rem; }
+  header .meta {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.25rem;
+    font-size: 0.88rem;
+    opacity: 0.88;
+  }
+  main { padding: 1.75rem 1.5rem 3rem; }
+  h2 {
+    margin: 2rem 0 0.75rem;
+    font-size: 1.28rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--line);
+    padding-bottom: 0.35rem;
+  }
+  h3 {
+    margin: 1.4rem 0 0.5rem;
+    font-size: 1.05rem;
+  }
+  p { margin: 0.55rem 0; }
+  ul, ol { margin: 0.4rem 0 0.8rem; padding-left: 1.3rem; }
+  li { margin: 0.28rem 0; }
+  code, .path {
+    font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+    font-size: 0.88em;
+    background: #eef1f5;
+    padding: 0.08em 0.35em;
+    border-radius: 3px;
+  }
+  .callout {
+    border-left: 4px solid var(--accent);
+    background: var(--card);
+    padding: 0.9rem 1.1rem;
+    margin: 1rem 0;
+    border-radius: 0 6px 6px 0;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .callout.good { border-left-color: var(--good); background: var(--good-bg); }
+  .callout.warn { border-left-color: var(--p1); background: var(--p1-bg); }
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0 1.5rem;
+  }
+  .stat {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+    text-align: center;
+  }
+  .stat .n { font-size: 1.7rem; font-weight: 700; line-height: 1.1; }
+  .stat .l { font-size: 0.78rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 0.25rem; }
+  .stat.p0 .n { color: var(--p0); }
+  .stat.p1 .n { color: var(--p1); }
+  .stat.p2 .n { color: var(--p2); }
+  .stat.p3 .n { color: var(--p3); }
+  .stat.good .n { color: var(--good); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--card);
+    margin: 0.75rem 0 1.25rem;
+    font-size: 0.93rem;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  th, td {
+    border: 1px solid var(--line);
+    padding: 0.55rem 0.7rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { background: #eef2f6; font-weight: 600; }
+  tr:nth-child(even) td { background: #fafbfc; }
+  .badge {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .badge.p0 { background: var(--p0-bg); color: var(--p0); }
+  .badge.p1 { background: var(--p1-bg); color: var(--p1); }
+  .badge.p2 { background: var(--p2-bg); color: var(--p2); }
+  .badge.p3 { background: var(--p3-bg); color: var(--p3); }
+  .badge.ok { background: var(--good-bg); color: var(--good); }
+  .finding {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1rem 1.15rem;
+    margin: 0.85rem 0;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.03);
+  }
+  .finding header-row {
+    display: block;
+  }
+  .finding .title {
+    font-weight: 650;
+    font-size: 1.02rem;
+    margin: 0.15rem 0 0.55rem;
+  }
+  .finding .meta-line {
+    color: var(--muted);
+    font-size: 0.86rem;
+    margin-bottom: 0.5rem;
+  }
+  .finding .why, .finding .fix, .finding .where {
+    margin: 0.4rem 0;
+  }
+  .finding .label {
+    font-weight: 650;
+    color: var(--muted);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  footer {
+    border-top: 1px solid var(--line);
+    padding: 1.25rem 1.5rem 2rem;
+    color: var(--muted);
+    font-size: 0.86rem;
+    background: #eef1f5;
+  }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+  .toc li { margin: 0.2rem 0; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <h1>Multi-tenant Gateway code review</h1>
+    <p>
+      Full review of the multi-tenant manager / multi-tenant Gateway work landed on
+      <strong>origin/main</strong> on <strong>2026-07-20</strong>, plus the open isolation
+      gaps those changes sit on top of. Read from shipped code only (this checkout was
+      33 commits behind at review time).
+    </p>
+    <div class="meta">
+      <span>Review date: 2026-07-20</span>
+      <span>Source of truth: origin/main</span>
+      <span>Scope: multi-tenant / hosted Gateway</span>
+      <span>Output: prioritized improvement backlog</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <h2 id="scope">1. What was reviewed</h2>
+  <p>
+    Today&rsquo;s multi-tenant-related merges (excluding the Fleet Map removal, which is
+    unrelated desktop cleanup):
+  </p>
+  <table>
+    <thead>
+      <tr><th>Commit</th><th>What it did</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>c0ccdaf6</code></td>
+        <td>Entitlement read: explicit <code>gateway</code> schema guard + PostgreSQL error diagnostics (#1954)</td>
+      </tr>
+      <tr>
+        <td><code>9d4b69dc</code></td>
+        <td>Production age sweep for abandoned voice-turn upload staging (#1952)</td>
+      </tr>
+      <tr>
+        <td><code>5d92287f</code></td>
+        <td>Director-removal event carries owning tenant; roster forget is tenant-scoped (#1942)</td>
+      </tr>
+      <tr>
+        <td><code>df078618</code></td>
+        <td><code>TenantSessionKey</code> + <code>TenantSessionMap</code> - state half of session-identifier unit (#1934)</td>
+      </tr>
+      <tr>
+        <td><code>f2028deb</code></td>
+        <td>Self-host provisioning transaction, routed but still disabled (#1928 / #1810)</td>
+      </tr>
+      <tr>
+        <td><code>f5bb926f</code></td>
+        <td>Hosted identity assertion reports the rejected value (#1929)</td>
+      </tr>
+      <tr>
+        <td><code>7a6d514b</code>, <code>2a5d14d8</code></td>
+        <td>Hosted dogfood guide + hosted quality-assurance report with screenshots</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>
+    Foundation code those changes depend on was also reviewed for fit: tenant identity,
+    tenant registry, entitlement registry, hosted tenant boundary, tenant pass for
+    background loops, Director registry composite key, enrollment, and remaining
+    unpartitioned Gateway stores.
+  </p>
+
+  <h2 id="verdict">2. Executive verdict</h2>
+  <div class="summary-grid">
+    <div class="stat good"><div class="n">Strong</div><div class="l">Design quality</div></div>
+    <div class="stat p0"><div class="n">9</div><div class="l">Priority 0 items</div></div>
+    <div class="stat p1"><div class="n">7</div><div class="l">Priority 1 items</div></div>
+    <div class="stat p2"><div class="n">6</div><div class="l">Priority 2 items</div></div>
+    <div class="stat p3"><div class="n">4</div><div class="l">Priority 3 items</div></div>
+  </div>
+
+  <div class="callout warn">
+    <strong>Bottom line.</strong> Today&rsquo;s code is careful, well-tested, and written in the
+    project&rsquo;s deny-by-default style. The dangerous problem is not &ldquo;today&rsquo;s commits are
+    sloppy&rdquo; - it is that multi-tenant isolation is still only partly installed.
+    Foundations land correctly; adoption into the fourteen session-keyed collections
+    and the remaining hosted surfaces has not finished. Charging customers (or turning
+    voice on) before those close would re-open real cross-tenant leak paths that the
+    team has already booked.
+  </div>
+
+  <div class="callout good">
+    <strong>What is genuinely good.</strong> The three-outcome entitlement model, the
+    typed removal payload, the physical partition in <code>TenantSessionMap</code>, the
+    ownership-safe self-host journal, and the admit-list voice sweep are senior work.
+    Tests that pin both &ldquo;the victim survives&rdquo; and &ldquo;the owner really was cleared&rdquo;
+    (destructibility controls) are exactly the right shape for multi-tenant code.
+  </div>
+
+  <h2 id="toc">3. Contents</h2>
+  <ol class="toc">
+    <li><a href="#strengths">What landed well</a></li>
+    <li><a href="#p0">Priority 0 - block go-live / security floor</a></li>
+    <li><a href="#p1">Priority 1 - bugs and incomplete work from today</a></li>
+    <li><a href="#p2">Priority 2 - correctness and maintainability</a></li>
+    <li><a href="#p3">Priority 3 - polish</a></li>
+    <li><a href="#roadmap">Suggested order of work</a></li>
+    <li><a href="#matrix">Finding matrix</a></li>
+  </ol>
+
+  <h2 id="strengths">4. What landed well</h2>
+  <ul>
+    <li>
+      <strong>Typed partition keys, not conventions.</strong>
+      <code>TenantSessionKey</code> cannot be built without a resolved <code>TenantId</code>.
+      <code>TenantSessionMap</code> has no string overload. A missing tenant fails at compile
+      time, not at runtime after a silent collision.
+    </li>
+    <li>
+      <strong>Injectivity discipline.</strong> No trimming, no case folding, whitespace refused
+      rather than cleaned - so two distinct session identifiers never become one key.
+    </li>
+    <li>
+      <strong>GetOrAdd with a single winner.</strong> The map does not trust
+      <code>ConcurrentDictionary.GetOrAdd</code>&rsquo;s multi-run factory; it uses
+      <code>TryAdd</code> so seed markers and first-seen clocks stay unique under contention.
+    </li>
+    <li>
+      <strong>Director removal carries the owner.</strong> <code>DirectorRemoval(TenantId, string)</code>
+      makes an unscoped removal inexpressible at the event boundary. The roster-cache
+      forget is now structurally scoped.
+    </li>
+    <li>
+      <strong>Faulting subscribers cannot kill the Gateway.</strong>
+      <code>RaiseDirectorRemoved</code> invokes each handler independently with a try/catch,
+      so one store failure cannot abort the process or starve later handlers.
+    </li>
+    <li>
+      <strong>Entitlement is three-state, not boolean.</strong>
+      Entitled / NotEntitled / Unknown correctly separates &ldquo;looked and unpaid&rdquo; from
+      &ldquo;could not look&rdquo;. Hosted enrollment maps those to 200 / 402 / 503 and never mints
+      on ignorance.
+    </li>
+    <li>
+      <strong>Self-host transaction is ownership-safe.</strong> Resume journal + Owned-only
+      rollback is the right model for provisioning a stranger&rsquo;s machine. Keeping the card
+      disabled until proven is honest product engineering.
+    </li>
+    <li>
+      <strong>Voice sweep admits only canonical upload directories.</strong> Refuse-list thinking
+      would delete a future sibling; the admit-list only deletes what this store itself writes.
+    </li>
+  </ul>
+
+  <!-- ===================== P0 ===================== -->
+  <h2 id="p0">5. Priority 0 - block go-live / security floor</h2>
+  <p>
+    These are not all introduced today, but they are the multi-tenant manager&rsquo;s real
+    readiness bar. Several are already open on GitHub. Today&rsquo;s work does not close them.
+  </p>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">1. TenantSessionKey / TenantSessionMap are not adopted into production</div>
+    <div class="meta-line">Today: <code>df078618</code> - state half only. Production Gateway still uses bare session-identifier dictionaries.</div>
+    <p class="where"><span class="label">Where</span><br>
+      Types live under <code>src/CcDirector.Core/Tenancy/</code>. Grep of origin/main shows
+      production use is limited to the types themselves and their unit tests. Gateway stores
+      still declare <code>ConcurrentDictionary&lt;string, ...&gt;</code> for session state.
+    </p>
+    <p class="why"><span class="label">Why it matters</span><br>
+      The type exists because fourteen retained collections can collide across accounts that
+      present the same raw session identifier. Shipping the type without rewiring those
+      collections does not reduce risk; it only documents it. On a multi-tenant Gateway this
+      is still cross-tenant overwrite / suppress / delete.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Adopt the map into the collections the type comment lists (needs-you clock, both
+      transcribing markers, governance state emitter, turn-end watcher, statistics indexes,
+      concurrency set, turn-brief caches) in small, tested pull requests - one store family
+      per pull request, with a two-tenant collision test for each.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">2. Voice paths still hard-code the local tenant</div>
+    <div class="meta-line">Open: #1890, #1893. Confirmed on origin/main in <code>GatewayWingmanVoiceEndpoint</code>.</div>
+    <p class="where"><span class="label">Where</span><br>
+      Multiple calls of the form <code>voice.Get(TenantId.Local, sid)</code>,
+      <code>voice.Mark(TenantId.Local, sid)</code>, <code>voice.StoreSpokenAsync(TenantId.Local, ...)</code>.
+      Background loops and the verb path both do this.
+    </p>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Voice state was partitioned (#1915), but the routes that drive it still write and read
+      the local partition. On hosted, account voice is dead or wrong; turning the synthesis
+      key on before these resolve would also arm a leak (already called out in today&rsquo;s
+      hosted quality-assurance report).
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Resolve request / bound-connection tenant on every voice route and every background
+      voice loop (via <code>ITenantPass</code>). Do not put a provider key in the vault until
+      both are proven live with two accounts.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">3. Dictation / utterance upload family is still unpartitioned</div>
+    <div class="meta-line">Open: #1884, #1896, #1897.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Recorded speech and plaintext transcripts on shared infrastructure. A replayed
+      idempotency key can hand one account another&rsquo;s transcript. This is the highest-value
+      data the product ever holds.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Partition staging, delivery records, archive, and telemetry by tenant before any
+      multi-tenant dictation is enabled. Pair with the voice sweep so abandoned audio under
+      a future partition is still bounded.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">4. Residual bare Director-id routes and credential-less register</div>
+    <div class="meta-line">Open: #1866. Code still documents <code>TryResolveLegacyKey</code> and <code>Get(string)</code> as temporary.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Composite registry keys only help callers that pass a tenant. Legacy bare-id lookup
+      answers with the freshest match across tenants - deliberately, to avoid a
+      denial-of-service via collision - which means cross-tenant addressing still exists on
+      every route not yet converted.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Convert remaining <code>/directors/{id}/...</code> and related surfaces to
+      <code>Get(TenantId, string)</code> from authenticated request tenant. Kill or host-deny
+      the credential-less HTTP register path on hosted.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">5. Fleet-wide aggregates and owner-settings surfaces are still tenant-blind</div>
+    <div class="meta-line">Open: #1924, #1932, #1917, #1863, #1921, #1923, and related.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Any enrolled tenant can still reach diagnostics rollups, launcher/machine control,
+      brain restart, AI model spend routes, stream write with caller-supplied ids, and more.
+      Isolation of the roster is worthless if a side door rewrites another account&rsquo;s world.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Keep the deny-list approach for owner-only routes on hosted until each has a real
+      tenant model. Prefer permanent deny for operator surfaces that have no multi-tenant
+      product meaning.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">6. Device keys stored in plaintext on shared storage</div>
+    <div class="meta-line">Open: #1878.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Bearer secrets for every tenant in one readable file. Compromise of the share is
+      compromise of every account&rsquo;s tunnel and cockpit cookie.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Hash at rest (or per-tenant sealed storage). Treat device keys like password hashes:
+      compare digests, never serve the raw secret back after mint.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">7. Hosted mode signal is a mutable environment flag</div>
+    <div class="meta-line">Open: #1868.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Losing <code>CC_GATEWAY_HOSTED</code> collapses every tenant into the single-tenant shape.
+      That is a silent, fleet-wide isolation failure, not a loud crash.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Fail closed when the deployment is the hosted image but the flag is absent or wrong
+      (image-baked marker, or refuse boot if Postgres multi-tenant schema is present without
+      hosted mode). Never silently become Local for everyone.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">8. Do not enable voice synthesis until partition is complete</div>
+    <div class="meta-line">Documented today in hosted quality-assurance report (#1926 follow-up prose).</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      The 503 message currently invites operators to add a vault key. Doing so would produce
+      audio and transcripts the code is not ready to isolate.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Change the error text so it does not invite a config fix. Keep the key out of the vault
+      until P0 voice and dictation items above are green on a two-account live proof.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p0">P0</span>
+    <div class="title">9. Session owner cache and transcribing marks are still bare-session maps</div>
+    <div class="meta-line">Production: <code>SessionOwnerCache</code>, <code>TranscribingSessions</code>.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Two accounts with the same session identifier share owner routing and the orange
+      &ldquo;transcribing&rdquo; mark. That is wrong routing and wrong UI, and it is the exact failure
+      class <code>TenantSessionMap</code> was built to prevent - but these stores were not
+      converted today.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Rewire both onto <code>TenantSessionMap</code> (or equivalent partition) as part of the
+      adoption series in finding 1.
+    </p>
+  </div>
+
+  <!-- ===================== P1 ===================== -->
+  <h2 id="p1">6. Priority 1 - bugs and incomplete work from today&rsquo;s code</h2>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">10. Fleet session-number allocator is still not tenant-scoped</div>
+    <div class="meta-line">Today: #1942 fixed roster forget; allocator left explicitly unscoped.</div>
+    <p class="where"><span class="label">Where</span><br>
+      <code>FleetSessionNumberAllocator.ReleaseForDirector(string)</code> and GatewayHost wiring:
+      <code>Registry.OnDirectorRemoved += removal =&gt; SessionNumbers.ReleaseForDirector(removal.DirectorId);</code>
+      Comments on the allocator admit: one tenant&rsquo;s removal can free another&rsquo;s numbers.
+    </p>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Not a data leak, but a real multi-tenant correctness bug: duplicated rail numbers across
+      accounts, and stolen free-list entries. The tenant is already on the event; the
+      subscriber throws it away.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Partition pool + assignment record by tenant. Change
+      <code>ReleaseForDirector(TenantId, string)</code> and every Allocate/Adopt call site to
+      pass the bound tenant. Add a two-tenant shared-director-id test that removal of A does
+      not free B&rsquo;s numbers.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">11. Today&rsquo;s removal path logs the raw tenant identifier</div>
+    <div class="meta-line">Violates the project&rsquo;s own <code>TenantId.ToLogString()</code> rule.</div>
+    <p class="where"><span class="label">Where</span><br>
+      <code>DirectorRegistry.RaiseDirectorRemoved</code>:
+      <code>tenant={key.Tenant.Value}</code><br>
+      <code>FleetRosterCache.Forget</code>:
+      <code>tenant {tenant.Value}</code>
+    </p>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Account tenant ids are stable GUIDs tied to billing subjects. The type system already
+      provides a one-way short tag for logs. Raw values in shared hosted logs expand the
+      blast radius of a log leak and break the privacy contract the rest of the tenancy
+      stack is written around.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Replace both with <code>tenant.ToLogString()</code>. Add a small test or analyzer rule that
+      new FileLog lines do not interpolate <code>.Tenant.Value</code> / raw account tenants.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">12. Voice age sweep does not cover future tenant partitions</div>
+    <div class="meta-line">Today: #1952. <code>DirFor</code> is still flat: <code>Path.Combine(_root, uid)</code>.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      The sweep correctly skips the <code>tenants</code> container name so it will not delete the
+      whole partition tree. That is good for today. When dictation/voice staging moves under
+      <code>tenants/&lt;tenant&gt;/&lt;upload&gt;</code>, abandoned audio under those paths will never be
+      swept - unbounded retention returns, only nested one directory deeper.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      When partitioning lands, either (a) sweep each tenant partition with the same
+      admit-list rules, or (b) keep a single flat staging root and put only durable artifacts
+      under tenant partitions. Land the sweep change in the same pull request as the path
+      change - never as a follow-up.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">13. Hosted Director-removal no longer clears snoozes</div>
+    <div class="meta-line">GatewayHost wires: clear only when not hosted.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      On hosted, removed Directors leave snooze rows as durable tombstones forever (until
+      live-session prune). That is a bounded leak of disk/table growth, and it can re-apply
+      hold semantics if a session id is reused later under the same tenant. The comment
+      explains why (background thread, no ambient tenant) but the product gap remains.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Teach <code>SnoozeRegistry.ClearForDirector(TenantId, string)</code> using the tenant now
+      present on <code>DirectorRemoval</code>. Re-enable the subscriber on hosted. Same pattern
+      as the roster fix.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">14. Bare capability maps on DirectorRegistry still keyed by director id only</div>
+    <div class="meta-line"><code>_everReachable</code>, <code>_stateReporting</code>.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Comments claim these are process capability flags with no client-served content. Still,
+      two tenants with the same director id share those flags: one account&rsquo;s stream Hello can
+      mark the id state-reporting for the other. On hosted that is real cross-tenant
+      influence of reconcile-poll skip behavior.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Key both by <code>DirectorKey</code> (tenant + id), or store the flag on the DirectorDto
+      entry itself so it cannot outlive the wrong partition.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">15. HTTP register still stamps Local and remains a collision surface</div>
+    <div class="meta-line">Documented in <code>TryResolveLegacyKey</code> / <code>Upsert</code> (http).</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Comments say Local-keyed HTTP entries are &ldquo;served to no account&rdquo; on hosted - good for
+      reads that are tenant-aware. They still pollute bare-id legacy resolution and can
+      participate in freshest-match behavior for unconverted routes.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      On hosted, refuse HTTP register/heartbeat entirely (401/404). Keep the path for
+      self-host only. That shrinks the legacy surface the conversion work has to reason about.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p1">P1</span>
+    <div class="title">16. Tenant email is write-once at mint; later logins never refresh it</div>
+    <div class="meta-line"><code>TenantRegistry.MintOrLookupBySubject</code>.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Email is stored only on a fresh mint. An account that first enrolled with a token that
+      carried no email keeps a null email forever, even after later enrollments supply one.
+      Hosted account status then reports &ldquo;identity not available&rdquo; for a fully valid tenant
+      (#1856 shape). Not a security hole; it is a product lie that confuses dogfood and
+      support.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      On existing lookup, if the row&rsquo;s email is null and the call supplied a non-empty email,
+      update the row. Never change the subject or tenant id. Still never use email as a key.
+    </p>
+  </div>
+
+  <!-- ===================== P2 ===================== -->
+  <h2 id="p2">7. Priority 2 - correctness and maintainability</h2>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">17. Entitlement schema guard is defense-in-depth only - do not over-claim</div>
+    <div class="meta-line">Today: #1954. Commit message correctly reframe as non-fix for emitted SQL.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Good change, good tests. Risk is future readers treating it as &ldquo;we fixed enrollment
+      503s&rdquo; when the real 503 path is still operational (database down, missing grant,
+      missing row data). The diagnostic SqlState/MessageText is the valuable half.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Keep the guard. Wire an operator dashboard or alert on repeated
+      <code>READ FAILED ... UNKNOWN</code> lines - that is the real production symptom.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">18. TenantId construction trims; identity systems may disagree</div>
+    <div class="meta-line">Open: #1854.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Constructor trims whitespace. Downstream path segments, hashes, and external systems
+      that do not trim will disagree. Multi-tenant path partitions that embed
+      <code>tenant.Value</code> (prompts, voice archive, turn jobs) inherit that disagreement.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Canonicalize once at construction (trim + reject internal whitespace + maybe lowercase
+      for GUID form) and document the single form. Align path partition helpers with that form.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">19. Self-host orchestrator is excellent but still unproven on a machine</div>
+    <div class="meta-line">Today: #1928. Card remains disabled; tests are pure harness.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Transaction logic is well covered. Real steps (download, tray install, enroll) are not.
+      Enabling the card without an isolated-box proof is how you half-provision a customer.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      One scripted install on a clean Windows VM that runs the real compensations (including
+      deliberate mid-step kill). Only then remove the disabled badge. Keep ownership rules as-is.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">20. Corrupt self-host journal fails open to empty</div>
+    <div class="meta-line"><code>SelfHostJournal.FromJson</code> swallows parse errors.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Documented: better a repeated step than a dead connect screen. Cost: ownership memory
+      is lost, so a later failure might not undo something a prior run created, or might
+      re-run a step that is only mostly idempotent.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      On parse failure, keep a side file <code>journal.corrupt.&lt;timestamp&gt;</code> for support, log
+      loudly, and still start fresh. Consider a schema version field so future format changes
+      do not look like corruption.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">21. TenantPass known-tenants list is push-store-only</div>
+    <div class="meta-line"><code>TenantPass</code> uses <code>PushedSessionStore.KnownTenants</code>.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      Background sweeps only visit tenants that currently have a live Director stream. A
+      tenant with durable work but no live Director (pending voice, pending dictation,
+      durable snooze) may never be visited by some loops. Correct for push-driven fleet
+      sweeps; wrong if reused for durable job drains.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Split &ldquo;live fleet tenants&rdquo; from &ldquo;tenants with durable work&rdquo;. Job stores should
+      enumerate their own partitions, not depend on the push store.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p2">P2</span>
+    <div class="title">22. Hosted identity assertion intermittent failure still open</div>
+    <div class="meta-line">Today: #1929 improved diagnostics; #1894 remains open.</div>
+    <p class="why"><span class="label">Why it matters</span><br>
+      The louder assertion is the right temporary instrument. A multi-tenant suite that
+      sometimes sees a foreign email is either a real isolation bug or a test-harness leak.
+      Either way it undermines confidence in the rest of the isolation proofs.
+    </p>
+    <p class="fix"><span class="label">Improvement</span><br>
+      Use the next red full-suite run to name the source, then fix root cause (shared fixture,
+      static cache, ambient tenant bleed). Do not weaken the assertion.
+    </p>
+  </div>
+
+  <!-- ===================== P3 ===================== -->
+  <h2 id="p3">8. Priority 3 - polish</h2>
+
+  <div class="finding">
+    <span class="badge p3">P3</span>
+    <div class="title">23. Comment-to-code ratio is very high</div>
+    <p>
+      The prose is excellent and has prevented real mistakes (schema guard reframe, ownership
+      rules, admit-list sweep). Still, some files are harder to scan than they need to be.
+      Prefer keeping the non-obvious &ldquo;why&rdquo; and folding repeated deny-by-default sermons into
+      one architecture page that types link to.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p3">P3</span>
+    <div class="title">24. TenantSessionKey.Value is powerful but easy to misuse as a path</div>
+    <p>
+      Docs say it is a dictionary key, not a path segment, and For() rejects separators. Still
+      easy for a later author to put <code>key.Value</code> into a filesystem path. Consider a
+      distinct type or analyzer for &ldquo;storage key vs path segment&rdquo; if adoption spreads.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p3">P3</span>
+    <div class="title">25. Self-host progress messages are good product copy - keep them centralized</div>
+    <p>
+      <code>SelfHostOrchestrator.Describe</code> is the right single place. When the card enables,
+      wire UI progress exclusively through that API so screens never invent their own step names.
+    </p>
+  </div>
+
+  <div class="finding">
+    <span class="badge p3">P3</span>
+    <div class="title">26. Review artifacts and dogfood docs should state image digest always</div>
+    <p>
+      Today&rsquo;s quality-assurance report already does this well. Keep that rule for every
+      hosted proof: merged on main is not deployed. Do not delete &ldquo;does not work yet&rdquo; lines
+      until seen on the running image.
+    </p>
+  </div>
+
+  <!-- ===================== ROADMAP ===================== -->
+  <h2 id="roadmap">9. Suggested order of work</h2>
+  <ol>
+    <li>
+      <strong>Stop digging.</strong> Do not put the voice synthesis key in the vault. Soften any
+      error text that invites that config change (P0 #8).
+    </li>
+    <li>
+      <strong>Close the removal-event family.</strong> Tenant-scope the session-number allocator
+      and hosted snooze clear using the tenant that is already on <code>DirectorRemoval</code>
+      (P1 #10, #13). Cheap, same pattern as today&rsquo;s roster fix.
+    </li>
+    <li>
+      <strong>Adopt TenantSessionMap into the fourteen session stores</strong> in small batches
+      with two-tenant collision tests (P0 #1, #9).
+    </li>
+    <li>
+      <strong>Voice + dictation full partition</strong> (routes, loops, staging, archive) with
+      sweep coverage for the new paths (P0 #2, #3; P1 #12).
+    </li>
+    <li>
+      <strong>Kill hosted legacy Director-id surfaces</strong> (P0 #4; P1 #14, #15).
+    </li>
+    <li>
+      <strong>Hosted deny ledger for owner/operator routes</strong> until each has a real model
+      (P0 #5).
+    </li>
+    <li>
+      <strong>Device key at-rest hardening and hosted-mode fail-closed</strong> (P0 #6, #7).
+    </li>
+    <li>
+      <strong>Self-host real-machine proof, then enable the card</strong> (P2 #19).
+    </li>
+    <li>
+      <strong>Polish:</strong> raw-tenant log scrub (P1 #11), email refresh (P1 #16), TenantId
+      canonicalize (P2 #18).
+    </li>
+  </ol>
+
+  <!-- ===================== MATRIX ===================== -->
+  <h2 id="matrix">10. Finding matrix</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Priority</th>
+        <th>Finding</th>
+        <th>Origin</th>
+        <th>Effort (rough)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>1</td><td><span class="badge p0">P0</span></td><td>Adopt TenantSessionMap into production stores</td><td>Today foundation only</td><td>Large series</td></tr>
+      <tr><td>2</td><td><span class="badge p0">P0</span></td><td>Voice routes/loops hard-code Local</td><td>#1890 #1893</td><td>Medium</td></tr>
+      <tr><td>3</td><td><span class="badge p0">P0</span></td><td>Dictation / utterance unpartitioned</td><td>#1884 #1896 #1897</td><td>Large</td></tr>
+      <tr><td>4</td><td><span class="badge p0">P0</span></td><td>Bare Director-id routes remain</td><td>#1866</td><td>Large series</td></tr>
+      <tr><td>5</td><td><span class="badge p0">P0</span></td><td>Fleet aggregates / owner routes tenant-blind</td><td>Several open</td><td>Large series</td></tr>
+      <tr><td>6</td><td><span class="badge p0">P0</span></td><td>Device keys plaintext at rest</td><td>#1878</td><td>Medium</td></tr>
+      <tr><td>7</td><td><span class="badge p0">P0</span></td><td>Hosted mode flag fail-open</td><td>#1868</td><td>Small-medium</td></tr>
+      <tr><td>8</td><td><span class="badge p0">P0</span></td><td>Do not arm voice key yet; fix invite text</td><td>QA report today</td><td>Small</td></tr>
+      <tr><td>9</td><td><span class="badge p0">P0</span></td><td>SessionOwnerCache / TranscribingSessions bare</td><td>Pre-existing</td><td>Medium</td></tr>
+      <tr><td>10</td><td><span class="badge p1">P1</span></td><td>Session-number allocator not tenant-scoped</td><td>Left open in #1942</td><td>Medium</td></tr>
+      <tr><td>11</td><td><span class="badge p1">P1</span></td><td>Raw tenant id in today&rsquo;s logs</td><td>Today #1942</td><td>Small</td></tr>
+      <tr><td>12</td><td><span class="badge p1">P1</span></td><td>Sweep must cover future partitions</td><td>Today #1952 footgun</td><td>Small with partition</td></tr>
+      <tr><td>13</td><td><span class="badge p1">P1</span></td><td>Hosted snooze clear disabled</td><td>GatewayHost</td><td>Small</td></tr>
+      <tr><td>14</td><td><span class="badge p1">P1</span></td><td>_everReachable / _stateReporting bare keys</td><td>DirectorRegistry</td><td>Small-medium</td></tr>
+      <tr><td>15</td><td><span class="badge p1">P1</span></td><td>HTTP register still Local + hosted surface</td><td>Legacy path</td><td>Small</td></tr>
+      <tr><td>16</td><td><span class="badge p1">P1</span></td><td>Email never refreshed after mint</td><td>TenantRegistry</td><td>Small</td></tr>
+      <tr><td>17</td><td><span class="badge p2">P2</span></td><td>Entitlement guard is not a 503 fix</td><td>Today #1954</td><td>Ops only</td></tr>
+      <tr><td>18</td><td><span class="badge p2">P2</span></td><td>TenantId canonicalize</td><td>#1854</td><td>Small</td></tr>
+      <tr><td>19</td><td><span class="badge p2">P2</span></td><td>Self-host needs real-machine proof</td><td>Today #1928</td><td>Medium</td></tr>
+      <tr><td>20</td><td><span class="badge p2">P2</span></td><td>Corrupt journal fails open</td><td>SelfHostJournal</td><td>Small</td></tr>
+      <tr><td>21</td><td><span class="badge p2">P2</span></td><td>TenantPass list is live-push only</td><td>ITenantPass</td><td>Medium</td></tr>
+      <tr><td>22</td><td><span class="badge p2">P2</span></td><td>Identity assertion flake source unknown</td><td>#1894 / #1929</td><td>Unknown</td></tr>
+      <tr><td>23-26</td><td><span class="badge p3">P3</span></td><td>Polish items (comments, key misuse, copy, digest discipline)</td><td>Various</td><td>Small</td></tr>
+    </tbody>
+  </table>
+
+  <h2 id="conclusion">11. Closing note</h2>
+  <div class="callout">
+    <p>
+      Today&rsquo;s multi-tenant work is high quality. The team is building the right kinds of
+      primitives: typed keys, three-state entitlement, ownership-safe provisioning, and
+      removal events that cannot drop the owner. The risk is sequencing - foundations land,
+      while production stores and hosted side doors still speak the single-tenant dialect.
+    </p>
+    <p>
+      Treat &ldquo;merged to main&rdquo; and &ldquo;safe to charge for hosted&rdquo; as different bars. The
+      code reviewed today advances the first. The priority-0 list is the second.
+    </p>
+  </div>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>
+      Generated from origin/main on 2026-07-20. Working tree was behind origin and was not
+      used as evidence. Paths and issue numbers refer to the DevThrottle repository
+      (thefrederiksen/devthrottle).
+    </p>
+    <p>
+      File: <span class="path">docs/reviews/multi-tenant-gateway-code-review-2026-07-20.html</span>
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/reviews/multi-tenant-gateway-code-review-2026-07-21.html
+++ b/docs/reviews/multi-tenant-gateway-code-review-2026-07-21.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Multi-tenant Gateway - Updated Review - 2026-07-21</title>
+<style>
+  :root {
+    --ink: #1a1d21;
+    --muted: #5c6570;
+    --line: #d8dde3;
+    --paper: #f7f8fa;
+    --card: #ffffff;
+    --p0: #8b1a1a;
+    --p0-bg: #fdecec;
+    --p1: #9a3412;
+    --p1-bg: #fff4ed;
+    --p2: #854d0e;
+    --p2-bg: #fef9c3;
+    --good: #14532d;
+    --good-bg: #ecfdf3;
+    --inflight: #1e3a5f;
+    --inflight-bg: #eef4fb;
+    --accent: #0f3d5c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: var(--ink);
+    background: var(--paper);
+    line-height: 1.55;
+    font-size: 15px;
+  }
+  header {
+    background: linear-gradient(135deg, #0f3d5c 0%, #1a5276 55%, #234e70 100%);
+    color: #fff;
+    padding: 2.25rem 1.5rem 2rem;
+  }
+  header .wrap, main, footer .wrap { max-width: 1000px; margin: 0 auto; }
+  header h1 {
+    margin: 0 0 0.4rem;
+    font-size: 1.7rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+  header p { margin: 0.35rem 0; opacity: 0.92; max-width: 54rem; }
+  header .meta {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.25rem;
+    font-size: 0.88rem;
+    opacity: 0.88;
+  }
+  main { padding: 1.75rem 1.5rem 3rem; }
+  h2 {
+    margin: 2rem 0 0.75rem;
+    font-size: 1.28rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--line);
+    padding-bottom: 0.35rem;
+  }
+  h3 { margin: 1.35rem 0 0.5rem; font-size: 1.05rem; }
+  p { margin: 0.55rem 0; }
+  ul, ol { margin: 0.4rem 0 0.8rem; padding-left: 1.3rem; }
+  li { margin: 0.28rem 0; }
+  code, .path {
+    font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+    font-size: 0.88em;
+    background: #eef1f5;
+    padding: 0.08em 0.35em;
+    border-radius: 3px;
+  }
+  .callout {
+    border-left: 4px solid var(--accent);
+    background: var(--card);
+    padding: 0.9rem 1.1rem;
+    margin: 1rem 0;
+    border-radius: 0 6px 6px 0;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .callout.good { border-left-color: var(--good); background: var(--good-bg); }
+  .callout.warn { border-left-color: var(--p1); background: var(--p1-bg); }
+  .callout.danger { border-left-color: var(--p0); background: var(--p0-bg); }
+  .callout.inflight { border-left-color: var(--inflight); background: var(--inflight-bg); }
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0 1.5rem;
+  }
+  .stat {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+    text-align: center;
+  }
+  .stat .n { font-size: 1.55rem; font-weight: 700; line-height: 1.1; }
+  .stat .l {
+    font-size: 0.76rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 0.25rem;
+  }
+  .stat.p0 .n { color: var(--p0); }
+  .stat.p1 .n { color: var(--p1); }
+  .stat.good .n { color: var(--good); }
+  .stat.inflight .n { color: var(--inflight); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--card);
+    margin: 0.75rem 0 1.25rem;
+    font-size: 0.92rem;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  th, td {
+    border: 1px solid var(--line);
+    padding: 0.5rem 0.65rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { background: #eef2f6; font-weight: 600; }
+  tr:nth-child(even) td { background: #fafbfc; }
+  .badge {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.15rem 0.45rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .badge.p0 { background: var(--p0-bg); color: var(--p0); }
+  .badge.p1 { background: var(--p1-bg); color: var(--p1); }
+  .badge.p2 { background: var(--p2-bg); color: var(--p2); }
+  .badge.ok { background: var(--good-bg); color: var(--good); }
+  .badge.pr { background: var(--inflight-bg); color: var(--inflight); }
+  .badge.miss { background: #f3e8ff; color: #6b21a8; }
+  .finding {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1rem 1.15rem;
+    margin: 0.85rem 0;
+  }
+  .finding .title {
+    font-weight: 650;
+    font-size: 1.02rem;
+    margin: 0.2rem 0 0.45rem;
+  }
+  .finding .meta-line {
+    color: var(--muted);
+    font-size: 0.86rem;
+    margin-bottom: 0.45rem;
+  }
+  .label {
+    font-weight: 650;
+    color: var(--muted);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .rank {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 0.95rem 1.1rem;
+    margin: 0.65rem 0;
+  }
+  .rank .num {
+    flex: 0 0 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.05rem;
+  }
+  .rank.do-now .num { background: var(--p0); }
+  .rank.merge .num { background: var(--inflight); }
+  .rank .body { flex: 1; }
+  .rank .body strong { display: block; margin-bottom: 0.25rem; }
+  footer {
+    border-top: 1px solid var(--line);
+    padding: 1.25rem 1.5rem 2rem;
+    color: var(--muted);
+    font-size: 0.86rem;
+    background: #eef1f5;
+  }
+  .delta { font-size: 0.92rem; }
+  .delta li { margin: 0.35rem 0; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <h1>Multi-tenant Gateway - updated review</h1>
+    <p>
+      Refresh of the 2026-07-20 review after a large wave of isolation work.
+      Shipped code is still nearly the same on <strong>origin/main</strong>;
+      the real change is <strong>about eighteen open pull requests</strong>
+      that implement denys, partitions, and hardening - most green, most not merged.
+    </p>
+    <div class="meta">
+      <span>Review date: 2026-07-21</span>
+      <span>Shipped truth: origin/main @ 7696b1de</span>
+      <span>Also reviewed: open pull requests + census map on PR 1936</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <h2>1. What changed since the last review</h2>
+
+  <div class="summary-grid">
+    <div class="stat good"><div class="n">2</div><div class="l">New merges on main</div></div>
+    <div class="stat inflight"><div class="n">~18</div><div class="l">Open isolation PRs</div></div>
+    <div class="stat p0"><div class="n">40</div><div class="l">Active unsafe census rows</div></div>
+    <div class="stat inflight"><div class="n">~15</div><div class="l">Rows covered by open PRs</div></div>
+    <div class="stat p0"><div class="n">~25</div><div class="l">Rows with no PR yet</div></div>
+  </div>
+
+  <div class="callout warn">
+    <strong>Important correction to yesterday&rsquo;s framing.</strong>
+    The previous review correctly described <em>shipped</em> main, but understated
+    how much is already written in parallel worktrees. Saying &ldquo;nothing is adopted&rdquo;
+    is true for main and false for the program as a whole. The bottleneck is no longer
+    &ldquo;design is missing&rdquo; - it is <strong>landing, rebasing, and filling the remaining
+    remedy units that still have no pull request</strong>.
+  </div>
+
+  <h3>Landed on main since the last review</h3>
+  <table>
+    <thead><tr><th>Pull request</th><th>What it does</th><th>Isolation impact</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>#1955</td>
+        <td>Map <code>entitlements.subject</code> as Postgres uuid via value converter</td>
+        <td>Corrects a real hosted enrollment read failure class - not a new partition</td>
+      </tr>
+      <tr>
+        <td>#1956</td>
+        <td>Hosted cockpit URL from one public base (<code>{base}/cockpit</code>)</td>
+        <td>Product / URL correctness - not multi-tenant isolation</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>In flight (implemented, not on main)</h3>
+  <table>
+    <thead>
+      <tr><th>Pull request</th><th>Closes / covers</th><th>Status</th><th>Kind</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>#1936</td><td>Census + remedy map (the specification)</td><td><span class="badge ok">Green</span></td><td>Docs - land first</td></tr>
+      <tr><td>#1951</td><td>One shared hosted refusal boundary for every deny family</td><td><span class="badge ok">Green</span></td><td>Primitive</td></tr>
+      <tr><td>#1898</td><td>Owner-settings group deny (#1863) - 31 routes</td><td><span class="badge ok">Green</span></td><td>Deny</td></tr>
+      <tr><td>#1903</td><td>Four content-read families deny</td><td><span class="badge ok">Green</span></td><td>Deny</td></tr>
+      <tr><td>#1904</td><td>Key-vault group deny</td><td><span class="badge ok">Green</span></td><td>Deny</td></tr>
+      <tr><td>#1907</td><td>Recording ingest + cached voice read deny</td><td><span class="badge ok">Green</span></td><td>Deny</td></tr>
+      <tr><td>#1939</td><td>Launcher / machine-control deny (#1917)</td><td><span class="badge ok">Green</span></td><td>Deny</td></tr>
+      <tr><td>#1940</td><td>Refuse shared-vault transcription provisioner on hosted</td><td><span class="badge ok">Green</span></td><td>Deny / pin</td></tr>
+      <tr><td>#1899</td><td>Hash device keys at rest (#1878)</td><td><span class="badge ok">Green</span></td><td>Harden</td></tr>
+      <tr><td>#1930</td><td>Stream ownership on StreamUp (#1923)</td><td><span class="badge ok">Green</span></td><td>Authorize</td></tr>
+      <tr><td>#1935</td><td>NetDiag results + rollups by tenant (census 21-22)</td><td><span class="badge ok">Green</span></td><td>Partition</td></tr>
+      <tr><td>#1933</td><td>Car-mode telemetry by device credential (census 40)</td><td><span class="badge ok">Green</span></td><td>Partition</td></tr>
+      <tr><td>#1909</td><td>Composite primary keys: snoozes, session_spend, push_subscriptions</td><td><span class="badge ok">Green</span></td><td>Data model</td></tr>
+      <tr><td>#1906</td><td>Prove context-less database routes are tenant-isolated</td><td><span class="badge ok">Green</span> blocked on #1909</td><td>Proof</td></tr>
+      <tr><td>#1900</td><td>Tenant-key dictation upload store (#1884 store half)</td><td><span class="badge p1">Conflicts</span></td><td>Partition</td></tr>
+      <tr><td>#1945</td><td>Require tenant to construct VoiceUploadStore</td><td><span class="badge p1">Conflicts</span></td><td>Structure</td></tr>
+      <tr><td>#1953</td><td>Hosted human account sign-in mint (backend, #474)</td><td><span class="badge ok">.NET pending / web green</span></td><td>Product</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout inflight">
+    <strong>If all green isolation pull requests land,</strong> the hosted box stops being
+    a free buffet for settings, vault keys, recording content, launcher/machine control,
+    and several read leaks - and several stores gain real partitions. That is a large step.
+    It still does <em>not</em> finish multi-tenant correctness: the biggest census work unit
+    (session-identifier family, 14 rows) and the statistics identity bundle (11 rows)
+    still have no pull request.
+  </div>
+
+  <h2>2. Previous findings - status update</h2>
+  <table>
+    <thead>
+      <tr><th>Previous item</th><th>Status now</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Adopt TenantSessionMap into production</td>
+        <td><span class="badge miss">Still missing</span> - types on main; zero production call sites; no adoption pull request</td>
+      </tr>
+      <tr>
+        <td>Voice hard-codes Local (#1890 / #1893)</td>
+        <td><span class="badge p0">Still wrong</span> - ~19 Local uses in wingman voice endpoint on main; store is partitioned, routes are not</td>
+      </tr>
+      <tr>
+        <td>Dictation unpartitioned (#1884)</td>
+        <td><span class="badge pr">In flight</span> - #1900 + #1945 (both conflicted; rebase required)</td>
+      </tr>
+      <tr>
+        <td>Bare Director-id routes (#1866)</td>
+        <td><span class="badge miss">Still missing</span> - no dedicated open pull request found</td>
+      </tr>
+      <tr>
+        <td>Owner / fleet-global surfaces</td>
+        <td><span class="badge pr">In flight</span> - #1898, #1903, #1904, #1907, #1939 (deny shape)</td>
+      </tr>
+      <tr>
+        <td>Device keys plaintext (#1878)</td>
+        <td><span class="badge pr">In flight</span> - #1899 green</td>
+      </tr>
+      <tr>
+        <td>Hosted mode flag fail-open (#1868)</td>
+        <td><span class="badge miss">Still missing</span></td>
+      </tr>
+      <tr>
+        <td>Session-number allocator not tenant-scoped</td>
+        <td><span class="badge miss">Still missing</span> - comments on main still admit the hole after #1942</td>
+      </tr>
+      <tr>
+        <td>Raw tenant id in removal logs</td>
+        <td><span class="badge miss">Still open</span> - small fix, not started</td>
+      </tr>
+      <tr>
+        <td>Hosted snooze clear disabled</td>
+        <td><span class="badge miss">Still open</span> - #1909 helps data model; removal subscriber still skips hosted</td>
+      </tr>
+      <tr>
+        <td>Stream write ownership (#1923)</td>
+        <td><span class="badge pr">In flight</span> - #1930 green</td>
+      </tr>
+      <tr>
+        <td>Self-host still disabled</td>
+        <td><span class="badge ok">Correct</span> - keep disabled until machine proof</td>
+      </tr>
+      <tr>
+        <td>Do not arm voice synthesis key</td>
+        <td><span class="badge ok">Still correct policy</span> - reinforced by #1907 deny of cached voice reads</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>3. What to do first - ranked action list</h2>
+  <p>
+    Split into two lanes: <strong>land what is already written</strong> (highest leverage
+    this week), then <strong>start new work that is still missing or wrong</strong>.
+  </p>
+
+  <h3>Lane A - land existing work (do this before opening more large units)</h3>
+
+  <div class="rank merge">
+    <div class="num">A1</div>
+    <div class="body">
+      <strong>Merge the census + remedy map (#1936)</strong>
+      Workers and reviewers keep reading a specification that is not on main. That has
+      already cost time. This is documentation only and unblocks everyone.
+    </div>
+  </div>
+
+  <div class="rank merge">
+    <div class="num">A2</div>
+    <div class="body">
+      <strong>Merge the shared hosted refusal primitive (#1951)</strong>
+      Every deny family should use one boundary. Landing this first makes later deny
+      pull requests rebasable onto one shape instead of five slightly different filters.
+      Green on both build lanes.
+    </div>
+  </div>
+
+  <div class="rank merge">
+    <div class="num">A3</div>
+    <div class="body">
+      <strong>Merge the deny family (security floor)</strong>
+      In roughly this order once A2 is in: #1898 (settings / AI models / telemetry consent),
+      #1904 (vault), #1903 (content reads), #1907 (recording + voice read), #1939 (launcher /
+      machine), #1940 (transcription provisioner pin). These close active public-signup
+      attack paths. Prefer rebasing each onto #1951 if they still roll their own filter.
+    </div>
+  </div>
+
+  <div class="rank merge">
+    <div class="num">A4</div>
+    <div class="body">
+      <strong>Merge authorize + partition greens</strong>
+      #1930 (stream ownership), #1899 (hashed device keys), #1935 (netdiag), #1933 (car-mode
+      telemetry), #1909 (composite primary keys), then #1906 (database route proof, after #1909).
+    </div>
+  </div>
+
+  <div class="rank merge">
+    <div class="num">A5</div>
+    <div class="body">
+      <strong>Rebase the conflicted upload pair (#1945, then #1900)</strong>
+      Both touch VoiceUploadStore. #1945 makes an unscoped store impossible to construct;
+      #1900 tenant-keys dictation. Conflicts mean they will rot if left open while denys land.
+      Rebase is work; rewriting is not.
+    </div>
+  </div>
+
+  <h3>Lane B - new work that is still missing or incorrectly implemented</h3>
+  <p>
+    These are the items that should actually be <em>started</em> as new implementation once
+    Lane A is moving - ranked by risk and by whether anything already covers them.
+  </p>
+
+  <div class="rank do-now">
+    <div class="num">1</div>
+    <div class="body">
+      <strong>Session-identifier family: adopt TenantSessionMap (14 census rows)</strong>
+      <span class="badge p0">Highest new-work priority</span>
+      <span class="badge miss">No pull request</span>
+      <p style="margin:0.4rem 0 0">
+        Foundation shipped (#1934). Production still uses bare session strings for
+        needs-you, both transcribing maps, governance state emitter, turn-end watcher,
+        turn-brief caches, fanout rate budget, and more. This is the largest remaining
+        active-unsafe work unit in the remedy map. Incorrect state: types exist and look
+        finished while the Gateway still collides.
+      </p>
+      <p style="margin:0.35rem 0 0"><span class="label">Start shape</span><br>
+        One derivation helper after <code>RequireBoundTenant</code> /
+        <code>ResolveReadTenant</code>. Convert stores in small batches (e.g. needs-you +
+        both transcribing marks first; then turn briefs; then governance / fanout). Every
+        batch needs a two-tenant same-raw-id collision test. Do not rename external session
+        identifiers.
+      </p>
+    </div>
+  </div>
+
+  <div class="rank do-now">
+    <div class="num">2</div>
+    <div class="body">
+      <strong>Voice routes and background loops still hard-code Local</strong>
+      <span class="badge p0">Incorrectly implemented</span>
+      <span class="badge miss">No full fix pull request</span>
+      <p style="margin:0.4rem 0 0">
+        Voice <em>state</em> is partitioned (#1915). Voice <em>call sites</em> still pass
+        <code>TenantId.Local</code> (~19 hits in <code>GatewayWingmanVoiceEndpoint</code>).
+        That is the classic half-fix: the store is multi-tenant; the product path is not.
+        Background loops (#1893) same bug. #1907 correctly denys some hosted voice <em>reads</em>
+        as an interim floor - that is not a substitute for making generation tenant-correct.
+      </p>
+      <p style="margin:0.35rem 0 0"><span class="label">Start shape</span><br>
+        Resolve request / bound-connection tenant on every voice route; drive background
+        generation through <code>ITenantPass</code>. Keep synthesis key out of the vault until
+        a two-account live proof passes. Pair with session-key adoption for any remaining
+        bare session marks the voice path touches.
+      </p>
+    </div>
+  </div>
+
+  <div class="rank do-now">
+    <div class="num">3</div>
+    <div class="body">
+      <strong>Statistics identity bundle + concurrency scalars (12 census rows)</strong>
+      <span class="badge p0">Missing</span>
+      <span class="badge miss">No pull request</span>
+      <p style="margin:0.4rem 0 0">
+        Eleven identity maps (repository / agent / model / checkout) plus concurrency hour
+        and process-wide scalars still fold every tenant into one shared statistics world.
+        Stats dashboard is already denied on hosted (#1888), so this is not the loudest
+        public leak - but push-time aggregation still mixes tenants in memory and on disk,
+        and any future per-tenant stats product will ship wrong numbers if this is left.
+      </p>
+      <p style="margin:0.35rem 0 0"><span class="label">Start shape</span><br>
+        Pass authenticated tenant into both aggregator call paths from DirectorHub and
+        roster fold. Partition all identity maps and the concurrency tracker by tenant.
+        Migrate legacy database mirrors with the memory maps in the same unit.
+      </p>
+    </div>
+  </div>
+
+  <div class="rank do-now">
+    <div class="num">4</div>
+    <div class="body">
+      <strong>Complete the Director-removal family (incorrectly incomplete)</strong>
+      <span class="badge p1">Partial fix on main</span>
+      <p style="margin:0.4rem 0 0">
+        #1942 fixed the event payload and roster forget. Still broken or incomplete:
+      </p>
+      <ul style="margin:0.3rem 0">
+        <li><code>FleetSessionNumberAllocator.ReleaseForDirector</code> still drops the tenant (census row 24)</li>
+        <li>Hosted snooze clear still skipped on removal</li>
+        <li>Raw tenant GUID still logged on removal / forget</li>
+        <li><code>_everReachable</code> / <code>_stateReporting</code> still bare Director ids</li>
+      </ul>
+      <p style="margin:0.35rem 0 0"><span class="label">Start shape</span><br>
+        One small pull request: tenant-scope the allocator end-to-end (allocate, adopt,
+        release, removal), re-enable hosted snooze clear with tenant, and switch logs to
+        <code>ToLogString()</code>. High leverage, low design risk - same pattern as #1942.
+      </p>
+    </div>
+  </div>
+
+  <div class="rank do-now">
+    <div class="num">5</div>
+    <div class="body">
+      <strong>Residual bare Director-id routes (#1866) + HTTP register on hosted</strong>
+      <span class="badge p0">Still active</span>
+      <span class="badge miss">No pull request</span>
+      <p style="margin:0.4rem 0 0">
+        Composite registry keys only help callers that pass a tenant. Legacy
+        <code>Get(string)</code> / <code>TryResolveLegacyKey</code> still pick the freshest
+        match across tenants. Credential-less HTTP register still stamps Local and pollutes
+        bare-id resolution. This is residual of a closed issue (#1847) that never finished
+        the route conversion.
+      </p>
+      <p style="margin:0.35rem 0 0"><span class="label">Start shape</span><br>
+        Inventory remaining bare-id callers; convert each to request/bound tenant; on hosted
+        refuse HTTP register/heartbeat entirely. One route family per pull request if needed.
+      </p>
+    </div>
+  </div>
+
+  <div class="rank">
+    <div class="num">6</div>
+    <div class="body">
+      <strong>Remaining remedy units without pull requests</strong>
+      <span class="badge p1">Missing</span>
+      <ul style="margin:0.3rem 0">
+        <li>Director event rings (census row 23)</li>
+        <li>Cron <code>_inFlight</code> overlap lock (row 13)</li>
+        <li>Machine-name family beyond the hosted deny (rows 14, 42, 66, 69) - permanent design is #1938</li>
+        <li>Broadcast rate budget + grant ownership (rows 1-2)</li>
+      </ul>
+      After items 1-5, cut these from the remedy map one work unit each. Do not invent a
+      parallel plan - the map already has the ingestion points.
+    </div>
+  </div>
+
+  <div class="rank">
+    <div class="num">7</div>
+    <div class="body">
+      <strong>Hosted mode fail-closed (#1868)</strong>
+      <span class="badge p0">Config footgun</span>
+      Losing <code>CC_GATEWAY_HOSTED</code> collapses isolation silently. Small independent
+      unit: image-baked hosted marker or refuse boot when multi-tenant schema is present
+      without hosted mode. Can ship in parallel with larger work.
+    </div>
+  </div>
+
+  <h2>4. What not to start yet</h2>
+  <ul>
+    <li>
+      <strong>Enabling voice synthesis on hosted</strong> - routes still Local; denys and
+      partitions for speech paths are incomplete. The QA warning still stands.
+    </li>
+    <li>
+      <strong>Enabling the self-host card</strong> - orchestrator is good; real-machine proof
+      is not done. A half-provision is worse than a disabled card.
+    </li>
+    <li>
+      <strong>Per-tenant stats product (#1886)</strong> - blocked until the statistics identity
+      bundle is partitioned and attribution exists.
+    </li>
+    <li>
+      <strong>Permanent tenant-scoped launcher (#1938)</strong> - the interim deny (#1939)
+      is the right floor; do not rebuild launcher multi-tenancy until denys are on main.
+    </li>
+    <li>
+      <strong>Opening more deny families that re-roll their own filter</strong> - use #1951
+      after it lands.
+    </li>
+  </ul>
+
+  <h2>5. Incorrectly implemented - the half-fixes to finish</h2>
+  <div class="callout danger">
+    These are more dangerous than pure missing work because the code looks multi-tenant
+    while one seam still is not.
+  </div>
+  <table>
+    <thead>
+      <tr><th>Half-fix</th><th>What is right</th><th>What is still wrong</th><th>Action</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Voice state</td>
+        <td>Store partitioned by tenant (#1915)</td>
+        <td>Routes and loops pass Local</td>
+        <td>Ranked item 2</td>
+      </tr>
+      <tr>
+        <td>Director removal</td>
+        <td>Event carries tenant; roster forget scoped</td>
+        <td>Numbers, snoozes, bare flags, raw log</td>
+        <td>Ranked item 4</td>
+      </tr>
+      <tr>
+        <td>Session key types</td>
+        <td>TenantSessionKey / Map designed and tested</td>
+        <td>Zero production adoption</td>
+        <td>Ranked item 1</td>
+      </tr>
+      <tr>
+        <td>Per-session HTTP routes</td>
+        <td>Many resolve request tenant (#1869)</td>
+        <td>Bare Director-id family still open (#1866)</td>
+        <td>Ranked item 5</td>
+      </tr>
+      <tr>
+        <td>Dictation</td>
+        <td>Store partition PRs written</td>
+        <td>Conflicted; complete path still dead / Local on hosted by design in #1900</td>
+        <td>Lane A5 then later re-enable</td>
+      </tr>
+      <tr>
+        <td>Prompts / stats</td>
+        <td>Prompts scoped; stats denied</td>
+        <td>Stats aggregation still global in memory/db</td>
+        <td>Ranked item 3</td>
+      </tr>
+      <tr>
+        <td>Entitlement read</td>
+        <td>Three-state gate + schema guard + uuid map</td>
+        <td>Operational: still returns 503 when DB/schema wrong - watch logs</td>
+        <td>Ops, not new code</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>6. Suggested program order (next 1-2 weeks)</h2>
+  <ol>
+    <li>Land Lane A (docs, primitive, denys, authorize, partitions, rebase upload pair).</li>
+    <li>Cut one worktree for <strong>session-number allocator + hosted snooze clear + log scrub</strong> (ranked item 4) - same-day finishable.</li>
+    <li>Cut the <strong>TenantSessionMap adoption series</strong> (ranked item 1) as multiple small pull requests from the remedy map session unit.</li>
+    <li>In parallel once denys are on main: <strong>voice Local removal</strong> (ranked item 2).</li>
+    <li>Then statistics identity bundle (ranked item 3) and bare Director-id conversion (ranked item 5).</li>
+    <li>Then remaining census units (event rings, cron in-flight, broadcast grant, #1868 fail-closed).</li>
+    <li>Only after speech paths are proven: consider voice key + re-enable dictation on hosted.</li>
+  </ol>
+
+  <h2>7. Bottom line</h2>
+  <div class="callout good">
+    <strong>Much more is implemented</strong> - in open pull requests, not on main. The
+    program has the right census, the right remedy map, and a large deny/partition wave
+    ready to land.
+  </div>
+  <div class="callout warn">
+    <strong>The most important things to start that are still missing or wrong:</strong>
+    <ol style="margin:0.5rem 0 0">
+      <li><strong>Adopt TenantSessionMap</strong> into the fourteen session-keyed stores (missing).</li>
+      <li><strong>Stop hard-coding Local on voice routes/loops</strong> (incorrect half-fix).</li>
+      <li><strong>Partition statistics identity + concurrency</strong> (missing; 12 rows).</li>
+      <li><strong>Finish Director-removal fallout</strong> - session numbers, snoozes, logs (incorrect half-fix).</li>
+      <li><strong>Convert residual bare Director-id routes</strong> (missing).</li>
+    </ol>
+    <p style="margin:0.6rem 0 0">
+      And before those, <strong>merge the green isolation pull requests</strong> - that is
+      the highest leverage work already sitting done.
+    </p>
+  </div>
+
+  <h2>8. Source notes</h2>
+  <ul class="delta">
+    <li>Shipped: <code>origin/main</code> at <code>7696b1de</code> (cockpit URL) / prior <code>3fa2588f</code> (entitlement uuid).</li>
+    <li>Census + remedy map: PR #1936 branch
+      <code>docs/architecture/hosted-gateway-process-global-collection-census-2026-07-20.md</code>
+      and
+      <code>docs/architecture/hosted-gateway-unsafe-collection-ingestion-map-2026-07-20.md</code>
+      (40 active unsafe rows; 11 remedy units).</li>
+    <li>Previous review: <code>docs/reviews/multi-tenant-gateway-code-review-2026-07-20.html</code>.</li>
+    <li>This document does not claim any open pull request is merged until it is on origin/main.</li>
+  </ul>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>
+      File:
+      <span class="path">docs/reviews/multi-tenant-gateway-code-review-2026-07-21.html</span>
+    </p>
+    <p>
+      Working tree was behind origin/main; all code claims are from origin/main or named
+      pull-request heads, not the stale checkout.
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/reviews/telemetry-removal-audit-2026-07-22.html
+++ b/docs/reviews/telemetry-removal-audit-2026-07-22.html
@@ -1,0 +1,444 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DevThrottle telemetry removal audit and confirmed policy — 2026-07-22</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --panel: #121a2d;
+      --panel-2: #17223a;
+      --line: #2b3a59;
+      --text: #edf3ff;
+      --muted: #aebbd1;
+      --cyan: #54d7e8;
+      --green: #75dfa5;
+      --amber: #ffc766;
+      --red: #ff8294;
+      --violet: #b9a4ff;
+      --code: #0a1325;
+      --shadow: 0 18px 55px rgba(0,0,0,.26);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 10% -10%, rgba(84,215,232,.14), transparent 34rem),
+        radial-gradient(circle at 95% 12%, rgba(185,164,255,.12), transparent 31rem),
+        var(--bg);
+      color: var(--text);
+      font: 15px/1.62 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    a { color: var(--cyan); text-decoration-thickness: 1px; text-underline-offset: 3px; }
+    code, .mono { font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace; }
+    code {
+      background: var(--code);
+      border: 1px solid rgba(84,215,232,.16);
+      border-radius: 6px;
+      padding: .08rem .32rem;
+      color: #d7f7ff;
+      overflow-wrap: anywhere;
+    }
+    .wrap { max-width: 1220px; margin: 0 auto; padding: 34px 24px 80px; }
+    header {
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: linear-gradient(135deg, rgba(23,34,58,.96), rgba(11,16,32,.96));
+      padding: clamp(24px, 5vw, 54px);
+      box-shadow: var(--shadow);
+      position: relative;
+      overflow: hidden;
+    }
+    header::after {
+      content: "";
+      position: absolute;
+      width: 310px;
+      height: 310px;
+      right: -140px;
+      top: -170px;
+      border: 54px solid rgba(84,215,232,.11);
+      border-radius: 50%;
+    }
+    .eyebrow { color: var(--cyan); font-weight: 760; letter-spacing: .11em; text-transform: uppercase; font-size: 12px; }
+    h1 { margin: 10px 0 14px; font-size: clamp(32px, 6vw, 62px); letter-spacing: -.045em; line-height: 1.02; max-width: 900px; }
+    .lede { max-width: 850px; color: var(--muted); font-size: clamp(16px, 2.2vw, 21px); margin: 0; }
+    .meta { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 24px; }
+    .chip { border: 1px solid var(--line); background: rgba(10,19,37,.68); border-radius: 999px; padding: 6px 11px; color: var(--muted); font-size: 13px; }
+    nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 30px; }
+    nav a { text-decoration: none; border: 1px solid var(--line); background: rgba(18,26,45,.8); border-radius: 9px; padding: 7px 10px; color: var(--muted); }
+    nav a:hover { color: var(--text); border-color: var(--cyan); }
+    section { margin-top: 28px; scroll-margin-top: 16px; }
+    .card { border: 1px solid var(--line); background: rgba(18,26,45,.91); border-radius: 17px; padding: clamp(18px, 3vw, 30px); box-shadow: 0 12px 34px rgba(0,0,0,.15); }
+    h2 { margin: 0 0 15px; font-size: clamp(23px, 3vw, 34px); letter-spacing: -.025em; }
+    h3 { margin: 26px 0 9px; font-size: 18px; }
+    p { margin: 9px 0; }
+    ul, ol { padding-left: 1.35rem; }
+    li + li { margin-top: 6px; }
+    .verdict {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .stat { border: 1px solid var(--line); background: var(--panel-2); border-radius: 14px; padding: 17px; min-height: 140px; }
+    .stat .label { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .09em; }
+    .stat strong { display: block; font-size: 22px; line-height: 1.15; margin: 8px 0; }
+    .yes { color: var(--green); }
+    .warn { color: var(--amber); }
+    .stop { color: var(--red); }
+    .info { color: var(--cyan); }
+    .callout { border-left: 4px solid var(--cyan); background: rgba(84,215,232,.08); border-radius: 0 10px 10px 0; padding: 13px 16px; margin: 17px 0; }
+    .callout.warnline { border-color: var(--amber); background: rgba(255,199,102,.08); }
+    .callout.stopline { border-color: var(--red); background: rgba(255,130,148,.08); }
+    .flow { display: grid; gap: 10px; margin: 19px 0 5px; }
+    .flow-row { display: grid; grid-template-columns: 1.2fr 40px 1.25fr 40px 1.4fr; align-items: stretch; }
+    .node { border: 1px solid var(--line); background: var(--panel-2); border-radius: 11px; padding: 13px; }
+    .node b { display: block; color: var(--text); margin-bottom: 4px; }
+    .node span { color: var(--muted); font-size: 13px; }
+    .arrow { display: grid; place-items: center; color: var(--cyan); font-weight: 900; font-size: 21px; }
+    .dead { border-color: rgba(255,199,102,.45); }
+    .active { border-color: rgba(117,223,165,.5); }
+    .capable { border-color: rgba(255,130,148,.48); }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; margin-top: 15px; }
+    table { width: 100%; border-collapse: collapse; min-width: 850px; font-size: 14px; }
+    th, td { text-align: left; vertical-align: top; padding: 12px 13px; border-bottom: 1px solid var(--line); }
+    th { background: #192642; color: #dce8fb; position: sticky; top: 0; z-index: 1; }
+    tr:last-child td { border-bottom: 0; }
+    tbody tr:hover td { background: rgba(84,215,232,.035); }
+    .badge { white-space: nowrap; display: inline-block; border-radius: 999px; padding: 2px 8px; font-weight: 750; font-size: 12px; border: 1px solid currentColor; }
+    .b-active { color: var(--green); }
+    .b-dead { color: var(--amber); }
+    .b-capable { color: var(--red); }
+    .b-local { color: var(--violet); }
+    .b-separate { color: var(--cyan); }
+    details { border: 1px solid var(--line); border-radius: 11px; background: rgba(10,19,37,.6); margin-top: 11px; }
+    summary { cursor: pointer; padding: 12px 14px; font-weight: 720; }
+    details > div { padding: 0 14px 15px; color: var(--muted); }
+    .files { columns: 2; column-gap: 30px; }
+    .files li { break-inside: avoid; }
+    .priority { display: grid; grid-template-columns: 92px 1fr; gap: 12px; padding: 13px 0; border-bottom: 1px solid var(--line); }
+    .priority:last-child { border-bottom: 0; }
+    .pnum { font-weight: 850; color: var(--cyan); font-size: 18px; }
+    .footer { color: var(--muted); text-align: center; margin-top: 28px; font-size: 13px; }
+    @media (max-width: 900px) {
+      .verdict { grid-template-columns: 1fr 1fr; }
+      .flow-row { grid-template-columns: 1fr; }
+      .arrow { transform: rotate(90deg); min-height: 34px; }
+      .files { columns: 1; }
+    }
+    @media (max-width: 560px) {
+      .wrap { padding: 16px 12px 50px; }
+      .verdict { grid-template-columns: 1fr; }
+      .priority { grid-template-columns: 1fr; gap: 2px; }
+      nav { display: none; }
+    }
+    @media print {
+      :root { color-scheme: light; }
+      body { background: white; color: #172033; }
+      .wrap { max-width: none; padding: 0; }
+      header, .card, .stat, .node, details { background: white; box-shadow: none; }
+      nav { display: none; }
+      a { color: #075985; }
+      code { background: #f3f6fa; color: #172033; }
+      section { break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <header>
+      <div class="eyebrow">Source audit · confirmed product direction</div>
+      <h1>Telemetry removal audit</h1>
+      <p class="lede">Where the setting appears, what it actually controls, what the Director and Gateway send today, and the owner-confirmed removal boundary for the implementation issue.</p>
+      <div class="meta">
+        <span class="chip">Reviewed 2026-07-22</span>
+        <span class="chip">Branch <span class="mono">main</span></span>
+        <span class="chip">Commit <span class="mono">f628f9bae85e</span></span>
+        <span class="chip">Repository version 1.5.0</span>
+        <span class="chip">Policy confirmed 2026-07-22</span>
+        <span class="chip">No product code changed</span>
+      </div>
+    </header>
+
+    <nav aria-label="Report sections">
+      <a href="#verdict">Verdict</a>
+      <a href="#flow">Current flow</a>
+      <a href="#egress">Cloud egress</a>
+      <a href="#inventory">Inventory</a>
+      <a href="#platforms">Windows / macOS</a>
+      <a href="#local-data">Local service data</a>
+      <a href="#removal">Removal plan</a>
+      <a href="#acceptance">Acceptance criteria</a>
+    </nav>
+
+    <section id="verdict" class="card">
+      <h2>Executive verdict</h2>
+      <div class="callout"><strong>Confirmed product policy.</strong> Self-hosted Gateways may retain local operational data required to provide features such as Your Throttle, but must never send behavioral telemetry to DevThrottle servers. DevThrottle-hosted Gateways need no telemetry consent choice and must not add separate startup, login, or usage telemetry beyond ordinary service traffic. The telemetry setting and its language are to be removed everywhere in the product.</div>
+      <div class="verdict">
+        <div class="stat"><span class="label">Remove the screen?</span><strong class="yes">Yes</strong><span>The Windows installer/update Privacy step is misleading and writes a setting that no live richer-usage path reads.</span></div>
+        <div class="stat"><span class="label">Active Director event</span><strong class="warn">Startup</strong><span>Every Avalonia Director launch posts machine and build identity to its configured Gateway.</span></div>
+        <div class="stat"><span class="label">Direct cloud telemetry</span><strong class="info">None by default</strong><span>The Director normally sends telemetry to its Gateway, not directly to <span class="mono">devthrottle.com</span>.</span></div>
+        <div class="stat"><span class="label">Cloud-capable Gateway path</span><strong class="stop">Remove it</strong><span>The durable login relay targets the DevThrottle telemetry API and is outside the confirmed policy.</span></div>
+      </div>
+
+      <div class="callout stopline"><strong>The toggle is not a trustworthy privacy control.</strong> The active Director-startup event is explicitly outside both consent gates. The richer <code>UsageTelemetry</code> recorder and <code>GatewayTelemetryConsent</code> reader exist, but there are no production construction or <code>Record</code> call sites. Turning either displayed toggle off therefore does not change the active startup event.</div>
+
+      <ul>
+        <li>The screenshot is the WPF setup/update wizard in <code>tools/cc-director-setup</code>. It appears on both fresh Windows installs and updates.</li>
+        <li>The wizard now has no sign-in token. It defaults the checkbox to ON, then writes only local <code>config.json → telemetry.enabled</code>; its documented account GET/PATCH cannot run on the current path.</li>
+        <li>The Cockpit has a second, separate fleet-wide ON-by-default setting at <code>config.json → telemetry_consent</code>. It is exposed in Settings → Privacy and in the Gateway settings snapshot.</li>
+        <li>The current sign-in implementation does not originate the login telemetry event: <code>GatewaySignInService</code> injects a no-op reporter. The relay and its default cloud destination nevertheless remain live and can accept events from older clients or another caller.</li>
+        <li>The same cross-platform Avalonia startup code runs on Windows and macOS. There is no macOS equivalent of the WPF Privacy wizard in this repository, but a macOS Director still posts the startup event to its configured Gateway.</li>
+      </ul>
+
+      <h3>Confirmed deployment boundary</h3>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Deployment</th><th>Data that may remain</th><th>Data that must stop</th><th>User setting</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Self-hosted Gateway</strong></td><td>Gateway-local data required to deliver a visible feature, including local Your Throttle statistics and requested service history.</td><td>Any startup, login, usage, behavioral, or diagnostic event sent to DevThrottle merely for observation or analytics.</td><td>None. There is no telemetry program to consent to.</td></tr>
+            <tr><td><strong>DevThrottle-hosted Gateway</strong></td><td>Prompts, audio, model requests, account operations, and other data required to provide the service the user invoked.</td><td>Separate startup, login, or usage telemetry events that duplicate what normal service operation already reveals.</td><td>None. The telemetry choice is unnecessary and misleading.</td></tr>
+            <tr><td><strong>All Directors</strong></td><td>Local application logs and feature state needed to operate the app, subject to normal retention and privacy rules.</td><td>Direct-to-cloud telemetry, Gateway-forwarded telemetry, dormant telemetry upload capability, and destination override seams.</td><td>Remove installer and Cockpit telemetry settings, routes, keys, caches, and wording.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="flow" class="card">
+      <h2>What the code does today</h2>
+      <div class="flow" role="img" aria-label="Telemetry data flows">
+        <div class="flow-row">
+          <div class="node dead"><b>Windows Setup / Update</b><span>Default-ON checkbox in the Privacy step</span></div>
+          <div class="arrow">→</div>
+          <div class="node dead"><b><code>telemetry.enabled</code></b><span>Local config mirror; server write skipped because token provider is always null</span></div>
+          <div class="arrow">→</div>
+          <div class="node dead"><b>No live consumer</b><span>Only the uninstantiated usage recorder reads it</span></div>
+        </div>
+        <div class="flow-row">
+          <div class="node dead"><b>Cockpit Settings → Privacy</b><span>Fleet-wide “Usage telemetry” switch</span></div>
+          <div class="arrow">→</div>
+          <div class="node dead"><b><code>telemetry_consent</code></b><span>Gateway config via GET/PUT <code>/gateway/telemetry-consent</code></span></div>
+          <div class="arrow">→</div>
+          <div class="node dead"><b>No production refresh / gate</b><span>Reader and cache exist only in tests and library code</span></div>
+        </div>
+        <div class="flow-row">
+          <div class="node active"><b>Avalonia Director launch</b><span>Windows and macOS; once Control API has a stable Director ID</span></div>
+          <div class="arrow">→</div>
+          <div class="node active"><b>Configured Gateway</b><span>POST <code>/telemetry/director-startup</code>; Gateway logs the event</span></div>
+          <div class="arrow">→</div>
+          <div class="node dead"><b>Cloud only if configured</b><span>No default startup-cloud URL; forwarding requires an environment variable</span></div>
+        </div>
+        <div class="flow-row">
+          <div class="node capable"><b>Legacy / other login caller</b><span>Current Gateway sign-in uses a no-op reporter</span></div>
+          <div class="arrow">→</div>
+          <div class="node capable"><b>Gateway durable queue</b><span>POST <code>/telemetry/login</code>; persisted, retried, Gateway bearer attached</span></div>
+          <div class="arrow">→</div>
+          <div class="node capable"><b>DevThrottle API by default</b><span>POST <code>https://devthrottle.com/api/v1/telemetry/login</code></span></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="egress" class="card">
+      <h2>Exactly what leaves the Director / Gateway</h2>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Path</th><th>Payload</th><th>Destination</th><th>Current reachability</th><th>Consent relationship</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><strong>Director startup</strong><br><code>App.axaml.cs:468-507</code><br><code>DevThrottleDirectorStartupTelemetryReporter.cs</code></td>
+              <td><code>director_id</code>, <code>machine_name</code>, <code>app_version</code>. No Authorization header is added by the reporter.</td>
+              <td>Normally <code>&lt;gateway.url&gt;/telemetry/director-startup</code>. A Director-side <code>DEVTHROTTLE_STARTUP_TELEMETRY_URL</code> override can point it anywhere.</td>
+              <td><span class="badge b-active">Active each launch</span></td>
+              <td>Always on. Neither local nor Gateway consent gates it.</td>
+            </tr>
+            <tr>
+              <td><strong>Gateway startup handling</strong><br><code>DirectorStartupTelemetryEndpoint.cs</code></td>
+              <td>Extracts and logs <code>director_id</code> and <code>app_version</code>. The Director log also contains machine name. If forwarding is configured, the full original body is queued.</td>
+              <td>Local Gateway log by default. Cloud forwarding only when Gateway-side <code>DEVTHROTTLE_STARTUP_TELEMETRY_URL</code> is set.</td>
+              <td><span class="badge b-active">Local record active</span><br><span class="badge b-dead">Cloud off by default</span></td>
+              <td>Always on.</td>
+            </tr>
+            <tr>
+              <td><strong>Login event</strong><br><code>DevThrottleLoginTelemetryReporter.cs</code></td>
+              <td><code>source: "app"</code>, optional <code>app_version</code> and <code>install_id</code>. Director access token is accepted by the method but not placed on this request.</td>
+              <td>Normally Gateway <code>/telemetry/login</code>. A Director-side <code>DEVTHROTTLE_TELEMETRY_URL</code> override can bypass that routing.</td>
+              <td><span class="badge b-dead">No current producer</span> Current Gateway sign-in injects <code>NoOpLoginTelemetryReporter</code>.</td>
+              <td>Always on if called.</td>
+            </tr>
+            <tr>
+              <td><strong>Gateway login relay</strong><br><code>TelemetryRelayEndpoint.cs</code><br><code>TelemetryRetryQueue.cs</code></td>
+              <td>Persists the inbound body plus target URL and queue metadata. At delivery time attaches the Gateway account bearer.</td>
+              <td>Defaults to <code>https://devthrottle.com/api/v1/telemetry/login</code>; retried every 30 seconds, FIFO, up to 1,000 events.</td>
+              <td><span class="badge b-capable">Live capability</span> Accepts older/external callers even though current sign-in emits none.</td>
+              <td>Always on; not linked to either displayed setting.</td>
+            </tr>
+            <tr>
+              <td><strong>Richer usage events</strong><br><code>UsageTelemetry.cs</code></td>
+              <td>Event name and UTC timestamp in local JSONL only.</td>
+              <td><code>config/director/devthrottle-usage-events.jsonl</code>; no uploader exists in this checkout.</td>
+              <td><span class="badge b-dead">Dormant</span> No production constructor or <code>Record</code> call.</td>
+              <td>Designed to require both toggles, but unused.</td>
+            </tr>
+            <tr>
+              <td><strong>Installer account flag</strong><br><code>AccountTelemetryClient.cs</code></td>
+              <td>GET reads <code>telemetry_enabled</code>; PATCH sends <code>{"enabled": bool}</code> with a bearer.</td>
+              <td><code>/api/v1/auth/me</code> and <code>/api/v1/account/telemetry</code> at <code>devthrottle.com</code>.</td>
+              <td><span class="badge b-dead">Skipped today</span> <code>BuildPrivacyStep()</code> supplies a null token provider.</td>
+              <td>This is the obsolete per-account consent model.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="callout"><strong>Answer to “what does the Director send to our API servers outside the Gateway?”</strong> For telemetry, the normal production answer from this checkout is <strong>nothing directly</strong>: the active startup report targets the configured Gateway, and that Gateway keeps it local unless a startup-cloud URL is explicitly configured. The login relay is the remaining default DevThrottle-cloud telemetry path, but the current sign-in flow does not generate a login event. Both Director reporter classes can be pointed directly at an arbitrary/cloud URL through environment overrides, so removal should delete those override seams too.</div>
+
+      <h3>Service traffic that is not telemetry</h3>
+      <p>Do not confuse removal with the product services the user explicitly excluded from this review. The Director sends captured audio to its configured Gateway for transcription. Desktop text-to-speech currently posts the actual text to <code>https://devthrottle.com/api/v1/audio/speech</code> with model, voice, and response format; that is requested service content, not behavioral telemetry. Account, device, credit, hosted-AI, transcription, notification, and sign-in traffic owned by the Gateway is likewise service operation and needs its own privacy inventory, not deletion under this telemetry issue.</p>
+    </section>
+
+    <section id="inventory" class="card">
+      <h2>Where the setting and system live</h2>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Layer</th><th>Files / symbols</th><th>Observed behavior</th><th>Removal consequence</th></tr></thead>
+          <tbody>
+            <tr><td>Windows setup UI</td><td><code>MainWindow.xaml</code>, <code>MainWindow.xaml.cs</code>, <code>Steps/PrivacyStep.xaml(.cs)</code>, <code>WizardStepFlow.cs</code></td><td>Privacy is step 3 of 6 on installs and updates. Checkbox defaults ON and cannot block Next.</td><td>Remove the rail row, step constant, cached control, build/apply methods, and renumber visible steps.</td></tr>
+            <tr><td>Setup persistence</td><td><code>TelemetryChoiceApplier.cs</code>, <code>TelemetrySettings.cs</code>, <code>AccountTelemetryClient.cs</code></td><td>Current setup writes only <code>telemetry.enabled</code> locally. Direct account API code remains callable but has no token in this wizard.</td><td>Delete classes and tests; remove stale config key rather than merely hiding the UI.</td></tr>
+            <tr><td>Cockpit UI</td><td><code>SettingsView.tsx</code>, <code>settingsTabs.ts</code>, <code>main.tsx</code></td><td>Privacy tab contains telemetry plus Wingman training capture. Old <code>/telemetry</code> route redirects to the Privacy tab.</td><td>Remove the telemetry card, route alias, and query alias. Retain training capture in an appropriately named settings section; do not preserve a Privacy tab solely as a telemetry vestige.</td></tr>
+            <tr><td>Web client / schema</td><td><code>telemetryClient.ts</code>, <code>settingsClient.ts</code>, generated <code>schema.ts</code></td><td>GET/PUT consent client plus a duplicate <code>telemetryConsent</code> property in the general settings snapshot.</td><td>Delete client module and type/property, then regenerate OpenAPI schema after routes are removed.</td></tr>
+            <tr><td>Gateway API / config</td><td><code>TelemetryConsentEndpoint.cs</code>, <code>TelemetryConsentConfig.cs</code>, <code>SettingsEndpoints.cs</code>, <code>TelemetryConsentDto.cs</code></td><td>Top-level <code>telemetry_consent</code>, default ON; GET/PUT endpoint and settings snapshot field.</td><td>Remove routes, mapping, field, DTO, config implementation, tests, and stale configuration.</td></tr>
+            <tr><td>Director usage gate</td><td><code>GatewayTelemetryConsent.cs</code>, <code>UsageTelemetry.cs</code>, <code>CcStorage</code></td><td>Last-known consent cache and local usage-event JSONL implementation. Neither is wired into production.</td><td>Delete dormant implementation and on-disk artifacts; remove misleading comments from neighboring config/cache classes.</td></tr>
+            <tr><td>Active startup report</td><td><code>App.axaml.cs</code>, <code>IDirectorStartupTelemetryReporter.cs</code>, <code>DevThrottleDirectorStartupTelemetryReporter.cs</code></td><td>Runs after Control API startup on every supported Avalonia platform.</td><td>Remove the call and reporter, not just the endpoint. This is the one active Director-side collection point.</td></tr>
+            <tr><td>Login report seam</td><td><code>ILoginTelemetryReporter.cs</code>, <code>DevThrottleLoginTelemetryReporter.cs</code>, <code>FirstRunLoginCoordinator.cs</code>, <code>GatewaySignInService.cs</code></td><td>Coordinator has a detached report hook; current Gateway sign-in substitutes a no-op.</td><td>Remove the reporter dependency and detached report block from the coordinator; delete the no-op adapter.</td></tr>
+            <tr><td>Gateway relay / storage</td><td><code>TelemetryRelayEndpoint.cs</code>, <code>DirectorStartupTelemetryEndpoint.cs</code>, <code>TelemetryRetryQueue.cs</code>, token-source types, <code>GatewayHost.cs</code></td><td>Login default-cloud forwarding; startup local record and optional cloud forwarding; durable disk queue.</td><td>Stop and delete the whole pipeline, including queued data and environment variables.</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <details>
+        <summary>Tests and verification assets that encode the current telemetry behavior</summary>
+        <div>
+          <ul class="files">
+            <li><code>src/CcDirector.Core.Tests/Account/AccountTelemetryClientTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Account/DevThrottleDirectorStartupTelemetryReporterTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Account/DevThrottleLoginTelemetryReporterTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Account/GatewayTelemetryConsentTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Account/TelemetrySettingsTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Account/UsageTelemetryTests.cs</code></li>
+            <li><code>src/CcDirector.Core.Tests/Configuration/TelemetryConsentConfigTests.cs</code></li>
+            <li><code>src/CcDirector.Gateway.Tests/DirectorStartupTelemetryEndpointTests.cs</code></li>
+            <li><code>src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs</code></li>
+            <li><code>src/CcDirector.Gateway.Tests/TelemetryConsentEndpointTests.cs</code></li>
+            <li><code>src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs</code></li>
+            <li><code>src/CcDirector.Gateway.Tests/TelemetryRetryQueueTests.cs</code></li>
+            <li><code>tools/cc-director-setup.Tests/TelemetryChoiceApplierTests.cs</code></li>
+            <li><code>tools/cc-director-setup.Tests/WizardStepFlowTests.cs</code></li>
+            <li><code>apps/cockpit/src/settings/settingsTabs.test.ts</code></li>
+            <li><code>scripts/test/drive-workstation-install.ps1</code></li>
+            <li><code>packages/client-core/browser-tests/snooze-presets-proof/harness-entry.tsx</code></li>
+          </ul>
+        </div>
+      </details>
+
+      <details>
+        <summary>Documentation and historical artifacts</summary>
+        <div>
+          <p>The active architectural source that most directly describes this system is <code>docs/architecture/GATEWAY_CENTRALIZATION_PLAN.md</code>. It documents the relay, startup event, two consent models, queue, and cloud endpoints and should be retired or rewritten.</p>
+          <p>Additional active plans/reviews mention telemetry consent, including <code>docs/plans/cc-devthrottle-installation-and-tool-healing-plan.md</code>, <code>docs/architecture/headless-gateway-mission-2026-07-14.md</code>, and Cockpit architecture/review documents. Historical proof under <code>docs/cencon/proof/issue-978</code>, <code>issue-979</code>, and <code>issue-1028</code> contains screenshots and route proofs. Remove telemetry claims from active and public documentation; ensure historical proof is not published as current product guidance.</p>
+          <p>A tracked lexical scan (excluding research, archived documents, and internal instruction directories) found 136 files containing “telemetry” or the usage-sharing phrases: 75 product-area files, 27 test files, and 34 documentation files. Many are false positives or separate local diagnostics, so a blind global delete is unsafe.</p>
+        </div>
+      </details>
+    </section>
+
+    <section id="platforms" class="card">
+      <h2>Windows and macOS</h2>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Platform</th><th>Consent screen</th><th>Startup event</th><th>Finding</th></tr></thead>
+          <tbody>
+            <tr><td>Windows</td><td><span class="badge b-active">Present</span> WPF setup/update wizard.</td><td><span class="badge b-active">Present</span> Shared Avalonia app.</td><td>Both the misleading page and active event need removal.</td></tr>
+            <tr><td>macOS</td><td><span class="badge b-dead">Not found</span> Mac installation is shell/app-bundle based; the WPF wizard is Windows-only.</td><td><span class="badge b-active">Present</span> Shared Avalonia app has no OS guard around startup reporting.</td><td>There is no page to remove, but telemetry code removal must be cross-platform.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p><code>scripts/local-build-mac.sh</code> also sets <code>DOTNET_CLI_TELEMETRY_OPTOUT=1</code>. That controls Microsoft’s .NET CLI telemetry during a local build; it is not DevThrottle telemetry and should remain.</p>
+    </section>
+
+    <section id="local-data" class="card">
+      <h2>Other code called “telemetry” that does not leave the Gateway</h2>
+      <p>The repository also uses “telemetry” for Gateway-local operational data. The confirmed rule is purpose-based: retain only data required to provide a user-facing local service, keep it local on self-hosted Gateways, and describe it as the feature’s history, statistics, or diagnostics—not as telemetry. Delete collection that has no continuing feature purpose.</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Store</th><th>Contents</th><th>Transmission</th><th>Confirmed treatment</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><code>TranscriptionTelemetryLog</code><br><code>transcription-log/transcription-YYYYMMDD.jsonl</code></td>
+              <td>Timing, model, audio size, errors, correction edits, and—by default—full raw and cleaned transcript text. Cockpit “Transcription Health” reads it.</td>
+              <td><span class="badge b-local">Gateway-local</span> The source explicitly says never sent.</td>
+              <td>Retain only the fields needed for the Transcription Health feature, keep them Gateway-local on self-hosted installs, and rename the implementation and documentation as transcription history/diagnostics. Define retention and user control; delete any fields that are not necessary for the feature.</td>
+            </tr>
+            <tr>
+              <td><code>CarModeTelemetryStore</code><br><code>carmode-telemetry.json</code><br><code>/carmode/telemetry*</code></td>
+              <td>Per-turn timings, counts, viewport measurements, playback state, version, and a 12-hex credential hash. No command or reply text.</td>
+              <td><span class="badge b-local">Gateway-local</span> Same-origin browser → Gateway only.</td>
+              <td>Keep only what the Car Mode diagnostics/performance feature needs, keep it Gateway-local on self-hosted installs, and rename the route, store, dashboard, types, and documentation. Delete the post/store/dashboard if that feature is retired.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout warnline"><strong>Do not mass-delete every “telemetry” string.</strong> Agent capability documentation describes third-party telemetry, the Mac build opts out of .NET CLI telemetry, and package lockfiles may name OpenTelemetry dependencies. Those references describe or disable external behavior and are not DevThrottle collection claims.</div>
+    </section>
+
+    <section id="removal" class="card">
+      <h2>Recommended removal issue scope</h2>
+      <div class="priority"><div class="pnum">P0</div><div><strong>Stop collection and forwarding first.</strong> Remove the startup call from <code>App.axaml.cs</code>; delete both reporter interfaces/implementations and environment overrides; remove login/startup Gateway routes; stop constructing/starting the queue; remove Gateway bearer attachment. Ensure any persisted queue cannot flush after upgrade.</div></div>
+      <div class="priority"><div class="pnum">P1</div><div><strong>Remove user-facing settings.</strong> Delete the Windows Privacy wizard step and its navigation/tests; remove the Cockpit telemetry card, old route redirect, tab alias, client module, and settings snapshot field. Keep or rename the Privacy tab only if Wingman training capture remains.</div></div>
+      <div class="priority"><div class="pnum">P2</div><div><strong>Remove settings and data at rest.</strong> Delete <code>telemetry.enabled</code>, top-level <code>telemetry_consent</code>, the Director consent cache, usage-event JSONL, and Gateway queue. Add a one-time, narrowly targeted migration/cleanup so upgrades do not leave the old settings or queued events behind.</div></div>
+      <div class="priority"><div class="pnum">P3</div><div><strong>Remove dormant code and contracts.</strong> Delete <code>UsageTelemetry</code>, <code>GatewayTelemetryConsent</code>, <code>TelemetryConsentConfig</code>, <code>AccountTelemetryClient</code>, DTOs, OpenAPI routes, and all behavior-specific tests. Regenerate <code>packages/client-core/src/api/schema.ts</code>.</div></div>
+      <div class="priority"><div class="pnum">P4</div><div><strong>Clean language and documentation.</strong> Rewrite or retire the centralization plan and active product docs. Rename the two retained local service-data systems as feature history/diagnostics, narrow them to feature-required fields, and document purpose, retention, user control, and the no-forwarding boundary. Keep historical proof out of current/public product guidance.</div></div>
+      <div class="priority"><div class="pnum">P5</div><div><strong>Coordinate the backend repository.</strong> This checkout references but does not implement <code>telemetry_enabled</code>, <code>/api/v1/account/telemetry</code>, and <code>/api/v1/telemetry/login</code>. Search the DevThrottle web/API repository for endpoint handlers, database columns, jobs, dashboards, retention, and existing rows before claiming telemetry has been fully removed.</div></div>
+
+      <h3>Upgrade-data handling</h3>
+      <ul>
+        <li>Delete only the exact known telemetry files/keys; never rewrite unrelated configuration sections.</li>
+        <li>Delete or quarantine <code>config/director/telemetry-queue.json</code> before any old flusher can start. Leaving it behind contradicts the promise because queued login events can be delivered later.</li>
+        <li>Remove <code>config/director/telemetry-consent-cache.json</code> and <code>config/director/devthrottle-usage-events.jsonl</code> if present.</li>
+        <li>Remove <code>telemetry.enabled</code> and <code>telemetry_consent</code> through the non-lossy configuration writer.</li>
+        <li>Do not attempt to erase ordinary application logs wholesale; document that older logs may contain prior startup-report lines, then set a retention decision.</li>
+      </ul>
+
+      <h3>Separate software-agreement issue</h3>
+      <p>Do not block telemetry removal on a replacement page. Track a separate issue such as <strong>“Add versioned software-agreement acceptance to setup”</strong>, with legal text/ownership, acceptance versioning, update behavior, offline behavior, and storage location defined before implementation. No GitHub issue was created during this review.</p>
+
+      <h3>Explicitly out of scope for deletion</h3>
+      <p>Normal service data is not telemetry merely because it crosses a network boundary. Prompts, audio, transcription requests, text-to-speech input, hosted-model calls, account operations, and device enrollment may continue when they are necessary to provide the feature the user invoked. They still require accurate privacy documentation and appropriate retention, but they are not controlled by—or justification for—a telemetry consent setting.</p>
+    </section>
+
+    <section id="acceptance" class="card">
+      <h2>Acceptance criteria for “remove telemetry”</h2>
+      <ol>
+        <li>Fresh install and update have no usage-sharing or telemetry step; the setup rail flows directly from Prerequisites to Skills (unless the future software-agreement issue changes the flow).</li>
+        <li>Cockpit has no usage-telemetry card, legacy <code>/telemetry</code> redirect, telemetry query alias, consent API call, or consent field in the general settings response.</li>
+        <li>No Director launch or sign-in code constructs or posts a telemetry event on Windows or macOS.</li>
+        <li>The Gateway exposes no <code>/telemetry/login</code>, <code>/telemetry/director-startup</code>, or <code>/gateway/telemetry-consent</code> route and starts no telemetry retry loop.</li>
+        <li>No configuration key, cache, usage-event sink, durable queue, telemetry DTO, or telemetry environment override remains.</li>
+        <li>An upgrade test seeds every known old key/file, runs the migration, proves those artifacts are gone, and proves unrelated configuration/data remains byte-for-byte or semantically intact.</li>
+        <li>A network-boundary test runs Director startup and sign-in against a recording HTTP handler and proves no telemetry request is attempted. Functional Gateway and hosted-service requests remain covered separately.</li>
+        <li>The backend repository independently removes or decommissions the referenced account/login telemetry endpoints, storage, dashboards, and historical retention.</li>
+        <li>Active documentation no longer says DevThrottle collects, shares, stores, forwards, or offers consent for usage telemetry. Third-party opt-out/reference documentation remains accurate.</li>
+        <li>The two Gateway-local systems currently named telemetry retain only feature-required data, are renamed/reclassified as local service history or diagnostics, have purpose/retention/user control documented, and have tests proving a self-hosted Gateway does not forward them to DevThrottle.</li>
+      </ol>
+    </section>
+
+    <section class="card">
+      <h2>Review method and limits</h2>
+      <p>This was a static, read-only audit of tracked source, tests, setup tooling, Cockpit/client code, Gateway code, schemas, and documentation in <code>D:\ReposFred\devthrottle</code> at the commit shown above. The supplied screenshot was matched to <code>tools/cc-director-setup/Steps/PrivacyStep.xaml</code>. Production call sites were distinguished from test-only and dormant library code by searching constructors, interface use, route mapping, and <code>Record</code>/report invocations.</p>
+      <p>The external DevThrottle web/API backend is not present in this checkout, so its current storage and endpoint implementation could not be verified here. Runtime packet capture was not required to establish the source paths, but the follow-up issue should add a recording-handler or integration proof before closure.</p>
+    </section>
+
+    <p class="footer">Confirmed implementation direction and source evidence for the telemetry-removal issue. This document update did not change product behavior.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Twelve documents written between 20 and 28 July that were never added to git. They existed in one working tree and nowhere else - not on GitHub, invisible to every other session, and one `git clean` from gone.

Found during a repository hygiene pass. Documentation only; no code changes.

## What is here

| Document | Why it is worth keeping |
|---|---|
| `architecture/multi-tenant-gateway-architecture-2026-07-21.html` | The architecture of the hosted multi-tenant Gateway |
| `architecture/multi-tenant-gateway-architecture-reference-2026-07-21.html` | A second, genuinely different architecture reference - the two differ by 1672 lines, verified, not a duplicate. **Moved** here from `docs/reviews/`, because a reference is not a review |
| `reviews/multi-tenant-gateway-code-review-2026-07-20.html` | The original isolation code review |
| `reviews/multi-tenant-gateway-code-review-2026-07-21.html` | The refresh after an isolation wave. It explicitly corrects the previous day's framing, so both are needed to read either |
| `reviews/telemetry-removal-audit-2026-07-22.html` | An audit **and a confirmed policy**. A policy record should not live untracked |
| `reviews/hosted-settings-per-tenant-qa-2026-07-22.html` | QA report for issue 2017 |
| `architecture/hosted-settings-redesign-2026-07-22.html` | What the Settings page should be on a hosted Gateway |
| `architecture/shared-workflow-library-plan-2026-07-24.html` | Architecture and implementation plan |
| `architecture/gateway-skill-library-mockups-2026-07-28.html` | Mockup screens for the skill library, currently being built |
| `HANDOVER-driver-activity-ledger-and-semantic-working-2026-07-24.md` | Named a handover, but it is not one - it states it is design and incident investigation only, with implementation still owed. Unimplemented design, not a session note |
| `MISSION-cockpit-fix-2026-07-23.md` | Mission brief |
| `MISSION-source-control-tab-2026-07-23.md` | Mission brief |

## What was deliberately left out

Three session handover notes, for work that has since shipped. A handover exists to move work from one session to another; once the work is merged its job is done. They are transient by design and are not worth carrying in the repository.

Two documents written this morning were also left alone, because the sessions that wrote them are still working.

## Checks

Scanned for credentials, keys, email addresses and assistant attribution before pushing, since this repository is public and design documents in this fleet have carried a machine password before. Clean.