### PR TITLE
Settings: take the AI tab out of the strip, keep the component

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -15,10 +15,13 @@ import { InjectedTextTab } from "./InjectedTextTab";
 //
 //   Notifications - how a session that needs you reaches you: snooze length, display time zone,
 //                   notifications on this device
-//   AI            - the hosted provider, the thinking models, the spoken language, the speech voice
 //   Transcription - the transcription model, how your microphones are measuring, and the two on-demand
 //                   checks (Test microphone, Test transcription)
 //   Car Mode      - the phone's hands-free fleet control: model, end phrase, live phrase tester
+//
+// The AI tab is no longer in the strip. It named the hosting models to customers, which the hosting
+// layer itself refuses to do, and most of it is inert on the hosted Gateway. It still renders in full at
+// /settings?tab=ai, where it does real work for a self-hosted Gateway - see client-core/settings/tabs.ts.
 //
 // The Transcription tab is new here and it is the reason the two surfaces were unified: the checks used
 // to live ONLY on the Transcription Health page on the desktop and on two standalone screens on the

--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -19,9 +19,10 @@ import { InjectedTextTab } from "./InjectedTextTab";
 //                   checks (Test microphone, Test transcription)
 //   Car Mode      - the phone's hands-free fleet control: model, end phrase, live phrase tester
 //
-// The AI tab is no longer in the strip. It named the hosting models to customers, which the hosting
-// layer itself refuses to do, and most of it is inert on the hosted Gateway. It still renders in full at
-// /settings?tab=ai, where it does real work for a self-hosted Gateway - see client-core/settings/tabs.ts.
+// The AI tab is no longer offered - not in the strip, and not by ?tab= either. It named the hosting
+// models to customers, which the hosting layer itself refuses to do, and most of it was inert on the
+// hosted Gateway anyway. The component is kept so this is reversible by one word, not rebuilt from
+// scratch - see client-core/settings/tabs.ts.
 //
 // The Transcription tab is new here and it is the reason the two surfaces were unified: the checks used
 // to live ONLY on the Transcription Health page on the desktop and on two standalone screens on the

--- a/packages/client-core/src/settings/SettingsTabs.test.tsx
+++ b/packages/client-core/src/settings/SettingsTabs.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { SettingsTabPanel, SettingsTabStrip } from "./SettingsTabs";
+import { setWingmanFastModel, setWingmanModel } from "../api/ai";
 
 // The account snapshot every AI-ish tab reads. Values are arbitrary but must be present: a tab that
 // renders "Loading..." forever proves nothing about its content.
@@ -48,6 +49,7 @@ function mount(ui: React.ReactNode) {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   // No Gateway in a unit test. Every card must therefore render its own explicit state - a heading and
   // either its content or its own error line - and never a blank panel.
   vi.stubGlobal("fetch", vi.fn(async () => {
@@ -61,27 +63,38 @@ afterEach(() => {
 });
 
 describe("the Settings tab strip", () => {
-  it("offers the four shared tabs on the phone", () => {
+  it("offers the three shared tabs on the phone", () => {
     mount(<SettingsTabStrip active="notifications" onSelect={() => {}} surface="mobile" />);
     expect(screen.getAllByRole("tab").map((t) => t.textContent)).toEqual([
       "Notifications",
-      "AI",
       "Transcription",
       "Car Mode",
     ]);
   });
 
   // The Cockpit-only tab, rendered (issue #550). The tab set decides this, not the shell, so the strip is
-  // where it can be seen: the same four in the same order, and one more that the phone above does not get.
-  it("offers those same four plus Injected text on the Cockpit", () => {
+  // where it can be seen: the same three in the same order, and one more that the phone above does not get.
+  it("offers those same three plus Injected text on the Cockpit", () => {
     mount(<SettingsTabStrip active="notifications" onSelect={() => {}} surface="cockpit" />);
     expect(screen.getAllByRole("tab").map((t) => t.textContent)).toEqual([
       "Notifications",
-      "AI",
       "Transcription",
       "Car Mode",
       "Injected text",
     ]);
+  });
+
+  // Hidden means hidden on both surfaces. Asserted through the RENDERED strip and not only through the
+  // tab list, because the strip is what a person actually sees; a list can be right while a shell puts a
+  // button back.
+  it("offers no AI button on either surface", () => {
+    for (const surface of ["cockpit", "mobile"] as const) {
+      const { unmount } = mount(
+        <SettingsTabStrip active="notifications" onSelect={() => {}} surface={surface} />,
+      );
+      expect(screen.queryByRole("tab", { name: "AI" })).toBeNull();
+      unmount();
+    }
   });
 
   it("marks exactly the active tab selected", () => {
@@ -114,6 +127,31 @@ describe("the Transcription tab", () => {
     mount(<SettingsTabPanel tab="transcription" transcriptionHealthHref="/transcription" />);
     await screen.findByText("test-transcription-model");
     expect(screen.getByRole("link", { name: "Transcription Health" })).toBeTruthy();
+  });
+});
+
+// The AI tab left the strip; the panel behind it did not leave the product. On a self-hosted Gateway
+// those pickers do real work, so the component stays and stays reachable by its own link - see tabs.ts.
+describe("the AI tab, hidden from the strip but still rendered when reached", () => {
+  it("draws the whole tab, with the account's saved models selected", async () => {
+    mount(<SettingsTabPanel tab="ai" />);
+
+    const thinking = (await screen.findByLabelText("Thinking model")) as HTMLSelectElement;
+    const fast = screen.getByLabelText("Fast model") as HTMLSelectElement;
+    expect(thinking.value).toBe("test-thinking-model");
+    expect(fast.value).toBe("test-fast-model");
+    expect(screen.getByLabelText("Speech model")).toBeTruthy();
+    expect(screen.getByLabelText("Voice")).toBeTruthy();
+  });
+
+  // The classic version of this bug: a control that is no longer in front of anybody quietly writes over
+  // what it holds - typically a null - the first time it is drawn. The stored models live on the Gateway
+  // per account, and merely rendering this tab must write NOTHING. Only a person choosing does that.
+  it("writes no model setting merely by being rendered", async () => {
+    mount(<SettingsTabPanel tab="ai" />);
+    await screen.findByLabelText("Thinking model");
+    expect(setWingmanModel).not.toHaveBeenCalled();
+    expect(setWingmanFastModel).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/client-core/src/settings/SettingsTabs.test.tsx
+++ b/packages/client-core/src/settings/SettingsTabs.test.tsx
@@ -130,9 +130,11 @@ describe("the Transcription tab", () => {
   });
 });
 
-// The AI tab left the strip; the panel behind it did not leave the product. On a self-hosted Gateway
-// those pickers do real work, so the component stays and stays reachable by its own link - see tabs.ts.
-describe("the AI tab, hidden from the strip but still rendered when reached", () => {
+// The AI tab is no longer offered anywhere - not in the strip, and not by ?tab= either. The COMPONENT is
+// still here and still built, because hiding it is meant to be reversible by one word rather than by
+// restoring a deleted screen (see tabs.ts). These are the checks that the thing being kept is still whole:
+// mounted directly, it draws in full and it writes nothing.
+describe("the AI tab, hidden but kept", () => {
   it("draws the whole tab, with the account's saved models selected", async () => {
     mount(<SettingsTabPanel tab="ai" />);
 
@@ -146,7 +148,8 @@ describe("the AI tab, hidden from the strip but still rendered when reached", ()
 
   // The classic version of this bug: a control that is no longer in front of anybody quietly writes over
   // what it holds - typically a null - the first time it is drawn. The stored models live on the Gateway
-  // per account, and merely rendering this tab must write NOTHING. Only a person choosing does that.
+  // per account, they are still what the wingman runs on, and merely rendering this tab must write
+  // NOTHING. Only a person choosing does that.
   it("writes no model setting merely by being rendered", async () => {
     mount(<SettingsTabPanel tab="ai" />);
     await screen.findByLabelText("Thinking model");

--- a/packages/client-core/src/settings/tabs.test.ts
+++ b/packages/client-core/src/settings/tabs.test.ts
@@ -2,23 +2,29 @@ import { describe, expect, it } from "vitest";
 import { visibleTabs, tabFromParam } from "./tabs";
 
 describe("visibleTabs", () => {
-  it("shows the four shared tabs on the phone, notifications first", () => {
+  it("shows the three shared tabs on the phone, notifications first", () => {
     expect(visibleTabs("mobile").map((t) => t.id)).toEqual([
       "notifications",
-      "ai",
       "transcription",
       "carmode",
     ]);
   });
 
-  it("shows the same four on the Cockpit, in the same order, plus its own Injected text", () => {
+  it("shows the same three on the Cockpit, in the same order, plus its own Injected text", () => {
     expect(visibleTabs("cockpit").map((t) => t.id)).toEqual([
       "notifications",
-      "ai",
       "transcription",
       "carmode",
       "injectedtext",
     ]);
+  });
+
+  // Hidden on BOTH surfaces, not on one - a tab dropped from the desktop strip and left on the phone
+  // would be precisely the drift this shared list exists to prevent.
+  it("keeps the AI tab out of the strip on both surfaces", () => {
+    for (const surface of ["cockpit", "mobile"] as const) {
+      expect(visibleTabs(surface).map((t) => t.id)).not.toContain("ai");
+    }
   });
 
   // The parity law: the desktop may go DEEPER, never sideways. Every tab the phone shows must also be on
@@ -60,6 +66,15 @@ describe("tabFromParam", () => {
     for (const surface of ["cockpit", "mobile"] as const) {
       expect(tabFromParam(null, surface)).toBe("notifications");
       expect(tabFromParam("nonsense", surface)).toBe("notifications");
+    }
+  });
+
+  // The other half of hiding a tab, and the half that is easy to leave out. Dropping it from the strip
+  // alone would send every existing ?tab=ai link to Notifications instead - which reads as the page
+  // having lost the setting rather than as the tab having been tidied away.
+  it("still resolves the hidden AI tab from its own link, on both surfaces", () => {
+    for (const surface of ["cockpit", "mobile"] as const) {
+      expect(tabFromParam("ai", surface)).toBe("ai");
     }
   });
 

--- a/packages/client-core/src/settings/tabs.test.ts
+++ b/packages/client-core/src/settings/tabs.test.ts
@@ -69,12 +69,13 @@ describe("tabFromParam", () => {
     }
   });
 
-  // The other half of hiding a tab, and the half that is easy to leave out. Dropping it from the strip
-  // alone would send every existing ?tab=ai link to Notifications instead - which reads as the page
-  // having lost the setting rather than as the tab having been tidied away.
-  it("still resolves the hidden AI tab from its own link, on both surfaces", () => {
+  // A hidden tab is not a back door either: no escape hatch was wanted, so ?tab=ai gets the same
+  // treatment as any other id that is not one of this surface's tabs. Asserted rather than left implied,
+  // because "hidden from the strip but still reachable by its link" is the other thing this could
+  // plausibly have meant, and it is not what was decided.
+  it("does not resolve the hidden AI tab from a link either, on either surface", () => {
     for (const surface of ["cockpit", "mobile"] as const) {
-      expect(tabFromParam("ai", surface)).toBe("ai");
+      expect(tabFromParam("ai", surface)).toBe("notifications");
     }
   });
 

--- a/packages/client-core/src/settings/tabs.ts
+++ b/packages/client-core/src/settings/tabs.ts
@@ -27,39 +27,75 @@ interface TabDef {
    * uncomfortable and needs the same kind of reason.
    */
   surface: "all" | "cockpit";
+  /**
+   * Not listed in the strip, but still REACHABLE by ?tab= on the surfaces it belongs to, and still
+   * rendered in full when reached.
+   *
+   * This is a narrower thing than removing a tab, and the difference is the whole point of the flag. A
+   * removed tab is gone for everybody. A hidden tab is one we have decided not to put in front of
+   * people, while the panel behind it keeps working for whoever needs it.
+   *
+   * The AI tab is the reason this exists. On the hosted Gateway it shows model identities straight to
+   * customers, which contradicts a rule the hosting layer already enforces one level down - speech
+   * provider names are replaced with "devthrottle" for every non-admin caller. Most of the tab is inert
+   * on hosted anyway: it says so itself, in its own words, because the live model catalog is refused
+   * there. On a SELF-HOSTED Gateway those same pickers do real work, so deleting the component would
+   * take a working feature away from self-hosters to solve a hosted presentation problem. Hidden, not
+   * deleted.
+   *
+   * A hidden tab is still a tab: its stored settings keep being written by its own controls when it is
+   * reached, and keep being read by the product. Hiding a control must never quietly reset what it
+   * holds - those settings live on the Gateway, per account, and nothing in this file touches them.
+   */
+  hidden?: true;
 }
 
 // The full ordered set. The order is the order you meet them: how the fleet reaches you, what it thinks
 // with, how it hears you, the hands-free mode built on all three, and last the text it hands your agents.
 const ALL_TABS: TabDef[] = [
   { id: "notifications", label: "Notifications", surface: "all" },
-  { id: "ai", label: "AI", surface: "all" },
+  { id: "ai", label: "AI", surface: "all", hidden: true },
   { id: "transcription", label: "Transcription", surface: "all" },
   { id: "carmode", label: "Car Mode", surface: "all" },
   { id: "injectedtext", label: "Injected text", surface: "cockpit" },
 ];
 
 /**
- * The tabs to show on this surface.
+ * Every tab this surface OWNS - listed or not. Not exported: it is the input to the two rules below,
+ * which are the only two questions a caller gets to ask.
  *
  * `surface` is REQUIRED rather than defaulting to "all": a caller that forgets it fails to compile,
  * instead of a phone quietly inheriting a tab it cannot render. That is the whole safety of this
  * mechanism - a default here would hand the mobile shell the Cockpit's list on the first careless call.
  */
-export function visibleTabs(surface: Surface): { id: TabId; label: string }[] {
-  return ALL_TABS.filter((t) => t.surface === "all" || t.surface === surface).map((t) => ({
-    id: t.id,
-    label: t.label,
-  }));
+function tabsOwnedBy(surface: Surface): TabDef[] {
+  return ALL_TABS.filter((t) => t.surface === "all" || t.surface === surface);
 }
 
 /**
- * Resolve the ?tab= parameter to a tab THIS surface actually shows. Unknown, missing, retired, or
- * not-on-this-surface values fall to the first tab (Notifications).
+ * The tabs to SHOW on this surface - what goes in the strip.
  *
- * It is filtered by surface for the same reason visibleTabs is: a phone opening a link to
- * ?tab=injectedtext must land on a real tab, not select a tab that its own strip does not list and its
- * own panel cannot draw. A deep link is not permission to render something.
+ * Hidden tabs are dropped here and only here. Everything else about them is unchanged, which is what
+ * makes hiding one a reversible edit to a single line of ALL_TABS.
+ */
+export function visibleTabs(surface: Surface): { id: TabId; label: string }[] {
+  return tabsOwnedBy(surface)
+    .filter((t) => t.hidden !== true)
+    .map((t) => ({ id: t.id, label: t.label }));
+}
+
+/**
+ * Resolve the ?tab= parameter to a tab this surface can actually render. Unknown, missing, retired, or
+ * not-on-this-surface values fall to the first VISIBLE tab (Notifications).
+ *
+ * It resolves against the tabs this surface OWNS, not the ones it lists, so a hidden tab stays reachable
+ * by its own link. That is deliberate, and it is the half of hiding that is easy to leave out: drop a tab
+ * from the strip alone and every existing link to it silently lands on Notifications instead, which reads
+ * as the page having lost the setting rather than as the tab having been tidied away.
+ *
+ * It is still filtered by surface, for the same reason visibleTabs is: a phone opening a link to
+ * ?tab=injectedtext must land on a real tab, not select a tab whose panel it cannot draw. A deep link is
+ * permission to reach a tab this surface owns - never permission to render one it does not.
  *
  * "machine", "telemetry", and "privacy" are retired ids (the "This machine" tab left in issue #2022; the
  * old standalone Telemetry page redirected to /settings?tab=telemetry, issue #1405; the Privacy tab was
@@ -67,7 +103,6 @@ export function visibleTabs(surface: Surface): { id: TabId; label: string }[] {
  * than on a tab that no longer exists.
  */
 export function tabFromParam(raw: string | null, surface: Surface): TabId {
-  const shown = visibleTabs(surface);
-  const match = shown.find((t) => t.id === raw);
-  return match ? match.id : shown[0].id;
+  const match = tabsOwnedBy(surface).find((t) => t.id === raw);
+  return match ? match.id : visibleTabs(surface)[0].id;
 }

--- a/packages/client-core/src/settings/tabs.ts
+++ b/packages/client-core/src/settings/tabs.ts
@@ -28,24 +28,23 @@ interface TabDef {
    */
   surface: "all" | "cockpit";
   /**
-   * Not listed in the strip, but still REACHABLE by ?tab= on the surfaces it belongs to, and still
-   * rendered in full when reached.
+   * Not offered. The tab is out of the strip, and ?tab= does not resolve to it either - it is simply not
+   * one of this surface's tabs any more, and an old link to it lands on the default like any other id
+   * that is no longer a tab.
    *
-   * This is a narrower thing than removing a tab, and the difference is the whole point of the flag. A
-   * removed tab is gone for everybody. A hidden tab is one we have decided not to put in front of
-   * people, while the panel behind it keeps working for whoever needs it.
+   * Then why keep the row at all, rather than deleting it? Because this is meant to be REVERSIBLE by one
+   * word. The row keeps the tab's identity, its label and its place in the order, and the panel behind it
+   * is still in the codebase and still built - see SettingsTabs. Deleting the row and its component would
+   * be a different, larger decision, and undoing it would be a rewrite rather than an edit.
    *
-   * The AI tab is the reason this exists. On the hosted Gateway it shows model identities straight to
-   * customers, which contradicts a rule the hosting layer already enforces one level down - speech
-   * provider names are replaced with "devthrottle" for every non-admin caller. Most of the tab is inert
-   * on hosted anyway: it says so itself, in its own words, because the live model catalog is refused
-   * there. On a SELF-HOSTED Gateway those same pickers do real work, so deleting the component would
-   * take a working feature away from self-hosters to solve a hosted presentation problem. Hidden, not
-   * deleted.
+   * The AI tab is the reason this exists. It showed hosting model identities straight to customers, which
+   * contradicts a rule the hosting layer already enforces one level down - the real provider is replaced
+   * with "devthrottle" for every caller who is not an admin. Most of the tab is inert on the hosted
+   * Gateway anyway: it says so itself, in its own words, because the live model catalog is refused there.
    *
-   * A hidden tab is still a tab: its stored settings keep being written by its own controls when it is
-   * reached, and keep being read by the product. Hiding a control must never quietly reset what it
-   * holds - those settings live on the Gateway, per account, and nothing in this file touches them.
+   * Hiding a control must never quietly reset what it holds. It does not here: the models this tab used
+   * to set live on the Gateway, per account, are written only when somebody chooses one, and are read by
+   * the product wherever the wingman runs. Nothing in that path goes through this file.
    */
   hidden?: true;
 }
@@ -61,48 +60,40 @@ const ALL_TABS: TabDef[] = [
 ];
 
 /**
- * Every tab this surface OWNS - listed or not. Not exported: it is the input to the two rules below,
- * which are the only two questions a caller gets to ask.
+ * The tabs to show on this surface.
  *
  * `surface` is REQUIRED rather than defaulting to "all": a caller that forgets it fails to compile,
  * instead of a phone quietly inheriting a tab it cannot render. That is the whole safety of this
  * mechanism - a default here would hand the mobile shell the Cockpit's list on the first careless call.
- */
-function tabsOwnedBy(surface: Surface): TabDef[] {
-  return ALL_TABS.filter((t) => t.surface === "all" || t.surface === surface);
-}
-
-/**
- * The tabs to SHOW on this surface - what goes in the strip.
  *
- * Hidden tabs are dropped here and only here. Everything else about them is unchanged, which is what
- * makes hiding one a reversible edit to a single line of ALL_TABS.
+ * Hidden tabs are dropped here, and this is the ONLY place they are dropped - every other rule in this
+ * file works off what this function returns, so hiding a tab needs no second edit anywhere.
  */
 export function visibleTabs(surface: Surface): { id: TabId; label: string }[] {
-  return tabsOwnedBy(surface)
-    .filter((t) => t.hidden !== true)
-    .map((t) => ({ id: t.id, label: t.label }));
+  return ALL_TABS.filter(
+    (t) => (t.surface === "all" || t.surface === surface) && t.hidden !== true,
+  ).map((t) => ({
+    id: t.id,
+    label: t.label,
+  }));
 }
 
 /**
- * Resolve the ?tab= parameter to a tab this surface can actually render. Unknown, missing, retired, or
- * not-on-this-surface values fall to the first VISIBLE tab (Notifications).
+ * Resolve the ?tab= parameter to a tab THIS surface actually shows. Unknown, missing, retired, hidden, or
+ * not-on-this-surface values fall to the first tab (Notifications).
  *
- * It resolves against the tabs this surface OWNS, not the ones it lists, so a hidden tab stays reachable
- * by its own link. That is deliberate, and it is the half of hiding that is easy to leave out: drop a tab
- * from the strip alone and every existing link to it silently lands on Notifications instead, which reads
- * as the page having lost the setting rather than as the tab having been tidied away.
- *
- * It is still filtered by surface, for the same reason visibleTabs is: a phone opening a link to
- * ?tab=injectedtext must land on a real tab, not select a tab whose panel it cannot draw. A deep link is
- * permission to reach a tab this surface owns - never permission to render one it does not.
+ * It is filtered by surface for the same reason visibleTabs is: a phone opening a link to
+ * ?tab=injectedtext must land on a real tab, not select a tab that its own strip does not list and its
+ * own panel cannot draw. A deep link is not permission to render something.
  *
  * "machine", "telemetry", and "privacy" are retired ids (the "This machine" tab left in issue #2022; the
  * old standalone Telemetry page redirected to /settings?tab=telemetry, issue #1405; the Privacy tab was
  * removed by issue #2017). They no longer resolve to a tab, so an old bookmark lands on the default rather
- * than on a tab that no longer exists.
+ * than on a tab that no longer exists. A hidden tab behaves exactly the same way, by the same rule and
+ * with no special case: it is not in the list this reads, so an old link to it lands on the default.
  */
 export function tabFromParam(raw: string | null, surface: Surface): TabId {
-  const match = tabsOwnedBy(surface).find((t) => t.id === raw);
-  return match ? match.id : visibleTabs(surface)[0].id;
+  const shown = visibleTabs(surface);
+  const match = shown.find((t) => t.id === raw);
+  return match ? match.id : shown[0].id;
 }


### PR DESCRIPTION
Implements thefrederiksen/devthrottle_internal#1005, part of the Language epic #1004, with the scope reduction the controlling session sent mid-flight (see below).

## What changed

`ai` is out of the visible Settings tab strip on both surfaces - the Cockpit and the phone. The component is not out of the codebase.

A tab definition gains a `hidden` flag. Hidden drops the tab from `visibleTabs`, and that is the only place it is dropped - every other rule in the file works off what `visibleTabs` returns, so `tabFromParam` is byte-identical to main and needs no special case.

## Why

The tab named the hosting models to customers - `zai-org/GLM-5.2`, `Qwen/Qwen2.5-72B-Instruct`, `hexgrad/Kokoro-82M` - which contradicts a rule the hosting layer already enforces one level down, in `website/api/_lib/speech-providers.js`, where the real provider is replaced with `devthrottle` for every caller who is not an admin. Most of the tab was inert on the hosted Gateway anyway; it said so in its own words, because the live model catalog is refused there.

Hiding rather than deleting also buys freedom: the best model can be served and later changed server-side without breaking a saved setting, because nobody has one.

## Scope reduction, taken mid-branch

The first commit kept `/settings?tab=ai` reachable, as #1005 asks, on the grounds that a self-hosted Gateway needs those pickers. The owner overruled that - self-hosters do not need the AI tab either - so the second commit removes the escape hatch. An old `?tab=ai` link now lands on Notifications, exactly like the retired `machine`, `telemetry` and `privacy` ids, by the same rule and with no special case. The test that asserted reachability is replaced by one that asserts the fallback, because "hidden from the strip but still reachable by its link" is the other thing this could plausibly have meant and it is not what was decided.

## The two things that still had to be right

**The component stays.** `AiTab.tsx` is untouched and still built. That is what keeps this reversible by one word rather than by restoring a deleted screen.

**The stored models still persist and are still used.** Verified rather than assumed: the thinking model and fast model are Gateway tenant settings (`brain_model_fast` and its thinking counterpart in `TenantSettingKeys`), written only by the explicit setter endpoints when somebody chooses a model, and read by `GatewayHost` when the wingman actually runs. Nothing in that path goes through the tab strip, and the only code that clears them is the explicit "reset to provider defaults" action, which is unchanged. There is a test that merely rendering the tab writes nothing - a hidden control that quietly overwrites what it holds is the usual way this goes wrong.

## Proof

The new assertions were checked by breaking them on purpose - un-hide the tab and seven fail: the three tab-list assertions, the fallback assertion, and the three rendered-strip assertions.

Green afterwards: `client-core` 77 test files, `cockpit` 29 test files, typecheck clean across all three workspaces, and eslint clean on every file touched. (The repo-wide `npm run lint` reports three pre-existing "Definition for rule was not found" errors in files this branch does not touch.)

Closes thefrederiksen/devthrottle_internal#1005
