### PR TITLE
Reduce unnecessary GitHub builds

### DIFF
--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -31,6 +31,13 @@ The four supporting rules (see the TRUNK DEVELOPMENT section of the global CLAUD
   concurrent agent uses its own worktree off origin/main.
 - Never commit directly on main. If the checkout is on main, create a branch first.
 
+## One remote build request per coherent batch
+
+Local commits are checkpoints; a push requests shared GitHub validation. Complete all known code,
+tests, proof, and applicable local checks before the first push. Do not push intermediate progress
+or a proof-only follow-up when both can be sent together. If remote checks expose a defect, gather
+and locally validate the complete known correction batch before pushing once more.
+
 ## Triggers
 
 Invoke with /commit or when user asks to commit changes.
@@ -109,7 +116,7 @@ If the checkout is on main, create a branch FIRST - never commit on main:
   git worktree add ../<repo>-wt-<short-desc> -b <type>/<short-desc> origin/main
   then cd into it. (See the "Shared checkout" rules in the global CLAUDE.md.)
 
-STEP 6: Commit and push
+STEP 6: Commit, then send one remote build request
 
 Stage the specific files using git add with each filename.
 Never use git add . or git add -A.
@@ -122,7 +129,7 @@ EOF
 
 Run git status to verify commit succeeded.
 
-Push with: git push -u origin HEAD.
+After every known file and local check is complete, push once with: git push -u origin HEAD.
 
 If push fails due to remote changes, run git pull --rebase then git push.
 
@@ -133,8 +140,9 @@ commit (Step 4), drive it home:
 
 1. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
 2. Wait for checks to go green: gh pr checks <number> --watch.
-   - If checks fail, fix the failure and push a NEW commit (never amend, never --no-verify),
-     then re-watch. Report the failure to the user if it is not quick and mechanical.
+   - If checks fail, gather every known correction, validate the whole correction batch locally,
+     and push the NEW commits together (never amend, never --no-verify), then re-watch. Report the
+     failure to the user if it is not quick and mechanical.
 3. Merge with squash once green: gh pr merge <number> --squash --delete-branch.
    (delete_branch_on_merge is ON, but --delete-branch is explicit and harmless.)
 4. Park the checkout back on main:

--- a/.claude/skills/developer-agent/skill.md
+++ b/.claude/skills/developer-agent/skill.md
@@ -206,31 +206,35 @@ git rev-parse --abbrev-ref HEAD   # confirm you are on issue-<n>-short-desc, in 
 
 Only when every acceptance criterion is met, the build is clean, and you have proof:
 
-1. **Commit the IMPLEMENTATION first** - every source/test file you changed goes onto the PR branch.
-   The handoff artifact is committed code, NEVER uncommitted working-tree edits. Open the PR if one
-   does not exist yet (`git push -u origin HEAD` then `gh pr create`).
+1. **Commit the IMPLEMENTATION locally first** - every source/test file you changed goes onto the
+   pull request branch. The handoff artifact is committed code, NEVER uncommitted working-tree edits.
+   Do NOT push or open the pull request yet: the implementation and its proof are one remote build
+   request.
 2. **Build the HTML report** - what was implemented, each acceptance criterion with its proof, the
    screenshots, the CenCon-impact statement, and an explicit "I believe this is finished."
 3. **Commit proof to the PR branch** under `docs/cencon/proof/issue-<n>/` (e.g. `report.html`,
    `before.png`, `after.png`). Committing to the PR branch is authorized; **do NOT merge to main**
    (only the human / the QA role inside the loop merges).
-4. **Post an issue comment** linking the proof repo-relative and the PR, using this comment format:
+4. **CLEAN-TREE AND ONE-PUSH GATE (mandatory).** Verify that implementation, tests, and proof are all
+   committed, then push them together once. You may NOT hand off with uncommitted work in progress
+   or unpushed commits:
+   ```bash
+   git status --porcelain   # MUST be empty - if not, commit/clean it before continuing
+   git stash list           # MUST show no stash you created - stashing is NOT a clean tree
+   git push -u origin HEAD  # ONE push after the complete handoff batch is locally ready
+   ```
+   If the pull request does not exist, create it only after that push (`gh pr create`). If it already
+   exists, do not make a ceremonial second push: the single push above updated it. If
+   `git status --porcelain` prints anything, you are not done: commit the remaining files (they are
+   part of your change) or, if they are stray, remove them - but the tree MUST be empty before you
+   proceed. **Never `git stash` to make the tree look empty** - a stash hides your work in progress
+   and hands quality assurance (and the human) a mess; commit it to the pull request branch instead.
+   Handing quality assurance a dirty tree or a stash is a defect.
+5. **Post an issue comment** linking the proof repo-relative and the PR, using this comment format:
    Release Notes, Changes, How to Test, Expected Result, Before/After:
    ```
    Proof: docs/cencon/proof/issue-<n>/report.html  (PR #<pr>)
    ```
-5. **CLEAN-TREE GATE (mandatory, before the label swap).** Verify the working tree is empty and the
-   branch is pushed - you may NOT hand off with uncommitted WIP or unpushed commits:
-   ```bash
-   git status --porcelain   # MUST be empty - if not, commit/clean it before continuing
-   git stash list           # MUST show no stash you created - stashing is NOT a clean tree
-   git push                 # the PR branch must be up to date on the remote
-   ```
-   If `git status --porcelain` prints anything, you are not done: commit the remaining files (they
-   are part of your change) or, if they are stray, remove them - but the tree MUST be empty before
-   you proceed. **Never `git stash` to make the tree look empty** - a stash hides your WIP and hands
-   QA (and the human) a mess; commit it to the PR branch instead. Handing QA a dirty tree or a stash
-   is a defect.
 6. **Swap the label** to `flow:ready-qa`, releasing whichever working-state label the issue carried.
    Inside the `implementation-loop` the issue is `flow:in-progress` (the loop's issue-level claim,
    issue #298); standalone it may still be `flow:ready-dev`. Remove BOTH so no working-state label

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -98,6 +98,13 @@ anywhere. Work that exists in one place is work you are one crash away from losi
 mission branch current and pushed is mission hygiene, in the same way that leaving the site tidy is
 part of building, not a favour to anyone.
 
+**Push safety without build churn.** Make local commits whenever they help, but make one remote push
+at a completed Manager handoff boundary after code, tests, proof, and the compact handoff note are
+ready. Do not split those artifacts into separate pushes. Do not open a pull request at the start of
+a mission merely to make the branch visible: open it when a coherent slice is ready for inspection,
+or keep it draft while the mission still expects more pushes. Recovery still wins over thrift - push
+before a reset when work would otherwise exist on only one machine.
+
 **The authority chain, stated once:**
 
 - Work accumulates on the mission branch. That is the ordinary operation of a mission and the
@@ -187,10 +194,10 @@ lives in the branch and the files.
 - The Architect keeps a short, current handoff note on disk (a few lines: the phase, the branch, what
   is done and pushed, what the next Worker task is, the acceptance row it proves). This note is the
   ONLY thing a fresh Manager needs.
-- To reset: make the outgoing Manager commit and push everything first (law 2 - never kill
-  uncommitted work), kill it, seat a new Manager named `Mission - Manager`, and hand it ONLY the
-  compact note plus a pointer to the mission brief and this workflow. Not the transcript. Not the
-  history. Just enough to keep going.
+- To reset: make the outgoing Manager commit everything, including proof and the compact handoff
+  note, then push that completed batch once (law 2 - never kill uncommitted work). Kill it, seat a
+  new Manager named `Mission - Manager`, and hand it ONLY the compact note plus a pointer to the
+  mission brief and this workflow. Not the transcript. Not the history. Just enough to keep going.
 - The Inspector is even more disposable: seated fresh for each inspection, given the diff to inspect
   and the sharp questions, and gone when its written review lands. Never keep an Inspector idle
   between phases.

--- a/.claude/skills/qa-agent/skill.md
+++ b/.claude/skills/qa-agent/skill.md
@@ -189,9 +189,11 @@ If ANY criterion fails or a regression/method violation is found:
 1. Write a **specific, reproducible defect**: which criterion failed, the exact steps, Expected vs
    Actual, and the screenshot proving the failure. Vague fails ("doesn't work") are not allowed -
    the Developer Agent must be able to act on it directly.
-2. Commit the failure screenshot(s) under `docs/cencon/proof/issue-<n>/` and reference them.
+2. Commit the failure screenshot(s) under `docs/cencon/proof/issue-<n>/` and reference them. Finish
+   the entire investigation first, then push the proof batch once so the next Developer receives it.
 3. Comment, then label `flow:qa-failed`:
 ```bash
+git push   # one push after every failure artifact is committed; proof-only changes use the cheap gate
 gh issue comment <ID> --repo example-org/devthrottle --body "$(cat defect.md)"
 gh issue edit <ID> --repo example-org/devthrottle --add-label flow:qa-failed --remove-label flow:ready-qa
 git status --porcelain   # MUST be empty - your failure screenshots are committed, the PR code stays put
@@ -210,8 +212,10 @@ it in a known state, then stop:
 
 1. Make sure everything is committed to the PR branch - `git status --porcelain` MUST be empty (commit
    your proof/investigation; never leave loose WIP).
-2. Ensure the PR exists and is up to date on the remote (`git push`). This open PR is the parked
-   artifact - it is the one and only sanctioned lingering PR.
+2. Ensure the pull request exists. If local commits are ahead of the remote, push the complete proof
+   and investigation batch once. If the remote is already current, do not make a ceremonial push.
+   This open pull request is the parked artifact - it is the one and only sanctioned lingering pull
+   request.
 3. Comment on the issue stating it is PARKED, why (the exact conflict/build failure), the PR number,
    and what the human needs to decide. Then label `flow:needs-human`:
    ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,68 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+# A newer pull-request push makes the older run stale. Main-branch runs use a unique run identifier,
+# so they are never cancelled. Release builds live in release.yml and are unaffected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Decide which builds are needed
+    runs-on: ubuntu-latest
+    outputs:
+      run_dotnet: ${{ steps.classify.outputs.run_dotnet }}
+      run_web: ${{ steps.classify.outputs.run_web }}
+      reason: ${{ steps.classify.outputs.reason }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          $allZeroes = "0000000000000000000000000000000000000000"
+          if ([string]::IsNullOrWhiteSpace($env:BASE_SHA) -or
+              [string]::IsNullOrWhiteSpace($env:HEAD_SHA) -or
+              $env:BASE_SHA -eq $allZeroes) {
+            $paths = @()
+          } else {
+            $paths = @(git diff --name-only --diff-filter=ACDMRT $env:BASE_SHA $env:HEAD_SHA)
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not determine changed paths."
+            }
+          }
+
+          $classification = ./scripts/ci/classify-changes.ps1 -Path $paths | ConvertFrom-Json
+          $runDotNet = $classification.run_dotnet.ToString().ToLowerInvariant()
+          $runWeb = $classification.run_web.ToString().ToLowerInvariant()
+          "run_dotnet=$runDotNet" >> $env:GITHUB_OUTPUT
+          "run_web=$runWeb" >> $env:GITHUB_OUTPUT
+          "reason=$($classification.reason)" >> $env:GITHUB_OUTPUT
+
+          "### Build decision" >> $env:GITHUB_STEP_SUMMARY
+          "Changed paths: $($classification.path_count)" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "| Build | Required |" >> $env:GITHUB_STEP_SUMMARY
+          "|---|---|" >> $env:GITHUB_STEP_SUMMARY
+          "| Microsoft .NET | $runDotNet |" >> $env:GITHUB_STEP_SUMMARY
+          "| Web | $runWeb |" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "Reason: $($classification.reason)" >> $env:GITHUB_STEP_SUMMARY
+
   build-and-test:
     name: Build & Test (.NET)
+    needs: changes
+    if: needs.changes.outputs.run_dotnet == 'true' && (github.event_name == 'push' || github.event.pull_request.draft == false)
     runs-on: windows-latest
 
     steps:
@@ -58,6 +116,8 @@ jobs:
   # platform-independent unit tests and a Vite build, and Ubuntu runners are quicker and cheaper.
   web:
     name: Build & Test (web)
+    needs: changes
+    if: needs.changes.outputs.run_web == 'true' && (github.event_name == 'push' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
 
     steps:
@@ -95,3 +155,49 @@ jobs:
 
       - name: Build the Cockpit
         run: npm run build --workspace @devthrottle/cockpit
+
+  decision:
+    name: Continuous integration decision
+    if: always()
+    needs: [changes, build-and-test, web]
+    runs-on: ubuntu-latest
+    env:
+      CHANGE_DECISION: ${{ needs.changes.result }}
+      DOTNET_DECISION: ${{ needs.build-and-test.result }}
+      WEB_DECISION: ${{ needs.web.result }}
+      RUN_DOTNET: ${{ needs.changes.outputs.run_dotnet }}
+      RUN_WEB: ${{ needs.changes.outputs.run_web }}
+      READY_FOR_FULL_VALIDATION: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
+      REASON: ${{ needs.changes.outputs.reason }}
+    steps:
+      - name: Require every selected build
+        shell: pwsh
+        run: |
+          $ready = $env:READY_FOR_FULL_VALIDATION -eq "true"
+          $dotNetRequired = $ready -and $env:RUN_DOTNET -eq "true"
+          $webRequired = $ready -and $env:RUN_WEB -eq "true"
+          $failures = [System.Collections.Generic.List[string]]::new()
+
+          if ($env:CHANGE_DECISION -ne "success") {
+            $failures.Add("Changed-path classification ended as $($env:CHANGE_DECISION).")
+          }
+          if ($dotNetRequired -and $env:DOTNET_DECISION -ne "success") {
+            $failures.Add("The Microsoft .NET build was required but ended as $($env:DOTNET_DECISION).")
+          }
+          if ($webRequired -and $env:WEB_DECISION -ne "success") {
+            $failures.Add("The web build was required but ended as $($env:WEB_DECISION).")
+          }
+
+          "### Final decision" >> $env:GITHUB_STEP_SUMMARY
+          "Ready for full validation: $ready" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "| Build | Selected | Result |" >> $env:GITHUB_STEP_SUMMARY
+          "|---|---|---|" >> $env:GITHUB_STEP_SUMMARY
+          "| Microsoft .NET | $dotNetRequired | $($env:DOTNET_DECISION) |" >> $env:GITHUB_STEP_SUMMARY
+          "| Web | $webRequired | $($env:WEB_DECISION) |" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "Reason: $($env:REASON)" >> $env:GITHUB_STEP_SUMMARY
+
+          if ($failures.Count -gt 0) {
+            throw ($failures -join " ")
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Agent Instructions
+
+## Remote pushes are build requests
+
+The repository's GitHub builds are shared and expensive. Local commits are checkpoints; a remote
+push requests shared validation.
+
+- Make as many local commits as help the work, but batch them into one push for each coherent,
+  reviewable change.
+- Before the first push, finish the implementation, tests, proof, and applicable local checks.
+- Do not push merely to save progress, refresh a pull request, or publish proof separately.
+- When more changes are already known, finish and validate that correction batch before pushing it.
+- During long missions, push once at a completed handoff boundary. Delay opening the pull request
+  until a coherent slice is ready, or keep it draft while more work is expected.
+- Push earlier when a remote handoff or recovery copy is genuinely required. Never suppress the
+  final validation required before merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,21 @@ Both sessions were confident. Both were wrong. Both were caught only because a t
 
 **When you state a fact about the code, it must come from origin/main or a worktree cut from it.** If you cannot say which, you do not know the fact - go and check. Saying "the code says X" when X came from a stale tree is reporting fiction as evidence.
 
+### REMOTE PUSHES ARE BUILD REQUESTS - BATCH THEM
+
+The repository's GitHub builds are shared and expensive. Local commits are checkpoints; a remote
+push requests shared validation.
+
+- Make as many local commits as help the work, but batch them into one push for each coherent,
+  reviewable change.
+- Before the first push, finish the implementation, tests, proof, and applicable local checks.
+- Do not push merely to save progress, refresh a pull request, or publish proof separately.
+- When more changes are already known, finish and validate that correction batch before pushing it.
+- During long missions, push once at a completed handoff boundary. Delay opening the pull request
+  until a coherent slice is ready, or keep it draft while more work is expected.
+- Push earlier when a remote handoff or recovery copy is genuinely required. Never suppress the
+  final validation required before merge.
+
 ### 0a. WRITE IN PLAIN ENGLISH - NO ABBREVIATIONS
 
 **Never use abbreviations, acronyms, initialisms, or jargon. Write out the full words in plain English, everywhere.**

--- a/scripts/ci/classify-changes.ps1
+++ b/scripts/ci/classify-changes.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [string[]] $Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$normalizedPaths = @(
+    $Path |
+        ForEach-Object {
+            $normalizedPath = $_.Replace("\", "/")
+            if ($normalizedPath.StartsWith("./", [System.StringComparison]::Ordinal)) {
+                $normalizedPath.Substring(2)
+            } else {
+                $normalizedPath
+            }
+        } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+
+if ($normalizedPaths.Count -eq 0) {
+    [pscustomobject]@{
+        run_dotnet = $true
+        run_web    = $true
+        path_count = 0
+        reason     = "No changed paths were available, so every build is required."
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+
+$documentationPrefixes = @(
+    ".claude/",
+    ".github/ISSUE_TEMPLATE/",
+    "docs/",
+    "mission/",
+    "research/"
+)
+$documentationFiles = @(
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "LICENSE.md",
+    "README.md",
+    "SECURITY.md"
+)
+$webPrefixes = @("apps/", "packages/")
+$webFiles = @("eslint.config.js", "package-lock.json", "package.json")
+$buildControlPrefixes = @(".github/workflows/", "scripts/ci/")
+
+$runDotNet = $false
+$runWeb = $false
+$categories = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+
+foreach ($changedPath in $normalizedPaths) {
+    $isBuildControl = $false
+    foreach ($prefix in $buildControlPrefixes) {
+        if ($changedPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $isBuildControl = $true
+            break
+        }
+    }
+
+    if ($isBuildControl) {
+        $runDotNet = $true
+        $runWeb = $true
+        [void] $categories.Add("build-control change")
+        continue
+    }
+
+    $isDocumentation = $documentationFiles -contains $changedPath
+    if (-not $isDocumentation) {
+        foreach ($prefix in $documentationPrefixes) {
+            if ($changedPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $isDocumentation = $true
+                break
+            }
+        }
+    }
+
+    if ($isDocumentation) {
+        [void] $categories.Add("documentation or agent-instruction change")
+        continue
+    }
+
+    $isWeb = $webFiles -contains $changedPath
+    if (-not $isWeb) {
+        foreach ($prefix in $webPrefixes) {
+            if ($changedPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $isWeb = $true
+                break
+            }
+        }
+    }
+
+    if ($isWeb) {
+        $runWeb = $true
+        [void] $categories.Add("web change")
+        continue
+    }
+
+    $runDotNet = $true
+    [void] $categories.Add("product or unknown change")
+}
+
+[pscustomobject]@{
+    run_dotnet = $runDotNet
+    run_web    = $runWeb
+    path_count = $normalizedPaths.Count
+    reason     = (@($categories) | Sort-Object) -join ", "
+} | ConvertTo-Json -Compress


### PR DESCRIPTION
## Why

Remote pushes currently start long shared builds even when an older run is already obsolete or the change only contains documentation and agent instructions.

## Changes

- Teach repository agents to batch implementation, tests, and proof into one remote push.
- Cancel superseded pull-request runs without cancelling main-branch or release runs.
- Use a fail-closed changed-path decision to avoid unrelated product and web builds.
- Keep draft pull requests on the inexpensive decision path until they are ready.
- Provide one final continuous integration decision suitable for the main-branch ruleset.

## Local validation

- Seven changed-path classifications passed.
- The workflow configuration parsed successfully.
- Updated skill metadata passed validation.
- The committed difference passed the whitespace check.