### PR TITLE
release: v1.8.8 - updating is checked afterwards, and undone when it fails

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.8.7</Version>
+    <Version>1.8.8</Version>
   </PropertyGroup>
 
   <!--

--- a/docs/public/release-notes/v1.8.8.md
+++ b/docs/public/release-notes/v1.8.8.md
@@ -1,0 +1,55 @@
+## v1.8.8 - July 29, 2026
+
+The release that makes updating trustworthy. DevThrottle has updated itself for a long time; from
+this version something is left behind to check that the update worked, and to put the previous
+version back when it did not.
+
+### An update that does not work is now undone
+
+- **A version that fails to start is put back rather than left on your machine.** Until now
+  DevThrottle replaced its own program file and started the new version, and that was the end of
+  it - nothing was left running that could tell whether the new version had actually come back. A
+  version that never started was written into the log as a success, and the last thing the log said
+  before going quiet was that the update had completed.
+- **The previous version is kept, and released only once the new one has proved itself.** It used to
+  be deleted early in start-up, which left a gap where a version could start, remove the only way
+  back, and then fail before finishing - leaving nothing to restore.
+- **A version that fails is not offered again.** It is recorded as a build that does not start, so
+  the same failure is not repeated every hour.
+- **Nothing is claimed on trust any more.** "The update finished" now means a running DevThrottle
+  reported its new version number, not that a request to start it was accepted.
+
+### On a Mac, a bad update could not be undone at all
+
+- **Both repair routines used to give up unless they were running on Windows.** Even without that,
+  there would have been nothing for them to use: updating on a Mac deleted the installed application
+  before moving the new one into place, so no copy of the working version survived. Both halves are
+  fixed, the previous version is now kept on Mac as well as Windows, and one set of rules decides
+  when to go back to it.
+
+### The launcher installs the update, so that something can check it
+
+- **The small companion that is always running now does the work.** It stops DevThrottle, puts the
+  new version in place, starts it, and keeps asking until the new version answers for itself. If it
+  never answers, the previous version is put back and started.
+- **Why it could not have been done any other way.** A program cannot replace itself and then
+  confirm the result, because the only thing that could do the confirming is the program that just
+  stopped. Something that outlives the replacement has to be the one to ask.
+- **An update still never interrupts your work.** DevThrottle updates only when it has no sessions
+  running, exactly as before. That decision now belongs to the launcher, where acting on it is safe,
+  and it is made by asking the running DevThrottle how many sessions it has rather than by reading a
+  file written at some earlier moment. If it cannot tell whether you are busy, it waits.
+- **A DevThrottle you closed stays closed.** Updating it would mean reopening an application you
+  deliberately closed, so it is left alone and picks the update up the next time you open it.
+
+### What to expect when this version arrives
+
+- **This update installs the way it always has.** It is put in place by the version you are running
+  now, so nothing about this one changes. Everything above applies to the updates that follow it.
+- **Opening DevThrottle by hand still installs a waiting update.** A machine whose launcher is
+  missing or switched off keeps updating exactly as it does today, and now with the repair and the
+  after-the-fact check described above.
+- **On a Mac, the launcher itself is updated by running the installer.** The launcher keeps itself up
+  to date on Windows only, so a Mac carries on updating through the app until the installer has been
+  run there once. The repair and the checking above are part of the application itself, so a Mac gets
+  those from this version regardless.


### PR DESCRIPTION
Version bump to 1.8.8 plus the release notes. One change ships in this release: the update-ownership work from #2285.

## What this release carries

The launcher now installs a DevThrottle update from outside the application, confirms the new version answers for itself, and puts the previous version back when it does not. Previously the application replaced its own program file and started the new version, which left nothing running that could tell whether the new version came back - a version that never started was recorded as a success and then logging stopped.

On a Mac a bad update could not be undone at all. Both repair routines gave up unless they were on Windows, and the Mac swap deleted the installed application before moving the new one in, so no copy of the working version survived for them to use even if the platform check had not been there. Both halves are fixed.

## Accuracy notes, checked against the shipped code rather than the design

Two claims in the notes were qualified after checking, because the tidy version of each would have been false:

- **This update installs the way it always has.** A machine on 1.8.7 uses the updater in the build it is already running to fetch 1.8.8. The new route governs the updates that come *after* this one. The notes say so rather than implying the improvement applies to its own delivery.
- **On a Mac the launcher is refreshed by running the installer.** `LauncherUpdater` is marked `[SupportedOSPlatform("windows")]` and the launcher's self-update is only called on Windows, so a Mac's launcher does not update itself. Until the installer is run there once, a Mac keeps updating through the application's own startup path. That path is also fixed in this version - the repair and the after-the-fact check live in the application - so a Mac does gain those immediately. The notes state this distinction instead of claiming the launcher-driven route everywhere.

Nothing else in the notes is flag-gated or design-only: the launcher's update pass is governed by the existing auto-update setting, which is on by default.

## Version number

Patch, not minor, following this repository's own precedent: v1.8.4 shipped remote start, stop and restart plus the centralized skill library as a patch bump, and this release is smaller in user-facing scope than that. Say the word if you would rather this were 1.9.0 - the number is cheap to change until the tag exists.

## Release notes not written for 1.8.5, 1.8.6 and 1.8.7

Flagging rather than fixing, since it is outside this release: `docs/public/release-notes/` has no file for those three versions, so there is no public record of what they contained. Worth a catch-up file if the changelog is meant to be complete.
