### PR TITLE
Cut cc-playwright from the shipped toolbelt (#1002)

### DIFF
--- a/.claude/skills/dev-throttle/SKILL.md
+++ b/.claude/skills/dev-throttle/SKILL.md
@@ -28,7 +28,7 @@ All tools are on PATH after install. For exact flags and examples, run any tool 
 `cc-gmail`, `cc-outlook` - read, send, and search Gmail and Outlook from the CLI.
 
 ### Web
-`cc-playwright` (Chromium browser + remote-debug + CDP; the default for form fills, sign-in, OTP, and React forms), `cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
+`cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
 
 ### Desktop automation
 `cc-click` (Windows UI: click, type, screenshot, OCR), `cc-trisight` (3-tier UI element detection: UIA + OCR + pixel), `cc-computer` (AI desktop agent with screenshot-in-the-loop).

--- a/docs/CC_TOOLS.md
+++ b/docs/CC_TOOLS.md
@@ -39,7 +39,7 @@ Node.js and .NET tools include both `.cmd` (Windows) and extensionless (Git Bash
 | Tool | Description | Requirements |
 |------|-------------|--------------|
 | cc-browser | Browser automation with persistent connections and navigation skills | Chrome Extension |
-| cc-playwright | Trusted-event browser CLI for React form fills, signin/OTP, dropdowns | Python, Playwright, Chrome or Edge |
+| cc-playwright | Scripted/CI browser CLI: repeatable tests, high-volume same-origin loops | Python, Playwright, Chrome or Edge; not shipped (dev-only, build from repo) |
 | cc-reddit | Reddit automation with human-like delays | Playwright, cc-browser |
 | cc-crawl4ai | AI-ready web crawler to clean markdown | Playwright browsers |
 | cc-websiteaudit | Website SEO/security/AI readiness audit | Node.js, Chrome (not yet built) |
@@ -359,7 +359,14 @@ cc-browser wait --selector ".done"
 
 ### cc-playwright
 
-Playwright-backed browser CLI. Trusted-event sibling to cc-browser for sites that reject untrusted CDP events (Luma, Stripe, react-hook-form). Launches its own Chromium browser (Chrome or Edge) instance with `--remote-debugging-port` and connects via Playwright's `connect_over_cdp`, which produces `isTrusted=true` events that React forms accept.
+Playwright-backed browser CLI for SCRIPTED work: repeatable tests, and high-volume same-origin loops where selectors are measurably cheaper than screenshot-and-click. Launches its own Chromium browser (Chrome or Edge) with `--remote-debugging-port` and connects via Playwright's `connect_over_cdp`.
+
+**Not shipped:** not part of the installed product (not in the "ship" allowlist in
+tools/registry.json). It stays in the repo and is buildable for dev with
+`scripts/build-all-tools.ps1 -Tool cc-playwright`. It was cut from the toolbelt in issue #1002:
+it is not the tool we reach for interactively, it is the only tool that would pull a browser
+engine onto a stranger's machine, and a developer who already runs Playwright has their own
+version and their own browsers.
 
 ```bash
 # Lifecycle (per connection)
@@ -399,11 +406,6 @@ cc-playwright wait --networkidle
 cc-playwright --connection linkedin start
 cc-playwright --connection linkedin navigate --url https://www.linkedin.com/feed/
 ```
-
-**When to use which:**
-- Use **cc-browser** when you need persistent connections, your existing browser session/cookies, or named workspaces.
-- Use **cc-playwright** when filling React-controlled forms, signin/OTP flows, payment pages up to card entry, dropdowns, file uploads, or any flow where cc-browser's clicks/fills silently fail because of `isTrusted` checks.
-- Both can run concurrently. Named cc-playwright connections share cookies with the matching cc-browser connection under `%LOCALAPPDATA%\cc-director\connections\<name>`; the implicit `default` connection uses its own profile at `%LOCALAPPDATA%\cc-playwright\profile`.
 
 ---
 

--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -51,13 +51,6 @@
       "note": "Auth-gated (device code). No zero-auth read-only command. Presence + version only."
     },
     {
-      "name": "cc-playwright",
-      "category": "Web",
-      "description": "Drive a real web browser - click, type, and fill in pages - with separate signed-in profiles that stay out of each other's way.",
-      "smoke": { "args": ["list"], "expectContains": null },
-      "note": null
-    },
-    {
       "name": "cc-devthrottle",
       "category": "Fleet",
       "description": "Run DevThrottle itself from the command line: your sessions, messages between them, schedules, and settings.",

--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -23,7 +23,7 @@ All tools are on PATH after install. For exact flags and examples, run any tool 
 `cc-gmail`, `cc-outlook` - read, send, and search Gmail and Outlook from the CLI.
 
 ### Web
-`cc-playwright` (Chromium browser + remote-debug + CDP; the default for form fills, sign-in, OTP, and React forms), `cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
+`cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
 
 ### Desktop automation
 `cc-click` (Windows UI: click, type, screenshot, OCR), `cc-trisight` (3-tier UI element detection: UIA + OCR + pixel), `cc-computer` (AI desktop agent with screenshot-in-the-loop).

--- a/tools/cc-devthrottle/src/setup_ops.py
+++ b/tools/cc-devthrottle/src/setup_ops.py
@@ -34,11 +34,13 @@ SETUP_CLI_COMMAND_NAMES = [
     "cc-director-setup-cli.exe",
 ]
 
-# Retired per-tool fleet commands that were consolidated into the single cc-devthrottle
-# command (issue #823). Their executables no longer ship, so any leftover bin shim pointing at
-# them fails with exit 127. The installer engine purges these (PythonToolsInstaller
-# .LegacyAliasShimNames - keep the two lists in sync); doctor reports their resolved path so a
-# machine that still carries one is visible.
+# Command names that no longer ship, and whose leftover bin shim points at a venv executable that
+# is gone: the retired per-tool fleet commands consolidated into the single cc-devthrottle command
+# (issue #823), plus cc-playwright, cut from the shipped toolbelt (issue #1002). A leftover fleet
+# alias fails with exit 127; a leftover shim for a tool dropped from the manifest instead tells a
+# healthy install that "cc-* tools are not fully installed", which is worse. The installer engine
+# purges these (PythonToolsInstaller.LegacyAliasShimNames - keep the two lists in sync); doctor
+# reports their resolved path so a machine that still carries one is visible.
 LEGACY_ALIAS_NAMES = [
     "cc-send",
     "cc-ask",
@@ -48,6 +50,7 @@ LEGACY_ALIAS_NAMES = [
     "cc-settings",
     "cc-cron",
     "cc-fleet-selftest",
+    "cc-playwright",
 ]
 
 

--- a/tools/cc-devthrottle/tests/test_setup_ops.py
+++ b/tools/cc-devthrottle/tests/test_setup_ops.py
@@ -144,9 +144,10 @@ def test_run_autostart_shells_to_setup_cli_autostart(monkeypatch):
 
 
 def test_legacy_alias_names_cover_all_retired_fleet_commands():
-    # The retired per-tool fleet commands consolidated into cc-devthrottle (issue #823). Kept in sync
-    # with the installer engine's PythonToolsInstaller.LegacyAliasShimNames so the same names the
-    # installer purges are the ones doctor reports. cc-fleet-selftest must be present (it was missing).
+    # The retired per-tool fleet commands consolidated into cc-devthrottle (issue #823), plus
+    # cc-playwright, cut from the shipped toolbelt (issue #1002). Kept in sync with the installer
+    # engine's PythonToolsInstaller.LegacyAliasShimNames so the same names the installer purges are
+    # the ones doctor reports. cc-fleet-selftest must be present (it was missing).
     assert setup_ops.LEGACY_ALIAS_NAMES == [
         "cc-send",
         "cc-ask",
@@ -156,6 +157,7 @@ def test_legacy_alias_names_cover_all_retired_fleet_commands():
         "cc-settings",
         "cc-cron",
         "cc-fleet-selftest",
+        "cc-playwright",
     ]
 
 

--- a/tools/cc-director-setup-engine.Tests/PythonToolsHealAndShimTests.cs
+++ b/tools/cc-director-setup-engine.Tests/PythonToolsHealAndShimTests.cs
@@ -209,14 +209,56 @@ public sealed class PythonToolsHealAndShimTests : IDisposable
     // --- Orphaned legacy alias shim purge (issue #823) --------------------------------------------
 
     [Fact]
-    public void LegacyAliasShimNames_AreTheEightRetiredFleetCommands()
+    public void LegacyAliasShimNames_AreTheRetiredFleetCommandsPlusUnshippedTools()
     {
-        // The retired per-tool fleet commands that were consolidated into cc-devthrottle. Guards the list
-        // against accidental drift and against ever including a shipping tool name (which would be purged).
+        // The retired per-tool fleet commands consolidated into cc-devthrottle (#823), plus cc-playwright,
+        // cut from the shipped toolbelt (#1002). Guards the list against accidental drift.
         Assert.Equal(
-            new[] { "cc-send", "cc-ask", "cc-spawn", "cc-sessions", "cc-whoami", "cc-settings", "cc-cron", "cc-fleet-selftest" },
+            new[]
+            {
+                "cc-send", "cc-ask", "cc-spawn", "cc-sessions", "cc-whoami", "cc-settings", "cc-cron", "cc-fleet-selftest",
+                "cc-playwright",
+            },
             PythonToolsInstaller.LegacyAliasShimNames);
-        Assert.DoesNotContain("cc-devthrottle", PythonToolsInstaller.LegacyAliasShimNames);
+    }
+
+    [Fact]
+    public void LegacyAliasShimNames_NameNoShippedTool()
+    {
+        // The property that makes the purge safe: it deletes shims by name, so a SHIPPED tool's name in
+        // this list would delete a live tool's shim on every install. That was previously asserted for
+        // one name (cc-devthrottle) by hand, which says nothing about the other eight - and the list now
+        // grows whenever a tool is unshipped, which is exactly when the mistake would be made. Checked
+        // against the shipped manifest itself so the guard cannot go stale as the shipped set changes.
+        var shipped = ShippedToolNames();
+        Assert.NotEmpty(shipped);
+        var overlap = PythonToolsInstaller.LegacyAliasShimNames.Where(shipped.Contains).ToArray();
+        Assert.Empty(overlap);
+    }
+
+    /// <summary>
+    /// The tool names in the shipped health manifest (src/CcDirector.Core/Tools/tools-manifest.json),
+    /// read off disk by walking up from the test binary - the same way the Core guard test finds it.
+    /// </summary>
+    private static HashSet<string> ShippedToolNames()
+    {
+        var relative = Path.Combine("src", "CcDirector.Core", "Tools", "tools-manifest.json");
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        string? found = null;
+        while (dir is not null && found is null)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate)) found = candidate;
+            dir = dir.Parent;
+        }
+        Assert.NotNull(found);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(found!));
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tool in doc.RootElement.GetProperty("tools").EnumerateArray())
+            if (tool.TryGetProperty("name", out var n) && n.GetString() is { } name)
+                names.Add(name);
+        return names;
     }
 
     [Fact]

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -389,17 +389,30 @@ public sealed class PythonToolsInstaller
     }
 
     /// <summary>
-    /// The retired per-tool fleet commands that were consolidated into the single cc-devthrottle command
+    /// Command names that no longer ship, and whose bin shim an older install may still be carrying.
+    /// Two groups:
+    /// <list type="bullet">
+    /// <item>The retired per-tool fleet commands consolidated into the single cc-devthrottle command
     /// (issue #823): cc-send, cc-ask, cc-spawn, cc-sessions, cc-whoami, cc-settings, cc-cron,
-    /// cc-fleet-selftest. Their executables no longer ship in the venv, so any bin shim an older install
-    /// left for them resolves to a missing target and fails with exit 127. The installer purges these on
-    /// every install/repair. Kept in sync with cc-devthrottle's setup_ops.LEGACY_ALIAS_NAMES (the doctor
-    /// diagnostic) so the same retired names are reported and cleaned. These names never overlap the
-    /// shipping tools, so purging them can never remove a live tool's shim.
+    /// cc-fleet-selftest.</item>
+    /// <item>cc-playwright, cut from the shipped toolbelt (issue #1002).</item>
+    /// </list>
+    /// In both cases the venv console script is gone, so a leftover shim resolves to a missing target.
+    /// For the fleet aliases that is exit 127; for a tool dropped from the manifest it is worse - the
+    /// self-checking shim body tells a HEALTHY install that "cc-* tools are not fully installed" and
+    /// sends the user to a repair that will never put the tool back. Note the ordinary
+    /// <c>RemoveManagedShims</c> pass cannot clean either group: it only walks the CURRENT manifest, and
+    /// these names are in no manifest. That is precisely why this explicit purge exists, and why cutting
+    /// a tool from the shipped set means adding its name here.
+    /// The installer purges these on every install/repair. Kept in sync with cc-devthrottle's
+    /// setup_ops.LEGACY_ALIAS_NAMES (the doctor diagnostic) so the same retired names are reported and
+    /// cleaned. These names never overlap the shipping tools, so purging them can never remove a live
+    /// tool's shim - guarded by a test against the shipped manifest rather than left as a promise.
     /// </summary>
     public static readonly IReadOnlyList<string> LegacyAliasShimNames = new[]
     {
         "cc-send", "cc-ask", "cc-spawn", "cc-sessions", "cc-whoami", "cc-settings", "cc-cron", "cc-fleet-selftest",
+        "cc-playwright",
     };
 
     /// <summary>

--- a/tools/registry.json
+++ b/tools/registry.json
@@ -84,9 +84,8 @@
       "name": "cc-playwright",
       "category": "web-social",
       "type": "python",
-      "description": "Playwright-backed browser CLI - trusted-event sibling to cc-browser for React form fills, signin/OTP flows, and dropdown selection",
+      "description": "Playwright-backed browser CLI for scripted or CI browser work - repeatable tests and high-volume same-origin loops. NOT shipped: our own guidance makes browser-harness the default for interactive browser work, this is the only tool that would pull a browser engine onto a stranger's machine, and a developer who already runs Playwright has their own version (issue #1002)",
       "built": true,
-      "ship": true,
       "requirements": ["Python 3.10+", "Playwright", "Chrome or Edge (Chromium)"]
     },
     {


### PR DESCRIPTION
Closes #1002.

## The cut

`"ship": true` is removed from `cc-playwright` in `tools/registry.json`, and its entry
leaves the Core health manifest with it. The registry flag is the real cut - the bundle
builder selects on it. Reproducing the builder's own selection line
(`scripts/build-python-bundle.ps1:74`) against the changed registry:

```
selected 8 shipped python tools: cc-pdf, cc-html, cc-word, cc-gmail, cc-outlook, cc-image, cc-vault, cc-devthrottle
cc-playwright selected: False
```

Registry and manifest agree at 8, which is what the shipped-tools guard pins:

```
registry ship:true python tools -> 8
core health manifest           -> 8
sets match  -> True
cc-playwright present anywhere -> False
```

The wizard's Tools step needs no edit: `_toolsTotalCount` is `catalog.Count`
(`FirstRunWizardDialog.axaml.cs:907`), the catalog is one descriptor per manifest entry
(`ToolCatalogService.cs:58-61`), and the rows are built from the catalog - so the title
becomes "8 tools, maintained for you" and nothing names the tool statically. I read that
code path rather than launching the wizard; I did not take a screenshot of the running
first-run wizard.

## Two things beyond the checklist

**The shipped skill told agents to reach for it.** `dev-throttle.skill.md` - the skill the
Gateway serves - named `cc-playwright` as "the default for form fills, sign-in, OTP, and
React forms". Left alone, an agent on a machine where the tool no longer exists would go
looking for it by name. Removed from the Gateway's copy and the repo's.

**A dropped tool leaves its shim behind, and the shim lies.** `RemoveManagedShims` only
walks the CURRENT manifest, so it cannot clean a name that has left it - which is exactly
why the explicit purge from #823 exists. Every EXISTING install keeps a
`bin\cc-playwright.cmd` whose venv target the next repair deletes. Observed on a real
install on this machine:

```
$ ls %LOCALAPPDATA%/cc-director/bin/ | grep playwright
cc-playwright
cc-playwright.cmd

$ cat %LOCALAPPDATA%/cc-director/bin/cc-playwright.cmd
@echo off
if not exist "%~dp0..\pyenv\Scripts\cc-playwright.exe" (
  echo cc-* tools are not fully installed - run the repair: Home ^> Fix it 1^>^&2
  exit /b 1
)
```

So the failure is not the #823 exit 127 - it is worse. A HEALTHY install would be told its
tools are broken and sent to a repair that will never put the tool back. `cc-playwright` is
added to `LegacyAliasShimNames` on both sides (C# engine and cc-devthrottle's
`setup_ops.LEGACY_ALIAS_NAMES`, which are required to stay in sync) with their guards
updated, so the next install or repair removes the stale shim and the command becomes
cleanly absent.

## The safety property is now actually tested

The purge deletes shims BY NAME, so a shipped tool's name in that list would delete a live
tool's shim on every install. That was asserted for exactly one name by hand
(`Assert.DoesNotContain("cc-devthrottle", ...)`), which says nothing about the other eight -
and the list now grows whenever a tool is unshipped, which is precisely when the mistake
would be made. It is now checked against the shipped manifest itself.

Validated by injecting a shipped name (`cc-vault`) into the purge list and confirming the
guard fails rather than passes:

```
temporarily injected a SHIPPED tool name (cc-vault) into the purge list
   Assert.Empty() Failure: Collection was not empty
   Assert.Equal() Failure: Collections differ
Failed!  - Failed: 2, Passed: 0, Total: 2
```

Injection reverted; the committed list contains no shipped name.

## Docs

`docs/CC_TOOLS.md` keeps the command reference but marks it **"Not shipped"** - the
convention `docs/public/tools/01-overview.md` already uses for `cc-crawl4ai`. The issue
keeps the source in the tree for scripted and CI use, so deleting its documentation would
have cost something and bought nothing. It is no longer presented as a shipped tool, in the
table or the section.

## Out of scope, untouched

The tool's source, its build scripts (`build-all-tools.ps1` / `build-tools.bat` already
build many non-shipped tools), and the Wingman test fixtures that merely quote the string
"cc-playwright" as sample terminal text - those parse terminal output and do not invoke
anything.

## Tests

`dotnet test cc-director.sln` - all seven test projects:

The whole solution returned **exit code 0**. Per-project results, all from that one run:

| project | result |
|---|---|
| CcDirector.Core.Tests | 3931 passed, 0 failed, 8 skipped |
| CcDirector.Gateway.Tests | 4450 passed, 0 failed, 17 skipped |
| CcDirector.Avalonia.Tests | 313 passed, 0 failed |
| CcDirector.HostedAgent.Tests | 88 passed, 0 failed |
| CcDirector.Launcher.Tests | 83 passed, 0 failed |
| CcDirector.Engine.Tests | 63 passed, 0 failed |
| CcDirector.Terminal.Avalonia.Tests | 24 passed, 0 failed |

Nothing failed. The skips are the Postgres-backed and GUI-dependent tests that need an
environment this machine does not provide; I did not diff the skip set against main.

Scope of that run, stated precisely: it covers every code change in this pull request. The
only edit made after it was `docs/CC_TOOLS.md`, which no test reads (`build-all-tools.ps1`
copies it as a release artifact, nothing asserts on it). I did not re-run the suite for a
markdown edit, because `CcDirector.Gateway.Tests` takes a per-user lock that several other
seats are queued behind tonight.

Also run, though CI does not run them: `python -m pytest tools/cc-devthrottle/tests/test_setup_ops.py`
(9 passed) and `tools/test_shipped_tools_contract.py`.

## One pre-existing problem worth a separate issue

`tools/test_shipped_tools_contract.py` is **red on origin/main**, before this change:
`cc-image: renders Rich tables but does not install the ASCII truncation patch`. Confirmed
on a pristine `origin/main` tree (1 failed, 39 passed there; 1 failed, 35 passed here - the
4 fewer passes are exactly cc-playwright's parametrized cases leaving the shipped set).
CI never runs this file, so a shipped-tool contract guard has been failing where nobody
sees it. Not fixed here - flagging it rather than folding an unrelated fix into the cut.
