### PR TITLE
Document skills: how they are downloaded and where they land

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -648,6 +648,11 @@ COMMANDS:
   session spawn    Open a new session on the local Director.
   message send     Send a message to one session, or broadcast with all.
   message ask      Ask one session a question and print its answer.
+  skill list       List every skill in the fleet library.
+  skill get        Print a skill in full, ready to follow.
+  skill pull       Pull a skill into a directory for editing.
+  skill push       Push a directory back as the skill's draft.
+  skill publish    Publish a draft - live fleet-wide, immediately.
   settings show    Display current settings.
   settings get     Get a specific setting value.
   settings set     Set a configuration value.
@@ -745,6 +750,70 @@ OPTIONS:
 
 Prints the new session's short id and full GUID; the session then appears in
 `cc-devthrottle session list`. A non-existent repository path exits non-zero with a clear error.
+
+### Skill Commands
+
+Read and author the fleet's skills. A skill is a directory in the Agent Skills standard - `SKILL.md`
+at its root plus any files it needs - held centrally on the Gateway and placed on each machine where
+every agent already looks. Publishing makes a skill live across the whole fleet immediately.
+
+```
+USAGE: cc-devthrottle skill COMMAND [ARGS]...
+
+COMMANDS:
+  list      List every skill in the library.
+  get       Print a skill in full - the body an agent follows.
+  show      Show one skill's register entry.
+  versions  List a skill's versions.
+  pull      Write a skill into a directory for editing.
+  push      Send a directory back as the skill's DRAFT.
+  publish   Publish the draft - live for every agent on every machine.
+  clone     Copy a skill under a new id (how a built-in is customised).
+  enable    Switch a skill on for the fleet.
+  disable   Switch a skill off - it is removed from disk on the next session launch.
+  delete    Delete a skill.
+```
+
+```
+USAGE: cc-devthrottle skill get ID [OPTIONS]
+
+ARGUMENTS:
+  ID  The skill id, for example move-session [required]
+
+OPTIONS:
+  --version INTEGER  A specific version instead of the published one
+```
+
+There is no offline fallback, deliberately: `skill get` resolves the current published version from
+the Gateway every time, and fails plainly if the Gateway cannot be reached. A stale skill that looks
+current is worse than a missing one that announces itself.
+
+```
+USAGE: cc-devthrottle skill pull ID --dir DIRECTORY [OPTIONS]
+USAGE: cc-devthrottle skill push ID --dir DIRECTORY [OPTIONS]
+
+OPTIONS (pull):
+  --dir     -d  Directory to write the skill into [required]
+  --version     A specific version instead of the published one
+
+OPTIONS (push):
+  --dir     -d  Directory holding the skill files [required]
+  --note    -n  One line on what changed
+  --force       Push even though the copy is stale
+```
+
+A pull writes an authoring directory:
+
+| File | Holds |
+|---|---|
+| `skill.json` | The register metadata - id, name, summary, triggers, the standard's frontmatter fields, and which files are executable |
+| `SKILL.md` | The body an agent reads |
+| Everything else | The supporting files, each at its own relative path (`references/tracing.md` is a file `tracing.md` inside a `references` directory) |
+| `.skill-hash` | Written by pull, sent back on push so a stale copy is refused rather than clobbering a concurrent author |
+
+A push sends text as text and everything else base64-encoded, so an image, an archive or a compiled
+program survives the round trip byte for byte. A push updates the DRAFT only - no agent sees it until
+`skill publish`.
 
 ### Selftest
 

--- a/docs/public/features/09-skills.md
+++ b/docs/public/features/09-skills.md
@@ -1,0 +1,133 @@
+# Skills
+
+**A skill is a folder of instructions an agent can pick up and follow. DevThrottle
+holds your skills centrally, downloads them to each machine while it runs, and
+writes them where every agent already looks - so a skill is fixed once and is
+live everywhere, on every agent, with nothing for you to install or update.**
+
+You manage them in the Cockpit under **Skills**.
+
+## What a skill is
+
+A skill is a directory with a `SKILL.md` file at its root, plus any files it
+needs - reference notes, scripts, images, data files, whole subdirectories. That
+shape is not ours. It is the Agent Skills open standard, and every agent
+DevThrottle runs reads exactly the same directory, byte for byte.
+
+This is the single most useful fact about skills: **there is no per-agent
+format**. One skill works in Claude Code, Codex, Gemini, Grok, pi, Copilot,
+Cursor and opencode without being converted, adapted or duplicated. The only
+thing that differs between agents is which folder the directory has to appear in,
+and DevThrottle handles that for you.
+
+A skill may carry real programs, not just prose. Files can be binary, and a file
+can be marked executable so a script in a skill actually runs. That is the point
+of downloading them at all: a skill that carries Python or a command-line program
+cannot be run from a website.
+
+## How your agents get them
+
+Two separate steps, deliberately kept apart so that nothing to do with the
+network can ever slow down or block a session starting.
+
+**Step one - DevThrottle downloads them.** As soon as DevThrottle connects to the
+Gateway, and about once a minute for as long as it is running, it fetches every
+skill you have switched on and stores it on the machine. This happens quietly in
+the background, nowhere near your sessions.
+
+**Step two - DevThrottle puts them where the agent looks.** When a session
+starts, the stored skills are written into the folders that session's agent
+reads. This step never touches the network, so it cannot delay a launch. If the
+Gateway is unreachable, the session still starts, using whatever the last
+download brought down.
+
+The practical result: **a session opens with skills that are at most about a
+minute old.**
+
+## Where they land on your disk
+
+Every skill is written **once**, into `~/.agents/skills` - the shared folder that
+the agent ecosystem standardised on.
+
+| Agent | Reads `~/.agents/skills` | What DevThrottle does |
+|---|---|---|
+| Codex | Yes | Nothing - it finds the folder on its own |
+| Gemini | Yes | Nothing |
+| Grok | Yes | Nothing |
+| pi | Yes | Nothing |
+| Copilot | Yes | Nothing |
+| opencode | Yes | Nothing |
+| Claude Code | No | One shortcut per skill into `~/.claude/skills` |
+| Cursor | Not documented | One shortcut per skill into `~/.cursor/skills` |
+
+Six of the eight need no configuration whatsoever. Claude Code does not read the
+shared folder - the request for it to do so is open and unshipped - and Cursor
+does not document doing so, so each skill also gets a shortcut in their own
+folder pointing at the same single copy.
+
+The shortcut is a directory junction on Windows and an ordinary symbolic link on
+Linux and macOS. Neither needs administrator rights. It matters that these are
+shortcuts and not second copies: **there is only ever one real copy of a skill on
+your machine, so there is nothing that can quietly drift out of step.**
+
+Skills are written under your home folder, never into the repository you are
+working in, so they never appear as untracked files in your working trees. The
+consequence is worth knowing: a downloaded skill is visible to every session on
+that machine, including sessions DevThrottle did not start.
+
+## Your own skills are never touched
+
+The central library is an **additional** source of skills, not a replacement.
+
+- A skill of your own in `~/.claude/skills` or in a repository's `.claude/skills`
+  keeps working exactly as it did.
+- If one of your skills has the same name as a central one, **yours wins.**
+  DevThrottle leaves it alone and records that it did.
+- DevThrottle marks everything it writes and only ever changes or removes its own
+  entries. It never replaces your skills folder itself.
+
+## Switching one off actually removes it
+
+DevThrottle matches what is on the machine to what the Gateway is currently
+serving, rather than adding to what is already there. So a skill you switch off,
+archive or delete in the Cockpit is **removed from disk** the next time a session
+starts on that machine.
+
+This is the reason skills are held centrally in the first place. A withdrawn
+instruction that keeps working from a leftover file on one machine is exactly the
+failure a central library exists to prevent.
+
+## What the agent is told at startup
+
+Your agents do not receive the full text of every skill - that would be a large
+tax on every session for capabilities most sessions never use. They receive one
+line per skill: its name and a one-line summary. The agent reads a skill's actual
+instructions only when it decides the skill is relevant to what you have asked.
+
+This is the progressive disclosure the standard specifies, and it is why a
+skill's summary is worth writing carefully: it is the only part every session
+pays for.
+
+## Writing and changing skills
+
+Two ways in, both producing the same thing:
+
+- **In the Cockpit**, under Skills: create a skill, add files and folders, edit
+  text in the browser, upload a binary, and publish.
+- **From the command line**, with `cc-devthrottle skill pull`, `push` and
+  `publish`. An agent can author a skill and publish it to your library itself.
+
+Drafts are private to you. Publishing makes a skill live across your whole fleet
+immediately - no release, and nothing to update on any machine.
+
+Built-in skills are read-only. To change one, clone it and edit your copy.
+
+## If a skill does not appear
+
+- **Is DevThrottle running and connected to the Gateway?** The download happens
+  in DevThrottle, so a machine where it is not running gets nothing new.
+- **Is the skill switched on?** Only enabled skills are downloaded.
+- **Did the session start before the skill was published?** Skills are placed at
+  session start. Start a new session and it will have it.
+- **Do you already have a skill of that name?** Yours wins, deliberately. Rename
+  one of them if you want both.

--- a/docs/public/index.json
+++ b/docs/public/index.json
@@ -31,7 +31,8 @@
         { "id": "wingman-and-voice", "title": "Wingman and Voice", "file": "features/05-wingman-and-voice.md" },
         { "id": "mobile", "title": "Mobile and In-Car", "file": "features/06-mobile.md" },
         { "id": "dialogs", "title": "Key Dialogs", "file": "features/07-dialogs.md" },
-        { "id": "injected-text", "title": "Injected Text", "file": "features/08-injected-text.md" }
+        { "id": "injected-text", "title": "Injected Text", "file": "features/08-injected-text.md" },
+        { "id": "skills", "title": "Skills", "file": "features/09-skills.md" }
       ]
     },
     {


### PR DESCRIPTION
## Why

The published documentation has **no Skills page at all**. The Features category carries eight pages - sessions, source control, panels, Wingman, mobile, dialogs, injected text - and not one of them covers the skill library. A user's only source was a single paragraph inside Installation plus a few release-note lines. The command line reference did not list the skill commands either.

The feature has been shipping for a while. This is the first page that explains it.

## What the page covers

- **What a skill is** - a directory in the Agent Skills standard, and the fact that one artifact serves all eight agent families with no per-agent format.
- **How the download works** - the two steps, kept apart deliberately: the Gateway fetch on connect and about once a minute after, nowhere near a session; then placement on disk at session launch, with no network call so it cannot slow or block a launch.
- **Where the files land** - once into `~/.agents/skills`, with a per-agent table showing which six need nothing at all and which two get a shortcut into their own folder.
- **That a machine's own skills always win and are never touched.**
- **That switching a skill off removes it from disk** rather than leaving it working from a leftover file.
- **What the agent is actually told** at startup - one line per skill, body read on use.
- **How to author one**, from the Cockpit or the command line, and a short "if a skill does not appear" section.

The command line reference gains the `cc-devthrottle skill` commands and the authoring directory layout, both missing entirely.

## Note on ordering

`docs/public/getting-started/02-installation.md` said "The installer places no skill files on your machine", which stopped being accurate once the Director began writing them. That sentence is corrected in #2260, which also lands the placement change this page describes.
