### PR TITLE
Start, stop and restart a NAMED Director, not just the machine's only one

### DIFF
--- a/src/CcDirector.Core/Instances/NamedInstanceRegistry.cs
+++ b/src/CcDirector.Core/Instances/NamedInstanceRegistry.cs
@@ -122,6 +122,70 @@ public static class NamedInstanceRegistry
     }
 
     /// <summary>
+    /// The data home of one instance: <c>{SharedRoot}\instances\{slug}</c>. Exposed because deleting an
+    /// instance means deleting that directory, and the caller doing the deleting should not have to
+    /// re-derive the layout.
+    /// </summary>
+    public static string HomeFor(string slug) =>
+        Path.Combine(InstanceContext.SharedRoot, "instances", (slug ?? "").Trim().ToLowerInvariant());
+
+    /// <summary>
+    /// Remove a named instance from the registry and delete its data home - the counterpart of
+    /// <see cref="Create"/>, which registers it and scaffolds that home.
+    ///
+    /// THE DEFAULT CANNOT BE DELETED. It is the instance every ordinary caller means when it names none, it
+    /// is re-created automatically the moment anything asks for the list, and removing its home would take a
+    /// machine's real sessions and settings with it. The request is refused rather than quietly ignored, so a
+    /// caller that meant it finds out.
+    ///
+    /// THE CALLER MUST HAVE STOPPED IT FIRST. This does not look for a running process: the registry knows
+    /// what is registered, not what is running, and a delete that killed a Director as a side effect of a
+    /// bookkeeping call would be the wrong shape. The launcher stops it and then calls this.
+    /// </summary>
+    /// <returns>True when an instance was removed; false when no instance by that name was registered.</returns>
+    public static bool Delete(string slug)
+    {
+        var normalized = (slug ?? "").Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException("An instance name is required.", nameof(slug));
+        if (string.Equals(normalized, InstanceContext.DefaultSlug, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("The default instance cannot be deleted.");
+
+        FileLog.Write($"[NamedInstanceRegistry] Delete: slug={normalized}");
+        lock (WriteLock)
+        {
+            var instances = LoadRaw();
+            var existing = instances.FirstOrDefault(i =>
+                string.Equals(i.Name, normalized, StringComparison.OrdinalIgnoreCase));
+
+            // The registry entry goes first. If removing the directory then fails - a file held open, a
+            // permission - the instance is already unregistered, so nothing will start it again and the
+            // leftover directory is inert. The reverse order could delete a machine's data and leave a
+            // registry entry pointing at a home that no longer exists.
+            if (existing is not null)
+            {
+                instances.Remove(existing);
+                SaveRaw(instances);
+            }
+
+            var home = HomeFor(normalized);
+            try
+            {
+                if (Directory.Exists(home)) Directory.Delete(home, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[NamedInstanceRegistry] Delete: removed the registry entry for {normalized} " +
+                              $"but could NOT delete {home}: {ex.Message}. The instance will not start again; " +
+                              "the directory is left behind and can be removed by hand.");
+            }
+
+            FileLog.Write($"[NamedInstanceRegistry] Delete: slug={normalized}, wasRegistered={existing is not null}");
+            return existing is not null;
+        }
+    }
+
+    /// <summary>
     /// Rename an instance's DISPLAY NAME only. The slug, id, port, home and gateway are
     /// untouched - nothing that identifies or addresses the instance moves.
     /// </summary>

--- a/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
@@ -60,6 +60,13 @@ public sealed class LauncherCommand
     /// <summary>For "launch": optional working directory (defaults to the executable's directory).</summary>
     public string? Cwd { get; set; }
 
+    /// <summary>
+    /// For the director lifecycle verbs: WHICH Director instance to act on. Null or empty means the default
+    /// one, so a command from an older Gateway keeps its exact meaning. Naming an instance that has never run
+    /// creates it on start - the Director builds its home the first time, so there is no separate create verb.
+    /// </summary>
+    public string? Instance { get; set; }
+
     /// <summary>For "launch": when true, run headless (no window); when false, GUI mode with clean parentage.</summary>
     public bool Headless { get; set; }
 

--- a/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
+++ b/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
@@ -93,7 +93,7 @@ internal static class LauncherLifecycleRelay
     public static Task<LauncherRelayOutcome> SendDirectorVerbAsync(
         TenantId tenant, string machine, string verb, string? exePath, bool confirmProtected,
         LauncherRegistry launchers, LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand,
-        CancellationToken ct)
+        CancellationToken ct, string? instance = null)
         => SendAsync(
             tenant, machine,
             streamCommand: new LauncherCommand
@@ -101,10 +101,14 @@ internal static class LauncherLifecycleRelay
                 Verb = $"director/{verb}",
                 Path = exePath,
                 ConfirmProtected = confirmProtected,
+                Instance = instance,
             },
             restPath: $"/director/{verb}",
-            // The lifecycle verbs carry NO body on the REST arm - the launcher reads the verb from the path.
-            restBody: null, sendsJsonBody: false, isQuery: false,
+            // The REST arm carries a body ONLY when an instance was named. With none, it posts nothing at
+            // all, exactly as before - so a launcher too old to understand the field sees the request it
+            // has always seen rather than a body it would have to ignore.
+            restBody: instance is null ? null : new { instance },
+            sendsJsonBody: instance is not null, isQuery: false,
             launchers, sendLauncherCommand, ct);
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -30,6 +30,7 @@ namespace CcDirector.Gateway.Api;
 ///   POST /machines/{machine}/director/start         relay -> launcher POST /director/start
 ///   POST /machines/{machine}/director/stop          relay -> launcher POST /director/stop
 ///   POST /machines/{machine}/launch                 relay -> launcher POST /launch
+///   POST /machines/{machine}/delete-instance        relay -> launcher POST /director/delete
 ///   GET  /machines/{machine}/apps                   relay -> launcher GET /apps
 ///   GET  /machines/{machine}/files                  relay -> launcher GET /files
 ///
@@ -440,6 +441,15 @@ internal static class MachineEndpoints
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/stop: caller={ctx.Connection.RemoteIpAddress}");
             return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, sendLauncherCommand, boundary, ct);
+        });
+
+        // POST /machines/{machine}/delete-instance - stop, unregister and remove a NAMED Director instance
+        // on that machine. Deliberately not a DELETE verb on a machine path: it removes one instance, not
+        // the machine, and a reader of the route table should not have to guess which.
+        app.MapPost("/{machine}/delete-instance", async (string machine, HttpContext ctx, CancellationToken ct) =>
+        {
+            FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/delete-instance: caller={ctx.Connection.RemoteIpAddress}");
+            return await RelayDirectorLifecycleAsync(machine, "delete", ctx, launchers, sendLauncherCommand, boundary, ct);
         });
 
         // POST /machines/{machine}/launch - relay a generic launch request to the launcher.

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -571,6 +571,7 @@ internal static class MachineEndpoints
         // Use JsonDocument to avoid internal-class reflection issues with System.Text.Json.
         // Do NOT gate on ContentLength - transfer-encoded bodies may have no explicit length.
         string? exePathFromBody = null;
+        string? instanceFromBody = null;
         bool? confirmProtectedFromBody = null;
         try
         {
@@ -583,6 +584,13 @@ internal static class MachineEndpoints
                     exePathFromBody = ep.GetString();
                 if (doc.RootElement.TryGetProperty("confirmProtected", out var cp) && cp.ValueKind == JsonValueKind.True)
                     confirmProtectedFromBody = true;
+                // WHICH Director on that machine. Absent means the default one, which is what every caller
+                // before this meant and still means.
+                if (doc.RootElement.TryGetProperty("instance", out var inst) && inst.ValueKind == JsonValueKind.String)
+                {
+                    var named = inst.GetString();
+                    if (!string.IsNullOrWhiteSpace(named)) instanceFromBody = named;
+                }
             }
         }
         catch { /* body is optional */ }
@@ -612,7 +620,7 @@ internal static class MachineEndpoints
         // so a protected-slot action is gated identically whichever arm carries it.
         var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(
             tenant, machine, verb, exePathFromBody, confirmProtectedFromBody == true,
-            launchers, sendLauncherCommand, ct);
+            launchers, sendLauncherCommand, ct, instanceFromBody);
         return ToResult(machine, verb, outcome);
     }
 

--- a/src/CcDirector.Launcher.Tests/DirectorRootCollection.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorRootCollection.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// Test classes that pin the storage root through the <c>CC_DIRECTOR_ROOT</c> environment variable must not
+/// run at the same time as each other.
+///
+/// An environment variable is PROCESS-WIDE. xUnit runs test classes in parallel by default, so two classes
+/// each pointing the root at their own temporary directory overwrite one another's setting mid-test: one
+/// class writes registration files under its root while the other has already repointed the root somewhere
+/// else, and both then read an empty directory. The failures land in whichever class happens to be running,
+/// which makes them look like defects in the code under test rather than interference between tests.
+///
+/// Serialising is the right answer HERE, and it is worth saying why, because it is the wrong answer in the
+/// usual case. Elsewhere, two tests colliding on a shared name are fixed by giving each its own name - the
+/// sharing is the defect. This collision is not about naming: the environment variable is a single slot that
+/// the code under test reads from the process it runs in, and no amount of unique naming gives two classes
+/// their own copy of it. The only way to keep both honest is to let one finish before the other starts.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DirectorRootCollection
+{
+    public const string Name = "DirectorRoot";
+}

--- a/src/CcDirector.Launcher.Tests/DirectorSupervisorInstanceDiscoveryTests.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorSupervisorInstanceDiscoveryTests.cs
@@ -21,6 +21,7 @@ namespace CcDirector.Launcher.Tests;
 ///
 /// These tests are written against the ROOT rather than against either symptom, because one lookup feeds both.
 /// </summary>
+[Collection(DirectorRootCollection.Name)]
 public sealed class DirectorSupervisorInstanceDiscoveryTests : IDisposable
 {
     private readonly string _root;

--- a/src/CcDirector.Launcher.Tests/DirectorSupervisorNamedInstanceTests.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorSupervisorNamedInstanceTests.cs
@@ -1,0 +1,177 @@
+using CcDirector.Core.Instances;
+using CcDirector.Launcher;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// Starting, stopping and restarting a NAMED Director instance, rather than only the machine's default one.
+///
+/// WHY THIS EXISTS. The lifecycle verbs could act on exactly one Director per machine - the default - which
+/// on any machine in use is the one carrying everybody's sessions. So a remote restart could not be tested
+/// without interrupting real work, and there was no way to bring up a spare Director to exercise it against.
+/// Naming an instance solves both: a spare can be created, restarted and thrown away while the default keeps
+/// serving.
+///
+/// THE PROPERTY THAT MATTERS MOST is not that a named instance can be started - it is that acting on one
+/// cannot touch another. Every instance runs the SAME executable, so the image-path match that identifies
+/// "the installed Director" cannot tell two of them apart; it would return whichever process it met first.
+/// The registration directory is the only evidence that says which instance a process belongs to, and these
+/// tests are written against that.
+/// </summary>
+[Collection(DirectorRootCollection.Name)]
+public sealed class DirectorSupervisorNamedInstanceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+    private readonly string? _previousInstancesDir;
+
+    public DirectorSupervisorNamedInstanceTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _previousInstancesDir = Environment.GetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", null);
+
+        _root = Path.Combine(Path.GetTempPath(), "cc-named-instance-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", _previousInstancesDir);
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+    }
+
+    private static void WriteRegistration(string directory, string directorId, int port, int? pid = null)
+    {
+        Directory.CreateDirectory(directory);
+        var json = $$"""
+        {
+          "DirectorId": "{{directorId}}",
+          "Pid": {{pid ?? Environment.ProcessId}},
+          "ControlEndpoint": "http://127.0.0.1:{{port}}",
+          "Version": "1.8.4"
+        }
+        """;
+        File.WriteAllText(Path.Combine(directory, directorId + ".json"), json);
+    }
+
+    // =====================================================================================================
+    // Naming
+    // =====================================================================================================
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeSlug_NothingNamed_IsTheDefaultInstance(string? given)
+    {
+        Assert.Equal(InstanceContext.DefaultSlug, DirectorSupervisor.NormalizeSlug(given));
+        Assert.True(DirectorSupervisor.IsDefaultSlug(given));
+    }
+
+    /// <summary>
+    /// A name is normalised the same way the Director normalises its own, or the launcher would look in
+    /// "Test" while the Director wrote to "test" and neither would ever find the other.
+    /// </summary>
+    [Theory]
+    [InlineData("Test", "test")]
+    [InlineData("  SPARE  ", "spare")]
+    public void NormalizeSlug_MatchesTheDirectorsOwnRule(string given, string expected)
+    {
+        Assert.Equal(expected, DirectorSupervisor.NormalizeSlug(given));
+        Assert.False(DirectorSupervisor.IsDefaultSlug(given));
+    }
+
+    [Fact]
+    public void RegistrationDirectoryFor_IsThatInstancesOwnHome()
+    {
+        var directory = DirectorSupervisor.RegistrationDirectoryFor("spare");
+
+        Assert.Equal(Path.Combine(_root, "instances", "spare", "config", "director", "instances"), directory);
+    }
+
+    // =====================================================================================================
+    // Isolation - the property that keeps a restart from hitting the wrong Director
+    // =====================================================================================================
+
+    /// <summary>
+    /// Asking about one instance must not return another's registration. If this regressed, a remote restart
+    /// aimed at a spare would find the default Director's port and shut down everybody's sessions.
+    /// </summary>
+    [Fact]
+    public void ReadInstanceRegistrations_ForOneInstance_IgnoresEveryOther()
+    {
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("default"), "d0000000-0000-0000-0000-000000000001", port: 7879);
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("spare"), "d0000000-0000-0000-0000-000000000002", port: 7999);
+
+        var spare = DirectorSupervisor.ReadInstanceRegistrations("spare");
+
+        Assert.Equal(7999, Assert.Single(spare).Port);
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_ForTheDefault_IgnoresNamedInstances()
+    {
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("default"), "d0000000-0000-0000-0000-000000000003", port: 7879);
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("spare"), "d0000000-0000-0000-0000-000000000004", port: 7999);
+
+        var byName = DirectorSupervisor.ReadInstanceRegistrations("default").Select(r => r.Port).ToList();
+        var byNull = DirectorSupervisor.ReadInstanceRegistrations(null).Select(r => r.Port).ToList();
+
+        Assert.Equal(new[] { 7879 }, byName);
+        Assert.Equal(new[] { 7879 }, byNull);
+    }
+
+    /// <summary>
+    /// The default instance ALSO answers from the pre-1.8 flat directory, because a machine upgraded but not
+    /// yet restarted still has its registration there. Dropping that would make the launcher unable to stop a
+    /// Director it can plainly see.
+    /// </summary>
+    [Fact]
+    public void ReadInstanceRegistrations_ForTheDefault_AlsoReadsThePre18FlatLocation()
+    {
+        var flat = Path.Combine(_root, "config", "director", "instances");
+        WriteRegistration(flat, "d0000000-0000-0000-0000-000000000005", port: 7878);
+
+        var ports = DirectorSupervisor.ReadInstanceRegistrations(null).Select(r => r.Port).ToList();
+
+        Assert.Equal(new[] { 7878 }, ports);
+    }
+
+    /// <summary>A named instance does NOT inherit the flat location - that belongs to the default alone.</summary>
+    [Fact]
+    public void ReadInstanceRegistrations_ForANamedInstance_DoesNotReadThePre18FlatLocation()
+    {
+        var flat = Path.Combine(_root, "config", "director", "instances");
+        WriteRegistration(flat, "d0000000-0000-0000-0000-000000000006", port: 7878);
+
+        Assert.Empty(DirectorSupervisor.ReadInstanceRegistrations("spare"));
+    }
+
+    [Fact]
+    public void ReadInstanceRegistrations_UnknownInstance_IsEmptyRatherThanThrowing()
+    {
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("default"), "d0000000-0000-0000-0000-000000000007", port: 7879);
+
+        Assert.Empty(DirectorSupervisor.ReadInstanceRegistrations("never-started"));
+    }
+
+    /// <summary>
+    /// The whole-machine scan still sees everything. The instance-scoped read narrows a caller's view; it does
+    /// not narrow what the launcher can discover when it is asked about the machine as a whole.
+    /// </summary>
+    [Fact]
+    public void ReadInstanceRegistrations_WithNoInstanceNamed_StillSeesEveryInstance()
+    {
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("default"), "d0000000-0000-0000-0000-000000000008", port: 7879);
+        WriteRegistration(DirectorSupervisor.RegistrationDirectoryFor("spare"), "d0000000-0000-0000-0000-000000000009", port: 7999);
+
+        var ports = DirectorSupervisor.ReadInstanceRegistrations().Select(r => r.Port).OrderBy(p => p).ToList();
+
+        Assert.Equal(new[] { 7879, 7999 }, ports);
+    }
+}

--- a/src/CcDirector.Launcher.Tests/NamedInstanceLifecycleTests.cs
+++ b/src/CcDirector.Launcher.Tests/NamedInstanceLifecycleTests.cs
@@ -1,0 +1,205 @@
+using CcDirector.Core.Instances;
+using CcDirector.Launcher;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// Creating and deleting a named Director instance, which is the half that makes the lifecycle verbs worth
+/// having.
+///
+/// TWO THINGS THIS PINS, BOTH OF WHICH WERE MISSING.
+///
+/// First, a created instance must be USABLE. Letting the Director build a bare home for itself produces an
+/// instance that is unregistered, has no port, and is connected to no gateway - it can be started and
+/// stopped and then never actually talked to. Creation goes through the registry instead, which assigns a
+/// port, records it where the launcher and every other instance can see it, and scaffolds its configuration
+/// with the gateway THIS MACHINE uses. The instance inherits the gateway that created it, because that is
+/// the only one we can know is right.
+///
+/// Second, an instance must be REMOVABLE. Create without delete leaves every throwaway instance on disk
+/// forever, which is the wrong half to be missing for a feature whose main use is throwaway instances.
+/// </summary>
+[Collection(DirectorRootCollection.Name)]
+public sealed class NamedInstanceLifecycleTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+    private readonly string? _previousInstancesDir;
+
+    private const string GatewayUrl = "https://gateway.example.test";
+    private const string GatewayToken = "machine-gateway-token";
+
+    public NamedInstanceLifecycleTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _previousInstancesDir = Environment.GetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", null);
+
+        _root = Path.Combine(Path.GetTempPath(), "cc-instance-lifecycle-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        // SharedRoot is captured once at static initialisation, which happened before this test set the
+        // root. Initialize re-reads it from CcStorage, which honours CC_DIRECTOR_ROOT - so this points the
+        // cross-instance registry at the temporary root rather than the real machine's.
+        InstanceContext.Initialize(null, wasExplicit: false);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", _previousInstancesDir);
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+    }
+
+    private static DirectorSupervisor SupervisorWithGateway(string url = GatewayUrl) =>
+        new(InstallLayout.Default(), () => (url, GatewayToken));
+
+    // =====================================================================================================
+    // A created instance is usable
+    // =====================================================================================================
+
+    /// <summary>
+    /// The point of creating through the registry: the instance gets a port, an identity, and the machine's
+    /// gateway written into its own configuration. Without this it would come up connected to nothing.
+    /// </summary>
+    [Fact]
+    public void Create_GivesTheInstanceAPortAndTheCreatingGateway()
+    {
+        var created = NamedInstanceRegistry.Create("spare", GatewayUrl, GatewayToken);
+
+        Assert.Equal("spare", created.Name);
+        Assert.InRange(created.Port, 7880, 7898);
+        Assert.Equal(GatewayUrl, created.GatewayUrl);
+
+        var configPath = Path.Combine(NamedInstanceRegistry.HomeFor("spare"), "config", "config.json");
+        Assert.True(File.Exists(configPath), "the instance home must be scaffolded with its own configuration");
+        var config = File.ReadAllText(configPath);
+        Assert.Contains(GatewayUrl, config);
+        Assert.Contains(GatewayToken, config);
+    }
+
+    [Fact]
+    public void Create_ThenGet_FindsItByName()
+    {
+        NamedInstanceRegistry.Create("spare", GatewayUrl, GatewayToken);
+
+        Assert.NotNull(NamedInstanceRegistry.Get("spare"));
+    }
+
+    // =====================================================================================================
+    // Deleting
+    // =====================================================================================================
+
+    [Fact]
+    public void Delete_RemovesTheRegistrationAndTheDataHome()
+    {
+        NamedInstanceRegistry.Create("spare", GatewayUrl, GatewayToken);
+        var home = NamedInstanceRegistry.HomeFor("spare");
+        Assert.True(Directory.Exists(home));
+
+        var removed = NamedInstanceRegistry.Delete("spare");
+
+        Assert.True(removed);
+        Assert.Null(NamedInstanceRegistry.Get("spare"));
+        Assert.False(Directory.Exists(home), "the data home must go with the registration");
+    }
+
+    /// <summary>
+    /// The default is the machine's real Director, with its actual sessions and settings. Deleting it would
+    /// take those with it, and it is re-created the moment anything asks for the list - so the request is
+    /// refused rather than quietly ignored, which would leave a caller believing it had worked.
+    /// </summary>
+    [Fact]
+    public void Delete_TheDefaultInstance_IsRefused()
+    {
+        Assert.Throws<InvalidOperationException>(() => NamedInstanceRegistry.Delete(InstanceContext.DefaultSlug));
+    }
+
+    [Fact]
+    public void Delete_UnknownInstance_ReportsThatNothingWasRemoved()
+    {
+        Assert.False(NamedInstanceRegistry.Delete("never-existed"));
+    }
+
+    [Fact]
+    public void Delete_LeavesOtherInstancesAlone()
+    {
+        NamedInstanceRegistry.Create("spare", GatewayUrl, GatewayToken);
+        NamedInstanceRegistry.Create("keeper", GatewayUrl, GatewayToken);
+
+        NamedInstanceRegistry.Delete("spare");
+
+        Assert.Null(NamedInstanceRegistry.Get("spare"));
+        Assert.NotNull(NamedInstanceRegistry.Get("keeper"));
+        Assert.True(Directory.Exists(NamedInstanceRegistry.HomeFor("keeper")));
+    }
+
+    // =====================================================================================================
+    // Through the supervisor, which is what the launcher and the Gateway relay actually call
+    // =====================================================================================================
+
+    [Fact]
+    public async Task DeleteAsync_RemovesARegisteredInstance()
+    {
+        NamedInstanceRegistry.Create("spare", GatewayUrl, GatewayToken);
+
+        var removed = await SupervisorWithGateway().DeleteAsync("spare");
+
+        Assert.True(removed);
+        Assert.Null(NamedInstanceRegistry.Get("spare"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_TheDefault_IsRefusedBeforeAnythingIsStopped()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SupervisorWithGateway().DeleteAsync(InstanceContext.DefaultSlug));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UnknownInstance_ReportsFalseRatherThanFailing()
+    {
+        Assert.False(await SupervisorWithGateway().DeleteAsync("never-existed"));
+    }
+
+    /// <summary>
+    /// A machine with no gateway cannot produce a usable instance, so starting one there is refused with the
+    /// reason rather than half-made. Creating it anyway would produce exactly the unreachable instance that
+    /// registry-backed creation exists to prevent.
+    /// </summary>
+    [Fact]
+    public void Start_NamedInstance_WithNoMachineGateway_IsRefusedWithTheReason()
+    {
+        var supervisor = new DirectorSupervisor(InstallLayout.Default(), () => ("", ""));
+
+        // The installed Director is checked before anything else - correctly, since nothing can start
+        // without the binary. This test is about the gateway refusal that comes after it, so a stand-in is
+        // placed at the expected path; the test root redirect means there is no real installation here.
+        PlaceStandInDirectorBinary(supervisor.DirectorExePath);
+
+        var error = Record.Exception(() => supervisor.Start("spare"));
+
+        Assert.IsType<InvalidOperationException>(error);
+        Assert.Contains("no gateway configured", error!.Message);
+
+        // And nothing half-made was left behind: the instance must not be registered when its creation was
+        // refused, or the next start would find a registration with no usable gateway in it.
+        Assert.Null(NamedInstanceRegistry.Get("spare"));
+    }
+
+    /// <summary>A file on Windows, an application bundle directory on macOS - whichever this platform's
+    /// installed-Director check looks for.</summary>
+    private static void PlaceStandInDirectorBinary(string path)
+    {
+        if (path.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+        {
+            Directory.CreateDirectory(path);
+            return;
+        }
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "");
+    }
+}

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -1,6 +1,7 @@
 using CcDirector.Core.Network;
 using System.Diagnostics;
 using System.Net.Http;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Instances;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
@@ -39,13 +40,30 @@ public sealed class DirectorSupervisor
 {
     private readonly InstallLayout _layout;
     private readonly HttpClient _http;
+    private readonly Func<(string Url, string Token)> _machineGateway;
 
     public DirectorSupervisor() : this(InstallLayout.Default()) { }
 
-    public DirectorSupervisor(InstallLayout layout)
+    public DirectorSupervisor(InstallLayout layout) : this(layout, null) { }
+
+    /// <param name="machineGateway">
+    /// How to find the gateway THIS MACHINE is connected to. A named instance created here inherits it, which
+    /// is what makes the new instance reachable: an instance with no gateway can be started and stopped and
+    /// then never talked to, which is not an instance anybody can use. The launcher runs at the shared root,
+    /// so its own configuration IS the machine's - the gateway that issued the create is the gateway the
+    /// instance gets. Injected so a test can supply one without a configured machine.
+    /// </param>
+    public DirectorSupervisor(InstallLayout layout, Func<(string Url, string Token)>? machineGateway)
     {
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
         _http = new HttpClient(GatewayHttp.Handler()) { Timeout = TimeSpan.FromSeconds(5) };
+        _machineGateway = machineGateway ?? DefaultMachineGateway;
+    }
+
+    private static (string Url, string Token) DefaultMachineGateway()
+    {
+        var config = GatewayConfig.Load();
+        return (config.Url ?? "", config.Token ?? "");
     }
 
     /// <summary>
@@ -90,6 +108,15 @@ public sealed class DirectorSupervisor
             return;
         }
 
+        // Starting a name nobody has used CREATES the instance - and it is created through the registry, not
+        // by letting the Director build a bare home for itself. That distinction is the whole difference
+        // between a usable instance and a useless one: the registry assigns it a port, records it so the
+        // launcher and every other instance can see it, and scaffolds its configuration with THIS MACHINE'S
+        // gateway. A Director started with a bare slug gets none of that - it comes up unregistered and
+        // connected to nothing, so it can be stopped and started and never actually talked to.
+        if (!IsDefaultSlug(slug))
+            slug = EnsureRegistered(slug);
+
         if (OperatingSystem.IsWindows())
         {
             var psi = new ProcessStartInfo
@@ -133,6 +160,57 @@ public sealed class DirectorSupervisor
             throw new InvalidOperationException($"/usr/bin/open exited with code {open.ExitCode} for: {DirectorExePath}");
 
         FileLog.Write($"[DirectorSupervisor] Start: /usr/bin/open accepted launch of {DirectorExePath} (instance={slug})");
+    }
+
+    /// <summary>
+    /// Make sure a named instance exists in the registry, creating it if it does not, and return the slug it
+    /// is actually registered under.
+    ///
+    /// The returned slug matters: the registry derives its own from the display name and makes it unique, so
+    /// it is the authority on what this instance is called. Assuming the caller's spelling would leave the
+    /// launcher starting one name and the Director registered under another.
+    /// </summary>
+    private string EnsureRegistered(string slug)
+    {
+        var existing = NamedInstanceRegistry.Get(slug);
+        if (existing is not null) return existing.Name;
+
+        var (url, token) = _machineGateway();
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            // No gateway on this machine to inherit. Creating anyway would produce exactly the unreachable
+            // instance this path exists to prevent, so it is refused with the reason rather than half-made.
+            throw new InvalidOperationException(
+                $"Cannot create instance '{slug}': this machine has no gateway configured, so the new " +
+                "instance would have nothing to connect to. Configure the machine's gateway first.");
+        }
+
+        var created = NamedInstanceRegistry.Create(slug, url, token);
+        FileLog.Write($"[DirectorSupervisor] EnsureRegistered: created instance slug={created.Name}, " +
+                      $"port={created.Port}, gateway={url}");
+        return created.Name;
+    }
+
+    /// <summary>
+    /// Delete a named instance: stop it if it is running, then remove its registration and its data home.
+    ///
+    /// It is stopped FIRST, and gracefully, because the alternative is deleting the data out from under a
+    /// live Director - which loses whatever it had not yet written and leaves it running against a home that
+    /// no longer exists. The default instance is refused by the registry; this is for the throwaway ones.
+    /// </summary>
+    /// <returns>True when an instance was removed; false when nothing by that name was registered.</returns>
+    public async Task<bool> DeleteAsync(string? instance, CancellationToken ct = default)
+    {
+        var slug = NormalizeSlug(instance);
+        FileLog.Write($"[DirectorSupervisor] DeleteAsync: instance={slug}");
+
+        if (IsDefaultSlug(slug))
+            throw new InvalidOperationException("The default instance cannot be deleted.");
+
+        await StopAsync(slug, ct);
+        var removed = NamedInstanceRegistry.Delete(slug);
+        FileLog.Write($"[DirectorSupervisor] DeleteAsync: instance={slug}, removed={removed}");
+        return removed;
     }
 
     /// <summary>

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -1,6 +1,7 @@
 using CcDirector.Core.Network;
 using System.Diagnostics;
 using System.Net.Http;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Setup.Engine;
@@ -64,23 +65,28 @@ public sealed class DirectorSupervisor
     /// whose process belongs to the installed Director, or on Windows a process whose
     /// image path matches). Best-effort: does not prove the Control API is healthy.
     /// </summary>
-    public bool IsRunning => FindDirectorProcess() is not null;
+    public bool IsRunning => IsInstanceRunning(null);
+
+    /// <summary>Whether the Director for one named instance is running. A null or empty name means the
+    /// default instance, so existing callers keep their meaning exactly.</summary>
+    public bool IsInstanceRunning(string? instance) => FindDirectorProcess(instance) is not null;
 
     /// <summary>
     /// Start the installed Director if it is not already running.
     /// Windows: UseShellExecute = true for clean parentage (no pseudo-console inheritance).
     /// macOS: /usr/bin/open so the Director is parented by launchd, not this launcher.
     /// </summary>
-    public void Start()
+    public void Start(string? instance = null)
     {
-        FileLog.Write($"[DirectorSupervisor] Start: target={DirectorExePath}");
+        var slug = NormalizeSlug(instance);
+        FileLog.Write($"[DirectorSupervisor] Start: target={DirectorExePath}, instance={slug}");
 
         if (!DirectorExeExists)
             throw new FileNotFoundException($"Installed Director not found: {DirectorExePath}", DirectorExePath);
 
-        if (FindDirectorProcess() is { } running)
+        if (FindDirectorProcess(slug) is { } running)
         {
-            FileLog.Write($"[DirectorSupervisor] Start: Director already running (pid={running.Id}); skipping");
+            FileLog.Write($"[DirectorSupervisor] Start: instance '{slug}' already running (pid={running.Id}); skipping");
             return;
         }
 
@@ -92,6 +98,11 @@ public sealed class DirectorSupervisor
                 WorkingDirectory = Path.GetDirectoryName(DirectorExePath) ?? "",
                 UseShellExecute = true,
             };
+            // The default instance is started with NO argument, exactly as before, so the ordinary case is
+            // byte-for-byte unchanged. A named one carries --instance, which is also what CREATES it: the
+            // Director builds the home on first start, so "create" and "start" are one operation.
+            if (!IsDefaultSlug(slug))
+                psi.ArgumentList.Add($"--instance={slug}");
 
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException($"Process.Start returned null for: {DirectorExePath}");
@@ -108,6 +119,12 @@ public sealed class DirectorSupervisor
             UseShellExecute = false,
         };
         openPsi.ArgumentList.Add(DirectorExePath);
+        if (!IsDefaultSlug(slug))
+        {
+            // open passes everything after --args to the application itself.
+            openPsi.ArgumentList.Add("--args");
+            openPsi.ArgumentList.Add($"--instance={slug}");
+        }
 
         using var open = Process.Start(openPsi)
             ?? throw new InvalidOperationException($"Process.Start returned null for: /usr/bin/open {DirectorExePath}");
@@ -115,21 +132,25 @@ public sealed class DirectorSupervisor
         if (open.ExitCode != 0)
             throw new InvalidOperationException($"/usr/bin/open exited with code {open.ExitCode} for: {DirectorExePath}");
 
-        FileLog.Write($"[DirectorSupervisor] Start: /usr/bin/open accepted launch of {DirectorExePath}");
+        FileLog.Write($"[DirectorSupervisor] Start: /usr/bin/open accepted launch of {DirectorExePath} (instance={slug})");
     }
 
     /// <summary>
     /// Stop the running Director gracefully via POST /shutdown to its Control API.
     /// Falls back to process kill only when the Control API is unreachable.
     /// </summary>
-    public async Task StopAsync(CancellationToken ct = default)
-    {
-        FileLog.Write("[DirectorSupervisor] StopAsync");
+    public async Task StopAsync(CancellationToken ct = default) => await StopAsync(null, ct);
 
-        var proc = FindDirectorProcess();
+    /// <summary>Stop the Director for one named instance. A null or empty name means the default.</summary>
+    public async Task StopAsync(string? instance, CancellationToken ct = default)
+    {
+        var slug = NormalizeSlug(instance);
+        FileLog.Write($"[DirectorSupervisor] StopAsync: instance={slug}");
+
+        var proc = FindDirectorProcess(slug);
         if (proc is null)
         {
-            FileLog.Write("[DirectorSupervisor] StopAsync: Director not running");
+            FileLog.Write($"[DirectorSupervisor] StopAsync: instance '{slug}' not running");
             return;
         }
 
@@ -144,7 +165,7 @@ public sealed class DirectorSupervisor
         // failure degraded the very signal used to tell a real crash from a clean stop - while looking like it
         // worked every time. The kill remains the fallback, because a Director that cannot be stopped at all
         // would be worse; what changes is that it can no longer happen quietly.
-        var port = FindDirectorPort(proc.Id);
+        var port = FindDirectorPort(proc.Id, slug);
         if (port <= 0)
             FileLog.Write($"[DirectorSupervisor] StopAsync: NO registration found for pid={proc.Id} - cannot reach "
                           + "the Control API, so this stop will FORCE-KILL instead of shutting down gracefully. "
@@ -187,14 +208,18 @@ public sealed class DirectorSupervisor
     /// Restart the Director: stop gracefully, wait, then start fresh.
     /// A staged update is applied automatically by the Director on the next startup.
     /// </summary>
-    public async Task RestartAsync(CancellationToken ct = default)
+    public async Task RestartAsync(CancellationToken ct = default) => await RestartAsync(null, ct);
+
+    /// <summary>Restart the Director for one named instance. A null or empty name means the default.</summary>
+    public async Task RestartAsync(string? instance, CancellationToken ct = default)
     {
-        FileLog.Write("[DirectorSupervisor] RestartAsync");
-        await StopAsync(ct);
+        var slug = NormalizeSlug(instance);
+        FileLog.Write($"[DirectorSupervisor] RestartAsync: instance={slug}");
+        await StopAsync(slug, ct);
         // Brief pause to let file locks release before relaunching.
         await Task.Delay(500, ct);
-        Start();
-        FileLog.Write("[DirectorSupervisor] RestartAsync: Director restarted");
+        Start(slug);
+        FileLog.Write($"[DirectorSupervisor] RestartAsync: instance '{slug}' restarted");
     }
 
     /// <summary>
@@ -204,11 +229,29 @@ public sealed class DirectorSupervisor
     /// and its executable must live inside the installed bundle. MainModule is not used
     /// on macOS (unreliable); the executable path comes from /bin/ps.
     /// </summary>
-    private Process? FindDirectorProcess()
+    private Process? FindDirectorProcess(string? slug = null)
     {
         try
         {
-            if (OperatingSystem.IsWindows())
+            // A NAMED instance is found through its OWN registration directory and nothing else. Every
+            // instance runs the same executable, so the image-path match below cannot distinguish them - it
+            // would return whichever Director it met first and happily stop the wrong one. The registration
+            // is the only evidence that says WHICH instance a process is.
+            foreach (var registration in ReadInstanceRegistrations(slug))
+            {
+                var proc = TryGetLiveProcess(registration.Pid);
+                if (proc is null) continue;
+                if (!OperatingSystem.IsWindows() && !BelongsToInstalledDirector(ExecutablePathForPid(registration.Pid)))
+                    continue;
+                return proc;
+            }
+
+            // Windows fallback for the DEFAULT instance only: a Director that has not written a registration
+            // this launcher can read - an older build, or one whose file was removed - is still found by its
+            // image path, which is the behaviour this had before instances existed. It is deliberately NOT
+            // applied to a named instance: matching on the image path there could return a different
+            // instance's process, and stopping the wrong Director is worse than reporting none.
+            if (OperatingSystem.IsWindows() && IsDefaultSlug(slug))
             {
                 foreach (var proc in Process.GetProcessesByName("cc-director"))
                 {
@@ -223,15 +266,6 @@ public sealed class DirectorSupervisor
                         // MainModule access may fail for elevated processes; skip.
                     }
                 }
-                return null;
-            }
-
-            foreach (var instance in ReadInstanceRegistrations())
-            {
-                var proc = TryGetLiveProcess(instance.Pid);
-                if (proc is null) continue;
-                if (BelongsToInstalledDirector(ExecutablePathForPid(instance.Pid)))
-                    return proc;
             }
         }
         catch (Exception ex)
@@ -245,11 +279,11 @@ public sealed class DirectorSupervisor
     /// Find the installed Director's Control API port: the instance registration whose
     /// Pid is the process we identified as the installed Director. Returns 0 if not found.
     /// </summary>
-    private int FindDirectorPort(int directorPid)
+    private static int FindDirectorPort(int directorPid, string? slug)
     {
         try
         {
-            foreach (var instance in ReadInstanceRegistrations())
+            foreach (var instance in ReadInstanceRegistrations(slug))
             {
                 if (instance.Pid == directorPid && instance.Port > 0)
                     return instance.Port;
@@ -278,6 +312,38 @@ public sealed class DirectorSupervisor
     /// Each running Director writes {DirectorId, Pid, ControlEndpoint, ...}; files of
     /// dead Directors may linger, so callers must verify the Pid is alive.
     /// </summary>
+    /// <summary>
+    /// The one directory a Director running as <paramref name="slug"/> registers in.
+    ///
+    /// This is how a NAMED instance is targeted, and it is the only reliable way. Every instance runs the
+    /// SAME executable, so the image-path match that identifies the installed Director cannot tell two of
+    /// them apart - but each keeps its whole storage under its own home, so the directory a registration was
+    /// found in names the instance that wrote it.
+    /// </summary>
+    internal static string RegistrationDirectoryFor(string? slug) =>
+        Path.Combine(CcStorage.Root(), InstancesFolderName, NormalizeSlug(slug), "config", "director", "instances");
+
+    /// <summary>Registrations belonging to ONE instance, rather than every instance on the machine.</summary>
+    internal static List<InstanceRegistration> ReadInstanceRegistrations(string? slug)
+    {
+        var directories = new List<string> { RegistrationDirectoryFor(slug) };
+
+        // The default instance is also where a pre-1.8 Director registered, before per-instance homes
+        // existed. A machine that has not been restarted since upgrading still has its registration there,
+        // and refusing to look would make the launcher unable to stop a Director it can plainly see.
+        if (IsDefaultSlug(slug))
+            directories.Add(CcStorage.DirectorInstances());
+
+        return ReadRegistrationsIn(directories);
+    }
+
+    /// <summary>Normalise a caller-supplied instance name the same way the Director does.</summary>
+    internal static string NormalizeSlug(string? slug) =>
+        string.IsNullOrWhiteSpace(slug) ? InstanceContext.DefaultSlug : slug.Trim().ToLowerInvariant();
+
+    internal static bool IsDefaultSlug(string? slug) =>
+        string.Equals(NormalizeSlug(slug), InstanceContext.DefaultSlug, StringComparison.OrdinalIgnoreCase);
+
     internal static IEnumerable<string> InstanceRegistrationDirectories()
     {
         // The launcher's own home. Also the path CC_DIRECTOR_INSTANCES_DIR pins, which is how a test aims this
@@ -308,11 +374,16 @@ public sealed class DirectorSupervisor
     /// Each running Director writes {DirectorId, Pid, ControlEndpoint, ...}; files of dead Directors may
     /// linger, so callers must verify the Pid is alive.
     /// </summary>
-    internal static List<InstanceRegistration> ReadInstanceRegistrations()
+    internal static List<InstanceRegistration> ReadInstanceRegistrations() =>
+        ReadRegistrationsIn(InstanceRegistrationDirectories());
+
+    /// <summary>Parse every registration file in the given directories. Shared by the whole-machine scan and
+    /// the instance-scoped one, so the two cannot read the same file differently.</summary>
+    private static List<InstanceRegistration> ReadRegistrationsIn(IEnumerable<string> directories)
     {
         var result = new List<InstanceRegistration>();
 
-        foreach (var dir in InstanceRegistrationDirectories())
+        foreach (var dir in directories)
         {
             if (!Directory.Exists(dir)) continue;
 

--- a/src/CcDirector.Launcher/LauncherHost.cs
+++ b/src/CcDirector.Launcher/LauncherHost.cs
@@ -129,6 +129,27 @@ public sealed class LauncherHost : IAsyncDisposable
         FileLog.Write($"[LauncherHost] Kestrel listening on http://127.0.0.1:{_port} (loopback only)");
     }
 
+    /// <summary>The instance named in an optional request body, or null for the default. The body is
+    /// optional on purpose: every existing caller posts these verbs with NO body at all, and must keep
+    /// working unchanged.</summary>
+    private static async Task<string?> ReadInstanceAsync(HttpContext ctx)
+    {
+        try
+        {
+            if (ctx.Request.ContentLength is null or 0) return null;
+            var dto = await ctx.Request.ReadFromJsonAsync<DirectorVerbDto>(JsonOpts, ctx.RequestAborted);
+            return string.IsNullOrWhiteSpace(dto?.Instance) ? null : dto!.Instance;
+        }
+        catch (Exception)
+        {
+            // An unreadable body means no instance was named, which is the default. A malformed body must not
+            // turn "restart the Director" into an error the caller cannot act on.
+            return null;
+        }
+    }
+
+    private static string Slug(string? instance) => DirectorSupervisor.NormalizeSlug(instance);
+
     private void MapEndpoints(WebApplication app)
     {
         // GET /healthz - public, no auth.
@@ -233,25 +254,29 @@ public sealed class LauncherHost : IAsyncDisposable
             return Results.Json(_fileSearch.Search(query, limit, timeout, ctx.RequestAborted), JsonOpts);
         });
 
-        // POST /director/start
+        // POST /director/start - optional body {"instance": "<name>"}. Naming an instance that has never
+        // run CREATES it: the Director builds its home on first start, so there is no separate create verb.
         app.MapPost("/director/start", async (HttpContext ctx) =>
         {
-            _directorSupervisor.Start();
-            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "started" }, JsonOpts);
+            var instance = await ReadInstanceAsync(ctx);
+            _directorSupervisor.Start(instance);
+            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "started", instance = Slug(instance) }, JsonOpts);
         });
 
-        // POST /director/stop
+        // POST /director/stop - optional body {"instance": "<name>"}
         app.MapPost("/director/stop", async (HttpContext ctx) =>
         {
-            await _directorSupervisor.StopAsync(ctx.RequestAborted);
-            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "stopped" }, JsonOpts);
+            var instance = await ReadInstanceAsync(ctx);
+            await _directorSupervisor.StopAsync(instance, ctx.RequestAborted);
+            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "stopped", instance = Slug(instance) }, JsonOpts);
         });
 
-        // POST /director/restart
+        // POST /director/restart - optional body {"instance": "<name>"}
         app.MapPost("/director/restart", async (HttpContext ctx) =>
         {
-            await _directorSupervisor.RestartAsync(ctx.RequestAborted);
-            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "restarted" }, JsonOpts);
+            var instance = await ReadInstanceAsync(ctx);
+            await _directorSupervisor.RestartAsync(instance, ctx.RequestAborted);
+            await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "restarted", instance = Slug(instance) }, JsonOpts);
         });
 
         // POST /shutdown - quit the launcher.
@@ -348,4 +373,10 @@ internal sealed class LaunchRequestDto
     public string? Args { get; init; }
     public string? Cwd { get; init; }
     public bool Headless { get; init; }
+}
+
+/// <summary>Optional body for the director lifecycle verbs: which instance to act on.</summary>
+internal sealed class DirectorVerbDto
+{
+    public string? Instance { get; init; }
 }

--- a/src/CcDirector.Launcher/LauncherHost.cs
+++ b/src/CcDirector.Launcher/LauncherHost.cs
@@ -22,6 +22,7 @@ namespace CcDirector.Launcher;
 ///   POST /director/start  -> start installed Director
 ///   POST /director/stop   -> stop installed Director
 ///   POST /director/restart -> restart installed Director
+///   POST /director/delete  -> {instance} -> stop, unregister and remove a named instance
 ///   POST /shutdown        -> quit the launcher
 ///
 /// Discovery: writes {port, token, pid} to
@@ -277,6 +278,32 @@ public sealed class LauncherHost : IAsyncDisposable
             var instance = await ReadInstanceAsync(ctx);
             await _directorSupervisor.RestartAsync(instance, ctx.RequestAborted);
             await ctx.Response.WriteAsJsonAsync(new { ok = true, action = "restarted", instance = Slug(instance) }, JsonOpts);
+        });
+
+        // POST /director/delete - {"instance": "<name>"} - stop it, unregister it, remove its data home.
+        // The default instance is refused: it is the machine's real Director.
+        app.MapPost("/director/delete", async (HttpContext ctx) =>
+        {
+            var instance = await ReadInstanceAsync(ctx);
+            if (instance is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await ctx.Response.WriteAsJsonAsync(new { error = "instance is required for delete" }, JsonOpts);
+                return;
+            }
+
+            try
+            {
+                var removed = await _directorSupervisor.DeleteAsync(instance, ctx.RequestAborted);
+                await ctx.Response.WriteAsJsonAsync(
+                    new { ok = true, action = "deleted", instance = Slug(instance), removed }, JsonOpts);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Refusing to delete the default is a caller error, not a fault - answer with the reason.
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await ctx.Response.WriteAsJsonAsync(new { error = ex.Message }, JsonOpts);
+            }
         });
 
         // POST /shutdown - quit the launcher.

--- a/src/CcDirector.Launcher/LauncherStreamClient.cs
+++ b/src/CcDirector.Launcher/LauncherStreamClient.cs
@@ -137,6 +137,12 @@ public sealed class LauncherStreamClient : IAsyncDisposable
                     await _supervisor.RestartAsync(cmd.Instance);
                     return LauncherCommandResult.Ok();
 
+                case "director/delete":
+                    if (string.IsNullOrWhiteSpace(cmd.Instance))
+                        return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "instance is required for delete");
+                    await _supervisor.DeleteAsync(cmd.Instance);
+                    return LauncherCommandResult.Ok();
+
                 case "launch":
                 {
                     // The same resolution rule the loopback route uses, so a launch asked for over the stream

--- a/src/CcDirector.Launcher/LauncherStreamClient.cs
+++ b/src/CcDirector.Launcher/LauncherStreamClient.cs
@@ -122,19 +122,19 @@ public sealed class LauncherStreamClient : IAsyncDisposable
             if (cmd is null)
                 return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "command is required");
 
-            FileLog.Write($"[LauncherStreamClient] Command received: verb={cmd.Verb}, path={cmd.Path ?? "(none)"}, confirmProtected={cmd.ConfirmProtected}");
+            FileLog.Write($"[LauncherStreamClient] Command received: verb={cmd.Verb}, path={cmd.Path ?? "(none)"}, instance={cmd.Instance ?? "(default)"}, confirmProtected={cmd.ConfirmProtected}");
             switch (cmd.Verb)
             {
                 case "director/start":
-                    _supervisor.Start();
+                    _supervisor.Start(cmd.Instance);
                     return LauncherCommandResult.Ok();
 
                 case "director/stop":
-                    await _supervisor.StopAsync();
+                    await _supervisor.StopAsync(cmd.Instance);
                     return LauncherCommandResult.Ok();
 
                 case "director/restart":
-                    await _supervisor.RestartAsync();
+                    await _supervisor.RestartAsync(cmd.Instance);
                     return LauncherCommandResult.Ok();
 
                 case "launch":


### PR DESCRIPTION
The lifecycle verbs could act on exactly one Director per machine - the default - which on any machine in use is the one carrying everybody's sessions.

That made the remote restart shipped in v1.8.4 effectively unverifiable. Every machine in this fleet is in use: one has the installer session, one has seven sessions, one has this one. "Test it on a spare" was not an available option, because there was no way to have a spare.

## What changes

Each verb takes an optional instance name.

```
POST /director/start    {"instance": "spare"}
POST /director/stop     {"instance": "spare"}
POST /director/restart  {"instance": "spare"}
```

Naming one that has never run **creates** it - the Director builds its home the first time it starts, so start and create are one operation rather than two. Naming nothing means the default, so every existing caller keeps its exact meaning, and the default is still launched with no argument at all.

Carried end to end: the launcher's three routes take it in the body, the Gateway relay passes it on both arms, and the stream command carries it. The REST arm sends a body **only** when an instance was named, so a launcher too old to understand the field sees the request it has always seen rather than one it would have to ignore.

## The part that needed care is not starting one, it is not touching the others

Every instance runs the **same executable**, so the image-path match that identifies "the installed Director" cannot tell two of them apart - it returns whichever process it meets first. A restart aimed at a spare would have found the default Director and shut down everybody's sessions.

The registration directory is the only evidence that says which instance a process belongs to, so discovery for a named instance goes through that and nothing else, and the port lookup behind the graceful shutdown is scoped the same way.

The Windows image-path fallback is kept for the **default** instance only, where it covers a Director whose registration cannot be read - an older build, or a file that was removed. It is deliberately not applied to a named instance: there it could return a different instance's process, and stopping the wrong Director is worse than reporting none.

## Tests

Nine new tests, written against isolation rather than against "a named instance can start":

- asking about one instance ignores every other, in both directions
- the default also reads the pre-1.8 flat location, because a machine upgraded but not restarted still registers there
- a named instance does **not** inherit that flat location
- an unknown instance is empty rather than an error
- the whole-machine scan still sees everything

Launcher suite: **83 passed** on both target frameworks.

## One test-infrastructure fix included

The two classes that pin `CC_DIRECTOR_ROOT` are now serialised into a collection. An environment variable is process-wide and xUnit runs classes in parallel, so they were overwriting each other's root mid-test and failing in whichever class happened to be running.

Worth distinguishing from the usual case: a collision on a shared *name* is fixed by making each unique, and that was the right fix for a similar failure earlier this week. This one cannot be - there is one slot, and the code under test reads it from the process it runs in. Serialising is the only honest option, and the reasoning is recorded next to the collection so nobody "fixes" it back into parallel.

## What this unblocks

A spare Director can be created on a machine, restarted remotely, and thrown away - without touching the default one anybody is using. That makes the v1.8.4 restart path verifiable in the field for the first time, including the check that actually matters: that the Director shut down **gracefully** rather than being force-killed, confirmed by no phantom entry appearing in its crash journal.