### PR TITLE
Stop the Gateway claiming a timed-out command did not run, and refuse to snooze a dead session (#819, #824)

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
@@ -106,7 +106,31 @@ public sealed class DirectorCommandRouterTimeoutTests
 
         // Assert - the degraded message is the SAME sentence minus the machine clause, never vaguer and never
         // a second message style. The machine name is presentation only.
-        Assert.Equal("The Director did not answer within 30 seconds. The command was not carried out.", result!.Error);
+        Assert.Equal(
+            "The Director did not answer within 30 seconds. It is not known whether the command was carried out.",
+            result!.Error);
+    }
+
+    [Fact]
+    public async Task TrySendAsync_Timeout_DoesNotClaimTheCommandWasSkipped()
+    {
+        // Act
+        var named = await DirectorCommandRouter.TrySendAsync(
+            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None,
+            TimeSpan.FromSeconds(30), machineName: "SOREN_NORTH");
+        var anonymous = await DirectorCommandRouter.TrySendAsync(
+            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None, TimeSpan.FromSeconds(30));
+
+        // Assert - a timeout proves only that the GATEWAY stopped waiting. The Director may have received the
+        // command, carried it out, and answered late, so the message must leave the outcome open. It used to end
+        // "The command was not carried out" - stated as fact - which is how a user came to re-tap Send and hand
+        // the agent the same prompt twice. Positive assertion first: an absence-only check would still pass if
+        // the sentence were deleted, which is a worse message than the wrong one.
+        foreach (var error in new[] { named!.Error, anonymous!.Error })
+        {
+            Assert.Contains("It is not known whether the command was carried out.", error!);
+            Assert.DoesNotContain("The command was not carried out", error);
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
@@ -536,6 +536,84 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
         Assert.Empty(fake.HoldCalls("h1"));                          // still no hold command from the endpoint
     }
 
+    [Fact]
+    public async Task Holding_a_session_that_has_already_exited_is_refused_and_records_nothing()
+    {
+        // ISSUE #824. Every edge that LIFTS a hold is driven by an ACTIVITY PUSH (SnoozeLandingObserver),
+        // and an exited session never transitions again - so a hold recorded AFTER the exit is permanent.
+        // The exit edge cannot save it either: dropping the hold when the session exits does nothing for a
+        // hold that arrives afterwards. The only place that can refuse it is the entry point.
+        var fake = await StartFakeAsync("x1", onHold: false, activityState: "Exited");
+
+        var resp = await _http.PostAsJsonAsync("sessions/x1/hold", new HoldRequest { OnHold = true, SnoozeMinutes = 12 * 60 });
+
+        // Refused, in plain English, naming the reason - not a silent 200 that parks it anyway.
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        Assert.Contains("exited", await resp.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+
+        // NOTHING was recorded. This is the assertion that matters: the old code took the not-working branch
+        // and wrote an ARMED entry with a live clock, which no edge in the system could ever clear.
+        Assert.Empty(_gw.SnoozeRegistry.Entries());
+
+        // And the row still reads as what it is. Grey "Exited", never grey "Snoozed". Read from the
+        // exited-inclusive roster: the default one drops exited rows, so it cannot show this either way.
+        var session = await GetSessionIncludingExited("x1");
+        Assert.False(session.OnHold);
+        Assert.Equal("Exited", SessionOrdering.StateLabel(session));
+    }
+
+    [Fact]
+    public async Task Holding_a_crashed_session_is_refused_so_the_crash_stays_visible()
+    {
+        // ISSUE #824, the expensive half. The fold reads OnHold BEFORE the base activity colour
+        // (SessionOrdering.EffectiveColor: `s.OnHold ? "grey"`) and StateLabel returns "Snoozed" first of
+        // all - so a hold on a CRASHED session paints deep-red "Crashed" over with grey "Snoozed" and keeps
+        // it hidden for the whole snooze length. That is the signal the owner most needs to see, masked by
+        // the one gesture a person triaging from a phone reaches for most easily.
+        //
+        // SCOPE, stated so this test is not read as more than it proves: the DEFAULT /sessions roster drops
+        // exited rows, so the masking bites on the exited-inclusive surface, which is what is read here. The
+        // permanent-registry-entry half (the other test) bites everywhere, roster or no roster.
+        var fake = await StartFakeAsync("x2", onHold: false, activityState: "Exited");
+        fake.SetCrashed("x2", true);
+        await fake.RePushAsync();
+
+        // Before: the crash is visible, and that is the state worth protecting.
+        var before = await GetSessionIncludingExited("x2");
+        Assert.Equal("error", SessionOrdering.EffectiveColor(before));
+        Assert.Equal("Crashed", SessionOrdering.StateLabel(before));
+
+        var resp = await _http.PostAsJsonAsync("sessions/x2/hold", new HoldRequest { OnHold = true });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+
+        // After: unchanged. Asserted POSITIVELY on the crash reading, so this cannot pass by the session
+        // having vanished from the roster or the fold having stopped ruling on it at all.
+        var after = await GetSessionIncludingExited("x2");
+        Assert.Equal("error", SessionOrdering.EffectiveColor(after));
+        Assert.Equal("Crashed", SessionOrdering.StateLabel(after));
+        Assert.Empty(_gw.SnoozeRegistry.Entries());
+    }
+
+    [Fact]
+    public async Task Unsnoozing_an_exited_session_is_still_allowed_because_it_is_the_repair()
+    {
+        // The guard is one-directional ON PURPOSE. Refusing the CLEAR as well would strand any hold that is
+        // already recorded - including every one written before this fix shipped - which is the exact state
+        // issue #824 is about. A hold that outlives its session must always be removable.
+        var fake = await StartFakeAsync("x3", onHold: false);
+
+        // Park it while it is alive (the ordinary path), then let it die underneath the hold.
+        var parked = await _http.PostAsJsonAsync("sessions/x3/hold", new HoldRequest { OnHold = true, SnoozeMinutes = 12 * 60 });
+        Assert.Equal(HttpStatusCode.OK, parked.StatusCode);
+        Assert.Single(_gw.SnoozeRegistry.Entries());
+        fake.SetActivity("x3", "Exited");
+
+        var released = await _http.PostAsJsonAsync("sessions/x3/hold", new HoldRequest { OnHold = false });
+
+        Assert.Equal(HttpStatusCode.OK, released.StatusCode);
+        Assert.Empty(_gw.SnoozeRegistry.Entries());
+    }
+
     /// <summary>Poll the fake's raw hold until it reaches the expected value (the reliable channel is
     /// fire-and-forget, so delivery is asynchronous), then assert - giving a clear failure if it never does.</summary>
     private static async Task WaitForHoldAsync(SnoozeFake fake, string sid, string expected)
@@ -560,6 +638,17 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
     private async Task<SessionDto> GetSession(string sid)
     {
         var sessions = await _http.GetFromJsonAsync<List<SessionDto>>("sessions", JsonOpts) ?? new();
+        return Assert.Single(sessions, s => s.SessionId == sid);
+    }
+
+    /// <summary>
+    /// Read a session from the EXITED-INCLUSIVE roster. The default /sessions read drops rows whose
+    /// ActivityState is "Exited", so an exited session is invisible there and the fold's ruling on it cannot
+    /// be observed at all; `?includeExited=true` is the supported query that keeps it in the set.
+    /// </summary>
+    private async Task<SessionDto> GetSessionIncludingExited(string sid)
+    {
+        var sessions = await _http.GetFromJsonAsync<List<SessionDto>>("sessions?includeExited=true", JsonOpts) ?? new();
         return Assert.Single(sessions, s => s.SessionId == sid);
     }
 
@@ -626,6 +715,11 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
 
         /// <summary>The other fact a Director reports: what it is doing.</summary>
         public void SetActivity(string sid, string activityState) { lock (_gate) _sessions[sid].ActivityState = activityState; }
+
+        /// <summary>It died rather than finished (issue #959). A crash is NOT an ActivityState - a crashed
+        /// session is "Exited" like any other - so it is a separate fact the Director reports, and the fold
+        /// turns it into deep-red "Crashed" instead of grey "Exited".</summary>
+        public void SetCrashed(string sid, bool value) { lock (_gate) _sessions[sid].Crashed = value; }
 
         /// <summary>Push the current state up the stream, as a real Director does on any change.</summary>
         public Task RePushAsync() => PushAsync();
@@ -743,6 +837,10 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
             ActivityState = s.ActivityState,
             Status = s.Status,
             StatusColor = s.StatusColor,
+            // Died-rather-than-finished (issue #959). Dropping it here would silently make the crash arm of
+            // the fold untestable - a crashed session would arrive looking like a clean exit - which is
+            // exactly the kind of gap this field list's own warning below is about.
+            Crashed = s.Crashed,
             // The Director's hold claim still crosses the wire, and the Gateway still ignores it - it is
             // overwritten in the fold from the registry. Kept here only so these tests can prove that.
             HoldState = s.HoldState,

--- a/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
+++ b/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
@@ -132,12 +132,18 @@ internal static class DirectorCommandRouter
 
     /// <summary>
     /// The timeout message. Written for a person reading it on a phone in a moving car: it names the machine,
-    /// says what did not happen, and gives the wait in whole seconds. No status code, no stack trace, no jargon.
+    /// says what was observed, and gives the wait in whole seconds. No status code, no stack trace, no jargon.
+    ///
+    /// Like <see cref="DescribeTunnelDrop"/>, it deliberately does not promise the command was skipped. A timeout
+    /// proves only that the GATEWAY stopped waiting: the Director may have received the command, carried it out,
+    /// and answered late. It used to end "The command was not carried out", which read as settled fact - so the
+    /// user re-tapped and the agent got the same prompt twice. The two messages hedge the same way because they
+    /// leave the caller in the same position: the outcome is genuinely unknown.
     /// </summary>
     private static string DescribeTimeout(string? machineName, TimeSpan wait) =>
         string.IsNullOrWhiteSpace(machineName)
-            ? $"The Director did not answer within {wait.TotalSeconds:0} seconds. The command was not carried out."
-            : $"The Director on {machineName} did not answer within {wait.TotalSeconds:0} seconds. The command was not carried out.";
+            ? $"The Director did not answer within {wait.TotalSeconds:0} seconds. It is not known whether the command was carried out."
+            : $"The Director on {machineName} did not answer within {wait.TotalSeconds:0} seconds. It is not known whether the command was carried out.";
 
     /// <summary>
     /// The mid-command tunnel-drop message. Same audience as <see cref="DescribeTimeout"/>. It deliberately does

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1668,6 +1668,34 @@ internal static class GatewayEndpoints
             if (snoozeRegistry is null)
                 return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
 
+            // A DEAD SESSION CANNOT BE SNOOZED (issue #824).
+            //
+            // Every edge that LIFTS a hold is driven by an activity push (SnoozeLandingObserver.Observe), and
+            // an exited session never pushes again. So a hold recorded AFTER the exit takes the not-working
+            // branch below, lands Held, and nothing in the system ever clears it: parked Snoozed forever.
+            // Worse, the fold reads OnHold BEFORE the base activity colour, so the row renders grey "Snoozed"
+            // over what should be grey "Exited" - or over DEEP RED "Crashed", hiding the one state that most
+            // needs the owner's eyes for the whole snooze length.
+            //
+            // This is the same rule the exit edge already applies in the other direction ("EXITED - drop the
+            // hold entirely... a dead session must never hide behind a Snoozed label"), stated once more at
+            // the entry point, because dropping on exit cannot help a hold that arrives after it.
+            //
+            // Only the PARK direction is refused. Clearing stays allowed unconditionally: un-holding a dead
+            // session is the repair, and refusing it would strand any hold that was already recorded.
+            if (holdReq.OnHold
+                && string.Equals(session.ActivityState?.Trim(), nameof(Core.Sessions.ActivityState.Exited),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/hold REFUSED - the session has exited; "
+                              + "a hold recorded now has no edge that could ever lift it");
+                return Results.Json(new
+                {
+                    error = "This session has exited, so it cannot be snoozed. There is no turn left to come "
+                            + "back to, and a snooze would hide how it ended."
+                }, statusCode: StatusCodes.Status409Conflict);
+            }
+
             // THE GATEWAY DECIDES, HERE, AND NOWHERE ELSE.
             //
             // This used to forward the hold to the Director, read HoldResponse.Pending back, and record


### PR DESCRIPTION
Fixes two small, well-scoped defects in the sessions area. Both are guards: one on a message that
overclaims, one on a state transition that has no way back.

## thefrederiksen/devthrottle_internal#819 - the timeout message stated a guess as fact

`DescribeTimeout` ended with **"The command was not carried out."** A timeout only proves the
*Gateway* stopped waiting. The Director may have received the command, carried it out, and answered
late. Users read the promise, re-tapped Send, and the agent received the same prompt twice.

The mid-command tunnel-drop message in the same file already refuses this exact overclaim on purpose,
and its own comment says why ("the Director may have run it before the connection died, and saying
otherwise would be a guess stated as fact"). The timeout message now mirrors its wording:

> The Director on SOREN_NORTH did not answer within 30 seconds. **It is not known whether the command
> was carried out.**

One string, both arms (named and un-named machine). The idempotency-key work in
thefrederiksen/devthrottle_internal#788 is the real fix for double-submits; this change is only about
the message not lying, and it was deliberately not expanded into that.

## thefrederiksen/devthrottle_internal#824 - snoozing a dead session parked it forever

Every edge that *lifts* a hold is driven by an activity push (`SnoozeLandingObserver.Observe`), and an
exited session never transitions again. So a hold recorded **after** the exit took the not-working
branch, landed `Held`, and nothing in the system could ever clear it. Dropping holds *on* exit cannot
help a hold that arrives *after* it.

`POST /sessions/{sid}/hold` now refuses the park with **409** when `ActivityState == Exited`.

The second half is worse than a stuck row. The fold reads `OnHold` **before** the base activity colour
(`SessionOrdering.EffectiveColor`: `s.OnHold ? "grey"`, and `StateLabel` returns `"Snoozed"` first of
all), so a hold on a **crashed** session painted grey "Snoozed" over deep-red "Crashed" - hiding the
one state that most needs the owner's eyes, for the whole snooze length, triggered by the gesture a
person triaging from a phone reaches for most easily.

**Only the park direction is refused.** Clearing stays allowed unconditionally: un-holding a dead
session is the repair, and refusing it would strand every hold already recorded - including any
written before this ships.

### Where the guard went, and why not where the issue said

The issue points at `Session.RequestHold` (`CcDirector.Core/Sessions/Session.cs:704-718`). **That method
no longer exists on main.** The hold ruling moved to the Gateway, and `Session.ApplyGatewayHold` is now
a dumb mirror whose own comment reads "If you are about to add an `if` to this method, you are putting
the bug back." So the guard is at the Gateway endpoint - the one place that rules on hold - not on the
Director.

That single placement also covers the other entry points the issue lists:

- `POST /sessions/{sid}/hold` - guarded here.
- `/fleet/hold` - with a Gateway configured, `ChooseHoldRoute` returns `HoldRoute.Gateway` and relays to
  the endpoint above, so it inherits the guard.
- `SessionCommandExecutor.Hold` - correctly a dumb mirror; no rule belongs there.

**Deliberately out of scope:** the `HoldRoute.LocalMirror` path, which only runs when there is *no*
Gateway at all. In that configuration there is no registry and no clock, so the failure this issue
describes cannot occur; guarding it would mean putting a ruling back on the Director, against the
architecture. Flagging it rather than silently ignoring it.

## Tests

- The wrong wording was **pinned by an existing test**, so that exact-equality assertion changed too.
- New: `TrySendAsync_Timeout_DoesNotClaimTheCommandWasSkipped` - asserts the new sentence positively on
  both arms, then asserts the old one is gone. Positive first on purpose: an absence-only check would
  still pass if the sentence were deleted entirely.
- New, driving the **real** hold endpoint against a real in-process `GatewayHost`:
  - `Holding_a_session_that_has_already_exited_is_refused_and_records_nothing` - 409, and
    `SnoozeRegistry.Entries()` is **empty**. That emptiness is the assertion that matters: the old code
    wrote an armed entry with a live clock that no edge could clear.
  - `Holding_a_crashed_session_is_refused_so_the_crash_stays_visible` - the row still reads `error` /
    `"Crashed"` before *and* after the refused call.
  - `Unsnoozing_an_exited_session_is_still_allowed_because_it_is_the_repair` - park while alive, let it
    die underneath the hold, clear it: 200 and the registry empties.
- `SnoozeFake` gained `SetCrashed`, and its hand-written `Clone` now carries `Crashed`. Without that
  field the crash arm of the fold is untestable while looking fine - which is exactly what that field
  list's own warning comment is about.

### Scope note on the crash-masking test

The **default** `/sessions` roster drops rows whose `ActivityState` is `Exited`, so the colour masking
bites on the exited-inclusive surface (`?includeExited=true`), which is what that test reads. The
permanent-registry-entry half bites everywhere, roster or no roster. Stated so the test is not read as
proving more than it does.

## Proof

- Full solution builds clean locally: `dotnet build cc-director.sln` - 0 warnings, 0 errors.
- **This pull request, full solution on CI: green.**
  [Build & Test (.NET)](https://github.com/thefrederiksen/devthrottle/actions/runs/30516434471/job/90787247888)
  and [Build & Test (web)](https://github.com/thefrederiksen/devthrottle/actions/runs/30516434471/job/90787247919)
  both pass.

### Revert proof - the tests were observed RED, on CI

A green *with* a fix proves the tests pass. It does not prove they can **fail**, and a test never
observed red is a test whose passing means nothing. So the new tests were run against `origin/main`'s
production code, on CI, in a clean environment:

**[Revert-proof run: Build & Test (.NET) - FAILED](https://github.com/thefrederiksen/devthrottle/actions/runs/30516519904/job/90787505664)**

That run is throwaway branch `proof/ses-guards-819-824-revert` (draft pull request #2293, since closed
and the branch deleted): `origin/main` production code with only this pull request's two test files
applied - `git diff origin/main --stat` was those two files and nothing else.

The expected result was **written into that pull request's body before the run**, so the outcome could
not be interpreted after the fact. It matched exactly:

| Pre-registered prediction | Result |
| --- | --- |
| `TrySendAsync_Timeout_WithoutAMachineName_KeepsTheSameMessageShape` RED | `[FAIL]` |
| `TrySendAsync_Timeout_DoesNotClaimTheCommandWasSkipped` RED | `[FAIL]` |
| `Holding_a_session_that_has_already_exited_is_refused_and_records_nothing` RED | `[FAIL]` |
| `Holding_a_crashed_session_is_refused_so_the_crash_stays_visible` RED | `[FAIL]` |
| `Unsnoozing_an_exited_session_is_still_allowed_because_it_is_the_repair` **GREEN** | **passed** |

Run totals: `Passed: 4450, Failed: 4, Skipped: 17`. Four predicted, four failed, nothing else.

That last row is the control that matters most. A guard which refuses **too much** goes
red-without-the-fix just as happily as a correct one, so proving the guard *fires* is not enough - this
proves it does not **over**-fire and block the repair path. Un-holding an exited session still works.
