### PR TITLE
A session that dies on a network blip resumes itself instead of waiting for a human

### DIFF
--- a/src/CcDirector.Gateway.Contracts/ActivityEventDtos.cs
+++ b/src/CcDirector.Gateway.Contracts/ActivityEventDtos.cs
@@ -124,11 +124,40 @@ public static class ActivityEventTypes
     /// <summary>A snooze entry was retired - the cause says why (the July 24 question).</summary>
     public const string SnoozeEnded = "snooze-ended";
 
+    /// <summary>
+    /// The session supervisor classified a terminating fault on a session that has just gone idle (issue
+    /// #915). The cause carries the fault class; the detail carries the matched SIGNATURE (our own token,
+    /// never the terminal line it came from).
+    /// </summary>
+    public const string SupervisorFaultDetected = "supervisor-fault-detected";
+
+    /// <summary>The supervisor is waiting before it re-sends "continue" - the detail carries the attempt
+    /// number and the delay it chose.</summary>
+    public const string SupervisorWaiting = "supervisor-waiting";
+
+    /// <summary>The supervisor sent "continue" into the session - the detail carries the attempt number and
+    /// whether the send landed.</summary>
+    public const string SupervisorContinueSent = "supervisor-continue-sent";
+
+    /// <summary>The supervised session started working again, so the recovery episode ended successfully.</summary>
+    public const string SupervisorRecovered = "supervisor-recovered";
+
+    /// <summary>The supervisor raised its hand instead of acting: a non-recoverable fault, an unclassified
+    /// one, a menu owning the screen, or the retry ceiling. The cause says which. This event type means a
+    /// PERSON WAS TOLD - it is never used for an episode that merely ended.</summary>
+    public const string SupervisorEscalated = "supervisor-escalated";
+
+    /// <summary>The supervisor stopped without acting and without raising a hand - the session is gone, or its
+    /// state is no longer one a "continue" may be sent to. Nothing needed a person's attention.</summary>
+    public const string SupervisorStoodDown = "supervisor-stood-down";
+
     /// <summary>Every legal event type, for validation.</summary>
     public static readonly IReadOnlyList<string> All = new[]
     {
         TurnSubmitted, BackendActivityStarted, TerminalOutputWhileSettled, ActivityTransition,
         TurnObservedInTranscript, SessionExited, SnoozeCreated, SnoozeLanded, SnoozeEnded,
+        SupervisorFaultDetected, SupervisorWaiting, SupervisorContinueSent, SupervisorRecovered,
+        SupervisorEscalated, SupervisorStoodDown,
     };
 }
 
@@ -190,12 +219,42 @@ public static class ActivityCauses
     /// <summary>The producer could not decide (the shadow classifier's honest "unknown").</summary>
     public const string Unknown = "unknown";
 
+    /// <summary>A transient transport fault ended the turn - a name-resolution failure, a reset connection,
+    /// a dropped socket (issue #915). The class the supervisor recovers from.</summary>
+    public const string TransientTransport = "transient-transport";
+
+    /// <summary>The model provider rate-limited the turn, so the supervisor backs off and resumes.</summary>
+    public const string RateLimited = "rate-limited";
+
+    /// <summary>The agent's context window filled up. Recovering it needs a compaction, which is phase 2
+    /// (thefrederiksen/devthrottle_internal#1403), so phase 1 escalates rather than sending into a session
+    /// that swallows prompts.</summary>
+    public const string ContextFull = "context-full";
+
+    /// <summary>The work itself cannot proceed - out of allowance, out of credits, a failed sign-in. Never
+    /// auto-continued.</summary>
+    public const string NonRecoverable = "non-recoverable";
+
+    /// <summary>The turn ended on a fault the deterministic classifier does not recognize, and the model
+    /// fallback either was switched off or could not decide.</summary>
+    public const string UnclassifiedFault = "unclassified-fault";
+
+    /// <summary>A menu owns the session's screen, so typing "continue" would answer it. The supervisor
+    /// refuses and raises its hand.</summary>
+    public const string MenuOwnsScreen = "menu-owns-screen";
+
+    /// <summary>The supervisor exhausted its retry ceiling, so a real outage raises a hand instead of
+    /// retrying forever.</summary>
+    public const string RetryCeiling = "retry-ceiling";
+
     /// <summary>Every legal cause, for validation.</summary>
     public static readonly IReadOnlyList<string> All = new[]
     {
         OwnerSubmit, AgentSubmit, FrameworkSubmit, BackendSignal, TerminalOutputOnly, QuietThreshold,
         DriverCompletion, OwnerTurn, ManualRelease, TimerExpired, SessionExit, WorkingObservation,
         SnoozeRequested, WorkSettled, DirectorRemoved, SessionNotLive, Unknown,
+        TransientTransport, RateLimited, ContextFull, NonRecoverable, UnclassifiedFault,
+        MenuOwnsScreen, RetryCeiling,
     };
 }
 

--- a/src/CcDirector.Gateway.Tests/SessionSupervisorLiveWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionSupervisorLiveWiringTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Supervision;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #915, THE WIRING PROOF. The engine tests beside this one prove the decision-making with a fake
+/// environment; this one proves the thing a fake can never prove - that a REAL session, on a REAL Gateway,
+/// crossing a REAL Working -> idle boundary, actually gets a "continue" typed into it over the tunnel.
+///
+/// Everything in the path is production code: the live <c>TurnEndWatcher</c>, the turn-end callback in
+/// <c>GatewayHost</c>, the supervisor and its real <c>GatewaySupervisorEnvironment</c>, the pushed roster read,
+/// and the tunnel verbs. The only stand-in is the Director at the far end, which answers the screen read with
+/// the exact line from the 2026-07-21 incident and records what it is asked to do.
+///
+/// REVERT-PROOF: delete the <c>_sessionSupervisor?.OnTurnEnd(signal)</c> line from the turn-end callback in
+/// GatewayHost and <see cref="AParkedSessionThatDiedOnAConnectionFault_IsSentContinueOverTheTunnel"/> goes RED -
+/// no prompt verb ever reaches the Director. The engine tests would all still pass, which is exactly why this
+/// test exists.
+///
+/// The tenant's first wait is turned down to the validated minimum (5 seconds) so the test costs seconds
+/// instead of the shipped 45.
+/// </summary>
+public sealed class SessionSupervisorLiveWiringTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string Session = "supervised-sess";
+    private const string DirectorId = "dir-supervised";
+
+    private TenantId _tenant;
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _director = null!;
+    private readonly ConcurrentQueue<DirectorCommand> _seen = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-supervisor-live-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    /// <summary>The live screen the fake Director answers with: the July 21 terminating fault.</summary>
+    private static readonly string[] FaultScreen =
+    {
+        "* Running gh pr checks...",
+        "API Error: Unable to connect to API (ENOTFOUND)",
+    };
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        var device = HostedTestEnrollment.Enroll(_gateway, "sub-sup", "sup@example.com", "dev-sup", "MS");
+        _tenant = device.Tenant;
+
+        // Turn the first wait down to the validated floor so this test costs seconds, and keep the ceiling at
+        // one send so the ladder ends immediately after the assertion below.
+        _gateway.TenantSettingsResolver.SetSessionSupervisorFirstRetrySeconds(_tenant, 5, DateTime.UtcNow);
+        _gateway.TenantSettingsResolver.SetSessionSupervisorMaxLongRetries(_tenant, 0, DateTime.UtcNow);
+
+        _director = await FakeTunnelDirector.StartAsync(_gateway, device.DeviceKey, DirectorId, "MS",
+            dispatch: cmd =>
+            {
+                _seen.Enqueue(cmd);
+                return cmd.Verb switch
+                {
+                    "screen-grid" => FakeTunnelDirector.Ok(new
+                    {
+                        sessionId = Session,
+                        rows = FaultScreen,
+                        cursorRow = -1,
+                        cursorCol = -1,
+                        cursorVisible = false,
+                        isAlternateScreen = true,
+                        hasGrid = true,
+                    }),
+                    "prompt" => FakeTunnelDirector.Ok(new { ok = true, sent = true }),
+                    _ => FakeTunnelDirector.Ok(new { ok = true }),
+                };
+            });
+
+        // The session is live on that Director and parked at a turn end, exactly as the roster would show it.
+        await _director.PushSnapshotAsync(ParkedSession());
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _director.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task AParkedSessionThatDiedOnAConnectionFault_IsSentContinueOverTheTunnel()
+    {
+        Assert.NotNull(_gateway.SessionSupervisorForTest);
+
+        // A REAL Working -> WaitingForInput boundary through the live watcher - the same two observations a
+        // Director's doorbell ping and heartbeat produce in production.
+        _gateway.TurnEndWatcherForTest!.Observe(_tenant, Session, "Working", DirectorId);
+        _gateway.TurnEndWatcherForTest!.Observe(_tenant, Session, "WaitingForInput", DirectorId);
+
+        // POSITIVE CONTROL FIRST: the supervisor read the session's live screen over the tunnel. Without this
+        // the absence of a prompt below could pass vacuously in an engine that never woke up at all.
+        Assert.NotNull(await WaitForVerb("screen-grid", TimeSpan.FromSeconds(10)));
+
+        // THE POINT: after the (shortened) wait, the session is sent "continue" - no human involved.
+        var prompt = await WaitForVerb("prompt", TimeSpan.FromSeconds(30));
+        Assert.NotNull(prompt);
+        var request = System.Text.Json.JsonSerializer.Deserialize<PromptRequest>(
+            prompt!.PayloadJson, FakeTunnelDirector.WebJson);
+        Assert.Equal(SessionSupervisor.ContinueText, request!.Text);
+        Assert.True(request.AppendEnter);
+        Assert.Equal(Session, prompt!.SessionId);
+    }
+
+    [Fact]
+    public async Task ASessionThatFinishedItsTurnCleanly_IsSentNothing()
+    {
+        // The same live path, with a healthy screen. The turn-end event fires, the supervisor reads the screen -
+        // and stops. This is the invariant that matters most: the engine must be silent on a finished turn.
+        _director.OnCommand(cmd =>
+        {
+            _seen.Enqueue(cmd);
+            return cmd.Verb switch
+            {
+                "screen-grid" => FakeTunnelDirector.Ok(new
+                {
+                    sessionId = Session,
+                    rows = new[] { "All three edits are done and the tests pass. Anything else?" },
+                    cursorRow = -1,
+                    cursorCol = -1,
+                    cursorVisible = false,
+                    isAlternateScreen = true,
+                    hasGrid = true,
+                }),
+                _ => FakeTunnelDirector.Ok(new { ok = true }),
+            };
+        });
+
+        _gateway.TurnEndWatcherForTest!.Observe(_tenant, Session, "Working", DirectorId);
+        _gateway.TurnEndWatcherForTest!.Observe(_tenant, Session, "WaitingForInput", DirectorId);
+
+        // POSITIVE CONTROL: the engine did wake up and did look.
+        Assert.NotNull(await WaitForVerb("screen-grid", TimeSpan.FromSeconds(10)));
+
+        // ABSENCE: well past the shortened first wait, nothing was ever typed into the session.
+        await Task.Delay(TimeSpan.FromSeconds(8));
+        Assert.DoesNotContain(_seen, c => c.Verb == "prompt");
+    }
+
+    private async Task<DirectorCommand?> WaitForVerb(string verb, TimeSpan within)
+    {
+        var deadline = DateTime.UtcNow + within;
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = _seen.FirstOrDefault(c => c.Verb == verb);
+            if (hit is not null) return hit;
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    private static SessionDto ParkedSession() => new()
+    {
+        SessionId = Session,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        IsAlternateScreen = true,
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+}

--- a/src/CcDirector.Gateway.Tests/SessionSupervisorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionSupervisorTests.cs
@@ -1,0 +1,609 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Briefing;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Supervision;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+// ============================================================================
+// Issue #915: the session supervisor. Overnight on 2026-07-21 a session printed
+// "API Error: Unable to connect to API (ENOTFOUND)" at 06:56 and sat dead until 09:32 - two hours
+// thirty-six minutes lost to a name-resolution blip that would have cleared itself in seconds.
+//
+// These tests walk the acceptance list on the issue, in order, with no real clock: the engine's only
+// wait is ISupervisorEnvironment.DelayAsync, so a two-hour escalation ladder is provable in
+// milliseconds AND the delay it chose for each attempt is an assertion rather than a stopwatch.
+//
+// The invariant under test throughout: NON-INTERRUPTIVE BY CONSTRUCTION. A clean turn end, a working
+// session, and a menu on the screen must all come back with zero keystrokes sent.
+// ============================================================================
+public sealed class SessionSupervisorTests
+{
+    private static readonly TenantId Tenant = TenantId.Local;
+    private const string Director = "dir-1";
+    private const string Session = "sid-1";
+
+    /// <summary>The composer box and mode footer every agent screen ends with.</summary>
+    private static readonly string[] Composer =
+    {
+        "╭────────────────────────────────╮",
+        "│ >                              │",
+        "╰────────────────────────────────╯",
+        "  ? for shortcuts",
+    };
+
+    private static string[] TransientFaultScreen() => new[]
+    {
+        "* Running gh pr checks...",
+        "API Error: Unable to connect to API (ENOTFOUND)",
+    }.Concat(Composer).ToArray();
+
+    private static string[] HealthyScreen() => new[]
+    {
+        "I have pushed the branch and opened the pull request. Anything else?",
+    }.Concat(Composer).ToArray();
+
+    private static string[] OutOfAllowanceScreen() => new[]
+    {
+        "Claude usage limit reached. Your limit will reset at 5pm.",
+    }.Concat(Composer).ToArray();
+
+    private static string[] UnknownFaultScreen() => new[]
+    {
+        "API Error: the upstream widget refused to reticulate",
+    }.Concat(Composer).ToArray();
+
+    /// <summary>
+    /// The supervisor's whole world, faked and recording. No clock, no tunnel, no model - so every test
+    /// asserts on what the engine DECIDED rather than on what a real Director happened to do.
+    /// </summary>
+    private sealed class FakeEnvironment : ISupervisorEnvironment
+    {
+        public SupervisorSettings Knobs = SupervisorSettings.Defaults;
+        public string[]? Screen;
+        public string? ActivityState = "WaitingForInput";
+        public bool MenuOnScreen;
+        public bool SendSucceeds = true;
+        public string? ModelReply;
+        public int ModelCalls;
+
+        public readonly List<TimeSpan> Waits = new();
+        public readonly List<string> ContinuesSent = new();
+        public readonly List<SupervisorRecord> Records = new();
+        public readonly List<SupervisorRecord> Escalations = new();
+
+        /// <summary>Runs at the start of each wait, so a test can make the world change mid-ladder exactly
+        /// as it does in production (the session starts working, the screen changes, the session exits).</summary>
+        public Action<int>? OnWait;
+
+        public SupervisorSettings Settings(TenantId tenant) => Knobs;
+
+        public Task<IReadOnlyList<string>?> ReadScreenRowsAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<string>?>(Screen);
+
+        public string? ReadActivityState(TenantId tenant, string sessionId) => ActivityState;
+
+        public Task<bool> IsMenuOnScreenAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+            => Task.FromResult(MenuOnScreen);
+
+        public Task<bool> SendContinueAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+        {
+            ContinuesSent.Add(sessionId);
+            return Task.FromResult(SendSucceeds);
+        }
+
+        public Task<string?> AskModelVerdictAsync(TenantId tenant, IReadOnlyList<string> rows, CancellationToken ct)
+        {
+            ModelCalls++;
+            return Task.FromResult(ModelReply);
+        }
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken ct)
+        {
+            Waits.Add(delay);
+            OnWait?.Invoke(Waits.Count);
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public void Record(SupervisorRecord record) => Records.Add(record);
+
+        public Task EscalateAsync(SupervisorRecord record, CancellationToken ct)
+        {
+            Records.Add(record);
+            Escalations.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public IEnumerable<SupervisorRecord> OfType(string eventType) => Records.Where(r => r.EventType == eventType);
+    }
+
+    // ---- acceptance 1: a transient connect failure recovers with no human input ---------------------------
+
+    [Fact]
+    public async Task ATransientConnectFailure_WaitsTheShortDelay_ThenSendsContinue()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 0 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        // The first send happens, then the ceiling of zero long retries ends the ladder - so this test reads
+        // the FIRST attempt precisely without a second one muddying it.
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Single(env.ContinuesSent);
+        Assert.Equal(TimeSpan.FromSeconds(SupervisorSettings.DefaultFirstRetrySeconds), Assert.Single(env.Waits));
+        var detected = Assert.Single(env.OfType(ActivityEventTypes.SupervisorFaultDetected));
+        Assert.Equal(ActivityCauses.TransientTransport, detected.Cause);
+        Assert.Contains("enotfound", detected.Detail);
+    }
+
+    // ---- acceptance 2: the error persisting escalates to the 15-minute cadence, and keeps going -----------
+
+    [Fact]
+    public async Task WhenTheFaultPersists_TheSecondAttemptOnwardsWaitsFifteenMinutes()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 3 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        // Four sends: the short one, then three on the long cadence. Then the ceiling.
+        Assert.Equal(4, env.ContinuesSent.Count);
+        Assert.Equal(
+            new[]
+            {
+                TimeSpan.FromSeconds(45),
+                TimeSpan.FromMinutes(15),
+                TimeSpan.FromMinutes(15),
+                TimeSpan.FromMinutes(15),
+            },
+            env.Waits);
+    }
+
+    // ---- acceptance 3: a non-transient stop is never auto-continued ---------------------------------------
+
+    [Fact]
+    public async Task RunningOutOfAllowance_SendsNothing_AndEscalates()
+    {
+        var env = new FakeEnvironment { Screen = OutOfAllowanceScreen() };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Empty(env.Waits);
+        var escalation = Assert.Single(env.Escalations);
+        Assert.Equal(ActivityCauses.NonRecoverable, escalation.Cause);
+    }
+
+    [Fact]
+    public async Task AFullContextWindow_SendsNothing_BecauseADeafSessionWouldSwallowIt()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = new[] { "Prompt is too long. Try /compact." }.Concat(Composer).ToArray(),
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Equal(ActivityCauses.ContextFull, Assert.Single(env.Escalations).Cause);
+    }
+
+    // ---- acceptance 4: a clean turn end and a working session are left alone ------------------------------
+
+    [Fact]
+    public async Task ACleanlyFinishedSession_IsLeftAlone_AndCostsOneScreenRead()
+    {
+        var env = new FakeEnvironment { Screen = HealthyScreen() };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Empty(env.Waits);
+        Assert.Empty(env.Records);          // nothing happened, so nothing is claimed to have happened
+        Assert.Equal(0, env.ModelCalls);    // and no model was asked about a healthy turn
+    }
+
+    [Fact]
+    public async Task ASessionThatStartedWorkingDuringTheWait_IsNeverSentAnything()
+    {
+        // Gate 3: the activity state is re-read immediately before every send. This is the hand-rolled
+        // watcher's failure mode - it interrupted a healthy mission a dozen times in one night - made
+        // unreachable rather than merely discouraged.
+        var env = new FakeEnvironment { Screen = TransientFaultScreen() };
+        env.OnWait = _ => env.ActivityState = "Working";
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        var recovered = Assert.Single(env.OfType(ActivityEventTypes.SupervisorRecovered));
+        Assert.Equal(ActivityCauses.WorkingObservation, recovered.Cause);
+        Assert.Empty(env.Escalations);
+    }
+
+    [Fact]
+    public async Task ASessionSittingOnAPermissionPrompt_IsNeverSteamRolled()
+    {
+        var env = new FakeEnvironment { Screen = TransientFaultScreen() };
+        env.OnWait = _ => env.ActivityState = "WaitingForPerm";
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Single(env.OfType(ActivityEventTypes.SupervisorStoodDown));
+    }
+
+    [Fact]
+    public async Task AMenuOwningTheScreen_IsNeverAnswered_ItEscalates()
+    {
+        // Gate 4: "continue" typed at a menu picks an option. Refuse and raise a hand instead.
+        var env = new FakeEnvironment { Screen = TransientFaultScreen(), MenuOnScreen = true };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Equal(ActivityCauses.MenuOwnsScreen, Assert.Single(env.Escalations).Cause);
+    }
+
+    [Fact]
+    public async Task AnUnreadableScreen_ProducesNoVerdictAndNoAction()
+    {
+        var env = new FakeEnvironment { Screen = null };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Empty(env.Records);
+        Assert.Empty(env.Escalations);
+    }
+
+    // ---- acceptance 5: the model fallback, on and off -----------------------------------------------------
+
+    [Fact]
+    public async Task AnUnrecognizedFault_WithTheModelFallbackOn_ActsOnTheVerdict()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = UnknownFaultScreen(),
+            ModelReply = SupervisorVerdict.TransientRecoverable,
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 0 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Equal(1, env.ModelCalls);
+        Assert.Single(env.ContinuesSent);
+        Assert.Contains("model verdict", Assert.Single(env.OfType(ActivityEventTypes.SupervisorFaultDetected)).Detail);
+    }
+
+    [Fact]
+    public async Task AnUnrecognizedFault_WithTheModelFallbackOff_EscalatesAsUnknown()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = UnknownFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { ModelFallbackEnabled = false },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Equal(0, env.ModelCalls);
+        Assert.Empty(env.ContinuesSent);
+        Assert.Equal(ActivityCauses.UnclassifiedFault, Assert.Single(env.Escalations).Cause);
+    }
+
+    [Fact]
+    public async Task AModelThatSaysTheSessionNeedsAHuman_IsNeverContinued()
+    {
+        var env = new FakeEnvironment { Screen = UnknownFaultScreen(), ModelReply = SupervisorVerdict.NeedsHuman };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Equal(ActivityCauses.NonRecoverable, Assert.Single(env.Escalations).Cause);
+    }
+
+    [Fact]
+    public async Task AModelThatMumbles_EscalatesRatherThanTyping()
+    {
+        // An unparsable answer is not a verdict. A model that mumbles must never be read as permission to
+        // type into somebody's session.
+        var env = new FakeEnvironment { Screen = UnknownFaultScreen(), ModelReply = "well, it might be either really" };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Equal(ActivityCauses.UnclassifiedFault, Assert.Single(env.Escalations).Cause);
+    }
+
+    [Fact]
+    public async Task AModelThatSaysTheTurnFinishedNormally_StopsQuietly()
+    {
+        var env = new FakeEnvironment { Screen = UnknownFaultScreen(), ModelReply = SupervisorVerdict.HealthyDone };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Empty(env.Escalations);
+    }
+
+    // ---- acceptance 6: the ceiling raises a hand instead of retrying forever ------------------------------
+
+    [Fact]
+    public async Task TheRetryCeiling_EscalatesInsteadOfLoopingForever()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 2 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Equal(3, env.ContinuesSent.Count);       // the short attempt plus two long ones
+        var escalation = Assert.Single(env.Escalations);
+        Assert.Equal(ActivityCauses.RetryCeiling, escalation.Cause);
+    }
+
+    [Fact]
+    public async Task TheCeilingBelongsToTheEpisode_NotToOneIdleTransition()
+    {
+        // THE GUARDRAIL AGAINST THE INFINITE BLIND LOOP. In a real outage a "continue" does produce a brief
+        // Working flicker before failing again, so a per-transition counter would reset forever and the
+        // ceiling would never fire. The count belongs to the fault episode: two idle transitions in one
+        // episode may not send more than the ceiling allows between them.
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 1 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        // First idle transition: one send lands, the session flickers Working (a turn that starts and dies on
+        // the same broken network), and this pass ends as recovered.
+        await RunOnePassInterruptedByTheSessionWorking(supervisor, env);
+        Assert.Single(env.ContinuesSent);
+        Assert.Single(env.OfType(ActivityEventTypes.SupervisorRecovered));
+        Assert.Equal(1, supervisor.EpisodeAttempts(Tenant, Session));
+
+        // Second idle transition on the SAME fault: it RESUMES the count, so exactly one more send is left
+        // before the ceiling. Without episode continuity this pass would start from one and send forever.
+        env.OnWait = null;
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Equal(2, env.ContinuesSent.Count);       // 1 + MaxLongRetries, across both transitions
+        Assert.Equal(ActivityCauses.RetryCeiling, Assert.Single(env.Escalations).Cause);
+    }
+
+    [Fact]
+    public async Task AHealthyTurnEnd_EndsTheEpisode_SoTheNextFaultStartsFromTheShortWait()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 1 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await RunOnePassInterruptedByTheSessionWorking(supervisor, env);
+        Assert.Equal(1, supervisor.EpisodeAttempts(Tenant, Session));
+
+        // The session recovers for real and finishes a turn cleanly - the only evidence that closes an episode.
+        env.OnWait = null;
+        env.Screen = HealthyScreen();
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+        Assert.Equal(0, supervisor.EpisodeAttempts(Tenant, Session));
+
+        // A LATER, unrelated blip therefore gets the short wait again, not the long cadence.
+        env.Screen = TransientFaultScreen();
+        env.Waits.Clear();
+        await RunOnePassInterruptedByTheSessionWorking(supervisor, env);
+        Assert.Equal(TimeSpan.FromSeconds(SupervisorSettings.DefaultFirstRetrySeconds), env.Waits[0]);
+    }
+
+    // ---- acceptance 7: everything the supervisor does is in the recovery log ------------------------------
+
+    [Fact]
+    public async Task EveryDecision_LandsInTheRecoveryLog_WithClassAttemptDelayAndResult()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 1 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        // detected -> waiting -> sent -> waiting -> sent -> escalated: nothing happens invisibly.
+        Assert.Equal(
+            new[]
+            {
+                ActivityEventTypes.SupervisorFaultDetected,
+                ActivityEventTypes.SupervisorWaiting,
+                ActivityEventTypes.SupervisorContinueSent,
+                ActivityEventTypes.SupervisorWaiting,
+                ActivityEventTypes.SupervisorContinueSent,
+                ActivityEventTypes.SupervisorEscalated,
+            },
+            env.Records.Select(r => r.EventType));
+
+        var waits = env.OfType(ActivityEventTypes.SupervisorWaiting).ToList();
+        Assert.Contains("attempt 1", waits[0].Detail);
+        Assert.Contains("45 seconds", waits[0].Detail);
+        Assert.Contains("attempt 2", waits[1].Detail);
+        Assert.Contains("15 minutes", waits[1].Detail);
+
+        var sends = env.OfType(ActivityEventTypes.SupervisorContinueSent).ToList();
+        Assert.Contains("delivered", sends[0].Detail);
+        Assert.All(env.Records, r => Assert.Equal(Session, r.SessionId));
+        Assert.All(env.Records, r => Assert.Equal(Director, r.DirectorId));
+    }
+
+    [Fact]
+    public async Task ASendThatDoesNotLand_IsRecordedHonestly()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            SendSucceeds = false,
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 0 },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Contains("did not land",
+            Assert.Single(env.OfType(ActivityEventTypes.SupervisorContinueSent)).Detail);
+    }
+
+    [Fact]
+    public async Task ASessionThatDisappearedDuringTheWait_IsNotChased()
+    {
+        var env = new FakeEnvironment { Screen = TransientFaultScreen() };
+        env.OnWait = _ => env.ActivityState = null;
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        // It stood down - it did not raise a hand, because a session that is gone needs nobody's attention.
+        Assert.Equal(ActivityCauses.SessionNotLive,
+            Assert.Single(env.OfType(ActivityEventTypes.SupervisorStoodDown)).Cause);
+        Assert.Empty(env.Escalations);
+    }
+
+    // ---- the master switch --------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task WithTheSupervisorSwitchedOff_NothingIsEvenRead()
+    {
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { Enabled = false },
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        await supervisor.SuperviseAsync(Tenant, Director, Session, CancellationToken.None);
+
+        Assert.Empty(env.ContinuesSent);
+        Assert.Empty(env.Records);
+    }
+
+    [Fact]
+    public void TheShippedDefaults_AreTheOnesTheOwnerAskedFor()
+    {
+        var defaults = SupervisorSettings.Defaults;
+        Assert.True(defaults.Enabled);                                  // default ON - the product decision
+        Assert.Equal(TimeSpan.FromSeconds(45), defaults.FirstRetry);
+        Assert.Equal(TimeSpan.FromMinutes(15), defaults.RetryCadence);
+        Assert.Equal(8, defaults.MaxLongRetries);                       // roughly two hours, then a hand up
+        Assert.True(defaults.ModelFallbackEnabled);
+    }
+
+    // ---- the live entry point: the Working -> idle event -------------------------------------------------
+
+    [Fact]
+    public async Task TheWorkingTransition_CancelsAWaitInFlight_AndEndsTheEpisodeAsRecovered()
+    {
+        // The real public path: a turn-end signal starts the ladder on a background task, and the Working
+        // transition (which the turn-end watcher also fires) cancels it. This is the second, independent
+        // guarantee that a working session is never sent anything.
+        var gate = new SemaphoreSlim(0, 1);
+        var env = new FakeEnvironment { Screen = TransientFaultScreen() };
+        using var supervisor = new SessionSupervisor(env);
+        env.OnWait = _ =>
+        {
+            // The session came back on its own while we were waiting.
+            supervisor.OnSessionWorking(Tenant, Session);
+            gate.Release();
+        };
+
+        supervisor.OnTurnEnd(new TurnEndSignal(Session, Director, Tenant, IsNewTurn: true));
+
+        Assert.True(await gate.WaitAsync(TimeSpan.FromSeconds(5)), "the supervisor never reached its first wait");
+        await WaitUntil(() => env.OfType(ActivityEventTypes.SupervisorRecovered).Any());
+        Assert.Empty(env.ContinuesSent);
+    }
+
+    [Fact]
+    public async Task ASecondTurnEndWhileAnEpisodeIsLive_DoesNotStackASecondLadder()
+    {
+        var reached = new SemaphoreSlim(0, 1);
+        var release = new SemaphoreSlim(0, 1);
+        var env = new FakeEnvironment
+        {
+            Screen = TransientFaultScreen(),
+            Knobs = SupervisorSettings.Defaults with { MaxLongRetries = 0 },
+        };
+        env.OnWait = _ =>
+        {
+            reached.Release();
+            release.Wait(TimeSpan.FromSeconds(5));
+        };
+        using var supervisor = new SessionSupervisor(env);
+
+        supervisor.OnTurnEnd(new TurnEndSignal(Session, Director, Tenant, IsNewTurn: true));
+        Assert.True(await reached.WaitAsync(TimeSpan.FromSeconds(5)), "the first ladder never started");
+
+        // A second signal for the same session arrives while the first ladder is mid-wait.
+        supervisor.OnTurnEnd(new TurnEndSignal(Session, Director, Tenant, IsNewTurn: true));
+        await Task.Delay(50);
+
+        // Still exactly one ladder: one detection, one wait.
+        Assert.Single(env.OfType(ActivityEventTypes.SupervisorFaultDetected));
+        Assert.Single(env.Waits);
+        release.Release();
+        supervisor.OnSessionWorking(Tenant, Session);
+    }
+
+    /// <summary>
+    /// One pass of the ladder that sends its first "continue" and is then interrupted by the session going
+    /// Working - the ordinary production sequence when a continue reaches a still-broken network. The
+    /// interruption arrives the way it really does: as a cancellation of the wait.
+    /// </summary>
+    private static async Task RunOnePassInterruptedByTheSessionWorking(SessionSupervisor supervisor, FakeEnvironment env)
+    {
+        using var pass = new CancellationTokenSource();
+        env.OnWait = waitNumber =>
+        {
+            // Wait 1 elapses and the continue is sent; on wait 2 the session is Working, which cancels.
+            if (waitNumber >= 2) pass.Cancel();
+        };
+        await supervisor.SuperviseAsync(Tenant, Director, Session, pass.Token);
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(10);
+        }
+        Assert.True(condition(), "the supervisor never reached the expected state");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SupervisorPlannerTests.cs
+++ b/src/CcDirector.Gateway.Tests/SupervisorPlannerTests.cs
@@ -1,0 +1,160 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Supervision;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+// ============================================================================
+// Issue #915: the recovery state machine and the model-fallback verdict reader, both pure - so the whole
+// escalation ladder (a two-hour shape in production) is asserted exactly, in milliseconds.
+// ============================================================================
+public sealed class SupervisorPlannerTests
+{
+    private static readonly SupervisorSettings Defaults = SupervisorSettings.Defaults;
+
+    [Fact]
+    public void ATransientFault_WaitsTheShortDelayOnce_ThenTheLongCadence()
+    {
+        var first = SupervisorPlanner.Next(SessionFaultClass.TransientTransport, attempt: 1, Defaults);
+        var second = SupervisorPlanner.Next(SessionFaultClass.TransientTransport, attempt: 2, Defaults);
+        var ninth = SupervisorPlanner.Next(SessionFaultClass.TransientTransport, attempt: 9, Defaults);
+
+        Assert.Equal(SupervisorActionKind.WaitThenContinue, first.Kind);
+        Assert.Equal(TimeSpan.FromSeconds(45), first.Delay);
+        Assert.Equal(TimeSpan.FromMinutes(15), second.Delay);
+        Assert.Equal(TimeSpan.FromMinutes(15), ninth.Delay);
+        Assert.Equal(ActivityCauses.TransientTransport, first.Cause);
+    }
+
+    [Fact]
+    public void OnePastTheCeiling_Escalates()
+    {
+        // Eight long retries after the short one is nine sends; the tenth attempt is an outage, not a blip.
+        var beyond = SupervisorPlanner.Next(SessionFaultClass.TransientTransport, attempt: 10, Defaults);
+
+        Assert.Equal(SupervisorActionKind.Escalate, beyond.Kind);
+        Assert.Equal(ActivityCauses.RetryCeiling, beyond.Cause);
+    }
+
+    [Fact]
+    public void AZeroCeiling_AllowsTheShortRetryAndNothingMore()
+    {
+        var settings = Defaults with { MaxLongRetries = 0 };
+
+        Assert.Equal(SupervisorActionKind.WaitThenContinue,
+            SupervisorPlanner.Next(SessionFaultClass.TransientTransport, 1, settings).Kind);
+        Assert.Equal(SupervisorActionKind.Escalate,
+            SupervisorPlanner.Next(SessionFaultClass.TransientTransport, 2, settings).Kind);
+    }
+
+    [Fact]
+    public void RateLimiting_StartsAtTheLongCadence_AndBacksOff_Capped()
+    {
+        // A throttled provider is not a blip: asking again 45 seconds later earns another refusal.
+        Assert.Equal(TimeSpan.FromMinutes(15), SupervisorPlanner.Next(SessionFaultClass.RateLimited, 1, Defaults).Delay);
+        Assert.Equal(TimeSpan.FromMinutes(30), SupervisorPlanner.Next(SessionFaultClass.RateLimited, 2, Defaults).Delay);
+        Assert.Equal(TimeSpan.FromMinutes(60), SupervisorPlanner.Next(SessionFaultClass.RateLimited, 3, Defaults).Delay);
+        // Capped, not unbounded.
+        Assert.Equal(SupervisorPlanner.MaxRateLimitedDelay,
+            SupervisorPlanner.Next(SessionFaultClass.RateLimited, 9, Defaults).Delay);
+    }
+
+    [Theory]
+    [InlineData(SessionFaultClass.NonRecoverable, ActivityCauses.NonRecoverable)]
+    [InlineData(SessionFaultClass.ContextFull, ActivityCauses.ContextFull)]
+    [InlineData(SessionFaultClass.Unclassified, ActivityCauses.UnclassifiedFault)]
+    public void TheClassesThatMustReachAHuman_NeverWaitAndNeverSend(SessionFaultClass fault, string expectedCause)
+    {
+        var action = SupervisorPlanner.Next(fault, attempt: 1, Defaults);
+
+        Assert.Equal(SupervisorActionKind.Escalate, action.Kind);
+        Assert.Equal(TimeSpan.Zero, action.Delay);
+        Assert.Equal(expectedCause, action.Cause);
+    }
+
+    [Fact]
+    public void ACleanTurnEnd_IsDoNothing()
+        => Assert.Equal(SupervisorActionKind.DoNothing,
+            SupervisorPlanner.Next(SessionFaultClass.None, attempt: 1, Defaults).Kind);
+
+    [Fact]
+    public void AttemptsAreOneBased_AndAZerothAttemptIsAProgrammingError()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => SupervisorPlanner.Next(SessionFaultClass.TransientTransport, attempt: 0, Defaults));
+
+    [Theory]
+    [InlineData(45, "45 seconds")]
+    [InlineData(900, "15 minutes")]
+    public void DelaysReadAsPlainEnglish(int seconds, string expected)
+        => Assert.Equal(expected, SupervisorPlanner.Describe(TimeSpan.FromSeconds(seconds)));
+
+    // ---- the model fallback's verdict reader ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData("transient_recoverable", SessionFaultClass.TransientTransport)]
+    [InlineData("needs_human", SessionFaultClass.NonRecoverable)]
+    [InlineData("healthy_done", SessionFaultClass.None)]
+    [InlineData("context_full", SessionFaultClass.ContextFull)]
+    public void EachVerdict_MapsToOneClass(string verdict, SessionFaultClass expected)
+        => Assert.Equal(expected, SupervisorVerdict.Map(verdict));
+
+    [Theory]
+    [InlineData("transient_recoverable")]
+    [InlineData("  transient_recoverable ")]
+    [InlineData("`transient_recoverable`")]
+    [InlineData("Verdict: transient_recoverable.")]
+    public void TheVerdictSurvivesTheWrappingAChatModelAdds(string reply)
+        => Assert.Equal(SupervisorVerdict.TransientRecoverable, SupervisorVerdict.Parse(reply));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("I am not sure what happened here")]
+    [InlineData("either transient_recoverable or needs_human")]
+    public void AnAbsentUndecidedOrUnreadableAnswer_IsNoVerdict(string? reply)
+    {
+        Assert.Null(SupervisorVerdict.Parse(reply));
+        // ...and no verdict maps to unclassified, which ESCALATES. A model that mumbles never becomes
+        // permission to type into somebody's session.
+        Assert.Equal(SessionFaultClass.Unclassified, SupervisorVerdict.Map(SupervisorVerdict.Parse(reply)));
+    }
+
+    [Fact]
+    public void TheQuestionStatesTheClosedAnswerSet_AndCarriesTheScreenTail()
+    {
+        var prompt = SupervisorVerdict.BuildPrompt(new[] { "line one", "", "API Error: something odd" });
+
+        foreach (var verdict in SupervisorVerdict.All)
+            Assert.Contains(verdict, prompt);
+        Assert.Contains("API Error: something odd", prompt);
+        Assert.Contains("one word only", prompt);
+    }
+
+    // ---- the settings bounds ------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(4, false)]
+    [InlineData(5, true)]
+    [InlineData(45, true)]
+    [InlineData(600, true)]
+    [InlineData(601, false)]
+    public void TheFirstWaitIsBounded_SoAnOverrideCannotHammerASession(int seconds, bool valid)
+        => Assert.Equal(valid, SupervisorSettings.IsValidFirstRetrySeconds(seconds));
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(120, true)]
+    [InlineData(121, false)]
+    public void TheCadenceIsBounded(int minutes, bool valid)
+        => Assert.Equal(valid, SupervisorSettings.IsValidRetryCadenceMinutes(minutes));
+
+    [Theory]
+    [InlineData(-1, false)]
+    [InlineData(0, true)]
+    [InlineData(48, true)]
+    [InlineData(49, false)]
+    public void TheCeilingIsBounded_SoThereIsNoWayToAskForAnEndlessLoop(int retries, bool valid)
+        => Assert.Equal(valid, SupervisorSettings.IsValidMaxLongRetries(retries));
+}

--- a/src/CcDirector.Gateway.Tests/TerminatingFaultClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/TerminatingFaultClassifierTests.cs
@@ -1,0 +1,162 @@
+using CcDirector.Gateway.Supervision;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+// ============================================================================
+// Issue #915, step 2 of the supervisor funnel: reading a session's live screen and deciding whether the turn
+// that just ended died on a fault - and which class of fault it was.
+//
+// This is the gate that keeps the whole feature non-interruptive, so it is pinned from both directions: the
+// July 21 ENOTFOUND line MUST classify as recoverable, and a healthy screen (or a stale error a later turn has
+// already scrolled past) MUST NOT.
+// ============================================================================
+public sealed class TerminatingFaultClassifierTests
+{
+    /// <summary>The composer box and mode footer Claude Code draws at the bottom of every screen.</summary>
+    private static readonly string[] Composer =
+    {
+        "╭──────────────────────────────────────────╮",
+        "│ >                                        │",
+        "╰──────────────────────────────────────────╯",
+        "  ? for shortcuts                    Bypass permissions",
+    };
+
+    private static string[] Screen(params string[] transcript) => transcript.Concat(Composer).ToArray();
+
+    [Fact]
+    public void TheJulyTwentyFirstLine_ClassifiesAsTransientTransport()
+    {
+        // The exact line from the incident that produced this issue.
+        var fault = TerminatingFaultClassifier.Classify(Screen(
+            "* Running gh pr checks...",
+            "API Error: Unable to connect to API (ENOTFOUND)"));
+
+        Assert.Equal(SessionFaultClass.TransientTransport, fault.Class);
+        Assert.Equal("enotfound", fault.Signature);
+        Assert.True(fault.IsRecoverable);
+    }
+
+    [Theory]
+    [InlineData("API Error: request failed (ECONNRESET)", "econnreset")]
+    [InlineData("Error: socket hang up", "socket hang up")]
+    [InlineData("fetch failed: connection reset by peer", "fetch failed")]
+    [InlineData("Request timed out after 60s", "request timed out")]
+    public void TransportFaults_AreRecoverable(string line, string expectedSignature)
+    {
+        var fault = TerminatingFaultClassifier.Classify(Screen(line));
+        Assert.Equal(SessionFaultClass.TransientTransport, fault.Class);
+        Assert.Equal(expectedSignature, fault.Signature);
+    }
+
+    [Fact]
+    public void ACleanTurnEnd_IsNoFaultAtAll()
+    {
+        var fault = TerminatingFaultClassifier.Classify(Screen(
+            "* Updated docs/plan.md with the new phase list",
+            "I have finished the three edits and the tests pass. What next?"));
+
+        Assert.Equal(SessionFaultClass.None, fault.Class);
+    }
+
+    [Fact]
+    public void AnOldErrorHighOnTheScreen_IsNotATerminatingFault()
+    {
+        // THE RULE THAT STOPS THE ENGINE RE-FIRING ON A SESSION IT ALREADY RESCUED. The error is still on the
+        // screen, but a whole turn has run since - so it did not terminate THIS turn and nothing may be sent.
+        var transcript = new List<string> { "API Error: Unable to connect to API (ENOTFOUND)" };
+        for (var i = 1; i <= TerminatingFaultClassifier.DefaultWindowLines + 2; i++)
+            transcript.Add($"* Step {i} completed and verified");
+        transcript.Add("All done - the branch is pushed and the pull request is open.");
+
+        var fault = TerminatingFaultClassifier.Classify(Screen(transcript.ToArray()));
+
+        Assert.Equal(SessionFaultClass.None, fault.Class);
+    }
+
+    [Fact]
+    public void OrdinaryProseMentioningAConnectionFailure_IsNotAFault()
+    {
+        // The strict test on the ACTING classes: a session that merely PRINTED the words must never be typed
+        // into. No error marker on the line, so no fault - the agent is discussing a log, not dying on one.
+        var fault = TerminatingFaultClassifier.Classify(Screen(
+            "The service log shows connection refused entries from last Tuesday.",
+            "Shall I open an issue for them?"));
+
+        Assert.Equal(SessionFaultClass.None, fault.Class);
+    }
+
+    [Theory]
+    [InlineData("API Error: 429 rate_limit_error - too many requests", SessionFaultClass.RateLimited)]
+    [InlineData("Error: overloaded_error", SessionFaultClass.RateLimited)]
+    public void ProviderThrottling_IsItsOwnClass(string line, SessionFaultClass expected)
+    {
+        Assert.Equal(expected, TerminatingFaultClassifier.Classify(Screen(line)).Class);
+    }
+
+    [Theory]
+    [InlineData("Claude usage limit reached. Your limit will reset at 5pm.")]
+    [InlineData("Your credit balance is too low to run this request.")]
+    [InlineData("API Error: 401 {\"type\":\"authentication_error\"}")]
+    public void FaultsThatAPersonMustFix_AreNeverRecoverable(string line)
+    {
+        var fault = TerminatingFaultClassifier.Classify(Screen(line));
+        Assert.Equal(SessionFaultClass.NonRecoverable, fault.Class);
+        Assert.False(fault.IsRecoverable);
+    }
+
+    [Fact]
+    public void AFullContextWindow_IsItsOwnClass_AndIsNotRecoverableInPhaseOne()
+    {
+        var fault = TerminatingFaultClassifier.Classify(Screen("Prompt is too long. Try /compact to shorten it."));
+        Assert.Equal(SessionFaultClass.ContextFull, fault.Class);
+        Assert.False(fault.IsRecoverable);
+    }
+
+    [Fact]
+    public void ASignInFailureBesideADroppedConnection_Escalates_RatherThanRetrying()
+    {
+        // Precedence: the class that refuses to act wins. Retrying something that can never succeed on its
+        // own is the expensive mistake.
+        var fault = TerminatingFaultClassifier.Classify(Screen(
+            "API Error: Unable to connect to API (ENOTFOUND)",
+            "API Error: 401 {\"type\":\"authentication_error\"}"));
+
+        Assert.Equal(SessionFaultClass.NonRecoverable, fault.Class);
+    }
+
+    [Fact]
+    public void AnErrorBannerWeDoNotRecognize_IsUnclassified_NotHealthy()
+    {
+        // The only input the model fallback accepts. It must not read as a clean turn end.
+        var fault = TerminatingFaultClassifier.Classify(Screen("API Error: the flux capacitor desynchronized"));
+        Assert.Equal(SessionFaultClass.Unclassified, fault.Class);
+    }
+
+    [Fact]
+    public void AnUnreadableScreen_IsNeverAFault()
+    {
+        Assert.Equal(SessionFaultClass.None, TerminatingFaultClassifier.Classify(null).Class);
+        Assert.Equal(SessionFaultClass.None, TerminatingFaultClassifier.Classify(Array.Empty<string>()).Class);
+        Assert.Equal(SessionFaultClass.None, TerminatingFaultClassifier.Classify(new[] { "", "   ", "\t" }).Class);
+    }
+
+    [Fact]
+    public void TheContentWindow_DropsChrome_AndKeepsOnlyTheTail()
+    {
+        var window = TerminatingFaultClassifier.ContentWindow(Screen("first line", "", "second line"), windowLines: 2);
+
+        // The composer box, the border rows, the footer and the blank line are all gone.
+        Assert.Equal(new[] { "first line", "second line" }, window);
+    }
+
+    [Fact]
+    public void AFaultInsideABorderedBox_IsStillRead()
+    {
+        // Some agents frame their errors. Stripping the border must not hide the fault.
+        var fault = TerminatingFaultClassifier.Classify(Screen(
+            "│ API Error: Unable to connect to API (ENOTFOUND)   │"));
+
+        Assert.Equal(SessionFaultClass.TransientTransport, fault.Class);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TerminatingFaultClassifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/TerminatingFaultClassifierTests.cs
@@ -41,7 +41,7 @@ public sealed class TerminatingFaultClassifierTests
     [InlineData("API Error: request failed (ECONNRESET)", "econnreset")]
     [InlineData("Error: socket hang up", "socket hang up")]
     [InlineData("fetch failed: connection reset by peer", "fetch failed")]
-    [InlineData("Request timed out after 60s", "request timed out")]
+    [InlineData("API Error: Request timed out after 60s", "request timed out")]
     public void TransportFaults_AreRecoverable(string line, string expectedSignature)
     {
         var fault = TerminatingFaultClassifier.Classify(Screen(line));
@@ -78,12 +78,24 @@ public sealed class TerminatingFaultClassifierTests
     public void OrdinaryProseMentioningAConnectionFailure_IsNotAFault()
     {
         // The strict test on the ACTING classes: a session that merely PRINTED the words must never be typed
-        // into. No error marker on the line, so no fault - the agent is discussing a log, not dying on one.
+        // into. "connection refused" is ordinary English, and no error marker sits beside it here, so there is
+        // no fault - the agent is discussing a log, not dying on one.
         var fault = TerminatingFaultClassifier.Classify(Screen(
             "The service log shows connection refused entries from last Tuesday.",
             "Shall I open an issue for them?"));
 
         Assert.Equal(SessionFaultClass.None, fault.Class);
+    }
+
+    [Fact]
+    public void TheSameProseWithTheAgentDyingOnIt_IsAFault()
+    {
+        // The other direction, so the rule above is a guard and not merely a way to miss things: the SAME
+        // English phrase with a failure marker beside it is the real thing.
+        var fault = TerminatingFaultClassifier.Classify(Screen("Error: connection refused by the API host"));
+
+        Assert.Equal(SessionFaultClass.TransientTransport, fault.Class);
+        Assert.Equal("connection refused", fault.Signature);
     }
 
     [Theory]

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1905,7 +1905,15 @@ public sealed class GatewayHost : IAsyncDisposable
                 // immediately - the waiting and the re-send happen on its own background task.
                 try
                 {
-                    _sessionSupervisor?.OnTurnEnd(signal);
+                    // ENTER THE OWNING TENANT'S SCOPE, exactly as the voice generation below does, and for the
+                    // same reason: everything the supervisor then touches is partitioned - the per-tenant
+                    // settings read, the tunnel connection lookup that carries its screen read and its send,
+                    // and the activity-ledger write. The scope is an async-local, so the background ladder the
+                    // engine starts inside this call inherits it and keeps it for the whole episode. Without
+                    // it the pass runs with no tenant in scope and every one of those reads is denied - the
+                    // engine would wake up and silently do nothing.
+                    using (_tenantBoundary.EnterScope(tenant))
+                        _sessionSupervisor?.OnTurnEnd(signal);
                 }
                 catch (Exception ex)
                 {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -584,6 +584,11 @@ public sealed class GatewayHost : IAsyncDisposable
     // the Working transition. The wingman narration (text and voice) now runs on the stateless
     // HostedInferenceBrain (a hosted model call), not the spawned BrainSupervisor.
     private TurnEndWatcher? _turnEndWatcher;
+    // The session supervisor (issue #915): the event-driven engine that auto-recovers a session which went
+    // idle on a TRANSIENT TRANSPORT fault - the July 21 overnight ENOTFOUND that cost two and a half hours.
+    // It rides the SAME Working -> idle boundary the watcher already observes, which is what makes it
+    // non-interruptive by construction: a Working session is never evaluated and never touched.
+    private Supervision.SessionSupervisor? _sessionSupervisor;
     private Wingman.WingmanVoiceService? _voiceService;
     // Voice mode is a standing intent, not a one-time action: a tenant that is in voice mode wants EVERY one
     // of its sessions narrating, including the ones that do not exist yet. This timer is how that intent
@@ -602,6 +607,10 @@ public sealed class GatewayHost : IAsyncDisposable
     /// transition (Working -&gt; Waiting) into the REAL onTurnEnd / onSessionWorking callbacks rather than a
     /// re-implementation. Null until StartAsync builds it.</summary>
     internal TurnEndWatcher? TurnEndWatcherForTest => _turnEndWatcher;
+
+    /// <summary>Test-only: the session supervisor (issue #915), so a test can drive a real Working -&gt; idle
+    /// transition into the REAL engine. Null until StartAsync builds it.</summary>
+    internal Supervision.SessionSupervisor? SessionSupervisorForTest => _sessionSupervisor;
     // Editable/versioned wingman instructions (issue #537); the voice translator reads the active set.
     // Constructed in the constructor body once the EF database is built (it persists to the data layer).
     private readonly Wingman.WingmanInstructionsStore _instructionsStore;
@@ -1735,6 +1744,48 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// Wire the session supervisor (issue #915) to the live Gateway. Every leg reuses machinery that already
+    /// exists: the tunnel caller for the screen read, the menu check and the send; the pushed roster snapshot
+    /// for the activity-state read, so liveness is NEVER established by dialing a session; the durable
+    /// activity ledger for the recovery log; and the owner-notify channel the network-diagnostics alerts use
+    /// for the escalation email.
+    /// </summary>
+    private Supervision.GatewaySupervisorEnvironment BuildSupervisorEnvironment()
+    {
+        var notify = new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
+        return new Supervision.GatewaySupervisorEnvironment(
+            settings: _tenantSettingsResolver,
+            // Resolve the owning Director within its OWN tenant (the registry is keyed by (tenant, director
+            // id)); a Director that is not connected to the tunnel resolves to null, which every read treats
+            // as "cannot tell" rather than as a fault.
+            route: (tenant, directorId) =>
+            {
+                var director = Registry.Get(tenant, directorId);
+                if (director is null) return null;
+                Api.DirectorCommandRouter.SendDirectorCommandAsync sendCommand = SendCommandAsync;
+                return new Api.SessionVerbClient(director, sendCommand);
+            },
+            activityState: (tenant, sessionId) =>
+                PushedSessions.TryLocate(tenant, sessionId, _streamStaleAfter)?.Session.ActivityState,
+            brainProvider: WingmanBrainAsync,
+            ledger: _activityEvents,
+            enterTenantScope: tenant => _tenantBoundary.EnterScope(tenant),
+            sendOwnerEmail: async (subject, body, ct) =>
+            {
+                var token = Account?.GetAccessTokenForForwarding();
+                if (string.IsNullOrEmpty(token))
+                {
+                    // Nobody is signed in, so there is no owner address to reach. Say so plainly rather than
+                    // reporting a send that never happened - the escalation still stands in the recovery log.
+                    FileLog.Write("[GatewayHost] supervisor escalation email SKIPPED: no signed-in account");
+                    return false;
+                }
+                var result = await notify.SendOwnerAsync(token, subject, body, null, null, ct).ConfigureAwait(false);
+                return result.Sent;
+            });
+    }
+
+    /// <summary>
     /// The port Kestrel actually bound, read from the running server's own addresses (issue #2161). Only
     /// called when the caller asked for an operating-system-assigned port. Throws rather than returning a
     /// placeholder: every consumer of <see cref="Port"/> builds a URL from it, so a silent 0 here would
@@ -1813,6 +1864,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
         _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
+
+        // The session supervisor (issue #915). It hangs off the SAME turn-end boundary as the voice refresh
+        // below, deliberately: that event is the only thing that can wake it, so a Working session is out of
+        // its reach by construction rather than by a rule somebody has to remember.
+        _sessionSupervisor ??= new Supervision.SessionSupervisor(BuildSupervisorEnvironment());
+        FileLog.Write("[GatewayHost] StartAsync: session supervisor armed (auto-recovery on a transient transport fault)");
+
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
@@ -1839,6 +1897,19 @@ public sealed class GatewayHost : IAsyncDisposable
                 catch (Exception ex)
                 {
                     FileLog.Write($"[GatewayHost] turn-end spend emit FAILED: sid={signal.SessionId}: {ex.Message}");
+                }
+
+                // Session supervision (issue #915): evaluate this idle transition for a terminating transport
+                // fault and, if there is one, recover it. Runs for EVERY session, not just voice ones, and is
+                // isolated so a supervision fault never breaks the voice refresh below. It returns
+                // immediately - the waiting and the re-send happen on its own background task.
+                try
+                {
+                    _sessionSupervisor?.OnTurnEnd(signal);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[GatewayHost] turn-end supervision FAILED: sid={signal.SessionId}: {ex.Message}");
                 }
 
                 // Voice sessions (issue #531): the turn just finished on its own, so re-make the
@@ -1875,6 +1946,11 @@ public sealed class GatewayHost : IAsyncDisposable
                 _ = directorId;
                 if (tenant.IsValid)
                     _voiceService?.OnSessionWorking(tenant, sid);
+                // Issue #915: the session is working again, so any recovery wait in flight for it is over -
+                // whether our "continue" landed or it came back on its own. This is the cancel that makes the
+                // engine incapable of sending into a session that is working.
+                if (tenant.IsValid)
+                    _sessionSupervisor?.OnSessionWorking(tenant, sid);
             },
             // Gateway Cleanup mission, Phase 2: under stream mode the catch-up / reconcile reads the push
             // store instead of HTTP-pulling each Director's session list (no dial).
@@ -3489,6 +3565,9 @@ public sealed class GatewayHost : IAsyncDisposable
         try { _voiceSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice sweep dispose error: {ex.Message}"); }
         _voiceSweepTimer = null;
         try { _turnEndWatcher?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] watcher dispose error: {ex.Message}"); }
+        // Issue #915: cancel any recovery wait in flight, so a Gateway shutdown does not leave a background
+        // ladder holding a token and re-sending into a fleet this process no longer owns.
+        try { _sessionSupervisor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] session supervisor dispose error: {ex.Message}"); }
         try { _voiceModeAllSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-mode sweep timer dispose error: {ex.Message}"); }
         _turnEndWatcher = null;
         try { Brain.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] brain dispose error: {ex.Message}"); }

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -121,6 +121,29 @@ public static class TenantSettingKeys
     /// </summary>
     public const string SpokenVoiceByLanguage = "spoken_voice_by_language";
 
+    // ---- the session supervisor (issue #915) ------------------------------------------------------------
+    // Like VoiceModeAll these have no operator global default to fall back to: they are one account's choice
+    // about its own unattended runs. Every default is documented on SupervisorSettings, and a stored value
+    // that is missing, unparsable, or outside the validated bounds degrades to that default - never to "no
+    // limit", which would be the infinite blind loop the issue forbids.
+
+    /// <summary>Whether the session supervisor may auto-recover this tenant's sessions. Default ON.</summary>
+    public const string SessionSupervisorEnabled = "session_supervisor_enabled";
+
+    /// <summary>The first (short) wait before the first "continue", in seconds. Default 45.</summary>
+    public const string SessionSupervisorFirstRetrySeconds = "session_supervisor_first_retry_seconds";
+
+    /// <summary>The long retry cadence, in minutes. Default 15.</summary>
+    public const string SessionSupervisorRetryCadenceMinutes = "session_supervisor_retry_cadence_minutes";
+
+    /// <summary>How many long-cadence retries before escalating instead of retrying forever. Default 8.</summary>
+    public const string SessionSupervisorMaxLongRetries = "session_supervisor_max_long_retries";
+
+    /// <summary>Whether the supervisor's model fallback may classify an unrecognized terminating error.
+    /// Separately switchable because it is the only tier that sends terminal text off the machine. Default
+    /// ON.</summary>
+    public const string SessionSupervisorModelFallbackEnabled = "session_supervisor_model_fallback_enabled";
+
     /// <summary>Every key this resolver serves, for validation and enumeration.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
@@ -128,5 +151,7 @@ public static class TenantSettingKeys
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
         VoiceModeAll, DictationSuggestionsInDailyEmail, DictationEmailCadence, DailyReportCadence,
         SpokenLanguage, SpokenVoiceByLanguage,
+        SessionSupervisorEnabled, SessionSupervisorFirstRetrySeconds, SessionSupervisorRetryCadenceMinutes,
+        SessionSupervisorMaxLongRetries, SessionSupervisorModelFallbackEnabled,
     };
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -300,6 +300,50 @@ public sealed class TenantSettingsResolver
         return Speech.SpokenLanguages.Require(stored);
     }
 
+    /// <summary>
+    /// This tenant's session-supervisor settings (issue #915) - the auto-recovery master switch, the two
+    /// waits, the retry ceiling and the model-fallback switch.
+    ///
+    /// Every value falls back to the documented default on <see cref="Supervision.SupervisorSettings"/> when
+    /// the tenant has expressed no choice, and ALSO when the stored value is unparsable or outside the
+    /// validated bounds. That direction is deliberate: a corrupt override must never widen the engine's
+    /// licence. A zero-second first wait would hammer a session and an unbounded ceiling would be the
+    /// infinite blind loop the issue explicitly forbids, so an unusable number reads as the shipped default,
+    /// never as "no limit".
+    /// </summary>
+    public Supervision.SupervisorSettings SessionSupervisor(TenantId tenant)
+    {
+        var defaults = Supervision.SupervisorSettings.Defaults;
+
+        var firstRetrySeconds = (int)defaults.FirstRetry.TotalSeconds;
+        var storedFirst = _store.Get(tenant, TenantSettingKeys.SessionSupervisorFirstRetrySeconds);
+        if (storedFirst is not null && int.TryParse(storedFirst, out var first)
+            && Supervision.SupervisorSettings.IsValidFirstRetrySeconds(first))
+            firstRetrySeconds = first;
+
+        var cadenceMinutes = (int)defaults.RetryCadence.TotalMinutes;
+        var storedCadence = _store.Get(tenant, TenantSettingKeys.SessionSupervisorRetryCadenceMinutes);
+        if (storedCadence is not null && int.TryParse(storedCadence, out var cadence)
+            && Supervision.SupervisorSettings.IsValidRetryCadenceMinutes(cadence))
+            cadenceMinutes = cadence;
+
+        var maxLongRetries = defaults.MaxLongRetries;
+        var storedCeiling = _store.Get(tenant, TenantSettingKeys.SessionSupervisorMaxLongRetries);
+        if (storedCeiling is not null && int.TryParse(storedCeiling, out var ceiling)
+            && Supervision.SupervisorSettings.IsValidMaxLongRetries(ceiling))
+            maxLongRetries = ceiling;
+
+        return new Supervision.SupervisorSettings
+        {
+            Enabled = ParseBool(_store.Get(tenant, TenantSettingKeys.SessionSupervisorEnabled)) ?? defaults.Enabled,
+            FirstRetry = TimeSpan.FromSeconds(firstRetrySeconds),
+            RetryCadence = TimeSpan.FromMinutes(cadenceMinutes),
+            MaxLongRetries = maxLongRetries,
+            ModelFallbackEnabled = ParseBool(_store.Get(tenant, TenantSettingKeys.SessionSupervisorModelFallbackEnabled))
+                                   ?? defaults.ModelFallbackEnabled,
+        };
+    }
+
     // ---- writes: validate like the global setters, then persist a per-tenant override -------------------
 
     /// <summary>Set the tenant's wingman model for a role.</summary>
@@ -456,6 +500,48 @@ public sealed class TenantSettingsResolver
         chosen[language.Code] = trimmed;
         _store.Set(tenant, TenantSettingKeys.SpokenVoiceByLanguage,
             System.Text.Json.JsonSerializer.Serialize(chosen), nowUtc);
+    }
+
+    /// <summary>Turn this tenant's session supervisor on or off (issue #915). Stored explicitly, like voice
+    /// mode, so "off" is a decision this account made rather than the absence of one.</summary>
+    public void SetSessionSupervisorEnabled(TenantId tenant, bool enabled, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.SessionSupervisorEnabled, enabled ? "true" : "false", nowUtc);
+
+    /// <summary>Turn this tenant's supervisor model fallback on or off.</summary>
+    public void SetSessionSupervisorModelFallbackEnabled(TenantId tenant, bool enabled, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.SessionSupervisorModelFallbackEnabled, enabled ? "true" : "false", nowUtc);
+
+    /// <summary>Set the first (short) wait before the supervisor's first "continue", in seconds.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Outside the validated bounds.</exception>
+    public void SetSessionSupervisorFirstRetrySeconds(TenantId tenant, int seconds, DateTime nowUtc)
+    {
+        if (!Supervision.SupervisorSettings.IsValidFirstRetrySeconds(seconds))
+            throw new ArgumentOutOfRangeException(nameof(seconds), seconds,
+                $"The first wait must be between {Supervision.SupervisorSettings.MinFirstRetrySeconds} and " +
+                $"{Supervision.SupervisorSettings.MaxFirstRetrySeconds} seconds.");
+        _store.Set(tenant, TenantSettingKeys.SessionSupervisorFirstRetrySeconds, seconds.ToString(), nowUtc);
+    }
+
+    /// <summary>Set this tenant's long retry cadence, in minutes.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Outside the validated bounds.</exception>
+    public void SetSessionSupervisorRetryCadenceMinutes(TenantId tenant, int minutes, DateTime nowUtc)
+    {
+        if (!Supervision.SupervisorSettings.IsValidRetryCadenceMinutes(minutes))
+            throw new ArgumentOutOfRangeException(nameof(minutes), minutes,
+                $"The retry cadence must be between {Supervision.SupervisorSettings.MinRetryCadenceMinutes} and " +
+                $"{Supervision.SupervisorSettings.MaxRetryCadenceMinutes} minutes.");
+        _store.Set(tenant, TenantSettingKeys.SessionSupervisorRetryCadenceMinutes, minutes.ToString(), nowUtc);
+    }
+
+    /// <summary>Set how many long-cadence retries this tenant allows before the supervisor escalates.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Outside the validated bounds.</exception>
+    public void SetSessionSupervisorMaxLongRetries(TenantId tenant, int retries, DateTime nowUtc)
+    {
+        if (!Supervision.SupervisorSettings.IsValidMaxLongRetries(retries))
+            throw new ArgumentOutOfRangeException(nameof(retries), retries,
+                $"The retry ceiling must be between {Supervision.SupervisorSettings.MinLongRetries} and " +
+                $"{Supervision.SupervisorSettings.MaxLongRetriesAllowed}.");
+        _store.Set(tenant, TenantSettingKeys.SessionSupervisorMaxLongRetries, retries.ToString(), nowUtc);
     }
 
     /// <summary>Record this tenant's daily-email cadence state after a mention is emitted.</summary>

--- a/src/CcDirector.Gateway/Speech/SpokenPaths.cs
+++ b/src/CcDirector.Gateway/Speech/SpokenPaths.cs
@@ -92,7 +92,7 @@ public static class SpokenPaths
     /// entry here is a one-line, review-visible act - the same shape the tenant-isolation gate uses for
     /// its global-table allowlist. There is no silent fourth category.
     ///
-    /// Both entries produce MACHINE-READ text, and nothing they produce ever reaches a person's ears.
+    /// Every entry produces MACHINE-READ text, and nothing they produce ever reaches a person's ears.
     /// </summary>
     public static readonly IReadOnlyDictionary<string, string> NotSpokenOutput = new Dictionary<string, string>(StringComparer.Ordinal)
     {
@@ -101,5 +101,11 @@ public static class SpokenPaths
         ["DictionarySuggestionScreen.BuildPrompt"] =
             "Screens candidate dictation-dictionary terms and returns JSON verdicts read by code. Nothing "
             + "it produces reaches a person's ears, or their eyes.",
+        ["SupervisorVerdict.BuildPrompt"] =
+            "Asks why a stalled session stopped and returns exactly ONE word from a fixed English answer "
+            + "set (transient_recoverable / needs_human / healthy_done / context_full), which code parses "
+            + "to decide whether to resume the session. Translating either half would break it: the words "
+            + "are an enumeration the parser matches, not prose, and an unparsable reply is deliberately "
+            + "treated as no verdict at all. Nothing it produces is ever spoken or shown.",
     };
 }

--- a/src/CcDirector.Gateway/Supervision/GatewaySupervisorEnvironment.cs
+++ b/src/CcDirector.Gateway/Supervision/GatewaySupervisorEnvironment.cs
@@ -1,0 +1,243 @@
+using CcDirector.AgentBrain;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Activity;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Settings;
+using CcDirector.Gateway.Wingman;
+
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// The production wiring of <see cref="ISupervisorEnvironment"/> (issue #915): the supervisor's reads, its
+/// one write, its recovery log and its escalation, each pointed at machinery that already exists.
+///
+/// Nothing here is new plumbing. The screen read and the menu check are the same tunnel read and the same
+/// pure classifier the voice cluster uses (<see cref="WaitingScreenReader"/>); the activity-state read is the
+/// pushed roster snapshot, so liveness is never established by dialing a session; the send is the ordinary
+/// prompt verb; the recovery log is the durable activity ledger, already tenant-scoped and already served
+/// over an endpoint; the escalation email is the owner-notify channel the network-diagnostics alerts use.
+///
+/// TENANT SCOPE. The engine runs its ladder on a background task that outlives the turn-end callback, so
+/// every operation that touches per-tenant storage enters that tenant's scope explicitly rather than
+/// inheriting an ambient one. A missing scope on hosted would be a cross-partition write, not merely a wrong
+/// answer.
+/// </summary>
+internal sealed class GatewaySupervisorEnvironment : ISupervisorEnvironment
+{
+    private readonly TenantSettingsResolver _settings;
+    private readonly Func<TenantId, string, SessionVerbClient?> _route;
+    private readonly Func<TenantId, string, string?> _activityState;
+    private readonly Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
+    private readonly ActivityEventStore? _ledger;
+    private readonly Func<TenantId, IDisposable>? _enterTenantScope;
+    private readonly Func<string, string, CancellationToken, Task<bool>>? _sendOwnerEmail;
+    private readonly Func<DateTime> _nowUtc;
+
+    private readonly object _emailGate = new();
+    private DateOnly _emailDay;
+    private int _emailsToday;
+
+    /// <summary>
+    /// How many escalation emails one day may carry. An escalation is already rare - it ends the episode and
+    /// a new one needs a fresh fault - but a cap means a pathological night cannot turn into a mailbox full
+    /// of identical messages. Matches the network-diagnostics alert cap in spirit.
+    /// </summary>
+    public const int DailyEscalationEmailCap = 10;
+
+    /// <param name="settings">The per-tenant settings resolver the supervisor's knobs are read from.</param>
+    /// <param name="route">Resolves a tunnel caller for (tenant, director id); null means that Director is
+    /// not connected, which every read below treats as "cannot tell" rather than as a fault.</param>
+    /// <param name="activityState">Reads a session's current activity state from the pushed roster snapshot,
+    /// or null when the session is no longer there.</param>
+    /// <param name="brainProvider">The model provider for step 3. The FAST role is used deliberately: this is
+    /// a one-word classification, and it is the model the tenant already chose for latency-sensitive work.</param>
+    /// <param name="ledger">The durable activity ledger the recovery log is written to. Optional: null means
+    /// the process log carries the record alone (older tests), and a ledger fault never stops a recovery.</param>
+    /// <param name="enterTenantScope">Enters a tenant's storage scope for the duration of a write. Optional
+    /// (self-host has one partition and the scope is inert).</param>
+    /// <param name="sendOwnerEmail">Sends the escalation email (subject, body). Optional: when the Gateway
+    /// has no signed-in account there is nobody to email, and the escalation still lands in the recovery log
+    /// and the process log.</param>
+    /// <param name="nowUtc">Clock seam for the daily email cap.</param>
+    public GatewaySupervisorEnvironment(
+        TenantSettingsResolver settings,
+        Func<TenantId, string, SessionVerbClient?> route,
+        Func<TenantId, string, string?> activityState,
+        Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider,
+        ActivityEventStore? ledger = null,
+        Func<TenantId, IDisposable>? enterTenantScope = null,
+        Func<string, string, CancellationToken, Task<bool>>? sendOwnerEmail = null,
+        Func<DateTime>? nowUtc = null)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _route = route ?? throw new ArgumentNullException(nameof(route));
+        _activityState = activityState ?? throw new ArgumentNullException(nameof(activityState));
+        _brainProvider = brainProvider ?? throw new ArgumentNullException(nameof(brainProvider));
+        _ledger = ledger;
+        _enterTenantScope = enterTenantScope;
+        _sendOwnerEmail = sendOwnerEmail;
+        _nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+    }
+
+    /// <inheritdoc />
+    public SupervisorSettings Settings(TenantId tenant) => _settings.SessionSupervisor(tenant);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>?> ReadScreenRowsAsync(
+        TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+    {
+        var route = _route(tenant, directorId);
+        if (route is null) return null;
+        try
+        {
+            var grid = await route.GetScreenGridAsync(sessionId, ct).ConfigureAwait(false);
+            if (grid is null || !grid.HasGrid) return null;
+            return grid.Rows;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewaySupervisorEnvironment] screen read FAILED sid={sessionId}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public string? ReadActivityState(TenantId tenant, string sessionId) => _activityState(tenant, sessionId);
+
+    /// <inheritdoc />
+    public async Task<bool> IsMenuOnScreenAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+    {
+        var route = _route(tenant, directorId);
+        if (route is null) return false;    // unreachable is not a menu; the send below will fail honestly
+        return await WaitingScreenReader.IsMenuAsync(route, sessionId, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SendContinueAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+    {
+        var route = _route(tenant, directorId);
+        if (route is null)
+        {
+            FileLog.Write($"[GatewaySupervisorEnvironment] continue NOT sent sid={sessionId}: director {directorId} is not connected");
+            return false;
+        }
+        var request = new PromptRequest { Text = SessionSupervisor.ContinueText, AppendEnter = true, WaitForIdle = false };
+        var (ok, _, error) = await route.PostPromptAsync(sessionId, request, ct).ConfigureAwait(false);
+        if (!ok)
+            FileLog.Write($"[GatewaySupervisorEnvironment] continue send FAILED sid={sessionId}: {error}");
+        return ok;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> AskModelVerdictAsync(TenantId tenant, IReadOnlyList<string> rows, CancellationToken ct)
+    {
+        try
+        {
+            using var brain = await _brainProvider(tenant, WingmanModelRole.Fast, ct).ConfigureAwait(false);
+            var result = await brain.AskAsync(SupervisorVerdict.BuildPrompt(rows), ct).ConfigureAwait(false);
+            return result?.Text;
+        }
+        catch (Exception ex)
+        {
+            // A model that cannot be asked leaves the fault unclassified, which escalates. It never
+            // degrades into an assumption that the session is safe to type into.
+            FileLog.Write($"[GatewaySupervisorEnvironment] model fallback FAILED: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task DelayAsync(TimeSpan delay, CancellationToken ct) => Task.Delay(delay, ct);
+
+    /// <inheritdoc />
+    public void Record(SupervisorRecord record)
+    {
+        if (record is null) return;
+        FileLog.Write($"[SessionSupervisor] {record.EventType} cause={record.Cause} sid={record.SessionId} " +
+                      $"director={record.DirectorId} tenant={record.Tenant.ToLogString()}: {record.Detail}");
+        AppendToLedger(record);
+    }
+
+    /// <inheritdoc />
+    public async Task EscalateAsync(SupervisorRecord record, CancellationToken ct)
+    {
+        if (record is null) return;
+        FileLog.Write($"[SessionSupervisor] ESCALATED cause={record.Cause} sid={record.SessionId} " +
+                      $"director={record.DirectorId} tenant={record.Tenant.ToLogString()}: {record.Detail}");
+        AppendToLedger(record);
+
+        if (_sendOwnerEmail is null) return;
+        if (!TakeEmailBudget())
+        {
+            FileLog.Write($"[SessionSupervisor] escalation email SKIPPED sid={record.SessionId}: daily cap of {DailyEscalationEmailCap} reached");
+            return;
+        }
+
+        var subject = $"DevThrottle: session {record.SessionId} needs you ({record.Cause})";
+        var body =
+            $"A session stopped and DevThrottle could not resume it on its own.{Environment.NewLine}{Environment.NewLine}" +
+            $"Session:  {record.SessionId}{Environment.NewLine}" +
+            $"Director: {record.DirectorId}{Environment.NewLine}" +
+            $"Reason:   {record.Cause}{Environment.NewLine}" +
+            $"Detail:   {record.Detail}{Environment.NewLine}{Environment.NewLine}" +
+            "Open the session to see what it is waiting on.";
+        try
+        {
+            var sent = await _sendOwnerEmail(subject, body, ct).ConfigureAwait(false);
+            FileLog.Write($"[SessionSupervisor] escalation email sid={record.SessionId}: sent={sent}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionSupervisor] escalation email FAILED sid={record.SessionId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>One record into the durable ledger, inside the owning tenant's scope. The ledger OBSERVES the
+    /// supervisor: an append fault is logged loudly and never turns a recovery into a failure.</summary>
+    private void AppendToLedger(SupervisorRecord record)
+    {
+        if (_ledger is null) return;
+        try
+        {
+            using var scope = _enterTenantScope?.Invoke(record.Tenant);
+            _ledger.AppendBatch(new[]
+            {
+                new ActivityEventRecord
+                {
+                    EventId = Guid.NewGuid(),
+                    DirectorSequence = 0,
+                    OccurredUtc = _nowUtc(),
+                    DirectorId = string.IsNullOrWhiteSpace(record.DirectorId) ? "gateway" : record.DirectorId,
+                    SessionId = record.SessionId,
+                    EventType = record.EventType,
+                    Cause = record.Cause,
+                    Detail = record.Detail,
+                },
+            });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionSupervisor] recovery-log append FAILED for {record.EventType} sid={record.SessionId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Take one unit of today's escalation email budget, rolling the day over as needed.</summary>
+    private bool TakeEmailBudget()
+    {
+        var today = DateOnly.FromDateTime(_nowUtc());
+        lock (_emailGate)
+        {
+            if (_emailDay != today)
+            {
+                _emailDay = today;
+                _emailsToday = 0;
+            }
+            if (_emailsToday >= DailyEscalationEmailCap) return false;
+            _emailsToday++;
+            return true;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Supervision/SessionFault.cs
+++ b/src/CcDirector.Gateway/Supervision/SessionFault.cs
@@ -1,0 +1,64 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// How a supervised turn ended (issue #915, phase 1 step 2). This is the closed set the deterministic
+/// classifier and the model fallback both answer in, and the only vocabulary the recovery state machine
+/// understands.
+/// </summary>
+public enum SessionFaultClass
+{
+    /// <summary>No fault on the screen - the turn ended cleanly and the session is supposed to be waiting.
+    /// The majority answer, and the one that costs nothing: the supervisor stops here.</summary>
+    None,
+
+    /// <summary>A transport fault: name resolution failed, the connection reset, the socket dropped. Clears
+    /// itself in seconds. This is the class the whole feature exists for.</summary>
+    TransientTransport,
+
+    /// <summary>The provider rate-limited the call. Recoverable, but only after backing off.</summary>
+    RateLimited,
+
+    /// <summary>The agent's context window is full. Recoverable ONLY by compacting first, which is phase 2
+    /// (thefrederiksen/devthrottle_internal#1403) - so phase 1 raises its hand rather than sending a prompt
+    /// into a session that swallows prompts.</summary>
+    ContextFull,
+
+    /// <summary>The work itself cannot proceed: out of allowance or credits, a failed sign-in, an invalid
+    /// key. Never auto-continued - it must reach a human.</summary>
+    NonRecoverable,
+
+    /// <summary>The turn ended abnormally but on nothing the deterministic table recognizes. Step 3 (the
+    /// model fallback) is the only thing that may resolve this; with the fallback off it escalates.</summary>
+    Unclassified,
+}
+
+/// <summary>
+/// One classified fault: the class, plus the SIGNATURE that matched.
+///
+/// The signature is deliberately OUR OWN token ("ENOTFOUND", "socket hang up", "credit balance"), never the
+/// terminal line it was found in. It is what goes in the recovery log and the process log, so the log stays
+/// diagnostic without carrying a customer's terminal content out of the tenant partition - the same line the
+/// activity ledger already draws (<see cref="ActivityEventRecord.Detail"/> is a control-flow note and never
+/// terminal text).
+/// </summary>
+public sealed record SessionFault(SessionFaultClass Class, string Signature)
+{
+    /// <summary>The no-fault answer.</summary>
+    public static readonly SessionFault None = new(SessionFaultClass.None, "");
+
+    /// <summary>True when this class is one the state machine may act on by re-sending "continue".</summary>
+    public bool IsRecoverable => Class is SessionFaultClass.TransientTransport or SessionFaultClass.RateLimited;
+
+    /// <summary>The activity-ledger cause for this class - the closed wire vocabulary the recovery log writes.</summary>
+    public string LedgerCause => Class switch
+    {
+        SessionFaultClass.TransientTransport => ActivityCauses.TransientTransport,
+        SessionFaultClass.RateLimited => ActivityCauses.RateLimited,
+        SessionFaultClass.ContextFull => ActivityCauses.ContextFull,
+        SessionFaultClass.NonRecoverable => ActivityCauses.NonRecoverable,
+        SessionFaultClass.Unclassified => ActivityCauses.UnclassifiedFault,
+        _ => ActivityCauses.Unknown,
+    };
+}

--- a/src/CcDirector.Gateway/Supervision/SessionSupervisor.cs
+++ b/src/CcDirector.Gateway/Supervision/SessionSupervisor.cs
@@ -1,0 +1,372 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Briefing;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// Everything the supervisor needs from the Gateway around it, as one seam. Production wires
+/// <see cref="GatewaySupervisorEnvironment"/>; the tests wire a fake with no clock, no tunnel and no model,
+/// which is what makes a two-hour escalation ladder provable in milliseconds.
+/// </summary>
+public interface ISupervisorEnvironment
+{
+    /// <summary>This tenant's supervisor settings.</summary>
+    SupervisorSettings Settings(TenantId tenant);
+
+    /// <summary>The session's LIVE screen rows, or null when it cannot be read (Director not connected, read
+    /// failed). Null is never treated as a fault - unreadable is not evidence.</summary>
+    Task<IReadOnlyList<string>?> ReadScreenRowsAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct);
+
+    /// <summary>The session's current activity state from the pushed roster snapshot ("Working",
+    /// "WaitingForInput", ...), or null when the session is no longer there. A cheap in-memory read: the
+    /// supervisor never dials a session to ask whether it is alive.</summary>
+    string? ReadActivityState(TenantId tenant, string sessionId);
+
+    /// <summary>True when a menu confidently owns the session's screen. Typing "continue" would answer it,
+    /// so the supervisor refuses.</summary>
+    Task<bool> IsMenuOnScreenAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct);
+
+    /// <summary>Send the continuation prompt into the session. Returns whether the send landed.</summary>
+    Task<bool> SendContinueAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct);
+
+    /// <summary>Step 3: ask the cheap model one tight question about an unrecognized terminating error, and
+    /// return its raw reply (or null when it could not be asked).</summary>
+    Task<string?> AskModelVerdictAsync(TenantId tenant, IReadOnlyList<string> rows, CancellationToken ct);
+
+    /// <summary>Wait. The engine's only clock, so a test can run the whole ladder instantly.</summary>
+    Task DelayAsync(TimeSpan delay, CancellationToken ct);
+
+    /// <summary>Append one record to the recovery log.</summary>
+    void Record(SupervisorRecord record);
+
+    /// <summary>Raise a hand: the escalated recovery-log record plus the owner email.</summary>
+    Task EscalateAsync(SupervisorRecord record, CancellationToken ct);
+}
+
+/// <summary>
+/// One line of the recovery log (issue #915). Nothing the supervisor does is invisible: every detection,
+/// wait, re-send, recovery and escalation writes one of these.
+///
+/// <paramref name="Detail"/> is a control-flow note - the attempt number, the delay, the outcome, the matched
+/// SIGNATURE - and never terminal content, so the log can be read without carrying a customer's screen out of
+/// their partition.
+/// </summary>
+public sealed record SupervisorRecord(
+    TenantId Tenant,
+    string DirectorId,
+    string SessionId,
+    string EventType,
+    string Cause,
+    string Detail);
+
+/// <summary>
+/// The session supervisor, phase 1 (issue #915): when a managed session goes idle after a TRANSIENT TRANSPORT
+/// fault, wait and resume it automatically instead of freezing until somebody notices.
+///
+/// WHY IT EXISTS. Overnight on 2026-07-21 a session printed "API Error: Unable to connect to API (ENOTFOUND)"
+/// at 06:56 and sat dead until 09:32 - two hours thirty-six minutes lost to a name-resolution blip that
+/// cleared itself in seconds. That is the unattended promise failing.
+///
+/// EVENT-DRIVEN, NOT A POLLER. The only thing that wakes it is a session crossing Working -> idle, which the
+/// existing <see cref="TurnEndWatcher"/> already observes. A session that is Working is never evaluated and
+/// never touched.
+///
+/// THE INVARIANT: NON-INTERRUPTIVE BY CONSTRUCTION. Four independent gates stand between an idle session and
+/// a keystroke:
+///   1. the Working -> idle event (a working session never reaches the engine at all);
+///   2. a POSITIVE fault signal on the live screen, inside the last few lines of real content - a clean turn
+///      end resolves at step 2 for free, and an old error further up the screen is not a terminating fault;
+///   3. a re-read of the session's activity state immediately before every send - if it has gone Working in
+///      the meantime, the episode ends as recovered and nothing is sent;
+///   4. a menu check before every send - a menu owning the screen escalates instead of being answered.
+/// The hand-rolled watcher this replaces violated the invariant by probing sessions to confirm liveness, and
+/// interrupted a healthy mission a dozen times in one night. Here that is not discouraged, it is unreachable.
+///
+/// A CATCH-UP COUNTS TOO. The watcher also fires for a session FIRST SEEN already waiting - a turn that ended
+/// before this Gateway started. Those are evaluated deliberately: a session parked on a name-resolution error
+/// since 03:00 is exactly the case this feature exists for, and it must not be skipped merely because the
+/// Gateway restarted after it died. The fault gate makes that safe - a catch-up with a clean screen is left
+/// alone like any other finished turn.
+///
+/// WHAT IT COSTS. One live-screen read per idle transition, and nothing else on the common path: no timer, no
+/// poll, no model call. A clean turn end is resolved by the pure classifier and stops there. The model is
+/// reached only for a turn that ended on an error nothing in the table recognizes - a rare minority of a
+/// minority.
+///
+/// AN EPISODE, NOT A TURN. The attempt count and the ceiling belong to the FAULT EPISODE, not to one idle
+/// transition. In a real outage a "continue" does produce a brief Working flicker before failing again, so a
+/// per-transition counter would reset forever and the ceiling would never fire - which is exactly the
+/// infinite blind loop the issue forbids. An episode ends when the session finishes a turn with NO fault on
+/// its screen, when it exits, or when the supervisor escalates.
+/// </summary>
+public sealed class SessionSupervisor : IDisposable
+{
+    private readonly ISupervisorEnvironment _env;
+
+    // The live recovery loops, keyed by (tenant, session). Presence means "an episode is being worked", so a
+    // second turn-end for the same session never stacks a second loop.
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), CancellationTokenSource> _running = new();
+
+    // How many sends this episode has made, per session. Survives the Working flicker a failed continue
+    // produces; cleared when the session finishes a turn cleanly, exits, or is escalated.
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), int> _episodeAttempts = new();
+
+    private bool _disposed;
+
+    public SessionSupervisor(ISupervisorEnvironment environment)
+        => _env = environment ?? throw new ArgumentNullException(nameof(environment));
+
+    /// <summary>The continuation text sent into a parked session. Deliberately the plainest possible verb -
+    /// it resumes the interrupted turn without adding an instruction the agent did not ask for.</summary>
+    public const string ContinueText = "continue";
+
+    /// <summary>
+    /// A session crossed into idle. Evaluates it and, if a recoverable fault ended the turn, runs the
+    /// recovery ladder in the background. Fire-and-forget by design: the turn-end handler must not wait.
+    /// </summary>
+    public void OnTurnEnd(TurnEndSignal signal)
+    {
+        if (_disposed || signal is null) return;
+        if (!signal.Tenant.IsValid) return;
+        if (string.IsNullOrEmpty(signal.SessionId)) return;
+
+        var key = (signal.Tenant, signal.SessionId);
+        var cts = new CancellationTokenSource();
+        if (!_running.TryAdd(key, cts))
+        {
+            // An episode is already being worked for this session; a second turn-end changes nothing.
+            cts.Dispose();
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await SuperviseAsync(signal.Tenant, signal.DirectorId, signal.SessionId, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // The session started working while we waited - the ordinary happy ending. Recorded by the
+                // waiter itself, so nothing to add here.
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[SessionSupervisor] episode FAILED: sid={signal.SessionId} director={signal.DirectorId}: {ex.Message}");
+            }
+            finally
+            {
+                // Remove OUR entry specifically: the key is the gate that stops a second loop starting, so
+                // it must not be cleared on behalf of a loop somebody else owns.
+                _running.TryRemove(new KeyValuePair<(TenantId, string), CancellationTokenSource>(key, cts));
+                cts.Dispose();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The session is working again. Cancels any wait in flight - the session recovered, on its own or
+    /// because our "continue" landed - so nothing further is sent.
+    /// </summary>
+    public void OnSessionWorking(TenantId tenant, string sessionId)
+    {
+        if (_disposed || !tenant.IsValid || string.IsNullOrEmpty(sessionId)) return;
+        if (_running.TryGetValue((tenant, sessionId), out var cts))
+        {
+            try { cts.Cancel(); }
+            catch (ObjectDisposedException) { /* the loop already finished and disposed it */ }
+        }
+    }
+
+    /// <summary>How many sends the current episode for this session has made (0 when there is no episode).
+    /// Exposed for tests and diagnosis.</summary>
+    internal int EpisodeAttempts(TenantId tenant, string sessionId)
+        => _episodeAttempts.TryGetValue((tenant, sessionId), out var n) ? n : 0;
+
+    /// <summary>
+    /// The funnel and the ladder for ONE idle session, awaited. This is the test entry point; production
+    /// reaches it through <see cref="OnTurnEnd"/>.
+    /// </summary>
+    internal async Task SuperviseAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
+    {
+        var settings = _env.Settings(tenant);
+        if (!settings.Enabled) return;
+
+        // ---- step 1 and 2: how did the turn end? ---------------------------------------------------------
+        var rows = await _env.ReadScreenRowsAsync(tenant, directorId, sessionId, ct).ConfigureAwait(false);
+        if (rows is null)
+        {
+            // Unreadable is not evidence of anything. Say so and stop - never guess a fault into existence.
+            FileLog.Write($"[SessionSupervisor] sid={sessionId}: screen unreadable at turn end - no verdict, no action");
+            return;
+        }
+
+        var fault = TerminatingFaultClassifier.Classify(rows);
+        if (fault.Class == SessionFaultClass.None)
+        {
+            // The majority path: a finished turn is SUPPOSED to wait. Costs one screen read and nothing else,
+            // and it ends the episode - the next fault starts counting from one again.
+            ClearEpisode(tenant, sessionId);
+            return;
+        }
+
+        var decidedByModel = false;
+        if (fault.Class == SessionFaultClass.Unclassified && settings.ModelFallbackEnabled)
+        {
+            var reply = await _env.AskModelVerdictAsync(tenant, rows, ct).ConfigureAwait(false);
+            var verdict = SupervisorVerdict.Parse(reply);
+            var mapped = SupervisorVerdict.Map(verdict);
+            decidedByModel = true;
+            FileLog.Write($"[SessionSupervisor] sid={sessionId}: model fallback verdict={verdict ?? "(none)"} -> {mapped}");
+            if (mapped == SessionFaultClass.None)
+            {
+                _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+                    ActivityEventTypes.SupervisorFaultDetected, ActivityCauses.Unknown,
+                    $"model verdict {verdict}: the turn ended cleanly - no action"));
+                ClearEpisode(tenant, sessionId);
+                return;
+            }
+            fault = new SessionFault(mapped, verdict ?? "unparsable-verdict");
+        }
+
+        _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+            ActivityEventTypes.SupervisorFaultDetected, fault.LedgerCause,
+            $"signature={fault.Signature}{(decidedByModel ? " (model verdict)" : "")}"));
+
+        // ---- the ladder ----------------------------------------------------------------------------------
+        var attempt = EpisodeAttempts(tenant, sessionId) + 1;
+        while (true)
+        {
+            if (ct.IsCancellationRequested)
+            {
+                // The session started working between the last send and this iteration - the ordinary happy
+                // ending when a "continue" lands. Record it rather than unwinding silently: a recovery that
+                // leaves no line in the recovery log is indistinguishable from one that never happened.
+                RecordRecovered(tenant, directorId, sessionId, attempt - 1, "started working after the last continue");
+                return;
+            }
+
+            var action = SupervisorPlanner.Next(fault.Class, attempt, settings);
+
+            if (action.Kind == SupervisorActionKind.DoNothing)
+            {
+                ClearEpisode(tenant, sessionId);
+                return;
+            }
+
+            if (action.Kind == SupervisorActionKind.Escalate)
+            {
+                await EscalateAsync(tenant, directorId, sessionId, action.Cause,
+                    $"{action.Detail} (signature={fault.Signature})", ct).ConfigureAwait(false);
+                return;
+            }
+
+            _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+                ActivityEventTypes.SupervisorWaiting, action.Cause,
+                $"attempt {attempt}: waiting {SupervisorPlanner.Describe(action.Delay)} before sending continue"));
+
+            try
+            {
+                await _env.DelayAsync(action.Delay, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // The session started working while we waited. That is the whole goal, whichever cause
+                // produced it, so the episode ends here as a success.
+                RecordRecovered(tenant, directorId, sessionId, attempt, "started working while the supervisor waited");
+                return;
+            }
+
+            // ---- gate 3: never send into a session that is not still parked ------------------------------
+            var state = _env.ReadActivityState(tenant, sessionId);
+            if (state is null)
+            {
+                _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+                    ActivityEventTypes.SupervisorStoodDown, ActivityCauses.SessionNotLive,
+                    $"attempt {attempt}: the session is gone - nothing to continue"));
+                ClearEpisode(tenant, sessionId);
+                return;
+            }
+            if (IsWorking(state))
+            {
+                RecordRecovered(tenant, directorId, sessionId, attempt, "already working by the time the wait ended");
+                return;
+            }
+            if (!IsParkedIdle(state))
+            {
+                // WaitingForPerm, Starting, Exiting: not a turn end the supervisor may act on. A real
+                // permission prompt in particular must never be steam-rolled by a typed "continue".
+                _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+                    ActivityEventTypes.SupervisorStoodDown, ActivityCauses.Unknown,
+                    $"attempt {attempt}: activity state {state} is not a parked turn end - stopping"));
+                ClearEpisode(tenant, sessionId);
+                return;
+            }
+
+            // ---- gate 4: a menu owns the screen -> refuse and raise a hand -------------------------------
+            if (await _env.IsMenuOnScreenAsync(tenant, directorId, sessionId, ct).ConfigureAwait(false))
+            {
+                await EscalateAsync(tenant, directorId, sessionId, ActivityCauses.MenuOwnsScreen,
+                    $"attempt {attempt}: a menu owns the screen, so \"{ContinueText}\" would answer it", ct)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            var sent = await _env.SendContinueAsync(tenant, directorId, sessionId, ct).ConfigureAwait(false);
+            _episodeAttempts[(tenant, sessionId)] = attempt;
+            _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+                ActivityEventTypes.SupervisorContinueSent, action.Cause,
+                $"attempt {attempt}: sent \"{ContinueText}\" - {(sent ? "delivered" : "the send did not land")}"));
+
+            attempt++;
+        }
+    }
+
+    /// <summary>
+    /// The session is working again, so this pass is over. The attempt count is deliberately NOT cleared: a
+    /// "continue" that reaches a still-broken network produces exactly this brief Working flicker before
+    /// failing again, so clearing here would reset the ladder on every cycle and the ceiling could never
+    /// fire - the infinite blind loop the issue forbids. The episode is closed by a turn that ends with NO
+    /// fault on the screen, which is the only evidence that the work actually resumed.
+    /// </summary>
+    private void RecordRecovered(TenantId tenant, string directorId, string sessionId, int attempt, string how)
+        => _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+            ActivityEventTypes.SupervisorRecovered, ActivityCauses.WorkingObservation,
+            $"attempt {attempt}: {how} - the attempt count is kept until a turn ends with no fault"));
+
+    private async Task EscalateAsync(TenantId tenant, string directorId, string sessionId,
+        string cause, string detail, CancellationToken ct)
+    {
+        var record = new SupervisorRecord(tenant, directorId, sessionId,
+            ActivityEventTypes.SupervisorEscalated, cause, detail);
+        ClearEpisode(tenant, sessionId);
+        await _env.EscalateAsync(record, ct).ConfigureAwait(false);
+    }
+
+    private void ClearEpisode(TenantId tenant, string sessionId)
+        => _episodeAttempts.TryRemove((tenant, sessionId), out _);
+
+    private static bool IsWorking(string state)
+        => string.Equals(state, "Working", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The two states that mean "a turn ended and the session is waiting" - the same pair the
+    /// turn-end watcher fires on and the auto-dismiss sweep acts on.</summary>
+    private static bool IsParkedIdle(string state)
+        => string.Equals(state, "WaitingForInput", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(state, "Idle", StringComparison.OrdinalIgnoreCase);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        foreach (var cts in _running.Values)
+        {
+            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+        }
+        _running.Clear();
+        _episodeAttempts.Clear();
+    }
+}

--- a/src/CcDirector.Gateway/Supervision/SessionSupervisor.cs
+++ b/src/CcDirector.Gateway/Supervision/SessionSupervisor.cs
@@ -333,9 +333,12 @@ public sealed class SessionSupervisor : IDisposable
     /// fault on the screen, which is the only evidence that the work actually resumed.
     /// </summary>
     private void RecordRecovered(TenantId tenant, string directorId, string sessionId, int attempt, string how)
-        => _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
+    {
+        var which = attempt > 0 ? $"attempt {attempt}" : "before any continue was sent";
+        _env.Record(new SupervisorRecord(tenant, directorId, sessionId,
             ActivityEventTypes.SupervisorRecovered, ActivityCauses.WorkingObservation,
-            $"attempt {attempt}: {how} - the attempt count is kept until a turn ends with no fault"));
+            $"{which}: {how} - the attempt count is kept until a turn ends with no fault"));
+    }
 
     private async Task EscalateAsync(TenantId tenant, string directorId, string sessionId,
         string cause, string detail, CancellationToken ct)

--- a/src/CcDirector.Gateway/Supervision/SupervisorPlanner.cs
+++ b/src/CcDirector.Gateway/Supervision/SupervisorPlanner.cs
@@ -1,0 +1,113 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>What the supervisor does next with a classified fault.</summary>
+public enum SupervisorActionKind
+{
+    /// <summary>Leave the session alone. The answer for a clean turn end - and the majority answer.</summary>
+    DoNothing,
+
+    /// <summary>Wait <see cref="SupervisorAction.Delay"/>, then re-send "continue" (subject to the engine's
+    /// own pre-send checks: still idle, no menu on the screen).</summary>
+    WaitThenContinue,
+
+    /// <summary>Touch nothing and raise a hand: the recovery log record, the loud process log line, and the
+    /// owner email.</summary>
+    Escalate,
+}
+
+/// <summary>One decision: what to do, how long to wait first, and the closed-vocabulary cause it is filed
+/// under in the recovery log.</summary>
+public sealed record SupervisorAction(SupervisorActionKind Kind, TimeSpan Delay, string Cause, string Detail);
+
+/// <summary>
+/// The recovery state machine (issue #915), pure so the whole escalation ladder is testable without waiting
+/// real minutes. Given the fault class, which attempt is next, and the tenant's settings, it returns the one
+/// action to take.
+///
+/// The ladder for a transient transport fault is exactly the shape the owner asked for: attempt 1 waits the
+/// short first retry, every attempt after it waits the long cadence, and once the ceiling is passed it
+/// escalates instead of retrying forever.
+/// </summary>
+public static class SupervisorPlanner
+{
+    /// <summary>A rate-limited backoff never grows past this, however many attempts it takes.</summary>
+    public static readonly TimeSpan MaxRateLimitedDelay = TimeSpan.FromMinutes(60);
+
+    /// <summary>
+    /// The next action. <paramref name="attempt"/> is 1-based and counts SENDS within one episode: attempt 1
+    /// is the first "continue" after the short wait, attempt 2 the first long-cadence one, and so on.
+    /// </summary>
+    public static SupervisorAction Next(SessionFaultClass fault, int attempt, SupervisorSettings settings)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+        if (attempt < 1) throw new ArgumentOutOfRangeException(nameof(attempt), attempt, "Attempts are 1-based.");
+
+        switch (fault)
+        {
+            case SessionFaultClass.None:
+                return new SupervisorAction(SupervisorActionKind.DoNothing, TimeSpan.Zero, ActivityCauses.Unknown,
+                    "the turn ended cleanly - nothing to recover");
+
+            case SessionFaultClass.NonRecoverable:
+                return new SupervisorAction(SupervisorActionKind.Escalate, TimeSpan.Zero, ActivityCauses.NonRecoverable,
+                    "the work itself cannot proceed, so continuing it would change nothing");
+
+            case SessionFaultClass.ContextFull:
+                // Phase 1 deliberately does not send here: a session whose context is full swallows prompts,
+                // so a "continue" would be silently eaten. Compact-then-continue is phase 2 (#1403).
+                return new SupervisorAction(SupervisorActionKind.Escalate, TimeSpan.Zero, ActivityCauses.ContextFull,
+                    "the context window is full - recovering it needs a compaction first (phase 2)");
+
+            case SessionFaultClass.Unclassified:
+                return new SupervisorAction(SupervisorActionKind.Escalate, TimeSpan.Zero, ActivityCauses.UnclassifiedFault,
+                    "the turn ended on a fault nothing here recognizes");
+
+            case SessionFaultClass.TransientTransport:
+            case SessionFaultClass.RateLimited:
+                if (attempt > 1 + settings.MaxLongRetries)
+                {
+                    return new SupervisorAction(SupervisorActionKind.Escalate, TimeSpan.Zero, ActivityCauses.RetryCeiling,
+                        $"gave up after {settings.MaxLongRetries} long retries - this is an outage, not a blip");
+                }
+                var delay = fault == SessionFaultClass.TransientTransport
+                    ? TransientDelay(attempt, settings)
+                    : RateLimitedDelay(attempt, settings);
+                var cause = fault == SessionFaultClass.TransientTransport
+                    ? ActivityCauses.TransientTransport
+                    : ActivityCauses.RateLimited;
+                return new SupervisorAction(SupervisorActionKind.WaitThenContinue, delay, cause,
+                    $"attempt {attempt} of {1 + settings.MaxLongRetries}, waiting {Describe(delay)}");
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(fault), fault, "Unknown fault class");
+        }
+    }
+
+    /// <summary>The short wait once, then the long cadence for every attempt after it.</summary>
+    private static TimeSpan TransientDelay(int attempt, SupervisorSettings settings)
+        => attempt == 1 ? settings.FirstRetry : settings.RetryCadence;
+
+    /// <summary>
+    /// Rate limiting starts at the long cadence and doubles, capped at <see cref="MaxRateLimitedDelay"/>: a
+    /// throttled provider is not a blip, and hammering it 45 seconds later earns another refusal.
+    ///
+    /// It does NOT honour a retry-after value, because there is none to honour here: the supervisor reads a
+    /// terminal screen, not an HTTP response, so the header the provider sent never reaches this code. A
+    /// number invented from screen text would be a fabricated measurement, so the backoff is the honest
+    /// answer instead.
+    /// </summary>
+    private static TimeSpan RateLimitedDelay(int attempt, SupervisorSettings settings)
+    {
+        var doublings = Math.Min(attempt - 1, 8);           // 2^8 is already far past the cap
+        var scaled = settings.RetryCadence * Math.Pow(2, doublings);
+        return scaled > MaxRateLimitedDelay ? MaxRateLimitedDelay : scaled;
+    }
+
+    /// <summary>A plain-English delay for the log and the recovery record.</summary>
+    public static string Describe(TimeSpan delay)
+        => delay < TimeSpan.FromMinutes(1)
+            ? $"{delay.TotalSeconds:0} seconds"
+            : $"{delay.TotalMinutes:0} minutes";
+}

--- a/src/CcDirector.Gateway/Supervision/SupervisorSettings.cs
+++ b/src/CcDirector.Gateway/Supervision/SupervisorSettings.cs
@@ -1,0 +1,63 @@
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// The session supervisor's knobs (issue #915), resolved per tenant with the documented defaults below. The
+/// engine reads these ONCE per recovery episode, so a change takes effect on the next fault rather than
+/// halfway through a wait.
+///
+/// Default ON. That is the product decision recorded on the issue: unattended runs surviving a network blip
+/// is the whole promise, so it is the out-of-the-box behaviour and an account opts OUT.
+/// </summary>
+public sealed record SupervisorSettings
+{
+    /// <summary>The master switch. Default on.</summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>The FIRST wait, before the first "continue" - long enough for a name-resolution blip to
+    /// clear, short enough that a night is not lost. Default 45 seconds.</summary>
+    public TimeSpan FirstRetry { get; init; } = TimeSpan.FromSeconds(DefaultFirstRetrySeconds);
+
+    /// <summary>The long cadence used from the second attempt on. Default 15 minutes.</summary>
+    public TimeSpan RetryCadence { get; init; } = TimeSpan.FromMinutes(DefaultRetryCadenceMinutes);
+
+    /// <summary>How many LONG-cadence attempts follow the first short one before the supervisor escalates
+    /// instead of retrying forever. Default 8 - roughly two hours of trying.</summary>
+    public int MaxLongRetries { get; init; } = DefaultMaxLongRetries;
+
+    /// <summary>
+    /// Whether step 3 - the model fallback - may look at an unrecognized terminating error. Default on, and
+    /// independently switchable because it is the ONLY tier that sends terminal text off the machine.
+    /// </summary>
+    public bool ModelFallbackEnabled { get; init; } = true;
+
+    public const int DefaultFirstRetrySeconds = 45;
+    public const int DefaultRetryCadenceMinutes = 15;
+    public const int DefaultMaxLongRetries = 8;
+
+    /// <summary>The shipped defaults, as one value.</summary>
+    public static readonly SupervisorSettings Defaults = new();
+
+    // ---- validation bounds ------------------------------------------------------------------------------
+    // A stored override outside these bounds is not honoured: a zero-second first retry would hammer a
+    // session, and a zero ceiling with a one-minute cadence would be the infinite blind loop the issue
+    // explicitly forbids. Out-of-bounds degrades to the documented default, never to "no limit".
+
+    public const int MinFirstRetrySeconds = 5;
+    public const int MaxFirstRetrySeconds = 600;
+    public const int MinRetryCadenceMinutes = 1;
+    public const int MaxRetryCadenceMinutes = 120;
+    public const int MinLongRetries = 0;
+    public const int MaxLongRetriesAllowed = 48;
+
+    /// <summary>True when a first-retry override is usable.</summary>
+    public static bool IsValidFirstRetrySeconds(int seconds)
+        => seconds >= MinFirstRetrySeconds && seconds <= MaxFirstRetrySeconds;
+
+    /// <summary>True when a cadence override is usable.</summary>
+    public static bool IsValidRetryCadenceMinutes(int minutes)
+        => minutes >= MinRetryCadenceMinutes && minutes <= MaxRetryCadenceMinutes;
+
+    /// <summary>True when a ceiling override is usable. Zero is legal and means "the short retry only".</summary>
+    public static bool IsValidMaxLongRetries(int retries)
+        => retries >= MinLongRetries && retries <= MaxLongRetriesAllowed;
+}

--- a/src/CcDirector.Gateway/Supervision/SupervisorVerdict.cs
+++ b/src/CcDirector.Gateway/Supervision/SupervisorVerdict.cs
@@ -1,0 +1,101 @@
+using System.Text;
+
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// Step 3 of the funnel (issue #915): the rare model fallback. It is reached ONLY when the turn ended on
+/// something that announces itself as an error and step 2's table did not recognize it - never on a Working
+/// session, never on a cleanly finished one, and never on the majority of idle transitions. It is also the
+/// only tier that sends terminal text off the machine, which is why it is independently switchable.
+///
+/// The question is tight and the answer set is fixed, so the engine acts on a verdict rather than on prose.
+/// An unparsable or absent answer is NOT a verdict: it stays unclassified and escalates. A model that
+/// mumbles must never be read as permission to type into somebody's session.
+/// </summary>
+public static class SupervisorVerdict
+{
+    /// <summary>The fixed answer set. Anything else is no verdict at all.</summary>
+    public const string TransientRecoverable = "transient_recoverable";
+    public const string NeedsHuman = "needs_human";
+    public const string HealthyDone = "healthy_done";
+    public const string ContextFull = "context_full";
+
+    /// <summary>How many lines of the screen tail the question carries.</summary>
+    public const int PromptTailLines = 20;
+
+    /// <summary>
+    /// Map a verdict word onto the engine's vocabulary. An unrecognized or missing verdict maps to
+    /// <see cref="SessionFaultClass.Unclassified"/>, which escalates - the fail-safe direction, because the
+    /// alternative is acting on a session on the strength of an answer nobody understood.
+    /// </summary>
+    public static SessionFaultClass Map(string? verdict)
+    {
+        var word = Normalize(verdict);
+        return word switch
+        {
+            TransientRecoverable => SessionFaultClass.TransientTransport,
+            NeedsHuman => SessionFaultClass.NonRecoverable,
+            HealthyDone => SessionFaultClass.None,
+            ContextFull => SessionFaultClass.ContextFull,
+            _ => SessionFaultClass.Unclassified,
+        };
+    }
+
+    /// <summary>
+    /// Pull the verdict word out of a model reply. Tolerant of the wrapping a chat model adds (quotes,
+    /// backticks, a trailing full stop, a leading "verdict:") but NOT of a reply that names two verdicts -
+    /// that is an undecided answer, and it returns null rather than picking the first one.
+    /// </summary>
+    public static string? Parse(string? reply)
+    {
+        if (string.IsNullOrWhiteSpace(reply)) return null;
+        var lower = reply.ToLowerInvariant();
+        string? found = null;
+        foreach (var candidate in All)
+        {
+            if (!lower.Contains(candidate, StringComparison.Ordinal)) continue;
+            if (found is not null) return null;      // two verdicts named - undecided
+            found = candidate;
+        }
+        return found;
+    }
+
+    /// <summary>Every legal verdict word.</summary>
+    public static readonly string[] All = { TransientRecoverable, NeedsHuman, HealthyDone, ContextFull };
+
+    /// <summary>
+    /// Build the one question the fallback asks. It states the closed answer set, forbids prose, and gives
+    /// the model only the tail of the screen - the same window the deterministic classifier looked at, plus
+    /// a little more context.
+    /// </summary>
+    public static string BuildPrompt(IReadOnlyList<string>? rows, int tailLines = PromptTailLines)
+    {
+        var tail = Tail(rows, tailLines);
+        var sb = new StringBuilder();
+        sb.AppendLine("A coding-agent session in a terminal has stopped and is waiting. Below is the tail of its");
+        sb.AppendLine("screen. Decide why it stopped and answer with EXACTLY ONE of these words and nothing else:");
+        sb.AppendLine();
+        sb.AppendLine($"  {TransientRecoverable}  - it died on a temporary network or transport failure that will clear by itself");
+        sb.AppendLine($"  {NeedsHuman}            - it stopped on something a person must fix (no allowance or credit left, a sign-in failure, a question it is waiting on)");
+        sb.AppendLine($"  {HealthyDone}           - it finished its work normally and is waiting for the next instruction");
+        sb.AppendLine($"  {ContextFull}           - it ran out of context window");
+        sb.AppendLine();
+        sb.AppendLine("If you are not sure, answer needs_human. Answer with one word only.");
+        sb.AppendLine();
+        sb.AppendLine("--- screen tail ---");
+        foreach (var line in tail) sb.AppendLine(line);
+        sb.AppendLine("--- end ---");
+        return sb.ToString();
+    }
+
+    private static IReadOnlyList<string> Tail(IReadOnlyList<string>? rows, int tailLines)
+    {
+        if (rows is null || rows.Count == 0 || tailLines <= 0) return Array.Empty<string>();
+        var content = rows.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.TrimEnd()).ToList();
+        if (content.Count <= tailLines) return content;
+        return content.GetRange(content.Count - tailLines, tailLines);
+    }
+
+    private static string Normalize(string? verdict)
+        => (verdict ?? "").Trim().Trim('"', '\'', '`', '.', ' ').ToLowerInvariant();
+}

--- a/src/CcDirector.Gateway/Supervision/TerminatingFaultClassifier.cs
+++ b/src/CcDirector.Gateway/Supervision/TerminatingFaultClassifier.cs
@@ -16,11 +16,13 @@ namespace CcDirector.Gateway.Supervision;
 /// merely REMEMBERS an old error must never be sent a "continue". This is the rule that stops the engine
 /// re-firing on a session it already rescued.
 ///
-/// THE ASYMMETRY IS DELIBERATE. For the two classes that ACT on a session (transient transport, rate
-/// limited) a class signature is not enough: the same line must also carry an error marker, so a session
+/// THE ASYMMETRY IS DELIBERATE. For the two classes that ACT on a session (transient transport, rate limited)
+/// an ordinary English signature is not enough: the same line must also carry an error marker, so a session
 /// whose agent happened to PRINT the words "connection refused" while discussing a log is never typed into.
-/// For the two classes that only RAISE A HAND (non-recoverable, context full) the signature alone is enough -
-/// they touch nothing, so the safe direction there is to notice more, not less.
+/// Signatures that cannot plausibly occur in ordinary prose - the errno codes, "socket hang up",
+/// "rate_limit_error" - stand on their own, because demanding a marker beside them would only lose real
+/// faults. For the two classes that only RAISE A HAND (non-recoverable, context full) the signature alone is
+/// always enough: they touch nothing, so the safe direction there is to notice more, not less.
 /// </summary>
 public static class TerminatingFaultClassifier
 {
@@ -44,9 +46,13 @@ public static class TerminatingFaultClassifier
             return new SessionFault(SessionFaultClass.NonRecoverable, nonRecoverable);
         if (FirstMatch(window, ContextFullSignatures, requireErrorMarker: false) is { } contextFull)
             return new SessionFault(SessionFaultClass.ContextFull, contextFull);
-        if (FirstMatch(window, RateLimitedSignatures, requireErrorMarker: true) is { } rateLimited)
+        if (FirstMatch(window, RateLimitedSelfEvident, requireErrorMarker: false) is { } rateLimitedPlain)
+            return new SessionFault(SessionFaultClass.RateLimited, rateLimitedPlain);
+        if (FirstMatch(window, RateLimitedGeneric, requireErrorMarker: true) is { } rateLimited)
             return new SessionFault(SessionFaultClass.RateLimited, rateLimited);
-        if (FirstMatch(window, TransientTransportSignatures, requireErrorMarker: true) is { } transient)
+        if (FirstMatch(window, TransientTransportSelfEvident, requireErrorMarker: false) is { } transientPlain)
+            return new SessionFault(SessionFaultClass.TransientTransport, transientPlain);
+        if (FirstMatch(window, TransientTransportGeneric, requireErrorMarker: true) is { } transient)
             return new SessionFault(SessionFaultClass.TransientTransport, transient);
 
         // Nothing recognized. If the turn nonetheless ended on something that announces itself as an error,
@@ -122,27 +128,46 @@ public static class TerminatingFaultClassifier
         return false;
     }
 
-    /// <summary>Words that mark a line as an agent-emitted failure rather than prose that merely mentions
-    /// one. Required before either ACTING class may match.</summary>
+    /// <summary>
+    /// Words that mark a line as an agent-emitted failure rather than prose that merely mentions one.
+    /// Required beside a GENERIC signature before either acting class may match.
+    ///
+    /// Deliberately NOT including "refused", "timed out" or "disconnected": each of those is already part of a
+    /// generic signature below, so listing it here would let that signature satisfy its own marker test and
+    /// the guard would wave through the very sentence it exists to reject.
+    /// </summary>
     private static readonly string[] ErrorMarkers =
     {
-        "error", "failed", "failure", "unable", "cannot", "can't", "refused", "timed out", "timeout",
-        "disconnect", "aborted", "retrying",
+        "error", "failed", "failure", "unable", "cannot", "can't", "aborted", "retrying",
     };
 
-    /// <summary>The transport faults this feature exists for. The July 21 incident matched the first one.</summary>
-    private static readonly string[] TransientTransportSignatures =
+    /// <summary>Transport faults that cannot plausibly appear in ordinary prose - an errno code or a runtime's
+    /// own error text. These stand on their own. The July 21 incident matched the first one.</summary>
+    private static readonly string[] TransientTransportSelfEvident =
     {
         "enotfound", "econnreset", "econnrefused", "etimedout", "eai_again", "epipe",
-        "socket hang up", "unable to connect to api", "fetch failed", "network error",
-        "connection error", "connection reset", "connection refused", "connection closed",
-        "request timed out", "getaddrinfo", "upstream connect error",
+        "socket hang up", "getaddrinfo", "upstream connect error", "fetch failed",
+        "unable to connect to api",
     };
 
-    /// <summary>Provider throttling and overload - recoverable, but only after backing off.</summary>
-    private static readonly string[] RateLimitedSignatures =
+    /// <summary>Transport faults phrased in ordinary English - a session could be DISCUSSING one of these
+    /// rather than dying on it, so they need an error marker on the same line.</summary>
+    private static readonly string[] TransientTransportGeneric =
     {
-        "rate limit", "rate_limit_error", "too many requests", "429", "overloaded_error", "overloaded",
+        "network error", "connection error", "connection reset", "connection refused",
+        "connection closed", "request timed out",
+    };
+
+    /// <summary>Provider throttling in the provider's own vocabulary - recoverable after backing off.</summary>
+    private static readonly string[] RateLimitedSelfEvident =
+    {
+        "rate_limit_error", "too many requests", "overloaded_error",
+    };
+
+    /// <summary>Throttling phrased in ordinary English, or a bare status number - marker required.</summary>
+    private static readonly string[] RateLimitedGeneric =
+    {
+        "rate limit", "429", "overloaded",
     };
 
     /// <summary>A full context window. Recoverable only by compacting first, which is phase 2.</summary>

--- a/src/CcDirector.Gateway/Supervision/TerminatingFaultClassifier.cs
+++ b/src/CcDirector.Gateway/Supervision/TerminatingFaultClassifier.cs
@@ -1,0 +1,181 @@
+namespace CcDirector.Gateway.Supervision;
+
+/// <summary>
+/// Step 2 of the supervisor funnel (issue #915): decide, from the session's LIVE screen alone, whether the
+/// turn that just ended died on a fault - and which class of fault. Pure, free, instant, no model call. Most
+/// idle sessions resolve to <see cref="SessionFaultClass.None"/> here and cost nothing.
+///
+/// THE SCREEN, NOT THE SCROLLBACK. Claude Code, Grok, OpenCode and Copilot hold the terminal ALTERNATE
+/// screen for the whole session, and the parser deliberately never commits alternate-screen frames to
+/// scrollback - so a buffer read comes back empty for exactly the agents this feature exists for. The live
+/// grid is the only place the terminating error is legible.
+///
+/// THE WINDOW IS WHAT KEEPS THIS NON-INTERRUPTIVE. A fault only counts when it is among the last
+/// <see cref="DefaultWindowLines"/> lines of real content on the screen. An error further up - one a later,
+/// perfectly healthy turn has already scrolled away from - is not a terminating fault, and a session that
+/// merely REMEMBERS an old error must never be sent a "continue". This is the rule that stops the engine
+/// re-firing on a session it already rescued.
+///
+/// THE ASYMMETRY IS DELIBERATE. For the two classes that ACT on a session (transient transport, rate
+/// limited) a class signature is not enough: the same line must also carry an error marker, so a session
+/// whose agent happened to PRINT the words "connection refused" while discussing a log is never typed into.
+/// For the two classes that only RAISE A HAND (non-recoverable, context full) the signature alone is enough -
+/// they touch nothing, so the safe direction there is to notice more, not less.
+/// </summary>
+public static class TerminatingFaultClassifier
+{
+    /// <summary>How many lines of real content at the end of the screen may hold a terminating fault.</summary>
+    public const int DefaultWindowLines = 12;
+
+    /// <summary>
+    /// Classify the tail of a session's live screen. <paramref name="rows"/> is the resolved grid
+    /// (<c>ScreenGridResponse.Rows</c>); null, empty or blank is <see cref="SessionFaultClass.None"/> -
+    /// an unreadable screen is never a fault, because acting on one would be guessing.
+    /// </summary>
+    public static SessionFault Classify(IReadOnlyList<string>? rows, int windowLines = DefaultWindowLines)
+    {
+        var window = ContentWindow(rows, windowLines);
+        if (window.Count == 0) return SessionFault.None;
+
+        // Class-major, in precedence order: a screen carrying BOTH an authentication failure and a dropped
+        // connection escalates rather than retrying. The dangerous mistake is retrying something that will
+        // never succeed on its own, so the classes that refuse to act are asked first.
+        if (FirstMatch(window, NonRecoverableSignatures, requireErrorMarker: false) is { } nonRecoverable)
+            return new SessionFault(SessionFaultClass.NonRecoverable, nonRecoverable);
+        if (FirstMatch(window, ContextFullSignatures, requireErrorMarker: false) is { } contextFull)
+            return new SessionFault(SessionFaultClass.ContextFull, contextFull);
+        if (FirstMatch(window, RateLimitedSignatures, requireErrorMarker: true) is { } rateLimited)
+            return new SessionFault(SessionFaultClass.RateLimited, rateLimited);
+        if (FirstMatch(window, TransientTransportSignatures, requireErrorMarker: true) is { } transient)
+            return new SessionFault(SessionFaultClass.TransientTransport, transient);
+
+        // Nothing recognized. If the turn nonetheless ended on something that announces itself as an error,
+        // say so honestly as UNCLASSIFIED - that is the only input step 3 (the model fallback) accepts. A
+        // screen with no error banner at all is a clean turn end, and the funnel stops.
+        if (FirstMatch(window, ErrorBanners, requireErrorMarker: false) is { } banner)
+            return new SessionFault(SessionFaultClass.Unclassified, banner);
+
+        return SessionFault.None;
+    }
+
+    /// <summary>
+    /// The last <paramref name="windowLines"/> lines of REAL CONTENT on the screen: blank rows, box borders,
+    /// the composer line and the agent's mode/shortcut footer are all chrome and are dropped, wherever they
+    /// sit. Public so a test can assert exactly which lines are in scope.
+    /// </summary>
+    public static IReadOnlyList<string> ContentWindow(IReadOnlyList<string>? rows, int windowLines = DefaultWindowLines)
+    {
+        if (rows is null || rows.Count == 0 || windowLines <= 0) return Array.Empty<string>();
+        var content = new List<string>();
+        foreach (var row in rows)
+        {
+            if (string.IsNullOrWhiteSpace(row)) continue;
+            if (IsChrome(row)) continue;
+            content.Add(row);
+        }
+        if (content.Count <= windowLines) return content;
+        return content.GetRange(content.Count - windowLines, windowLines);
+    }
+
+    /// <summary>The first signature present in the window, or null. When <paramref name="requireErrorMarker"/>
+    /// is set, the matching line must ALSO carry an error marker.</summary>
+    private static string? FirstMatch(IReadOnlyList<string> window, string[] signatures, bool requireErrorMarker)
+    {
+        foreach (var line in window)
+        {
+            var lower = line.ToLowerInvariant();
+            if (requireErrorMarker && !HasErrorMarker(lower)) continue;
+            foreach (var signature in signatures)
+            {
+                if (lower.Contains(signature, StringComparison.Ordinal))
+                    return signature;
+            }
+        }
+        return null;
+    }
+
+    private static bool HasErrorMarker(string lowerLine)
+    {
+        foreach (var marker in ErrorMarkers)
+        {
+            if (lowerLine.Contains(marker, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>Screen furniture: a blank row, a pure box border, the composer input line, or the agent's
+    /// mode/shortcut footer. None of these can carry a terminating fault.</summary>
+    private static bool IsChrome(string row)
+    {
+        var trimmed = row.Trim();
+        if (trimmed.Length == 0) return true;
+
+        var stripped = trimmed.Trim(BorderGlyphs).Trim();
+        if (stripped.Length == 0) return true;                                  // border-only row
+        if (stripped[0] == '>' || stripped[0] == '❯') return true;         // the composer line
+
+        var lower = stripped.ToLowerInvariant();
+        foreach (var anchor in FooterAnchors)
+        {
+            if (lower.Contains(anchor, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>Words that mark a line as an agent-emitted failure rather than prose that merely mentions
+    /// one. Required before either ACTING class may match.</summary>
+    private static readonly string[] ErrorMarkers =
+    {
+        "error", "failed", "failure", "unable", "cannot", "can't", "refused", "timed out", "timeout",
+        "disconnect", "aborted", "retrying",
+    };
+
+    /// <summary>The transport faults this feature exists for. The July 21 incident matched the first one.</summary>
+    private static readonly string[] TransientTransportSignatures =
+    {
+        "enotfound", "econnreset", "econnrefused", "etimedout", "eai_again", "epipe",
+        "socket hang up", "unable to connect to api", "fetch failed", "network error",
+        "connection error", "connection reset", "connection refused", "connection closed",
+        "request timed out", "getaddrinfo", "upstream connect error",
+    };
+
+    /// <summary>Provider throttling and overload - recoverable, but only after backing off.</summary>
+    private static readonly string[] RateLimitedSignatures =
+    {
+        "rate limit", "rate_limit_error", "too many requests", "429", "overloaded_error", "overloaded",
+    };
+
+    /// <summary>A full context window. Recoverable only by compacting first, which is phase 2.</summary>
+    private static readonly string[] ContextFullSignatures =
+    {
+        "prompt is too long", "context limit reached", "context window is full", "conversation is too long",
+    };
+
+    /// <summary>Faults that mean the work cannot proceed. Never auto-continued (issue #758's class).</summary>
+    private static readonly string[] NonRecoverableSignatures =
+    {
+        "credit balance is too low", "out of credits", "insufficient credits", "usage limit reached",
+        "invalid api key", "invalid x-api-key", "authentication_error", "authentication failed",
+        "oauth token has expired", "please run /login", "permission_error", "403 forbidden",
+    };
+
+    /// <summary>A line that announces itself as a failure without naming a class we know. The ONLY thing
+    /// that reaches step 3.</summary>
+    private static readonly string[] ErrorBanners =
+    {
+        "api error", "error:", "fatal:", "unhandled exception", "request failed",
+    };
+
+    private static readonly string[] FooterAnchors =
+    {
+        "bypass permissions", "plan mode", "accept edits", "shift+tab to cycle", "? for shortcuts",
+    };
+
+    private static readonly char[] BorderGlyphs =
+    {
+        '│','┃','┆','┇','┊','┋','╎','╏','║',
+        '╭','╮','╰','╯','┌','┐','└','┘',
+        '╔','╗','╚','╝',
+        '─','━','═','┄','┅','┈','┉','|',' ','\t','\r',
+    };
+}


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#915 (phase 1).

## What was losing us the night

Overnight on 2026-07-21 a session printed `API Error: Unable to connect to API (ENOTFOUND)` at 06:56 and sat dead until 09:32. Two hours thirty-six minutes of build time gone to a name-resolution blip that cleared itself in seconds. Nothing was wrong with the agent, the machine, or the work - the session simply had nobody to type "continue" into it.

This adds the session supervisor: when a managed session goes idle after a transient transport fault, the Gateway waits and resumes it on its own.

## How it works

It is a deterministic engine in the Gateway, event-driven on the ONE event the turn-end watcher already publishes: a session crossing Working to idle. There is no poller, no cron, and no always-on model.

The funnel on each idle transition:

1. **Read the session's live screen.** Claude Code, Grok, OpenCode and Copilot hold the terminal alternate screen for the whole session and the parser never commits alternate-screen frames to scrollback, so a buffer read comes back empty for exactly the agents this feature exists for. The live grid is the only place the terminating error is legible - the same tunnel read the voice cluster already makes.
2. **Classify it, free and instant** (`TerminatingFaultClassifier`, pure): transient transport, rate limited, context full, not recoverable, unclassified, or no fault at all. A clean turn end stops here, which is the majority of idle transitions.
3. **Ask a cheap model, rarely** (`SupervisorVerdict`): only for a turn that ended on something announcing itself as an error that the table does not recognize. One tight question, a fixed four-word answer set, and an unparsable answer is no verdict - it escalates rather than acting.

Then the ladder the issue asked for (`SupervisorPlanner`, pure): wait 45 seconds and send `continue`; if the session is still parked, wait 15 minutes and send again; after 8 long retries escalate instead of retrying forever. Rate limiting starts at the cadence and doubles to a 60-minute cap.

## The invariant: non-interruptive by construction

The hand-rolled watcher this replaces interrupted a healthy mission a dozen times in one night by probing sessions to confirm liveness. Four independent gates now stand between an idle session and a keystroke:

1. the Working-to-idle event - a working session never reaches the engine at all;
2. a positive fault signal within the last twelve lines of real content on the screen, so an old error a later healthy turn has scrolled past is not a terminating fault (this is the rule that stops the engine re-firing on a session it already rescued);
3. a re-read of the activity state immediately before every send - Working, gone, or a permission prompt all end the pass with nothing sent;
4. a menu check before every send - a menu owning the screen escalates rather than being answered, because "continue" typed at a menu picks an option.

Two more deliberate choices, both asymmetric on purpose:

- Signatures are split by whether they could occur in ordinary prose. An English phrase (`connection refused`, `rate limit`) needs a failure marker on the same line before either ACTING class may match, so a session whose agent merely printed those words while discussing a log is never typed into - and the marker list deliberately excludes any word that is part of a signature, or the signature would satisfy its own test. Errno codes and runtime error text (`ENOTFOUND`, `socket hang up`, `rate_limit_error`) stand alone, because demanding a marker beside them would only lose real faults. The two classes that merely RAISE A HAND always match on the signature alone - they touch nothing, so noticing more is the safe direction there.
- The attempt count belongs to the fault EPISODE, not to one idle transition. In a real outage a `continue` does produce a brief Working flicker before failing again, so a per-transition counter would reset forever and the ceiling could never fire - the infinite blind loop the issue forbids. An episode closes only when a turn ends with no fault on the screen.

## Recovery log and escalation

Every detection, wait, send, recovery, stand-down and escalation writes one record to the durable activity ledger (tenant-scoped, already served by `GET /activity-events`) and one line to the process log, carrying the fault class, the attempt number, the delay chosen, the outcome, and the model verdict when one was used.

The record carries the matched SIGNATURE - our own token, `enotfound` - never the terminal line it came from, so the log stays diagnostic without carrying a customer's screen out of their partition. That is the line the ledger already draws.

Escalation raises a hand two ways: the escalated ledger record, and an owner email through the same notify channel the network-diagnostics alerts use (capped at ten a day, and skipped with a plain log line when no account is signed in - never a reported send that did not happen).

## Settings, per tenant, default on

`session_supervisor_enabled` (on), `session_supervisor_first_retry_seconds` (45), `session_supervisor_retry_cadence_minutes` (15), `session_supervisor_max_long_retries` (8), `session_supervisor_model_fallback_enabled` (on). Each is bounds-validated, and a value that is missing, unparsable, or out of bounds degrades to the shipped default - never to "no limit".

## Proof

**GREEN on this branch's head `e9a5def27`** - run [30534485019](https://github.com/thefrederiksen/devthrottle/actions/runs/30534485019) attempt 2, both legs `success` (.NET 59m5s, web 1m21s). The .NET leg runs `dotnet test cc-director.sln -c Release --no-build`, so `CcDirector.Gateway.Tests` - which holds every test for this change - is covered on a clean checkout with no local build state. Verified by comparing the run's `headSha` against the branch head rather than reading the tick.

A green belongs to a COMMIT, and this branch had three heads. The full history, because two of them are the interesting part:

| head | run | outcome |
|---|---|---|
| `a4ea14d6` | [30516013364](https://github.com/thefrederiksen/devthrottle/actions/runs/30516013364) | green. **Superseded** - it predates two rebases, and is NOT evidence for what merged. |
| `1d666fed7` | [30530580078](https://github.com/thefrederiksen/devthrottle/actions/runs/30530580078) | **RED.** One failure in 4644 - the spoken-language completeness guard. See below. |
| `e9a5def27` | [30534485019](https://github.com/thefrederiksen/devthrottle/actions/runs/30534485019) | attempt 1 red on an unrelated nondeterministic test; **attempt 2 GREEN**. |

Attempt 1 failed on `Core.Tests.Tenancy.TenantSessionMapTests.Contend_GetOrAddOnOneKey_HasExactlyOneWinnerPerRound`, which is not this change: the diff touches zero `CcDirector.Core` files, and the same Core suite ran green / green / red across three runs of this branch with identical Core code between the last two - same code, different outcome, so nondeterminism rather than a property of anything written here. The test's own message is why a re-run was admissible: *"no round ever ran the value factory more than once, so the callers never actually contended for the same key and this test proved nothing"* - it did not EXERCISE its subject, rather than finding it broken. Had it reported a violated invariant, a re-run would not have been admissible. Filed separately; the remedy is a barrier so contention happens by construction, or reporting inconclusive rather than failed.

The two live wiring tests, which decide whether this feature exists at all, on the green run:

```
Passed SessionSupervisorLiveWiringTests.AParkedSessionThatDiedOnAConnectionFault_IsSentContinueOverTheTunnel
Passed SessionSupervisorLiveWiringTests.ASessionThatFinishedItsTurnCleanly_IsSentNothing
```

### The red run, and why it could not have happened earlier

`SpokenLanguageContractTests.Every_prompt_builder_in_the_gateway_is_registered_or_named_as_not_spoken` failed on `1d666fed7`. It was a correct catch, and it was unreachable before the rebase: that guard arrived in #2295 with the French and Spanish work, so **this change and that guard had never met**. Two correct changes, each green alone, red together - which no review of either could have found, and no amount of care substitutes for running the suite on the commit that contains both.

The guard's design is why it caught it: every prompt builder in the Gateway is either a registered spoken path bound by the spoken-output contract, or named on `SpokenPaths.NotSpokenOutput` with a reason, and there is deliberately no silent third category. Its default state is failure. `SupervisorVerdict.BuildPrompt` is now named there with its reason - it returns one word from a fixed English answer set that code parses, so translating either half would break it, and an unparsable reply is deliberately no verdict at all.

The two live wiring tests, which are what decide whether this feature exists at all, were green on the `a4ea14d6` run and are unchanged since:

```
Passed SessionSupervisorLiveWiringTests.AParkedSessionThatDiedOnAConnectionFault_IsSentContinueOverTheTunnel [5 s]
Passed SessionSupervisorLiveWiringTests.ASessionThatFinishedItsTurnCleanly_IsSentNothing [8 s]
```

### The two defects the first run found, because they are the interesting half

An earlier run of this branch was 80 passed, 3 failed. Neither cause was a typo, and both are the shape this release has been about - a check that cannot go red, and a component that fails without saying so.

**1. The guard was tautological.** An acting fault class needs a failure marker beside its signature, so a session that merely PRINTED the words "connection refused" while discussing a log is never typed into. But `refused` was itself in the marker list - so the `connection refused` signature satisfied its own precondition, and the rule waved through the exact sentence it exists to reject. A guard that supplies its own evidence cannot fail, and a test over it goes green while proving nothing. Signatures are now split by whether they can plausibly occur in ordinary prose: errno codes and runtime error text (`ENOTFOUND`, `socket hang up`, `rate_limit_error`) stand alone, English phrases need a marker that is not part of the phrase. Both directions are pinned - the prose sentence is not a fault, and the same phrase with `Error:` in front of it is.

**2. The supervisor woke up and silently did nothing.** The turn-end callback runs with no tenant in scope, and every read the engine makes is partitioned: the per-tenant settings, the tunnel connection lookup that carries both the screen read and the send, and the ledger write. With no scope each one is denied, so the engine evaluated every transition and reached nothing. **Every engine test passed while the feature was inert in production.** It now enters the owning tenant's scope exactly as the voice generation beside it does; the scope is an async-local, so the background ladder inherits it for the whole episode. This was caught only because the live wiring test failed at its POSITIVE CONTROL - the screen read never arrived at the Director - which is precisely why that test exists and why it asserts the read before it asserts the absence of anything.

### What the tests pin

The engine tests inject the clock, so the full two-hour escalation ladder is asserted exactly - the delay chosen for each attempt is an assertion, not a stopwatch. Every item on the issue's acceptance list has a named test:

- the exact July 21 line classifies as recoverable, and an identical line further up the screen with a healthy turn below it does not;
- a transient fault waits 45 seconds then sends once; a persisting one waits 15 minutes per attempt after that;
- out of allowance, a full context window, a menu, an unrecognized fault with the fallback off, and a model that mumbles all send nothing;
- a clean turn end sends nothing, records nothing, and asks no model;
- the ceiling escalates, and it survives the Working flicker across two idle transitions;
- the full record sequence for one episode is pinned, with the attempt number and the delay in each line;
- and the live wiring test drives a real Working-to-idle boundary on a real Gateway and asserts the `continue` prompt actually arrives at the Director over the tunnel. Delete the one wiring line in `GatewayHost` and it goes red while every engine test stays green.

## What is deliberately NOT in this change

- **No rehearsal against a real agent.** The live wiring test uses a real Gateway, the real watcher, the real engine and the real tunnel verbs, but the Director at the far end is a fake that answers the screen read with the incident line. Nothing has yet watched a genuine network blip recover a genuine Claude session on this build.
- **No settings screen.** The knobs are Gateway-side values with defaults. A settings card belongs in `packages/client-core` so both surfaces get it at once, and that is its own increment.
- **No new Cockpit view for the recovery log.** The records are queryable through the existing activity-events endpoint; nothing renders them yet.
- **Context-full recovery stays phase 2** (thefrederiksen/devthrottle_internal#1403). A session whose context is full swallows prompts, so sending into one would be silently eaten - phase 1 escalates instead.
- **A silent stall is not caught.** A turn that announced "proceeding to X" and stopped with no error leaves no fault on the screen, so the funnel stops at step one. That needs the check-in timer from #764, and asking a model about every clean turn end would be both a cost on every turn and a route back to interrupting healthy sessions.
- **No retry-after honouring.** The supervisor reads a terminal screen, not an HTTP response, so the header the provider sent never reaches this code. Backoff is the honest answer; a number invented from screen text would be a fabricated measurement.
