### PR TITLE
release: v1.8.7 - Chrome and Edge are found on a Mac

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.6</Version>
+    <Version>1.8.7</Version>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Bumps the product version in Directory.Build.props from 1.8.6 to 1.8.7 so the v1.8.7 tag can be cut. No other change.

## Why this release exists

Version 1.8.6 tells Mac users "Neither Chrome nor Edge is installed on this machine" on the Browsers step of the setup wizard, even when both applications are in /Applications, and the screen offers no way past it. The fix is on main (pull request 2278, proven on a real Mac) and is in no release yet.

## What ships, and what does not

Main also carried the named Director instances change (pull request 2271). An adversarial review found six defects in it, three of them critical, including a path traversal recursive delete reachable from an authenticated relay route. That change was reverted on main by pull request 2279 before this bump, so version 1.8.7 does not carry it. Releases 1.8.3 through 1.8.6 are all clean of it as well.

## Verification

Directory.Build.props is the single source of truth for the product version; no .csproj declares its own <Version>, confirmed by grep over origin/main. The release workflow refuses to publish when the tag and Directory.Build.props disagree, so the tag will be cut only after this merges.
