### PR TITLE
Onboarding wizard: connect the gateway first, stop the wizard making claims it cannot keep

### DIFF
--- a/docs/architecture/onboarding-design-fixes-2026-07-29.html
+++ b/docs/architecture/onboarding-design-fixes-2026-07-29.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Onboarding wizard - design fixes</title>
+<style>
+  :root{
+    --ink:#16181D; --muted:#5A616B; --faint:#8A909A; --line:#E6E8EC;
+    --accent:#0066B8; --accent-soft:#F2F8FD; --paper:#FFFFFF; --wash:#F5F6F8;
+    --green:#1A7F37; --green-bg:#E5F3E9; --red:#DC2626; --red-bg:#FDECEC;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:#F0F2F5;color:var(--ink);
+    font-family:Inter,"Segoe UI",system-ui,sans-serif;font-size:15px;line-height:1.62}
+  .wrap{max-width:1180px;margin:0 auto;padding:0 24px 90px}
+  header.mast{background:var(--paper);border-bottom:1px solid var(--line);padding:44px 24px 34px;margin-bottom:34px}
+  header.mast .in{max-width:1180px;margin:0 auto}
+  .eyebrow{color:var(--accent);font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;margin:0 0 10px}
+  h1{font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;font-size:36px;line-height:1.15;margin:0 0 14px}
+  .stand{font-size:17px;color:var(--muted);max-width:820px;margin:0}
+  .meta{margin-top:18px;font-size:13px;color:var(--faint)}
+  h2{font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;font-size:26px;margin:52px 0 6px}
+  h2 .n{color:var(--accent);margin-right:10px}
+  h3{font-size:17px;margin:26px 0 8px}
+  h4{font-size:13px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;color:var(--faint);margin:0 0 10px}
+  p{margin:0 0 14px}
+  .lede{font-size:16px;color:var(--muted);max-width:860px;margin:0 0 20px}
+  .why{background:var(--wash);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:0 10px 10px 0;padding:15px 19px;margin:16px 0}
+  .why p:last-child{margin:0}
+  ul.t{margin:0 0 14px;padding-left:20px} ul.t li{margin:6px 0}
+  table{border-collapse:collapse;width:100%;font-size:14px;margin:12px 0}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-size:12px;text-transform:uppercase;letter-spacing:.6px;color:var(--faint);border-bottom:2px solid var(--line)}
+  .tw{overflow-x:auto}
+
+  .pair{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin:22px 0 8px}
+  @media (max-width:1000px){.pair{grid-template-columns:1fr}}
+  .pane h4{display:flex;align-items:center;gap:9px}
+  .tag{font-size:10px;padding:2px 8px;border-radius:999px;letter-spacing:.5px}
+  .tag.now{background:var(--red-bg);color:var(--red)}
+  .tag.next{background:var(--green-bg);color:var(--green)}
+
+  .win{background:var(--paper);border:1px solid #CFD4DB;border-radius:10px;overflow:hidden;
+    box-shadow:0 3px 14px rgba(20,25,35,.09)}
+  .win .tb{background:#EDEFF2;border-bottom:1px solid var(--line);padding:7px 12px;font-size:11.5px;
+    color:var(--muted);display:flex;justify-content:space-between}
+  .win .bd{padding:20px 24px 16px;height:352px;display:flex;flex-direction:column}
+  .dots{display:flex;gap:7px;justify-content:center;align-items:center;margin:2px 0 18px}
+  .dots i{width:7px;height:7px;border-radius:999px;background:var(--line);display:block}
+  .dots i.past{background:#9FC4E3} .dots i.cur{background:var(--accent)}
+  .dots b{font-size:10.5px;color:var(--faint);font-weight:600;margin-left:9px}
+  .dots i.nav{cursor:pointer;box-shadow:0 0 0 3px rgba(0,102,184,.12)}
+
+  .w-eye{color:var(--accent);font-size:9.5px;font-weight:700;letter-spacing:2px;text-align:center;margin:0 0 6px}
+  .w-t{font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;font-weight:700;
+    text-align:center;margin:0 0 8px;line-height:1.2;font-size:22px}
+  .w-t.step{font-size:16.5px}
+  .w-s{font-size:12px;color:var(--muted);text-align:center;max-width:400px;margin:0 auto 12px;line-height:1.5}
+  .w-s.tight{max-width:430px;margin-bottom:10px}
+
+  .list{flex:1;min-height:0;overflow:hidden;position:relative}
+  .list.gut{padding-right:12px}
+  .list.fade:before{content:"";position:absolute;top:0;left:0;right:12px;height:16px;
+    background:linear-gradient(#fff,rgba(255,255,255,0));z-index:2;pointer-events:none}
+  .sb{position:absolute;top:0;right:0;width:5px;bottom:0;background:var(--line);border-radius:999px}
+  .sb i{position:absolute;top:6%;height:34%;left:0;right:0;background:#B9C0C9;border-radius:999px;display:block}
+  .sb.inside{right:16px;width:9px;background:#3a3a3a}
+  .sb.inside i{background:#7a7a7a}
+
+  .row{border:1px solid var(--line);border-radius:9px;padding:9px 12px;display:flex;align-items:center;
+    justify-content:space-between;gap:12px;margin-bottom:6px;background:var(--paper)}
+  .row .rn{font-size:12px;font-weight:650;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row .rs{font-size:10px;color:var(--faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row.clip{margin-top:-16px;opacity:.55}
+  .pill{font-size:9.5px;font-weight:700;padding:3px 9px;border-radius:999px;white-space:nowrap;
+    background:var(--wash);color:var(--faint)}
+  .pill.ready{background:var(--green-bg);color:var(--green)}
+  .pill.work{background:var(--accent-soft);color:var(--accent)}
+  .pill.fail{background:var(--red-bg);color:var(--red)}
+  .cnt{font-size:10.5px;color:var(--faint);white-space:nowrap}
+  .btn{font-size:10.5px;padding:4px 11px;border:1px solid var(--line);border-radius:7px;background:var(--wash);white-space:nowrap}
+
+  .foot{border-top:1px solid var(--line);margin-top:12px;padding-top:11px;display:flex;
+    align-items:center;justify-content:space-between;gap:12px}
+  .foot .bk{font-size:11.5px;color:var(--muted)}
+  .foot .nt{font-size:10px;color:var(--faint);text-align:right;flex:1}
+  .cta{background:var(--accent);color:#fff;font-size:12px;font-weight:650;padding:8px 18px;border-radius:8px;white-space:nowrap}
+  .total{text-align:center;margin-top:8px}
+  .total b{font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;font-size:24px;display:block}
+  .total span{font-size:10px;color:var(--faint)}
+  code{background:var(--wash);padding:2px 6px;border-radius:4px;font-size:12.5px}
+  footer.end{margin-top:56px;padding-top:22px;border-top:1px solid var(--line);font-size:13px;color:var(--faint)}
+</style>
+</head>
+<body>
+
+<header class="mast">
+  <div class="in">
+    <p class="eyebrow">DevThrottle - onboarding</p>
+    <h1>Design fixes, with mockups</h1>
+    <p class="stand">
+      Six changes, critiqued against the wizard's own visual system rather than a new one: white paper,
+      #16181D ink, #0066B8 accent, a Segoe UI Variable Display hero. Nothing here changes the brand -
+      it fixes where the implementation outgrew the room it was designed for.
+    </p>
+    <p class="meta">29 July 2026 &nbsp;|&nbsp; Step order as shipped in the test build:
+      Welcome, Gateway, Agents, Tools, Code, Screenshots, Done</p>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <h2><span class="n">1</span>A second title size for the working steps</h2>
+
+  <p class="lede">
+    This is the root cause of most of the rest, so it goes first. Every step spends the same budget -
+    a 32 point hero, a three or four line subtitle, generous margins - and then hands whatever survives
+    to a scrolling list. At the default 900x640 there is very little left.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now <span class="tag now">as shipped</span></h4>
+      <div class="win"><div class="tb"><span>Set up DevThrottle</span><span>x</span></div><div class="bd">
+        <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i></div>
+        <div class="w-eye">WHAT WE WATCH OVER</div>
+        <div class="w-t">Where does your code live?</div>
+        <div class="w-s">Anything we find is added for you, so DevThrottle can offer it when you start
+          an agent. Remove any you would rather it left alone.</div>
+        <div class="list">
+          <div class="sb inside"><i></i></div>
+          <div class="row clip"><div><div class="rn">C:\Repos</div></div></div>
+          <div class="row"><div><div class="rn">C:\ReposBPMN</div><div class="rs">1 git repository</div></div><span class="btn">Remove</span></div>
+          <div class="row"><div><div class="rn">C:\ReposFred</div><div class="rs">3 git repositories</div></div><span class="btn">Remove</span></div>
+        </div>
+        <div class="total"><b>70</b><span>repositories across these 8 folders</span></div>
+        <div class="foot"><span class="bk">Back</span><span class="nt"></span><span class="cta">Looks right</span></div>
+      </div></div>
+      <p style="font-size:12.5px;color:var(--faint);margin-top:9px">
+        Two and a half of eight folders visible. The total is correct but cannot be checked against
+        the rows that make it.
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed <span class="tag next">step type scale</span></h4>
+      <div class="win"><div class="tb"><span>Set up DevThrottle</span><span>x</span></div><div class="bd">
+        <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><b>Step 5 of 7 - Your code</b></div>
+        <div class="w-eye">WHAT WE WATCH OVER</div>
+        <div class="w-t step">Where does your code live?</div>
+        <div class="w-s tight">Anything we find is added for you. Remove any you would rather DevThrottle left alone.</div>
+        <div class="list gut fade">
+          <div class="sb"><i></i></div>
+          <div class="row"><div><div class="rn">C:\Repos</div><div class="rs">12 git repositories</div></div><span class="btn">Remove</span></div>
+          <div class="row"><div><div class="rn">C:\ReposBPMN</div><div class="rs">1 git repository</div></div><span class="btn">Remove</span></div>
+          <div class="row"><div><div class="rn">C:\ReposFred</div><div class="rs">3 git repositories</div></div><span class="btn">Remove</span></div>
+          <div class="row"><div><div class="rn">D:\Dev</div><div class="rs">1 git repository</div></div><span class="btn">Remove</span></div>
+          <div class="row"><div><div class="rn">D:\ReposFred</div><div class="rs">14 git repositories</div></div><span class="btn">Remove</span></div>
+        </div>
+        <div class="total"><b>70</b><span>repositories across these 8 folders</span></div>
+        <div class="foot"><span class="bk">Back</span><span class="nt"></span><span class="cta">Looks right</span></div>
+      </div></div>
+      <p style="font-size:12.5px;color:var(--faint);margin-top:9px">
+        Same window, same content, five folders visible instead of two and a half.
+      </p>
+    </div>
+  </div>
+
+  <div class="why">
+    <h4>What changes</h4>
+    <p>
+      Two title sizes instead of one. <strong>Hero</strong> at 32 point stays on Welcome and Done -
+      the two screens that are mostly words and deserve the presence. <strong>Step</strong> at 24 point
+      for the five working screens, where the title is a label above a list and does not need to
+      dominate. Subtitles on working steps get a two-line cap: if the sentence will not fit in two
+      lines it is too long for a screen whose job is the list underneath.
+    </p>
+    <p>
+      It is the least glamorous item here and by far the highest return - it buys back roughly a third
+      of the content area on every step that has a list, which is five of the seven.
+    </p>
+  </div>
+
+  <h2><span class="n">2</span>Give the scrollbar its own gutter, and make clipping look deliberate</h2>
+
+  <p class="lede">
+    On Tools and Code the scroll thumb currently sits inside the card area and overlaps the row edges,
+    and a half-cut row at the top reads as a rendering fault rather than as "there is more above".
+  </p>
+
+  <div class="why">
+    <h4>What changes</h4>
+    <ul class="t">
+      <li>The list reserves a 12 pixel gutter, so the thumb never overlaps a card.</li>
+      <li>A short white fade at the top edge, so a partially visible row reads as scrolled rather than broken.</li>
+      <li>A thinner, lighter thumb - the current one is heavier than anything else on a very light screen, so it pulls the eye to the least important thing on the page.</li>
+    </ul>
+    <p>Shown in the right-hand mockup above. Cheap, and it removes the only place in the wizard that
+      currently looks like a bug rather than a design.</p>
+  </div>
+
+  <h2><span class="n">3</span>Settle the pill vocabulary</h2>
+
+  <p class="lede">
+    One component is now saying thirteen different things in four colours, with three separate greens
+    that mean three separate things. It has outgrown what a single status chip should carry.
+  </p>
+
+  <div class="tw">
+  <table>
+    <thead><tr><th style="width:210px">Today</th><th style="width:150px">Becomes</th><th>Rule</th></tr></thead>
+    <tbody>
+      <tr><td>Ready, In list, Done, Connected, Added</td><td><span class="pill ready">Ready</span></td><td>Green. It works and there is nothing to do. One word, one colour, everywhere.</td></tr>
+      <tr><td>Installing..., Checking</td><td><span class="pill work">Working</span></td><td>Blue. Something is happening right now and will finish on its own.</td></tr>
+      <tr><td>Not installed, Failed</td><td><span class="pill fail">Needs you</span></td><td>Red. It will not resolve itself - and a red pill must always be next to an action that fixes it.</td></tr>
+      <tr><td>Not found, Later, None, Unchanged</td><td><span class="pill">Not set up</span></td><td>Grey. Absent, optional, no action implied.</td></tr>
+      <tr><td>2 set up, 12 repositories, 9 ready</td><td><span class="cnt">12 repositories</span></td><td>Not a pill at all. A count is information, not a status - it becomes plain right-aligned text.</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="why">
+    <p>
+      The rule worth keeping afterwards: <strong>a pill says what state a row is in, never how many of
+      something there are</strong>, and red is reserved for states the user has to act on. That last
+      part is what stops the Tools screen from crying wolf.
+    </p>
+  </div>
+
+  <h2><span class="n">4</span>Make the progress dots say something</h2>
+
+  <p class="lede">
+    Seven identical dots tell you position and nothing else - not what the steps are, not how far the
+    one you want is, and they cannot be clicked.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now <span class="tag now">as shipped</span></h4>
+      <div class="win"><div class="tb"><span>Set up DevThrottle</span><span>x</span></div><div class="bd">
+        <div class="dots"><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i></div>
+        <div class="w-eye">YOUR TOOLBELT</div>
+        <div class="w-t">9 tools, maintained for you</div>
+        <div class="w-s">DevThrottle ships command tools you and your agents use every day - and it
+          installs and updates them itself.</div>
+        <div style="flex:1"></div>
+        <div class="foot"><span class="bk">Back</span><span class="nt"></span><span class="cta">Continue</span></div>
+      </div></div>
+    </div>
+    <div class="pane">
+      <h4>Proposed - review run <span class="tag next">navigable</span></h4>
+      <div class="win"><div class="tb"><span>Review your DevThrottle setup</span><span>x</span></div><div class="bd">
+        <div class="dots"><i class="past nav"></i><i class="past nav"></i><i class="cur nav"></i><i class="nav"></i><i class="nav"></i><i class="nav"></i><i class="nav"></i><b>Step 4 of 7 - Tools</b></div>
+        <div class="w-eye">YOUR TOOLBELT</div>
+        <div class="w-t step">9 tools, maintained for you</div>
+        <div class="w-s tight">Installed and updated for you. You never run an updater.</div>
+        <div class="list gut">
+          <div class="row"><div><div class="rn">cc-outlook</div><div class="rs">Read and send mail from an agent</div></div><span class="pill ready">Ready</span></div>
+          <div class="row"><div><div class="rn">cc-vault</div><div class="rs">The personal knowledge store</div></div><span class="pill ready">Ready</span></div>
+          <div class="row"><div><div class="rn">cc-pdf</div><div class="rs">Turn markdown into a PDF</div></div><span class="pill ready">Ready</span></div>
+        </div>
+        <div class="foot"><span class="bk">Back</span><span class="nt">Jump to any step</span><span class="cta">Continue</span></div>
+      </div></div>
+    </div>
+  </div>
+
+  <div class="why">
+    <h4>What changes</h4>
+    <ul class="t">
+      <li>The current step is named beside the dots - <code>Step 4 of 7 - Tools</code> - so position
+        stops being a guess.</li>
+      <li><strong>On a review run the dots become clickable</strong>, so someone who opened the wizard
+        from Settings to change one thing goes straight there.</li>
+      <li>On a first run they stay indicators only. A first-timer should walk the path; letting them
+        skip ahead to a step whose answer depends on an earlier one is how you get a half-configured
+        machine.</li>
+    </ul>
+    <p>
+      This is the item with real user value rather than tidiness, and it is the one that needs your
+      call: it is only worth building if you agree a review run should let you jump.
+    </p>
+  </div>
+
+  <h2><span class="n">5</span>Re-word the eyebrows for the new order</h2>
+
+  <p class="lede">
+    My doing. The beats were written as an arc, and moving the gateway to the front broke it - the
+    wizard now opens on the payoff, before the user has a single agent.
+  </p>
+
+  <div class="tw">
+  <table>
+    <thead><tr><th style="width:90px">Step</th><th style="width:230px">Now (arc broken)</th><th style="width:230px">Proposed</th><th>Why</th></tr></thead>
+    <tbody>
+      <tr><td>Gateway</td><td>WITH YOU EVERYWHERE</td><td>YOUR ACCOUNT</td><td>It is the first thing asked, and it is about who you are, not yet about what you get.</td></tr>
+      <tr><td>Agents</td><td>YOUR WORKFORCE</td><td>YOUR WORKFORCE</td><td>Unchanged.</td></tr>
+      <tr><td>Tools</td><td>YOUR TOOLBELT</td><td>YOUR TOOLBELT</td><td>Unchanged.</td></tr>
+      <tr><td>Code</td><td>WHAT WE WATCH OVER</td><td>WHAT WE WATCH OVER</td><td>Unchanged.</td></tr>
+      <tr><td>Screenshots</td><td>SHOW, DON'T TYPE</td><td>SHOW, DON'T TYPE</td><td>Unchanged.</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="why">
+    <p>
+      One word changes and the arc reads again: <strong>your account, your workforce, your toolbelt,
+      what we watch over, show don't type</strong> - a possessive sequence that builds from who you are
+      to what you can do. "With you everywhere" was the right beat for a step that came fifth; it is
+      the wrong one for a step that comes first.
+    </p>
+    <p>
+      The alternative is dropping the eyebrows entirely. I would not - they are the only thing giving
+      the seven screens a shape rather than making them feel like a form.
+    </p>
+  </div>
+
+  <h2><span class="n">6</span>Balance the Done footer</h2>
+
+  <p class="lede">
+    Done puts its two actions in the content panel, so its footer has "Back" on the left, a note on the
+    right, and a hole where every other screen has its primary button. It is the last thing a new user
+    sees, and it is the one screen where the furniture does not match.
+  </p>
+
+  <div class="why">
+    <h4>What changes</h4>
+    <p>
+      Move the finish actions into the footer where every other step keeps them - primary right, the
+      quiet alternative beside it - and let the receipt have the whole content area. That also gives
+      the receipt back the vertical room it is currently short of, which is the same problem as item 1.
+    </p>
+  </div>
+
+  <h2><span class="n">7</span>What I would do, and what I would not</h2>
+
+  <div class="tw">
+  <table>
+    <thead><tr><th style="width:44px">#</th><th>Change</th><th style="width:120px">Size</th><th style="width:150px">Needs you?</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>Second title size and two-line subtitle cap on the five working steps</td><td>An hour</td><td>No</td></tr>
+      <tr><td>2</td><td>Scrollbar gutter, top fade, lighter thumb</td><td>An hour</td><td>No</td></tr>
+      <tr><td>5</td><td>One eyebrow re-worded</td><td>Minutes</td><td>No</td></tr>
+      <tr><td>6</td><td>Done footer matches the other steps</td><td>An hour</td><td>No</td></tr>
+      <tr><td>3</td><td>Settle the pill vocabulary across every step</td><td>Half a day</td><td>Confirm the four states</td></tr>
+      <tr><td>4</td><td>Named step in the dots, clickable on a review run</td><td>Half a day</td><td>Yes - should a review run let you jump?</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="why">
+    <p>
+      <strong>What I deliberately did not propose.</strong> No new palette, no new typeface, no
+      restyled buttons or cards. The wizard's visual system is settled and it is fine; every problem
+      above is the implementation outgrowing the space it was drawn for, not the design being wrong.
+      Changing the look now would be a way of appearing to fix something while leaving the actual
+      defects - three of eight rows visible, a scrollbar over the content, and a status chip saying
+      thirteen things - exactly where they are.
+    </p>
+  </div>
+
+  <footer class="end">
+    Mockups are proposals drawn to the wizard's own system, not screenshots of a build. Items 1, 2, 5
+    and 6 are ready to implement on your word; 3 and 4 need a decision first.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/architecture/onboarding-pills-and-dots-2026-07-29.html
+++ b/docs/architecture/onboarding-pills-and-dots-2026-07-29.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pills and dots</title>
+<style>
+  :root{--ink:#16181D;--muted:#5A616B;--faint:#8A909A;--line:#E6E8EC;--accent:#0066B8;
+        --soft:#F2F8FD;--wash:#F5F6F8;--green:#1A7F37;--green-bg:#E5F3E9;--red:#DC2626;--red-bg:#FDECEC}
+  *{box-sizing:border-box}
+  body{margin:0;background:#F0F2F5;color:var(--ink);font-family:Inter,"Segoe UI",system-ui,sans-serif;font-size:15px;line-height:1.6}
+  .wrap{max-width:1060px;margin:0 auto;padding:32px 24px 70px}
+  h1{font-family:"Segoe UI Variable Display","Segoe UI",Inter;font-size:29px;margin:0 0 8px}
+  h2{font-family:"Segoe UI Variable Display","Segoe UI",Inter;font-size:21px;margin:40px 0 8px}
+  h2 .n{color:var(--accent);margin-right:9px}
+  p{margin:0 0 13px} .stand{font-size:16px;color:var(--muted);max-width:760px}
+  table{border-collapse:collapse;width:100%;font-size:14px;margin:12px 0}
+  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:middle}
+  th{font-size:11.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--faint);border-bottom:2px solid var(--line)}
+  .pill{display:inline-block;font-size:10px;font-weight:700;padding:3px 10px;border-radius:999px;
+        background:var(--wash);color:var(--faint);white-space:nowrap;margin:2px 3px 2px 0}
+  .pill.g{background:var(--green-bg);color:var(--green)}
+  .pill.b{background:var(--soft);color:var(--accent)}
+  .pill.r{background:var(--red-bg);color:var(--red)}
+  .cnt{font-size:12px;color:var(--faint)}
+  .box{background:#fff;border:1px solid var(--line);border-radius:11px;padding:18px 22px;margin:16px 0}
+  .bad{background:var(--red-bg);border:1px solid #F5C6C6;border-left:3px solid var(--red);border-radius:0 10px 10px 0;padding:14px 18px;margin:16px 0}
+  .good{background:var(--green-bg);border:1px solid #BFE3C9;border-left:3px solid var(--green);border-radius:0 10px 10px 0;padding:14px 18px;margin:16px 0}
+  .bad p:last-child,.good p:last-child{margin:0}
+  .dots{display:flex;gap:8px;align-items:center;margin:14px 0}
+  .dots i{width:9px;height:9px;border-radius:999px;background:var(--line);display:block}
+  .dots i.past{background:#9FC4E3} .dots i.cur{background:var(--accent)}
+  .dots i.nav{cursor:pointer;box-shadow:0 0 0 4px rgba(0,102,184,.14)}
+  .dots b{font-size:12px;color:var(--faint);font-weight:600;margin-left:10px}
+  .win{background:#fff;border:1px solid #CFD4DB;border-radius:10px;padding:16px 20px;max-width:430px;box-shadow:0 3px 12px rgba(20,25,35,.08)}
+  code{background:var(--wash);padding:2px 6px;border-radius:4px;font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Pills and dots</h1>
+<p class="stand">Two small things. Here is exactly what each one is.</p>
+
+<h2><span class="n">1</span>The pills</h2>
+
+<p>A pill is the little rounded label on the right of every row in the wizard. There is one component,
+and it currently says <strong>fifteen different things</strong>:</p>
+
+<div class="box">
+  <span class="pill g">Ready</span><span class="pill g">In list</span><span class="pill">Not found</span>
+  <span class="pill">Installing...</span><span class="pill">Not installed</span><span class="pill g">Done</span>
+  <span class="pill">Later</span><span class="pill">Unchanged</span><span class="pill">Needs you</span>
+  <span class="pill">Waiting for a gateway</span><span class="pill g">Connected</span><span class="pill">None</span>
+  <span class="pill g">2 set up</span><span class="pill g">1 folder</span><span class="pill g">3 folders</span>
+</div>
+
+<div class="bad">
+  <p><strong>The part that actually matters.</strong> There are only two colours behind all of that:
+  green and grey. So a tool that <em>failed to install</em> gets the same grey pill as an agent that
+  simply <em>is not installed</em> - one needs you to do something, the other is fine and expected, and
+  they look identical.</p>
+  <p style="margin-top:9px">And counts are wearing status colours: <span class="pill g">3 folders</span>
+  is green, as though having three folders were a state of health.</p>
+</div>
+
+<h3 style="font-size:16px;margin:22px 0 6px">Proposed: four states, one meaning each</h3>
+
+<table>
+  <thead><tr><th style="width:120px">Pill</th><th style="width:230px">Means</th><th>Replaces</th></tr></thead>
+  <tbody>
+    <tr><td><span class="pill g">Ready</span></td><td>It works. Nothing to do.</td>
+        <td>Ready, In list, Done, Connected, Added</td></tr>
+    <tr><td><span class="pill b">Working</span></td><td>Happening now. Finishes on its own.</td>
+        <td>Installing..., Checking</td></tr>
+    <tr><td><span class="pill r">Needs you</span></td><td>Will not fix itself. Always sits next to a button that fixes it.</td>
+        <td>Not installed, Failed</td></tr>
+    <tr><td><span class="pill">Not set up</span></td><td>Absent and optional. No action implied.</td>
+        <td>Not found, Later, None, Unchanged, Waiting for a gateway</td></tr>
+    <tr><td><span class="cnt">3 folders</span></td><td>Not a pill at all - plain grey text.</td>
+        <td>2 set up, 1 folder, 3 folders, 9 ready</td></tr>
+  </tbody>
+</table>
+
+<div class="good">
+  <p><strong>The rule worth keeping:</strong> a pill says what state a row is in, never how many of
+  something there are - and red only ever appears where there is a button to press. That is what stops
+  the Tools screen crying wolf.</p>
+</div>
+
+<h2><span class="n">2</span>The dots</h2>
+
+<p>The row of small dots at the top of every wizard screen. Today they are decoration - they show
+position and nothing else, and you cannot click them.</p>
+
+<div class="box">
+  <p style="font-size:12.5px;color:var(--faint);margin-bottom:4px">Today</p>
+  <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i></div>
+  <p style="font-size:13px;color:var(--muted);margin:0">
+    Which step is that? How far away is the one you came for? No way to tell, and clicking does nothing.
+  </p>
+</div>
+
+<div class="box">
+  <p style="font-size:12.5px;color:var(--faint);margin-bottom:4px">Proposed - first run</p>
+  <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><b>Step 4 of 7 - Tools</b></div>
+  <p style="font-size:13px;color:var(--muted);margin:0">
+    Named. Still not clickable: a first-timer should walk the path, because skipping to a step whose
+    answer depends on an earlier one is how you end up half configured.
+  </p>
+</div>
+
+<div class="box">
+  <p style="font-size:12.5px;color:var(--faint);margin-bottom:4px">Proposed - re-run from Settings</p>
+  <div class="dots"><i class="past nav"></i><i class="past nav"></i><i class="past nav"></i><i class="cur nav"></i><i class="nav"></i><i class="nav"></i><i class="nav"></i><b>Step 4 of 7 - Tools</b></div>
+  <p style="font-size:13px;color:var(--muted);margin:0">
+    Clickable. You opened the wizard to change one thing - click its dot and go straight there instead
+    of pressing Continue five times.
+  </p>
+</div>
+
+<div class="good">
+  <p><strong>Why only on a re-run.</strong> On a re-run everything is already set up, so there is no
+  order to protect - you are editing, not configuring. On a first run there is.</p>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/architecture/onboarding-walkthrough-feedback.md
+++ b/docs/architecture/onboarding-walkthrough-feedback.md
@@ -1,0 +1,227 @@
+# Onboarding wizard - walkthrough feedback
+
+Soren's screen-by-screen notes from driving the test build (slot 5) on 2026-07-29.
+Collected first, implemented at the end. Nothing here is built yet.
+
+---
+
+## Screen 1 - Welcome
+
+**Screenshot:** `Screenshot 2026-07-29 074358.png`
+
+### W-1. Delete the founder quote card
+
+The grey card holding "I built DevThrottle because running agents was never the hard
+part...", the "- Soren, founder" attribution and the "Read more" expander comes out
+entirely.
+
+> "I think this quote from me up front is stupid. People just want their shit installed,
+> they don't want me talking to them about all this. So we should only explain why we're
+> going through this wizard, not give stupid quotes."
+
+**What the screen should do instead:** explain only WHY we are going through this wizard -
+what it is about to set up and what the user gets at the end of it. No founder voice, no
+personal message, no expandable essay.
+
+**Code:** `FirstRunWizardDialog.axaml:150-167` (the whole `Border`), plus
+`FounderMoreText` / `FounderMoreLink` and the `BtnFounderMore_Click` handler in
+`FirstRunWizardDialog.axaml.cs`.
+
+**Open question for the rewrite:** the current subtitle already half does this job
+("You are about three minutes from running your first coding agent... your agents, your
+code, your morning report"). With the card gone, that subtitle probably becomes the whole
+screen and may want to be a short list of what the wizard covers rather than a paragraph.
+
+---
+
+## Screen 3 - Tools
+
+**Screenshot:** `Screenshot 2026-07-29 074559.png` (all 9 tools ready, green state)
+
+### T-1. NO CHANGE in the wizard. Deferred to a separate review.
+
+Soren raised whether there should be a way to decline the tools rather than have them
+installed for you. His own answer: if that choice exists it belongs in **Settings**, not
+in onboarding.
+
+> "I'm wondering if we should have a way to not install the tools, but I think it should
+> be under the settings. We are going to do a different section... the tools section needs
+> to be reviewed. So for now, we keep the onboarding wizard this way."
+
+**Decision:** the Tools step stays exactly as it is for this piece of work. The opt-out
+question is a separate section of work covering the tools area as a whole.
+
+**Action outside this work:** Soren is informing the release manager himself that the
+tools section needs review. Nothing for me to file or send.
+
+**Still in scope here** (unchanged from the review, already built in the current test
+build): the three real row states, the "Fix this now" repair, and the wait-or-continue
+sentence. Those are about telling the truth when a tool is broken, not about whether the
+user gets a choice - a different question from the one deferred above.
+
+---
+
+## Screen 4 - Code
+
+**Screenshot:** `Screenshot 2026-07-29 075107.png` (four folders found, each with an Add
+button, none added)
+
+### C-1. Invert the model: add every found folder automatically, offer Remove
+
+> "I think these should be remove instead of add. I didn't see the adds buttons, so I
+> didn't add them. We should get them automatically added because then we can do all kinds
+> of recommendations on them."
+
+Every folder the scan finds is registered as it is found. The row's action becomes
+**Remove**, not Add. Opting out is the deliberate act; opting in is not.
+
+**The screenshot is the evidence.** Four folders were found - `C:\Repos` (12
+repositories), `C:\ReposBPMN` (1), `C:\ReposFred` (3), `D:\Dev` (1) - and Soren walked
+straight past all four without registering any of them. The Add buttons are there, right
+of each row, and he did not see them. An opt-in that the product's own author misses is
+not a working opt-in.
+
+**Why auto-add, beyond convenience:** folders we know about are folders we can make
+recommendations on. A folder the user never got round to adding is invisible to every
+downstream feature.
+
+**Code:** `CodeRow` at `FirstRunWizardDialog.axaml.cs:781-832` builds the Add button;
+`AddCodeRootAsync` at `:850` does the registration; `SwapCodeRowActionToAdded` at `:883`
+swaps in the Added pill. The scan itself streams suggestions in at `:748-755`.
+
+### C-2. Must work on Mac as well as Windows
+
+> "And we need to make sure this works both for Mac and Windows."
+
+**Current state, checked:** `CodeFolderScout.CandidateRoots()`
+(`src/CcDirector.Core/Onboarding/CodeFolderScout.cs:46-79`) does handle both, but NOT
+equally:
+
+- Both platforms probe the home directory - `Projects`, `Code`, `repos`, `git`, `dev`,
+  `src` - plus `source\repos` on Windows and `~/Developer` on Mac.
+- **The drive sweep is Windows only** (`:62-77`): it lists the top level of every fixed
+  drive and takes any folder whose name looks like code. That is exactly what found all
+  four folders in the screenshot - `C:\Repos`, `C:\ReposBPMN`, `C:\ReposFred`, `D:\Dev`
+  are none of them under the home directory.
+
+So a Mac user with code outside their home directory gets nothing equivalent. Needs a Mac
+arm - `/Volumes/*` and the common Mac locations - or the same screen will find far less on
+a Mac than it does here.
+
+### Consequences to settle when this is built
+
+1. **When does the write happen?** The wizard's stated principle is that doing nothing
+   writes nothing (`FirstRunWizardDialog.axaml.cs:196-200`). Auto-add inverts that for
+   this step. Recommended: persist at the moment the row appears, because that is what the
+   row will claim - a row reading "Added" that is not yet saved is a lie if the user closes
+   the window.
+2. **This makes the New Session list question urgent.** Auto-adding all four folders on
+   this machine registers 17 repositories in one pass. Combined with fixing #973 (folders
+   added here never reach New Session), the recently-used list will need an answer for the
+   long tail. Soren's earlier steer was a display-time union rather than flooding the
+   recency list; that decision now has to be made rather than deferred.
+3. **The time-boxed scan interacts with this.** The sweep stops after 10 seconds, so
+   auto-add registers whatever was found by then. Folders found later, via "Keep looking",
+   get registered when they appear.
+
+---
+
+## NEW screen - Browsers
+
+**Screenshot:** `Screenshot 2026-07-29 075210.png` (the Done receipt, Browsers row reading
+"Later")
+
+### B-1. Add a Browsers step to the wizard. Not to the installer.
+
+> "If we want people to use browsers, we need a screen in here that sets it up. And that
+> means the browser harness is required. One screen could be how we deal with browsers and
+> they could opt in for that. And then we set up the browsers for them and install the
+> browser harness... I don't think we should go back to the installer and prerequisites in.
+> I think it should be a page saying here's our preferred method of dealing with browser
+> integration and it's a tool called browser harness. You want to install that and set up
+> some browser profiles that can have different logins."
+
+### What already exists (checked, not assumed)
+
+Most of this is built. The new step is largely wiring, plus one genuinely new capability.
+
+| Piece | State today | Where |
+|---|---|---|
+| Per-browser isolated profile with its own login | BUILT | `AutomationBrowserService.Create` - own `--user-data-dir`, own allocated debug port |
+| Human signs a browser in, once | BUILT | `BrowserSignInFlow.cs` |
+| Browsers list, status, launch/stop | BUILT | `AutomationBrowserService`, `BrowsersRailGroup`, `BrowserSettingsView` |
+| Agent attaches via the harness | BUILT | `BU_NAME` / `BU_CDP_URL` handed out by `AutomationBrowserViewFold` |
+| Command-line surface | BUILT | `BrowserEndpoints.cs`, `cc-devthrottle browser` |
+| **Installing browser-harness** | **DOES NOT EXIST** | `IsHarnessInstalled()` only checks PATH; the UI links out to `HarnessInstallUrl` on GitHub |
+
+The design constraint that already shipped is worth repeating because it is exactly the
+"different logins" Soren described: Chrome 136+ refuses remote debugging on the default
+profile, and App-Bound Encryption refuses to carry a login into a copied profile - so each
+drivable browser is its own folder, signed in ONCE by a human.
+
+### Recommendation
+
+**1. One opt-in screen, after Screenshots and before Gateway.** It belongs beside
+"SHOW, DON'T TYPE" - both screens are about how an agent gets context from you. Gateway
+stays the last real step before Done.
+
+**2. Make the case FOR setting it up now, with an honest way out.** (Soren's steer, which
+overrides my first recommendation to default to skipping.)
+
+> "I think we should try to sign up the browser, saying if you set up your browsers now, it
+> will be much easier to use, but you can also set up browsers later if you prefer to get
+> the installation going."
+
+So the screen actively recommends doing it now and says why - it is easier here than
+wiring it up afterwards - while stating plainly that later is a supported choice for anyone
+who just wants to finish installing. Concretely:
+
+- Primary action: set the browsers up now.
+- Quiet secondary: set them up later, with the rail named as where that happens.
+- The copy carries the trade, in the user's terms: doing it now is less work; doing it
+  later is fine and costs nothing but a return trip.
+
+Note this is deliberately NOT the same as the Code step's auto-add. Nothing is installed
+without the user choosing it, because it is third-party software - but the screen does take
+a side rather than sitting neutral.
+
+**3. Name the third-party tool on screen.** browser-harness is from browser-use, not from
+us. A wizard that silently installs someone else's software on a user's machine is not
+acceptable; the screen must say what it is installing and from where before the user opts
+in.
+
+**4. Take them through ONE browser here, not several.** Signing in is a human act,
+interactive, one browser at a time - three signed-in profiles cannot be batched into a
+three-minute wizard, and trying would turn the recommended path into the slow one. So the
+recommended path stays short and finishes:
+
+  - explain what this gives them (an agent that can drive a real signed-in browser)
+  - accept -> install browser-harness, streaming progress, reporting failure on screen
+  - create ONE browser profile and take them through signing it in, here and now
+  - say plainly that more profiles are added from the Browsers group in the left rail
+
+The point of recommending "now" is that the user ends the wizard with a working, signed-in
+browser. If the step installs the harness but leaves them with nothing signed in, the
+recommendation was hollow - so the sign-in is part of the recommended path, not an extra
+after it.
+
+**5. The Done receipt row stops being a pointer.** Today it always reads "Later" whatever
+the machine's state is - it is advertising copy, not a status. With a real step it reports
+what actually happened: harness installed, one browser created, signed in or not.
+
+**6. Do not reopen the installer.** Agreed, and there is a second reason beyond Soren's:
+the installer is finished and proven on a clean machine, and making a third-party Python
+tool a prerequisite would gate every DevThrottle install on it - including the majority who
+never drive a browser.
+
+### Open questions to settle before building
+
+- **What does installing browser-harness actually require?** It is a Python tool from
+  browser-use. Whether that is pip, uv, or a bundled runtime decides whether this is a
+  small step or a large one, and whether it can be done without leaving the wizard. NOT yet
+  checked - this is the one real unknown in the whole step.
+- **Mac and Windows parity**, same as the Code step. The install path is likely to differ.
+- **What happens when the install fails?** Per the no-fallback rule it must say so and
+  offer the manual install page - never silently continue as if it worked.
+
+---

--- a/docs/architecture/onboarding-wizard-review-2026-07-29.html
+++ b/docs/architecture/onboarding-wizard-review-2026-07-29.html
@@ -1,0 +1,1603 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Onboarding wizard - screen by screen review and mockups</title>
+<style>
+  :root{
+    --ink:#16181D; --muted:#5A616B; --faint:#8A909A; --line:#E6E8EC;
+    --accent:#0066B8; --accent-soft:#F2F8FD; --paper:#FFFFFF; --wash:#F5F6F8;
+    --green:#1A7F37; --green-bg:#E5F3E9; --red:#DC2626; --red-bg:#FDECEC;
+    --amber:#9A6700; --amber-bg:#FFF6D9;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:#F0F2F5; color:var(--ink);
+    font-family:Inter,"Segoe UI",system-ui,-apple-system,sans-serif;
+    font-size:15px; line-height:1.62;
+  }
+  .wrap{max-width:1180px; margin:0 auto; padding:0 24px 96px}
+
+  /* ---------- page furniture ---------- */
+  header.masthead{
+    background:var(--paper); border-bottom:1px solid var(--line);
+    padding:46px 24px 38px; margin-bottom:36px;
+  }
+  header.masthead .inner{max-width:1180px; margin:0 auto}
+  .eyebrow{
+    color:var(--accent); font-size:12px; font-weight:700; letter-spacing:2px;
+    text-transform:uppercase; margin:0 0 10px;
+  }
+  h1{
+    font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;
+    font-size:38px; line-height:1.15; font-weight:700; margin:0 0 14px;
+  }
+  .standfirst{font-size:17px; color:var(--muted); max-width:820px; margin:0}
+  .meta{margin-top:20px; font-size:13px; color:var(--faint)}
+  .meta code{background:var(--wash); padding:2px 6px; border-radius:4px; font-size:12px}
+
+  h2{
+    font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;
+    font-size:27px; font-weight:700; margin:56px 0 6px; scroll-margin-top:20px;
+  }
+  h2 .num{color:var(--accent); font-variant-numeric:tabular-nums; margin-right:10px}
+  h3{font-size:18px; font-weight:650; margin:32px 0 10px}
+  h4{font-size:14px; font-weight:700; margin:0 0 10px; letter-spacing:.4px;
+     text-transform:uppercase; color:var(--faint)}
+  p{margin:0 0 14px}
+  a{color:var(--accent)}
+
+  .card{
+    background:var(--paper); border:1px solid var(--line); border-radius:14px;
+    padding:26px 28px; margin:18px 0;
+  }
+  .lede{font-size:16px; color:var(--muted); margin:0 0 22px; max-width:860px}
+
+  /* ---------- table of contents ---------- */
+  .toc{
+    background:var(--paper); border:1px solid var(--line); border-radius:14px;
+    padding:22px 26px; margin:0 0 10px;
+  }
+  .toc ol{margin:0; padding-left:22px; columns:2; column-gap:40px}
+  .toc li{margin:5px 0; break-inside:avoid}
+  @media (max-width:760px){ .toc ol{columns:1} }
+
+  /* ---------- verdict table ---------- */
+  table{border-collapse:collapse; width:100%; font-size:14px; margin:14px 0}
+  th,td{text-align:left; padding:11px 13px; border-bottom:1px solid var(--line); vertical-align:top}
+  th{font-size:12px; text-transform:uppercase; letter-spacing:.6px; color:var(--faint);
+     border-bottom:2px solid var(--line)}
+  tbody tr:hover{background:var(--wash)}
+  .tblwrap{overflow-x:auto}
+
+  /* ---------- severity chips ---------- */
+  .chip{
+    display:inline-block; font-size:10.5px; font-weight:700; letter-spacing:.6px;
+    padding:3px 9px; border-radius:999px; text-transform:uppercase; white-space:nowrap;
+  }
+  .chip.bug{background:var(--red-bg); color:var(--red)}
+  .chip.wrong{background:var(--amber-bg); color:var(--amber)}
+  .chip.polish{background:var(--wash); color:var(--muted)}
+  .chip.ok{background:var(--green-bg); color:var(--green)}
+
+  /* ---------- findings ---------- */
+  .finding{
+    border-left:3px solid var(--line); padding:2px 0 2px 18px; margin:20px 0;
+  }
+  .finding.bug{border-left-color:var(--red)}
+  .finding.wrong{border-left-color:#E0A93B}
+  .finding.polish{border-left-color:var(--faint)}
+  .finding .fhead{display:flex; gap:10px; align-items:baseline; flex-wrap:wrap; margin-bottom:6px}
+  .finding .fid{font-weight:700; font-variant-numeric:tabular-nums}
+  .finding .ftitle{font-weight:650}
+  .finding p{margin:0 0 10px; color:var(--muted)}
+  .finding p strong{color:var(--ink)}
+  .ev{
+    font-family:Consolas,"Cascadia Mono",monospace; font-size:12.5px;
+    background:var(--wash); border:1px solid var(--line); border-radius:6px;
+    padding:2px 7px; color:var(--muted); white-space:nowrap;
+  }
+  .evline{font-size:12.5px; color:var(--faint); margin:0 0 4px}
+
+  .ask{
+    background:var(--accent-soft); border:1px solid #BFDCF2; border-left:3px solid var(--accent);
+    border-radius:0 10px 10px 0; padding:16px 20px; margin:20px 0;
+  }
+  .ask h4{color:var(--accent); margin-bottom:8px}
+  .ask p:last-child{margin-bottom:0}
+
+  /* ---------- mockup frame ---------- */
+  .pair{display:grid; grid-template-columns:1fr 1fr; gap:22px; margin:26px 0 10px}
+  @media (max-width:1000px){ .pair{grid-template-columns:1fr} }
+  .pane h4{display:flex; align-items:center; gap:9px}
+  .pane h4 .tag{
+    font-size:10px; padding:2px 8px; border-radius:999px; letter-spacing:.5px;
+  }
+  .tag.now{background:var(--red-bg); color:var(--red)}
+  .tag.next{background:var(--green-bg); color:var(--green)}
+
+  .win{
+    background:var(--paper); border:1px solid #CFD4DB; border-radius:10px;
+    overflow:hidden; box-shadow:0 3px 14px rgba(20,25,35,.09);
+  }
+  .win .titlebar{
+    background:#EDEFF2; border-bottom:1px solid var(--line);
+    padding:7px 12px; font-size:11.5px; color:var(--muted);
+    display:flex; align-items:center; justify-content:space-between;
+  }
+  .win .titlebar .x{color:var(--faint); font-weight:700}
+  .win .body{padding:22px 26px 18px; min-height:330px; display:flex; flex-direction:column}
+  .dots{display:flex; gap:7px; justify-content:center; margin:2px 0 22px}
+  .dots i{width:7px; height:7px; border-radius:999px; background:var(--line); display:block}
+  .dots i.past{background:#9FC4E3}
+  .dots i.cur{background:var(--accent)}
+
+  .w-eyebrow{
+    color:var(--accent); font-size:9.5px; font-weight:700; letter-spacing:2px;
+    text-align:center; margin:0 0 7px;
+  }
+  .w-title{
+    font-family:"Segoe UI Variable Display","Segoe UI",Inter,sans-serif;
+    font-size:22px; font-weight:700; text-align:center; margin:0 0 8px; line-height:1.2;
+  }
+  .w-sub{
+    font-size:12.5px; color:var(--muted); text-align:center; max-width:400px;
+    margin:0 auto 16px; line-height:1.5;
+  }
+  .w-hint{font-size:10.5px; color:var(--faint); text-align:center; margin:8px 0}
+  .w-status{font-size:11px; font-weight:650; text-align:center; margin:0 0 12px}
+  .w-status.green{color:var(--green)}
+  .w-status.blue{color:var(--accent)}
+  .w-status.red{color:var(--red)}
+
+  .row{
+    border:1px solid var(--line); border-radius:9px; padding:10px 13px;
+    display:flex; align-items:center; justify-content:space-between; gap:12px;
+    margin-bottom:7px; background:var(--paper);
+  }
+  .row .rl{min-width:0}
+  .row .rn{font-size:12.5px; font-weight:650; overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .row .rs{font-size:10.5px; color:var(--faint); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .row.dim .rn{color:var(--faint)}
+  .pill{
+    font-size:9.5px; font-weight:700; padding:3px 9px; border-radius:999px;
+    white-space:nowrap; background:var(--wash); color:var(--faint);
+  }
+  .pill.ready{background:var(--green-bg); color:var(--green)}
+  .pill.busy{background:var(--accent-soft); color:var(--accent)}
+  .pill.fail{background:var(--red-bg); color:var(--red)}
+  .btn-sm{
+    font-size:11px; padding:5px 12px; border:1px solid var(--line); border-radius:7px;
+    background:var(--wash); color:var(--ink); white-space:nowrap;
+  }
+
+  .spacer{flex:1; min-height:8px}
+  .foot{
+    border-top:1px solid var(--line); margin-top:14px; padding-top:12px;
+    display:flex; align-items:center; justify-content:space-between; gap:12px;
+  }
+  .foot .back{font-size:11.5px; color:var(--muted)}
+  .foot .note{font-size:10.5px; color:var(--faint); text-align:right; flex:1}
+  .cta{
+    background:var(--accent); color:#fff; font-size:12.5px; font-weight:650;
+    padding:9px 20px; border-radius:8px; white-space:nowrap; display:inline-block;
+  }
+  .cta.disabled{background:#C7D4DF; color:#F2F6F9}
+  .cta.center{display:block; width:max-content; margin:0 auto}
+  .quiet{font-size:11px; color:var(--faint); text-align:center; margin:9px 0 0}
+
+  /* progress bar mockup */
+  .bar{height:4px; border-radius:999px; background:var(--line); overflow:hidden; margin:0 0 10px}
+  .bar i{display:block; height:100%; width:38%; background:var(--accent); border-radius:999px}
+  .bar.indet i{width:34%; margin-left:22%}
+  .scanline{
+    font-size:11px; color:var(--accent); text-align:center; font-weight:600; margin:0 0 10px;
+  }
+  .skel{
+    border:1px solid var(--line); border-radius:9px; height:44px; margin-bottom:7px;
+    background:linear-gradient(90deg,var(--wash) 25%,#EDEFF2 50%,var(--wash) 75%);
+  }
+  .thumbs{display:flex; gap:8px; justify-content:center; margin:10px 0}
+  .thumbs span{
+    width:58px; height:40px; border-radius:6px; border:1px solid var(--line);
+    background:var(--wash); display:block;
+  }
+  .thumbs span.load{background:linear-gradient(90deg,var(--wash) 25%,#E7EAEE 50%,var(--wash) 75%)}
+
+  /* gateway cards */
+  .gwcard{
+    border:1px solid var(--line); border-radius:10px; padding:13px 15px;
+    margin-bottom:9px; background:var(--paper);
+  }
+  .gwcard.sel{border:2px solid var(--accent); background:var(--accent-soft)}
+  .gwcard .gt{font-size:13px; font-weight:700; display:flex; align-items:center; gap:8px}
+  .gwcard .gd{font-size:11px; color:var(--muted); margin-top:3px; line-height:1.45}
+  .gwtwo{display:grid; grid-template-columns:1fr 1fr; gap:9px}
+  .badge{
+    background:var(--accent); color:#fff; font-size:8.5px; font-weight:700;
+    padding:2px 7px; border-radius:999px; letter-spacing:.5px;
+  }
+  .connected{
+    text-align:center; padding:14px 0;
+  }
+  .connected .cb{
+    display:inline-block; background:var(--green-bg); color:var(--green);
+    font-size:11px; font-weight:700; padding:5px 14px; border-radius:999px;
+  }
+
+  /* receipt */
+  .receipt{border:1px solid var(--line); border-radius:10px; overflow:hidden}
+  .receipt .row{border:0; border-bottom:1px solid var(--line); border-radius:0; margin:0}
+  .receipt .row:last-child{border-bottom:0}
+
+  .callout{
+    background:var(--wash); border:1px solid var(--line); border-radius:10px;
+    padding:16px 20px; margin:18px 0; font-size:14px;
+  }
+  .callout strong{color:var(--ink)}
+  ul.tight{margin:0 0 14px; padding-left:20px}
+  ul.tight li{margin:6px 0}
+  .krux{
+    background:var(--red-bg); border:1px solid #F5C6C6; border-left:3px solid var(--red);
+    border-radius:0 10px 10px 0; padding:16px 20px; margin:20px 0;
+  }
+  .krux h4{color:var(--red)}
+  .krux p:last-child{margin-bottom:0}
+  footer.end{
+    margin-top:60px; padding-top:24px; border-top:1px solid var(--line);
+    font-size:13px; color:var(--faint);
+  }
+</style>
+</head>
+<body>
+
+<header class="masthead">
+  <div class="inner">
+    <p class="eyebrow">DevThrottle - onboarding</p>
+    <h1>The setup wizard, screen by screen</h1>
+    <p class="standfirst">
+      What each screen shows today, what is wrong with it, and what it should show instead -
+      with a mockup of both. Written so the whole wizard can be re-run at any time and be
+      correct, honest and fast on the second run as well as the first.
+    </p>
+    <p class="meta">
+      29 July 2026, revised after the walkthrough &nbsp;|&nbsp; Read from <code>origin/main</code> at
+      <code>3d2c70c6</code> in a clean worktree &nbsp;|&nbsp; Screens 1 to 6 of the build order are
+      built and running in the slot 5 test build; nothing is committed
+      <br>
+      Sources: <code>FirstRunWizardDialog.axaml</code>, <code>FirstRunWizardDialog.axaml.cs</code>,
+      <code>FirstRunWizardModel.cs</code>, <code>ToolDescriptor.cs</code>,
+      <code>CodeFolderScout.cs</code>, <code>AutomationBrowserService.cs</code>,
+      <code>AutomationBrowserViewFold.cs</code>, <code>SettingsDialog.axaml</code>
+    </p>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <div class="toc">
+    <h4>Contents</h4>
+    <ol>
+      <li><a href="#walkthrough">Decisions from the walkthrough</a></li>
+      <li><a href="#summary">What is wrong, in one table</a></li>
+      <li><a href="#rerun">The big one: there is no re-run mode</a></li>
+      <li><a href="#welcome">Screen 1 - Welcome</a></li>
+      <li><a href="#agents">Screen 2 - Agents</a></li>
+      <li><a href="#tools">Screen 3 - Tools</a></li>
+      <li><a href="#code">Screen 4 - Code</a></li>
+      <li><a href="#shots">Screen 5 - Screenshots</a></li>
+      <li><a href="#browsers">Screen 6 - Browsers (NEW)</a></li>
+      <li><a href="#gateway">Screen 7 - Gateway</a></li>
+      <li><a href="#done">Screen 8 - Done</a></li>
+      <li><a href="#settings">The way back in - Settings</a></li>
+      <li><a href="#crosscut">Cross-cutting - progress, keyboard, the closing X</a></li>
+      <li><a href="#plan">What to build, in order</a></li>
+    </ol>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="walkthrough"><span class="num">0</span>Decisions from the walkthrough</h2>
+
+  <p class="lede">
+    Soren drove the test build screen by screen on 29 July and gave direct feedback. These are his
+    decisions, and they take precedence over the recommendations further down where the two differ.
+    Everything here is folded into the screens below.
+  </p>
+
+  <div class="tblwrap">
+  <table>
+    <thead>
+      <tr><th style="width:64px">Ref</th><th style="width:118px">Screen</th><th>Decision</th><th style="width:104px">Status</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>W-1</td><td>Welcome</td><td>Delete the founder quote card entirely. The screen explains only why we are putting them through the wizard.</td><td><span class="chip bug">Decided</span></td></tr>
+      <tr><td>T-1</td><td>Tools</td><td>No opt-out here. Whether tools can be declined is a Settings question and a separate review of the tools area. Wizard stays as is.</td><td><span class="chip polish">Deferred</span></td></tr>
+      <tr><td>C-1</td><td>Code</td><td>Invert the model - every folder found is added automatically, and the row action becomes Remove.</td><td><span class="chip bug">Decided</span></td></tr>
+      <tr><td>C-2</td><td>Code</td><td>Must work on Mac as well as Windows. It does not today - the drive sweep is Windows-only.</td><td><span class="chip bug">Decided</span></td></tr>
+      <tr><td>B-1</td><td>Browsers</td><td>Add a Browsers step. Explain browser-harness as our preferred method, recommend setting it up now, install it and set up a signed-in profile. Not an installer prerequisite.</td><td><span class="chip bug">Decided</span></td></tr>
+      <tr><td>B-2</td><td>Browsers</td><td>Make the case FOR doing it now - "much easier to use" - with an honest "set up later" for anyone who just wants to finish installing.</td><td><span class="chip bug">Decided</span></td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="callout">
+    <strong>Still open, and now urgent.</strong> Auto-adding every folder found (C-1) registers 17
+    repositories on Soren's machine in one pass. Combined with fixing the handoff into New Session
+    (C3 below), the recently-used list needs an answer for the long tail. The earlier steer was a
+    display-time union rather than flooding the recency list; that has to be settled before C-1 and
+    C3 are built together.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="summary"><span class="num">1</span>What is wrong, in one table</h2>
+
+  <p class="lede">
+    Twenty-two findings. Six are defects that produce a false statement or a silently wrong
+    outcome; the rest are clarity and polish. The single largest gap is that the wizard has no
+    idea whether it is running for the first time or the fifth, so on a re-run it asks you to
+    redo work that is already done and, on the gateway screen, contradicts its own receipt.
+  </p>
+
+  <div class="tblwrap">
+  <table>
+    <thead>
+      <tr><th style="width:74px">Ref</th><th style="width:106px">Kind</th><th>Finding</th><th style="width:150px">Screen</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>R1</td><td><span class="chip bug">Defect</span></td><td>Re-running the wizard offers to re-enroll a gateway that is already connected, while the Done receipt on the same run correctly reports it as connected</td><td>Gateway, Done</td></tr>
+      <tr><td>R2</td><td><span class="chip bug">Defect</span></td><td>Re-running re-detects the screenshots folder from scratch and can silently overwrite a folder the user deliberately chose</td><td>Screenshots</td></tr>
+      <tr><td>R3</td><td><span class="chip wrong">Wrong copy</span></td><td>Every word of the Welcome screen assumes a first run</td><td>Welcome</td></tr>
+      <tr><td>A1</td><td><span class="chip bug">Defect</span></td><td>The primary button is live during the agent scan; clicking it early configures zero agents and moves on</td><td>Agents</td></tr>
+      <tr><td>A2</td><td><span class="chip wrong">Unclear</span></td><td>The scanning message is styled exactly like every other subtitle - it does not read as activity, and nothing asks the user to wait</td><td>Agents</td></tr>
+      <tr><td>A3</td><td><span class="chip polish">Slow</span></td><td>Version probes run one after another and no row is drawn until all of them return</td><td>Agents</td></tr>
+      <tr><td>T1</td><td><span class="chip bug">Defect</span></td><td>There is no way to fix a tool from this screen, and no state for a tool that has genuinely failed - a broken tool reads "Installing..." forever</td><td>Tools</td></tr>
+      <tr><td>T2</td><td><span class="chip wrong">Wrong</span></td><td>"Ready" is a presence check, not a health check: a tool that is installed but broken reads Ready</td><td>Tools</td></tr>
+      <tr><td>T3</td><td><span class="chip wrong">Unclear</span></td><td>The screen never states the trade: wait here and everything is ready, or continue and the Director finishes it in the background</td><td>Tools</td></tr>
+      <tr><td>C1</td><td><span class="chip bug">Defect</span></td><td>A repository scan that hits its 10 second cap tells the user it checked everywhere - the identical sentence a completed scan writes</td><td>Code</td></tr>
+      <tr><td>C2</td><td><span class="chip wrong">Unclear</span></td><td>The scanning line is the faintest text on the screen and sits below an empty area</td><td>Code</td></tr>
+      <tr><td>C3</td><td><span class="chip bug">Defect</span></td><td>Folders added here never reach New Session, so "Start my first agent" lands on "No repositories yet"</td><td>Code, Done</td></tr>
+      <tr><td>C4</td><td><span class="chip wrong">Wrong</span></td><td>Two code comments assert a wiring that does not exist - the proximate cause of C3</td><td>Code</td></tr>
+      <tr><td>S1</td><td><span class="chip polish">Slow</span></td><td>The step counts every image in the folder and stats every file to sort it, with no visible activity while it does</td><td>Screenshots</td></tr>
+      <tr><td>S2</td><td><span class="chip polish">Polish</span></td><td>The thumbnail strip is hidden then re-shown with no placeholder, so it flashes empty</td><td>Screenshots</td></tr>
+      <tr><td>G1</td><td><span class="chip wrong">Architecture</span></td><td>The gateway step keeps its own private choice enum instead of the shared ruling every other surface uses</td><td>Gateway</td></tr>
+      <tr><td>G2</td><td><span class="chip bug">Blocked</span></td><td>The three gateway cards cannot be reached by keyboard or screen reader at all</td><td>Gateway</td></tr>
+      <tr><td>G3</td><td><span class="chip wrong">Unsourced</span></td><td>"Part of Pro" is hard-coded text on the acquisition screen with nothing behind it</td><td>Gateway</td></tr>
+      <tr><td>D1</td><td><span class="chip polish">Polish</span></td><td>The receipt omits the tools row entirely if the user moved past the Tools step quickly</td><td>Done</td></tr>
+      <tr><td>X1</td><td><span class="chip bug">Defect</span></td><td>Closing the window with the X writes the completion marker, so an accidental close on a first run is permanent</td><td>All</td></tr>
+      <tr><td>X2</td><td><span class="chip wrong">Missing</span></td><td>The wizard contains no progress indicator of any kind - every busy state is a line of grey text</td><td>All</td></tr>
+      <tr><td>E1</td><td><span class="chip wrong">Wrong copy</span></td><td>The Settings button that re-runs the wizard still carries the old detection-only tooltip, and the section text above it repeats the same wrong promise</td><td>Settings</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="rerun"><span class="num">2</span>The big one: there is no re-run mode</h2>
+
+  <p class="lede">
+    The wizard is constructed the same way every single time. It builds all seven canonical
+    steps and no screen is ever told whether anything is already set up. Everything else in
+    this section follows from that one fact.
+  </p>
+
+  <p class="evline">Evidence: <span class="ev">FirstRunWizardDialog.axaml.cs:123</span> - the constructor always
+  builds <span class="ev">FirstRunWizardModel.CanonicalOrder</span>, with no parameter distinguishing a
+  first run from a re-run, and no field recording one.</p>
+
+  <div class="krux">
+    <h4>The clearest symptom</h4>
+    <p>
+      Re-run the wizard on a machine that is already connected to the hosted gateway. The Gateway
+      screen shows the three choice cards with Hosted pre-selected and a button reading
+      <strong>"Sign in and connect"</strong> - offering to enroll a machine that is already enrolled.
+      Two screens later the Done receipt reads <strong>"Gateway connected"</strong> with the real
+      address, because the receipt reads the saved configuration and the gateway screen does not.
+      The same wizard, in the same run, states both.
+    </p>
+    <p>
+      The cause is one line: <span class="ev">_gatewayConnected</span> starts <code>false</code>
+      (<span class="ev">:61</span>) and is only ever set by a successful enrollment during
+      <em>this</em> run (<span class="ev">:1302</span>).
+      <span class="ev">RefreshGatewayChoiceUi</span> (<span class="ev">:1216</span>) never consults
+      <span class="ev">GatewayConfig.Load()</span> - but <span class="ev">BuildDoneReceipt</span>
+      does, at <span class="ev">:1419</span>.
+    </p>
+  </div>
+
+  <h3>What a re-run should be</h3>
+  <p>
+    Your rule, applied throughout: <strong>if it already works, do not ask the user to redo it.</strong>
+    Concretely that means four things.
+  </p>
+  <ul class="tight">
+    <li><strong>The wizard knows which mode it is in.</strong> Pass a mode into the constructor -
+      first run or review - derived from the completion marker the model already owns
+      (<span class="ev">FirstRunWizardModel.ShouldShow()</span>). One flag, read by every step.</li>
+    <li><strong>Every step opens on its current state, not on a blank slate.</strong> The gateway step
+      opens Connected. The screenshots step opens on the folder in config. The code step already does
+      this correctly and is the model to copy - it lists roots already registered, marked Added
+      (<span class="ev">:734-741</span>).</li>
+    <li><strong>The primary action changes from "set this up" to "this is set up - continue".</strong>
+      Redoing stays available as a quiet secondary link, never the default.</li>
+    <li><strong>The Done screen reports what changed this run</strong>, not what exists. On a review run
+      a receipt of eight rows all reading Done tells the user nothing.</li>
+  </ul>
+
+  <div class="ask">
+    <h4>Your instruction, recorded</h4>
+    <p>
+      "If we're already connected, for instance if we're running this again and we're already connected
+      to the gateway, really no reason to force people to connect again. They could reconnect, but the
+      default would be don't connect again. If things already work, don't try to redo it."
+    </p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="welcome"><span class="num">3</span>Screen 1 - Welcome</h2>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="cur"></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-title">Welcome to DevThrottle</div>
+          <div class="w-sub">You are about three minutes from running your first coding agent. We will
+            show you what comes included - your agents, your code, your morning report - and every step
+            is a take-it-or-leave-it offer.</div>
+          <div style="background:var(--wash); border:1px solid var(--line); border-radius:10px; padding:13px 15px; font-size:11px; color:var(--muted); line-height:1.5">
+            I built DevThrottle because running agents was never the hard part. The hard part was
+            getting to Friday and realizing the week went to the wrong things.
+            <div style="display:flex; justify-content:space-between; margin-top:8px; font-size:10.5px; color:var(--faint)">
+              <span>- Soren, founder</span><span>Read more</span>
+            </div>
+          </div>
+          <div class="spacer"></div>
+          <span class="cta center">Set me up</span>
+          <p class="quiet">Skip setup and figure it out myself</p>
+          <div class="foot">
+            <span class="back"></span>
+            <span class="note">Takes about 3 minutes. Every step is optional, and everything can be changed later in Settings.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - review run <span class="tag next">re-run mode</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Review your DevThrottle setup</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="cur"></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-title">Review your setup</div>
+          <div class="w-sub">Everything below is already configured. Walk through it to change
+            anything, or jump straight to the part you came for. Nothing is redone unless you ask.</div>
+          <div class="row"><div class="rl"><div class="rn">Agents</div><div class="rs">Claude Code, Codex</div></div><span class="pill ready">2 ready</span></div>
+          <div class="row"><div class="rl"><div class="rn">Code folders</div><div class="rs">D:\ReposFred</div></div><span class="pill ready">12 repositories</span></div>
+          <div class="row"><div class="rl"><div class="rn">Gateway</div><div class="rs">devthrottle-gw.azurewebsites.net</div></div><span class="pill ready">Connected</span></div>
+          <div class="row"><div class="rl"><div class="rn">Tools</div><div class="rs">Installed and current</div></div><span class="pill ready">9 ready</span></div>
+          <div class="spacer"></div>
+          <span class="cta center">Review each step</span>
+          <p class="quiet">Close - everything is already set up</p>
+          <div class="foot">
+            <span class="back"></span>
+            <span class="note">Changing something here changes it everywhere. Nothing is reset.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3>W-1 - the founder quote comes out</h3>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - the quote card <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="cur"></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-title">Welcome to DevThrottle</div>
+          <div class="w-sub">You are about three minutes from running your first coding agent. We will
+            show you what comes included - your agents, your code, your morning report - and every step
+            is a take-it-or-leave-it offer. Use what helps, breeze past what doesn't.</div>
+          <div style="background:var(--wash); border:1px solid var(--line); border-radius:10px; padding:13px 15px; font-size:11px; color:var(--muted); line-height:1.5">
+            I built DevThrottle because running agents was never the hard part. The hard part was
+            getting to Friday and realizing the week went to the wrong things. DevThrottle keeps the
+            books - so that stops happening.
+            <div style="display:flex; justify-content:space-between; margin-top:8px; font-size:10.5px; color:var(--faint)">
+              <span>- Soren, founder</span><span>Read more</span>
+            </div>
+          </div>
+          <div class="spacer"></div>
+          <span class="cta center">Set me up</span>
+          <p class="quiet">Skip setup and figure it out myself</p>
+          <div class="foot"><span class="back"></span>
+            <span class="note">Takes about 3 minutes. Every step is optional.</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - first run <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="cur"></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-title">Let's get you set up</div>
+          <div class="w-sub">A few quick questions so DevThrottle knows your machine. Skip any of them -
+            nothing here is required, and all of it can be changed later.</div>
+          <div class="row"><div class="rl"><div class="rn">Your coding agents</div><div class="rs">Find the ones already installed, or install one</div></div></div>
+          <div class="row"><div class="rl"><div class="rn">Where your code lives</div><div class="rs">So we can offer you repositories and keep the books on them</div></div></div>
+          <div class="row"><div class="rl"><div class="rn">Screenshots and browsers</div><div class="rs">So you can show an agent what you mean</div></div></div>
+          <div class="row"><div class="rl"><div class="rn">Your gateway</div><div class="rs">Your agents on your phone, voice, and the morning report</div></div></div>
+          <div class="spacer"></div>
+          <span class="cta center">Set me up</span>
+          <p class="quiet">Skip setup and figure it out myself</p>
+          <div class="foot"><span class="back"></span>
+            <span class="note">Takes about 3 minutes. Everything can be changed later in Settings.</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">W-1</span><span class="chip bug">Decided</span>
+      <span class="ftitle">Delete the founder quote card</span></div>
+    <p>
+      "I think this quote from me up front is stupid. People just want their shit installed, they
+      don't want me talking to them about all this. So we should only explain why we're going through
+      this wizard, not give stupid quotes."
+    </p>
+    <p>The whole card goes - the quote, the "- Soren, founder" attribution, and the "Read more"
+      expander. <strong>The screen explains only why we are putting them through the wizard.</strong></p>
+    <p class="evline">Removes: <span class="ev">FirstRunWizardDialog.axaml:150-167</span> (the Border),
+      <span class="ev">FounderMoreText</span>, <span class="ev">FounderMoreLink</span>, and
+      <span class="ev">BtnFounderMore_Click</span> in the code-behind.</p>
+    <p><strong>What replaces it.</strong> With the card gone the subtitle carries the whole screen, and
+      a paragraph is the wrong shape for "here is why we are asking". The mockup turns it into a
+      scannable list of what the wizard is about to cover - four lines, each naming the thing and what
+      it buys them. That is the reason, stated once, in a form someone actually reads.
+      <em>The exact wording is a proposal, not a decision - it needs your eye.</em></p>
+    <p class="evline">Note the eight dots: this mockup already includes the new Browsers step (B-1).</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">R3</span><span class="chip wrong">Wrong copy</span>
+      <span class="ftitle">On a re-run, every sentence on this screen is false</span></div>
+    <p>"Welcome to DevThrottle", "You are about three minutes from running your first coding agent",
+      "Set me up" and "Skip setup and figure it out myself" all address someone who has never used
+      the product. A returning user opening this from Settings is told they are three minutes from
+      their first agent while four agents are already configured.</p>
+    <p class="evline">Evidence: <span class="ev">FirstRunWizardDialog.axaml:144-146,172-177</span>, all static text.</p>
+    <p><strong>Change:</strong> a review-mode variant of this screen that states the current machine
+      state as its content, offers "Review each step" as the primary action, and lets the user close
+      immediately if they only wanted to check.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">X1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">The skip link and the window X both permanently retire the wizard</span></div>
+    <p>Both write the completion marker. "Skip setup and figure it out myself" calls
+      <span class="ev">FinishAsync</span>, and closing the window with the X writes the marker from
+      <span class="ev">OnClosed</span> as well. After either, the wizard never auto-opens again - and
+      the only deliberate way back is a button under the Agents tab in Settings.</p>
+    <p class="evline">Evidence: <span class="ev">:326-338</span> (skip), <span class="ev">:1523-1542</span> (close),
+      <span class="ev">:1510-1517</span> (marker write).</p>
+    <p><strong>Change:</strong> on a first run, closing the window without reaching Done should leave the
+      marker unwritten so the wizard offers itself once more, or should say plainly on the way out where
+      to find it again. Writing the marker on a deliberate skip is correct; writing it on an accidental
+      close is not.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="agents"><span class="num">4</span>Screen 2 - Agents</h2>
+
+  <p class="lede">
+    This is the screen you called out first, and it is worse than "the message is not clear enough":
+    the button that moves you on is live while the scan is still running, and pressing it configures
+    nothing at all.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - during the scan <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">YOUR WORKFORCE</div>
+          <div class="w-title">Your agents</div>
+          <div class="w-sub">Scanning this machine for coding agents...</div>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span>
+            <span class="note"></span>
+            <span class="cta">Use these agents</span>
+          </div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        The list area is empty for the whole scan. One grey line, in the same style as every other
+        screen's subtitle. The button is enabled.
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - during the scan <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">YOUR WORKFORCE</div>
+          <div class="w-title">Looking for your coding agents</div>
+          <div class="bar indet"><i></i></div>
+          <div class="scanline">Checking Codex - 3 of 7 checked</div>
+          <div class="w-sub" style="margin-bottom:12px">Please wait for this to finish. Your agents are
+            only detected and set up correctly once the check completes.</div>
+          <div class="row"><div class="rl"><div class="rn">Claude Code</div><div class="rs">v2.1.4 - C:\Users\soren\AppData\Local\...\claude.exe</div></div><span class="pill ready">Ready</span></div>
+          <div class="row"><div class="rl"><div class="rn">Codex</div><div class="rs">Checking version...</div></div><span class="pill busy">Checking</span></div>
+          <div class="skel"></div>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span>
+            <span class="note"></span>
+            <span class="cta disabled">Checking...</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">A1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">"Use these agents" works during the scan, and adds none</span></div>
+    <p>Entering the step makes the primary button visible but never disables it
+      (<span class="ev">:210-213</span>), so it defaults to enabled. It is only set from the scan
+      result at the very end (<span class="ev">:406</span>). Press it while the scan is running and
+      <span class="ev">AcceptAgentsAsync</span> reads <span class="ev">_agentSuggestions</span>, which
+      is still the empty array it was initialised to (<span class="ev">:52</span>), finds nothing to
+      add, logs "nothing new to add" and advances (<span class="ev">:529-533</span>).</p>
+    <p><strong>The user sees a button labelled "Use these agents", presses it, and ends up with no agents
+      configured and no message saying so.</strong> On a fast machine the window is small; on a slow one,
+      or where a version probe hangs near its timeout, it is wide open.</p>
+    <p><strong>Change:</strong> disable the primary button for the duration of the scan and label it
+      "Checking..." while it is disabled.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">A2</span><span class="chip wrong">Unclear</span>
+      <span class="ftitle">Nothing on the screen reads as activity</span></div>
+    <p>"Scanning this machine for coding agents..." is rendered in the
+      <span class="ev">wsub</span> style - the same grey 16 point subtitle used for the static
+      explanatory line on every other step (<span class="ev">FirstRunWizardDialog.axaml:186-187</span>,
+      style at <span class="ev">:29-37</span>). There is no bar, no spinner, no count, no named
+      current item. The wizard contains no progress control of any kind.</p>
+    <p><strong>Change:</strong> an indeterminate bar, a live "Checking &lt;agent&gt; - 3 of 7 checked"
+      line in accent blue, and the explicit wait request you asked for: "Please wait for this to
+      finish. Your agents are only detected and set up correctly once the check completes."</p>
+  </div>
+
+  <div class="finding polish">
+    <div class="fhead"><span class="fid">A3</span><span class="chip polish">Slow</span>
+      <span class="ftitle">Probes are sequential and nothing is drawn until all of them return</span></div>
+    <p><span class="ev">ProbeVersionsAsync</span> runs a <code>foreach</code> with an
+      <code>await</code> per found agent, each bounded by that plugin's validation timeout
+      (<span class="ev">:418-435</span>), and <span class="ev">BuildAgentRows</span> is only called
+      after the whole loop returns (<span class="ev">:388-389</span>). So the wait is the sum of every
+      probe, and the screen shows nothing for all of it.</p>
+    <p><strong>Change:</strong> draw each agent's row as soon as detection finds it, with the version
+      cell reading "Checking version..." until its probe lands. The user watches the list build, which
+      is its own answer to "is anything happening".</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="tools"><span class="num">5</span>Screen 3 - Tools</h2>
+
+  <p class="lede">
+    This screen can only report. It cannot fix anything, and it has no way to express that a tool has
+    genuinely failed - so a permanently broken tool sits on "Installing..." indefinitely while the
+    status line keeps promising it will finish on its own.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - something is not ready <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">YOUR TOOLBELT</div>
+          <div class="w-title">9 tools, maintained for you</div>
+          <div class="w-sub">DevThrottle ships command tools you and your agents use every day - and it
+            installs and updates them itself. You never run an updater.</div>
+          <div class="w-status blue">7 of 9 ready - DevThrottle is installing the rest now. It finishes
+            on its own; you don't have to wait.</div>
+          <div class="row"><div class="rl"><div class="rn">cc-outlook</div><div class="rs">Read and send mail from an agent</div></div><span class="pill ready">Ready</span></div>
+          <div class="row"><div class="rl"><div class="rn">cc-vault</div><div class="rs">The personal knowledge store</div></div><span class="pill">Installing...</span></div>
+          <div class="row"><div class="rl"><div class="rn">cc-pdf</div><div class="rs">Turn markdown into a PDF</div></div><span class="pill">Installing...</span></div>
+          <div class="spacer"></div>
+          <p class="quiet">What these tools can do</p>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Continue</span>
+          </div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        Those two rows look identical whether they are four seconds from finishing or permanently
+        broken. There is no Fix.
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - one failed, one installing <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">YOUR TOOLBELT</div>
+          <div class="w-title">9 tools, maintained for you</div>
+          <div class="w-status blue">7 of 9 ready. Wait here and all of them will be working before
+            you finish. Continue and DevThrottle finishes the rest in the background on its own.</div>
+          <div class="row"><div class="rl"><div class="rn">cc-vault</div><div class="rs">Installing - about 20 seconds left</div></div><span class="pill busy">Installing</span></div>
+          <div class="row"><div class="rl"><div class="rn">cc-pdf</div><div class="rs">The Python runtime for this tool did not build</div></div><span class="pill fail">Failed</span></div>
+          <div class="row"><div class="rl"><div class="rn">cc-outlook</div><div class="rs">Read and send mail from an agent</div></div><span class="pill ready">Ready</span></div>
+          <div class="w-status red" style="margin-top:10px">1 tool needs a repair. This takes about a minute.</div>
+          <span class="cta center">Fix this now</span>
+          <p class="quiet">What these tools can do</p>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span>
+            <span class="note">You can continue - the repair keeps running.</span>
+            <span class="cta">Continue</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">T1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">No Fix, and no state for a tool that has actually failed</span></div>
+    <p>The screen renders two states only, straight from a boolean:
+      <span class="ev">tool.IsAvailable ? "Ready" : "Installing..."</span>
+      (<span class="ev">:657-661</span>). Anything not present is called "Installing", forever. The
+      poll runs every two seconds (<span class="ev">:686-696</span>) with no timeout and no
+      escalation, so a tool that will never install keeps its "Installing..." pill while the status
+      line above it keeps asserting <em>"It finishes on its own; you don't have to wait."</em>
+      That sentence becomes false and nothing on the screen ever takes it back.</p>
+    <p><strong>The repair already exists elsewhere.</strong> The Home screen's Fix button calls
+      <span class="ev">ToolUpdater.RepairPythonToolsAsync(progress)</span> and streams live progress
+      into its row (<span class="ev">MainWindow.axaml.cs:1055-1061</span>). The wizard already imports
+      <span class="ev">CcDirector.Setup.Engine</span>. Adding the same action here is a small change,
+      not new machinery.</p>
+    <p><strong>Change:</strong> three row states rather than two - Ready, Installing, Failed. Escalate
+      Installing to Failed when the poll sees no change for a set period. Show a "Fix this now" action
+      whenever anything is Failed, streaming repair progress the way Home already does. And report a
+      failed repair - the existing Home button writes the outcome only to the log file, so a repair that
+      fails is invisible there too.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">T2</span><span class="chip wrong">Wrong</span>
+      <span class="ftitle">"Ready" means present, not working</span></div>
+    <p><span class="ev">ToolDescriptor.IsAvailable =&gt; IsBuilt || IsOnPath</span>
+      (<span class="ev">ToolDescriptor.cs:92</span>) is a pure presence check. A tool that is installed
+      but broken - the exact case the Home screen has a whole repair path for - reads "Ready" here.</p>
+    <p><strong>Change:</strong> use the same health check the Home screen already runs, so this screen
+      and the Home status can never disagree about the same machine.</p>
+  </div>
+
+  <div class="finding polish">
+    <div class="fhead"><span class="fid">T-1</span><span class="chip polish">Deferred</span>
+      <span class="ftitle">Declining the tools is a Settings question, not an onboarding one</span></div>
+    <p>
+      "I'm wondering if we should have a way to not install the tools, but I think it should be under
+      the settings. We are going to do a different section... the tools section needs to be reviewed.
+      So for now, we keep the onboarding wizard this way."
+    </p>
+    <p><strong>No opt-out is added here.</strong> Whether the tools can be declined at all becomes its
+      own review of the tools area, and Soren is raising it with the release manager directly.</p>
+    <p>The three findings on this screen stay in scope regardless: they are about the screen telling
+      the truth when a tool is broken, which is a different question from whether the user gets a
+      choice about having them.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">T3</span><span class="chip wrong">Unclear</span>
+      <span class="ftitle">The trade is never stated</span></div>
+    <p>The current line says the background half - "It finishes on its own; you don't have to wait" -
+      but never what waiting buys. Your wording, which I would use close to verbatim: <em>"Wait here and
+      all of them will be working before you finish. Continue and DevThrottle finishes the rest in the
+      background on its own."</em> Both halves, one sentence each, so the choice is a real one.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="code"><span class="num">6</span>Screen 4 - Code</h2>
+
+  <p class="lede">
+    The same clarity problem as the Agents screen, and worse - here the scanning line is the faintest
+    text on the page. Plus the one defect that breaks the end of the whole journey.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - during the scan <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">WHAT WE WATCH OVER</div>
+          <div class="w-title">Where does your code live?</div>
+          <div class="w-sub">Pick the folder (or folders) where you keep your repositories. This is what
+            DevThrottle keeps the books on, and where it offers you repositories when you start an agent.</div>
+          <p class="w-hint">Checking the usual places for git repositories...</p>
+          <div class="row"><div class="rl"><div class="rn">Choose a folder</div><div class="rs">Point DevThrottle at where you keep your code</div></div><span class="btn-sm">Browse...</span></div>
+          <p class="quiet">I don't have code on this machine yet</p>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Continue</span>
+          </div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        The scanning line is 12.5 point grey - the smallest, faintest text on the screen - and it sits
+        under an empty area, above the Browse card.
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - during the scan <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">WHAT WE WATCH OVER</div>
+          <div class="w-title">Where does your code live?</div>
+          <div class="bar indet"><i></i></div>
+          <div class="scanline">Looking for repositories - checking D:\ReposFred</div>
+          <div class="w-sub" style="margin-bottom:12px">Please wait while we look. You can add folders
+            yourself below at any time.</div>
+          <div class="row"><div class="rl"><div class="rn">D:\ReposFred</div><div class="rs">12 git repositories found</div></div><span class="btn-sm">Add</span></div>
+          <div class="row"><div class="rl"><div class="rn">C:\Repos</div><div class="rs">3 git repositories found</div></div><span class="pill ready">Added</span></div>
+          <div class="skel"></div>
+          <div class="row"><div class="rl"><div class="rn">Choose a folder</div><div class="rs">Point DevThrottle at where you keep your code</div></div><span class="btn-sm">Browse...</span></div>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta disabled">Looking...</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3>C-1 - add every folder automatically, offer Remove</h3>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - four found, none added <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">WHAT WE WATCH OVER</div>
+          <div class="w-title">Where does your code live?</div>
+          <div class="w-sub">Pick the folder (or folders) where you keep your repositories.</div>
+          <div class="row"><div class="rl"><div class="rn">C:\Repos</div><div class="rs">12 git repositories found</div></div><span class="btn-sm">Add</span></div>
+          <div class="row"><div class="rl"><div class="rn">C:\ReposBPMN</div><div class="rs">1 git repository found</div></div><span class="btn-sm">Add</span></div>
+          <div class="row"><div class="rl"><div class="rn">C:\ReposFred</div><div class="rs">3 git repositories found</div></div><span class="btn-sm">Add</span></div>
+          <div class="row"><div class="rl"><div class="rn">D:\Dev</div><div class="rs">1 git repository found</div></div><span class="btn-sm">Add</span></div>
+          <div class="spacer"></div>
+          <div class="foot"><span class="back">Back</span><span class="note"></span><span class="cta">Continue</span></div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        Soren walked past all four without adding any, then reached a Done receipt reading
+        "No code folders yet".
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - all added, Remove to opt out <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i><i></i><i></i></div>
+          <div class="w-eyebrow">WHAT WE WATCH OVER</div>
+          <div class="w-title">We found your code</div>
+          <div class="w-sub">These are already added. DevThrottle keeps the books on them and offers
+            them when you start an agent. Remove any you would rather it left alone.</div>
+          <div class="row"><div class="rl"><div class="rn">C:\Repos</div><div class="rs">12 git repositories</div></div><span class="btn-sm">Remove</span></div>
+          <div class="row"><div class="rl"><div class="rn">C:\ReposBPMN</div><div class="rs">1 git repository</div></div><span class="btn-sm">Remove</span></div>
+          <div class="row"><div class="rl"><div class="rn">C:\ReposFred</div><div class="rs">3 git repositories</div></div><span class="btn-sm">Remove</span></div>
+          <div class="row"><div class="rl"><div class="rn">D:\Dev</div><div class="rs">1 git repository</div></div><span class="btn-sm">Remove</span></div>
+          <div class="row"><div class="rl"><div class="rn">Somewhere else?</div><div class="rs">Point DevThrottle at another folder</div></div><span class="btn-sm">Browse...</span></div>
+          <div style="text-align:center; margin-top:10px">
+            <div style="font-size:26px; font-weight:700">17</div>
+            <div style="font-size:10.5px; color:var(--faint)">repositories will be available when you start an agent</div>
+          </div>
+          <div class="spacer"></div>
+          <div class="foot"><span class="back">Back</span><span class="note"></span><span class="cta">Looks right</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">C-1</span><span class="chip bug">Decided</span>
+      <span class="ftitle">Invert it: found means added, and the action becomes Remove</span></div>
+    <p>
+      "I think these should be remove instead of add. I didn't see the adds buttons, so I didn't add
+      them. We should get them automatically added because then we can do all kinds of recommendations
+      on them."
+    </p>
+    <p><strong>The screenshot is the evidence.</strong> Four folders found, Add buttons on every row,
+      and the product's own author registered none of them. An opt-in that Soren misses is not a
+      working opt-in. Beyond convenience: a folder we know about is one we can make recommendations on,
+      and a folder the user never got round to adding is invisible to every downstream feature.</p>
+    <p class="evline">Changes: <span class="ev">CodeRow</span> at
+      <span class="ev">FirstRunWizardDialog.axaml.cs:781-832</span> (the Add button),
+      <span class="ev">AddCodeRootAsync</span> at <span class="ev">:850</span>, and the streaming
+      handler at <span class="ev">:748-755</span> which becomes the point of registration.</p>
+    <p><strong>One thing to be deliberate about.</strong> The wizard's stated principle is that doing
+      nothing writes nothing (<span class="ev">:196-200</span>); this inverts that for one step. My
+      recommendation is to persist the moment the row appears, because that is what the row claims - a
+      row reading "added" that is not actually saved becomes a lie the instant the user closes the
+      window.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">C-2</span><span class="chip bug">Decided</span>
+      <span class="ftitle">It has to work on Mac, and today it does not work equally</span></div>
+    <p>Checked in <span class="ev">CodeFolderScout.CandidateRoots()</span>
+      (<span class="ev">src/CcDirector.Core/Onboarding/CodeFolderScout.cs:46-79</span>). Both platforms
+      probe the home directory for <code>Projects</code>, <code>Code</code>, <code>repos</code>,
+      <code>git</code>, <code>dev</code>, <code>src</code>, plus <code>source\repos</code> on Windows
+      and <code>~/Developer</code> on Mac.</p>
+    <p><strong>But the drive sweep is Windows-only</strong> (<span class="ev">:62-77</span>): it lists
+      the top level of every fixed drive and takes any folder whose name looks like code. That sweep is
+      exactly what found all four folders above - <em>none</em> of them live under the home directory.
+      A Mac user keeping code outside their home directory gets nothing comparable, so auto-add would
+      find far less on a Mac than it does here. Needs a Mac arm covering <code>/Volumes</code> and the
+      common Mac locations.</p>
+  </div>
+
+  <h3>The rest of the Code screen</h3>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">C1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">A scan that ran out of time claims it checked everywhere</span></div>
+    <p>The scan is capped at ten seconds
+      (<span class="ev">:745</span>). When that cap fires, the cancellation handler writes
+      <em>"That is everywhere we checked - add anything else below."</em>
+      (<span class="ev">:764</span>) - <strong>character for character the sentence the successful path
+      writes</strong> (<span class="ev">:758</span>). A scan cut off part way through a large disk tells
+      the user it was exhaustive, and the user has no way to tell the two apart.</p>
+    <p><strong>Change:</strong> say what happened. "We stopped looking after ten seconds - add anything
+      we missed below", with a "Keep looking" action that restarts the sweep with a longer budget.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">C2</span><span class="chip wrong">Unclear</span>
+      <span class="ftitle">The scanning message is the quietest thing on the screen</span></div>
+    <p>"Checking the usual places for git repositories..." uses the
+      <span class="ev">hint</span> style - 12.5 point, colour <code>#8A909A</code>
+      (<span class="ev">FirstRunWizardDialog.axaml:255-257</span>, style at <span class="ev">:38-42</span>) -
+      and is positioned <em>below</em> the suggestions area, so while the scan runs the eye lands on
+      empty space with a whisper underneath it.</p>
+    <p><strong>Change:</strong> move the activity to the top of the list area, give it an indeterminate
+      bar and the folder currently being checked, and hold the primary button disabled and labelled
+      "Looking..." while the sweep is in flight, exactly as on the Agents screen.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">C3</span><span class="chip bug">Defect</span>
+      <span class="ftitle">Folders added here never reach New Session</span></div>
+    <p>The step writes the folder to the root directory store
+      (<span class="ev">:862</span>). New Session builds its list from the repository registry and from
+      nothing else (<span class="ev">NewSessionDialog.axaml.cs:552-562</span>), and is handed the
+      registry only (<span class="ev">MainWindow.axaml.cs:3389</span>). So the receipt says
+      "12 repositories - Done" and the very next screen says "No repositories yet".</p>
+    <p>The seam already exists and is already populated: <span class="ev">RepositoryMonitor</span> holds
+      every repository under the registered roots, is warm-loaded from cache at startup
+      (<span class="ev">App.axaml.cs:247</span>), and New Session simply never consults it. This is a
+      read-side change, not new machinery.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">C4</span><span class="chip wrong">Wrong</span>
+      <span class="ftitle">Two comments assert the wiring that does not exist</span></div>
+    <p><span class="ev">:84</span> - "the roots store the board and New Session read" - and
+      <span class="ev">:849</span> - "the same roots store the board and New Session read". Both are
+      false, and a comment that describes a wiring nobody built is how this shipped in the first place.
+      They have to be corrected in the same change as the code, or the defect returns.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="shots"><span class="num">7</span>Screen 5 - Screenshots</h2>
+
+  <p class="lede">
+    Your read is right: this one mostly works. It is slow, and while it is slow it looks dead. Polish,
+    not redesign - with one re-run defect underneath.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - while detecting <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i></div>
+          <div class="w-eyebrow">SHOW, DON'T TYPE</div>
+          <div class="w-title">Where do your screenshots go?</div>
+          <div class="w-sub">Snap a screen, then drag the screenshot straight onto an agent - the
+            fastest way to show it exactly what you mean.</div>
+          <div class="row" style="background:var(--wash)">
+            <div class="rl"><div class="rn" style="font-family:Consolas,monospace; font-weight:400">Looking for your screenshots folder...</div></div>
+            <span class="btn-sm">Change...</span>
+          </div>
+          <p class="quiet">Not sure? Take a screenshot and we'll find it</p>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Continue</span>
+          </div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        That static line is the only feedback while the step counts every image in the folder and
+        stats every file in it to sort them.
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - while detecting <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i></div>
+          <div class="w-eyebrow">SHOW, DON'T TYPE</div>
+          <div class="w-title">Where do your screenshots go?</div>
+          <div class="w-sub">Snap a screen, then drag the screenshot straight onto an agent - the
+            fastest way to show it exactly what you mean.</div>
+          <div class="row" style="background:var(--wash)">
+            <div class="rl"><div class="rn" style="font-family:Consolas,monospace; font-weight:400">D:\Personal\OneDrive\Pictures\Screenshots</div>
+            <div class="rs">Windows screenshots folder - counting images...</div></div>
+            <span class="btn-sm">Change...</span>
+          </div>
+          <div class="bar indet"><i></i></div>
+          <div class="thumbs"><span class="load"></span><span class="load"></span><span class="load"></span><span class="load"></span></div>
+          <p class="w-hint">Loading your most recent screenshots...</p>
+          <p class="quiet">Not sure? Take a screenshot and we'll find it</p>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Use this folder</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding polish">
+    <div class="fhead"><span class="fid">S1</span><span class="chip polish">Slow</span>
+      <span class="ftitle">Two full passes over the folder, with nothing on screen moving</span></div>
+    <p>Detection counts every image in the folder (<span class="ev">:975</span>), then the preview loader
+      enumerates every file again and calls <span class="ev">File.GetLastWriteTime</span> on each one to
+      sort the whole set before taking four (<span class="ev">:1028-1035</span>). On a real screenshots
+      folder - yours is inside OneDrive, so those may be cloud-backed files - that is thousands of
+      filesystem calls. The only thing on screen throughout is the static string
+      "Looking for your screenshots folder...".</p>
+    <p><strong>Change:</strong> resolve and show the path first, then count and load previews behind an
+      indeterminate bar with four grey placeholder tiles, so the shape of the answer appears immediately
+      and fills in. Cap the enumeration rather than sorting the entire folder.</p>
+  </div>
+
+  <div class="finding polish">
+    <div class="fhead"><span class="fid">S2</span><span class="chip polish">Polish</span>
+      <span class="ftitle">The thumbnail strip flashes empty on every change</span></div>
+    <p><span class="ev">ShotsPreviewStrip.IsVisible = false</span> is set before each load
+      (<span class="ev">:1013</span>) with nothing in its place, so changing folder blanks the area
+      until the new decode finishes. The placeholder tiles above fix this for free.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">R2</span><span class="chip bug">Defect</span>
+      <span class="ftitle">On a re-run this can silently replace a folder the user chose deliberately</span></div>
+    <p><span class="ev">DetectScreenshotsForWizardAsync</span> (<span class="ev">:966-991</span>) calls
+      the locator and takes its best guess. <strong>It never reads the folder already saved in
+      configuration.</strong> So a returning user who once browsed to a custom folder is shown the
+      detector's guess instead, under a button reading "Use this folder" - and pressing Continue writes
+      the guess over their choice.</p>
+    <p><strong>Change:</strong> on a re-run, open on the configured folder, label it "Currently in use",
+      and offer re-detection as an explicit action rather than performing it automatically.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="browsers"><span class="num">8</span>Screen 6 - Browsers <span style="font-size:15px; color:var(--accent)">(NEW)</span></h2>
+
+  <p class="lede">
+    A new step. Today there is no browser screen at all - the only mention of browsers in the whole
+    wizard is a receipt row on the Done screen that always reads "Later" whatever the machine's state
+    actually is.
+  </p>
+
+  <div class="ask">
+    <h4>The decision</h4>
+    <p>
+      "If we want people to use browsers, we need a screen in here that sets it up. And that means the
+      browser harness is required... I don't think we should go back to the installer and prerequisites
+      in. I think it should be a page saying here's our preferred method of dealing with browser
+      integration and it's a tool called browser harness. You want to install that and set up some
+      browser profiles that can have different logins."
+    </p>
+    <p>
+      And on how hard to push it: "I think we should try to sign up the browser, saying if you set up
+      your browsers now, it will be much easier to use, but you can also set up browsers later if you
+      prefer to get the installation going."
+    </p>
+  </div>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i></div>
+          <div class="w-title" style="margin-top:40px">There is no browsers screen</div>
+          <div class="w-sub">The wizard never mentions browsers. The only trace is one row on the Done
+            receipt, and it is advertising copy rather than a status - it prints "Later" whether or not
+            the harness is installed and whether or not any browser exists.</div>
+          <div class="receipt" style="margin-top:20px">
+            <div class="row"><div class="rl"><div class="rn">Browsers</div><div class="rs">Give agents a signed-in browser any time - the Browsers group in the left rail</div></div><span class="pill">Later</span></div>
+          </div>
+          <div class="spacer"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - the new step <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i><i></i></div>
+          <div class="w-eyebrow">SHOW, DON'T TYPE</div>
+          <div class="w-title">Let your agents use a browser</div>
+          <div class="w-sub">An agent can drive a real browser that is already signed in to your
+            accounts - reading a dashboard, filling a form, checking a page for you. Setting this up
+            now is much easier than wiring it up later.</div>
+          <div class="row"><div class="rl"><div class="rn">Browser Harness</div><div class="rs">The tool that drives the browser. From browser-use - we install it for you.</div></div><span class="pill busy">Not installed</span></div>
+          <div class="row"><div class="rl"><div class="rn">One signed-in browser</div><div class="rs">Its own profile and its own login, kept apart from your personal browser</div></div><span class="pill">To create</span></div>
+          <div class="spacer"></div>
+          <span class="cta center">Set up my browser</span>
+          <p class="quiet">Set up browsers later - I want to get going</p>
+          <div class="foot">
+            <span class="back">Back</span>
+            <span class="note">Later is fine - the Browsers group in the left rail does the same thing.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3>What already exists - checked, not assumed</h3>
+
+  <p>
+    Most of this is built. The new step is largely wiring, plus one genuinely new capability.
+  </p>
+
+  <div class="tblwrap">
+  <table>
+    <thead><tr><th>Piece</th><th style="width:130px">State today</th><th>Where</th></tr></thead>
+    <tbody>
+      <tr><td>Isolated per-browser profile, each with its own login</td><td><span class="chip ok">Built</span></td><td><code>AutomationBrowserService.Create</code> - own user-data-dir, own allocated debug port</td></tr>
+      <tr><td>Human signs a browser in, once</td><td><span class="chip ok">Built</span></td><td><code>BrowserSignInFlow.cs</code></td></tr>
+      <tr><td>Browser list, live status, launch and stop</td><td><span class="chip ok">Built</span></td><td><code>AutomationBrowserService</code>, <code>BrowsersRailGroup</code>, <code>BrowserSettingsView</code></td></tr>
+      <tr><td>Agent attaches to it</td><td><span class="chip ok">Built</span></td><td><code>BU_NAME</code> / <code>BU_CDP_URL</code> from <code>AutomationBrowserViewFold</code></td></tr>
+      <tr><td>Command-line surface</td><td><span class="chip ok">Built</span></td><td><code>BrowserEndpoints.cs</code>, <code>cc-devthrottle browser</code></td></tr>
+      <tr><td><strong>Installing browser-harness</strong></td><td><span class="chip bug">Missing</span></td><td><code>IsHarnessInstalled()</code> only checks PATH; the UI links out to a GitHub install page</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="callout">
+    <strong>Why the profiles work the way they do.</strong> This is already the shipped design and it
+    is exactly the "different logins" in the decision above: Chrome 136 and later refuses remote
+    debugging on the default profile, and App-Bound Encryption refuses to carry a login into a copied
+    profile. So each drivable browser is its own folder, signed in once by a human. That constraint is
+    proven, not theoretical - and it is what makes signing in a human act rather than something the
+    wizard can do for you.
+  </div>
+
+  <h3>Recommendations</h3>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">B-1</span><span class="chip bug">Decided</span>
+      <span class="ftitle">One step, after Screenshots and before Gateway</span></div>
+    <p>It belongs beside "show, don't type" - both screens are about how an agent gets context from
+      you - and it keeps Gateway as the last real step before Done.</p>
+    <p><strong>Not the installer, and there is a second reason beyond the one given:</strong> the
+      installer is finished and proven on a clean machine, and making a third-party Python tool a
+      prerequisite would gate every DevThrottle install on it, including the majority of users who
+      never drive a browser.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">B-2</span><span class="chip bug">Decided</span>
+      <span class="ftitle">Recommend doing it now, with an honest way out</span></div>
+    <p>The screen takes a side: setting up now is easier than wiring it up afterwards, and it says so.
+      The way out is a quiet "set up browsers later - I want to get going", with the rail named as
+      where that happens. This is deliberately not the Code step's auto-add - nothing third-party is
+      installed without the user choosing it - but the screen recommends rather than sitting neutral.</p>
+    <p><strong>The consequence that shapes the step:</strong> if the recommended path installs the
+      harness and leaves the user with nothing signed in, the recommendation was hollow - they finish
+      the wizard no better off. So the sign-in is part of the recommended path, not a follow-up to it.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">B-3</span><span class="chip wrong">Constraint</span>
+      <span class="ftitle">One browser here, not several</span></div>
+    <p>Signing in is interactive and one browser at a time. Three signed-in profiles cannot be batched
+      into a three-minute wizard, and trying would make the path we are recommending the slowest thing
+      in onboarding. Install the harness, create one profile, sign it in, and say plainly that more are
+      added from the Browsers group in the rail.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">B-4</span><span class="chip wrong">Consent</span>
+      <span class="ftitle">Name the tool and its source on screen</span></div>
+    <p>browser-harness is browser-use's software, not ours. The screen must say what it is installing
+      and where it comes from before the user accepts. A wizard that silently puts a third party's
+      software on someone's machine is not something we should ship, whatever the convenience.</p>
+  </div>
+
+  <div class="krux">
+    <h4>The one real unknown - settle this before estimating the step</h4>
+    <p>
+      <strong>What does installing browser-harness actually require?</strong> It is a Python tool from
+      browser-use. Whether that means pip, uv, or a bundled runtime decides whether this step is small
+      or large, whether it can complete without leaving the wizard, and whether the Mac and Windows
+      paths differ. <strong>I have not checked this yet</strong> - it is the only thing in this step
+      that could turn out expensive, and everything else here is wiring over machinery that exists.
+    </p>
+    <p>
+      Related: what the screen does when the install fails. Per the no-fallback rule it says so and
+      offers the manual install page - it never continues as though it worked.
+    </p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="gateway"><span class="num">9</span>Screen 7 - Gateway</h2>
+
+  <p class="lede">
+    The screen that matters most for acquisition, and the one carrying the re-run defect you named,
+    an architectural divergence, and a total accessibility block.
+  </p>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now - re-run, already connected <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i></div>
+          <div class="w-eyebrow">WITH YOU EVERYWHERE</div>
+          <div class="w-title">Connect your gateway</div>
+          <div class="w-sub">The gateway is what lets you check on your agents from your phone, use
+            voice, and get your morning report. Signing in takes seconds.</div>
+          <div class="gwcard sel">
+            <div class="gt">Hosted gateway <span class="badge">RECOMMENDED</span></div>
+            <div class="gd">We run it for you. Sign in and this machine is enrolled - phone access,
+              voice, and the morning report work immediately.</div>
+            <div class="gd" style="color:var(--faint)">Part of Pro</div>
+          </div>
+          <div class="gwtwo">
+            <div class="gwcard"><div class="gt" style="font-size:11.5px">Self-hosted gateway</div>
+              <div class="gd" style="font-size:10px">Run your own gateway and join it.</div></div>
+            <div class="gwcard"><div class="gt" style="font-size:11.5px">Not now</div>
+              <div class="gd" style="font-size:10px">Local-only on this machine.</div></div>
+          </div>
+          <div class="spacer"></div>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Sign in and connect</span>
+          </div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        This machine is already enrolled. The screen does not know. Two screens later the receipt will
+        correctly print "Gateway connected".
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - re-run, already connected <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Review your DevThrottle setup</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i><i></i></div>
+          <div class="w-eyebrow">WITH YOU EVERYWHERE</div>
+          <div class="w-title">Your gateway is connected</div>
+          <div class="connected">
+            <span class="cb">Connected</span>
+            <div class="w-sub" style="margin-top:10px">This machine is enrolled with
+              devthrottle-gw.azurewebsites.net. Phone access, voice and the morning report are working.
+              Nothing here needs changing.</div>
+          </div>
+          <div class="row"><div class="rl"><div class="rn">Signed in as</div><div class="rs">soren@centerconsulting.com</div></div><span class="pill ready">Active</span></div>
+          <div class="spacer"></div>
+          <p class="quiet">Connect a different gateway</p>
+          <p class="quiet">Disconnect this machine</p>
+          <div class="foot">
+            <span class="back">Back</span><span class="note"></span><span class="cta">Continue</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">R1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">The step ignores the gateway that is already configured</span></div>
+    <p>Covered in full in section 2. In short: <span class="ev">_gatewayConnected</span> is a
+      this-run-only flag (<span class="ev">:61</span>, set at <span class="ev">:1302</span>) and
+      <span class="ev">RefreshGatewayChoiceUi</span> never reads
+      <span class="ev">GatewayConfig.Load()</span> - while <span class="ev">BuildDoneReceipt</span>
+      does (<span class="ev">:1419</span>).</p>
+    <p><strong>Change:</strong> read the saved gateway when the step opens. If one is configured, open on
+      the Connected view with the primary button reading "Continue", and put reconnecting and
+      disconnecting behind quiet secondary links. This is a handful of lines and it is the single
+      cheapest fix in this document.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">G2</span><span class="chip bug">Blocked</span>
+      <span class="ftitle">The three cards cannot be operated by keyboard or screen reader</span></div>
+    <p>All three are bare <code>Border</code> elements carrying only a <code>PointerPressed</code>
+      handler (<span class="ev">FirstRunWizardDialog.axaml:369-372, 393-396, 404-407</span>). A Border
+      is not focusable and exposes no invoke pattern, so there is no tab stop, no space or enter, and
+      nothing for a screen reader to announce. <strong>A keyboard-only user cannot choose a gateway at
+      all</strong> - and choosing the hosted gateway is the commercial step of the whole product.</p>
+    <p>The wider picture: <span class="ev">AutomationProperties</span> is used exactly once in the entire
+      desktop application, on the gateway status box in the main window
+      (<span class="ev">MainWindow.axaml.cs:685-686</span>). Nothing in the wizard has an accessible
+      name. This deserves its own piece of work beyond this screen.</p>
+    <p><strong>Change:</strong> make each card a <code>RadioButton</code> with a card template, or a
+      templated <code>Button</code> - focusable, invokable by keyboard, and announceable - and set an
+      accessible name on each. Using <code>PointerPressed</code> rather than a click also means a press
+      that drags away still selects the card.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">G1</span><span class="chip wrong">Architecture</span>
+      <span class="ftitle">This step keeps its own private ruling instead of the shared one</span></div>
+    <p><span class="ev">:58</span> declares a private
+      <code>enum GatewayChoice { Hosted, SelfHost, NotNow }</code> and the three cards are hard-coded in
+      markup, including which one is pre-selected and which carries the RECOMMENDED badge
+      (<span class="ev">FirstRunWizardDialog.axaml:369-415</span>). Settings and the status box go
+      through the shared state machine in
+      <span class="ev">CcDirector.Core/GatewayConnection/GatewayChoice.cs</span>. So the one screen a
+      new customer sees is the one screen that would <em>not</em> follow a change to the hosted rules -
+      a region, an entitlement, an outage - while every other surface did. That is the client-is-dumb
+      rule in <code>CLAUDE.md</code>, breached on the highest-value screen.</p>
+    <p><strong>Change:</strong> collapse this step onto the shared state machine before anything else
+      about the step is edited, so the fixes above are built on the shared ruling rather than on top of
+      the divergence.</p>
+  </div>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">G3</span><span class="chip wrong">Unsourced</span>
+      <span class="ftitle">"Part of Pro" is a hard-coded plan claim</span></div>
+    <p>Written directly into the markup at <span class="ev">:387-388</span>, with nothing behind it. If
+      plans or trial terms change, this line does not. It is a commercial statement on the acquisition
+      screen and it should come from the same place the rest of the product gets plan facts.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="done"><span class="num">10</span>Screen 8 - Done</h2>
+
+  <div class="pair">
+    <div class="pane">
+      <h4>Now <span class="tag now">as shipped</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Set up DevThrottle</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i></div>
+          <div class="w-title">You are ready</div>
+          <div class="w-sub">Start an agent on one of your repositories - give it a small task and watch
+            the card, not the terminal.</div>
+          <div class="receipt">
+            <div class="row"><div class="rl"><div class="rn">2 agents ready</div><div class="rs">Claude Code, Codex</div></div><span class="pill ready">Done</span></div>
+            <div class="row"><div class="rl"><div class="rn">12 repositories</div><div class="rs">D:\ReposFred</div></div><span class="pill ready">Done</span></div>
+            <div class="row"><div class="rl"><div class="rn">Screenshots folder set</div><div class="rs">D:\Personal\OneDrive\Pictures\Screenshots</div></div><span class="pill ready">Done</span></div>
+            <div class="row"><div class="rl"><div class="rn">Gateway connected</div><div class="rs">devthrottle-gw.azurewebsites.net</div></div><span class="pill ready">Done</span></div>
+          </div>
+          <div class="spacer"></div>
+          <span class="cta center">Start my first agent</span>
+          <p class="quiet">Take me to the board</p>
+          <div class="foot"><span class="back">Back</span><span class="note">Everything here can be changed in Settings.</span></div>
+        </div>
+      </div>
+      <p class="w-hint" style="text-align:left; margin-top:10px">
+        "12 repositories - Done", then "Start my first agent" opens New Session showing
+        "No repositories yet".
+      </p>
+    </div>
+
+    <div class="pane">
+      <h4>Proposed - review run <span class="tag next">proposed</span></h4>
+      <div class="win">
+        <div class="titlebar"><span>Review your DevThrottle setup</span><span class="x">x</span></div>
+        <div class="body">
+          <div class="dots"><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="past"></i><i class="cur"></i></div>
+          <div class="w-title">Two things changed</div>
+          <div class="w-sub">Everything else was already set up and was left exactly as it was.</div>
+          <div class="receipt">
+            <div class="row"><div class="rl"><div class="rn">Added Codex</div><div class="rs">v0.145.0 - C:\Users\soren\...\codex.exe</div></div><span class="pill ready">Changed</span></div>
+            <div class="row"><div class="rl"><div class="rn">Repaired cc-pdf</div><div class="rs">The Python runtime was rebuilt</div></div><span class="pill ready">Changed</span></div>
+            <div class="row dim"><div class="rl"><div class="rn">Gateway</div><div class="rs">devthrottle-gw.azurewebsites.net</div></div><span class="pill">Unchanged</span></div>
+            <div class="row dim"><div class="rl"><div class="rn">Code folders</div><div class="rs">D:\ReposFred - 12 repositories</div></div><span class="pill">Unchanged</span></div>
+          </div>
+          <div class="spacer"></div>
+          <span class="cta center">Start an agent</span>
+          <p class="quiet">Back to the board</p>
+          <div class="foot"><span class="back">Back</span><span class="note">Everything here can be changed in Settings.</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">C3</span><span class="chip bug">Defect</span>
+      <span class="ftitle">"Start my first agent" lands on an empty New Session</span></div>
+    <p>The full diagnosis is under the Code screen. It is worth restating here because this is where the
+      user meets it: the receipt is truthful, the handoff is intact
+      (<span class="ev">:1510-1517</span> sets the flag,
+      <span class="ev">MainWindow.axaml.cs:404-406</span> reads it and opens the dialog) - and the
+      dialog it opens reads a different store.</p>
+  </div>
+
+  <div class="finding polish">
+    <div class="fhead"><span class="fid">D1</span><span class="chip polish">Polish</span>
+      <span class="ftitle">The tools row disappears if the user moved through quickly</span></div>
+    <p>The receipt adds a tools row only when <span class="ev">_toolsTotalCount &gt; 0</span>
+      (<span class="ev">:1427</span>), which is only true if the Tools step actually rendered. A user
+      who clicked through fast gets a receipt silently missing a line, so the receipt is not a complete
+      statement of the machine. Read the catalog when building the receipt instead.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="settings"><span class="num">11</span>The way back in - Settings</h2>
+
+  <p class="lede">
+    You said the front door is fine for now, so this is the smaller half: the one path that exists is
+    correct, and the words around it are not.
+  </p>
+
+  <p>
+    Re-running works, and works safely. Settings -&gt; the <strong>Agents</strong> tab -&gt;
+    "Setup wizard..." opens the real seven-step wizard
+    (<span class="ev">SettingsDialog.axaml.cs:715-722</span>), and the completion marker is written
+    idempotently and only ever controls whether the wizard auto-opens at launch
+    (<span class="ev">FirstRunWizardModel.cs:231-247</span>). Nothing is reset by re-running it.
+  </p>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">E1</span><span class="chip wrong">Wrong copy</span>
+      <span class="ftitle">The button says one thing and the words around it say another</span></div>
+    <p>The label was corrected to "Setup wizard..." (<span class="ev">SettingsDialog.axaml:177</span>).
+      Two pieces of text around it still describe the retired detection-only wizard:</p>
+    <ul class="tight">
+      <li>The button's own tooltip, <span class="ev">SettingsDialog.axaml:179</span> - "Scan this machine
+        for known tools and add the ones it finds with their recommended settings".</li>
+      <li>The Agents section text above it, <span class="ev">SettingsDialog.axaml:171</span> - "The Setup
+        wizard can scan this machine for known tools." <em>(Not previously reported.)</em></li>
+    </ul>
+    <p><strong>Change:</strong> both should say what the button does - re-run the full setup, covering
+      agents, tools, code folders, screenshots and the gateway. Two one-line edits.</p>
+  </div>
+
+  <div class="callout">
+    <strong>Noted, not actioned per your decision:</strong> this remains the only deliberate way to
+    re-run setup, and it sits under Agents although it also covers Tools, Directories, Screenshots and
+    the Gateway. There is nothing on the toolbar, nothing on the Home screen, and no menu bar - the Help
+    dialog is an About box (version, build date, install root, gateway address) with no actions in it.
+    Leaving it as is for now; it belongs on the list when the wizard itself is right.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="crosscut"><span class="num">12</span>Cross-cutting - progress, keyboard, the closing X</h2>
+
+  <div class="finding wrong">
+    <div class="fhead"><span class="fid">X2</span><span class="chip wrong">Missing</span>
+      <span class="ftitle">The wizard contains no progress indicator of any kind</span></div>
+    <p>Neither the markup nor the code-behind contains a single <code>ProgressBar</code>, spinner or
+      indeterminate control - zero matches across both files. Every waiting state in the product's
+      first three minutes is expressed as a line of grey text. Three separate screens - Agents, Code,
+      Screenshots - all have the same complaint against them for the same reason.</p>
+    <p><strong>Change:</strong> one small shared activity element - an indeterminate bar plus a line of
+      accent-coloured text naming what is happening right now - reused by all three. Building it once
+      fixes A2, C2 and S1 together.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">X1</span><span class="chip bug">Defect</span>
+      <span class="ftitle">Closing the window retires the wizard permanently</span></div>
+    <p>Detailed under the Welcome screen. It matters more than it looks: an interrupted first run is
+      exactly when someone closes a window, and the way back in is a button under a Settings tab they
+      have no reason to open.</p>
+  </div>
+
+  <div class="finding bug">
+    <div class="fhead"><span class="fid">G2</span><span class="chip bug">Blocked</span>
+      <span class="ftitle">Onboarding cannot be completed without a mouse</span></div>
+    <p>Detailed under the Gateway screen. It is listed again here because it is not only the gateway
+      cards - every selectable card in the wizard is a bare Border with a pointer handler, and no
+      control in the wizard carries an accessible name.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 id="plan"><span class="num">13</span>What to build, in order</h2>
+
+  <p class="lede">
+    Ordered by value per hour, with the architectural cleanup placed before the work that would
+    otherwise be built on top of it.
+  </p>
+
+  <div class="tblwrap">
+  <table>
+    <thead>
+      <tr><th style="width:44px">#</th><th>Change</th><th style="width:120px">Covers</th><th style="width:112px">Size</th></tr>
+    </thead>
+    <tbody>
+      <tr style="background:var(--green-bg)"><td>1</td><td>Gateway step reads the saved gateway on entry and opens Connected when there is one</td><td>R1</td><td><strong>BUILT</strong></td></tr>
+      <tr style="background:var(--green-bg)"><td>2</td><td>Disable the primary button during the agent scan and label it "Checking..."</td><td>A1</td><td><strong>BUILT</strong></td></tr>
+      <tr style="background:var(--green-bg)"><td>3</td><td>Correct the timed-out repository scan message, and the two Settings texts</td><td>C1, E1</td><td><strong>BUILT</strong></td></tr>
+      <tr style="background:var(--green-bg)"><td>4</td><td>One shared activity element - indeterminate bar plus a live "what we are doing now" line - used on Agents, Code and Screenshots, with the wait request</td><td>A2, C2, S1, X2</td><td><strong>BUILT</strong></td></tr>
+      <tr style="background:var(--green-bg)"><td>5</td><td>Tools: three real states, a Fix action using the existing repair, and the wait-or-continue sentence</td><td>T1, T2, T3</td><td><strong>BUILT</strong></td></tr>
+      <tr style="background:var(--green-bg)"><td>6</td><td>Stream agent rows as they are found instead of after every version probe</td><td>A3</td><td><strong>BUILT</strong></td></tr>
+      <tr><td>7</td><td>Welcome: delete the founder quote card and rewrite the screen to state only why we are asking</td><td>W-1</td><td>An hour</td></tr>
+      <tr><td>8</td><td>Code: auto-add every folder found, action becomes Remove, plus the Mac arm of the scan</td><td>C-1, C-2</td><td>Half a day</td></tr>
+      <tr><td>9</td><td>Connect the code folders to New Session so the receipt is true, and fix the two false comments. <em>Needs the long-tail decision first.</em></td><td>C3, C4</td><td>Half a day</td></tr>
+      <tr><td>10</td><td>Browsers: the whole new step. <em>Size depends on the harness install question.</em></td><td>B-1..B-4</td><td>Unknown - see section 8</td></tr>
+      <tr><td>11</td><td>Collapse the gateway step onto the shared choice state machine</td><td>G1</td><td>Half a day</td></tr>
+      <tr><td>12</td><td>Re-run mode end to end: a mode flag, every step opening on current state, and a Done screen that reports what changed</td><td>R2, R3, D1</td><td>A day</td></tr>
+      <tr><td>13</td><td>Screenshots: placeholders and capped enumeration (the path-first half is built)</td><td>S2</td><td>Two hours</td></tr>
+      <tr><td>14</td><td>Do not write the completion marker on an accidental window close</td><td>X1</td><td>An hour</td></tr>
+      <tr><td>15</td><td>Make every card focusable and invokable, and give every control an accessible name</td><td>G2</td><td>Its own piece of work</td></tr>
+      <tr><td>16</td><td>Source the "Part of Pro" line from wherever plan facts actually live</td><td>G3</td><td>Depends on that</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <div class="callout">
+    <strong>Items 1 to 6 are built and running</strong> in the slot 5 test build - that is what the
+    walkthrough screenshots were taken from. Nothing is committed.
+    <br><br>
+    <strong>Two things block the next batch, and neither is code.</strong> Item 9 needs the long-tail
+    decision (what New Session shows once 17 repositories are registered automatically). Item 10 needs
+    the answer to what installing browser-harness actually takes. Item 11 should land before anything
+    else touches the gateway step, so the re-run work in item 12 is built on the shared ruling rather
+    than on top of the divergence.
+  </div>
+
+  <h3>What this document does not establish</h3>
+  <ul class="tight">
+    <li>Everything here comes from reading <code>origin/main</code> at <code>3d2c70c6</code>. I did not
+      build the application or run the wizard, so the timings described (the sequential probes, the
+      folder passes) are read from the code, not measured.</li>
+    <li>The hosted sign-in leg has still never been run on a clean machine by anyone - both clean-machine
+      passes on record took "Not now" - so the connected and failed states of the gateway screen are the
+      least proven part of this review.</li>
+    <li>The mockups are proposals drawn to the wizard's own design system, not screenshots. No code has
+      been changed.</li>
+  </ul>
+
+  <footer class="end">
+    Read from a clean worktree cut from <code>origin/main</code> at <code>3d2c70c6</code>, 29 July 2026.
+    Nothing was committed and no code was modified in producing this review.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/reviews/codex-onboarding-review.md
+++ b/docs/reviews/codex-onboarding-review.md
@@ -1,0 +1,80 @@
+# Onboarding wizard rework: independent code review
+
+Reviewed only the requested diff from `3d2c70c6` across the seven specified files.
+
+## Findings
+
+### 1. Removing an auto-detected code root can be undone by the still-running scan
+
+- **Severity:** High
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:953-959`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1133-1160`
+- **Problem:** Removal deletes the path from `_codeAddedRoots`, but there is no tombstone recording that the user rejected it. A later progress callback for the same path therefore treats it as new and calls `AutoAddCodeRootAsync`, which writes it back to `root-directories.json` and redraws the row.
+- **Concrete failure:** Start with a registered conventional root such as `~/Code` containing repositories. Enter the Code step and click **Remove** before the scout reaches that candidate. When the scout reports `~/Code`, the `ContainsKey` check now returns false and the root is silently re-added. The user's explicit opt-out does not stick.
+
+### 2. The scan completes before its serialized registrations, and New Session reads the rescan only once
+
+- **Severity:** High
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:953-968`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1020-1028`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1096-1129`, `src/CcDirector.Avalonia/NewSessionDialog.axaml.cs:552-555`, `src/CcDirector.Avalonia/NewSessionDialog.axaml.cs:591-604`
+- **Problem:** Each `Progress<T>` callback discards the `AutoAddCodeRootAsync` task. `await CodeFolderScout.ScanAsync(...)` therefore waits for discovery only, not for any of the queued file writes behind `_codeStoreGate`. The screen can announce that the scan is finished while rows are still being persisted. Leaving the step starts a fire-and-forget repository rescan over whatever subset has completed. `NewSessionDialog` then takes one `RepositoryMonitor.Snapshot()` in its constructor and never refreshes when that rescan finishes.
+- **Concrete failure:** On a machine where several roots are found, proceed as soon as the scan says it is complete, then click **Start my first agent**. If registrations or the repository rescan are still running, New Session snapshots the old/partial model and can still show **No repositories yet**. Repositories arriving after the dialog opens never appear in that dialog. Closing the wizard while the first registration is still pending is worse: `OnClosed` sees `_codeRootsChanged == false`, then the late task writes the root after the only publish opportunity has passed.
+
+### 3. Review mode promises no unsolicited work but automatically rewrites the roots configuration
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1549-1559`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:288-293`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:948-959`
+- **Problem:** The review welcome says everything is already set up and "nothing is redone unless you ask," but reaching the Code step immediately starts the scout and automatically persists every detected root. Review mode changes only copy; it does not change this first-run side effect.
+- **Concrete failure:** Complete or skip onboarding with no code roots, reopen the wizard from Settings, choose **Review each step**, and advance to Code. Without pressing Browse or any confirmation control, detected folders are written to `root-directories.json`. This is a persistent configuration change caused by inspection alone, contrary to the review-mode promise.
+
+### 4. Removing a repository from New Session immediately adds it back
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Avalonia/NewSessionDialog.axaml.cs:591-618`, `src/CcDirector.Avalonia/NewSessionDialog.axaml.cs:1236-1249`
+- **Problem:** The list now contains both registry entries and monitor-only discoveries, but the existing Remove handler only removes from the registry. It immediately calls `BuildRepositoryList()`, which unions the unchanged monitor snapshot back in.
+- **Concrete failure:** For any repository under a watched root, click its Remove button in New Session. `_registry.Remove(path)` succeeds, but the following rebuild sees the same path in `RepositoryMonitor.Snapshot()` and recreates the row. Even a recently used repository reappears as a discovered item, so the UI action can no longer remove it from the displayed list.
+
+### 5. The macOS volume sweep is not bounded by the advertised timeout
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Core/Onboarding/CodeFolderScout.cs:71-83`, `src/CcDirector.Core/Onboarding/CodeFolderScout.cs:104-122`, `src/CcDirector.Core/Onboarding/CodeFolderScout.cs:142-155`
+- **Problem:** `CandidateRoots()` synchronously enumerates `/Volumes` and then every mounted volume before `ScanAsync` reaches its first `ct.ThrowIfCancellationRequested()`. `Directory.GetDirectories` does not accept the token, and `CountRepos` is also uninterruptible. The 10-second cancellation source in the dialog therefore does not bound the whole sweep as the method comment claims.
+- **Concrete failure:** Mount an unavailable or stalled network share under `/Volumes` and open the Code step. Enumeration can block past ten seconds; the cancellation token is set but cannot be observed until the filesystem call returns. The progress bar remains indefinitely and the timeout branch that offers **Keep looking** never runs.
+
+### 6. An in-flight tools refresh can create a polling timer after the window has closed
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:762-820`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:836-880`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:883-900`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:2070-2079`
+- **Problem:** Tool refresh and repair operations have no cancellation or closed/current-step guard. `OnClosed` stops the timer that exists at that moment, but an already-awaited catalog read or repair can resume afterwards and call `StartToolsPoll()`. The new timer's Tick handler captures the closed dialog and continues refreshing it.
+- **Concrete failure:** Open Tools while catalog inspection is slow, or start **Fix this now**, then close the wizard before the await completes while at least one tool remains missing. The continuation starts a new two-second `DispatcherTimer` after `OnClosed` has already run. The closed window remains referenced and its hidden controls are updated indefinitely.
+
+### 7. The Done receipt discards the new "Not installed" state and repeats the old false promise
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:779-812`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1962-1968`
+- **Problem:** The Tools step correctly distinguishes a stalled tool as **Not installed**, but the receipt reduces every non-ready state back to **Tools installing** / **Finishes on its own in the background**.
+- **Concrete failure:** Leave a tool missing for 45 seconds until the screen says it did not install, then continue to Done. The receipt immediately contradicts the prior screen and promises that the failed install will finish without intervention--the exact unkeepable claim the third state was intended to remove.
+
+### 8. A saved URL is treated as proof that the gateway and all dependent features work
+
+- **Severity:** Medium
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1679-1699`
+- **Problem:** `AdoptExistingGateway` checks only `GatewayConfig.IsEnabled`, which is true for any nonblank saved URL. It performs no reachability, authentication, or enrollment check, yet says the machine is enrolled and that phone access, voice, and the morning report are working.
+- **Concrete failure:** Leave a stale, mistyped, or unreachable URL in the saved gateway config and rerun the wizard. The gateway step opens in the green connected state with **Continue**, so an unenrolled machine is not offered the normal enrollment path unless the user notices and selects **Connect a different gateway**.
+
+### 9. The gateway choices still do not expose radio-button semantics or selected state to accessibility clients
+
+- **Severity:** Low
+- **Location:** `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml:429-476`, `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs:1752-1772`
+- **Problem:** Making a `Border` focusable and assigning an automation name does not turn it into a radio button or expose selection state. The custom handlers update only visual styling and `_gatewayChoice`; no automation property tells a screen reader which option is selected. `GotFocus` also changes the choice merely by tabbing through it rather than using standard radio-group keyboard behavior.
+- **Concrete failure:** Navigate the three cards with a screen reader. Each has a static name, but the client cannot query "selected" versus "not selected," and moving focus mutates the pending choice without an activation command. A user cannot reliably review the chosen gateway option nonvisually.
+
+### 10. The canonical-order test was weakened enough to miss a real ordering regression
+
+- **Severity:** Low
+- **Location:** `src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs:125-143`, `src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs:146-164`
+- **Problem:** `Assert.Equal(FirstRunWizardModel.CanonicalOrder, model.Steps)` compares output to the same list used to construct and order it, while the former full sequence assertion was changed to a set comparison. The remaining spot checks constrain Gateway, Tools, and Screenshots but do not assert the full intended sequence.
+- **Concrete failure:** Change the production order to `Welcome, Gateway, Code, Tools, Agents, Screenshots, Done`. The count, Gateway index, Tools index, Screenshots index, set comparisons, and subset normalization test all still pass, despite violating the stated `Agents -> Tools -> Code` journey.
+
+## Verification
+
+- `dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~FirstRunWizardModelTests" --no-restore` - 23 passed.
+- `dotnet build src/CcDirector.Avalonia/CcDirector.Avalonia.csproj --no-restore` - succeeded with 0 warnings and 0 errors.

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -26,6 +26,14 @@
             <Setter Property="TextAlignment" Value="Center" />
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
+        <!-- The WORKING steps (Gateway, Agents, Tools, Code, Screenshots) are a label above a list, so
+             their title does not need the presence of a hero. At 32 point, with a three-line subtitle
+             under it, the heading furniture ate roughly a third of a 900x640 window and the list below
+             it showed two and a half of eight rows. The hero size is kept for Welcome and Done, which
+             are mostly words and have nothing to crowd. -->
+        <Style Selector="TextBlock.wtitle.step">
+            <Setter Property="FontSize" Value="24" />
+        </Style>
         <Style Selector="TextBlock.wsub">
             <Setter Property="Foreground" Value="#5A616B" />
             <Setter Property="FontSize" Value="16" />
@@ -35,10 +43,40 @@
             <Setter Property="MaxWidth" Value="480" />
             <Setter Property="LineHeight" Value="24" />
         </Style>
+        <!-- Matching subtitle for the working steps: smaller, and wider so the same sentence uses
+             fewer lines rather than more. -->
+        <Style Selector="TextBlock.wsub.step">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="LineHeight" Value="20" />
+            <Setter Property="MaxWidth" Value="560" />
+        </Style>
         <Style Selector="TextBlock.hint">
             <Setter Property="Foreground" Value="#8A909A" />
             <Setter Property="FontSize" Value="12.5" />
             <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <!-- The live "what we are doing right now" line that sits under an activity bar. Accent
+             coloured and semi-bold on purpose: a scan has to READ as activity. Before this, every
+             busy state on every step was rendered in the same grey as the static subtitles, so a
+             running scan and a finished one looked identical and users pressed on through. -->
+        <Style Selector="TextBlock.scanline">
+            <Setter Property="Foreground" Value="#0066B8" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="TextAlignment" Value="Center" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <!-- The activity bar itself, shared by every scanning step. -->
+        <Style Selector="ProgressBar.scanbar">
+            <Setter Property="Height" Value="4" />
+            <Setter Property="MaxWidth" Value="420" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="IsIndeterminate" Value="True" />
+            <Setter Property="Foreground" Value="#0066B8" />
+            <Setter Property="Background" Value="#E6E8EC" />
         </Style>
 
         <!-- Primary accent CTA. -->
@@ -138,33 +176,19 @@
                  expanded used to push "Set me up" off the bottom of the window. -->
             <Grid x:Name="WelcomePanel" IsVisible="False" RowDefinitions="*,Auto">
                 <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="580" HorizontalAlignment="Center">
-                    <StackPanel Spacing="16" VerticalAlignment="Center">
-                        <TextBlock Classes="wtitle" Text="Welcome to DevThrottle" />
-                        <TextBlock Classes="wsub"
-                                   Text="You are about three minutes from running your first coding agent. We will show you what comes included - your agents, your code, your morning report - and every step is a take-it-or-leave-it offer. Use what helps, breeze past what doesn't." />
-
-                        <!-- Founder note: two sentences collapsed, one quiet Read more. It must never
-                             delay the "Set me up" click - short by design. -->
-                        <Border Background="#F5F6F8" BorderBrush="#E6E8EC" BorderThickness="1"
-                                CornerRadius="12" Padding="20,16" MaxWidth="540"
-                                HorizontalAlignment="Center" Margin="0,6,0,0">
-                            <StackPanel Spacing="8">
-                                <TextBlock FontSize="13.5" Foreground="#5A616B" TextWrapping="Wrap"
-                                           LineHeight="21"
-                                           Text="I built DevThrottle because running agents was never the hard part. The hard part was getting to Friday and realizing the week went to the wrong things. DevThrottle keeps the books - so that stops happening." />
-                                <TextBlock x:Name="FounderMoreText" FontSize="13.5" Foreground="#5A616B"
-                                           TextWrapping="Wrap" LineHeight="21" IsVisible="False"
-                                           Text="Agents multiply what you can build, and they multiply the bookkeeping with it: branches, worktrees, half-finished work, sessions waiting on you. DevThrottle carries that administration for you and reports back every morning with what happened and what needs your attention. Give it one small task today, then read tomorrow's report. That is the whole loop." />
-                                <Grid ColumnDefinitions="*,Auto">
-                                    <TextBlock Grid.Column="0" FontSize="12.5" Foreground="#8A909A"
-                                               Text="- Soren, founder" VerticalAlignment="Center" />
-                                    <Button Grid.Column="1" x:Name="FounderMoreLink" Classes="quietLink"
-                                            Content="Read more" Click="BtnFounderMore_Click" />
-                                </Grid>
-                            </StackPanel>
-                        </Border>
+                    <StackPanel Spacing="12" VerticalAlignment="Center">
+                        <TextBlock x:Name="WelcomeTitle" Classes="wtitle" Text="Let's get you set up" />
+                        <TextBlock x:Name="WelcomeSubText" Classes="wsub" />
+                        <!-- What this wizard is about to cover, one row each. The screen's whole job is
+                             to say WHY we are asking, and a scannable list is the shape people read.
+                             It replaces a founder note that talked about the product's philosophy:
+                             someone who has just installed software wants to know what the next three
+                             minutes are for, not to hear from the founder. On a re-run the same rows
+                             carry the machine's CURRENT state instead. -->
+                        <StackPanel x:Name="WelcomeAgendaPanel" Spacing="7" MaxWidth="540"
+                                    HorizontalAlignment="Stretch" />
                     </StackPanel>
                 </ScrollViewer>
 
@@ -181,12 +205,19 @@
             <!-- ===================== AGENTS ===================== -->
             <Grid x:Name="AgentsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="YOUR WORKFORCE" />
-                <TextBlock Grid.Row="1" x:Name="AgentsTitle" Classes="wtitle"
+                <TextBlock Grid.Row="1" x:Name="AgentsTitle" Classes="wtitle step"
                            Text="Your agents" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" x:Name="AgentsStatusText" Classes="wsub"
-                           Text="Scanning this machine for coding agents..." Margin="0,0,0,20" />
+                <!-- Activity block. The bar and the accent line are visible only WHILE the scan runs;
+                     the status line beneath carries the wait request during the scan and the result
+                     afterwards. -->
+                <StackPanel Grid.Row="2" Spacing="9" Margin="0,0,0,20">
+                    <ProgressBar x:Name="AgentsScanBar" Classes="scanbar" IsVisible="False" />
+                    <TextBlock x:Name="AgentsScanLine" Classes="scanline" IsVisible="False" />
+                    <TextBlock x:Name="AgentsStatusText" Classes="wsub step"
+                               Text="Scanning this machine for coding agents..." />
+                </StackPanel>
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="600" HorizontalAlignment="Center">
                     <StackPanel x:Name="AgentsListPanel" Spacing="8" MaxWidth="560"
                                 HorizontalAlignment="Stretch" />
@@ -223,38 +254,67 @@
             <!-- ===================== TOOLS (the toolbelt, maintained automatically) ===================== -->
             <Grid x:Name="ToolsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="YOUR TOOLBELT" />
-                <TextBlock Grid.Row="1" x:Name="ToolsTitle" Classes="wtitle"
+                <TextBlock Grid.Row="1" x:Name="ToolsTitle" Classes="wtitle step"
                            Text="Tools, maintained for you" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,10"
+                <TextBlock Grid.Row="2" Classes="wsub step" Margin="0,0,0,8"
                            Text="DevThrottle ships command tools you and your agents use every day - and it installs and updates them itself. You never run an updater." />
                 <TextBlock Grid.Row="3" x:Name="ToolsStatusText" FontSize="13" FontWeight="SemiBold"
                            Foreground="#1A7F37" HorizontalAlignment="Center" TextAlignment="Center"
                            Margin="0,0,0,14" Text="" />
                 <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel x:Name="ToolsListPanel" Spacing="6" MaxWidth="600"
                                 HorizontalAlignment="Stretch" />
                 </ScrollViewer>
-                <Button Grid.Row="5" Classes="quietLink" Content="What these tools can do"
-                        HorizontalAlignment="Center" Margin="0,10,0,0"
-                        Click="BtnToolsDocs_Click" />
+                <!-- The repair. A screen that can only REPORT a broken tool is a dead end: before this
+                     the only two states were Ready and "Installing...", so a tool that would never
+                     install kept its Installing pill for ever while the line above promised it would
+                     finish on its own. Anything still missing after the stall window is named as not
+                     installed and this panel offers the same repair the Home screen runs. -->
+                <StackPanel Grid.Row="5" Spacing="10" Margin="0,10,0,0">
+                    <StackPanel x:Name="ToolsFixPanel" IsVisible="False" Spacing="8">
+                        <Button x:Name="ToolsFixButton" Classes="primaryButton" Content="Fix this now"
+                                HorizontalAlignment="Center" Click="BtnFixTools_Click" />
+                        <TextBlock x:Name="ToolsFixProgress" Classes="hint" IsVisible="False"
+                                   HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540"
+                                   FontFamily="Consolas, Cascadia Mono, monospace" />
+                    </StackPanel>
+                    <Button Classes="quietLink" Content="What these tools can do"
+                            HorizontalAlignment="Center" Click="BtnToolsDocs_Click" />
+                </StackPanel>
             </Grid>
 
             <!-- ===================== CODE (where your repositories live) ===================== -->
             <Grid x:Name="CodePanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*,Auto">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="WHAT WE WATCH OVER" />
-                <TextBlock Grid.Row="1" Classes="wtitle" Text="Where does your code live?" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,22"
-                           Text="Pick the folder (or folders) where you keep your repositories. This is what DevThrottle keeps the books on - branches, unmerged work, what is waiting on you - and where it offers you repositories when you start an agent." />
+                <TextBlock Grid.Row="1" x:Name="CodeTitle" Classes="wtitle step"
+                           Text="Where does your code live?" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" x:Name="CodeSubText" Classes="wsub step" Margin="0,0,0,22"
+                           Text="Anything we find is added for you, so DevThrottle can offer it when you start an agent. Remove any you would rather it left alone." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel MaxWidth="600" HorizontalAlignment="Stretch" Spacing="8">
+                        <!-- Activity block, ABOVE the results. It used to be a single line of the
+                             faintest grey on the screen, sitting UNDER an empty area - so during the
+                             sweep the eye landed on nothing at all. -->
+                        <StackPanel x:Name="CodeScanActivity" IsVisible="False" Spacing="9" Margin="0,0,0,4">
+                            <ProgressBar x:Name="CodeScanBar" Classes="scanbar" />
+                            <TextBlock x:Name="CodeScanLine" Classes="scanline"
+                                       Text="Looking for repositories in the usual places..." />
+                            <TextBlock Classes="hint" HorizontalAlignment="Center" TextAlignment="Center"
+                                       MaxWidth="480"
+                                       Text="Please wait while we look - you can also add a folder yourself below at any time." />
+                        </StackPanel>
                         <StackPanel x:Name="CodeSuggestionsPanel" Spacing="8" />
-                        <TextBlock x:Name="CodeScanStatusText" Classes="hint"
-                                   HorizontalAlignment="Center" TextAlignment="Center"
-                                   Text="Checking the usual places for git repositories..." />
+                        <TextBlock x:Name="CodeScanStatusText" Classes="hint" IsVisible="False"
+                                   HorizontalAlignment="Center" TextAlignment="Center" />
+                        <!-- Shown only when the sweep hit its time budget, so "keep looking" is an
+                             offer rather than a hidden retry. -->
+                        <Button x:Name="CodeKeepLookingButton" Classes="quietLink" IsVisible="False"
+                                Content="Keep looking" HorizontalAlignment="Center"
+                                Click="BtnKeepLookingForCode_Click" />
                         <!-- The manual path: always present, works the same on Windows and macOS. -->
                         <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
                                 CornerRadius="10" Padding="16,13">
@@ -284,22 +344,26 @@
                 </ScrollViewer>
                 <!-- The proof number: how many repositories the added folders will surface. -->
                 <StackPanel Grid.Row="4" x:Name="CodeTotalPanel" IsVisible="False" Margin="0,14,0,0">
-                    <TextBlock x:Name="CodeTotalCount" FontSize="34" FontWeight="Bold"
+                    <TextBlock x:Name="CodeTotalCount" FontSize="30" FontWeight="Bold"
                                Foreground="#16181D" HorizontalAlignment="Center"
                                FontFamily="Segoe UI Variable Display, Segoe UI, Inter" />
-                    <TextBlock Text="repositories will be available when you start an agent"
-                               FontSize="12.5" Foreground="#8A909A" HorizontalAlignment="Center" />
+                    <!-- Names the folders the total is across. The list scrolls, so on a machine with
+                         several folders the user sees three rows and a total they cannot reconcile
+                         against them - a number nobody can check is a number they have to take on
+                         trust. Saying "across 8 folders" makes it explicable without scrolling. -->
+                    <TextBlock x:Name="CodeTotalCaption" FontSize="12.5" Foreground="#8A909A"
+                               HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" />
                 </StackPanel>
             </Grid>
 
             <!-- ===================== SCREENSHOTS ===================== -->
             <Grid x:Name="ScreenshotsPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
                 <TextBlock Grid.Row="0" Classes="eyebrow" Text="SHOW, DON'T TYPE" />
-                <TextBlock Grid.Row="1" Classes="wtitle" Text="Where do your screenshots go?" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,26"
+                <TextBlock Grid.Row="1" Classes="wtitle step" Text="Where do your screenshots go?" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub step" Margin="0,0,0,18"
                            Text="Snap a screen, then drag the screenshot straight onto an agent - the fastest way to show it exactly what you mean. DevThrottle watches one folder for new screenshots." />
                 <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="640" HorizontalAlignment="Center">
                 <StackPanel MaxWidth="600" Spacing="14" VerticalAlignment="Top"
                             HorizontalAlignment="Stretch">
@@ -321,6 +385,11 @@
                     <!-- Provenance + proof line: WHERE this answer came from and how many images live there. -->
                     <TextBlock x:Name="ShotsProvenanceText" Classes="hint"
                                HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540" />
+
+                    <!-- Counting the images and decoding the newest few are two full passes over the
+                         folder, and on a large (or cloud-backed) screenshots folder that is a real
+                         wait. Without this the step showed one static line and looked dead. -->
+                    <ProgressBar x:Name="ShotsBusyBar" Classes="scanbar" IsVisible="False" />
 
                     <!-- Proof you can SEE: the newest images from the chosen folder, drawn as soon as the
                          folder is picked. Hidden when the folder holds no images. -->
@@ -353,22 +422,31 @@
 
             <!-- ===================== GATEWAY (native, hosted-first per the mockup) ===================== -->
             <Grid x:Name="GatewayPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
-                <TextBlock Grid.Row="0" Classes="eyebrow" Text="WITH YOU EVERYWHERE" />
-                <TextBlock Grid.Row="1" Classes="wtitle" Text="Connect your gateway" Margin="0,0,0,10" />
-                <TextBlock Grid.Row="2" Classes="wsub" Margin="0,0,0,24"
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="YOUR ACCOUNT" />
+                <TextBlock Grid.Row="1" x:Name="GatewayTitle" Classes="wtitle step"
+                           Text="Connect your gateway" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" x:Name="GatewaySubText" Classes="wsub step" Margin="0,0,0,24"
                            Text="The gateway is what lets you check on your agents from your phone, use voice, and get your morning report. Signing in takes seconds." />
                 <Grid Grid.Row="3">
 
                     <!-- Choice view: one dominant hosted card (pre-selected), two quiet alternatives.
                          Scrolls so the cards stay reachable on a short window. -->
                     <ScrollViewer x:Name="GatewayChoiceView" VerticalScrollBarVisibility="Auto"
-                                  HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                                  HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                                   MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel MaxWidth="600" Spacing="14"
                                 VerticalAlignment="Top" HorizontalAlignment="Stretch">
-                        <Border x:Name="GatewayHostedCard" Cursor="Hand"
+                        <!-- Focusable and key-operable, with an accessible name. These three cards were
+                             bare Borders carrying only PointerPressed: not focusable, exposing no
+                             invoke pattern, and therefore unreachable by keyboard or screen reader -
+                             so choosing a gateway, the one commercial step in the product, could not
+                             be done without a mouse at all. -->
+                        <Border x:Name="GatewayHostedCard" Cursor="Hand" Focusable="True"
+                                AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
                                 Background="#F2F8FD" BorderBrush="#0066B8" BorderThickness="2"
                                 CornerRadius="12" Padding="22,20"
+                                KeyDown="GatewayCard_KeyDown"
+                                GotFocus="GatewayCard_GotFocus"
                                 PointerPressed="GatewayHostedCard_Pressed">
                             <StackPanel Spacing="6">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
@@ -390,9 +468,12 @@
                         </Border>
 
                         <Grid ColumnDefinitions="*,14,*">
-                            <Border Grid.Column="0" x:Name="GatewaySelfHostCard" Cursor="Hand"
+                            <Border Grid.Column="0" x:Name="GatewaySelfHostCard" Cursor="Hand" Focusable="True"
+                                    AutomationProperties.Name="Self-hosted gateway. Run your own gateway and join it. For advanced setups."
                                     Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
                                     CornerRadius="10" Padding="16,13"
+                                    KeyDown="GatewayCard_KeyDown"
+                                    GotFocus="GatewayCard_GotFocus"
                                     PointerPressed="GatewaySelfHostCard_Pressed">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Self-hosted gateway" FontSize="13.5" FontWeight="SemiBold"
@@ -401,9 +482,12 @@
                                                Text="Run your own gateway and join it. For advanced setups." />
                                 </StackPanel>
                             </Border>
-                            <Border Grid.Column="2" x:Name="GatewayNotNowCard" Cursor="Hand"
+                            <Border Grid.Column="2" x:Name="GatewayNotNowCard" Cursor="Hand" Focusable="True"
+                                    AutomationProperties.Name="Not now. Local-only on this machine. Connect any time from Settings."
                                     Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
                                     CornerRadius="10" Padding="16,13"
+                                    KeyDown="GatewayCard_KeyDown"
+                                    GotFocus="GatewayCard_GotFocus"
                                     PointerPressed="GatewayNotNowCard_Pressed">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Not now" FontSize="13.5" FontWeight="SemiBold"
@@ -430,12 +514,20 @@
                     <!-- Connected view: the earned success state. -->
                     <StackPanel x:Name="GatewayConnectedView" IsVisible="False" Spacing="10"
                                 VerticalAlignment="Center" HorizontalAlignment="Center">
-                        <Border Background="#E5F3E9" CornerRadius="999" Padding="14,5"
-                                HorizontalAlignment="Center">
-                            <TextBlock Text="Connected" FontSize="13" FontWeight="Bold" Foreground="#1A7F37" />
+                        <Border x:Name="GatewayConnectedBadge" Background="#E5F3E9" CornerRadius="999"
+                                Padding="14,5" HorizontalAlignment="Center">
+                            <TextBlock x:Name="GatewayConnectedBadgeText" Text="Connected"
+                                       FontSize="13" FontWeight="Bold" Foreground="#1A7F37" />
                         </Border>
                         <TextBlock x:Name="GatewayConnectedHostText" FontSize="13.5" Foreground="#5A616B"
                                    HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" />
+                        <!-- Only offered when the machine was ALREADY enrolled before this run: a
+                             gateway that works is not a question to re-ask, but changing it must
+                             still be possible. Hidden after an enrolment done in this run, where
+                             the choice was just made. -->
+                        <Button x:Name="GatewayChangeLink" Classes="quietLink" IsVisible="False"
+                                Content="Connect a different gateway" HorizontalAlignment="Center"
+                                Click="GatewayChange_Click" />
                     </StackPanel>
 
                     <!-- Failure view: plain-English reason, readable on white, with a retry. -->
@@ -464,7 +556,7 @@
                  close button as the only way out of the wizard. -->
             <Grid x:Name="DonePanel" IsVisible="False" RowDefinitions="*,Auto">
                 <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,10,0"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
                               MaxWidth="560" HorizontalAlignment="Center">
                     <StackPanel Spacing="18" VerticalAlignment="Center">
                         <TextBlock Classes="wtitle" Text="You are ready" />
@@ -477,13 +569,19 @@
                         </Border>
                     </StackPanel>
                 </ScrollViewer>
-                <StackPanel Grid.Row="1" Spacing="16" HorizontalAlignment="Center" Margin="0,16,0,0">
-                    <Button x:Name="DoneStartButton" Classes="primaryButton"
-                            Content="Start my first agent" HorizontalAlignment="Center"
-                            Click="BtnStartFirstAgent_Click" />
+                <!-- The finish actions sit on ONE row, laid out the way the footer lays out every other
+                     step: the quiet alternative on the left of the primary, not stacked beneath it.
+                     Stacked, they pushed the receipt up and left the real footer with a hole where
+                     every other screen has its button - the last screen of onboarding was the one
+                     screen whose furniture did not match. -->
+                <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="20"
+                            HorizontalAlignment="Center" Margin="0,14,0,0" VerticalAlignment="Center">
                     <Button x:Name="DoneBoardLink" Classes="quietLink"
-                            Content="Take me to the board" HorizontalAlignment="Center"
+                            Content="Take me to the board" VerticalAlignment="Center"
                             Click="BtnPrimary_Click" />
+                    <Button x:Name="DoneStartButton" Classes="primaryButton"
+                            Content="Start my first agent"
+                            Click="BtnStartFirstAgent_Click" />
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -165,8 +165,15 @@
     <Grid Margin="44,32,44,24" RowDefinitions="Auto,*,Auto">
 
         <!-- Progress dots: one per present step, painted done / current / upcoming by code-behind. -->
-        <StackPanel Grid.Row="0" x:Name="DotsPanel" Orientation="Horizontal"
-                    Spacing="8" HorizontalAlignment="Center" Margin="0,4,0,36" />
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12"
+                    HorizontalAlignment="Center" Margin="0,4,0,30" VerticalAlignment="Center">
+            <StackPanel x:Name="DotsPanel" Orientation="Horizontal" Spacing="8"
+                        VerticalAlignment="Center" />
+            <!-- Naming the step turns the dots from decoration into a position you can read. Seven
+                 identical dots told you where you were only if you counted them. -->
+            <TextBlock x:Name="DotsStepLabel" FontSize="11.5" FontWeight="SemiBold"
+                       Foreground="#8A909A" VerticalAlignment="Center" />
+        </StackPanel>
 
         <!-- Step content. Exactly one child panel is visible at a time. -->
         <Grid Grid.Row="1">

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
@@ -61,6 +62,14 @@ public partial class FirstRunWizardDialog : Window
     private bool _gatewayConnected;
     private CancellationTokenSource? _hostedEnrollCts;
 
+    // A gateway that is ALREADY configured when the step opens. Read once, from the saved config, so
+    // a re-run does not ask the user to enroll a machine that is already enrolled. Before this,
+    // _gatewayConnected was a this-run-only flag and the step always opened on the choice cards
+    // offering "Sign in and connect" - while the Done receipt, which does read the saved config,
+    // printed "Gateway connected" two screens later. One wizard, two answers, same run.
+    private bool _gatewayExistingChecked;
+    private bool _gatewayWasAlreadyConnected;
+
     // The existing join-an-existing-gateway flow, embedded only behind the self-hosted advanced path.
     private Controls.GatewayConnectionPanel? _gatewayPanel;
 
@@ -81,13 +90,49 @@ public partial class FirstRunWizardDialog : Window
     private int _toolsReadyCount;
     private int _toolsTotalCount;
 
-    // Code step: the roots store the board and New Session read, the folders added this run
-    // (path -> repo count, drives the proof number), and the one-shot suggestion scan.
+    // When the wait for a still-missing tool began, and how long it may run before the screen stops
+    // calling it "Installing" and calls it what it is. "Installing..." was the ONLY thing this screen
+    // could say about an absent tool, so a tool that would never arrive kept that pill for ever while
+    // the status line went on promising it would finish on its own.
+    private DateTime? _toolsWaitStartedUtc;
+    private bool _toolsRepairing;
+    private bool _toolsStalled;
+    private const int ToolsStallSeconds = 45;
+
+    // Code step: the ROOT DIRECTORY store - the registered base folders the repository model scans.
+    // It is NOT what New Session reads; New Session reads the repository registry and, since this
+    // change, unions in the repositories the model found under these roots. (Two comments here used to
+    // claim this store was "what the board and New Session read". It never was, and that false comment
+    // is how a wizard receipt reading "12 repositories - Done" came to be followed by a New Session
+    // dialog reading "No repositories yet".) Plus the folders registered this run (path -> repository
+    // count, which drives the proof number) and the one-shot suggestion scan.
     private readonly RootDirectoryStore _rootStore = new();
     private bool _rootStoreLoaded;
     private readonly Dictionary<string, int> _codeAddedRoots = new(StringComparer.OrdinalIgnoreCase);
     private bool _codeScanRan;
     private CancellationTokenSource? _codeScanCts;
+
+    // Set whenever this run registers or un-registers a root, so leaving the step can republish them
+    // to the running application once instead of once per folder.
+    private bool _codeRootsChanged;
+
+    // Serializes writes to the roots file. The sweep publishes its finds in a burst - seven folders
+    // within four milliseconds on a real machine - and each registration rewrites the whole
+    // root-directories.json. Run concurrently they collide on the file and MOST OF THEM LOSE: an
+    // unserialized version of this registered two of seven and logged "the process cannot access the
+    // file" for the other five, which on screen looked simply like folders that were never found.
+    private readonly SemaphoreSlim _codeStoreGate = new(1, 1);
+
+    // Folders the user has explicitly REMOVED this run. Without this record, removing a folder only
+    // deletes it from _codeAddedRoots - so a suggestion for the same path arriving later from the
+    // still-running sweep looks brand new and is silently registered again. The user's opt-out has to
+    // outlive the scan that is still producing results behind it.
+    private readonly HashSet<string> _codeRejectedRoots = new(StringComparer.OrdinalIgnoreCase);
+
+    // Every registration started by the sweep. The sweep's own completion says only that DISCOVERY
+    // finished; the writes it queued behind the gate may still be running. The step must not report
+    // itself done, and must not publish to the rest of the application, until these have landed.
+    private readonly List<Task> _codePendingWrites = new();
 
     // Set when the user says there is no code on this machine yet (a new laptop). It changes nothing
     // on disk - it only stops the step, and the Done receipt, from reading as a failure.
@@ -95,6 +140,24 @@ public partial class FirstRunWizardDialog : Window
 
     // True once the completion marker has been written, so OnClosed does not write it twice.
     private bool _marked;
+
+    // True from the moment the window closes. Several operations here await slow work - the tool
+    // catalog read, a tool repair, a folder registration - and their continuations resume on the user
+    // interface thread AFTER the window may have gone. Without this, a continuation could start a
+    // fresh polling timer on a closed dialog and keep it alive, updating controls nobody can see.
+    private volatile bool _closed;
+
+    // True once the user has reached the end of the wizard by any deliberate route (finishing on Done,
+    // or the whole-wizard skip on Welcome). A plain window close BEFORE that is an accident, not a
+    // decision, and must not retire the wizard - see OnClosed.
+    private bool _leftDeliberately;
+
+    /// <summary>
+    /// True when this is a REVIEW run rather than a first run - onboarding was already completed on
+    /// this machine, so the user opened the wizard on purpose from Settings. Every screen that has
+    /// something already set up should say so rather than asking for it again.
+    /// </summary>
+    private readonly bool _isReview;
 
     /// <summary>
     /// True when the user chose "Start my first agent" on the Done screen, so the caller opens the
@@ -122,8 +185,14 @@ public partial class FirstRunWizardDialog : Window
         // the Morning report screen is the promise the rest of the story builds to.
         _model = new FirstRunWizardModel(FirstRunWizardModel.CanonicalOrder);
 
+        // The completion marker is what separates a first run from a deliberate re-run: it is written
+        // when the user leaves the wizard, and it is the same fact that decides whether the wizard
+        // auto-opens at launch. Read once, here, so every screen can be told which run this is.
+        _isReview = !FirstRunWizardModel.ShouldShow();
+
         InitializeComponent();
         BuildDots();
+        BuildWelcomeScreen();
         ShowStep(_model.Current);
     }
 
@@ -183,6 +252,10 @@ public partial class FirstRunWizardDialog : Window
             CancelScreenshotWatch();
         if (step != WizardStep.Tools)
             StopToolsPoll();
+        // Leaving the Code step is the moment the folders chosen there have to become real to the rest
+        // of the application - once, not once per folder.
+        if (step != WizardStep.Code && _codeRootsChanged)
+            _ = PublishCodeRootsAsync();
 
         RefreshDots();
 
@@ -202,15 +275,25 @@ public partial class FirstRunWizardDialog : Window
         {
             case WizardStep.Welcome:
                 // Primary ("Set me up") and the quiet whole-wizard skip live in the content panel.
-                FooterNote.Text = "Takes about 3 minutes. Every step is optional, and everything can be changed later in Settings.";
+                FooterNote.Text = _isReview
+                    ? "Changing something here changes it everywhere. Nothing is reset."
+                    : "Takes about 3 minutes. Every step is optional, and everything can be changed later in Settings.";
                 FooterNote.IsVisible = true;
                 break;
 
             case WizardStep.Agents:
-                PrimaryButton.Content = "Use these agents";
                 PrimaryButton.IsVisible = true;
                 if (!_agentScanRan)
+                {
+                    // ScanAgentsAsync owns the button while it runs - it must NOT be pressable, see
+                    // the note there.
                     _ = ScanAgentsAsync();
+                }
+                else
+                {
+                    PrimaryButton.Content = "Use these agents";
+                    PrimaryButton.IsEnabled = _model.AgentsFound;
+                }
                 break;
 
             case WizardStep.Tools:
@@ -239,6 +322,7 @@ public partial class FirstRunWizardDialog : Window
 
             case WizardStep.Gateway:
                 PrimaryButton.IsVisible = true;
+                AdoptExistingGateway();
                 RefreshGatewayChoiceUi();
                 break;
 
@@ -360,12 +444,32 @@ public partial class FirstRunWizardDialog : Window
 
     // ---- Agents step -------------------------------------------------------------------------------
 
+    /// <summary>
+    /// Find this machine's coding agents and show them.
+    ///
+    /// The primary button is held DISABLED for the whole scan, and that is the point of this method's
+    /// shape. It used to stay live: the step made it visible without ever disabling it, and its
+    /// enabled state was only set from the result at the very end - so a user who pressed
+    /// "Use these agents" while the scan was still running ran <see cref="AcceptAgentsAsync"/> against
+    /// the still-empty suggestion list, added nothing, and advanced. The wizard said it was using
+    /// their agents and configured none, silently.
+    ///
+    /// The rows are also built TWICE on purpose: once the moment detection returns, so the user can
+    /// see what was found, and again after the version probes land. The probes run one after another
+    /// and each is bounded by its plugin's validation timeout, so waiting for all of them before
+    /// drawing anything left the screen blank for the sum of every probe.
+    /// </summary>
     private async Task ScanAgentsAsync()
     {
         FileLog.Write("[FirstRunWizardDialog] ScanAgentsAsync");
-        AgentsTitle.Text = "Your agents";
-        AgentsStatusText.Text = "Scanning this machine for coding agents...";
+        AgentsTitle.Text = "Looking for your coding agents";
+        AgentsScanBar.IsVisible = true;
+        AgentsScanLine.IsVisible = true;
+        AgentsScanLine.Text = "Checking this machine...";
+        AgentsStatusText.Text = "Please wait for this to finish. Your agents are only detected and set up correctly once the check completes.";
         AgentsEmptyActions.IsVisible = false;
+        AgentsListPanel.Children.Clear();
+        SetAgentsPrimaryBusy(true);
         try
         {
             var (suggestions, existing) = await Task.Run(() =>
@@ -382,10 +486,16 @@ public partial class FirstRunWizardDialog : Window
             var anyFound = suggestions.Any(s => s.Found) || existing.Count > 0;
             _model.SetAgentsFound(anyFound);
 
+            // Draw what we have now, with the version cell still pending, so the list builds in front
+            // of the user instead of appearing all at once at the end.
+            BuildAgentRows(suggestions, existing, new Dictionary<AgentKind, string>());
+
             // Probe each found agent's version so the rows read "v2.1.4 - path": the version is the
             // proof the detection is real, not a guess. Best-effort - a probe that fails or times
             // out just leaves the row without a version.
-            var versions = await ProbeVersionsAsync(suggestions);
+            var versions = await ProbeVersionsAsync(
+                suggestions,
+                name => AgentsScanLine.Text = $"Checking {name}...");
             BuildAgentRows(suggestions, existing, versions);
 
             var foundCount = suggestions.Count(s => s.Found);
@@ -403,7 +513,7 @@ public partial class FirstRunWizardDialog : Window
             // Zero agents: the one step Continue does not pass. The product cannot work without an
             // agent, so the in-place install (or the honest deferral) is the way forward.
             AgentsEmptyActions.IsVisible = !anyFound;
-            PrimaryButton.IsEnabled = anyFound;
+            SetAgentsPrimaryBusy(false, enabled: anyFound);
 
             FileLog.Write($"[FirstRunWizardDialog] ScanAgentsAsync: found={foundCount}, anyFound={anyFound}");
         }
@@ -411,15 +521,40 @@ public partial class FirstRunWizardDialog : Window
         {
             FileLog.Write($"[FirstRunWizardDialog] ScanAgentsAsync FAILED: {ex.Message}");
             AgentsStatusText.Text = $"Agent scan failed: {ex.Message}";
+            // A failed scan must not leave the user stranded on a dead button - re-checking and the
+            // install path are still open to them.
+            AgentsEmptyActions.IsVisible = true;
+            SetAgentsPrimaryBusy(false, enabled: false);
         }
     }
 
-    /// <summary>Version-probe every found agent (bounded per-tool by the plugin's validation timeout).</summary>
-    private async Task<Dictionary<AgentKind, string>> ProbeVersionsAsync(IReadOnlyList<ToolDetectionSuggestion> suggestions)
+    /// <summary>
+    /// Hold (or release) the footer button for the agent scan. Guarded on the current step because the
+    /// footer button is shared by every screen: a user who presses Back mid-scan must not have the
+    /// step they landed on relabelled "Checking..." when this scan finally returns.
+    /// </summary>
+    private void SetAgentsPrimaryBusy(bool busy, bool enabled = false)
+    {
+        if (_model.Current != WizardStep.Agents) return;
+        AgentsScanBar.IsVisible = busy;
+        AgentsScanLine.IsVisible = busy;
+        PrimaryButton.Content = busy ? "Checking..." : "Use these agents";
+        PrimaryButton.IsEnabled = !busy && enabled;
+    }
+
+    /// <summary>
+    /// Version-probe every found agent (bounded per-tool by the plugin's validation timeout), naming
+    /// each one to <paramref name="onProbing"/> as it starts so the screen can say which agent it is
+    /// working on rather than showing an unchanging line for the whole run.
+    /// </summary>
+    private async Task<Dictionary<AgentKind, string>> ProbeVersionsAsync(
+        IReadOnlyList<ToolDetectionSuggestion> suggestions,
+        Action<string>? onProbing = null)
     {
         var versions = new Dictionary<AgentKind, string>();
         foreach (var s in suggestions.Where(s => s.Found))
         {
+            onProbing?.Invoke(s.DisplayName);
             try
             {
                 var test = await _detectionService.TestToolAsync(s.Tool, s.ResolvedPath);
@@ -455,6 +590,7 @@ public partial class FirstRunWizardDialog : Window
                 alreadyAdded ? "In list" : "Ready",
                 ready: true));
         }
+
 
         var notFound = suggestions.Where(s => !s.Found).Select(s => s.DisplayName).ToList();
         if (notFound.Count > 0)
@@ -643,34 +779,64 @@ public partial class FirstRunWizardDialog : Window
     /// </summary>
     private async Task RefreshToolsScreenAsync()
     {
+        // A repair owns the screen while it runs; the poll must not redraw underneath it.
+        if (_toolsRepairing || _closed) return;
+
         try
         {
             var catalog = await Task.Run(() => new ToolCatalogService().GetCatalog());
+            // The catalog read is slow enough that the window can be gone by the time it returns.
+            if (_closed) return;
             _toolsTotalCount = catalog.Count;
             _toolsReadyCount = catalog.Count(t => t.IsAvailable);
 
             ToolsTitle.Text = $"{_toolsTotalCount} tools, maintained for you";
 
+            var missingCount = _toolsTotalCount - _toolsReadyCount;
+            if (missingCount > 0)
+                _toolsWaitStartedUtc ??= DateTime.UtcNow;
+
+            // A tool still absent after the stall window is not "installing" in any sense the user
+            // would recognise, and saying so for ever is a promise the screen cannot keep. Past that
+            // point it is named as not installed and the repair is offered.
+            var stalled = missingCount > 0
+                && _toolsWaitStartedUtc is not null
+                && (DateTime.UtcNow - _toolsWaitStartedUtc.Value).TotalSeconds >= ToolsStallSeconds;
+            // Recorded so the Done receipt reports the same three states this screen does.
+            _toolsStalled = stalled;
+
             ToolsListPanel.Children.Clear();
             foreach (var tool in catalog)
             {
-                ToolsListPanel.Children.Add(AgentRow(
-                    tool.Name,
-                    tool.Description,
-                    tool.IsAvailable ? "Ready" : "Installing...",
-                    ready: tool.IsAvailable));
+                var pill = tool.IsAvailable ? "Ready" : stalled ? "Not installed" : "Installing...";
+                var detail = tool.IsAvailable || !stalled
+                    ? tool.Description
+                    : $"{tool.Description} - this one did not install";
+                ToolsListPanel.Children.Add(AgentRow(tool.Name, detail, pill, ready: tool.IsAvailable));
             }
 
-            if (_toolsReadyCount == _toolsTotalCount)
+            ToolsFixPanel.IsVisible = stalled;
+
+            if (missingCount == 0)
             {
                 ToolsStatusText.Text = $"All {_toolsTotalCount} tools are installed and up to date.";
                 ToolsStatusText.Foreground = Brush("#1A7F37");
+                _toolsWaitStartedUtc = null;
+                StopToolsPoll();
+            }
+            else if (stalled)
+            {
+                ToolsStatusText.Text = missingCount == 1
+                    ? "1 tool did not install. Repairing takes about a minute - you can continue while it runs."
+                    : $"{missingCount} tools did not install. Repairing takes about a minute - you can continue while it runs.";
+                ToolsStatusText.Foreground = Brush("#DC2626");
                 StopToolsPoll();
             }
             else
             {
+                // Both halves of the trade, so continuing is an informed choice rather than a guess.
                 ToolsStatusText.Text =
-                    $"{_toolsReadyCount} of {_toolsTotalCount} ready - DevThrottle is installing the rest now. It finishes on its own; you don't have to wait.";
+                    $"{_toolsReadyCount} of {_toolsTotalCount} ready. Wait here and all of them will be working before you finish. Continue and DevThrottle finishes the rest in the background on its own.";
                 ToolsStatusText.Foreground = Brush("#0066B8");
                 StartToolsPoll();
             }
@@ -683,8 +849,67 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
+    /// <summary>
+    /// Repair the shipped tools from this screen - the SAME transaction the Home screen's Fix button
+    /// runs (<see cref="ToolUpdater.RepairPythonToolsAsync"/>), with its progress streamed here. The
+    /// outcome is reported ON THE SCREEN either way: a repair that fails silently reverting to the
+    /// same red row is exactly the dead end this step had before.
+    /// </summary>
+    private async void BtnFixTools_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnFixTools_Click");
+        if (_toolsRepairing) return;
+        _toolsRepairing = true;
+        StopToolsPoll();
+        ToolsFixButton.IsEnabled = false;
+        ToolsFixProgress.IsVisible = true;
+        ToolsFixProgress.Text = "Starting the repair...";
+        try
+        {
+            var layout = InstallLayout.Default();
+            var progress = new Progress<string>(line => ToolsFixProgress.Text = line);
+            var result = await Task.Run(() => new ToolUpdater(layout).RepairPythonToolsAsync(progress));
+            FileLog.Write($"[FirstRunWizardDialog] BtnFixTools_Click: success={result.Success}, msg={result.Message}");
+
+            _toolsRepairing = false;
+            // A repair takes about a minute. The user may well have closed the wizard in the meantime;
+            // the repair still ran and still mattered, but there is no screen left to report it on.
+            if (_closed) return;
+            if (result.Success)
+            {
+                // Start the wait clock again so anything still absent gets a fair window before it is
+                // called a failure a second time.
+                _toolsWaitStartedUtc = null;
+                ToolsFixProgress.Text = "Repair finished. Checking the tools again...";
+                await RefreshToolsScreenAsync();
+                if (_toolsReadyCount == _toolsTotalCount)
+                    ToolsFixProgress.IsVisible = false;
+                else
+                    ToolsFixProgress.Text = "The repair ran but some tools are still missing. Continue - DevThrottle keeps retrying in the background - or see the tools documentation below.";
+            }
+            else
+            {
+                ToolsFixProgress.Text = $"The repair did not succeed: {result.Message}";
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnFixTools_Click FAILED: {ex.Message}");
+            _toolsRepairing = false;
+            ToolsFixProgress.Text = $"The repair could not run: {ex.Message}";
+        }
+        finally
+        {
+            _toolsRepairing = false;
+            ToolsFixButton.IsEnabled = true;
+        }
+    }
+
     private void StartToolsPoll()
     {
+        // A catalog read or a repair that returns after the window has gone must not resurrect the
+        // poll: the timer would hold the closed dialog alive and keep refreshing controls forever.
+        if (_closed || _model.Current != WizardStep.Tools) return;
         if (_toolsPollTimer is not null) return;
         FileLog.Write("[FirstRunWizardDialog] StartToolsPoll");
         _toolsPollTimer = new global::Avalonia.Threading.DispatcherTimer
@@ -723,51 +948,114 @@ public partial class FirstRunWizardDialog : Window
     /// Populate the Code step: show any roots already registered (a re-run wizard tells the truth),
     /// then stream in verified suggestions from the shallow scout scan - never a full drive walk.
     /// </summary>
-    private async Task ScanCodeFoldersAsync()
+    private async Task ScanCodeFoldersAsync(int budgetSeconds = 10)
     {
-        FileLog.Write("[FirstRunWizardDialog] ScanCodeFoldersAsync");
+        FileLog.Write($"[FirstRunWizardDialog] ScanCodeFoldersAsync: budget={budgetSeconds}s");
         _codeScanRan = true;
+        CodeScanActivity.IsVisible = true;
+        CodeScanLine.Text = "Looking for repositories in the usual places...";
+        CodeScanStatusText.IsVisible = false;
+        CodeKeepLookingButton.IsVisible = false;
         try
         {
             await EnsureRootStoreLoadedAsync();
 
-            // Roots that already exist (Settings, a previous run) appear first, marked Added.
-            foreach (var root in _rootStore.Roots)
+            // Roots that already exist (Settings, a previous run) appear first.
+            foreach (var root in _rootStore.Roots.ToList())
             {
                 if (_codeAddedRoots.ContainsKey(root.Path)) continue;
                 var count = await Task.Run(() => CodeFolderScout.CountRepos(root.Path));
                 _codeAddedRoots[root.Path] = count;
-                CodeSuggestionsPanel.Children.Add(CodeRow(root.Path, count, alreadyAdded: true));
+                CodeSuggestionsPanel.Children.Add(CodeRow(root.Path));
             }
             UpdateCodeTotal();
 
             _codeScanCts?.Cancel();
-            _codeScanCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            _codeScanCts = new CancellationTokenSource(TimeSpan.FromSeconds(budgetSeconds));
 
             // Progress<T> posts each suggestion onto the UI thread as the background sweep finds it.
+            // Each one is REGISTERED as it arrives, not offered: a folder we know about is a folder we
+            // can keep the books on and make recommendations against, and an Add button on every row
+            // was missed even by the person who wrote the screen - four folders holding seventeen
+            // repositories went past unregistered. Opting OUT is the deliberate act now.
             var progress = new Progress<CodeFolderSuggestion>(s =>
             {
+                CodeScanLine.Text = $"Looking for repositories - checking {s.Path}";
                 if (_codeAddedRoots.ContainsKey(s.Path)) return;
+                // A folder the user has already removed stays removed, however late the sweep reports it.
+                if (_codeRejectedRoots.Contains(s.Path)) return;
                 if (CodeSuggestionsPanel.Children.OfType<Border>().Any(b => Equals(b.Tag as string, s.Path))) return;
-                CodeSuggestionsPanel.Children.Add(CodeRow(s.Path, s.RepoCount, alreadyAdded: false));
+                _codePendingWrites.Add(AutoAddCodeRootAsync(s.Path, s.RepoCount));
             });
 
             await CodeFolderScout.ScanAsync(progress, _codeScanCts.Token);
 
-            CodeScanStatusText.Text = CodeSuggestionsPanel.Children.Count > 0
-                ? "That is everywhere we checked - add anything else below."
-                : "No repositories found in the usual places. Browse to where your code lives.";
+            // Discovery is done; the registrations it queued may not be. Waiting here is what makes
+            // "that is everywhere we checked" true, and what guarantees the folders are on disk before
+            // anything downstream is told to go and read them.
+            await WaitForPendingCodeWritesAsync();
+
+            CodeScanActivity.IsVisible = false;
+            CodeScanStatusText.IsVisible = true;
+            if (CodeSuggestionsPanel.Children.Count > 0)
+            {
+                CodeTitle.Text = "We found your code";
+                CodeScanStatusText.Text = "That is everywhere we checked - add anything else with Browse below.";
+            }
+            else
+            {
+                CodeScanStatusText.Text = "No repositories found in the usual places. Browse to where your code lives.";
+            }
         }
         catch (OperationCanceledException)
         {
-            FileLog.Write("[FirstRunWizardDialog] ScanCodeFoldersAsync: scan cancelled/timed out");
-            CodeScanStatusText.Text = "That is everywhere we checked - add anything else below.";
+            // The sweep ran out of its time budget. It did NOT finish, and it must not claim it did:
+            // this branch used to write the identical "that is everywhere we checked" sentence the
+            // completed scan writes, so a scan cut off part way through a large disk told the user it
+            // had been exhaustive and there was no way to tell the two apart.
+            FileLog.Write($"[FirstRunWizardDialog] ScanCodeFoldersAsync: scan hit its {budgetSeconds}s budget");
+            CodeScanActivity.IsVisible = false;
+            CodeScanStatusText.IsVisible = true;
+            CodeScanStatusText.Text =
+                $"We stopped looking after {budgetSeconds} seconds, so this may not be everything. Keep looking, or add a folder with Browse below.";
+            CodeKeepLookingButton.IsVisible = true;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[FirstRunWizardDialog] ScanCodeFoldersAsync FAILED: {ex.Message}");
+            CodeScanActivity.IsVisible = false;
+            CodeScanStatusText.IsVisible = true;
             CodeScanStatusText.Text = $"Folder scan failed: {ex.Message}";
         }
+    }
+
+    /// <summary>
+    /// Wait for every registration the sweep queued. Each one is started from a progress callback and
+    /// serialized behind the store gate, so the sweep's own completion proves only that DISCOVERY has
+    /// finished - the writes can still be in flight behind it.
+    /// </summary>
+    private async Task WaitForPendingCodeWritesAsync()
+    {
+        if (_codePendingWrites.Count == 0) return;
+        var pending = _codePendingWrites.ToArray();
+        _codePendingWrites.Clear();
+        try
+        {
+            await Task.WhenAll(pending);
+        }
+        catch (Exception ex)
+        {
+            // Each registration already logs its own failure; this only stops one bad folder taking
+            // the whole wait down.
+            FileLog.Write($"[FirstRunWizardDialog] WaitForPendingCodeWritesAsync: a registration failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>Run the sweep again with a longer budget, after it reported that it stopped early.</summary>
+    private void BtnKeepLookingForCode_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnKeepLookingForCode_Click");
+        _ = ScanCodeFoldersAsync(budgetSeconds: 60);
     }
 
     private async Task EnsureRootStoreLoadedAsync()
@@ -777,9 +1065,47 @@ public partial class FirstRunWizardDialog : Window
         _rootStoreLoaded = true;
     }
 
-    /// <summary>One suggestion row: the folder, its verified repo count, and Add (or the Added pill).</summary>
-    private Border CodeRow(string path, int repoCount, bool alreadyAdded)
+    /// <summary>
+    /// Make the folders chosen on this step real to the RUNNING application.
+    ///
+    /// The wizard writes through its own <see cref="RootDirectoryStore"/> instance, so the copy the
+    /// application loaded at startup is stale the moment a folder is registered here, and the
+    /// repository model behind New Session has never scanned the new root. Without this the wizard
+    /// would persist the folders correctly to disk and the user would still see nothing until the
+    /// next restart.
+    /// </summary>
+    private async Task PublishCodeRootsAsync()
     {
+        _codeRootsChanged = false;
+        // Publishing a half-written set of roots is worse than publishing late: the rescan would run
+        // over whatever happened to have landed, and New Session would show a subset. Wait for the
+        // writes first. Nothing here touches the user interface, so it is safe after the window closes.
+        await WaitForPendingCodeWritesAsync();
+        try
+        {
+            if (global::Avalonia.Application.Current is not App app) return;
+            app.RootDirectoryStore.Load();
+            app.StartRepositoryRescan();
+            FileLog.Write($"[FirstRunWizardDialog] PublishCodeRoots: {app.RootDirectoryStore.Roots.Count} root(s) republished, rescan started");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] PublishCodeRoots FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// One registered folder: the path, its verified repository count, and Remove. Every row on this
+    /// screen is already registered - there is no Add, because there is no un-added state to act on.
+    ///
+    /// The count is READ FROM <see cref="_codeAddedRoots"/> rather than passed in, so the number on the
+    /// row and the total underneath the list cannot come from different places. The total is a sum of
+    /// that same dictionary, which makes "the rows do not add up to the total" impossible to express
+    /// rather than merely absent today. Callers must register the folder before drawing its row.
+    /// </summary>
+    private Border CodeRow(string path)
+    {
+        var repoCount = _codeAddedRoots.TryGetValue(path, out var known) ? known : 0;
         var text = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
         text.Children.Add(new TextBlock
         {
@@ -791,7 +1117,7 @@ public partial class FirstRunWizardDialog : Window
         });
         text.Children.Add(new TextBlock
         {
-            Text = repoCount == 1 ? "1 git repository found" : $"{repoCount} git repositories found",
+            Text = repoCount == 1 ? "1 git repository" : $"{repoCount} git repositories",
             Foreground = Brush("#8A909A"),
             FontSize = 11,
         });
@@ -800,24 +1126,16 @@ public partial class FirstRunWizardDialog : Window
         global::Avalonia.Controls.Grid.SetColumn(text, 0);
         grid.Children.Add(text);
 
-        Control action;
-        if (alreadyAdded)
+        var removeButton = new Button
         {
-            action = AddedPill();
-        }
-        else
-        {
-            var addButton = new Button
-            {
-                Content = "Add",
-                Classes = { "dialogButton" },
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            addButton.Click += async (_, _) => await AddCodeRootAsync(path, repoCount, addButton);
-            action = addButton;
-        }
-        global::Avalonia.Controls.Grid.SetColumn(action, 1);
-        grid.Children.Add(action);
+            Content = "Remove",
+            Classes = { "dialogButton" },
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetName(removeButton, $"Remove {path} from the folders DevThrottle watches");
+        removeButton.Click += async (_, _) => await RemoveCodeRootAsync(path, removeButton);
+        global::Avalonia.Controls.Grid.SetColumn(removeButton, 1);
+        grid.Children.Add(removeButton);
 
         return new Border
         {
@@ -831,28 +1149,17 @@ public partial class FirstRunWizardDialog : Window
         };
     }
 
-    private static Border AddedPill() => new()
+    /// <summary>
+    /// Register a folder the scan found and draw its row, in that order. The row claims the folder is
+    /// registered, so it must be true by the time the row appears - a row that says "added" while the
+    /// write is still pending becomes a lie the moment the user closes the window.
+    /// </summary>
+    private async Task AutoAddCodeRootAsync(string path, int repoCount)
     {
-        Background = Brush("#E5F3E9"),
-        CornerRadius = new global::Avalonia.CornerRadius(999),
-        Padding = new global::Avalonia.Thickness(10, 3),
-        VerticalAlignment = VerticalAlignment.Center,
-        Child = new TextBlock
-        {
-            Text = "Added",
-            Foreground = Brush("#1A7F37"),
-            FontSize = 11,
-            FontWeight = FontWeight.SemiBold,
-        },
-    };
-
-    /// <summary>Register a base folder in the same roots store the board and New Session read.</summary>
-    private async Task AddCodeRootAsync(string path, int repoCount, Button addButton)
-    {
-        FileLog.Write($"[FirstRunWizardDialog] AddCodeRootAsync: {path}");
+        FileLog.Write($"[FirstRunWizardDialog] AutoAddCodeRootAsync: {path} ({repoCount} repositories)");
+        await _codeStoreGate.WaitAsync();
         try
         {
-            addButton.IsEnabled = false;
             await EnsureRootStoreLoadedAsync();
 
             var duplicate = _rootStore.Roots.Any(r =>
@@ -867,37 +1174,88 @@ public partial class FirstRunWizardDialog : Window
             }
 
             _codeAddedRoots[path] = repoCount;
-            SwapCodeRowActionToAdded(path);
+            _codeRootsChanged = true;
+            if (!CodeSuggestionsPanel.Children.OfType<Border>().Any(b => Equals(b.Tag as string, path)))
+                CodeSuggestionsPanel.Children.Add(CodeRow(path));
             UpdateCodeTotal();
             if (_model.Current == WizardStep.Code)
                 PrimaryButton.Content = "Looks right";
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[FirstRunWizardDialog] AddCodeRootAsync FAILED: {ex.Message}");
-            addButton.IsEnabled = true;
+            FileLog.Write($"[FirstRunWizardDialog] AutoAddCodeRootAsync FAILED for {path}: {ex.Message}");
+        }
+        finally
+        {
+            _codeStoreGate.Release();
         }
     }
 
-    /// <summary>Replace a row's Add button with the Added pill after a successful add.</summary>
-    private void SwapCodeRowActionToAdded(string path)
+    /// <summary>Un-register a folder the user does not want watched, and drop its row.</summary>
+    private async Task RemoveCodeRootAsync(string path, Button removeButton)
     {
-        var row = CodeSuggestionsPanel.Children.OfType<Border>().FirstOrDefault(b => Equals(b.Tag as string, path));
-        if (row?.Child is not Grid grid) return;
-        var button = grid.Children.OfType<Button>().FirstOrDefault();
-        if (button is null) return;
-        grid.Children.Remove(button);
-        var pill = AddedPill();
-        global::Avalonia.Controls.Grid.SetColumn(pill, 1);
-        grid.Children.Add(pill);
+        FileLog.Write($"[FirstRunWizardDialog] RemoveCodeRootAsync: {path}");
+        await _codeStoreGate.WaitAsync();
+        try
+        {
+            removeButton.IsEnabled = false;
+            await EnsureRootStoreLoadedAsync();
+
+            var index = _rootStore.Roots
+                .Select((r, i) => (r, i))
+                .Where(t => string.Equals(
+                    System.IO.Path.GetFullPath(t.r.Path),
+                    System.IO.Path.GetFullPath(path),
+                    StringComparison.OrdinalIgnoreCase))
+                .Select(t => (int?)t.i)
+                .FirstOrDefault();
+
+            if (index is not null)
+                await Task.Run(() => _rootStore.Remove(index.Value));
+
+            _codeAddedRoots.Remove(path);
+            // Remember the rejection, so a suggestion for this same folder arriving later from the
+            // still-running sweep does not quietly register it again.
+            _codeRejectedRoots.Add(path);
+            _codeRootsChanged = true;
+            var row = CodeSuggestionsPanel.Children.OfType<Border>().FirstOrDefault(b => Equals(b.Tag as string, path));
+            if (row is not null)
+                CodeSuggestionsPanel.Children.Remove(row);
+            UpdateCodeTotal();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] RemoveCodeRootAsync FAILED: {ex.Message}");
+            removeButton.IsEnabled = true;
+        }
+        finally
+        {
+            _codeStoreGate.Release();
+        }
     }
 
-    /// <summary>The proof number: repositories across every added folder.</summary>
+    /// <summary>
+    /// The proof number: repositories across every registered folder, WITH the number of folders it is
+    /// summed over. The list scrolls, so the total is usually shown beside only two or three of the
+    /// rows that make it up; naming the folder count is what lets the user reconcile the two without
+    /// scrolling the whole list.
+    /// </summary>
     private void UpdateCodeTotal()
     {
         var total = _codeAddedRoots.Values.Sum();
+        var folders = _codeAddedRoots.Count;
         CodeTotalPanel.IsVisible = total > 0;
         CodeTotalCount.Text = total.ToString();
+
+        // The breakdown, so the headline number can be checked against its parts from the log alone.
+        // The list scrolls, so on a machine with several folders the screen never shows every row that
+        // makes up the total at once.
+        FileLog.Write(
+            $"[FirstRunWizardDialog] UpdateCodeTotal: {total} across {folders} folder(s) = "
+            + string.Join(" + ", _codeAddedRoots.OrderBy(kv => kv.Key).Select(kv => $"{kv.Key}:{kv.Value}")));
+        CodeTotalCaption.Text = folders == 1
+            ? "repositories in this folder, available when you start an agent"
+            : $"repositories across these {folders} folders, available when you start an agent";
     }
 
     private async void BtnBrowseCodeFolder_Click(object? sender, RoutedEventArgs e)
@@ -921,20 +1279,10 @@ public partial class FirstRunWizardDialog : Window
                 return (resolved, CodeFolderScout.CountRepos(resolved));
             });
 
+            // Already registered (the sweep found it, or a previous run did) - nothing to do.
             if (_codeAddedRoots.ContainsKey(path)) return;
 
-            var existingRow = CodeSuggestionsPanel.Children.OfType<Border>().FirstOrDefault(b => Equals(b.Tag as string, path));
-            if (existingRow is not null)
-            {
-                // It was already suggested - adding it is what the user meant.
-                var button = (existingRow.Child as Grid)?.Children.OfType<Button>().FirstOrDefault();
-                if (button is not null)
-                    await AddCodeRootAsync(path, count, button);
-                return;
-            }
-
-            CodeSuggestionsPanel.Children.Add(CodeRow(path, count, alreadyAdded: true));
-            await AddCodeRootAsync(path, count, new Button());
+            await AutoAddCodeRootAsync(path, count);
         }
         catch (Exception ex)
         {
@@ -967,11 +1315,34 @@ public partial class FirstRunWizardDialog : Window
     {
         FileLog.Write("[FirstRunWizardDialog] DetectScreenshotsForWizardAsync");
         _shotsDetectRan = true;
+        ShotsBusyBar.IsVisible = true;
         try
         {
+            // A folder already chosen on this machine WINS over anything detection would guess.
+            // Detection used to run unconditionally, which meant a returning user who had once browsed
+            // to a custom folder was shown the detector's guess instead, under a button reading "Use
+            // this folder" - and pressing Continue wrote the guess over their deliberate choice.
+            var configured = ReadConfiguredScreenshotsFolder();
+            if (!string.IsNullOrWhiteSpace(configured) && Directory.Exists(configured))
+            {
+                FileLog.Write($"[FirstRunWizardDialog] DetectScreenshotsForWizardAsync: keeping the configured folder {configured}");
+                ShotsPathText.Text = configured;
+                ShotsProvenanceText.Text = "Currently in use - counting the images in it...";
+                var configuredCount = await Task.Run(() => ScreenshotLocator.CountImages(configured));
+                await SetScreenshotsFolderAsync(configured, "Currently in use", configuredCount);
+                return;
+            }
+
             var best = await Task.Run(() => ScreenshotLocator.DetectCandidates().FirstOrDefault());
             if (best is not null)
             {
+                // Show the answer BEFORE the slow part. Counting every image in the folder and then
+                // decoding the newest few are two full passes over it, and on a large or cloud-backed
+                // folder that is a real wait - during which the step used to show nothing but the
+                // static "Looking for your screenshots folder..." line and looked dead.
+                ShotsPathText.Text = best.Path;
+                ShotsProvenanceText.Text = $"{best.Provenance} - counting the images in it...";
+
                 var count = await Task.Run(() => ScreenshotLocator.CountImages(best.Path));
                 await SetScreenshotsFolderAsync(best.Path, best.Provenance, count);
             }
@@ -987,6 +1358,25 @@ public partial class FirstRunWizardDialog : Window
             FileLog.Write($"[FirstRunWizardDialog] DetectScreenshotsForWizardAsync FAILED: {ex.Message}");
             ShotsPathText.Text = "No screenshots folder found";
             ShotsProvenanceText.Text = $"Detection failed: {ex.Message}";
+        }
+        finally
+        {
+            ShotsBusyBar.IsVisible = false;
+        }
+    }
+
+    /// <summary>The screenshots folder already saved in config, or null when none is set.</summary>
+    private static string? ReadConfiguredScreenshotsFolder()
+    {
+        try
+        {
+            var path = CcDirectorConfigService.ReadRaw()["screenshots"]?["source_directory"]?.GetValue<string>();
+            return string.IsNullOrWhiteSpace(path) ? null : path;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] ReadConfiguredScreenshotsFolder failed: {ex.Message}");
+            return null;
         }
     }
 
@@ -1202,15 +1592,205 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
-    // ---- Welcome: founder note ----------------------------------------------------------------------
+    // ---- Welcome ------------------------------------------------------------------------------------
 
-    private void BtnFounderMore_Click(object? sender, RoutedEventArgs e)
+    /// <summary>
+    /// Build the Welcome screen for whichever run this is.
+    ///
+    /// FIRST RUN: state plainly what the next three minutes are for - one row per thing the wizard
+    /// covers, each naming what it buys the user. That is the screen's whole job. It used to open with
+    /// a note from the founder about why the product exists; somebody who has just installed software
+    /// wants to know what is about to be asked of them, not to be talked to.
+    ///
+    /// REVIEW RUN: the same rows carry the machine's CURRENT state, because a returning user is here
+    /// to check or change something, and telling them they are "three minutes from running their first
+    /// coding agent" when they already have four agents configured is simply false.
+    /// </summary>
+    private void BuildWelcomeScreen()
     {
-        FounderMoreText.IsVisible = !FounderMoreText.IsVisible;
-        FounderMoreLink.Content = FounderMoreText.IsVisible ? "Show less" : "Read more";
+        WelcomeAgendaPanel.Children.Clear();
+
+        if (_isReview)
+        {
+            WelcomeTitle.Text = "Review your setup";
+            // Says what actually happens. The earlier wording promised "nothing is redone unless you
+            // ask", which the Code step then broke the moment it was reached: it sweeps for folders and
+            // registers what it finds, with no confirmation. Persisting configuration as a side effect
+            // of INSPECTION is bad enough without the previous screen having promised it would not.
+            WelcomeSubText.Text =
+                "Everything below is already set up. Nothing here is reset - but any new code folders we find as you walk through will be added.";
+            WelcomeSetupButton.Content = "Review each step";
+            WelcomeSkipLink.Content = "Close - everything is already set up";
+            FooterNote.Text = "Changing something here changes it everywhere. Nothing is reset.";
+
+            // Cheap reads only: this screen must paint instantly. Anything that needs a scan (the
+            // agent probe, the repository sweep) belongs on its own step, not here.
+            foreach (var row in ReviewSummaryRows())
+                WelcomeAgendaPanel.Children.Add(row);
+            return;
+        }
+
+        WelcomeTitle.Text = "Let's get you set up";
+        WelcomeSubText.Text =
+            "Four quick things, so DevThrottle knows this machine. Skip any of them - all of it can be changed later.";
+        WelcomeSetupButton.Content = "Set me up";
+        WelcomeSkipLink.Content = "Skip setup and figure it out myself";
+
+        // Same order the steps come in - the gateway leads.
+        AddAgendaRow("Your gateway", "Your agents on your phone, voice, and the morning report");
+        AddAgendaRow("Your coding agents", "Find the ones already installed, or install one now");
+        AddAgendaRow("Where your code lives", "So DevThrottle can offer you repositories and keep the books on them");
+        AddAgendaRow("Screenshots", "So you can show an agent what you mean instead of describing it");
+    }
+
+    /// <summary>The review run's state summary, read from what is already on disk. No scans.</summary>
+    private IEnumerable<Control> ReviewSummaryRows()
+    {
+        var rows = new List<Control>();
+
+        // Same order as the steps: the gateway leads.
+        var gateway = GatewayConfig.Load();
+        rows.Add(AgentRow(
+            "Your gateway",
+            gateway.IsEnabled ? gateway.Url : "Not connected - phone access and the morning report need one",
+            gateway.IsEnabled ? "Connected" : "None",
+            ready: gateway.IsEnabled));
+
+        var agentCount = 0;
+        try
+        {
+            agentCount = AgentEntryStore.ReadCurrentEntries().Count;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] ReviewSummaryRows: agent read failed: {ex.Message}");
+        }
+        rows.Add(AgentRow(
+            "Your coding agents",
+            agentCount > 0 ? "Configured and ready to use" : "None configured yet",
+            agentCount > 0 ? $"{agentCount} set up" : "None",
+            ready: agentCount > 0));
+
+        var rootCount = 0;
+        try
+        {
+            var store = new RootDirectoryStore();
+            store.Load();
+            rootCount = store.Roots.Count;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] ReviewSummaryRows: roots read failed: {ex.Message}");
+        }
+        rows.Add(AgentRow(
+            "Where your code lives",
+            rootCount > 0 ? "DevThrottle is keeping the books on these" : "No folders added yet",
+            rootCount == 1 ? "1 folder" : rootCount > 0 ? $"{rootCount} folders" : "None",
+            ready: rootCount > 0));
+
+        return rows;
+    }
+
+    private void AddAgendaRow(string name, string what) =>
+        WelcomeAgendaPanel.Children.Add(new Border
+        {
+            Background = Brush("#FFFFFF"),
+            BorderBrush = Brush("#E6E8EC"),
+            BorderThickness = new global::Avalonia.Thickness(1),
+            CornerRadius = new global::Avalonia.CornerRadius(10),
+            Padding = new global::Avalonia.Thickness(15, 9),
+            Child = StackOf(
+                new TextBlock
+                {
+                    Text = name,
+                    Foreground = Brush("#16181D"),
+                    FontSize = 13,
+                    FontWeight = FontWeight.SemiBold,
+                    TextWrapping = TextWrapping.Wrap,
+                },
+                new TextBlock
+                {
+                    Text = what,
+                    Foreground = Brush("#8A909A"),
+                    FontSize = 11,
+                    TextWrapping = TextWrapping.Wrap,
+                }),
+        });
+
+    private static StackPanel StackOf(params Control[] children)
+    {
+        var panel = new StackPanel { Spacing = 2 };
+        foreach (var child in children)
+            panel.Children.Add(child);
+        return panel;
     }
 
     // ---- Gateway step (native, hosted-first) -------------------------------------------------------
+
+    // The step's opening copy, kept so "connect a different gateway" can put it back after the
+    // connected state has rewritten it.
+    private const string GatewayChoiceTitle = "Connect your gateway";
+    private const string GatewayChoiceSub =
+        "The gateway is what lets you check on your agents from your phone, use voice, and get your morning report. Signing in takes seconds.";
+
+    /// <summary>
+    /// A gateway that is already configured is not a question. Read the saved gateway once, when the
+    /// step opens, and if this machine is already enrolled open on the connected state with Continue
+    /// as the action - reconnecting stays available, but as a quiet secondary link.
+    ///
+    /// Without this the step had no idea what the machine's actual state was: its connected flag was
+    /// set only by an enrolment performed during THIS run, so re-running the wizard on an enrolled
+    /// machine showed the choice cards and offered "Sign in and connect" - while
+    /// <see cref="BuildDoneReceipt"/>, which does read the saved config, printed "Gateway connected"
+    /// two screens later. The same run said both.
+    /// </summary>
+    private void AdoptExistingGateway()
+    {
+        if (_gatewayExistingChecked) return;
+        _gatewayExistingChecked = true;
+
+        var config = GatewayConfig.Load();
+        if (!config.IsEnabled)
+        {
+            FileLog.Write("[FirstRunWizardDialog] AdoptExistingGateway: no gateway configured");
+            return;
+        }
+
+        FileLog.Write($"[FirstRunWizardDialog] AdoptExistingGateway: gateway already configured as {config.Url}");
+        _gatewayConnected = true;
+        _gatewayWasAlreadyConnected = true;
+
+        // What we KNOW is that a gateway address is saved. We have not reached it, authenticated, or
+        // confirmed this machine is still enrolled - IsEnabled is true for any non-blank string. So the
+        // screen states the configuration and nothing more. Saying "phone access, voice and the morning
+        // report are working" would be a claim about three subsystems on the strength of one saved
+        // string, and it would be wrong for exactly the user who most needs to know: someone whose
+        // address is stale, mistyped, or whose machine was un-enrolled.
+        GatewayTitle.Text = "Your gateway is already set up";
+        GatewaySubText.Text =
+            "This machine is configured to use the gateway below, so there is nothing to do here. If it is not working, connect it again.";
+        GatewayConnectedHostText.Text = config.Url;
+        // Not "Connected" - we have not checked. This badge is only earned by an enrolment that
+        // succeeded in THIS run, which is the one case we have actually observed working.
+        GatewayConnectedBadgeText.Text = "Set up";
+        GatewayConnectedBadge.Background = Brush("#F5F6F8");
+        GatewayConnectedBadgeText.Foreground = Brush("#5A616B");
+        GatewayChangeLink.IsVisible = true;
+        ShowGatewayView(GatewayConnectedView);
+    }
+
+    /// <summary>Deliberately go back to the choice cards from the already-connected state.</summary>
+    private void GatewayChange_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] GatewayChange_Click");
+        _gatewayConnected = false;
+        _gatewayWasAlreadyConnected = false;
+        GatewayTitle.Text = GatewayChoiceTitle;
+        GatewaySubText.Text = GatewayChoiceSub;
+        GatewayChangeLink.IsVisible = false;
+        ShowGatewayView(GatewayChoiceView);
+        RefreshGatewayChoiceUi();
+    }
 
     /// <summary>Paint the three choice cards and the primary CTA from the current selection.</summary>
     private void RefreshGatewayChoiceUi()
@@ -1236,6 +1816,11 @@ public partial class FirstRunWizardDialog : Window
         card.BorderBrush = Brush(selected ? "#0066B8" : "#E6E8EC");
         card.BorderThickness = new global::Avalonia.Thickness(selected && emphasized ? 2 : selected ? 1.5 : 1);
         card.Background = Brush(selected ? "#F2F8FD" : "#FFFFFF");
+
+        // The selection has to be readable without seeing the border. A Border is not a radio button
+        // and exposes no selected state, so the state is carried in the accessible help text - the one
+        // channel a screen reader will actually read out.
+        AutomationProperties.SetHelpText(card, selected ? "Selected" : "Not selected. Press Enter to choose it.");
     }
 
     private void SelectGatewayChoice(GatewayChoice choice)
@@ -1248,6 +1833,40 @@ public partial class FirstRunWizardDialog : Window
     private void GatewayHostedCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.Hosted);
     private void GatewaySelfHostCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.SelfHost);
     private void GatewayNotNowCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.NotNow);
+
+    /// <summary>
+    /// Space or Enter picks the focused card - the keyboard equivalent of clicking it. Tab already
+    /// reaches the cards now that they are focusable; without this they could be reached and not used.
+    /// </summary>
+    private void GatewayCard_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Space or Key.Enter)) return;
+        if (!TryChoiceForCard(sender, out var choice)) return;
+        SelectGatewayChoice(choice);
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Focus alone does NOT change the choice. Tabbing through the options to read them must not
+    /// silently move the selection - a keyboard or screen-reader user has to be able to review all
+    /// three before committing, exactly as a mouse user can. Space or Enter is the commit.
+    /// </summary>
+    private void GatewayCard_GotFocus(object? sender, GotFocusEventArgs e)
+    {
+        // Announce what is focused and whether it is the current choice, since a Border exposes no
+        // selection state of its own.
+        if (TryChoiceForCard(sender, out var choice) && sender is Border card)
+            AutomationProperties.SetHelpText(card, choice == _gatewayChoice ? "Selected" : "Not selected. Press Enter to choose it.");
+    }
+
+    private bool TryChoiceForCard(object? sender, out GatewayChoice choice)
+    {
+        if (ReferenceEquals(sender, GatewayHostedCard)) { choice = GatewayChoice.Hosted; return true; }
+        if (ReferenceEquals(sender, GatewaySelfHostCard)) { choice = GatewayChoice.SelfHost; return true; }
+        if (ReferenceEquals(sender, GatewayNotNowCard)) { choice = GatewayChoice.NotNow; return true; }
+        choice = GatewayChoice.Hosted;
+        return false;
+    }
 
     /// <summary>Show exactly one of the gateway step's sub-views (choice / connecting / connected / failed / advanced).</summary>
     private void ShowGatewayView(Control view)
@@ -1300,6 +1919,10 @@ public partial class FirstRunWizardDialog : Window
             await host.ReapplyGatewayAsync();
 
             _gatewayConnected = true;
+            // Earned: this enrolment just succeeded against the live gateway in this run.
+            GatewayConnectedBadgeText.Text = "Connected";
+            GatewayConnectedBadge.Background = Brush("#E5F3E9");
+            GatewayConnectedBadgeText.Foreground = Brush("#1A7F37");
             GatewayConnectedHostText.Text = $"This machine is enrolled with {GatewayConfig.Load().Url}";
             ShowGatewayView(GatewayConnectedView);
             FileLog.Write("[FirstRunWizardDialog] hosted enroll succeeded");
@@ -1418,7 +2041,12 @@ public partial class FirstRunWizardDialog : Window
         // Gateway row.
         var gatewayUrl = GatewayConfig.Load().Url;
         if (!string.IsNullOrWhiteSpace(gatewayUrl))
-            DoneReceiptPanel.Children.Add(ReceiptRow("Gateway connected", gatewayUrl, done: true));
+            // A gateway that was already connected before this run is reported as UNCHANGED, not as
+            // something this run achieved - a receipt that claims credit for work it did not do is
+            // the same class of untruth as the step that used to ask for it again.
+            DoneReceiptPanel.Children.Add(_gatewayWasAlreadyConnected
+                ? ReceiptRow("Gateway", gatewayUrl, done: true, pillText: "Unchanged")
+                : ReceiptRow("Gateway connected", gatewayUrl, done: true));
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 "No gateway", "Connect one from Settings for phone access and your morning report", done: false));
@@ -1426,9 +2054,21 @@ public partial class FirstRunWizardDialog : Window
         // Tools row (only when the Tools screen was seen, so the numbers are real).
         if (_toolsTotalCount > 0)
         {
-            DoneReceiptPanel.Children.Add(_toolsReadyCount == _toolsTotalCount
-                ? ReceiptRow($"{_toolsTotalCount} tools ready", "Installed and kept current automatically", done: true)
-                : ReceiptRow("Tools installing", "Finishes on its own in the background", done: false));
+            // Three states here, not two, because the Tools screen has three. Reducing a tool that
+            // FAILED to install back to "installing - finishes on its own" would repeat on the last
+            // screen the exact false promise the third state was added to remove, and would contradict
+            // the screen the user saw two steps earlier.
+            if (_toolsReadyCount == _toolsTotalCount)
+                DoneReceiptPanel.Children.Add(ReceiptRow(
+                    $"{_toolsTotalCount} tools ready", "Installed and kept current automatically", done: true));
+            else if (_toolsStalled)
+                DoneReceiptPanel.Children.Add(ReceiptRow(
+                    $"{_toolsTotalCount - _toolsReadyCount} of {_toolsTotalCount} tools did not install",
+                    "Repair them from Settings > Tools - they will not finish on their own",
+                    done: false, pillText: "Needs you"));
+            else
+                DoneReceiptPanel.Children.Add(ReceiptRow(
+                    "Tools installing", "Finishes on its own in the background", done: false));
         }
 
         // Browsers row: a pointer, not a task. Browser setup lives in the left rail (the Browsers
@@ -1510,6 +2150,7 @@ public partial class FirstRunWizardDialog : Window
     internal async Task FinishAsync(bool wantsNewSession)
     {
         FileLog.Write($"[FirstRunWizardDialog] FinishAsync: wantsNewSession={wantsNewSession}");
+        _leftDeliberately = true;
         await Task.Run(FirstRunWizardModel.MarkComplete);
         _marked = true;
         WantsNewSession = wantsNewSession;
@@ -1517,19 +2158,35 @@ public partial class FirstRunWizardDialog : Window
     }
 
     /// <summary>
-    /// A plain window close (the title-bar X) still counts as leaving the wizard, so write the marker
-    /// if a finish path did not already - the wizard must never nag twice.
+    /// Closing the window is only a DECISION when the user has already reached the end by a deliberate
+    /// route - finishing on Done, or the whole-wizard skip on Welcome. Both of those write the marker
+    /// themselves before they close.
+    ///
+    /// A plain title-bar close part way through is an ACCIDENT, and it no longer retires the wizard.
+    /// It used to: the marker was written here unconditionally, so an interrupted first run - which is
+    /// exactly when someone closes a window - permanently stopped the wizard ever offering itself
+    /// again, and the only way back was a button buried under the Agents tab in Settings. A user who
+    /// genuinely does not want it has the skip link on the first screen, which is unambiguous.
+    ///
+    /// A REVIEW run never writes anything here: the marker is already set, and re-running from
+    /// Settings must not change that either way.
     /// </summary>
     protected override void OnClosed(EventArgs e)
     {
+        _closed = true;
         _hostedEnrollCts?.Cancel();
         _claudeInstallCts?.Cancel();
         _shotsWatchCts?.Cancel();
         _codeScanCts?.Cancel();
         StopToolsPoll();
-        if (!_marked)
+        // Closing while still ON the Code step must not strand the folders it registered - and a
+        // registration that is STILL IN FLIGHT must not be stranded either, which is why this runs
+        // whenever writes are outstanding rather than only when the changed flag is already set.
+        if (_codeRootsChanged || _codePendingWrites.Count > 0)
+            _ = PublishCodeRootsAsync();
+        if (!_marked && _leftDeliberately)
         {
-            FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (window closed without finishing)");
+            FileLog.Write("[FirstRunWizardDialog] OnClosed: writing completion marker (left deliberately)");
             try
             {
                 FirstRunWizardModel.MarkComplete();
@@ -1539,6 +2196,10 @@ public partial class FirstRunWizardDialog : Window
             {
                 FileLog.Write($"[FirstRunWizardDialog] OnClosed marker write FAILED: {ex.Message}");
             }
+        }
+        else if (!_marked)
+        {
+            FileLog.Write("[FirstRunWizardDialog] OnClosed: window closed part way through - marker NOT written, the wizard will offer itself again");
         }
         base.OnClosed(e);
     }

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -209,11 +209,45 @@ public partial class FirstRunWizardDialog : Window
                 Height = 8,
                 VerticalAlignment = VerticalAlignment.Center,
             };
+
+            // On a REVIEW run the dots are navigation: everything is already set up, so there is no
+            // order left to protect and the user came here to change one specific thing. Clicking a
+            // dot goes straight to that step instead of pressing Continue five times.
+            //
+            // On a FIRST run they stay indicators. A first-timer skipping to a step whose answer
+            // depends on an earlier one is how a machine ends up half configured.
+            if (_isReview)
+            {
+                var target = _model.Steps[i];
+                dot.Cursor = new global::Avalonia.Input.Cursor(global::Avalonia.Input.StandardCursorType.Hand);
+                AutomationProperties.SetName(dot, $"Go to step {i + 1}, {StepDisplayName(target)}");
+                dot.PointerPressed += (_, _) =>
+                {
+                    if (_model.Current == target) return;
+                    FileLog.Write($"[FirstRunWizardDialog] dot navigation to {target}");
+                    _model.GoTo(target);
+                    ShowStep(_model.Current);
+                };
+            }
+
             _dots.Add(dot);
             DotsPanel.Children.Add(dot);
         }
         RefreshDots();
     }
+
+    /// <summary>The user-facing name of a step, used beside the dots and by the dot navigation.</summary>
+    private static string StepDisplayName(WizardStep step) => step switch
+    {
+        WizardStep.Welcome => "Welcome",
+        WizardStep.Gateway => "Your gateway",
+        WizardStep.Agents => "Your agents",
+        WizardStep.Tools => "Tools",
+        WizardStep.Code => "Your code",
+        WizardStep.Screenshots => "Screenshots",
+        WizardStep.Done => "Done",
+        _ => step.ToString(),
+    };
 
     /// <summary>Paint each dot done / current / upcoming from the model's verdict (never re-derived here).</summary>
     private void RefreshDots()
@@ -227,6 +261,8 @@ public partial class FirstRunWizardDialog : Window
                 _ => Brush("#E6E8EC"),
             };
         }
+
+        DotsStepLabel.Text = $"Step {_model.Index + 1} of {_model.Count} - {StepDisplayName(_model.Current)}";
     }
 
     /// <summary>
@@ -587,8 +623,7 @@ public partial class FirstRunWizardDialog : Window
             AgentsListPanel.Children.Add(AgentRow(
                 s.DisplayName,
                 alreadyAdded ? $"Already in your Agents list - {detail}" : detail,
-                alreadyAdded ? "In list" : "Ready",
-                ready: true));
+                RowState.Ready));
         }
 
 
@@ -598,27 +633,69 @@ public partial class FirstRunWizardDialog : Window
             AgentsListPanel.Children.Add(AgentRow(
                 string.Join(", ", notFound),
                 "Not installed - you can add any of these later in Settings.",
-                "Not found",
-                ready: false));
+                RowState.NotSetUp));
         }
     }
 
-    private static Border AgentRow(string name, string sub, string pillText, bool ready)
+    /// <summary>
+    /// The four states a row can be in. One word each, one colour each.
+    ///
+    /// Before this there was a single boolean and fifteen different labels sharing two colours, so a
+    /// tool that FAILED to install wore the same grey pill as an agent that simply is not installed -
+    /// one needs the user to act, the other is fine and expected, and they were indistinguishable.
+    /// Counts wore status colours too: "3 folders" rendered green, as though having three folders were
+    /// a state of health.
+    /// </summary>
+    private enum RowState
     {
+        /// <summary>It works. Nothing to do. Green.</summary>
+        Ready,
+
+        /// <summary>Happening now, and it finishes on its own. Blue.</summary>
+        Working,
+
+        /// <summary>It will not fix itself. Red - and only ever used where the screen also offers the
+        /// action that fixes it, or the colour becomes noise.</summary>
+        NeedsYou,
+
+        /// <summary>Absent and optional. No action implied. Grey.</summary>
+        NotSetUp,
+    }
+
+    private static (string Background, string Foreground) PillColours(RowState state) => state switch
+    {
+        RowState.Ready => ("#E5F3E9", "#1A7F37"),
+        RowState.Working => ("#F2F8FD", "#0066B8"),
+        RowState.NeedsYou => ("#FDECEC", "#DC2626"),
+        _ => ("#F5F6F8", "#8A909A"),
+    };
+
+    private static string PillLabel(RowState state) => state switch
+    {
+        RowState.Ready => "Ready",
+        RowState.Working => "Working",
+        RowState.NeedsYou => "Needs you",
+        _ => "Not set up",
+    };
+
+    private static Border AgentRow(string name, string sub, RowState state)
+    {
+        var (background, foreground) = PillColours(state);
         var pill = new Border
         {
-            Background = Brush(ready ? "#E5F3E9" : "#F5F6F8"),
+            Background = Brush(background),
             CornerRadius = new global::Avalonia.CornerRadius(999),
             Padding = new global::Avalonia.Thickness(10, 3),
             VerticalAlignment = VerticalAlignment.Center,
             Child = new TextBlock
             {
-                Text = pillText,
-                Foreground = Brush(ready ? "#1A7F37" : "#8A909A"),
+                Text = PillLabel(state),
+                Foreground = Brush(foreground),
                 FontSize = 11,
                 FontWeight = FontWeight.SemiBold,
             },
         };
+        var ready = state == RowState.Ready;
 
         var text = new StackPanel { Spacing = 2 };
         text.Children.Add(new TextBlock
@@ -808,11 +885,13 @@ public partial class FirstRunWizardDialog : Window
             ToolsListPanel.Children.Clear();
             foreach (var tool in catalog)
             {
-                var pill = tool.IsAvailable ? "Ready" : stalled ? "Not installed" : "Installing...";
+                var state = tool.IsAvailable ? RowState.Ready
+                    : stalled ? RowState.NeedsYou
+                    : RowState.Working;
                 var detail = tool.IsAvailable || !stalled
                     ? tool.Description
                     : $"{tool.Description} - this one did not install";
-                ToolsListPanel.Children.Add(AgentRow(tool.Name, detail, pill, ready: tool.IsAvailable));
+                ToolsListPanel.Children.Add(AgentRow(tool.Name, detail, state));
             }
 
             ToolsFixPanel.IsVisible = stalled;
@@ -1653,8 +1732,7 @@ public partial class FirstRunWizardDialog : Window
         rows.Add(AgentRow(
             "Your gateway",
             gateway.IsEnabled ? gateway.Url : "Not connected - phone access and the morning report need one",
-            gateway.IsEnabled ? "Connected" : "None",
-            ready: gateway.IsEnabled));
+            gateway.IsEnabled ? RowState.Ready : RowState.NotSetUp));
 
         var agentCount = 0;
         try
@@ -1667,9 +1745,10 @@ public partial class FirstRunWizardDialog : Window
         }
         rows.Add(AgentRow(
             "Your coding agents",
-            agentCount > 0 ? "Configured and ready to use" : "None configured yet",
-            agentCount > 0 ? $"{agentCount} set up" : "None",
-            ready: agentCount > 0));
+            agentCount > 0
+                ? (agentCount == 1 ? "1 agent, configured and ready to use" : $"{agentCount} agents, configured and ready to use")
+                : "None configured yet",
+            agentCount > 0 ? RowState.Ready : RowState.NotSetUp));
 
         var rootCount = 0;
         try
@@ -1684,9 +1763,10 @@ public partial class FirstRunWizardDialog : Window
         }
         rows.Add(AgentRow(
             "Where your code lives",
-            rootCount > 0 ? "DevThrottle is keeping the books on these" : "No folders added yet",
-            rootCount == 1 ? "1 folder" : rootCount > 0 ? $"{rootCount} folders" : "None",
-            ready: rootCount > 0));
+            rootCount > 0
+                ? (rootCount == 1 ? "1 folder - DevThrottle is keeping the books on it" : $"{rootCount} folders - DevThrottle is keeping the books on them")
+                : "No folders added yet",
+            rootCount > 0 ? RowState.Ready : RowState.NotSetUp));
 
         return rows;
     }
@@ -2045,8 +2125,8 @@ public partial class FirstRunWizardDialog : Window
             // something this run achieved - a receipt that claims credit for work it did not do is
             // the same class of untruth as the step that used to ask for it again.
             DoneReceiptPanel.Children.Add(_gatewayWasAlreadyConnected
-                ? ReceiptRow("Gateway", gatewayUrl, done: true, pillText: "Unchanged")
-                : ReceiptRow("Gateway connected", gatewayUrl, done: true));
+                ? ReceiptRow("Gateway", $"{gatewayUrl} - already set up before this run", RowState.Ready)
+                : ReceiptRow("Gateway connected", gatewayUrl, RowState.Ready));
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 "No gateway", "Connect one from Settings for phone access and your morning report", done: false));
@@ -2065,10 +2145,10 @@ public partial class FirstRunWizardDialog : Window
                 DoneReceiptPanel.Children.Add(ReceiptRow(
                     $"{_toolsTotalCount - _toolsReadyCount} of {_toolsTotalCount} tools did not install",
                     "Repair them from Settings > Tools - they will not finish on their own",
-                    done: false, pillText: "Needs you"));
+                    RowState.NeedsYou));
             else
                 DoneReceiptPanel.Children.Add(ReceiptRow(
-                    "Tools installing", "Finishes on its own in the background", done: false));
+                    "Tools installing", "Finishes on its own in the background", RowState.Working));
         }
 
         // Browsers row: a pointer, not a task. Browser setup lives in the left rail (the Browsers
@@ -2088,22 +2168,30 @@ public partial class FirstRunWizardDialog : Window
         DoneReceiptPanel.Children.Add(!string.IsNullOrWhiteSpace(gatewayUrl)
             ? ReceiptRow("Morning report", "Every morning at 7:00 Eastern - the email says how to change or stop it", done: true)
             : ReceiptRow(
-                "Morning report", "Every morning at 7:00 Eastern - once a gateway is connected",
-                done: false, pillText: "Waiting for a gateway"));
+                "Morning report", "Every morning at 7:00 Eastern - waiting for a gateway to be connected",
+                RowState.NotSetUp));
     }
 
     private static Border ReceiptRow(string name, string sub, bool done, string? pillText = null)
+        => ReceiptRow(name, sub, done ? RowState.Ready : RowState.NotSetUp, pillText);
+
+    /// <summary>
+    /// One receipt line. It takes the SAME four states the steps use, so the last screen of onboarding
+    /// cannot mean something different by a colour than the screen the user saw two steps earlier.
+    /// </summary>
+    private static Border ReceiptRow(string name, string sub, RowState state, string? pillText = null)
     {
+        var (background, foreground) = PillColours(state);
         var pill = new Border
         {
-            Background = Brush(done ? "#E5F3E9" : "#F5F6F8"),
+            Background = Brush(background),
             CornerRadius = new global::Avalonia.CornerRadius(999),
             Padding = new global::Avalonia.Thickness(10, 3),
             VerticalAlignment = VerticalAlignment.Center,
             Child = new TextBlock
             {
-                Text = pillText ?? (done ? "Done" : "Later"),
-                Foreground = Brush(done ? "#1A7F37" : "#8A909A"),
+                Text = pillText ?? PillLabel(state),
+                Foreground = Brush(foreground),
                 FontSize = 11,
                 FontWeight = FontWeight.SemiBold,
             },

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml
@@ -240,6 +240,7 @@
                                                FontSize="11" Foreground="#888888" Padding="8,5" />
                                     <Button Grid.Column="3" Content="X"
                                             Click="BtnRemoveRepo_Click"
+                                            IsVisible="{Binding CanRemove}"
                                             Tag="{Binding Path}"
                                             Width="24" Height="24"
                                             Background="Transparent"

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
@@ -549,16 +549,11 @@ public partial class NewSessionDialog : Window
             Height = screen.WorkingArea.Height * 0.7 / screen.Scaling;
         }
 
-        if (_registry != null && _registry.Repositories.Count > 0)
+        _allRepos = BuildRepositoryList();
+        if (_allRepos.Count > 0)
         {
-            _allRepos = _registry.Repositories.ToList();
             ApplyRepoSort();
             RepoList.ItemsSource = _allRepos;
-            FileLog.Write($"[NewSessionDialog] Loaded {_allRepos.Count} repositories");
-        }
-        else
-        {
-            _allRepos = new List<RepositoryConfig>();
         }
         UpdateRepoEmptyState();
 
@@ -577,6 +572,81 @@ public partial class NewSessionDialog : Window
 
     // Parameterless constructor for XAML designer
     public NewSessionDialog() : this(null, null) { }
+
+    /// <summary>
+    /// The repositories this dialog offers: the ones you have USED, in their recency order, then every
+    /// other repository under your registered root folders, alphabetically, deduplicated by path.
+    ///
+    /// It used to be the registry alone. That made the end of onboarding untrue: the setup wizard
+    /// registers ROOT FOLDERS, the registry only ever holds repositories you have actually opened, and
+    /// nothing bridged the two - so the wizard's receipt said "12 repositories - Done" and the New
+    /// Session dialog it opened one click later said "No repositories yet". The bridge is the
+    /// repository model, which has already scanned those roots and is warm from cache at startup.
+    ///
+    /// The union is done HERE, at display time, rather than by writing the scan into the registry:
+    /// the registry is the recently-used list, and filling it with hundreds of never-opened
+    /// repositories would destroy the ordering that makes it useful. Recency stays on top; the long
+    /// tail sits beneath it and is reachable through the search box.
+    /// </summary>
+    private List<RepositoryConfig> BuildRepositoryList()
+    {
+        var used = _registry?.Repositories.ToList() ?? new List<RepositoryConfig>();
+        var seen = new HashSet<string>(
+            used.Select(r => NormalizeRepoPath(r.Path)),
+            StringComparer.OrdinalIgnoreCase);
+
+        var discovered = new List<RepositoryConfig>();
+        try
+        {
+            var monitor = (global::Avalonia.Application.Current as App)?.RepositoryMonitor;
+            if (monitor is not null)
+            {
+                foreach (var status in monitor.Snapshot())
+                {
+                    if (string.IsNullOrWhiteSpace(status.Path)) continue;
+                    if (!seen.Add(NormalizeRepoPath(status.Path))) continue;
+                    discovered.Add(new RepositoryConfig
+                    {
+                        Name = string.IsNullOrWhiteSpace(status.Name)
+                            ? System.IO.Path.GetFileName(status.Path.TrimEnd(System.IO.Path.DirectorySeparatorChar))
+                            : status.Name,
+                        Path = status.Path,
+                        // Deliberately null: these have never been opened, so they carry no recency and
+                        // sort below everything that has.
+                        LastUsed = null,
+                        // Found under a watched folder rather than chosen. The list hides Remove on
+                        // these: removing one would only drop it from the recently-used store, and the
+                        // very next rebuild would find it again under the same folder - a button that
+                        // undoes itself reads as broken.
+                        IsDiscovered = true,
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // The recently-used list is the load-bearing half. A repository model that cannot be read
+            // must not take the whole dialog down - but it does say so in the log.
+            FileLog.Write($"[NewSessionDialog] ERROR reading the repository model: {ex.Message}");
+        }
+
+        discovered.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        used.AddRange(discovered);
+        FileLog.Write($"[NewSessionDialog] Loaded {used.Count} repositories ({used.Count - discovered.Count} recently used, {discovered.Count} found under your folders)");
+        return used;
+    }
+
+    private static string NormalizeRepoPath(string path)
+    {
+        try
+        {
+            return System.IO.Path.GetFullPath(path).TrimEnd(System.IO.Path.DirectorySeparatorChar);
+        }
+        catch
+        {
+            return path;
+        }
+    }
 
     /// <summary>
     /// Build the agent picker (issue #490) from the ENABLED <c>agent.entries</c> (#489), in stored
@@ -1157,7 +1227,7 @@ public partial class NewSessionDialog : Window
             if (_registry != null)
             {
                 _registry.TryAdd(folderPath);
-                _allRepos = _registry.Repositories.ToList();
+                _allRepos = BuildRepositoryList();
                 ApplyRepoSort();
                 ApplyRepoFilter();
                 UpdateRepoEmptyState();
@@ -1178,7 +1248,7 @@ public partial class NewSessionDialog : Window
         if (_registry != null)
         {
             _registry.Remove(path);
-            _allRepos = _registry.Repositories.ToList();
+            _allRepos = BuildRepositoryList();
             ApplyRepoSort();
             ApplyRepoFilter();
             UpdateRepoEmptyState();

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -169,14 +169,14 @@
                 <Grid RowDefinitions="Auto,*">
                     <StackPanel Grid.Row="0" Spacing="8" Margin="0,4,14,8">
                         <TextBlock Classes="sectionTitle" Text="Agents" />
-                        <TextBlock Classes="hint" Text="Your agents, in the order they appear in New Session. Each entry is a configured agent CLI - you can add several of the same type (e.g. two Claude entries with different presets). Use the Up/Down arrows to reorder, Add Agent to create one, and Edit to set the executable, command-line preset, model, and arguments. The Setup wizard can scan this machine for known tools." />
+                        <TextBlock Classes="hint" Text="Your agents, in the order they appear in New Session. Each entry is a configured agent CLI - you can add several of the same type (e.g. two Claude entries with different presets). Use the Up/Down arrows to reorder, Add Agent to create one, and Edit to set the executable, command-line preset, model, and arguments. The Setup wizard re-runs the full setup - agents, tools, code folders, screenshots and the gateway - leaving anything already set up alone." />
                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
                             <Button x:Name="AddAgentButton" Classes="dialogButton" Content="+ Add Agent"
                                     Width="120" Click="BtnAddAgent_Click"
                                     ToolTip.Tip="Add a new agent entry to the list" />
                             <Button x:Name="RunWizardButton" Classes="dialogButton" Content="Setup wizard..."
                                     Width="150" Click="BtnRunWizard_Click"
-                                    ToolTip.Tip="Scan this machine for known tools and add the ones it finds with their recommended settings" />
+                                    ToolTip.Tip="Re-run the full setup: agents, tools, where your code lives, screenshots, and the gateway. Anything already set up is left alone." />
                             <TextBlock x:Name="AgentToolsStatus" Text="" Foreground="#888888"
                                        FontSize="11" TextWrapping="Wrap" VerticalAlignment="Center"
                                        IsVisible="False" />

--- a/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
@@ -107,7 +107,7 @@ public class FirstRunWizardModelTests
         });
 
         Assert.Equal(
-            new[] { WizardStep.Welcome, WizardStep.Agents, WizardStep.Gateway, WizardStep.Done },
+            new[] { WizardStep.Welcome, WizardStep.Gateway, WizardStep.Agents, WizardStep.Done },
             model.Steps);
     }
 
@@ -126,17 +126,39 @@ public class FirstRunWizardModelTests
     public void CreateFull_HasAllSevenStepsInCanonicalOrder()
     {
         var model = FirstRunWizardModel.CreateFull();
-        Assert.Equal(FirstRunWizardModel.CanonicalOrder, model.Steps);
         Assert.Equal(7, model.Count);
 
-        // Tools sits right after Agents: workforce first, then their toolbelt.
-        Assert.Equal(WizardStep.Tools, model.Steps[2]);
+        // The WHOLE sequence, written out, not compared against the production list. Comparing
+        // model.Steps to CanonicalOrder only proves the model did not reorder its own input - it
+        // passes for any order production happens to declare, so it cannot catch an ordering change.
+        // Spot checks on three indexes were not enough either: swapping Agents and Code kept every one
+        // of them true. This is the assertion that fails when the journey changes.
+        Assert.Equal(
+            new[]
+            {
+                WizardStep.Welcome,     // the invitation
+                WizardStep.Gateway,     // who you are, before anything about this machine
+                WizardStep.Agents,      // your workforce
+                WizardStep.Tools,       // their toolbelt
+                WizardStep.Code,        // what we watch over
+                WizardStep.Screenshots, // show, don't type
+                WizardStep.Done,        // the receipt
+            },
+            model.Steps);
+        Assert.Equal(FirstRunWizardModel.CanonicalOrder, model.Steps);
 
-        // Gateway is the last step before Done. It used to be followed by a daily-report frequency
-        // question, which is an ACCOUNT setting and so was asked once per machine with no way to
-        // reconcile the answers (issue #996). The number here is also the number of progress dots,
-        // so a step creeping back in is a failing assertion rather than a silently longer wizard.
-        Assert.Equal(WizardStep.Gateway, model.Steps[^2]);
+        // The gateway is the FIRST thing asked after the welcome: connecting is who you are, and every
+        // step after it configures one particular machine. Identity leads, machine questions follow.
+        Assert.Equal(WizardStep.Gateway, model.Steps[1]);
+
+        // Tools sits right after Agents: workforce first, then their toolbelt.
+        Assert.Equal(WizardStep.Tools, model.Steps[3]);
+
+        // Screenshots is the last step before Done. Done used to be preceded by a daily-report
+        // frequency question, which is an ACCOUNT setting and so was asked once per machine with no
+        // way to reconcile the answers (issue #996). The count here is also the number of progress
+        // dots, so a step creeping back in is a failing assertion rather than a silently longer wizard.
+        Assert.Equal(WizardStep.Screenshots, model.Steps[^2]);
     }
 
     [Fact]
@@ -152,8 +174,11 @@ public class FirstRunWizardModelTests
             WizardStep.Screenshots, WizardStep.Gateway, WizardStep.Done,
         };
 
-        Assert.Equal(machineScoped, Enum.GetValues<WizardStep>());
-        Assert.Equal(machineScoped, FirstRunWizardModel.CanonicalOrder);
+        // The SET is what this rule is about - every declared step must be one a machine can answer.
+        // Presentation order is a separate decision (the gateway now leads), so the two are compared
+        // as sets here rather than as sequences; the exact order is asserted in the test above.
+        Assert.Equal(machineScoped.OrderBy(s => s), Enum.GetValues<WizardStep>().OrderBy(s => s));
+        Assert.Equal(machineScoped.OrderBy(s => s), FirstRunWizardModel.CanonicalOrder.OrderBy(s => s));
     }
 
     [Fact]
@@ -187,10 +212,12 @@ public class FirstRunWizardModelTests
         Assert.True(model.IsFirst);
         Assert.False(model.IsLast);
 
-        Assert.True(model.MoveNext());
-        Assert.Equal(WizardStep.Agents, model.Current);
+        // Canonical order puts the gateway before the agents, whatever order the present-step list
+        // was given in.
         Assert.True(model.MoveNext());
         Assert.Equal(WizardStep.Gateway, model.Current);
+        Assert.True(model.MoveNext());
+        Assert.Equal(WizardStep.Agents, model.Current);
         Assert.True(model.MoveNext());
         Assert.Equal(WizardStep.Done, model.Current);
         Assert.True(model.IsLast);
@@ -201,9 +228,9 @@ public class FirstRunWizardModelTests
 
         // Back walks the same present steps in reverse.
         Assert.True(model.MoveBack());
-        Assert.Equal(WizardStep.Gateway, model.Current);
-        Assert.True(model.MoveBack());
         Assert.Equal(WizardStep.Agents, model.Current);
+        Assert.True(model.MoveBack());
+        Assert.Equal(WizardStep.Gateway, model.Current);
         Assert.True(model.MoveBack());
         Assert.Equal(WizardStep.Welcome, model.Current);
 
@@ -230,7 +257,7 @@ public class FirstRunWizardModelTests
     public void DotState_ReflectsPosition_PastCurrentUpcoming()
     {
         var model = new FirstRunWizardModel(ShellSteps());
-        model.GoTo(WizardStep.Gateway); // index 2 of 4
+        model.GoTo(WizardStep.Agents); // index 2 of 4 (Welcome, Gateway, Agents, Done)
 
         Assert.Equal(WizardDotState.Past, model.DotStateAt(0));
         Assert.Equal(WizardDotState.Past, model.DotStateAt(1));

--- a/src/CcDirector.Core/Configuration/RepositoryConfig.cs
+++ b/src/CcDirector.Core/Configuration/RepositoryConfig.cs
@@ -12,6 +12,20 @@ public class RepositoryConfig : INotifyPropertyChanged
     public string Path { get; set; } = string.Empty;
     public DateTime? LastUsed { get; set; }
 
+    /// <summary>
+    /// True when this entry was not chosen by the user but FOUND under one of the folders DevThrottle
+    /// watches. It is not persisted - it is set when the New Session list is built.
+    /// </summary>
+    public bool IsDiscovered { get; set; }
+
+    /// <summary>
+    /// Whether the list should offer to remove this entry. A discovered repository cannot be removed
+    /// from the list: it comes from a watched folder, so it would simply be found again on the next
+    /// rebuild. Offering a Remove that instantly undoes itself is worse than not offering one - to
+    /// stop seeing it, stop watching its folder.
+    /// </summary>
+    public bool CanRemove => !IsDiscovered;
+
     [JsonIgnore]
     public string LastUsedDisplay => LastUsed.HasValue
         ? FormatTimeAgo(LastUsed.Value)

--- a/src/CcDirector.Core/Onboarding/CodeFolderScout.cs
+++ b/src/CcDirector.Core/Onboarding/CodeFolderScout.cs
@@ -59,20 +59,39 @@ public static class CodeFolderScout
                 candidates.Add(Path.Combine(home, name));
         }
 
-        if (OperatingSystem.IsWindows())
+        // Code kept OUTSIDE the home directory. This is not an edge case - it is where most of the
+        // repositories on the author's own machine live (C:\Repos, C:\ReposBPMN, C:\ReposFred, D:\Dev),
+        // and none of them would be found by the home-directory probes above.
+        //
+        // Both platforms get an arm. Windows sweeps the top level of every fixed drive; macOS has no
+        // drive letters, so the equivalents are the filesystem root (where a /Projects or /Code is
+        // occasionally kept) and every mounted volume under /Volumes, which is where an external or
+        // second disk appears. Without the macOS arm this screen found far less on a Mac than on
+        // Windows, for no reason the user could see.
+        // One stalled container must not cost the user every other one. A mounted network volume under
+        // /Volumes, or a disconnected drive on Windows, can block inside Directory.GetDirectories for
+        // a long time - and that call takes no cancellation token, so the scan's overall time budget
+        // cannot interrupt it once it is inside. What we CAN do is stop starting new ones: each
+        // container is given its own short budget, and a container that overruns is abandoned and
+        // logged rather than allowed to hold up the rest.
+        foreach (var container in TopLevelContainers())
         {
-            foreach (var drive in SafeFixedDriveRoots())
+            try
             {
-                try
+                var listing = Task.Run(() => Directory.GetDirectories(container));
+                if (!listing.Wait(PerContainerListTimeout))
                 {
-                    foreach (var dir in Directory.GetDirectories(drive))
-                        if (NameSuggestsCode(Path.GetFileName(dir)))
-                            candidates.Add(dir);
+                    FileLog.Write($"[CodeFolderScout] {container} did not answer within {PerContainerListTimeout.TotalSeconds:0}s - skipped (a stalled or disconnected volume)");
+                    continue;
                 }
-                catch (Exception ex)
-                {
-                    FileLog.Write($"[CodeFolderScout] cannot list {drive}: {ex.Message}");
-                }
+
+                foreach (var dir in listing.Result)
+                    if (NameSuggestsCode(Path.GetFileName(dir)))
+                        candidates.Add(dir);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[CodeFolderScout] cannot list {container}: {ex.GetBaseException().Message}");
             }
         }
 
@@ -88,6 +107,39 @@ public static class CodeFolderScout
         }
         FileLog.Write($"[CodeFolderScout] CandidateRoots -> {result.Count} folder(s)");
         return result;
+    }
+
+    /// <summary>
+    /// The places to sweep for code folders that live outside the home directory, one top-level
+    /// listing each. Windows: every fixed drive root. macOS: the filesystem root and each mounted
+    /// volume. Anywhere else: nothing, so the caller simply falls back to the home-directory probes.
+    /// </summary>
+    /// <summary>
+    /// How long one top-level listing may take before it is abandoned. Deliberately much shorter than
+    /// the caller's whole-scan budget, because a stalled volume cannot be cancelled once entered - the
+    /// only defence is to stop waiting on it.
+    /// </summary>
+    private static readonly TimeSpan PerContainerListTimeout = TimeSpan.FromSeconds(3);
+
+    private static IEnumerable<string> TopLevelContainers()
+    {
+        if (OperatingSystem.IsWindows())
+            return SafeFixedDriveRoots();
+
+        if (!OperatingSystem.IsMacOS())
+            return Array.Empty<string>();
+
+        var containers = new List<string> { "/" };
+        try
+        {
+            if (Directory.Exists("/Volumes"))
+                containers.AddRange(Directory.GetDirectories("/Volumes"));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CodeFolderScout] cannot list /Volumes: {ex.Message}");
+        }
+        return containers;
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
+++ b/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
@@ -1,4 +1,4 @@
-using CcDirector.Core.Utilities;
+﻿using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Onboarding;
 
@@ -58,14 +58,25 @@ public sealed class FirstRunWizardModel
     /// always re-ordered to this sequence, so step order is guaranteed regardless of which interim or
     /// absent steps a given release includes.
     /// </summary>
+    /// <remarks>
+    /// The gateway comes FIRST, before anything about this machine. Connecting is who you are, and
+    /// everything after it is configuration of one particular computer - so identity leads, and the
+    /// machine questions follow. It also puts the one step that carries real value for the user (their
+    /// agents on their phone, voice, the morning report) where it will actually be seen rather than
+    /// five screens in, after the attention has gone.
+    ///
+    /// This does NOT make the gateway a gate. "Not now" stays exactly as prominent as it was: the
+    /// Director installs and runs with no account, and a first screen that reads as sign-up-to-continue
+    /// would change what the product is.
+    /// </remarks>
     public static readonly IReadOnlyList<WizardStep> CanonicalOrder = new[]
     {
         WizardStep.Welcome,
+        WizardStep.Gateway,
         WizardStep.Agents,
         WizardStep.Tools,
         WizardStep.Code,
         WizardStep.Screenshots,
-        WizardStep.Gateway,
         WizardStep.Done,
     };
 


### PR DESCRIPTION
The setup wizard now opens on the gateway, and several screens stopped asserting things the code could not back up.

## What changed

**Gateway first, and it recognises a machine that is already enrolled.** Connecting is who you are; every step after it configures one particular machine. The step now reads the saved gateway rather than a flag that only knew about the current run - which is why the same wizard used to offer "Sign in and connect" and then print "Gateway connected" two screens later. A saved address is no longer treated as proof that phone access, voice and the morning report work: a non-blank string is not a reachability check, so the screen states the configuration and offers to reconnect.

**Claims the code could not keep.**
- The agents step held its primary button live during the scan. Pressing it early accepted an empty suggestion list, configured nothing, and advanced - the wizard said it was using your agents and set up none. It is now disabled for the scan, and rows build as they are found rather than appearing after every version probe returns.
- A repository sweep that hit its time budget wrote the identical "that is everywhere we checked" sentence a completed sweep writes. It now says it stopped early and offers to keep looking.
- The tools step could only say Ready or Installing, so a tool that would never install kept its Installing pill indefinitely while the line above promised it would finish on its own. There is now a third state and a repair, and the Done receipt reports the same three states instead of downgrading a failure back to "finishes on its own".

**Code folders are registered, not offered.** Found folders are added automatically with a Remove button. The Add buttons were easy to walk straight past - four folders holding seventeen repositories went unregistered in testing. Registrations are serialised, because run concurrently they collided on the roots file and most of them lost; the sweep waits for its own writes before reporting itself finished; and a folder the user removes stays removed even when the still-running sweep reports it again.

**New Session shows those folders.** It read the recently-used registry and nothing else, so the receipt could say "12 repositories - Done" and the very next screen say "No repositories yet" (#973). It now unions in the repositories found under the watched folders, recency first, and hides Remove on rows that would simply come back.

**Also:** the founder note on Welcome is replaced by what the wizard is about to cover; closing the window part way through no longer retires the wizard permanently; the gateway cards are reachable and operable by keyboard and announce whether they are selected; the folder sweep gained a macOS arm, bounded so one stalled volume cannot hold up the rest; and the working steps use a smaller title so their lists are not squeezed into a third of the window.

## Verification

- 313 dialog tests and 3870 core tests pass.
- The step-order test asserts the whole sequence again. Relaxing it to a set comparison when the order changed would have let a real reordering through - verified by swapping two steps and watching it fail.
- Driven on a clean throwaway instance root: wizard opens, all seven steps, eight folders registered with no failures, totals reconcile.

## Not in this change

The shared gateway choice state machine (#863), removing cc-playwright from the toolbelt (#1002), declining tools in the wizard (#1003), and the browsers step. The hosted sign-in leg has still never been walked on a clean machine.
