### PR TITLE
Onboarding wizard: a Browsers step that installs the harness and signs one browser in

### DIFF
--- a/src/CcDirector.Avalonia/ConfirmDialog.axaml
+++ b/src/CcDirector.Avalonia/ConfirmDialog.axaml
@@ -14,7 +14,11 @@
                    TextWrapping="Wrap" />
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-            <Button x:Name="ConfirmButton" Content="Remove" Width="100" Height="30"
+            <!-- MinWidth, never a fixed Width. These buttons carry a label the CALLER supplies, and a
+                 fixed width silently clipped anything longer than "Remove" - the browser sign-in
+                 confirmation read "Done - I am s". A button that truncates its own instruction is worse
+                 than no label at all, so they size to their content and the number is only a floor. -->
+            <Button x:Name="ConfirmButton" Content="Remove" MinWidth="100" Height="30" Padding="14,0"
                     Click="BtnConfirm_Click"
                     Background="#007ACC" Foreground="White"
                     BorderThickness="0"
@@ -22,7 +26,7 @@
                     HorizontalContentAlignment="Center"
                     VerticalContentAlignment="Center"
                     IsDefault="True" />
-            <Button x:Name="CancelButton" Content="Cancel" Width="90" Height="30"
+            <Button x:Name="CancelButton" Content="Cancel" MinWidth="90" Height="30" Padding="14,0"
                     Click="BtnCancel_Click"
                     Background="#3C3C3C" Foreground="#CCCCCC"
                     BorderThickness="0"

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
@@ -37,14 +37,21 @@
                     <TextBlock Text="Turn on browser control" Foreground="#CCCCCC"
                                FontSize="13" FontWeight="SemiBold" />
                     <TextBlock Classes="hint"
-                               Text="To let your agents drive these browsers, install Browser Harness - the open-source tool DevThrottle uses. Your browsers below stay listed and ready; they just cannot be driven until it is installed." />
+                               Text="To let your agents drive these browsers, install Browser Harness - the tool DevThrottle uses to drive them, made by browser-use. DevThrottle installs it for you, into its own environment. Your browsers below stay listed and ready; they just cannot be driven until it is installed." />
                     <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
-                        <Button Classes="dialogButton" Content="Install Browser Harness"
+                        <Button x:Name="HarnessInstallButton" Classes="dialogButton"
+                                Content="Install Browser Harness"
                                 MinWidth="180" Click="BtnInstallHarness_Click"
-                                ToolTip.Tip="Open the Browser Harness install guide in your browser" />
+                                ToolTip.Tip="Install browser-harness on this machine" />
                         <Button Classes="dialogButton" Content="Check again"
                                 Click="BtnRefresh_Click"
                                 ToolTip.Tip="Re-check whether browser-harness is now on PATH" />
+                        <!-- Offered only when OUR install has failed - the manual route is a fallback for
+                             the user, never a substitute for trying (issue #1012). -->
+                        <Button x:Name="HarnessManualLink" Classes="dialogButton" IsVisible="False"
+                                Content="Open the install page"
+                                Click="BtnHarnessInstallPage_Click"
+                                ToolTip.Tip="Open the browser-harness install guide in your browser" />
                     </StackPanel>
                 </StackPanel>
             </Grid>

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
@@ -120,17 +120,58 @@ public partial class BrowserSettingsView : UserControl
         await RefreshAsync();
     }
 
-    private void BtnInstallHarness_Click(object? sender, RoutedEventArgs e)
+    /// <summary>
+    /// Install browser-harness on this machine (issue #1012). This button used to open a GitHub install
+    /// page and leave the user to it - which also made the wizard's "set browsers up later, in the
+    /// Browsers group" a promise that led to a documentation page rather than to a working browser. It
+    /// now runs the same installer the wizard runs.
+    /// </summary>
+    private async void BtnInstallHarness_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[BrowserSettingsView] BtnInstallHarness_Click: installing");
+        HarnessInstallButton.IsEnabled = false;
+        HarnessManualLink.IsVisible = false;
+        try
+        {
+            var progress = new Progress<string>(line => StatusText.Text = line);
+            var result = await Task.Run(() => BrowserHarnessInstaller.InstallAsync(progress));
+
+            StatusText.Text = result.Message;
+            if (!result.Success)
+            {
+                // Say what went wrong and offer the manual page. Never re-check and never continue as
+                // though it had worked (CLAUDE.md rule 3).
+                FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click FAILED: {result.Message}");
+                HarnessManualLink.IsVisible = true;
+                return;
+            }
+
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click FAILED: {ex.Message}");
+            StatusText.Text = $"Could not install Browser Harness: {ex.Message}";
+            HarnessManualLink.IsVisible = true;
+        }
+        finally
+        {
+            HarnessInstallButton.IsEnabled = true;
+        }
+    }
+
+    /// <summary>The manual install page, offered only after our own install failed.</summary>
+    private void BtnHarnessInstallPage_Click(object? sender, RoutedEventArgs e)
     {
         try
         {
-            FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
+            FileLog.Write($"[BrowserSettingsView] BtnHarnessInstallPage_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(AutomationBrowserViewFold.HarnessInstallUrl)
                 { UseShellExecute = true });
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[BrowserSettingsView] BtnInstallHarness_Click FAILED: {ex.Message}");
+            FileLog.Write($"[BrowserSettingsView] BtnHarnessInstallPage_Click FAILED: {ex.Message}");
             StatusText.Text = $"Could not open the install guide: {ex.Message}";
         }
     }

--- a/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
@@ -25,11 +25,25 @@ internal static class BrowserSignInFlow
         FileLog.Write($"[BrowserSignInFlow] RunAsync: id={view.Id}");
         await Task.Run(() => AutomationBrowserService.SignInAsync(view.Id));
 
+        // Say WHAT to sign in to. The old wording said only "sign in", which left the one instruction
+        // that matters unanswered: a browser profile is worth exactly what it is signed in to, and a
+        // user who signs in to nothing gets a browser their agents cannot do anything useful with.
+        // Both routes are named because both are legitimate - a browser account carries everything at
+        // once, and per-site logins keep the profile to just the accounts it is meant to reach.
+        var accountKind = view.Browser.Equals("Edge", StringComparison.OrdinalIgnoreCase)
+            ? "a Microsoft account"
+            : "a Google account";
+
         var dialog = new ConfirmDialog(
             "Sign in once",
-            $"A \"{view.Name}\" window just opened on its sign-in page. Sign in by hand in that window - " +
-            "DevThrottle never types your credentials. The login is saved in this browser's own profile " +
-            "and lasts until the account signs it out.\n\nWhen you are signed in, click Done.",
+            $"A \"{view.Name}\" window just opened on its sign-in page. Sign in by hand in that window - "
+            + "DevThrottle never types your credentials.\n\n"
+            + $"Sign in to whatever you want this browser to reach: {accountKind} to bring your profile "
+            + "across, or just the individual websites you want an agent to use. Whatever is signed in "
+            + "here is what your agents can drive - nothing else.\n\n"
+            + "The logins are kept in this browser's own profile, apart from your everyday browser, and "
+            + "last until the account signs them out.\n\n"
+            + "When you are signed in, click Done.",
             confirmLabel: "Done - I am signed in",
             cancelLabel: "Not yet");
         var confirmed = await dialog.ShowDialog<bool?>(owner) == true;

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
@@ -109,7 +109,7 @@
                  discovered-but-dimmed rows above and this inline install link. -->
             <Button x:Name="InstallLink" Classes="railRow" IsVisible="False"
                     Click="InstallLink_Click"
-                    ToolTip.Tip="Open the Browser Harness install guide in your browser">
+                    ToolTip.Tip="Set up browser control in Settings - DevThrottle installs Browser Harness for you">
                 <TextBlock Text="Install Browser Harness" Foreground="#4A9EFF"
                            FontSize="11" FontWeight="SemiBold" />
             </Button>

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
@@ -133,19 +133,16 @@ public partial class BrowsersRailGroup : UserControl
         ManageRequested?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Open the Browsers settings, where the install runs (issue #1012). The rail is a narrow strip with
+    /// no room to report a multi-step install honestly - progress, and a failure with its reason and the
+    /// manual page - so it hands over to the screen that has. It no longer opens a GitHub page: the
+    /// product installs the harness itself now.
+    /// </summary>
     private void InstallLink_Click(object? sender, RoutedEventArgs e)
     {
-        try
-        {
-            FileLog.Write($"[BrowsersRailGroup] InstallLink_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(AutomationBrowserViewFold.HarnessInstallUrl)
-                { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[BrowsersRailGroup] InstallLink_Click FAILED: {ex.Message}");
-            Notified?.Invoke(this, $"Could not open the install guide: {ex.Message}");
-        }
+        FileLog.Write("[BrowsersRailGroup] InstallLink_Click -> manage");
+        ManageRequested?.Invoke(this, EventArgs.Empty);
     }
 
     // ---- rows ----

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -97,6 +97,13 @@
         <Style Selector="Button.primaryButton:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="#005BA4" />
         </Style>
+        <!-- A disabled primary must still LOOK like the button it is. The theme's disabled brushes are
+             near-white on this near-white footer, so a step doing work ("Setting up...", "Checking...")
+             appeared to have no primary button at all - the screen read as broken rather than busy. -->
+        <Style Selector="Button.primaryButton:disabled /template/ ContentPresenter">
+            <Setter Property="Background" Value="#9FC4E3" />
+            <Setter Property="TextElement.Foreground" Value="#FFFFFF" />
+        </Style>
 
         <!-- Secondary / neutral button (install guide, re-check). -->
         <Style Selector="Button.dialogButton">
@@ -422,6 +429,60 @@
                                    MaxWidth="480" />
                         <Button Classes="quietLink" Content="Stop watching" HorizontalAlignment="Center"
                                 Click="BtnCancelWatchScreenshot_Click" />
+                    </StackPanel>
+                </StackPanel>
+                </ScrollViewer>
+            </Grid>
+
+            <!-- ===================== BROWSERS (issue #1012) =====================
+                 The step RECOMMENDS setting up now rather than sitting neutral, and names both the
+                 tool and who makes it BEFORE the user accepts - we never put a third party's
+                 software on someone's machine without saying whose it is. The way out is quiet but
+                 real, and it names where "later" happens so it is not a dead end. -->
+            <Grid x:Name="BrowsersPanel" IsVisible="False" RowDefinitions="Auto,Auto,Auto,*">
+                <TextBlock Grid.Row="0" Classes="eyebrow" Text="A BROWSER OF ITS OWN" />
+                <TextBlock Grid.Row="1" Classes="wtitle step" Text="Let your agents use a browser" Margin="0,0,0,10" />
+                <TextBlock Grid.Row="2" Classes="wsub step" Margin="0,0,0,18"
+                           Text="An agent can drive a real browser that is already signed in to your accounts - reading a dashboard, filling in a form, checking a page for you. Setting this up now is much easier than wiring it up later." />
+                <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0"
+                              MaxWidth="640" HorizontalAlignment="Center">
+                <StackPanel MaxWidth="600" Spacing="14" VerticalAlignment="Top"
+                            HorizontalAlignment="Stretch">
+
+                    <!-- The two things this step delivers, each carrying its own live state. -->
+                    <StackPanel x:Name="BrowsersRowsPanel" Spacing="10" />
+
+                    <!-- Real work, shown as it happens: creating the environment and downloading the
+                         harness takes about half a minute, and a screen that sat still through it
+                         would look like nothing was happening. -->
+                    <ProgressBar x:Name="BrowsersBusyBar" Classes="scanbar" IsVisible="False" />
+                    <TextBlock x:Name="BrowsersStatusText" Classes="hint" IsVisible="False"
+                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="540" />
+
+                    <!-- A failed install says so and offers the manual page. It NEVER continues as
+                         though it had worked (CLAUDE.md rule 3). This box is the only place the step
+                         shows red, and the retry sits on the same screen. -->
+                    <Border x:Name="BrowsersErrorBox" IsVisible="False" Background="#FDECEC"
+                            BorderBrush="#F5C2C2" BorderThickness="1" CornerRadius="10" Padding="14,12">
+                        <StackPanel Spacing="8">
+                            <TextBlock x:Name="BrowsersErrorText" Foreground="#B42318" FontSize="12.5"
+                                       TextWrapping="Wrap" />
+                            <Button Classes="quietLink" HorizontalAlignment="Left"
+                                    Content="Open the browser-harness install page"
+                                    Click="BtnBrowsersInstallPage_Click" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- The honest way out. Deliberately quiet next to the primary action, and it
+                         names the rail so "later" is somewhere real rather than a vague promise. -->
+                    <StackPanel x:Name="BrowsersLaterPanel" HorizontalAlignment="Center" Spacing="4">
+                        <Button Classes="quietLink" HorizontalAlignment="Center"
+                                Content="Set up browsers later - I want to get going"
+                                Click="BtnBrowsersLater_Click" />
+                        <TextBlock Classes="hint" HorizontalAlignment="Center" TextAlignment="Center"
+                                   MaxWidth="540"
+                                   Text="Later is fine - the Browsers group in the left rail does the same thing." />
                     </StackPanel>
                 </StackPanel>
                 </ScrollViewer>

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using CcDirector.Core.Agents;
+using CcDirector.Core.Browsers;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.GatewayConnection;
 using System.Text.Json.Nodes;
@@ -138,6 +139,17 @@ public partial class FirstRunWizardDialog : Window
     // on disk - it only stops the step, and the Done receipt, from reading as a failure.
     private bool _codeNoneOnThisMachine;
 
+    // Browsers step (issue #1012): whether browser-harness resolves on this machine, the ONE browser
+    // this step sets up (more are added from the rail - signing in is interactive and cannot be
+    // batched), whether a run is in flight, and the last failure. The failure is held rather than
+    // logged and forgotten because the screen has to keep SAYING it: an install that failed must never
+    // read as one that worked.
+    private bool _browsersHarnessInstalled;
+    private AutomationBrowserView? _browsersView;
+    private bool _browsersBusy;
+    private bool _browsersRefreshed;
+    private string? _browsersError;
+
     // True once the completion marker has been written, so OnClosed does not write it twice.
     private bool _marked;
 
@@ -245,6 +257,7 @@ public partial class FirstRunWizardDialog : Window
         WizardStep.Tools => "Tools",
         WizardStep.Code => "Your code",
         WizardStep.Screenshots => "Screenshots",
+        WizardStep.Browsers => "Browsers",
         WizardStep.Done => "Done",
         _ => step.ToString(),
     };
@@ -279,6 +292,7 @@ public partial class FirstRunWizardDialog : Window
         ToolsPanel.IsVisible = step == WizardStep.Tools;
         CodePanel.IsVisible = step == WizardStep.Code;
         ScreenshotsPanel.IsVisible = step == WizardStep.Screenshots;
+        BrowsersPanel.IsVisible = step == WizardStep.Browsers;
         GatewayPanel.IsVisible = step == WizardStep.Gateway;
         DonePanel.IsVisible = step == WizardStep.Done;
 
@@ -356,6 +370,17 @@ public partial class FirstRunWizardDialog : Window
                     _ = DetectScreenshotsForWizardAsync();
                 break;
 
+            case WizardStep.Browsers:
+                // One of only two steps whose primary button DOES something rather than simply moving
+                // on (the other is Agents with none found). This screen recommends rather than sitting
+                // neutral, so its primary sets browsers up and the way past is the quiet link in the
+                // panel - which is exactly the shape of the recommendation: easy now, fine later.
+                PrimaryButton.IsVisible = true;
+                RefreshBrowsersButton();
+                if (!_browsersRefreshed)
+                    _ = RefreshBrowsersScreenAsync();
+                break;
+
             case WizardStep.Gateway:
                 PrimaryButton.IsVisible = true;
                 AdoptExistingGateway();
@@ -375,6 +400,12 @@ public partial class FirstRunWizardDialog : Window
                 FooterNote.Text = "Everything here can be changed in Settings.";
                 FooterNote.IsVisible = true;
                 BuildDoneReceipt();
+                // On a review run the dots are navigation, so Done can be reached without ever opening
+                // the Browsers step - and the receipt would then report browsers from no reading at
+                // all, which is exactly the always-wrong row this replaced. Read the machine, then
+                // rebuild the receipt with the answer.
+                if (!_browsersRefreshed)
+                    _ = RefreshBrowsersForReceiptAsync();
                 break;
         }
     }
@@ -398,6 +429,15 @@ public partial class FirstRunWizardDialog : Window
                 case WizardStep.Screenshots:
                     await SaveScreenshotsFolderAsync();
                     Advance();
+                    break;
+
+                case WizardStep.Browsers:
+                    // Once the browser is set up the button is an ordinary Continue; until then it is
+                    // the offer itself, and pressing it does the work rather than skipping past it.
+                    if (BrowsersAreReady())
+                        Advance();
+                    else
+                        await SetUpBrowserAsync();
                     break;
 
                 case WizardStep.Gateway:
@@ -1685,6 +1725,256 @@ public partial class FirstRunWizardDialog : Window
     /// to check or change something, and telling them they are "three minutes from running their first
     /// coding agent" when they already have four agents configured is simply false.
     /// </summary>
+    // ---- Browsers step (issue #1012) ---------------------------------------------------------------
+
+    /// <summary>
+    /// True when this step has delivered what it promises: the harness is installed AND one browser has
+    /// actually been signed in. Signed-in is read from the browser's own record rather than from its
+    /// live status, because a browser the user has since closed is still set up - "Stopped" is a
+    /// statement about a process, not about whether the login exists.
+    /// </summary>
+    private bool BrowsersAreReady() => _browsersHarnessInstalled && _browsersView?.LastSignedInUtc is not null;
+
+    /// <summary>
+    /// Read the machine's actual browser state - is the harness resolvable, and is there a browser
+    /// already - then repaint. Both reads happen off the interface thread: the browser fold probes each
+    /// browser's debug port, which is a network round trip.
+    /// </summary>
+    private async Task RefreshBrowsersScreenAsync()
+    {
+        FileLog.Write("[FirstRunWizardDialog] RefreshBrowsersScreenAsync");
+        _browsersRefreshed = true;
+        try
+        {
+            var installed = await Task.Run(AutomationBrowserViewFold.IsHarnessInstalled);
+            var browsers = await Task.Run(() => AutomationBrowserViewFold.ListAsync());
+
+            if (_closed) return;
+
+            _browsersHarnessInstalled = installed;
+            // This step sets up ONE browser (recommendation B-3): signing in is interactive and one at
+            // a time, so a wizard that tried to do three would be the slowest thing in onboarding. Any
+            // others a machine already has are the rail's business, not this screen's.
+            _browsersView = browsers.Count > 0 ? browsers[0] : null;
+            FileLog.Write($"[FirstRunWizardDialog] RefreshBrowsersScreenAsync: harness={installed}, browsers={browsers.Count}");
+        }
+        catch (Exception ex)
+        {
+            // A state read that fails must not paint a state: leave the rows where they were and say
+            // what happened, rather than showing "Not installed" on the strength of a failed check.
+            FileLog.Write($"[FirstRunWizardDialog] RefreshBrowsersScreenAsync FAILED: {ex.Message}");
+            _browsersError = $"Could not read this machine's browser setup: {ex.Message}";
+        }
+
+        if (!_closed) RefreshBrowsersUi();
+    }
+
+    /// <summary>Read the browser state for the Done receipt when the Browsers step was never opened, then
+    /// redraw the receipt so it reports the machine rather than an unread default.</summary>
+    private async Task RefreshBrowsersForReceiptAsync()
+    {
+        await RefreshBrowsersScreenAsync();
+        if (!_closed && _model.Current == WizardStep.Done)
+            BuildDoneReceipt();
+    }
+
+    /// <summary>Repaint the two rows, the busy indicator, the error box and the primary button from the
+    /// state already decided - this method makes no decisions of its own beyond wording.</summary>
+    private void RefreshBrowsersUi()
+    {
+        BrowsersRowsPanel.Children.Clear();
+
+        var harnessState = _browsersError is not null ? RowState.NeedsYou
+            : _browsersHarnessInstalled ? RowState.Ready
+            : _browsersBusy ? RowState.Working
+            : RowState.NotSetUp;
+        BrowsersRowsPanel.Children.Add(AgentRow(
+            "Browser Harness",
+            _browsersHarnessInstalled
+                ? "Installed - the tool that drives the browser, from browser-use"
+                // The vendor is named BEFORE the user accepts (recommendation B-4). We do not put a
+                // third party's software on someone's machine without saying whose it is.
+                : "The tool that drives the browser. From browser-use - we install it for you.",
+            harnessState));
+
+        var signedIn = _browsersView?.LastSignedInUtc is not null;
+        var browserState = signedIn ? RowState.Ready
+            : _browsersView is not null ? RowState.NeedsYou
+            : _browsersBusy ? RowState.Working
+            : RowState.NotSetUp;
+        BrowsersRowsPanel.Children.Add(AgentRow(
+            signedIn && _browsersView is not null ? _browsersView.Name : "One signed-in browser",
+            signedIn && _browsersView is not null
+                ? _browsersView.Subtitle
+                : _browsersView is not null
+                    ? "Created, but nobody has signed in to it yet - sign in and agents can use it"
+                    : "Its own profile and its own login, kept apart from your personal browser",
+            browserState));
+
+        BrowsersBusyBar.IsVisible = _browsersBusy;
+        BrowsersStatusText.IsVisible = _browsersBusy && !string.IsNullOrWhiteSpace(BrowsersStatusText.Text);
+
+        BrowsersErrorBox.IsVisible = _browsersError is not null;
+        BrowsersErrorText.Text = _browsersError ?? "";
+
+        // While work is in flight there is nothing to defer TO - the way out comes back the moment the
+        // step is idle again, whether it succeeded or failed.
+        BrowsersLaterPanel.IsVisible = !_browsersBusy && !BrowsersAreReady();
+
+        RefreshBrowsersButton();
+    }
+
+    /// <summary>
+    /// The single next action this step offers, in the footer's primary button. The footer button is
+    /// SHARED by every step, so this refuses to touch it unless the Browsers step is the one on screen -
+    /// the Done receipt reads browser state too, and without this guard that read would relabel Done's
+    /// button while the user was looking at it.
+    /// </summary>
+    private void RefreshBrowsersButton()
+    {
+        if (_model.Current != WizardStep.Browsers) return;
+
+        if (_browsersBusy)
+        {
+            PrimaryButton.Content = "Setting up...";
+            PrimaryButton.IsEnabled = false;
+            return;
+        }
+
+        PrimaryButton.IsEnabled = true;
+        PrimaryButton.Content = _browsersError is not null ? "Try again"
+            : BrowsersAreReady() ? "Continue"
+            : _browsersView is not null && _browsersHarnessInstalled ? "Sign in to this browser"
+            : "Set up my browser";
+    }
+
+    /// <summary>
+    /// The recommended path, run end to end: install the harness, make one browser with its own profile,
+    /// and take the user through signing it in. The sign-in is PART of this, not a follow-up - a step
+    /// that installed a tool and left the user with nothing signed in would have recommended nothing.
+    ///
+    /// Every stage that can fail stops the run and says why. Nothing here continues as though a failed
+    /// stage had worked (CLAUDE.md rule 3).
+    /// </summary>
+    private async Task SetUpBrowserAsync()
+    {
+        FileLog.Write("[FirstRunWizardDialog] SetUpBrowserAsync");
+        _browsersBusy = true;
+        _browsersError = null;
+        BrowsersStatusText.Text = "";
+        RefreshBrowsersUi();
+
+        try
+        {
+            // 1. The harness. Skipped entirely when the machine already has one - including one the
+            //    user installed themselves, which we never rebuild over the top of.
+            if (!_browsersHarnessInstalled)
+            {
+                var progress = new Progress<string>(line =>
+                {
+                    if (_closed) return;
+                    BrowsersStatusText.Text = line;
+                    BrowsersStatusText.IsVisible = true;
+                });
+
+                var result = await Task.Run(() => BrowserHarnessInstaller.InstallAsync(progress));
+                if (_closed) return;
+
+                if (!result.Success)
+                {
+                    // Say so, and leave the manual install page on screen. The step does NOT go on to
+                    // create a browser: without the harness there would be nothing to drive it with,
+                    // and a green browser row under a failed install would be a lie.
+                    _browsersError = result.Message;
+                    FileLog.Write($"[FirstRunWizardDialog] SetUpBrowserAsync: harness install failed: {result.Message}");
+                    return;
+                }
+
+                _browsersHarnessInstalled = true;
+                BrowsersStatusText.Text = result.Message;
+                RefreshBrowsersUi();
+            }
+
+            // 2. One browser with its own profile and its own port. Reuses whatever this machine
+            //    already has rather than adding a second one nobody asked for.
+            if (_browsersView is null)
+            {
+                BrowsersStatusText.Text = "Creating a browser with its own profile...";
+                BrowsersStatusText.IsVisible = true;
+
+                var kind = await Task.Run(PickBrowserKind);
+                var created = await Task.Run(() => AutomationBrowserService.Create("Agent browser", kind));
+                _browsersView = await Task.Run(() => AutomationBrowserViewFold.FoldAsync(created));
+                if (_closed) return;
+                FileLog.Write($"[FirstRunWizardDialog] SetUpBrowserAsync: created browser id={_browsersView.Id}, kind={kind}");
+            }
+
+            // 3. The human signs in. DevThrottle opens the page and records the confirmation; the
+            //    credentials are typed by the person, in the browser window - that constraint is why
+            //    this step sets up one browser and not several.
+            BrowsersStatusText.Text = "Waiting for you to sign in...";
+            _browsersBusy = false;
+            RefreshBrowsersUi();
+
+            var confirmed = await Controls.BrowserSignInFlow.RunAsync(this, _browsersView);
+            if (_closed) return;
+            FileLog.Write($"[FirstRunWizardDialog] SetUpBrowserAsync: sign-in confirmed={confirmed}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] SetUpBrowserAsync FAILED: {ex.Message}");
+            _browsersError = ex.Message;
+        }
+        finally
+        {
+            if (!_closed)
+            {
+                _browsersBusy = false;
+                BrowsersStatusText.Text = "";
+                // Re-read rather than assume: the sign-in is recorded by the flow, and the browser's
+                // own record is the only honest source for whether it happened.
+                await RefreshBrowsersScreenAsync();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Which browser to set up. Chrome first because it is what most people have signed in to, Edge
+    /// otherwise. THROWS when neither is installed, naming both - there is nothing to substitute.
+    /// </summary>
+    private static BrowserKind PickBrowserKind()
+    {
+        var installed = BrowserLauncher.DetectBrowsers();
+        if (installed.Any(b => b.Kind == BrowserKind.Chrome)) return BrowserKind.Chrome;
+        if (installed.Any(b => b.Kind == BrowserKind.Edge)) return BrowserKind.Edge;
+        throw new InvalidOperationException(
+            "Neither Chrome nor Edge is installed on this machine, so there is no browser to set up. "
+            + "Install one, then set browsers up from the Browsers group in the left rail.");
+    }
+
+    /// <summary>The honest way out: move on, having done nothing and written nothing. The panel names
+    /// the rail as where this happens instead, so "later" is somewhere real.</summary>
+    private void BtnBrowsersLater_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnBrowsersLater_Click: deferred to the Browsers rail group");
+        Advance();
+    }
+
+    /// <summary>The manual route, offered only when our install failed - never instead of trying.</summary>
+    private void BtnBrowsersInstallPage_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnBrowsersInstallPage_Click -> {AutomationBrowserViewFold.HarnessInstallUrl}");
+            Process.Start(new ProcessStartInfo(AutomationBrowserViewFold.HarnessInstallUrl) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnBrowsersInstallPage_Click FAILED: {ex.Message}");
+            BrowsersErrorText.Text = $"{_browsersError}\n\nCould not open the install page: {ex.Message}";
+        }
+    }
+
     private void BuildWelcomeScreen()
     {
         WelcomeAgendaPanel.Children.Clear();
@@ -1711,7 +2001,7 @@ public partial class FirstRunWizardDialog : Window
 
         WelcomeTitle.Text = "Let's get you set up";
         WelcomeSubText.Text =
-            "Four quick things, so DevThrottle knows this machine. Skip any of them - all of it can be changed later.";
+            "Five quick things, so DevThrottle knows this machine. Skip any of them - all of it can be changed later.";
         WelcomeSetupButton.Content = "Set me up";
         WelcomeSkipLink.Content = "Skip setup and figure it out myself";
 
@@ -1720,6 +2010,7 @@ public partial class FirstRunWizardDialog : Window
         AddAgendaRow("Your coding agents", "Find the ones already installed, or install one now");
         AddAgendaRow("Where your code lives", "So DevThrottle can offer you repositories and keep the books on them");
         AddAgendaRow("Screenshots", "So you can show an agent what you mean instead of describing it");
+        AddAgendaRow("A browser for your agents", "One browser with its own login, so an agent can read a page or fill in a form for you");
     }
 
     /// <summary>The review run's state summary, read from what is already on disk. No scans.</summary>
@@ -2151,10 +2442,30 @@ public partial class FirstRunWizardDialog : Window
                     "Tools installing", "Finishes on its own in the background", RowState.Working));
         }
 
-        // Browsers row: a pointer, not a task. Browser setup lives in the left rail (the Browsers
-        // group above Repositories) where it is always one click away - the wizard just plants it.
-        DoneReceiptPanel.Children.Add(ReceiptRow(
-            "Browsers", "Give agents a signed-in browser any time - the Browsers group in the left rail", done: false));
+        // Browsers row. This used to print "Later" whatever the machine's state was - advertising copy
+        // wearing a status pill, and it stayed wrong even after the user set a browser up two screens
+        // earlier. It now reports what actually happened (issue #1012).
+        //
+        // Note the deliberate absence of red here: a browser created but never signed in DOES need the
+        // user, but this screen offers no way to fix it, and red where no fix is offered is noise. It
+        // is reported as not set up, naming the rail as where it gets finished.
+        if (_browsersView?.LastSignedInUtc is not null)
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                $"Browser ready - {_browsersView.Name}",
+                $"{_browsersView.Subtitle} - agents can drive it from now on", RowState.Ready));
+        else if (_browsersView is not null)
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                $"Browser created - {_browsersView.Name}",
+                "Nobody has signed in to it yet - finish that in the Browsers group in the left rail",
+                RowState.NotSetUp));
+        else if (_browsersHarnessInstalled)
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                "Browser Harness installed",
+                "No browser set up yet - add one from the Browsers group in the left rail", RowState.NotSetUp));
+        else
+            DoneReceiptPanel.Children.Add(ReceiptRow(
+                "Browsers",
+                "Give agents a signed-in browser any time - the Browsers group in the left rail", done: false));
 
         // Morning report row. There is no longer a frequency question in the wizard - the report is
         // one person, one email, and asking about it once per machine could never reconcile (issue

--- a/src/CcDirector.Core.Tests/Browsers/BrowserHarnessInstallerTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/BrowserHarnessInstallerTests.cs
@@ -1,0 +1,240 @@
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Tests for the browser-harness installer (issue #1012). What is asserted here is everything that can
+/// be settled without reaching PyPI: where the harness is placed, that its own environment is kept apart
+/// from the shared cc-* tools venv, the shim bodies, how the shim directory reaches this process's PATH,
+/// and - the one that matters most - that a machine which CANNOT install says so instead of continuing
+/// as though it had worked (CLAUDE.md rule 3, no fallbacks).
+///
+/// These redirect CcStorage with CC_DIRECTOR_ROOT and also take over PATH, because the production code's
+/// first question is "is the harness already on PATH?" and this machine may well have one. They therefore
+/// join the serialized config-environment collection - two of them running at once would trade PATHs.
+/// </summary>
+[Collection("ConfigEnvSerial")]
+public class BrowserHarnessInstallerTests
+{
+    /// <summary>
+    /// Run <paramref name="body"/> with the storage root pointed at a fresh temp directory and PATH set
+    /// to exactly <paramref name="path"/> (empty by default, so no harness on the machine can resolve and
+    /// leak into the result). Both are restored afterwards, whatever happens.
+    /// </summary>
+    private static void WithRootAndPath(Action<string> body, string path = "")
+    {
+        var oldRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        var root = Path.Combine(Path.GetTempPath(), "cc-director-harness-tests", Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        Environment.SetEnvironmentVariable("PATH", path);
+        try
+        {
+            Directory.CreateDirectory(root);
+            body(root);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", oldRoot);
+            Environment.SetEnvironmentVariable("PATH", oldPath);
+            try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); }
+            catch (IOException) { /* a temp dir we could not remove must not fail the test */ }
+        }
+    }
+
+    // --- Where things go ---------------------------------------------------------------------------
+
+    [Fact]
+    public void EnvDir_IsItsOwn_NotTheSharedToolsVenv()
+    {
+        WithRootAndPath(root =>
+        {
+            // The harness must NOT land in pyenv: that venv is deleted and rebuilt by the tools-bundle
+            // installer on every release, which would silently remove the harness again, and the
+            // harness pins dependency versions the cc-* tools do not share.
+            var sharedVenv = Path.Combine(root, "pyenv");
+            Assert.NotEqual(sharedVenv, BrowserHarnessInstaller.EnvDir);
+            Assert.False(
+                BrowserHarnessInstaller.EnvDir.StartsWith(sharedVenv + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase),
+                "the harness environment must not live inside the shared tools venv");
+
+            Assert.Equal(Path.Combine(root, "harness-env"), BrowserHarnessInstaller.EnvDir);
+        });
+    }
+
+    [Fact]
+    public void ConsoleScript_LivesInsideTheHarnessEnvironment()
+    {
+        WithRootAndPath(_ =>
+            Assert.StartsWith(
+                BrowserHarnessInstaller.EnvDir + Path.DirectorySeparatorChar,
+                BrowserHarnessInstaller.ConsoleScript,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ShimDir_OnWindows_IsTheManagedBinEveryToolShimAlreadyUses()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // This is the whole PATH argument: the shim goes where cc-devthrottle.cmd already lives, a
+        // directory the product itself put on PATH. Anywhere else and a successful install could still
+        // fail detection.
+        WithRootAndPath(root => Assert.Equal(Path.Combine(root, "bin"), BrowserHarnessInstaller.ShimDir));
+    }
+
+    [Fact]
+    public void BundledPython_IsTheOneDevThrottleShips()
+    {
+        WithRootAndPath(root =>
+        {
+            var expected = OperatingSystem.IsWindows()
+                ? Path.Combine(root, "python", "python.exe")
+                : Path.Combine(root, "python", "bin", "python3");
+            Assert.Equal(expected, BrowserHarnessInstaller.BundledPython);
+        });
+    }
+
+    // --- The failure that must never be silent -----------------------------------------------------
+
+    [Fact]
+    public async Task InstallAsync_WithNoBundledPython_FailsLoudly_AndCreatesNothing()
+    {
+        await WithRootAndPathAsync(async _ =>
+        {
+            var result = await BrowserHarnessInstaller.InstallAsync();
+
+            Assert.False(result.Success);
+            // The message has to name the missing thing and what to do about it - this is the text the
+            // wizard shows, and "something went wrong" would leave the user with nowhere to go.
+            Assert.Contains("bundled Python is missing", result.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(BrowserHarnessInstaller.BundledPython, result.Message);
+            Assert.Null(result.Version);
+
+            // Nothing half-built is left behind: no environment, and above all no shim, since a shim
+            // pointing at an absent console script is the "installed" lie this whole design avoids.
+            Assert.False(Directory.Exists(BrowserHarnessInstaller.EnvDir));
+            Assert.False(File.Exists(Path.Combine(BrowserHarnessInstaller.ShimDir, "browser-harness.cmd")));
+        });
+    }
+
+    [Fact]
+    public async Task InstallAsync_WhenAlreadyOnPath_LeavesTheExistingInstallAlone()
+    {
+        // A user who installed browser-harness themselves (uv, or their own Python) must not have it
+        // rebuilt underneath them, and we must not claim to have installed what was already there.
+        var borrowedDir = Path.Combine(Path.GetTempPath(), "cc-director-harness-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(borrowedDir);
+        var fakeExe = Path.Combine(borrowedDir, OperatingSystem.IsWindows() ? "browser-harness.cmd" : "browser-harness");
+        File.WriteAllText(fakeExe, OperatingSystem.IsWindows() ? "@echo off\r\n" : "#!/bin/sh\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(fakeExe, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        try
+        {
+            await WithRootAndPathAsync(async _ =>
+            {
+                var result = await BrowserHarnessInstaller.InstallAsync();
+
+                Assert.True(result.Success);
+                Assert.Contains("already installed", result.Message, StringComparison.OrdinalIgnoreCase);
+                // Untouched: no environment of ours was built over the top of theirs.
+                Assert.False(Directory.Exists(BrowserHarnessInstaller.EnvDir));
+            }, path: borrowedDir);
+        }
+        finally
+        {
+            try { Directory.Delete(borrowedDir, recursive: true); } catch (IOException) { }
+        }
+    }
+
+    // --- The shims ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void WindowsShimBody_RunsTheConsoleScript_AndRefusesWhenItIsMissing()
+    {
+        const string target = @"C:\root\harness-env\Scripts\browser-harness.exe";
+        var body = BrowserHarnessInstaller.BuildWindowsShimBody(target);
+
+        Assert.Contains($"\"{target}\" %*", body);
+        // The guard is what turns a removed environment into a sentence the user can act on instead of
+        // cmd.exe's "is not recognized".
+        Assert.Contains($"if not exist \"{target}\"", body);
+        Assert.Contains("exit /b 1", body);
+        Assert.Contains("\r\n", body);
+    }
+
+    [Fact]
+    public void BashShimBody_UsesForwardSlashes_SoGitBashCanExecIt()
+    {
+        var body = BrowserHarnessInstaller.BuildWindowsBashShimBody(@"C:\root\harness-env\Scripts\browser-harness.exe");
+
+        Assert.StartsWith("#!/bin/sh\n", body);
+        Assert.Contains("C:/root/harness-env/Scripts/browser-harness.exe", body);
+        Assert.DoesNotContain("\r\n", body);
+        Assert.Contains("\"$@\"", body);
+    }
+
+    // --- PATH handling -----------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(@"C:\a;C:\b", @"C:\b", true)]
+    [InlineData(@"C:\a;C:\b\", @"C:\b", true)]      // a trailing separator is the same directory
+    [InlineData(@"C:\a; C:\b ", @"C:\b", true)]      // padded entries are the same directory
+    [InlineData(@"C:\a;C:\bc", @"C:\b", false)]      // a prefix is NOT the same directory
+    [InlineData("", @"C:\b", false)]
+    public void PathContains_RecognisesTheSameDirectory_AndOnlyThat(string searchPath, string dir, bool expected)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        Assert.Equal(expected, BrowserHarnessInstaller.PathContains(searchPath, dir));
+    }
+
+    [Fact]
+    public void PathContains_OnWindows_IgnoresCase()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        Assert.True(BrowserHarnessInstaller.PathContains(@"C:\Program Files;C:\Users\me\bin", @"c:\users\me\BIN"));
+    }
+
+    [Fact]
+    public void EnsureShimDirOnProcessPath_AddsItOnce_AndKeepsWhatWasThere()
+    {
+        WithRootAndPath(_ =>
+        {
+            var existing = Environment.GetEnvironmentVariable("PATH");
+            Assert.False(BrowserHarnessInstaller.PathContains(existing, BrowserHarnessInstaller.ShimDir));
+
+            BrowserHarnessInstaller.EnsureShimDirOnProcessPath();
+            var after = Environment.GetEnvironmentVariable("PATH");
+            Assert.True(BrowserHarnessInstaller.PathContains(after, BrowserHarnessInstaller.ShimDir));
+            Assert.Contains(@"C:\already\here", after);
+
+            // Idempotent: a second install (or a repair) must not keep stacking the same entry.
+            BrowserHarnessInstaller.EnsureShimDirOnProcessPath();
+            Assert.Equal(after, Environment.GetEnvironmentVariable("PATH"));
+        }, path: @"C:\already\here");
+    }
+
+    /// <summary>The async form of <see cref="WithRootAndPath"/>.</summary>
+    private static async Task WithRootAndPathAsync(Func<string, Task> body, string path = "")
+    {
+        var oldRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        var root = Path.Combine(Path.GetTempPath(), "cc-director-harness-tests", Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        Environment.SetEnvironmentVariable("PATH", path);
+        try
+        {
+            Directory.CreateDirectory(root);
+            await body(root);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", oldRoot);
+            Environment.SetEnvironmentVariable("PATH", oldPath);
+            try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); }
+            catch (IOException) { /* a temp dir we could not remove must not fail the test */ }
+        }
+    }
+}

--- a/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Onboarding/FirstRunWizardModelTests.cs
@@ -123,10 +123,10 @@ public class FirstRunWizardModelTests
     }
 
     [Fact]
-    public void CreateFull_HasAllSevenStepsInCanonicalOrder()
+    public void CreateFull_HasAllEightStepsInCanonicalOrder()
     {
         var model = FirstRunWizardModel.CreateFull();
-        Assert.Equal(7, model.Count);
+        Assert.Equal(8, model.Count);
 
         // The WHOLE sequence, written out, not compared against the production list. Comparing
         // model.Steps to CanonicalOrder only proves the model did not reorder its own input - it
@@ -142,6 +142,7 @@ public class FirstRunWizardModelTests
                 WizardStep.Tools,       // their toolbelt
                 WizardStep.Code,        // what we watch over
                 WizardStep.Screenshots, // show, don't type
+                WizardStep.Browsers,    // give an agent a signed-in browser
                 WizardStep.Done,        // the receipt
             },
             model.Steps);
@@ -154,11 +155,15 @@ public class FirstRunWizardModelTests
         // Tools sits right after Agents: workforce first, then their toolbelt.
         Assert.Equal(WizardStep.Tools, model.Steps[3]);
 
-        // Screenshots is the last step before Done. Done used to be preceded by a daily-report
-        // frequency question, which is an ACCOUNT setting and so was asked once per machine with no
-        // way to reconcile the answers (issue #996). The count here is also the number of progress
-        // dots, so a step creeping back in is a failing assertion rather than a silently longer wizard.
-        Assert.Equal(WizardStep.Screenshots, model.Steps[^2]);
+        // Browsers is the last step before Done, and it sits immediately after Screenshots (issue
+        // #1012): both are about how an agent gets context from you, and Browsers is the one step that
+        // can ask for an interactive sign-in, so it goes after everything else has been delivered.
+        // Done must never be preceded by a daily-report frequency question again - that is an ACCOUNT
+        // setting, so it was asked once per machine with no way to reconcile the answers (issue #996).
+        // The count above is also the number of progress dots, so a step creeping back in is a failing
+        // assertion rather than a silently longer wizard.
+        Assert.Equal(WizardStep.Browsers, model.Steps[^2]);
+        Assert.Equal(WizardStep.Screenshots, model.Steps[^3]);
     }
 
     [Fact]
@@ -171,7 +176,7 @@ public class FirstRunWizardModelTests
         var machineScoped = new[]
         {
             WizardStep.Welcome, WizardStep.Agents, WizardStep.Tools, WizardStep.Code,
-            WizardStep.Screenshots, WizardStep.Gateway, WizardStep.Done,
+            WizardStep.Screenshots, WizardStep.Browsers, WizardStep.Gateway, WizardStep.Done,
         };
 
         // The SET is what this rule is about - every declared step must be one a machine can answer.

--- a/src/CcDirector.Core/Browsers/BrowserHarnessInstaller.cs
+++ b/src/CcDirector.Core/Browsers/BrowserHarnessInstaller.cs
@@ -1,0 +1,386 @@
+using System.Diagnostics;
+using System.Text;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Browsers;
+
+/// <summary>The outcome of a browser-harness install, with the steps taken (for the log and the UI).</summary>
+/// <param name="Success">True when the harness is installed AND resolvable by the same check the product uses.</param>
+/// <param name="Message">One sentence a user can read. On failure this says what went wrong, never a euphemism.</param>
+/// <param name="Steps">The ordered steps taken, for the log.</param>
+/// <param name="Version">The installed harness version when we could read it, else null.</param>
+public sealed record BrowserHarnessInstallResult(
+    bool Success, string Message, IReadOnlyList<string> Steps, string? Version);
+
+/// <summary>
+/// Installs browser-harness - browser-use's Python tool, the thing that actually drives the automation
+/// browsers - onto this machine, without asking the user to install anything themselves.
+///
+/// WHY IT DOES NOT USE uv. The documented install is
+/// <c>uv tool install --python 3.12 browser-harness</c>, but uv is a BUILD-TIME dependency of this
+/// repository (scripts/build-python-bundle.ps1 bakes the Python bundle with it) and is never shipped to
+/// a user's machine. Shipping it would mean shipping a second package manager to run one pip install,
+/// and <c>uv tool install</c> drops its executable in the user's own local bin - a directory we do not
+/// manage and cannot guarantee is on the PATH this Director resolves against, so a "successful" install
+/// could still fail the detection check.
+///
+/// WHAT IT DOES INSTEAD. Everything needed already ships:
+///   * the relocatable CPython 3.12 under <c>&lt;root&gt;\python</c> (browser-harness needs >= 3.11),
+///   * a <c>bin</c> directory we own and that is already on PATH - it is where every cc-* tool shim lives.
+/// So: build a DEDICATED venv beside them, pip-install browser-harness into it, and write the same style
+/// of shim into that same bin. Detection then cannot miss it, because the shim lands in the directory the
+/// resolver provably already searches.
+///
+/// WHY A DEDICATED VENV AND NOT THE SHARED TOOLS VENV. Two reasons, both proven rather than assumed:
+///   * browser-harness pins its dependencies exactly (pillow==12.2.0 among them) and the shared venv
+///     carries a different pillow, so sharing would silently downgrade a dependency out from under the
+///     cc-* tools.
+///   * <see cref="T:CcDirector.Setup.Engine.PythonToolsInstaller"/> DELETES and rebuilds the shared venv
+///     on every tools-bundle update, which would remove the harness again on the next release without
+///     anyone touching it.
+/// Its own directory costs about 40 MB and survives every tools update.
+///
+/// NO FALLBACK (CLAUDE.md rule 3). Every failure here returns Success=false with the reason. Nothing is
+/// substituted, no second route is attempted, and the caller is expected to say so and offer
+/// <see cref="AutomationBrowserViewFold.HarnessInstallUrl"/>. A half-install never reports success: the
+/// console script must exist AND resolve before this returns true.
+/// </summary>
+public static class BrowserHarnessInstaller
+{
+    /// <summary>The PyPI distribution installed. Named here once so the log, the UI and the command agree.</summary>
+    public const string Distribution = "browser-harness";
+
+    /// <summary>Who makes it. Shown to the user BEFORE they accept - we never install a third party's
+    /// software without naming the third party (issue #1012, recommendation B-4).</summary>
+    public const string Vendor = "browser-use";
+
+    /// <summary>
+    /// Bound for creating the venv. It takes seconds; the bound only exists so a wedged interpreter
+    /// fails loudly in finite time instead of hanging the wizard forever.
+    /// </summary>
+    public static readonly TimeSpan VenvCreateTimeout = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// Bound for the pip install. Measured at about twenty seconds on a warm machine for twelve
+    /// packages; ten minutes is generous for a slow link and still bounded.
+    /// </summary>
+    public static readonly TimeSpan PipInstallTimeout = TimeSpan.FromMinutes(10);
+
+    /// <summary>The harness's own virtual environment, kept apart from the shared cc-* tools venv.</summary>
+    public static string EnvDir => Path.Combine(CcStorage.Root(), "harness-env");
+
+    /// <summary>The venv's executables directory: Scripts on Windows, bin elsewhere.</summary>
+    public static string EnvBinDir => Path.Combine(EnvDir, OperatingSystem.IsWindows() ? "Scripts" : "bin");
+
+    /// <summary>The venv's own interpreter, which is what runs pip.</summary>
+    public static string EnvPython => Path.Combine(EnvBinDir, OperatingSystem.IsWindows() ? "python.exe" : "python3");
+
+    /// <summary>The console script pip generates for the harness inside the venv.</summary>
+    public static string ConsoleScript =>
+        Path.Combine(EnvBinDir, OperatingSystem.IsWindows() ? $"{Distribution}.exe" : Distribution);
+
+    /// <summary>
+    /// The CPython that ships with DevThrottle - the same interpreter the cc-* tools venv is built from.
+    /// The harness venv is created from it so the machine needs no Python of its own.
+    /// </summary>
+    public static string BundledPython => OperatingSystem.IsWindows()
+        ? Path.Combine(CcStorage.Root(), "python", "python.exe")
+        : Path.Combine(CcStorage.Root(), "python", "bin", "python3");
+
+    /// <summary>
+    /// Where the shim goes so the harness is on PATH: the managed <c>bin</c> on Windows (every cc-* shim
+    /// lives there), and <c>~/.local/bin</c> on macOS (where the tool symlinks go and which the Director
+    /// .app launcher already prepends to PATH).
+    /// </summary>
+    public static string ShimDir => OperatingSystem.IsWindows()
+        ? CcStorage.Bin()
+        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "bin");
+
+    /// <summary>
+    /// Install browser-harness, reporting each step. Idempotent: a machine that already has it (ours, or
+    /// one the user installed themselves) is left alone and reported as already installed.
+    /// </summary>
+    /// <param name="progress">Receives one short line per step, for the wizard's status text.</param>
+    public static async Task<BrowserHarnessInstallResult> InstallAsync(
+        IProgress<string>? progress = null, CancellationToken ct = default)
+    {
+        var steps = new List<string>();
+        void Step(string m)
+        {
+            steps.Add(m);
+            FileLog.Write($"[BrowserHarnessInstaller] {m}");
+            progress?.Report(m);
+        }
+
+        FileLog.Write("[BrowserHarnessInstaller] InstallAsync");
+
+        // 0. Already there? Never rebuild a working install - and never claim credit for one either.
+        //    A user who installed the harness themselves (with uv, or into their own Python) resolves
+        //    here and we leave their install completely alone.
+        if (AutomationBrowserViewFold.IsHarnessInstalled())
+        {
+            Step($"{Distribution} is already installed on this machine");
+            return new BrowserHarnessInstallResult(true, $"{Distribution} is already installed.", steps, ReadVersion());
+        }
+
+        // 1. The interpreter we install into has to actually be here. It ships with DevThrottle, so its
+        //    absence means a broken or partial installation - say that, rather than failing later inside
+        //    a venv command with a Win32 error nobody can act on.
+        if (!File.Exists(BundledPython))
+        {
+            return Fail(steps,
+                $"DevThrottle's bundled Python is missing (expected at {BundledPython}). "
+                + "Repair the installation from Home, then set up browsers again.");
+        }
+
+        // 2. Create the venv. Rebuilt from scratch each time we get here: we only get here when the
+        //    harness does NOT resolve, so anything already in this directory is a leftover from a failed
+        //    or interrupted run, and reusing it would be building on a state we never verified.
+        Step("Creating a Python environment for the harness");
+        try
+        {
+            if (Directory.Exists(EnvDir)) Directory.Delete(EnvDir, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            return Fail(steps, $"could not clear the previous harness environment at {EnvDir}: {ex.Message}");
+        }
+
+        var (venvExit, venvOut) = await RunAsync(BundledPython, new[] { "-m", "venv", EnvDir }, VenvCreateTimeout, null, ct)
+            .ConfigureAwait(false);
+        if (venvExit != 0)
+            return Fail(steps, $"creating the Python environment failed ({venvExit}): {Trim(venvOut)}");
+        if (!File.Exists(EnvPython))
+            return Fail(steps, $"creating the Python environment reported success but produced no interpreter at {EnvPython}.");
+
+        // 3. Install the distribution. pip's own lines drive the status text so the user watches real
+        //    work rather than a spinner that means nothing.
+        Step($"Installing {Distribution} from {Vendor}");
+        var pipArgs = new[]
+        {
+            "-m", "pip", "install", "--disable-pip-version-check", "--no-warn-script-location",
+            "--progress-bar=off", Distribution,
+        };
+        var (pipExit, pipOut) = await RunAsync(EnvPython, pipArgs, PipInstallTimeout, line =>
+        {
+            FileLog.Write($"[pip] {line}");
+            if (line.StartsWith("Collecting ", StringComparison.Ordinal)
+                || line.StartsWith("Downloading ", StringComparison.Ordinal))
+            {
+                progress?.Report(line.Trim());
+            }
+            else if (line.StartsWith("Installing collected packages", StringComparison.Ordinal))
+            {
+                progress?.Report("Installing packages...");
+            }
+        }, ct).ConfigureAwait(false);
+
+        if (pipExit == TimeoutExitCode)
+            return Fail(steps, $"installing {Distribution} took longer than {PipInstallTimeout.TotalMinutes:F0} minutes and was stopped.");
+        if (pipExit != 0)
+            return Fail(steps, $"installing {Distribution} failed ({pipExit}): {Trim(pipOut)}");
+
+        // 4. pip exiting zero is not proof the command exists. Check the console script is really on
+        //    disk BEFORE writing a shim, so we can never leave a shim pointing at nothing.
+        if (!File.Exists(ConsoleScript))
+            return Fail(steps, $"{Distribution} installed but produced no {Distribution} command at {ConsoleScript}.");
+
+        // 5. Put it on PATH the same way every cc-* tool gets there.
+        Step("Putting the harness on the PATH");
+        try
+        {
+            WriteShim();
+        }
+        catch (Exception ex)
+        {
+            return Fail(steps, $"could not write the {Distribution} shim into {ShimDir}: {ex.Message}");
+        }
+
+        // 6. The shim directory is one WE manage, so a Director that started before it existed on PATH
+        //    would otherwise not see the tool until it restarted - and neither would the agents it
+        //    launches, which inherit this process's environment. Add it here so the install is usable
+        //    immediately. This is not a fallback: it makes the install effective, and the verdict below
+        //    is still the product's own resolution check, which is free to fail.
+        EnsureShimDirOnProcessPath();
+
+        // 7. The verdict is the SAME check the rest of the product uses to decide whether the harness is
+        //    installed. Anything less would let this report success while the Browsers screen keeps
+        //    saying "Not installed".
+        if (!AutomationBrowserViewFold.IsHarnessInstalled())
+        {
+            return Fail(steps,
+                $"{Distribution} installed to {ConsoleScript}, but the {Distribution} command still does not "
+                + $"resolve on this machine's PATH (expected via {ShimDir}).");
+        }
+
+        var version = ReadVersion();
+        Step($"{Distribution} is installed{(version is null ? "" : $" ({version})")}");
+        return new BrowserHarnessInstallResult(
+            true,
+            version is null ? $"{Distribution} is installed." : $"{Distribution} {version} is installed.",
+            steps,
+            version);
+    }
+
+    /// <summary>
+    /// The installed harness version, read from the venv's own metadata, or null when it cannot be read.
+    /// Decoration for the status line only - never load-bearing, so an unreadable version degrades to
+    /// "no version shown" rather than failing an install that otherwise worked.
+    /// </summary>
+    public static string? ReadVersion()
+    {
+        try
+        {
+            if (!File.Exists(EnvPython)) return null;
+            var (exit, output) = RunAsync(
+                EnvPython,
+                new[] { "-c", $"import importlib.metadata as m; print(m.version('{Distribution}'))" },
+                TimeSpan.FromSeconds(20), null, CancellationToken.None).GetAwaiter().GetResult();
+            if (exit != 0) return null;
+            var line = output.Split('\n').Select(l => l.Trim()).FirstOrDefault(l => l.Length > 0);
+            return string.IsNullOrWhiteSpace(line) ? null : line;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserHarnessInstaller] ReadVersion failed (non-fatal): {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Write the PATH shim(s) for the harness: .cmd plus a bare-name shell shim on Windows, a
+    /// symlink on macOS - exactly the shapes the cc-* tool shims already use.</summary>
+    private static void WriteShim()
+    {
+        Directory.CreateDirectory(ShimDir);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var link = Path.Combine(ShimDir, Distribution);
+            if (File.Exists(link) || Directory.Exists(link)) File.Delete(link);
+            File.CreateSymbolicLink(link, ConsoleScript);
+            return;
+        }
+
+        File.WriteAllText(Path.Combine(ShimDir, $"{Distribution}.cmd"), BuildWindowsShimBody(ConsoleScript));
+        // Also a bare-name shell shim: Git Bash does not resolve the .cmd through PATHEXT, and agents
+        // driving bash call the tool by bare name. CMD and PowerShell ignore this file (no PATHEXT
+        // match), so the two cannot conflict.
+        File.WriteAllText(Path.Combine(ShimDir, Distribution), BuildWindowsBashShimBody(ConsoleScript));
+    }
+
+    /// <summary>The body of the Windows .cmd shim. It checks its target exists first, so a machine whose
+    /// harness environment was removed gets an actionable sentence instead of cmd.exe's raw
+    /// "is not recognized".</summary>
+    internal static string BuildWindowsShimBody(string consoleScript) =>
+        "@echo off\r\n"
+        + $"if not exist \"{consoleScript}\" (\r\n"
+        + $"  echo {Distribution} is not installed - set it up from the Browsers group in DevThrottle 1>&2\r\n"
+        + "  exit /b 1\r\n"
+        + ")\r\n"
+        + $"\"{consoleScript}\" %*\r\n";
+
+    /// <summary>The body of the bare-name shim Git Bash runs (LF endings, shebang), forwarding to the
+    /// same console script.</summary>
+    internal static string BuildWindowsBashShimBody(string consoleScript) =>
+        "#!/bin/sh\n"
+        + $"# bash-runnable bare-name shim for '{Distribution}' (Git Bash does not resolve the .cmd via PATHEXT).\n"
+        + $"exec \"{consoleScript.Replace('\\', '/')}\" \"$@\"\n";
+
+    /// <summary>
+    /// Prepend the shim directory to THIS process's PATH when it is not already there, so a freshly
+    /// installed harness resolves without restarting the Director - and so does every agent session
+    /// launched afterwards, since they inherit this environment.
+    /// </summary>
+    internal static void EnsureShimDirOnProcessPath()
+    {
+        var current = Environment.GetEnvironmentVariable("PATH") ?? "";
+        if (PathContains(current, ShimDir))
+            return;
+
+        Environment.SetEnvironmentVariable("PATH", ShimDir + Path.PathSeparator + current);
+        FileLog.Write($"[BrowserHarnessInstaller] added {ShimDir} to this process's PATH");
+    }
+
+    /// <summary>True when <paramref name="searchPath"/> already lists <paramref name="dir"/>, comparing
+    /// the way the platform does (case-insensitively on Windows) and ignoring a trailing separator.</summary>
+    internal static bool PathContains(string? searchPath, string dir)
+    {
+        if (string.IsNullOrEmpty(searchPath) || string.IsNullOrWhiteSpace(dir)) return false;
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var target = dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return searchPath
+            .Split(Path.PathSeparator)
+            .Select(p => p.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+            .Any(p => p.Length > 0 && string.Equals(p, target, comparison));
+    }
+
+    /// <summary>The exit code reported when a bounded run was killed for exceeding its timeout.</summary>
+    internal const int TimeoutExitCode = -3;
+
+    /// <summary>
+    /// Run a bounded child process, streaming its output lines to <paramref name="onLine"/> and returning
+    /// the exit code with the combined output. A run that exceeds <paramref name="timeout"/> is killed and
+    /// reported as <see cref="TimeoutExitCode"/> - it never hangs the caller.
+    /// </summary>
+    private static async Task<(int exit, string output)> RunAsync(
+        string exe, string[] args, TimeSpan timeout, Action<string>? onLine, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = exe,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var output = new StringBuilder();
+        using var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+
+        void Collect(string? line)
+        {
+            if (line is null) return;
+            lock (output) output.AppendLine(line);
+            try { onLine?.Invoke(line); }
+            catch (Exception ex) { FileLog.Write($"[BrowserHarnessInstaller] output handler threw: {ex.Message}"); }
+        }
+
+        process.OutputDataReceived += (_, e) => Collect(e.Data);
+        process.ErrorDataReceived += (_, e) => Collect(e.Data);
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch (Exception ex) { FileLog.Write($"[BrowserHarnessInstaller] could not kill {exe}: {ex.Message}"); }
+            // A cancellation the CALLER asked for is not a timeout - surface it as one.
+            ct.ThrowIfCancellationRequested();
+            lock (output) return (TimeoutExitCode, output.ToString());
+        }
+
+        lock (output) return (process.ExitCode, output.ToString());
+    }
+
+    private static string Trim(string s)
+    {
+        var text = s.Trim();
+        return text.Length > 400 ? text[..400] : text;
+    }
+
+    private static BrowserHarnessInstallResult Fail(List<string> steps, string message)
+    {
+        FileLog.Write($"[BrowserHarnessInstaller] FAILED: {message}");
+        return new BrowserHarnessInstallResult(false, message, steps, null);
+    }
+}

--- a/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
+++ b/src/CcDirector.Core/Onboarding/FirstRunWizardModel.cs
@@ -23,6 +23,7 @@ public enum WizardStep
     Tools,
     Code,
     Screenshots,
+    Browsers,
     Gateway,
     Done,
 }
@@ -68,6 +69,12 @@ public sealed class FirstRunWizardModel
     /// This does NOT make the gateway a gate. "Not now" stays exactly as prominent as it was: the
     /// Director installs and runs with no account, and a first screen that reads as sign-up-to-continue
     /// would change what the product is.
+    ///
+    /// Browsers comes LAST of the real steps, straight after Screenshots (issue #1012). The two belong
+    /// beside each other - both are about how an agent gets context from you rather than about the agent
+    /// itself - and it is the one step that can ask for a browser sign-in, which is interactive and
+    /// cannot be hurried. Putting it last means the wizard has already delivered everything else before
+    /// it asks for the minute that costs the most.
     /// </remarks>
     public static readonly IReadOnlyList<WizardStep> CanonicalOrder = new[]
     {
@@ -77,6 +84,7 @@ public sealed class FirstRunWizardModel
         WizardStep.Tools,
         WizardStep.Code,
         WizardStep.Screenshots,
+        WizardStep.Browsers,
         WizardStep.Done,
     };
 


### PR DESCRIPTION
Closes the last outstanding piece of onboarding work: the wizard now has a Browsers step (internal issue 1012, a release must-have).

## What it does

A step after Screenshots and before Done. It recommends setting browsers up now rather than sitting neutral, names browser-harness and that it comes from browser-use before the user accepts, and on acceptance installs the harness, creates one browser with its own profile, and takes the user through signing it in. The way out is a quiet "set up browsers later - I want to get going", naming the Browsers group in the left rail as where that happens.

One browser, not several: signing in is interactive and one at a time. And the sign-in is part of the recommended path rather than a follow-up, because a step that installed a tool and left nothing signed in would have recommended nothing.

## The install route

Installing browser-harness was the only piece that did not already exist. This does not ship uv. uv is a build-time dependency of this repository, and `uv tool install` places its executable in a directory we do not manage, so a successful install could still fail the detection check.

Instead the harness gets its own virtual environment, built from the CPython DevThrottle already ships, plus a shim in the same bin directory every cc-* tool shim lives in - which is provably on the PATH the Director resolves against.

Its own environment rather than the shared cc-* tools venv, for two measured reasons:

- browser-harness pins `pillow==12.2.0`; the shared venv carries a different pillow, so sharing would downgrade a dependency under the tools.
- `PythonToolsInstaller` deletes and rebuilds that venv on every tools-bundle update, which would silently remove the harness again on the next release.

Cost: about 29 seconds and 40 MB.

A failed install says so and offers the manual install page. It never continues as though it worked, and no shim is ever written pointing at a console script that is not there.

## Also in here

The Browsers rail group and the Browsers settings tab now run the same installer instead of opening a documentation page, so the step's "you can do this later, in the rail" leads somewhere that works.

Three defects found by using the step rather than by reading it:

- The shared confirmation dialog had a fixed button width that silently clipped whatever label the caller passed - the browser sign-in confirmation read "Done - I am s". Buttons now size to their content, which fixes every caller.
- The sign-in dialog never said what to sign in to. It now names both routes: a Google or Microsoft account to bring a profile across, or just the individual websites you want that browser to reach - and states that whatever is signed in there is exactly what agents can drive.
- A disabled primary button rendered near-invisible on the wizard's white footer, so a step doing work looked like a step with no button.

The Done receipt reports what actually happened, replacing a row that printed "Later" regardless of machine state. Red appears only where the same screen offers the fix, so a browser created but not signed in reads as not set up on the receipt, naming the rail, rather than as an alarm with no button next to it.

## Proof

Run on a clean throwaway instance root, with the harness this machine already has hidden from PATH so the install path genuinely ran:

- Step 7 of 8 - Browsers, in place after Screenshots.
- Offer state: Browser Harness "Not set up", subtitle "The tool that drives the browser. From browser-use - we install it for you."
- Install with live progress; the log shows the environment created in 10 seconds, browser-harness 0.1.8 installed in 19 seconds, the shim written, and the version confirmed through the product's own detection check.
- "Agent browser" created (Chrome, its own user-data-dir, port 9310), sign-in dialog shown, then both rows Ready.
- Done receipt: "Browser ready - Agent browser".

Suites: CcDirector.Core.Tests 3912 passed, CcDirector.Avalonia.Tests 313 passed. The whole-sequence wizard order test was updated deliberately - it still writes out all eight steps in order rather than comparing sets.

Not touched: the installer and its prerequisites, and the self-hosted gateway path.
