### PR TITLE
Surface prompts that were never delivered instead of whispering them into a log (internal#811)

### DIFF
--- a/apps/cockpit/src/sessions/SessionDetail.tsx
+++ b/apps/cockpit/src/sessions/SessionDetail.tsx
@@ -12,6 +12,7 @@ import { SourceControlTab } from "./SourceControlTab";
 import { QueuePanel } from "./QueuePanel";
 import { ScreenshotsPanel } from "./ScreenshotsPanel";
 import { appendToCompose } from "./composerInsert";
+import { promptDeliveryHistory, promptDeliveryNotice } from "@devthrottle/client-core/sessions/delivery";
 
 // The selected session's detail region (issue #972): the live terminal (issue #971's TerminalPane,
 // reused verbatim) stacked over the driver action bar and the composer, with a tabbed dock for the
@@ -139,6 +140,17 @@ export function SessionDetail() {
           )}
         </div>
 
+        {/* A prompt to this session was not delivered (issue internal#811). It sits directly above the
+            composer - the place the words were typed and the place the next attempt will be made - and it
+            stays until something actually lands. The sentence is the Gateway's, rendered verbatim. */}
+        {selected && promptDeliveryNotice(selected) !== null && (
+          <div className="delivery-failure-banner" role="alert">
+            <span className="delivery-failure-title">{promptDeliveryNotice(selected)}</span>
+            {promptDeliveryHistory(selected) !== null && (
+              <span className="delivery-failure-history">{promptDeliveryHistory(selected)}</span>
+            )}
+          </div>
+        )}
         <SessionActionBar sessionId={sessionId} capabilities={selected?.driverCapabilities} />
         <SessionComposer
           sessionId={sessionId}

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -14,6 +14,11 @@ import {
   snoozeExpired,
 } from "@devthrottle/client-core/sessions/ordering";
 import { changesBadge, changesTitle } from "@devthrottle/client-core/sessions/changes";
+import {
+  DELIVERY_BADGE_TEXT,
+  hasUndeliveredPrompt,
+  promptDeliveryTitle,
+} from "@devthrottle/client-core/sessions/delivery";
 import { supervisionStats } from "@devthrottle/client-core/sessions/supervision";
 import { machinePortLabel } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -311,9 +316,14 @@ function RosterRow({
   // this roster and the mobile one cannot say it two different ways. Null on a clean tree AND on an
   // unknown one - see client-core/sessions/changes for why those stay distinct upstream.
   const changes = changesBadge(session);
-  // The tag row (changes / voice / hold-time / snooze-ended / winding-down / last-seen / waiting) renders
-  // only when it has something to say, so a plain working session stays a compact two lines (name + state).
+  // A prompt to this session did not go and nothing has landed since (issue internal#811). The Gateway
+  // decides that and writes the words; the card only has to refuse to be quiet about it.
+  const undelivered = hasUndeliveredPrompt(session);
+  // The tag row (not-delivered / changes / voice / hold-time / snooze-ended / winding-down / last-seen /
+  // waiting) renders only when it has something to say, so a plain working session stays a compact two
+  // lines (name + state).
   const hasTags =
+    undelivered ||
     changes !== null ||
     holdCountdown !== null ||
     snoozeExpired(session) ||
@@ -351,6 +361,14 @@ function RosterRow({
           {/* Line 4 (only when there is something to show): the tags and the live waiting timer. */}
           {hasTags && (
             <span className="roster-tags">
+              {/* First chip in the row, in alarm red: the user's words did not reach the agent. Everything
+                  else on this card describes what the session is doing; only this one says something was
+                  lost. It leads. */}
+              {undelivered && (
+                <span className="roster-tag not-delivered" title={promptDeliveryTitle(session) ?? undefined}>
+                  {DELIVERY_BADGE_TEXT}
+                </span>
+              )}
               {changes !== null && (
                 <span className="roster-tag changes" title={changesTitle(session) ?? undefined}>
                   {changes}

--- a/apps/cockpit/src/sessions/rosterDeliveryBadge.test.tsx
+++ b/apps/cockpit/src/sessions/rosterDeliveryBadge.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// The roster's "not delivered" badge (issue internal#811): a prompt to this session never reached the
+// agent, so the user's words are gone.
+//
+// The case worth a test is the one that was silent when it was wrong. On 2026-07-15 two spoken prompts
+// failed to submit and every screen in the product carried on as if nothing had happened - the only
+// witness was a line in a Director log file, and it went unread for two days. A row that says nothing
+// about a lost prompt is the defect, so these tests assert the badge APPEARS, and that it stays quiet in
+// the two cases where being loud would be noise: a failure that already recovered, and composer retries
+// that cost the user nothing.
+
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  setVoiceModeAllSessions: vi.fn(async () => ({ changed: 0, skipped: 0 })),
+}));
+
+vi.mock("./SessionMenu", () => ({
+  SessionMenu: () => null,
+}));
+
+import { SessionRoster } from "./SessionRoster";
+
+type RosterSession = Record<string, unknown>;
+
+function session(overrides: RosterSession): RosterSession {
+  return {
+    sessionId: "s1",
+    directorId: "dir-A",
+    name: "a session",
+    machineName: "desk",
+    activityState: "Working",
+    effectiveColor: "blue",
+    effectiveColorHex: "#3B82F6",
+    stateLabel: "Working",
+    triageBucket: "active",
+    ...overrides,
+  };
+}
+
+function renderRoster(sessions: RosterSession[]) {
+  return render(
+    <MemoryRouter>
+      <SessionRoster
+        // The component takes SessionDto[]; the test builds the subset of fields the roster reads.
+        sessions={sessions as never}
+        directors={[]}
+        portByDirector={new Map()}
+        selectedId={undefined}
+        view="my-order"
+        error={null}
+        onView={() => {}}
+        onNewSession={() => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+const NOTICE = "Your last prompt was not delivered - the agent never received it. The composer never echoed.";
+
+afterEach(() => cleanup());
+
+describe("the roster's not-delivered badge", () => {
+  it("shows the badge when the Gateway says a prompt was lost", () => {
+    renderRoster([session({ promptDeliveryNotice: NOTICE })]);
+
+    const badge = screen.getByText("not delivered");
+    expect(badge).toBeTruthy();
+    expect(badge.className).toContain("not-delivered");
+  });
+
+  it("puts the Gateway's sentence in the tooltip, with the history when there is one", () => {
+    renderRoster([
+      session({ promptDeliveryNotice: NOTICE, failedPromptDeliveries: 2, composerEchoMisses: 6 }),
+    ]);
+
+    expect(screen.getByText("not delivered").getAttribute("title")).toBe(
+      `${NOTICE} (2 failed deliveries on this session, 6 composer retries)`,
+    );
+  });
+
+  it("shows nothing for a session that has never lost a prompt", () => {
+    renderRoster([session({})]);
+
+    expect(screen.queryByText("not delivered")).toBeNull();
+  });
+
+  it("shows nothing once a later prompt got through, even though the counts remain", () => {
+    // The alarm answers "are my words gone right now". A retry that landed answers it: no.
+    renderRoster([session({ failedPromptDeliveries: 4, composerEchoMisses: 9 })]);
+
+    expect(screen.queryByText("not delivered")).toBeNull();
+  });
+
+  it("does not repaint the dot - the agent is doing exactly what it was doing", () => {
+    // The colour describes the AGENT. It never heard the prompt, so nothing about it changed; recolouring
+    // it would tell a lie about the agent in order to tell the truth about the delivery.
+    const { container } = renderRoster([session({ promptDeliveryNotice: NOTICE })]);
+
+    const dot = container.querySelector(".roster-dot") as HTMLElement;
+    expect(dot.style.backgroundColor).toBe("rgb(59, 130, 246)");
+  });
+});

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -938,6 +938,17 @@ body {
   color: #f5d060;
 }
 
+/* A prompt to this session was NOT delivered - the user's words never reached the agent (issue
+   internal#811). Alarm red, because this is the one chip that reports a LOSS rather than a state. The dot
+   is deliberately untouched: the agent is doing exactly what it was doing, having heard nothing, and
+   recolouring it would tell a lie about the agent to tell the truth about the delivery. */
+.roster-tag.not-delivered {
+  background: rgba(220, 68, 68, 0.18);
+  border-color: rgba(220, 68, 68, 0.7);
+  color: #f08a8a;
+  font-weight: 600;
+}
+
 /* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour): the dot
    still tells the truth about the work while this rides beside it. Mirrors the desktop rail's badge. */
 .roster-tag.winding-down {
@@ -1054,6 +1065,30 @@ body {
   flex: 1 1 auto;
   min-height: 0;
   height: auto;
+}
+
+/* "Your last prompt was not delivered" (issue internal#811), pinned above the action bar and the composer.
+   It does not fade and it cannot be dismissed: it goes away when a prompt actually lands, which is the
+   only thing that fixes it. Two lines - the Gateway's sentence, then how often this has happened here. */
+.delivery-failure-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  background: rgba(220, 68, 68, 0.14);
+  border-top: 1px solid rgba(220, 68, 68, 0.7);
+  flex: 0 0 auto;
+}
+
+.delivery-failure-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f08a8a;
+}
+
+.delivery-failure-history {
+  font-size: 11.5px;
+  color: var(--text-dim);
 }
 
 .action-bar {

--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -182,6 +182,15 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
       </div>
 
       {manage.error !== null && <div className="banner banner-error" role="alert">{manage.error}</div>}
+      {/* A prompt to this session was NOT delivered - the user's words never reached the agent (issue
+          internal#811). It lives on the shared app bar so it is on EVERY per-session screen: the loss
+          usually happens while the phone is somewhere else entirely (a dictation sent from the roster,
+          the screen locked), so a banner that only existed on one tab would be a banner nobody sees.
+          Sticky by design - it clears when a prompt actually lands, never on a tap and never on a timer -
+          because a failure the user can wave away is how two spoken prompts went missing for two days. */}
+      {manage.deliveryNotice !== null && (
+        <div className="banner banner-not-delivered" role="alert">{manage.deliveryNotice}</div>
+      )}
       {/* The snooze pill. A DEFERRED snooze reads "Snoozing when it finishes" (asked for while the agent is
           working, so it arms when the work ends) - this is what makes snoozing a busy session give instant
           feedback instead of looking like nothing happened. An armed snooze reads the Gateway FOLD

--- a/apps/mobile/src/components/useSessionManage.ts
+++ b/apps/mobile/src/components/useSessionManage.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { holdSession, killSession, listSessions } from "@devthrottle/client-core/api/client";
 import { classify, isDeferredHold, isWorking, snoozeCountdown } from "@devthrottle/client-core/sessions/ordering";
+import { promptDeliveryNotice } from "@devthrottle/client-core/sessions/delivery";
 import {
   isSnoozing,
   optimisticHoldFor,
@@ -42,6 +43,10 @@ export interface SessionManage {
   snoozed: boolean;
   // "wakes in 3h 48m" from the Gateway-owned snooze clock, or null when there is no running clock.
   holdCountdown: string | null;
+  // "Your last prompt was not delivered ..." - the Gateway's sentence for a prompt that never reached the
+  // agent (issue internal#811), or null when nothing was lost. Rendered VERBATIM by the app bar, so every
+  // per-session screen says it, not just the one the user happened to be on when it happened.
+  deliveryNotice: string | null;
   busy: boolean;
   error: string | null;
   setError: (message: string | null) => void;
@@ -62,6 +67,7 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
   const [working, setWorking] = useState(false);
   const [snoozed, setSnoozed] = useState(false);
   const [holdCountdown, setHoldCountdown] = useState<string | null>(null);
+  const [deliveryNotice, setDeliveryNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // While a toggle is in flight the optimistic state must not be clobbered by a slower poll.
@@ -83,6 +89,10 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
         // Whether snoozing NOW would defer (working) or arm (settled) - drives the optimistic affordance.
         setWorking(isWorking(match));
         setHoldCountdown(snoozeCountdown(match));
+        // A prompt that did not reach the agent (issue internal#811). Read on the SAME poll as the hold
+        // state so the banner appears without the user doing anything - the failure happened while they
+        // were looking at some other screen, which is exactly why it has to find them.
+        setDeliveryNotice(promptDeliveryNotice(match));
         // classify fails loud against a Gateway that did not stamp triageBucket; in this polling loop a
         // mixed-version blip must not throw the refresh, so keep the last verdict on that rare miss.
         try {
@@ -185,6 +195,7 @@ export function useSessionManage(sessionId: string | undefined): SessionManage {
     deferred,
     snoozed,
     holdCountdown,
+    deliveryNotice,
     busy,
     error,
     setError,

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { useVoiceModeAll } from "@devthrottle/client-core/voice/useVoiceModeAll"
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
 import { classify, contextLine, deletionReason, dotHex, inBucket, inDesktopOrder, inWaitingOrder, isWorking, pendingDeletion, repoLeaf, snoozeCountdown, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
+import { DELIVERY_BADGE_TEXT, hasUndeliveredPrompt, promptDeliveryTitle } from "@devthrottle/client-core/sessions/delivery";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -616,6 +617,15 @@ function SessionRow({ session, mark, fromTab = "all" }: { session: SessionDto; m
               an expired snooze on its own (the dead-man's switch fired) - so the reader knows this is a
               "go see why it went quiet" item, not a fresh turn-end. */}
           {snoozeExpired(session) && <span className="row-snooze-ended">Snooze ended</span>}
+          {/* A prompt to this session was NOT delivered - the user's words never reached the agent (issue
+              internal#811). Sticky and red, never a toast: the loss stays on the card until something
+              actually lands. Two spoken prompts died in a log file on 2026-07-15 because no card said
+              anything. The Gateway writes the sentence; this row only refuses to be quiet. */}
+          {hasUndeliveredPrompt(session) && (
+            <span className="row-not-delivered" title={promptDeliveryTitle(session) ?? undefined}>
+              {DELIVERY_BADGE_TEXT}
+            </span>
+          )}
           {/* A session flagged for deletion wears a neutral "winding down" badge (a BADGE, never a colour):
               the dot keeps telling the truth about the work while this rides beside it. */}
           {windingDown && (

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -152,6 +152,16 @@ body {
   color: #ffb4b4;
 }
 
+/* "Your last prompt was not delivered" (issue internal#811). Louder than banner-error on purpose: an
+   error banner reports that an action you just took failed and you can see it fail; this reports that
+   words you believed had been sent were thrown away, possibly minutes ago on another screen. */
+.banner-not-delivered {
+  background: rgba(220, 68, 68, 0.18);
+  border: 1px solid rgba(220, 68, 68, 0.7);
+  color: #ffb4b4;
+  font-weight: 600;
+}
+
 .banner-info {
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.35);
@@ -362,6 +372,25 @@ a.banner-btn {
   background: rgba(217, 145, 32, 0.16);
   border: 1px solid rgba(217, 145, 32, 0.55);
   color: #d99120;
+}
+
+/* A prompt to this session was NOT delivered - the words never reached the agent (issue internal#811).
+   Same badge shape as the snooze-ended one, in alarm red, because this is the only badge on the card that
+   reports a LOSS rather than a state. Sticky: it clears when a prompt lands, not on a timer and not on a
+   tap. The dot is deliberately untouched - the agent is doing what it was doing, having heard nothing. */
+.row-not-delivered {
+  display: inline-block;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 1px 7px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  background: rgba(220, 68, 68, 0.18);
+  border: 1px solid rgba(220, 68, 68, 0.7);
+  color: #f08a8a;
 }
 
 /* The Gateway-owned hold time on a snoozed row ("wakes in 3h 48m"), right-aligned on the status line like

--- a/packages/client-core/src/sessions/delivery.test.ts
+++ b/packages/client-core/src/sessions/delivery.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "../api/client";
+import {
+  DELIVERY_BADGE_TEXT,
+  hasUndeliveredPrompt,
+  promptDeliveryHistory,
+  promptDeliveryNotice,
+  promptDeliveryTitle,
+} from "./delivery";
+
+// A row as the Gateway stamps it. Extra keys are what the augmented type covers.
+function session(extra: Record<string, unknown> = {}): SessionDto {
+  return { sessionId: "s1", ...extra } as unknown as SessionDto;
+}
+
+describe("promptDeliveryNotice", () => {
+  it("renders the Gateway's sentence verbatim", () => {
+    const notice = "Your last prompt was not delivered - the agent never received it. The composer never echoed.";
+    expect(promptDeliveryNotice(session({ promptDeliveryNotice: notice }))).toBe(notice);
+  });
+
+  it("says nothing when the Gateway stamped nothing", () => {
+    expect(promptDeliveryNotice(session())).toBeNull();
+  });
+
+  it("says nothing on an old Gateway that cannot stamp it, rather than composing its own words", () => {
+    // The client is dumb. Given the raw facts but no verdict, the honest answer is silence - inventing a
+    // sentence here is exactly the second-answer defect the Gateway fold exists to prevent.
+    const s = session({ promptDeliveryUnresolved: true, failedPromptDeliveries: 3 });
+    expect(promptDeliveryNotice(s)).toBeNull();
+    expect(hasUndeliveredPrompt(s)).toBe(false);
+  });
+
+  it("treats a blank stamp as nothing to say", () => {
+    expect(promptDeliveryNotice(session({ promptDeliveryNotice: "   " }))).toBeNull();
+  });
+});
+
+describe("hasUndeliveredPrompt", () => {
+  it("is true exactly when there is a notice, so the badge and the banner cannot disagree", () => {
+    expect(hasUndeliveredPrompt(session({ promptDeliveryNotice: "gone" }))).toBe(true);
+    expect(hasUndeliveredPrompt(session())).toBe(false);
+  });
+
+  it("stays quiet once the failure is resolved, even with counts still on the row", () => {
+    // A retry got through. The counts remain (they are the history); the alarm does not.
+    const s = session({ failedPromptDeliveries: 4, composerEchoMisses: 9 });
+    expect(hasUndeliveredPrompt(s)).toBe(false);
+  });
+});
+
+describe("promptDeliveryHistory", () => {
+  it("says nothing for a single failure and no retries - the notice already covers it", () => {
+    expect(promptDeliveryHistory(session({ failedPromptDeliveries: 1 }))).toBeNull();
+  });
+
+  it("names repeated failures", () => {
+    expect(promptDeliveryHistory(session({ failedPromptDeliveries: 4 }))).toBe("4 failed deliveries on this session");
+  });
+
+  it("names composer retries, singular and plural", () => {
+    expect(promptDeliveryHistory(session({ composerEchoMisses: 1 }))).toBe("1 composer retry");
+    expect(promptDeliveryHistory(session({ composerEchoMisses: 6 }))).toBe("6 composer retries");
+  });
+
+  it("joins both when both happened", () => {
+    expect(promptDeliveryHistory(session({ failedPromptDeliveries: 2, composerEchoMisses: 6 }))).toBe(
+      "2 failed deliveries on this session, 6 composer retries",
+    );
+  });
+
+  it("coerces the numeric-string form the serializer can emit", () => {
+    expect(promptDeliveryHistory(session({ composerEchoMisses: "3" }))).toBe("3 composer retries");
+  });
+
+  it("treats an unparseable or negative count as nothing rather than rendering junk", () => {
+    expect(promptDeliveryHistory(session({ composerEchoMisses: "many", failedPromptDeliveries: -2 }))).toBeNull();
+  });
+});
+
+describe("promptDeliveryTitle", () => {
+  it("is the notice alone when there is no history worth adding", () => {
+    const s = session({ promptDeliveryNotice: "Your last prompt was not delivered.", failedPromptDeliveries: 1 });
+    expect(promptDeliveryTitle(s)).toBe("Your last prompt was not delivered.");
+  });
+
+  it("appends the history when this session has form", () => {
+    const s = session({
+      promptDeliveryNotice: "Your last prompt was not delivered.",
+      failedPromptDeliveries: 2,
+      composerEchoMisses: 6,
+    });
+    expect(promptDeliveryTitle(s)).toBe(
+      "Your last prompt was not delivered. (2 failed deliveries on this session, 6 composer retries)",
+    );
+  });
+
+  it("is null when there is no notice, so no tooltip is attached to a badge that is not there", () => {
+    expect(promptDeliveryTitle(session({ failedPromptDeliveries: 9 }))).toBeNull();
+  });
+});
+
+describe("the badge text", () => {
+  it("names the loss rather than the mechanism", () => {
+    // "not delivered" is what happened to the user. "echo miss" is what happened to the terminal, and
+    // nobody reading a roster at speed can act on that.
+    expect(DELIVERY_BADGE_TEXT).toBe("not delivered");
+  });
+});

--- a/packages/client-core/src/sessions/delivery.ts
+++ b/packages/client-core/src/sessions/delivery.ts
@@ -1,0 +1,86 @@
+// The one place any web client turns "a prompt to this session did not go" into something to render
+// (issue internal#811).
+//
+// WHY THIS FILE EXISTS. On 2026-07-15 two spoken prompts failed to submit. The Director wrote
+// "Command FAILED: the composer never echoed the typed text" into a log file and nothing else happened -
+// no badge, no banner, nothing on any screen. The words were gone and the bug went on losing more of them
+// for two days, because the only witness was a file nobody reads. A delivery failure is the user's
+// sentence being deleted; it belongs on the screen.
+//
+// THE DIVISION OF LABOUR. The Director counts the failures (only the machine running the terminal can see
+// one happen). The Gateway folds the SENTENCE - SessionOrdering.PromptDeliveryNotice - so every client
+// renders one set of words it did not compose (CLAUDE.md rule 7). This file does no ruling: it reads the
+// stamped fields and decides only the SHAPE of the badge and its tooltip, once, so the Cockpit roster and
+// the mobile roster cannot say the same fact two different ways.
+import type { SessionDto } from "../api/client";
+
+// The generated schema.ts does not carry these fields yet, so they are augmented here - the same way
+// uncommittedCount is augmented in changes.ts and the Gateway-stamped fields are in ordering.ts.
+type SessionWithDelivery = SessionDto & {
+  promptDeliveryNotice?: string | null;
+  promptDeliveryUnresolved?: boolean | null;
+  failedPromptDeliveries?: number | string | null;
+  composerEchoMisses?: number | string | null;
+};
+
+/** Coerce the numeric-string form the serializer can emit; anything unparseable counts as zero. */
+function count(raw: number | string | null | undefined): number {
+  if (raw === null || raw === undefined) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+/**
+ * The Gateway's plain-English notice that this session's last prompt was lost, or null when there is
+ * nothing to say. Rendered VERBATIM - a client never composes these words and never decides when they
+ * apply. Null on an old Gateway that does not stamp it, which is the honest answer: no verdict arrived,
+ * so none is shown.
+ */
+export function promptDeliveryNotice(session: SessionDto): string | null {
+  const notice = (session as SessionWithDelivery).promptDeliveryNotice;
+  if (typeof notice !== "string") return null;
+  const trimmed = notice.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Should this session's row wear the loud "not delivered" badge? True only while the failure is live -
+ * the last send failed and nothing has landed since. Driven by the Gateway's notice, so the badge and the
+ * banner cannot disagree about whether there is a problem.
+ */
+export function hasUndeliveredPrompt(session: SessionDto): boolean {
+  return promptDeliveryNotice(session) !== null;
+}
+
+/** The badge text. Short, because it sits in a row of chips; the tooltip carries the detail. */
+export const DELIVERY_BADGE_TEXT = "not delivered";
+
+/**
+ * The badge's tooltip: the Gateway's sentence, plus how often this has happened on this session when it
+ * has happened more than once. The counts are shown ONLY here and never as their own chip - a number on
+ * the row would compete with the thing the reader must act on, which is that their words are gone.
+ */
+export function promptDeliveryTitle(session: SessionDto): string | null {
+  const notice = promptDeliveryNotice(session);
+  if (notice === null) return null;
+  const history = promptDeliveryHistory(session);
+  return history === null ? notice : `${notice} (${history})`;
+}
+
+/**
+ * How often delivery has gone wrong on this session, in plain words, or null when there is nothing worth
+ * saying - a single failure and no composer retries is already fully described by the notice.
+ *
+ * Counts SURVIVE a recovery on purpose: "this has failed four times today" stays true after the fifth
+ * attempt gets through, and it is the number that says whether the session is sick or was unlucky once.
+ */
+export function promptDeliveryHistory(session: SessionDto): string | null {
+  const s = session as SessionWithDelivery;
+  const failures = count(s.failedPromptDeliveries);
+  const misses = count(s.composerEchoMisses);
+  const parts: string[] = [];
+  if (failures > 1) parts.push(`${failures} failed deliveries on this session`);
+  if (misses > 0) parts.push(misses === 1 ? "1 composer retry" : `${misses} composer retries`);
+  return parts.length > 0 ? parts.join(", ") : null;
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -586,6 +586,26 @@
                                                        FontSize="9"
                                                        FontWeight="SemiBold" />
                                         </Border>
+                                        <!-- Not-delivered badge (issue internal#811): a prompt to this
+                                             session never reached the agent - the user's words are gone.
+                                             The ONE badge on this row that is not neutral gray, and the
+                                             only one that reports a LOSS rather than a state, so it is
+                                             red and it leads. Still a BADGE, NEVER A COLOUR: the agent
+                                             is doing exactly what it was doing, having heard nothing, so
+                                             the dot keeps telling the truth about the work. It clears
+                                             when a prompt actually lands, never on a click. -->
+                                        <Border Background="#33DC4444"
+                                                CornerRadius="6"
+                                                Padding="6,1"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                IsVisible="{Binding HasUndeliveredPrompt}"
+                                                ToolTip.Tip="{Binding UndeliveredPromptTooltip}">
+                                            <TextBlock Text="NOT DELIVERED"
+                                                       Foreground="#F08A8A"
+                                                       FontSize="9"
+                                                       FontWeight="SemiBold" />
+                                        </Border>
                                         <!-- Winding-down badge (defect 23): the session is flagged for
                                              deletion and the reaper will remove it shortly. A BADGE,
                                              NEVER A COLOUR (owner's ruling, 14 July 2026): pending

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -85,6 +85,10 @@ public class SessionViewModel : INotifyPropertyChanged
         // The uncommitted-file count now arrives from the Director's monitor rather than from a timer this
         // window owns, so the badge needs its own invalidation the same way every other pushed fact does.
         session.OnUncommittedCountChanged += OnUncommittedCountChangedVm;
+        // A prompt was lost, or a later one landed and cleared the alarm (issue internal#811). Its own
+        // handler, like the deletion badge, because it is a raw local FACT and not one of the Gateway-fold
+        // inputs RaiseFoldProjection re-reads.
+        session.OnPromptDeliveryChanged += OnPromptDeliveryChangedVm;
 
         if (session.PromptQueue != null)
         {
@@ -347,6 +351,31 @@ public class SessionViewModel : INotifyPropertyChanged
     /// </summary>
     public bool IsPendingDeletion => Session.PendingDeletion;
 
+    /// <summary>
+    /// True when a prompt to this session was NOT delivered and nothing has landed since - the user's
+    /// words are gone right now (issue internal#811). Drives the rail's red "NOT DELIVERED" badge.
+    ///
+    /// THE RAIL CALLS THE SHARED FOLD HERE, AND THAT IS NOT A RELAPSE. The rail deliberately does not
+    /// fold the COLOUR (see <see cref="EffectiveColor"/>): that fold reads inputs only the Gateway has -
+    /// a phone dictation, a voice summary in preparation, the snooze clock - so a local re-run diverges.
+    /// This fold reads the opposite kind of input. Every fact behind it is DIRECTOR-LOCAL and firsthand:
+    /// only the machine running the terminal can see a submit fail, and <see cref="FoldInput"/> carries
+    /// those facts because this Director is the thing that reported them upward in the first place.
+    /// Calling <see cref="SessionOrdering.PromptDeliveryNotice"/> here is therefore the SAME answer the
+    /// Gateway gives, from the same function - not a second one - and it survives the tunnel being down,
+    /// which is exactly when a delivery is most likely to have failed.
+    ///
+    /// A BADGE, NEVER A COLOUR, for the same reason as the winding-down badge above: the agent never
+    /// heard the prompt, so nothing about what it is DOING changed. Recolouring the dot would tell a lie
+    /// about the agent in order to tell the truth about the delivery.
+    /// </summary>
+    public bool HasUndeliveredPrompt => SessionOrdering.PromptDeliveryNotice(FoldInput) is not null;
+
+    /// <summary>The "NOT DELIVERED" badge tooltip: the Gateway fold's own sentence, so the rail, the
+    /// Cockpit and the phone all say the words once.</summary>
+    public string UndeliveredPromptTooltip =>
+        SessionOrdering.PromptDeliveryNotice(FoldInput) ?? "";
+
     /// <summary>The "winding down" badge tooltip: the human reason captured when the session was
     /// flagged (e.g. "jobs-auto: nothing to report"), or a plain fallback when none was given.</summary>
     public string PendingDeletionTooltip => Session.DeletionReason is { } reason
@@ -357,6 +386,17 @@ public class SessionViewModel : INotifyPropertyChanged
     /// badge on the UI thread. This is the session's own signal (<see cref="Session.OnPendingDeletionChanged"/>);
     /// the rail used to learn about deletion only because MarkForDeletion wrote a colour, which it no
     /// longer does and was never allowed to.</summary>
+    /// <summary>Issue internal#811: the delivery alarm turned on or off - repaint the badge on the UI
+    /// thread. Both properties move together; they read the same fold.</summary>
+    private void OnPromptDeliveryChangedVm()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            OnPropertyChanged(nameof(HasUndeliveredPrompt));
+            OnPropertyChanged(nameof(UndeliveredPromptTooltip));
+        });
+    }
+
     private void OnPendingDeletionChangedVm(bool _)
     {
         Dispatcher.UIThread.Post(() =>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -44,6 +44,35 @@ internal static class ControlEndpoints
             MachineName = Environment.MachineName,
         }));
 
+        // ===== Prompts that did not go (issue internal#811) =====
+        // The question the issue is named after - "how often is this happening?" - answered without
+        // grepping a log file. Every session's row already carries its own counts and shows the loud
+        // badge; this is the FLEET view for a person or an agent asking the Director directly.
+        //
+        // In-memory and process-lifetime, exactly like the browser error ring: the FileLog line remains
+        // the durable record, and an empty list means nothing has failed since this Director started - it
+        // never means nothing ever failed. Carries no prompt text, only its length.
+        app.MapGet("/prompt-delivery-failures", (int? count) =>
+        {
+            var max = count is > 0 ? count.Value : 50;
+            var recent = CcDirector.Core.Input.PromptDeliveryFailures.Recent(max);
+            return Results.Json(new
+            {
+                failedDeliveries = recent.Count(r => r.Kind == "failed-delivery"),
+                composerEchoMisses = recent.Count(r => r.Kind == "composer-echo-miss"),
+                note = "In memory since this Director started. The durable record is the Director log.",
+                recent = recent.Select(r => new
+                {
+                    atUtc = r.AtUtc,
+                    sessionId = r.SessionId.ToString(),
+                    kind = r.Kind,
+                    source = r.Source,
+                    reason = r.Reason,
+                    textLength = r.TextLength,
+                }),
+            });
+        });
+
         // The launch-time "fleet awareness" preamble for a session: its own identity plus the
         // cc-devthrottle commands to reach the rest of the fleet. The Claude SessionStart hook fetches this
         // and injects it as additionalContext so the agent knows the fleet instantly, with no
@@ -1593,6 +1622,9 @@ internal static class ControlEndpoints
         // Issue #335: build the viewUrl from the resolved tailnetEndpoint and the configured
         // gatewayUrl. Format: {tailnetEndpoint}/sessions/{sid}/view?gw={gatewayBase}
         // Only set when a real (non-empty) tailnetEndpoint resolved - never a loopback lie.
+        // The prompt-delivery ledger for this session, read once for the row (issue internal#811).
+        var deliveryTally = CcDirector.Core.Input.PromptDeliveryFailures.Tally(s.Id);
+
         var viewUrl = "";
         if (!string.IsNullOrEmpty(tailnetEndpoint))
         {
@@ -1660,6 +1692,15 @@ internal static class ControlEndpoints
             // Only a Director can see this: desktop typing never leaves the machine, and the origin is
             // known only at the input choke points. The Gateway rules on what it means.
             LastOwnerTurnAtUtc = s.LastOwnerTurnAtUtc,
+            // Prompts that did not go (issue internal#811). Only this machine can see a delivery fail, so
+            // the counts and the unresolved flag are reported here as FACTS; the Gateway folds the words.
+            // Before this they existed solely as a line in a Director log file, which is how two spoken
+            // prompts were lost on 2026-07-15 and nobody found out for two days.
+            FailedPromptDeliveries = deliveryTally.FailedDeliveries,
+            ComposerEchoMisses = deliveryTally.ComposerEchoMisses,
+            LastPromptDeliveryFailureAtUtc = deliveryTally.LastFailureAtUtc,
+            LastPromptDeliveryFailureReason = deliveryTally.LastFailureReason,
+            PromptDeliveryUnresolved = deliveryTally.Unresolved,
             PendingDeletion = s.PendingDeletion,
             DeletionReason = s.DeletionReason,
             WingmanEnabled = s.WingmanEnabled,

--- a/src/CcDirector.Core.Tests/Input/PromptDeliveryFailuresTests.cs
+++ b/src/CcDirector.Core.Tests/Input/PromptDeliveryFailuresTests.cs
@@ -1,0 +1,219 @@
+using CcDirector.Core.Input;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Input;
+
+/// <summary>
+/// The ledger of prompts that did not go (issue internal#811). These tests pin the three things the
+/// surfaces depend on: that a failure is COUNTED, that "your words are gone right now" is distinct from
+/// "this went wrong earlier and recovered", and that a lucky retry never erases the history.
+///
+/// The ledger is a process-wide static (one Director, one ledger, read from the session mapper), so every
+/// test resets it first and uses its own session id.
+/// </summary>
+[Collection("PromptDeliveryFailures")]
+public sealed class PromptDeliveryFailuresTests
+{
+    public PromptDeliveryFailuresTests() => PromptDeliveryFailures.ResetForTests();
+
+    [Fact]
+    public void Tally_SessionThatNeverFailed_IsAllZeroAndSaysNothing()
+    {
+        var tally = PromptDeliveryFailures.Tally(Guid.NewGuid());
+
+        Assert.Equal(0, tally.FailedDeliveries);
+        Assert.Equal(0, tally.ComposerEchoMisses);
+        Assert.Null(tally.LastFailureAtUtc);
+        Assert.Null(tally.LastFailureReason);
+        Assert.False(tally.Unresolved);
+    }
+
+    [Fact]
+    public void RecordFailedDelivery_CountsItAndMarksTheSessionUnresolved()
+    {
+        var session = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordFailedDelivery(
+            session, "Delivery", "the composer never echoed the typed text after 2 attempts", 739);
+
+        var tally = PromptDeliveryFailures.Tally(session);
+        Assert.Equal(1, tally.FailedDeliveries);
+        Assert.True(tally.Unresolved);
+        Assert.NotNull(tally.LastFailureAtUtc);
+        Assert.Contains("never echoed", tally.LastFailureReason);
+    }
+
+    [Fact]
+    public void RecordDeliverySucceeded_ClearsTheAlarmButKeepsTheCount()
+    {
+        // THE DISTINCTION THE WHOLE FEATURE RESTS ON. "Unresolved" is the alarm - your words are gone right
+        // now - and a later prompt landing is the only thing that answers it. The COUNT is the history, and
+        // a lucky retry must not be able to erase the fact that this session ate a prompt.
+        var session = Guid.NewGuid();
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", "the composer never echoed", 739);
+
+        PromptDeliveryFailures.RecordDeliverySucceeded(session);
+
+        var tally = PromptDeliveryFailures.Tally(session);
+        Assert.False(tally.Unresolved);
+        Assert.Equal(1, tally.FailedDeliveries);
+        Assert.NotNull(tally.LastFailureAtUtc);
+    }
+
+    [Fact]
+    public void RecordFailedDelivery_AfterARecovery_RaisesTheAlarmAgain()
+    {
+        var session = Guid.NewGuid();
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", "first loss", 10);
+        PromptDeliveryFailures.RecordDeliverySucceeded(session);
+
+        PromptDeliveryFailures.RecordFailedDelivery(session, "UserInput", "second loss", 20);
+
+        var tally = PromptDeliveryFailures.Tally(session);
+        Assert.True(tally.Unresolved);
+        Assert.Equal(2, tally.FailedDeliveries);
+        Assert.Equal("second loss", tally.LastFailureReason);
+    }
+
+    [Fact]
+    public void RecordDeliverySucceeded_OnASessionThatNeverFailed_ChangesNothing()
+    {
+        var session = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordDeliverySucceeded(session);
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(session));
+    }
+
+    [Fact]
+    public void RecordComposerEchoMiss_IsCountedButRaisesNoAlarm()
+    {
+        // A miss that recovers on the retype costs the user nothing, so it must never light the "your words
+        // are gone" alarm. It is still counted, because the misses are the leading indicator of the losses -
+        // on 2026-07-15 there were six misses and two of them became losses, and nobody could see either.
+        var session = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordComposerEchoMiss(session, "ClaudeDriver", attempt: 1, textLength: 739);
+        PromptDeliveryFailures.RecordComposerEchoMiss(session, "ClaudeDriver", attempt: 2, textLength: 739);
+
+        var tally = PromptDeliveryFailures.Tally(session);
+        Assert.Equal(2, tally.ComposerEchoMisses);
+        Assert.Equal(0, tally.FailedDeliveries);
+        Assert.False(tally.Unresolved);
+    }
+
+    [Fact]
+    public void EchoMissesAndFailures_AreCountedOnSeparateLanes()
+    {
+        var session = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordComposerEchoMiss(session, "ClaudeDriver", 1, 739);
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", "gone", 739);
+
+        var tally = PromptDeliveryFailures.Tally(session);
+        Assert.Equal(1, tally.ComposerEchoMisses);
+        Assert.Equal(1, tally.FailedDeliveries);
+    }
+
+    [Fact]
+    public void Ledgers_AreKeptApartPerSession()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordFailedDelivery(a, "Delivery", "gone", 5);
+
+        Assert.True(PromptDeliveryFailures.Tally(a).Unresolved);
+        Assert.False(PromptDeliveryFailures.Tally(b).Unresolved);
+    }
+
+    [Fact]
+    public void EmptySessionId_IsIgnoredRatherThanBecomingAPhantomLedger()
+    {
+        // The submit routes that carry no session (the driver and backend call sites) pass the default id.
+        // Counting those together under one empty guid would invent a "session" nothing can render.
+        PromptDeliveryFailures.RecordComposerEchoMiss(Guid.Empty, "CodexDriver", 1, 40);
+        PromptDeliveryFailures.RecordFailedDelivery(Guid.Empty, "Agent", "gone", 40);
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(Guid.Empty));
+        Assert.Empty(PromptDeliveryFailures.Recent());
+    }
+
+    [Fact]
+    public void Recent_ReturnsTheFleetWideHistoryNewestFirst()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        PromptDeliveryFailures.RecordFailedDelivery(a, "Delivery", "first", 1);
+        PromptDeliveryFailures.RecordComposerEchoMiss(b, "PiDriver", 1, 2);
+        PromptDeliveryFailures.RecordFailedDelivery(b, "UserInput", "third", 3);
+
+        var recent = PromptDeliveryFailures.Recent();
+
+        Assert.Equal(3, recent.Count);
+        Assert.Equal("third", recent[0].Reason);
+        Assert.Equal("failed-delivery", recent[0].Kind);
+        Assert.Equal("composer-echo-miss", recent[1].Kind);
+        Assert.Equal("first", recent[2].Reason);
+    }
+
+    [Fact]
+    public void Recent_IsCappedSoALoopingFailureCannotGrowWithoutBound()
+    {
+        var session = Guid.NewGuid();
+        for (var i = 0; i < PromptDeliveryFailures.RingCapacity + 25; i++)
+            PromptDeliveryFailures.RecordFailedDelivery(session, "Agent", $"loss {i}", 1);
+
+        var recent = PromptDeliveryFailures.Recent();
+
+        Assert.Equal(PromptDeliveryFailures.RingCapacity, recent.Count);
+        // Newest survive: the last one recorded is the first one returned.
+        Assert.Equal($"loss {PromptDeliveryFailures.RingCapacity + 24}", recent[0].Reason);
+        // The per-session COUNT is not capped - it counted every one of them.
+        Assert.Equal(PromptDeliveryFailures.RingCapacity + 25, PromptDeliveryFailures.Tally(session).FailedDeliveries);
+    }
+
+    [Fact]
+    public void Reason_IsOneLineAndLengthCappedSoARowCanRenderIt()
+    {
+        var session = Guid.NewGuid();
+        var sprawling = "line one\r\nline two " + new string('x', PromptDeliveryFailures.MaxReasonChars);
+
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", sprawling, 1);
+
+        var reason = PromptDeliveryFailures.Tally(session).LastFailureReason!;
+        Assert.DoesNotContain('\n', reason);
+        Assert.DoesNotContain('\r', reason);
+        Assert.True(reason.Length <= PromptDeliveryFailures.MaxReasonChars + 3, $"reason was {reason.Length} chars");
+    }
+
+    [Fact]
+    public void Reason_ThatIsBlank_StillSaysSomethingRatherThanNothing()
+    {
+        var session = Guid.NewGuid();
+
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", "   ", 1);
+
+        Assert.Equal("the send failed without saying why", PromptDeliveryFailures.Tally(session).LastFailureReason);
+    }
+
+    [Fact]
+    public void Forget_DropsTheSessionsCountersWhenNothingCanRenderThemAnyMore()
+    {
+        var session = Guid.NewGuid();
+        PromptDeliveryFailures.RecordFailedDelivery(session, "Delivery", "gone", 1);
+
+        PromptDeliveryFailures.Forget(session);
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(session));
+        // The fleet-wide history is NOT forgotten with the session - it is the record of what happened.
+        Assert.Single(PromptDeliveryFailures.Recent());
+    }
+}
+
+/// <summary>
+/// The ledger is process-wide, so every test that writes to it runs in one collection rather than in
+/// parallel with the others - two tests resetting it under each other would make both flaky.
+/// </summary>
+[CollectionDefinition("PromptDeliveryFailures", DisableParallelization = true)]
+public sealed class PromptDeliveryFailuresCollection { }

--- a/src/CcDirector.Core.Tests/Input/SessionPromptDeliveryFailureTests.cs
+++ b/src/CcDirector.Core.Tests/Input/SessionPromptDeliveryFailureTests.cs
@@ -1,0 +1,143 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Input;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Input;
+
+/// <summary>
+/// The delivery boundary (issue internal#811). <see cref="Session.SendTextAsync"/> is the one place in
+/// the Director that knows BOTH which session the words were for AND whether they went. Before this, a
+/// throw here travelled up as an error string on whichever caller happened to be listening plus a line in
+/// a log file - which is how two spoken prompts were lost on 2026-07-15 and nobody noticed for two days.
+///
+/// Watched failing before the catch existed: without it every assertion below reads zero.
+/// </summary>
+[Collection("PromptDeliveryFailures")]
+public sealed class SessionPromptDeliveryFailureTests
+{
+    public SessionPromptDeliveryFailureTests() => PromptDeliveryFailures.ResetForTests();
+
+    [Fact]
+    public async Task SendTextAsync_WhenTheSubmitThrows_CountsTheLostPromptAgainstTheSession()
+    {
+        var backend = new ScriptedBackend { Fail = true };
+        using var session = NewSession(backend);
+
+        await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
+            () => session.SendTextAsync("the words the owner spoke", SendSource.Delivery));
+
+        var tally = PromptDeliveryFailures.Tally(session.Id);
+        Assert.Equal(1, tally.FailedDeliveries);
+        Assert.True(tally.Unresolved);
+        Assert.Contains("composer never echoed", tally.LastFailureReason);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_WhenTheSubmitThrows_StillPropagatesTheException()
+    {
+        // Counting the loss is not the same as handling it. The caller's own error path - the 502 the
+        // dictation endpoint returns, the phone's retry - must be completely undisturbed by the ledger.
+        var backend = new ScriptedBackend { Fail = true };
+        using var session = NewSession(backend);
+
+        var ex = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
+            () => session.SendTextAsync("hello", SendSource.Delivery));
+
+        Assert.Contains("composer never echoed", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_ThatSucceeds_LeavesNothingToReport()
+    {
+        var backend = new ScriptedBackend();
+        using var session = NewSession(backend);
+
+        await session.SendTextAsync("hello", SendSource.UserInput);
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(session.Id));
+    }
+
+    [Fact]
+    public async Task SendTextAsync_ThatLandsAfterAFailure_ClearsTheAlarmAndKeepsTheCount()
+    {
+        var backend = new ScriptedBackend { Fail = true };
+        using var session = NewSession(backend);
+        await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(() => session.SendTextAsync("lost", SendSource.Delivery));
+
+        backend.Fail = false;
+        await session.SendTextAsync("this one got through", SendSource.Delivery);
+
+        var tally = PromptDeliveryFailures.Tally(session.Id);
+        Assert.False(tally.Unresolved);
+        Assert.Equal(1, tally.FailedDeliveries);
+    }
+
+    [Fact]
+    public async Task Dispose_ForgetsTheSessionsCountersButNotTheFleetHistory()
+    {
+        var backend = new ScriptedBackend { Fail = true };
+        var session = NewSession(backend);
+        await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(() => session.SendTextAsync("lost", SendSource.Delivery));
+        var id = session.Id;
+
+        session.Dispose();
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(id));
+        Assert.Single(PromptDeliveryFailures.Recent());
+    }
+
+    private static Session NewSession(ISessionBackend backend)
+    {
+        // The Embedded restore constructor: it is the one that does NOT take the ConPTY route, so the
+        // submit under test is the backend's own SendTextAsync and the test needs no terminal at all.
+        var s = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\repo",
+            workingDirectory: @"C:\test\repo",
+            claudeArgs: null,
+            backend: backend,
+            claudeSessionId: null,
+            activityState: ActivityState.Idle,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: null,
+            customColor: null);
+        s.MarkRunning();
+        return s;
+    }
+
+    /// <summary>A backend whose send either lands or throws the real submit failure, on command.</summary>
+    private sealed class ScriptedBackend : ISessionBackend
+    {
+        public bool Fail { get; set; }
+
+        public int ProcessId => 1;
+        public string Status => "Running";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface, never raised here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+
+        public Task SendTextAsync(string text)
+        {
+            if (Fail)
+                throw new ComposerNotAcceptingInputException(
+                    "[ClaudeDriver] EchoVerifiedSubmit: the composer never echoed the typed text after 2 attempts");
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Core.Tests/Input/TerminalSubmitEchoMissCountTests.cs
+++ b/src/CcDirector.Core.Tests/Input/TerminalSubmitEchoMissCountTests.cs
@@ -1,0 +1,83 @@
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Input;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Tests.Drivers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Input;
+
+/// <summary>
+/// Composer echo misses are COUNTED against the session they happened on (issue internal#811).
+///
+/// This is the leading indicator nobody could see. On 2026-07-15 there were six echo-miss events and two
+/// of them turned into lost prompts; every one of the six existed only as a line in a Director log file.
+/// The miss itself raises no alarm - the retype usually works - but a session quietly racking them up is
+/// the session about to eat somebody's words.
+/// </summary>
+[Collection("PromptDeliveryFailures")]
+public sealed class TerminalSubmitEchoMissCountTests
+{
+    private static readonly TimeSpan FastVerifyBeat = TimeSpan.FromMilliseconds(20);
+
+    public TerminalSubmitEchoMissCountTests() => PromptDeliveryFailures.ResetForTests();
+
+    [Fact]
+    public async Task ComposerThatNeverEchoes_CountsAMissPerAttemptAgainstTheNamedSession()
+    {
+        var sessionId = Guid.NewGuid();
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
+
+        await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
+            () => TerminalSubmit.SharedSubmitAsync(
+                backend,
+                "a dictation the composer refuses to take",
+                "ClaudeDriver",
+                echoTimeout: TimeSpan.FromMilliseconds(20),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                enterSettleDelay: TimeSpan.FromMilliseconds(1),
+                submitVerifyBeat: FastVerifyBeat,
+                sessionId: sessionId));
+
+        var tally = PromptDeliveryFailures.Tally(sessionId);
+        // Two attempts, both missed, before the submit gives up and throws.
+        Assert.Equal(2, tally.ComposerEchoMisses);
+        // The THROW is what the session boundary counts as the lost delivery; this layer only counts
+        // misses, so nothing here claims a failed delivery on its own.
+        Assert.Equal(0, tally.FailedDeliveries);
+        Assert.False(tally.Unresolved);
+    }
+
+    [Fact]
+    public async Task ComposerThatEchoesFirstTime_CountsNothing()
+    {
+        var sessionId = Guid.NewGuid();
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+
+        await TerminalSubmit.SharedSubmitAsync(
+            backend, "hello world", "ClaudeDriver", submitVerifyBeat: FastVerifyBeat, sessionId: sessionId);
+
+        Assert.Equal(PromptDeliveryTally.Empty, PromptDeliveryFailures.Tally(sessionId));
+    }
+
+    [Fact]
+    public async Task SubmitWithNoSessionId_CountsNothingRatherThanInventingAPhantomSession()
+    {
+        // The driver and backend call sites have no session to name. Their misses must not pile up under
+        // one empty id and render as a "session" nobody can open.
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
+
+        await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
+            () => TerminalSubmit.SharedSubmitAsync(
+                backend,
+                "an unattributed submit",
+                "CodexDriver",
+                echoTimeout: TimeSpan.FromMilliseconds(20),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                enterSettleDelay: TimeSpan.FromMilliseconds(1),
+                submitVerifyBeat: FastVerifyBeat));
+
+        Assert.Empty(PromptDeliveryFailures.Recent());
+    }
+}

--- a/src/CcDirector.Core/Drivers/TerminalSubmit.cs
+++ b/src/CcDirector.Core/Drivers/TerminalSubmit.cs
@@ -72,6 +72,10 @@ public static class TerminalSubmit
     /// <see cref="ScreenShowsText"/>).
     /// <paramref name="submitVerifyBeat"/> overrides the post-Enter watchdog's beat length; tests pass
     /// a fast one so the suite does not wait out real-time beats.
+    /// <paramref name="sessionId"/> attributes composer-echo misses to a session in
+    /// <see cref="PromptDeliveryFailures"/> so they can be counted and shown on that session's row
+    /// (issue internal#811). Default (empty) on the driver and backend routes, which have no session
+    /// to name; the Director's own send path passes it.
     /// </summary>
     public static async Task SharedSubmitAsync(
         ISessionBackend backend,
@@ -83,7 +87,8 @@ public static class TerminalSubmit
         TimeSpan? pollInterval = null,
         TimeSpan? enterSettleDelay = null,
         Func<string[]>? screenSnapshot = null,
-        TimeSpan? submitVerifyBeat = null)
+        TimeSpan? submitVerifyBeat = null,
+        Guid sessionId = default)
     {
         ArgumentNullException.ThrowIfNull(backend);
 
@@ -101,7 +106,8 @@ public static class TerminalSubmit
                 pollInterval,
                 enterSettleDelay,
                 screenSnapshot,
-                submitVerifyBeat);
+                submitVerifyBeat,
+                sessionId);
             return;
         }
 
@@ -115,7 +121,7 @@ public static class TerminalSubmit
 
             if (!string.IsNullOrWhiteSpace(backend.WorkingDirectory))
             {
-                await SubmitViaAtReferenceAsync(backend, textForCheck, driverTag, echoTimeout, pollInterval, enterSettleDelay, screenSnapshot, submitVerifyBeat);
+                await SubmitViaAtReferenceAsync(backend, textForCheck, driverTag, echoTimeout, pollInterval, enterSettleDelay, screenSnapshot, submitVerifyBeat, sessionId);
                 return;
             }
         }
@@ -130,7 +136,8 @@ public static class TerminalSubmit
                 pollInterval,
                 enterSettleDelay,
                 screenSnapshot,
-                submitVerifyBeat);
+                submitVerifyBeat,
+                sessionId);
         }
         else
         {
@@ -152,7 +159,8 @@ public static class TerminalSubmit
         TimeSpan? pollInterval = null,
         TimeSpan? enterSettleDelay = null,
         Func<string[]>? screenSnapshot = null,
-        TimeSpan? submitVerifyBeat = null)
+        TimeSpan? submitVerifyBeat = null,
+        Guid sessionId = default)
         => await SharedSubmitAsync(
             backend,
             text,
@@ -163,7 +171,8 @@ public static class TerminalSubmit
             pollInterval,
             enterSettleDelay,
             screenSnapshot,
-            submitVerifyBeat);
+            submitVerifyBeat,
+            sessionId);
 
     private static async Task EchoVerifiedInlineSubmitAsync(
         ISessionBackend backend,
@@ -173,7 +182,8 @@ public static class TerminalSubmit
         TimeSpan? pollInterval = null,
         TimeSpan? enterSettleDelay = null,
         Func<string[]>? screenSnapshot = null,
-        TimeSpan? submitVerifyBeat = null)
+        TimeSpan? submitVerifyBeat = null,
+        Guid sessionId = default)
     {
         ArgumentNullException.ThrowIfNull(backend);
 
@@ -224,6 +234,10 @@ public static class TerminalSubmit
             FileLog.Write($"[{driverTag}] EchoVerifiedSubmit: composer echo not seen on attempt {attempt} " +
                           $"(len={text.Length}) - clearing the composer and retyping. " +
                           EchoMissDiagnostics(buffer, cursor, screenSnapshot, needle, visibleTailNeedle));
+            // Count it as well as log it (issue internal#811). A miss that recovers on the retype costs
+            // the user nothing, so it raises no alarm - but it is the leading indicator of the failures
+            // that DO cost them their words, and it was invisible until somebody grepped a log file.
+            PromptDeliveryFailures.RecordComposerEchoMiss(sessionId, driverTag, attempt, text.Length);
             backend.Write(EscapeByte);
             await Task.Delay(TimeSpan.FromMilliseconds(300));
         }
@@ -283,7 +297,8 @@ public static class TerminalSubmit
         TimeSpan? pollInterval = null,
         TimeSpan? enterSettleDelay = null,
         Func<string[]>? screenSnapshot = null,
-        TimeSpan? submitVerifyBeat = null)
+        TimeSpan? submitVerifyBeat = null,
+        Guid sessionId = default)
     {
         var tempPath = LargeInputHandler.CreateTempFile(text, backend.WorkingDirectory);
         var relRef = LargeInputHandler.MakeAtReference(tempPath, backend.WorkingDirectory);
@@ -298,7 +313,8 @@ public static class TerminalSubmit
             pollInterval,
             enterSettleDelay,
             screenSnapshot,
-            submitVerifyBeat);
+            submitVerifyBeat,
+            sessionId);
     }
 
     private static async Task SubmitViaInstructionFileAsync(
@@ -311,7 +327,8 @@ public static class TerminalSubmit
         TimeSpan? pollInterval = null,
         TimeSpan? enterSettleDelay = null,
         Func<string[]>? screenSnapshot = null,
-        TimeSpan? submitVerifyBeat = null)
+        TimeSpan? submitVerifyBeat = null,
+        Guid sessionId = default)
     {
         var tempPath = LargeInputHandler.CreateTempFile(text, backend.WorkingDirectory);
         var relRef = LargeInputHandler.MakeAtReference(tempPath, backend.WorkingDirectory);
@@ -332,7 +349,8 @@ public static class TerminalSubmit
                 pollInterval,
                 enterSettleDelay,
                 screenSnapshot,
-                submitVerifyBeat);
+                submitVerifyBeat,
+                sessionId);
         }
         else
         {

--- a/src/CcDirector.Core/Input/PromptDeliveryFailures.cs
+++ b/src/CcDirector.Core/Input/PromptDeliveryFailures.cs
@@ -1,0 +1,213 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Input;
+
+/// <summary>
+/// One prompt that did not reach an agent, or one composer echo that had to be retyped. The record
+/// carries no prompt TEXT - only its length - because the ledger is read by surfaces the operator may
+/// show to somebody else, and "how long were the words" is enough to recognise which send this was.
+/// </summary>
+/// <param name="AtUtc">When the attempt failed.</param>
+/// <param name="SessionId">The session the words were meant for.</param>
+/// <param name="Kind">
+/// <c>"failed-delivery"</c> - the send threw and the user's words did NOT go - or
+/// <c>"composer-echo-miss"</c> - the composer did not echo the typed text, so it was cleared and
+/// retyped. A miss is a warning, not a loss: the retype usually succeeds. Both are counted because
+/// the misses are the early signal that the failures are coming.
+/// </param>
+/// <param name="Source">Who was sending: UserInput, Delivery (a dictation), Agent, Framework.</param>
+/// <param name="Reason">Plain-English reason, already trimmed to something a person can read.</param>
+/// <param name="TextLength">How many characters were being delivered.</param>
+public sealed record PromptDeliveryFailure(
+    DateTime AtUtc,
+    Guid SessionId,
+    string Kind,
+    string Source,
+    string Reason,
+    int TextLength);
+
+/// <summary>What the ledger knows about one session, for the row that renders it.</summary>
+/// <param name="FailedDeliveries">How many sends to this session have failed outright.</param>
+/// <param name="ComposerEchoMisses">How many composer echoes had to be cleared and retyped.</param>
+/// <param name="LastFailureAtUtc">When the most recent outright failure happened; null if none has.</param>
+/// <param name="LastFailureReason">Why it failed, in plain English; null if none has.</param>
+/// <param name="Unresolved">
+/// True when the LAST thing that happened to this session was a failed delivery - nothing has been
+/// delivered successfully since. This is the difference between "your words are gone right now" (say so,
+/// loudly) and "a send failed earlier and the retry got through" (a count, not an alarm).
+/// </param>
+public sealed record PromptDeliveryTally(
+    int FailedDeliveries,
+    int ComposerEchoMisses,
+    DateTime? LastFailureAtUtc,
+    string? LastFailureReason,
+    bool Unresolved)
+{
+    /// <summary>A session nothing has ever gone wrong on.</summary>
+    public static readonly PromptDeliveryTally Empty = new(0, 0, null, null, false);
+}
+
+/// <summary>
+/// THE LEDGER OF PROMPTS THAT DID NOT GO (issue internal#811).
+///
+/// WHY THIS EXISTS. On 2026-07-15 the owner spoke into his phone twice and both times the delivery
+/// failed - <c>Command FAILED: the composer never echoed the typed text</c>. That sentence was written
+/// to a Director log file and nowhere else, so it sat unread for two days while the bug kept losing his
+/// words. A failed delivery is not a diagnostic detail: it is the user's sentence, deleted. It has to be
+/// visible without anyone grepping a log.
+///
+/// So every failure is now COUNTED here as well as logged, and the counts ride the session row all the
+/// way to the Cockpit and the phone. The log line remains the durable record - this ledger is in memory
+/// and process-lifetime, exactly like the browser error ring - but the ledger is the thing that gets
+/// SEEN.
+///
+/// The ledger holds facts, not verdicts: counts, timestamps, and whether the last attempt failed. The
+/// Gateway turns those into the words a client renders (CLAUDE.md rule 7 - the client is dumb).
+/// </summary>
+public static class PromptDeliveryFailures
+{
+    /// <summary>How many recent failures the fleet-wide ring keeps. Process-lifetime, newest win.</summary>
+    internal const int RingCapacity = 200;
+
+    /// <summary>Longest reason we keep. A stack-trace-length message is not a thing to render.</summary>
+    internal const int MaxReasonChars = 300;
+
+    private sealed class SessionLedger
+    {
+        public int FailedDeliveries;
+        public int ComposerEchoMisses;
+        public DateTime? LastFailureAtUtc;
+        public string? LastFailureReason;
+        public bool Unresolved;
+    }
+
+    private static readonly ConcurrentDictionary<Guid, SessionLedger> Ledgers = new();
+    private static readonly object RingLock = new();
+    private static readonly Queue<PromptDeliveryFailure> Ring = new();
+
+    /// <summary>
+    /// The composer did not echo the text on this attempt, so it is being cleared and retyped. Counted
+    /// but never surfaced as an alarm on its own: the retype usually works, and the delivery that
+    /// follows decides whether the words were lost. Rising misses are the warning that the losses are
+    /// coming, which is exactly what nobody could see before this was counted.
+    /// </summary>
+    public static void RecordComposerEchoMiss(Guid sessionId, string driverTag, int attempt, int textLength)
+    {
+        if (sessionId == Guid.Empty) return;
+
+        var ledger = Ledgers.GetOrAdd(sessionId, _ => new SessionLedger());
+        lock (ledger)
+            ledger.ComposerEchoMisses++;
+
+        Push(new PromptDeliveryFailure(
+            DateTime.UtcNow, sessionId, "composer-echo-miss", driverTag,
+            $"the composer did not echo the typed text on attempt {attempt} - clearing and retyping",
+            textLength));
+
+        FileLog.Write($"[PromptDeliveryFailures] composer echo miss: session={sessionId}, " +
+                      $"driver={driverTag}, attempt={attempt}, len={textLength}");
+    }
+
+    /// <summary>
+    /// A send threw: the user's words did not go. Stamps the session UNRESOLVED so every surface can say
+    /// so until something actually lands.
+    /// </summary>
+    public static void RecordFailedDelivery(Guid sessionId, string source, string reason, int textLength)
+    {
+        if (sessionId == Guid.Empty) return;
+
+        var trimmed = Trim(reason);
+        var at = DateTime.UtcNow;
+
+        var ledger = Ledgers.GetOrAdd(sessionId, _ => new SessionLedger());
+        lock (ledger)
+        {
+            ledger.FailedDeliveries++;
+            ledger.LastFailureAtUtc = at;
+            ledger.LastFailureReason = trimmed;
+            ledger.Unresolved = true;
+        }
+
+        Push(new PromptDeliveryFailure(at, sessionId, "failed-delivery", source, trimmed, textLength));
+
+        FileLog.Write($"[PromptDeliveryFailures] FAILED DELIVERY: session={sessionId}, source={source}, " +
+                      $"len={textLength}, reason={trimmed}");
+    }
+
+    /// <summary>
+    /// Something was delivered to this session. Clears the unresolved flag - the words are going through
+    /// again, so the alarm has nothing left to warn about - while KEEPING the counts, which are the
+    /// history of how often this happens and must not be erased by a lucky retry.
+    /// </summary>
+    /// <returns>
+    /// True only when this actually CLEARED a live alarm. Callers use it to repaint exactly once instead
+    /// of on every successful prompt, which is most of them.
+    /// </returns>
+    public static bool RecordDeliverySucceeded(Guid sessionId)
+    {
+        if (sessionId == Guid.Empty) return false;
+        if (!Ledgers.TryGetValue(sessionId, out var ledger)) return false;
+
+        lock (ledger)
+        {
+            if (!ledger.Unresolved) return false;
+            ledger.Unresolved = false;
+        }
+
+        FileLog.Write($"[PromptDeliveryFailures] delivery recovered: session={sessionId} - " +
+                      "a later prompt landed, so the unresolved failure is cleared");
+        return true;
+    }
+
+    /// <summary>What to report on this session's row. Never null - a clean session reports zeros.</summary>
+    public static PromptDeliveryTally Tally(Guid sessionId)
+    {
+        if (sessionId == Guid.Empty || !Ledgers.TryGetValue(sessionId, out var ledger))
+            return PromptDeliveryTally.Empty;
+
+        lock (ledger)
+            return new PromptDeliveryTally(
+                ledger.FailedDeliveries,
+                ledger.ComposerEchoMisses,
+                ledger.LastFailureAtUtc,
+                ledger.LastFailureReason,
+                ledger.Unresolved);
+    }
+
+    /// <summary>The fleet-wide recent list, newest first, so a diagnostic read needs no log file.</summary>
+    public static IReadOnlyList<PromptDeliveryFailure> Recent(int max = RingCapacity)
+    {
+        if (max <= 0) return Array.Empty<PromptDeliveryFailure>();
+        lock (RingLock)
+            return Ring.Reverse().Take(max).ToList();
+    }
+
+    /// <summary>Drop a dead session's ledger so a long-lived Director does not accumulate them.</summary>
+    public static void Forget(Guid sessionId) => Ledgers.TryRemove(sessionId, out _);
+
+    /// <summary>Wipe everything. Tests only - a shared static needs a way back to a known state.</summary>
+    internal static void ResetForTests()
+    {
+        Ledgers.Clear();
+        lock (RingLock)
+            Ring.Clear();
+    }
+
+    private static void Push(PromptDeliveryFailure record)
+    {
+        lock (RingLock)
+        {
+            Ring.Enqueue(record);
+            while (Ring.Count > RingCapacity)
+                Ring.Dequeue();
+        }
+    }
+
+    private static string Trim(string reason)
+    {
+        var oneLine = (reason ?? "").Replace('\r', ' ').Replace('\n', ' ').Trim();
+        if (oneLine.Length == 0) return "the send failed without saying why";
+        return oneLine.Length <= MaxReasonChars ? oneLine : oneLine[..MaxReasonChars] + "...";
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1,6 +1,7 @@
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Claude;
+using CcDirector.Core.Input;
 using CcDirector.Core.Memory;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
@@ -2364,25 +2365,67 @@ public sealed class Session : IDisposable
         catch (Exception ex) { FileLog.Write($"[Session] OnTurnSubmitted handler failed: session={Id}, {ex.Message}"); }
     }
 
+    /// <summary>
+    /// Raised when this session's prompt-delivery alarm turns on (a send was lost) or off (a later send
+    /// landed) - issue internal#811. The desktop rail subscribes so its red "NOT DELIVERED" badge appears
+    /// and clears without waiting for some unrelated repaint; the Gateway learns the same fact from the
+    /// session row on the next push.
+    /// </summary>
+    public event Action? OnPromptDeliveryChanged;
+
+    private void RaisePromptDeliveryChanged()
+    {
+        try { OnPromptDeliveryChanged?.Invoke(); }
+        catch (Exception ex) { FileLog.Write($"[Session] OnPromptDeliveryChanged handler failed: session={Id}, {ex.Message}"); }
+    }
+
     public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
 
         FileLog.Write($"[Session] SendTextAsync: session={Id}, source={source}, driver={Driver.Kind}, text=\"{(text.Length > 60 ? text[..60] + "..." : text)}\", len={text.Length}");
-        if (BackendType is SessionBackendType.ConPty)
+        // THE delivery boundary (issue internal#811). Everything below this try either delivered the
+        // user's words or threw; there is no third outcome, and no other place in the Director knows both
+        // "which session" and "did it go". A throw here used to travel up as an error string on whichever
+        // caller happened to be listening and a line in a log file nobody reads - which is how two spoken
+        // prompts were lost on 2026-07-15 and went unnoticed for two days. Now the loss is counted against
+        // the session and rides its row to every screen.
+        //
+        // ON THE "TRY-CATCH AT ENTRY POINTS ONLY" RULE (CLAUDE.md #4): this catch does not HANDLE
+        // anything. It records a fact and rethrows the same exception, untouched, so every caller's error
+        // path - the 502 the dictation endpoint returns, the phone's retry, the error the composer shows -
+        // behaves exactly as it did before. The rule exists to stop a catch swallowing a failure and
+        // continuing in a degraded state; this one exists to stop a failure being swallowed by SILENCE.
+        // A test pins the rethrow so it cannot quietly become a handler.
+        try
         {
-            await Drivers.TerminalSubmit.SharedSubmitAsync(
-                _backend,
-                text,
-                Driver.Kind.ToString(),
-                BracketedPasteEnabled,
-                requireEcho: Driver.Kind != Agents.AgentKind.Copilot,
-                screenSnapshot: SnapshotScreenRows);
+            if (BackendType is SessionBackendType.ConPty)
+            {
+                await Drivers.TerminalSubmit.SharedSubmitAsync(
+                    _backend,
+                    text,
+                    Driver.Kind.ToString(),
+                    BracketedPasteEnabled,
+                    requireEcho: Driver.Kind != Agents.AgentKind.Copilot,
+                    screenSnapshot: SnapshotScreenRows,
+                    sessionId: Id);
+            }
+            else
+            {
+                await _backend.SendTextAsync(text);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            await _backend.SendTextAsync(text);
+            PromptDeliveryFailures.RecordFailedDelivery(Id, source.ToString(), ex.Message, text?.Length ?? 0);
+            RaisePromptDeliveryChanged();
+            throw;
         }
+
+        // Only a send that CLEARED a live alarm repaints anything - the common case is a session that has
+        // never lost a prompt, and it must not repaint the rail on every turn.
+        if (PromptDeliveryFailures.RecordDeliverySucceeded(Id))
+            RaisePromptDeliveryChanged();
         IsBrandNew = false;
         // A submitted turn supersedes a hold ONLY when the OWNER submitted it (issue #470 refined). Not
         // every send is the owner coming back: a fleet message from another agent (SendSource.Agent) and
@@ -3113,6 +3156,9 @@ public sealed class Session : IDisposable
         _backend.StatusChanged -= OnBackendStatusChanged;
         if (_htmlParserFeed is not null && _backend.Buffer is not null)
             _backend.Buffer.OnBytesWritten -= _htmlParserFeed;
+        // Nothing can render this session's row any more, so its delivery tally has no reader left. The
+        // fleet-wide recent ring keeps the history; only the per-session counters are dropped.
+        PromptDeliveryFailures.Forget(Id);
         _backend.Dispose();
     }
 }

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -208,6 +208,55 @@ public sealed class SessionDto
     public DateTime? LastOwnerTurnAtUtc { get; set; }
 
     /// <summary>
+    /// How many prompts to this session have FAILED to be delivered - the send threw, so the user's words
+    /// never reached the agent (issue internal#811). Reported by the owning Director from
+    /// <c>PromptDeliveryFailures</c>; 0 from a Director too old to count them. Counts survive a recovery,
+    /// so this is the honest "how often does this happen here" number, not a live alarm - that is
+    /// <see cref="PromptDeliveryUnresolved"/>.
+    /// </summary>
+    public int FailedPromptDeliveries { get; set; }
+
+    /// <summary>
+    /// How many times this session's composer failed to echo typed text and had to be cleared and retyped.
+    /// A miss that recovers costs the user nothing, which is why it is a count and never an alarm - but it
+    /// is the leading indicator of the outright failures, and it was invisible outside a log file until
+    /// issue internal#811. Reported by the owning Director; 0 from a Director too old to count them.
+    /// </summary>
+    public int ComposerEchoMisses { get; set; }
+
+    /// <summary>
+    /// When the most recent prompt delivery to this session failed, or null if none ever has. Reported by
+    /// the owning Director.
+    /// </summary>
+    public DateTime? LastPromptDeliveryFailureAtUtc { get; set; }
+
+    /// <summary>
+    /// Why the most recent delivery failed, in the words the submit protocol used ("the composer never
+    /// echoed the typed text after 2 attempts ..."), or null if none ever has. Reported by the owning
+    /// Director, one line, length-capped. A client never renders this as the headline - the Gateway's
+    /// <see cref="PromptDeliveryNotice"/> is the headline - but it is the detail behind it.
+    /// </summary>
+    public string? LastPromptDeliveryFailureReason { get; set; }
+
+    /// <summary>
+    /// True when the LAST thing that happened on this session was a failed delivery and nothing has landed
+    /// since: the user's words are gone RIGHT NOW. Cleared by the next successful delivery. Reported by the
+    /// owning Director, because only the Director can see whether a later send got through.
+    ///
+    /// This is the fact; the Gateway turns it into <see cref="PromptDeliveryNotice"/>, the words a client
+    /// renders.
+    /// </summary>
+    public bool PromptDeliveryUnresolved { get; set; }
+
+    /// <summary>
+    /// Gateway-owned plain-English notice that this session lost a prompt, or null when there is nothing to
+    /// say. Folded once by <c>SessionOrdering.PromptDeliveryNotice</c> from the Director-reported facts
+    /// above and rendered VERBATIM by every client (CLAUDE.md rule 7). Always null in Director-local
+    /// responses, which carry the raw facts and no verdict.
+    /// </summary>
+    public string? PromptDeliveryNotice { get; set; }
+
+    /// <summary>
     /// Gateway-owned presentation color after all overlays are folded in
     /// (<see cref="SessionOrdering.EffectiveColor"/>): on-hold, transcribing, explaining,
     /// briefing, and voice-generation state. Stamped by the Gateway aggregator so browser

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -382,6 +382,31 @@ public static class SessionOrdering
     }
 
     /// <summary>
+    /// THE ONE PLACE that turns "a prompt to this session did not go" into words (issue internal#811),
+    /// or null when there is nothing to say. Every client renders the returned string VERBATIM - no client
+    /// re-derives it, counts anything, or decides what a delivery failure means (CLAUDE.md rule 7).
+    ///
+    /// It speaks ONLY while the failure is UNRESOLVED - the last send threw and nothing has landed since,
+    /// so the user's words are gone right now. Once a later prompt gets through, the alarm has nothing to
+    /// warn about and goes quiet; the COUNTS stay on the row, because "this happened four times today" is a
+    /// fact worth keeping and a lucky retry must not erase it.
+    ///
+    /// Why this is a notice and not a colour: the session's colour says what the AGENT is doing, and the
+    /// agent is doing exactly what it was doing before - it never heard anything. Recolouring it would say
+    /// something false about the agent to say something true about the delivery. The notice says the true
+    /// thing in its own words.
+    /// </summary>
+    public static string? PromptDeliveryNotice(SessionDto s)
+    {
+        if (!s.PromptDeliveryUnresolved) return null;
+
+        var reason = (s.LastPromptDeliveryFailureReason ?? "").Trim();
+        return reason.Length == 0
+            ? "Your last prompt was not delivered - the agent never received it."
+            : $"Your last prompt was not delivered - the agent never received it. {reason}";
+    }
+
+    /// <summary>
     /// Classify a session for triage, folded in the same order as <see cref="EffectiveColor"/> and
     /// <see cref="StateLabel"/> so all three always agree.
     ///

--- a/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
@@ -86,6 +86,34 @@ public sealed class ControlApiHostTests : IAsyncLifetime
     // route-not-found, not session-not-found - so they green-lit machinery that no longer exists.)
 
     [Fact]
+    public async Task PromptDeliveryFailures_answers_how_often_this_is_happening_without_a_log_file()
+    {
+        // Issue internal#811. The whole point of the issue is that "Command FAILED: the composer never
+        // echoed the typed text" existed ONLY in a log file, so nobody found out for two days. This route
+        // is the fleet-wide answer a person or an agent can just ask the Director for.
+        CcDirector.Core.Input.PromptDeliveryFailures.ResetForTests();
+        var session = Guid.NewGuid();
+        CcDirector.Core.Input.PromptDeliveryFailures.RecordComposerEchoMiss(session, "ClaudeDriver", 1, 739);
+        CcDirector.Core.Input.PromptDeliveryFailures.RecordFailedDelivery(
+            session, "Delivery", "the composer never echoed the typed text after 2 attempts", 739);
+
+        using var doc = JsonDocument.Parse(await _client.GetStringAsync("prompt-delivery-failures"));
+        var root = doc.RootElement;
+
+        Assert.Equal(1, root.GetProperty("failedDeliveries").GetInt32());
+        Assert.Equal(1, root.GetProperty("composerEchoMisses").GetInt32());
+        var newest = root.GetProperty("recent").EnumerateArray().First();
+        Assert.Equal("failed-delivery", newest.GetProperty("kind").GetString());
+        Assert.Equal(session.ToString(), newest.GetProperty("sessionId").GetString());
+        Assert.Contains("never echoed", newest.GetProperty("reason").GetString());
+        // The prompt TEXT is never served - only how long it was.
+        Assert.Equal(739, newest.GetProperty("textLength").GetInt32());
+        Assert.False(newest.TryGetProperty("text", out _));
+
+        CcDirector.Core.Input.PromptDeliveryFailures.ResetForTests();
+    }
+
+    [Fact]
     public async Task Shutdown_triggers_callback()
     {
         Assert.False(_shutdownRequested);

--- a/src/CcDirector.Gateway.Tests/PromptDeliveryNoticeFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/PromptDeliveryNoticeFoldTests.cs
@@ -1,0 +1,95 @@
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Gateway fold that turns "a prompt to this session did not go" into words (issue internal#811).
+/// The client is dumb: it renders the returned string verbatim and never decides for itself what a
+/// delivery failure means (CLAUDE.md rule 7). These tests pin what the fold will and will not say.
+/// </summary>
+public sealed class PromptDeliveryNoticeFoldTests
+{
+    [Fact]
+    public void NoFailureEverRecorded_SaysNothing()
+    {
+        Assert.Null(SessionOrdering.PromptDeliveryNotice(new SessionDto()));
+    }
+
+    [Fact]
+    public void UnresolvedFailure_NamesTheLossAndCarriesTheReason()
+    {
+        var s = new SessionDto
+        {
+            PromptDeliveryUnresolved = true,
+            FailedPromptDeliveries = 1,
+            LastPromptDeliveryFailureReason = "the composer never echoed the typed text after 2 attempts",
+        };
+
+        var notice = SessionOrdering.PromptDeliveryNotice(s);
+
+        Assert.NotNull(notice);
+        Assert.Contains("not delivered", notice);
+        Assert.Contains("never echoed", notice);
+    }
+
+    [Fact]
+    public void UnresolvedFailure_WithNoReason_StillSaysTheWordsWereLost()
+    {
+        // A Director that reports the flag but no reason must not produce a notice that trails off. The
+        // headline is the part that matters and it does not depend on the detail.
+        var s = new SessionDto { PromptDeliveryUnresolved = true, FailedPromptDeliveries = 1 };
+
+        var notice = SessionOrdering.PromptDeliveryNotice(s);
+
+        Assert.Equal("Your last prompt was not delivered - the agent never received it.", notice);
+    }
+
+    [Fact]
+    public void ResolvedFailure_SaysNothingEvenThoughTheCountsRemain()
+    {
+        // THE POINT OF THE UNRESOLVED FLAG. Four failures earlier today, all of them retried successfully:
+        // there is nothing for the user to act on, so the alarm is silent. The counts stay on the row for
+        // whoever wants to know how sick this session is - they are not the alarm.
+        var s = new SessionDto
+        {
+            PromptDeliveryUnresolved = false,
+            FailedPromptDeliveries = 4,
+            ComposerEchoMisses = 9,
+            LastPromptDeliveryFailureReason = "the composer never echoed the typed text after 2 attempts",
+            LastPromptDeliveryFailureAtUtc = DateTime.UtcNow.AddMinutes(-30),
+        };
+
+        Assert.Null(SessionOrdering.PromptDeliveryNotice(s));
+    }
+
+    [Fact]
+    public void EchoMissesAlone_AreNeverAnAlarm()
+    {
+        // A miss that recovered on the retype cost the user nothing. Shouting about it would train the
+        // reader to ignore the badge that DOES mean their words are gone.
+        var s = new SessionDto { ComposerEchoMisses = 6, PromptDeliveryUnresolved = false };
+
+        Assert.Null(SessionOrdering.PromptDeliveryNotice(s));
+    }
+
+    [Fact]
+    public void TheNotice_DoesNotTouchTheColourTheLabelOrTheBucket()
+    {
+        // The session's colour describes what the AGENT is doing, and the agent is doing exactly what it
+        // was doing - it never heard anything. Recolouring it would say something false about the agent in
+        // order to say something true about the delivery, so the notice is its own channel.
+        var s = new SessionDto
+        {
+            ActivityState = "Working",
+            StatusColor = "blue",
+            PromptDeliveryUnresolved = true,
+            LastPromptDeliveryFailureReason = "gone",
+        };
+
+        Assert.Equal("blue", SessionOrdering.EffectiveColor(s));
+        Assert.Equal("Working", SessionOrdering.StateLabel(s));
+        Assert.Equal(SessionOrdering.TriageBucket.Active, SessionOrdering.Classify(s));
+        Assert.NotNull(SessionOrdering.PromptDeliveryNotice(s));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -3440,6 +3440,10 @@ internal static class GatewayEndpoints
                               "docs/new_architecture/session-state.html.");
             s.EffectiveColorHex = SessionColorPalette.HexFor(effectiveColor);
             s.StateLabel = SessionOrdering.StateLabel(s);
+            // The words for a prompt that did not go (issue internal#811), folded here beside the colour and
+            // the label so every client renders one sentence it did not compose. Null on a session that has
+            // not lost anything, which is almost all of them.
+            s.PromptDeliveryNotice = SessionOrdering.PromptDeliveryNotice(s);
             s.TriageBucket = SessionOrdering.Classify(s) switch
             {
                 SessionOrdering.TriageBucket.NeedsYou => "needsYou",


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#811.

## Why

On 2026-07-15 the owner spoke into his phone twice and both deliveries failed - `Command FAILED: the composer never echoed the typed text`, on sessions `59d2e552` and `fe2ec700`. That sentence went into a Director log file and nowhere else, so it sat unread for two days while the bug kept losing his words. Six composer echo-miss events that day, four recovered, two lost outright, and not one of them appeared on any screen.

A failed delivery is not a diagnostic detail. It is the user's sentence, deleted. The issue's definition of done is exactly this: **a failed delivery is visible without anyone grepping a log file.**

This pairs with internal#664, which is the work that makes delivery reliable. This one is what happens when it still fails.

## What this claims, exactly

**When a delivery failure is DETECTED, the user is now told, instead of it going into a log nobody reads.** That is the whole of it, and on 15 July that gap cost two real lost prompts two days of silence.

It does **not** claim that every real failure is detected. Detection is whatever the submit protocol already catches, and internal#810 says plainly that we have no proof a send actually sends: the submit harness exists and has never been run, and the current bar - "the text appeared in the terminal" - is exactly what a parked, unsubmitted prompt passes. #810 is deferred, so this work lands on an unproven foundation.

Read "failed deliveries are now surfaced" as the narrower sentence above, not the stronger one. A silent loss that the submit protocol never notices is still silent after this change, and closing that is #810's job, not this one's.

## What changed

**The Director counts it** - `src/CcDirector.Core/Input/PromptDeliveryFailures.cs`. Only the machine running the terminal can see a submit fail. Two lanes, deliberately separate:

- **failed delivery** - `Session.SendTextAsync` threw, so the words did not go. It stamps the session UNRESOLVED and **rethrows the exception untouched**, so the 502 the dictation endpoint returns, the phone's retry, and the composer's error message all behave exactly as before.
- **composer echo miss** - the composer did not echo and the text was cleared and retyped. Counted, never an alarm: the retype usually works and costs the user nothing. It is the leading indicator of the losses, and it was the thing nobody could see.

A later prompt landing clears the alarm and **keeps** the counts, so a lucky retry cannot erase the history of a session that eats prompts.

**The Gateway writes the words once** - `SessionOrdering.PromptDeliveryNotice`. Every client renders that string verbatim; no client re-derives what a delivery failure means (CLAUDE.md rule 7). It is a **badge, never a colour**: the agent is doing exactly what it was doing, having heard nothing, so recolouring the dot would tell a lie about the agent in order to tell the truth about the delivery. A test pins that the colour, the label and the triage bucket are all untouched.

**Where it now shows:**

| Surface | What appears |
|---|---|
| Cockpit roster | red `not delivered` chip, first in the tag row, counts in the tooltip |
| Cockpit session page | sticky banner directly above the composer |
| Mobile roster | red sticky badge on the card |
| Mobile session screens | banner on the shared app bar, so it is on Chat, Terminal **and** Voice - the loss usually happens while the phone is somewhere else entirely |
| Desktop rail | red `NOT DELIVERED` badge |
| `GET /prompt-delivery-failures` | the fleet-wide "how often is this happening", answered by asking the Director |

The desktop rail calls the **same** shared fold with its own local facts rather than waiting for a Gateway stamp. That is not the re-folding the rail gave up for colour: every input here is Director-local and firsthand, so it is the same answer from the same function - and it keeps working with the tunnel down, which is exactly when a delivery is most likely to have failed.

## Proof

`dotnet test cc-director.sln` - **0 failed** across every project (Core 3953 passed, Gateway 4457 passed, Avalonia 313, HostedAgent 88, Launcher 83, Engine 63, Terminal.Avalonia 24; the 25 skips are the pre-existing Postgres/live-process ones).

Web: `npm run typecheck` clean across all three workspaces; client-core 838 passed; Cockpit 241 passed; both shells production-build.

**Watched failing first**, not assumed:

- Remove the `catch` in `Session.SendTextAsync` -> 3 of 5 delivery-boundary tests fail (`Expected: 1, Actual: 0`).
- Remove the `RecordComposerEchoMiss` call in `TerminalSubmit` -> the attribution test fails (`Expected: 2, Actual: 0`).
- Replace the roster chip with `{false && ...}` -> 2 of 5 render tests fail.

Restored each time and re-ran green.

## What is NOT proven here

- **Detection coverage is inherited, not established here** - see "What this claims, exactly" above. Every test drives a failure the submit protocol already raises; none proves the protocol raises one for every real loss (internal#810).
- **No live drive.** No real dictation was made to fail against a running Director and phone. The proof is at the unit and endpoint level: the real `Session.SendTextAsync` with a backend that throws the real `ComposerNotAcceptingInputException`, the real `TerminalSubmit` against a composer that never echoes, the real Control API route over loopback HTTP, and the real roster component rendering.
- **The mobile shell has no test harness in this repo** (`apps/mobile` has no test script). Its two surfaces - the roster badge and the app-bar banner - are covered by the shared `client-core` tests behind them, plus typecheck and the production Vite build. Named rather than papered over.
- **`schema.ts` is not regenerated.** The new fields are augmented in `client-core/sessions/delivery.ts`, the same way `uncommittedCount` and the Gateway-stamped fields already are.

## Three lint errors in `npm run lint`

`sw.test.ts`, `Recorder.tsx`, `VoiceMode.tsx` - all "Definition for rule ... was not found", all in files this branch does not touch. Pre-existing; CI does not run `lint`.

