### PR TITLE
A held session is listable, so the ghost card can be reaped

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -371,17 +371,43 @@ internal static class ControlEndpoints
             return (answer, outcome);
         }
 
-        // GET /fleet/sessions - the fleet directory. With a Gateway, relay its aggregated list;
-        // standalone, serve this Director's own sessions (the no-Gateway acceptance criterion).
+        // GET /fleet/sessions - the fleet directory, and the roster EVERY cc-devthrottle verb resolves a
+        // target against before it sends anything. That makes it the reap floor: a session this roster
+        // omits cannot be named, so it cannot be interrupted, messaged or marked done. Issue #1019 - a card
+        // that no tool could remove, with restarting the Director as the only remedy - was two independent
+        // omissions from this one list.
         app.MapGet("/fleet/sessions", async (CancellationToken ct) =>
         {
+            // Omission one: EVERY session this Director is still holding belongs on the roster, including
+            // crashed and exited-pending-reap rows. This store is the same store the desktop rail renders,
+            // and a crashed session is deliberately KEPT in it (issue #959) so the user sees that work
+            // stopped - in ActivityState.Exited, because a crash was never modelled as its own state. The
+            // filter that used to sit here dropped exactly that state, so the one row the user could SEE
+            // and most needed to clear was the one row the CLI could not NAME. The reaper on the other
+            // side was always willing: /fleet/done finds a session in this store and ReapPendingDeletions
+            // removes an Exited one. Only the naming was impossible.
+            var own = sessionManager.ListSessions()
+                .Select(s => MapWithIdentity(s, turnSummaryCache))
+                .ToList();
+
             var gw = gatewayClientProvider?.Invoke();
             if (gw is { IsEnabled: true })
             {
                 try
                 {
                     var fleet = await gw.ListFleetSessionsAsync(ct);
-                    return Results.Json(fleet);
+                    // Omission two: the relayed list silently DROPS the sessions of a Director the Gateway
+                    // cannot reach while still returning 200 (see GatewayClient.ListFleetSessionsAsync).
+                    // A Director whose registration is failing therefore vanishes from its OWN fleet
+                    // listing, which is how three live local sessions came to be denied by the CLI and the
+                    // Control API at once while the rail still showed them. A Director is first-hand
+                    // authority on its own machine, so its rows go back in. The Gateway's copy WINS for any
+                    // session it already knows: the session numbers and identity stamping it hands out are
+                    // never overwritten here.
+                    var (roster, restored) = UnionOwnSessions(fleet, own);
+                    if (restored.Count > 0)
+                        FileLog.Write($"[ControlEndpoints] /fleet/sessions: the Gateway roster omitted {restored.Count} of this Director's own session(s); served from the local store: {string.Join(", ", restored)}");
+                    return Results.Json(roster);
                 }
                 catch (Exception ex)
                 {
@@ -391,11 +417,7 @@ internal static class ControlEndpoints
                 }
             }
 
-            var local = sessionManager.ListSessions()
-                .Where(s => s.ActivityState != ActivityState.Exited)
-                .Select(s => MapWithIdentity(s, turnSummaryCache))
-                .ToList();
-            return Results.Json(local);
+            return Results.Json(own);
         });
 
         // GET /fleet/repositories + /fleet/worktrees - the repository/worktree directory (#510 phase C).
@@ -1446,6 +1468,42 @@ internal static class ControlEndpoints
         => gatewayEnabled ? HoldRoute.Gateway
          : sessionIsLocal ? HoldRoute.LocalMirror
          : HoldRoute.NotFound;
+
+    /// <summary>
+    /// Fold this Director's OWN sessions into the fleet roster relayed from the Gateway (issue #1019), and
+    /// report which of them the relay had left out.
+    ///
+    /// The relay is authoritative for the fleet and STAYS authoritative for every session it knows: a row
+    /// already in <paramref name="fleet"/> is returned untouched, so the session numbers and identity
+    /// stamping the Gateway hands out are never overwritten by a local copy. This adds only the rows the
+    /// relay omitted - which it does silently, while still returning 200, for any Director it cannot reach.
+    /// A Director is first-hand authority on its own machine and must never deny a session it is itself
+    /// holding, because this roster is what the CLI resolves an id against before it can reap anything.
+    ///
+    /// A row with no session id cannot be addressed by any caller, so it is never restored on that basis.
+    /// </summary>
+    internal static (List<SessionDto> Roster, List<string> Restored) UnionOwnSessions(
+        IReadOnlyList<SessionDto> fleet, IReadOnlyList<SessionDto> own)
+    {
+        var roster = new List<SessionDto>(fleet);
+        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in fleet)
+        {
+            if (!string.IsNullOrEmpty(s.SessionId))
+                known.Add(s.SessionId);
+        }
+
+        var restored = new List<string>();
+        foreach (var s in own)
+        {
+            if (string.IsNullOrEmpty(s.SessionId) || !known.Add(s.SessionId))
+                continue;
+            roster.Add(s);
+            restored.Add(s.SessionId);
+        }
+
+        return (roster, restored);
+    }
 
     /// <summary>Folder name of a repo path, for display fallback. Empty path -> "Unknown Project".</summary>
     // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's claude-sessions core

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -752,7 +752,22 @@ public sealed class SessionManager : IDisposable
         catch (Exception ex)
         {
             session.MarkFailed();
+            // Issue #1019, defect 3: a create that fails must SAY SO somewhere a person can find it later.
+            // _log is optional - anything that constructs a SessionManager without one (the Control API's
+            // own host among them) failed completely silently, which is why the original report could not
+            // tell a failed spawn from a UI glitch after the fact. FileLog always lands in the Director log.
+            FileLog.Write($"[SessionManager] CreateSession FAILED: session={id}, repo={repoPath}, agent={agent.Kind}, backend={backendType}: {ex.Message}");
             _log?.Invoke($"Failed to create session for {repoPath}: {ex.Message}");
+
+            // Release the worktree reservation this create took out. It is reserved just BEFORE
+            // backend.Start, but the matching release is wired in WireSessionReaper, which runs only from
+            // RaiseSessionCreated - i.e. only once the session is already in the roster. A throw between
+            // those two points therefore left a PERMANENT reservation held by a session id that no longer
+            // exists anywhere, silently blocking the worktree reaper from ever cleaning that directory up.
+            // Release is idempotent and keyed by session id, so this is safe whether or not we got as far
+            // as reserving.
+            _reservations.Release(id.ToString());
+
             session.Dispose();
             throw;
         }

--- a/src/CcDirector.Gateway.Tests/GhostSessionReapableTests.cs
+++ b/src/CcDirector.Gateway.Tests/GhostSessionReapableTests.cs
@@ -1,0 +1,301 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1019 - the card that nothing could remove. Three sessions were spawned, each call returned a
+/// session id, and afterwards every tool denied they existed: the fleet listing, the Director's own
+/// GET /fleet/sessions, and `session done` / `interrupt` / `buffer` all reported no such session, while one
+/// card stayed on the rail, frozen. Restarting the Director was the only remedy.
+///
+/// The mechanism is not a lost session - it is a roster that omitted rows the Director was still holding.
+/// GET /fleet/sessions is what every cc-devthrottle verb resolves an id against BEFORE it sends anything, so
+/// a row missing from that one list cannot be named, and a row that cannot be named cannot be reaped. Two
+/// independent omissions put rows there:
+///
+///   1. The listing filtered out ActivityState.Exited. A CRASHED session sits in exactly that state (a crash
+///      was never modelled as its own state, it lives on Session.Crashed) and is deliberately KEPT in the
+///      roster and on the rail (issue #959) so the user sees that work stopped. So the one row the user could
+///      SEE and most needed to clear was the one row the CLI could not name. No Gateway required.
+///   2. With a Gateway configured the listing served the relayed roster ONLY, and that relay silently drops
+///      the sessions of a Director it cannot reach while still returning 200. A Director whose registration
+///      was failing - which is what the report shows in the logs - therefore vanished from its own fleet
+///      listing, live sessions and all.
+///
+/// The reap machinery on the other side was always willing: /fleet/done finds a session in the local store
+/// and ReapPendingDeletions explicitly reaps an Exited one. Only the naming was impossible. These tests
+/// prove the naming, then drive the reap to completion.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class GhostSessionReapableTests : IAsyncLifetime
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private ControlApiHost _host = null!;
+    private SessionManager _sm = null!;
+    private HttpClient _client = null!;
+
+    public GhostSessionReapableTests()
+    {
+        // Isolate CC_DIRECTOR_ROOT so this Director has NO Gateway configured. That is the point: omission
+        // one needs no Gateway at all, so the ghost must be reapable on a plain standalone Director.
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ghost-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _sm = new SessionManager(new AgentOptions())
+        {
+            // Reap a flagged session on the first sweep instead of 30s later, so the test drives the real
+            // reaper rather than a shortened copy of it.
+            DeletionGraceMs = 0,
+        };
+        _host = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", DirectorAuth.LoadOrCreateToken());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>A backend whose process exit can be driven, so the REAL crash decision runs.</summary>
+    private sealed class ExitableBackend : ISessionBackend
+    {
+        public int ProcessId => 4321;
+        public string Status => "Exitable";
+        public bool IsRunning => !_exited;
+        public bool HasExited => _exited;
+        public CircularTerminalBuffer? Buffer => null;
+        private bool _exited;
+
+#pragma warning disable CS0067 // required by the interface, unused here
+        public event Action<string>? StatusChanged;
+#pragma warning restore CS0067
+        public event Action<int>? ProcessExited;
+
+        public void RaiseExit(int code)
+        {
+            _exited = true;
+            ProcessExited?.Invoke(code);
+        }
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Put a session in the live roster and crash it for real - nothing sets Session.Crashed by hand, the
+    /// producer decides it from a genuine process exit, so this cannot pass on a fact production never emits.
+    /// This is the exact state the report's frozen card was in: held in the store, shown on the rail, no
+    /// process behind it.
+    /// </summary>
+    private Session AdoptCrashedSession()
+    {
+        var backend = new ExitableBackend();
+        var session = new Session(
+            Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null,
+            backend, SessionBackendType.ConPty);
+        session.MarkRunning();
+        _sm.AdoptSession(session);
+
+        session.ApplyTerminalActivityState(ActivityState.Working);
+        backend.RaiseExit(1);   // the real producer decides crash-vs-clean
+
+        Assert.True(session.Crashed);                                  // a genuine crash...
+        Assert.Equal(ActivityState.Exited, session.ActivityState);      // ...in the state the filter dropped
+        Assert.NotNull(_sm.GetSession(session.Id));                     // ...and still held, per issue #959
+        return session;
+    }
+
+    private async Task<List<SessionDto>> GetFleetAsync()
+    {
+        var resp = await _client.GetAsync("fleet/sessions");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var sessions = await resp.Content.ReadFromJsonAsync<List<SessionDto>>();
+        Assert.NotNull(sessions);
+        return sessions!;
+    }
+
+    // ===== Omission one: a held row must be nameable =====
+
+    [Fact]
+    public async Task CrashedSession_theDirectorStillHolds_isListedSoTheCliCanNameIt()
+    {
+        var ghost = AdoptCrashedSession();
+
+        var fleet = await GetFleetAsync();
+
+        // The whole of the report's second defect is this assertion. It failed before the fix: the roster
+        // filtered ActivityState.Exited, so `cc-devthrottle session done <id>` could not resolve an id it
+        // could not list and answered "No session matches" for a card plainly visible on the rail.
+        Assert.Contains(fleet, s => string.Equals(s.SessionId, ghost.Id.ToString(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task CrashedSession_isListedAsCrashed_notSilentlyDressedUpAsLive()
+    {
+        // Listing it must not mean lying about it. The row carries the crash fact, so `session list` shows
+        // a dead session as dead rather than implying there is an agent behind it.
+        var ghost = AdoptCrashedSession();
+
+        var row = (await GetFleetAsync())
+            .Single(s => string.Equals(s.SessionId, ghost.Id.ToString(), StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(row.Crashed);
+        Assert.Equal("Exited", row.ActivityState);
+    }
+
+    // ===== And once nameable, it must actually go away =====
+
+    [Fact]
+    public async Task CrashedSession_isReapableEndToEnd_soTheCardCanBeCleared()
+    {
+        // The report's "there is no supported way to clear it": every tool denied the session, and restarting
+        // the Director was the only remedy. This drives the whole supported route instead - list it, mark it
+        // done through the real endpoint, let the real reaper sweep - and proves the row is gone afterwards.
+        var ghost = AdoptCrashedSession();
+
+        Assert.Contains(await GetFleetAsync(),
+            s => string.Equals(s.SessionId, ghost.Id.ToString(), StringComparison.OrdinalIgnoreCase));
+
+        var done = await _client.PostAsJsonAsync("fleet/done",
+            new FleetDoneRequest { ToSessionId = ghost.Id.ToString(), Reason = "ghost card, issue #1019" });
+        Assert.Equal(HttpStatusCode.OK, done.StatusCode);
+        var body = await done.Content.ReadFromJsonAsync<FleetDoneResponse>();
+        Assert.NotNull(body);
+        Assert.True(body!.Accepted);
+
+        _sm.ReapPendingDeletions();
+
+        // The reaper's removal is fire-and-forget, so wait for it rather than assuming it already ran.
+        var removed = false;
+        for (var i = 0; i < 40 && !removed; i++)
+        {
+            if (_sm.GetSession(ghost.Id) is null) { removed = true; break; }
+            await Task.Delay(50);
+        }
+        Assert.True(removed, "the flagged ghost session was never removed from the roster");
+
+        Assert.DoesNotContain(await GetFleetAsync(),
+            s => string.Equals(s.SessionId, ghost.Id.ToString(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task UnknownSession_stillFailsLoud_soListingHeldRowsDidNotWeakenTheGuard()
+    {
+        // The counterpart: widening the roster must not make the Director accept an id it has never seen.
+        // A genuinely unknown target with no Gateway is still a clear 404, never a silent accept.
+        var resp = await _client.PostAsJsonAsync("fleet/done",
+            new FleetDoneRequest { ToSessionId = Guid.NewGuid().ToString(), Reason = "never existed" });
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+}
+
+/// <summary>
+/// Issue #1019, omission two: the pure fold that puts this Director's own sessions back into the roster
+/// relayed from the Gateway. The relay drops an unreachable Director's sessions silently while still
+/// returning 200, so a Director whose registration is failing disappears from its own fleet listing.
+/// </summary>
+public sealed class UnionOwnSessionsTests
+{
+    private static SessionDto Row(string id, string? name = null) =>
+        new() { SessionId = id, Name = name ?? id };
+
+    [Fact]
+    public void OwnSessionsTheRelayOmitted_areRestored_andReported()
+    {
+        var fleet = new List<SessionDto> { Row("aaaa"), Row("bbbb") };
+        var own = new List<SessionDto> { Row("cccc"), Row("dddd") };
+
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(fleet, own);
+
+        Assert.Equal(new[] { "aaaa", "bbbb", "cccc", "dddd" }, roster.Select(s => s.SessionId));
+        // Reported, because a roster silently repaired is a roster that hides the registration failure that
+        // needed repairing - the report's third defect was that nothing was written down anywhere.
+        Assert.Equal(new[] { "cccc", "dddd" }, restored);
+    }
+
+    [Fact]
+    public void SessionsTheRelayAlreadyKnows_keepTheGatewaysCopy_notTheLocalOne()
+    {
+        // The Gateway hands out the session numbers and stamps identity, so its row must survive untouched.
+        // Preferring a local copy here would quietly overwrite that on every listing.
+        var gatewayRow = Row("aaaa", name: "as the Gateway knows it");
+        var localRow = Row("aaaa", name: "as this Director knows it");
+
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(
+            new List<SessionDto> { gatewayRow }, new List<SessionDto> { localRow });
+
+        Assert.Single(roster);
+        Assert.Same(gatewayRow, roster[0]);
+        Assert.Empty(restored);
+    }
+
+    [Fact]
+    public void IdMatching_isCaseInsensitive_soCasingNeverDuplicatesARow()
+    {
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(
+            new List<SessionDto> { Row("AAAA-BBBB") }, new List<SessionDto> { Row("aaaa-bbbb") });
+
+        Assert.Single(roster);
+        Assert.Empty(restored);
+    }
+
+    [Fact]
+    public void ARowWithNoSessionId_isNeverRestored_becauseNoCallerCouldAddressIt()
+    {
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(
+            new List<SessionDto>(), new List<SessionDto> { new() { SessionId = "" }, Row("cccc") });
+
+        Assert.Equal(new[] { "cccc" }, roster.Select(s => s.SessionId));
+        Assert.Equal(new[] { "cccc" }, restored);
+    }
+
+    [Fact]
+    public void AnEmptyRelayRoster_stillYieldsOurOwnSessions()
+    {
+        // The reported shape: the Gateway knew nothing about this Director, so the relay carried none of its
+        // rows. Every one of them is ours to report.
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(
+            new List<SessionDto>(), new List<SessionDto> { Row("aaaa"), Row("bbbb") });
+
+        Assert.Equal(new[] { "aaaa", "bbbb" }, roster.Select(s => s.SessionId));
+        Assert.Equal(new[] { "aaaa", "bbbb" }, restored);
+    }
+
+    [Fact]
+    public void NoOwnSessions_leavesTheRelayedRosterExactlyAsItCame()
+    {
+        var fleet = new List<SessionDto> { Row("aaaa"), Row("bbbb") };
+
+        var (roster, restored) = ControlEndpoints.UnionOwnSessions(fleet, new List<SessionDto>());
+
+        Assert.Equal(new[] { "aaaa", "bbbb" }, roster.Select(s => s.SessionId));
+        Assert.Empty(restored);
+    }
+}

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -164,6 +164,16 @@ def list_sessions(json_output: bool) -> None:
         machine = director.field(s, "machineName", "MachineName") or "-"
         repo = director.field(s, "repoPath", "RepoPath")
         status = director.field(s, "activityState", "ActivityState") or "-"
+        # Issue #1019: a session the Director is still holding now appears here even after its process is
+        # gone, which is what makes a dead row nameable and therefore reapable. A crash was never modelled
+        # as its own activity state - it reads "Exited", byte-identical to a session that finished on
+        # purpose - so say it, from the RAW crash fact the Director puts on the wire. We render that fact,
+        # we do not rule on it: deciding what a state MEANS belongs to the Gateway fold, never to a client.
+        # Read the boolean DIRECTLY, not through director.field: field stringifies, and the string
+        # "False" is truthy, so every row would be reported as a crash. Absent is not true either - a
+        # roster row carrying no crash fact is not a crash.
+        if s.get("crashed", s.get("Crashed")) is True:
+            status = f"{status} (crashed)"
         marker = " (you)" if me and sid.lower() == me.lower() else ""
         table.add_row(number_text, director.short_id(sid) + marker, name, machine, _repo_name(repo), status)
 

--- a/tools/cc-devthrottle/tests/test_session_list_crashed.py
+++ b/tools/cc-devthrottle/tests/test_session_list_crashed.py
@@ -1,0 +1,97 @@
+"""Tests for `cc-devthrottle session list`: a crashed session does not read as one that finished on purpose.
+
+Issue #1019. The Director's roster used to hide every session in ActivityState.Exited, which is the state a
+CRASHED session sits in - a crash was never modelled as its own state, it lives on the separate
+Session.Crashed fact. Hiding those rows is what made the reported ghost card unremovable: `session done`
+resolves its target against this listing, so a row it could not show was a row no verb could name.
+
+Those rows are listed now. That fixes the reap, and it creates a second-order risk this file pins: the
+STATUS column reads activityState, so a crashed session would print "Exited" - byte-identical to a clean
+exit. That is the exact misreading issue #959 was filed for twice. So the raw crash fact is surfaced.
+
+Rendering the fact is not ruling on it: the CLI prints what the Director put on the wire and never decides
+what a state MEANS - that fold belongs to the Gateway.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import session_ops  # noqa: E402
+
+CRASHED_ID = "3c09c008-fcf9-49f0-bd4e-787465654a6e"
+CLEAN_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def serve_fleet(monkeypatch):
+    """Serve a chosen fleet roster from the Director, without any real HTTP."""
+
+    def serve(sessions):
+        monkeypatch.delenv("CC_SESSION_ID", raising=False)
+        monkeypatch.setattr(session_ops.director, "get_json", lambda path: sessions)
+
+    return serve
+
+
+def _row(sid, name, *, activity_state, crashed):
+    return {
+        "sessionId": sid,
+        "name": name,
+        "machineName": "SOREN",
+        "repoPath": r"D:\ReposFred\_demo\flask",
+        "activityState": activity_state,
+        "crashed": crashed,
+    }
+
+
+def test_crashed_session_is_marked_crashed_not_just_exited(serve_fleet, capsys):
+    # The reported card: held by the Director, no process behind it, and it must not look like a clean exit.
+    serve_fleet([_row(CRASHED_ID, "flask - routing audit", activity_state="Exited", crashed=True)])
+
+    session_ops.list_sessions(json_output=False)
+
+    # Assert on the short id and the marker, not the full name: with stdout a pipe, Rich renders the table
+    # at 80 columns and elides the NAME cell, so asserting on the name would pin terminal width, not behaviour.
+    out = capsys.readouterr().out
+    assert "crashed" in out
+    assert "3c09c008" in out
+
+
+def test_cleanExit_isNotLabelledCrashed(serve_fleet, capsys):
+    # The other half of the contract: a session that finished on purpose must not gain a crash marker.
+    serve_fleet([_row(CLEAN_ID, "done on purpose", activity_state="Exited", crashed=False)])
+
+    session_ops.list_sessions(json_output=False)
+
+    out = capsys.readouterr().out
+    assert "crashed" not in out
+    assert "Exited" in out
+
+
+def test_missing_crash_fact_is_not_treated_as_crashed(serve_fleet, capsys):
+    # An older Director, or any roster row that simply carries no crash fact, must not be reported as a
+    # crash. Absent is not true.
+    serve_fleet([{
+        "sessionId": CLEAN_ID,
+        "name": "no crash fact on the wire",
+        "activityState": "Working",
+    }])
+
+    session_ops.list_sessions(json_output=False)
+
+    assert "crashed" not in capsys.readouterr().out
+
+
+def test_crashed_row_is_listed_at_all_soItCanBeNamedAndReaped(serve_fleet, capsys):
+    # The whole point of #1019: the id must reach the operator, because `session done <id>` is how the card
+    # gets cleared and the id is what they need to type.
+    serve_fleet([_row(CRASHED_ID, "flask - routing audit", activity_state="Exited", crashed=True)])
+
+    session_ops.list_sessions(json_output=False)
+
+    assert "3c09c008" in capsys.readouterr().out


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1019.

> Note on the reference: `devthrottle#1019` in this repository is a different, unrelated issue, so the link is fully qualified deliberately. A bare `#1019` would have pointed at the wrong one.

## What was actually wrong

The session was never lost. It was **held, displayed, and denied** — and the denial came from one list.

`GET /fleet/sessions` is the roster every `cc-devthrottle` verb resolves a target against *before it sends anything*. That makes it the reap floor: a session this roster omits cannot be named, and a session that cannot be named cannot be interrupted, messaged, or marked done. Two independent omissions put rows there.

**Omission one — the roster hid exactly the rows that need reaping.** The listing filtered out `ActivityState.Exited`. A crashed session sits in precisely that state (a crash was never modelled as its own state; it lives on the separate `Session.Crashed` fact) and is **deliberately kept** in the roster and on the rail by issue #959, so the user sees that work stopped. So the one row the user could *see* and most needed to clear was the one row the command line could not *name*. This needs no Gateway at all.

**Omission two — with a Gateway configured, the Director served the relayed roster only.** That relay silently drops the sessions of a Director it cannot reach while still returning 200 (documented on `GatewayClient.ListFleetSessionsAsync`). A Director whose registration was failing — which is what the report's logs show — therefore vanished from its own fleet listing, live sessions and all.

Both explain the report's four "verified absent" rows with one mechanism, and they explain why the card stayed on screen: the rail renders the local store, which was right, while every tool read a roster that had dropped the row.

**The reap machinery was always willing.** `/fleet/done` looks the session up in the local store and would have found it; `ReapPendingDeletions` explicitly reaps an `Exited` session. Only the naming was impossible. That is why "restart the Director" was the only remedy.

## What changed

1. **`GET /fleet/sessions` lists every session this Director holds** — the store is the same store the rail renders, so a row the user can see is now a row the command line can name.
2. **This Director's own sessions are unioned into the relayed roster**, with the Gateway's copy winning for any session it already knows, so the session numbers and identity stamping it hands out are never overwritten. When the relay omitted rows, that is now written to the Director log naming the count and the ids — the diagnostic the report found missing.
3. **A failed create no longer leaves debris or silence.** `SessionManager.CreateSession` reserves the worktree just before `backend.Start`, but the matching release is wired in `RaiseSessionCreated`, which runs only once the session is in the roster. A throw in between left a permanent reservation held by a session id that no longer existed anywhere, silently blocking the worktree reaper. It is released now, and the failure is written through `FileLog` rather than only the optional `_log` that several callers never supply.
4. **`session list` marks a crashed row as crashed.** Listing dead rows is what makes them reapable, and the STATUS column reads `activityState`, so a crash would have printed `Exited` — byte-identical to a session that finished on purpose, the exact misreading #959 was filed for twice. The raw crash fact is now surfaced. The client renders the fact and does not rule on it; deciding what a state *means* stays in the Gateway fold.

## Against the issue's four asks

1. *Spawn must not return an id unless the session was actually created.* Already true on the local leg, and now true end to end in the sense that matters: the id spawn returns is an id every verb can resolve. See the correction below.
2. *Roll back the UI card when the start fails, or never add it until the session is confirmed.* Already the behaviour — the rail is only ever populated from `RaiseSessionCreated`, which runs after the store insert, so a card cannot precede a confirmed session. No change needed, and I have not made one.
3. *Log the failure path.* Done — the failed create writes through `FileLog`, and an omitted roster row is now logged with its count and ids.
4. *`session done` should succeed on a ghost.* Done, at the root rather than by special-casing: the ghost is now nameable, so the reap path that always worked can be reached. `CrashedSession_isReapableEndToEnd` walks it.

## One correction to the issue

Defect 1 says spawn "returns a session id for a session that was never created". The create path does not do that: the local leg of `/fleet/spawn` re-reads the session out of the store after the executor returns and fails with a 500 if it is absent (`ControlEndpoints.CreateLocalSessionAsync`). The session in the report **was** created — that is why a card appeared at all, since the rail is only ever populated from `RaiseSessionCreated`, after the store insert.

What actually happened is worse in a way the report captures correctly: spawn returned an id that no read path would then accept. That is fixed here at the root — create and read now agree by construction, so the id spawn hands back is an id every verb can resolve. I have not invented a guard for a code path that does not exist.

**Left deliberately unfixed, and worth its own issue:** the remote (`--machine`) leg can time out at 30 seconds (`DirectorCommandRouter.DefaultCommandTimeout`) while the target Director goes on to create a perfectly live session. The caller is told it failed and never learns the id. That is the inverse leak and needs an idempotency key or a reconciliation pass, not a patch here.

## Proof

**The regression tests fail on purpose.** With the `ActivityState.Exited` filter reinstated and everything else unchanged, the three endpoint tests fail with the roster empty while the Director holds the session:

```
Failed GhostSessionReapableTests.CrashedSession_theDirectorStillHolds_isListedSoTheCliCanNameIt
  Assert.Contains() Failure: Filter not matched in collection
  Collection: []
Failed GhostSessionReapableTests.CrashedSession_isListedAsCrashed_notSilentlyDressedUpAsLive
Failed GhostSessionReapableTests.CrashedSession_isReapableEndToEnd_soTheCardCanBeCleared
Total tests: 10   Passed: 7   Failed: 3
```

The tests drive the real producer — a backend raising a genuine process exit into `Session.OnBackendProcessExited`, so nothing sets `Crashed` by hand and the test cannot pass on a fact production never emits — then the real endpoint, the real `/fleet/done`, and the real `ReapPendingDeletions`. `CrashedSession_isReapableEndToEnd` walks the whole supported route the report found impossible: list it, mark it done, sweep, and confirm the row is gone.

`UnknownSession_stillFailsLoud` is the counterpart: widening the roster must not make the Director accept an id it has never seen, and a genuinely unknown target with no Gateway is still a clear 404.

The command line change is pinned the same way — it renders a bare `Exited` without it.

**The command line tests are green:** `157 passed` in `tools/cc-devthrottle` (153 before, plus the 4 added here).

### What is NOT yet proven, stated plainly

`dotnet test cc-director.sln` ran with the fix in place and **six of the seven projects are green with zero failures** — `83, 83, 63, 313, 24, 88` passed, and `3931 passed / 8 skipped` on Core.Tests. The 8 are pre-existing deliberate skips, not failures; there is not one `Failed` line in the run.

The seventh project, `CcDirector.Gateway.Tests` — the one holding the tests above — **did not run.** Its per-user suite lock was held continuously by other worktrees (`dt-tools-1002`, then `devthrottle.wt-audit5`), so after 45 minutes it refused to start rather than run alongside a live holder, which is that lock working as designed. `vstest` reports that refusal as `Test Run Aborted`, which is why the solution run exits non-zero.

So: **these tests are proven to fail without the fix, and have not yet been observed passing with it.** Those holders are legitimately working, so I have not ended anyone else's run to get the lock. A retry is waiting for the lock to go free; I will post the result here as a comment, pass or fail, and this should not merge until that green is on the record.
