### PR TITLE
Launch the agent executable the wizard recorded, not a bare command name

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1680,9 +1680,14 @@ public partial class MainWindow : Window
     /// </summary>
     private string? _lastSessionCreateError;
 
-    /// <summary>Construct the <see cref="IAgent"/> strategy for the given agent kind.</summary>
+    /// <summary>
+    /// Construct the <see cref="IAgent"/> strategy for the given agent kind, for the launches where
+    /// no entry was picked by hand (workspace restore, the quick-launch paths). Issue #1050: the
+    /// executable comes from the configured agent entry, so these launches find an agent the
+    /// onboarding wizard installed off PATH exactly as <see cref="CreateAgentForEntry"/> does.
+    /// </summary>
     private IAgent CreateAgent(AgentKind agentKind) =>
-        AgentPluginRegistry.CreateAgent(agentKind, _sessionManager.Options);
+        AgentLaunchDefaults.CreateAgentForKind(agentKind, _sessionManager.Options);
 
     /// <summary>
     /// Build a catalog agent (issue #490) whose executable path is the selected entry's configured

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -525,7 +525,12 @@ internal static class SessionCommandExecutor
         }
         else
         {
-            agent = AgentPluginRegistry.CreateAgent(kind, sessionManager.Options);
+            // Issue #1050: the EXECUTABLE comes from the configured agent entry, exactly like the
+            // arguments resolved just below. Building the agent from AgentOptions alone launched the
+            // per-type default - a bare "claude" - and ignored the absolute path the onboarding
+            // wizard had just recorded for the binary it installed, so a clean machine could not
+            // start a session with the agent its own wizard reported as ready.
+            agent = AgentLaunchDefaults.CreateAgentForKind(kind, sessionManager.Options);
         }
 
         // Issue #1017: with no explicit Args, inherit the configured default launch line for this kind

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -543,7 +543,10 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
 
             if (!AgentPluginRegistry.Contains(kind))
                 return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"agent {kind} is not a built-in plugin target");
-            var agent = AgentPluginRegistry.CreateAgent(kind, sessionManager.Options);
+            // Issue #1050: launch the executable recorded on the configured agent entry, not the
+            // per-type default in AgentOptions - on a machine whose agent was installed by the
+            // onboarding wizard, only the entry knows where the binary is.
+            var agent = AgentLaunchDefaults.CreateAgentForKind(kind, sessionManager.Options);
 
             try
             {

--- a/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
@@ -394,4 +394,152 @@ public sealed class AgentLaunchDefaultsTests : IDisposable
         Assert.Throws<ArgumentNullException>(
             () => AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, null!));
     }
+
+    // ===== The executable, from the SAME entry as the arguments (issue #1050) =====
+    //
+    // The clean-machine install failure: the onboarding wizard installs Claude Code, records the
+    // binary's absolute path on the agent entry, and reports it ready - while the launch path took its
+    // arguments from that entry and its EXECUTABLE from AgentOptions, whose bare "claude" default is
+    // what nothing writes any more. These pin the property that closes it: for a caller that knows
+    // only the KIND, the executable is the one recorded on the entry.
+
+    [Fact]
+    public void CreateAgentForKind_EntryHasPath_LaunchesTheEntrysExecutable()
+    {
+        // The exact clean-install shape: the machine-level ClaudePath is the untouched bare default,
+        // and the only place that knows where the wizard put the binary is the entry.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true,
+                "executable_path": "C:/Users/qa/.local/bin/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var agent = AgentLaunchDefaults.CreateAgentForKind(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Equal("C:/Users/qa/.local/bin/claude.exe", agent.ExecutablePath);
+        Assert.Equal(AgentKind.ClaudeCode, agent.Kind);
+    }
+
+    [Fact]
+    public void CreateAgentForKind_EntryHasPath_DoesNotUseTheBareDefault()
+    {
+        // Stated separately because the bare default is the failure: "claude" is what CreateProcess
+        // was handed, and it is what must NOT come out of here when an entry knows better.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true,
+                "executable_path": "C:/Users/qa/.local/bin/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var agent = AgentLaunchDefaults.CreateAgentForKind(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.NotEqual("claude", agent.ExecutablePath);
+    }
+
+    [Fact]
+    public void CreateAgentForKind_ArgsAndExecutableComeFromTheSameEntry()
+    {
+        // The defect class in one assertion: two halves that must not be able to come from two
+        // sources. The entry's preset decides the arguments AND the entry's path decides the binary.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true,
+                "executable_path": "C:/Users/qa/.local/bin/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+        var options = new AgentOptions();
+
+        var agent = AgentLaunchDefaults.CreateAgentForKind(AgentKind.ClaudeCode, options);
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, options);
+
+        Assert.Equal("C:/Users/qa/.local/bin/claude.exe", agent.ExecutablePath);
+        Assert.Equal(ClaudeAuto, args);
+    }
+
+    [Fact]
+    public void CreateAgentForKind_BlankEntryPath_UsesThePerTypeDefault()
+    {
+        // An entry with no recorded path knows nothing, so the per-type path in AgentOptions is the
+        // only candidate. That is the documented default for a machine with no agent library, and it
+        // is not silent: an unresolvable command is refused by name at launch, never handed to
+        // CreateProcess to fail with a bare error.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var agent = AgentLaunchDefaults.CreateAgentForKind(
+            AgentKind.ClaudeCode, new AgentOptions { ClaudePath = "C:/tools/claude.exe" });
+
+        Assert.Equal("C:/tools/claude.exe", agent.ExecutablePath);
+    }
+
+    [Fact]
+    public void CreateAgentForKind_PrefersTheEnabledEntry()
+    {
+        // Same entry the desktop New Session dialog pre-selects: the first ENABLED one of that kind.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": false, "executable_path": "C:/old/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" },
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/current/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var agent = AgentLaunchDefaults.CreateAgentForKind(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Equal("C:/current/claude.exe", agent.ExecutablePath);
+    }
+
+    [Fact]
+    public void ResolveEntryExecutablePath_NoEntryForKind_ReturnsNull()
+    {
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.exe",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        Assert.Null(AgentLaunchDefaults.ResolveEntryExecutablePath(AgentKind.Codex, new AgentOptions()));
+    }
+
+    [Fact]
+    public void CreateAgentForKind_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => AgentLaunchDefaults.CreateAgentForKind(AgentKind.ClaudeCode, null!));
+    }
 }

--- a/src/CcDirector.Core.Tests/Sessions/AgentLaunchDiagnosticsTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/AgentLaunchDiagnosticsTests.cs
@@ -1,0 +1,122 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// What a launch that FAILS has to say for itself (devthrottle_internal issue #1050).
+///
+/// On the first clean-machine walk of v1.8.7 a session died with the whole of "CreateProcess failed."
+/// - no Win32 error code, no executable, no command line, no working directory - and the person saw
+/// only "HTTP 500 from the Director". It took a QA seat four experimental eliminations to place,
+/// because ERROR_FILE_NOT_FOUND, ERROR_DIRECTORY and ERROR_NOT_ENOUGH_MEMORY are three different bugs
+/// and the log distinguished none of them. These tests pin the evidence a failed launch must carry,
+/// so the NEXT launch failure - whatever its cause - is readable from the log alone.
+///
+/// CC_DIRECTOR_ROOT is redirected so the Claude hook-settings file a launch installs is written to an
+/// isolated temp folder, never the developer's own.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class AgentLaunchDiagnosticsTests : IDisposable
+{
+    private static bool OnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _repo;
+
+    public AgentLaunchDiagnosticsTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-launchdiag-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _repo = Path.Combine(_root, "repo");
+        Directory.CreateDirectory(_repo);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ===== An unresolvable agent command is refused by name, before CreateProcess =====
+
+    [Fact]
+    public void CreateSession_AgentCommandDoesNotResolve_ThrowsNamingTheAgentAndTheCommand()
+    {
+        // This is the clean-machine state exactly: the configured command is a bare name that is on
+        // no PATH, so there is nothing to launch. Handing it to CreateProcess anyway is what produced
+        // a bare "CreateProcess failed."; the launch now refuses it and says which agent, which
+        // command, and what to do about it.
+        var command = "claude-1050-not-installed";
+        var manager = new SessionManager(new AgentOptions { ClaudePath = command });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.CreateSession(_repo));
+
+        Assert.Contains("Claude Code", ex.Message);
+        Assert.Contains(command, ex.Message);
+        Assert.Contains("PATH", ex.Message);
+        Assert.Contains("Settings", ex.Message);
+    }
+
+    [Fact]
+    public void CreateSession_AgentCommandDoesNotResolve_DoesNotReportOnlyCreateProcessFailed()
+    {
+        // The exact regression: three words that name no cause. The message may not be this again.
+        var manager = new SessionManager(new AgentOptions { ClaudePath = "claude-1050-not-installed" });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.CreateSession(_repo));
+
+        Assert.NotEqual("CreateProcess failed.", ex.Message);
+    }
+
+    // ===== A launch that reaches CreateProcess and fails carries the Win32 error =====
+
+    [Fact]
+    public void ConPtyBackend_Start_MissingExecutable_MessageCarriesWin32ErrorCode()
+    {
+        if (!OnWindows) return; // ConPTY is a Windows pseudo-console; the Unix host reports errno already.
+
+        // An absolute path to a file that is not there: CreateProcess answers ERROR_FILE_NOT_FOUND (2).
+        // The point is not the number - it is that the number, its system text, the command line and
+        // the working directory all reach the message a caller logs.
+        var missing = Path.Combine(_root, "no-such-agent.exe");
+        using var backend = new ConPtyBackend(bufferSizeBytes: 4096);
+
+        var ex = Assert.Throws<Win32Exception>(
+            () => backend.Start(missing, "--some-arg", _repo, 120, 30));
+
+        Assert.Equal(2, ex.NativeErrorCode);
+        Assert.Contains("Win32 error 2", ex.Message);
+        Assert.Contains(missing, ex.Message);
+        Assert.Contains(_repo, ex.Message);
+    }
+
+    // ===== A launch that succeeds records WHICH executable it launched =====
+
+    [Fact]
+    public void CreateSession_RecordsTheResolvedExecutableOnTheSession()
+    {
+        // The launch fact the log did not have and no test could pin: the resolved executable actually
+        // handed to CreateProcess. A session that started can say what it started.
+        var shell = OnWindows
+            ? Path.Combine(Environment.SystemDirectory, "cmd.exe")
+            : "/bin/sh";
+        var manager = new SessionManager(new AgentOptions { ClaudePath = shell });
+
+        var session = manager.CreateSession(_repo);
+        try
+        {
+            Assert.Equal(shell, session.LaunchExecutable);
+        }
+        finally
+        {
+            session.Dispose();
+        }
+    }
+}

--- a/src/CcDirector.Core/ConPty/ProcessHost.cs
+++ b/src/CcDirector.Core/ConPty/ProcessHost.cs
@@ -45,6 +45,20 @@ public sealed class ProcessHost : IDisposable
 
         string commandLine = string.IsNullOrEmpty(args) ? $"\"{exePath}\"" : $"\"{exePath}\" {args}";
 
+        // Say what is about to be launched, BEFORE trying it. A launch that fails leaves nothing else
+        // behind: the only other line is the caller's failure message, and for a whole release the
+        // Claude path printed no executable at all, so there was no way to see from the outside what
+        // CreateProcess was actually handed (devthrottle_internal issue #1050).
+        //
+        // Only the NAMES of the injected variables are recorded, never their values: this dictionary
+        // carries agent credentials (CURSOR_API_KEY, COPILOT_GITHUB_TOKEN), and a launch line is not
+        // the place to write a token to disk.
+        var envNames = environmentVars is null || environmentVars.Count == 0
+            ? "(none)"
+            : string.Join(",", environmentVars.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase));
+        FileLog.Write($"[ProcessHost] Start: exe={exePath}, args={(string.IsNullOrEmpty(args) ? "(none)" : args)}, " +
+                      $"workingDir={workingDir ?? "(inherited)"}, injectedEnv={envNames}");
+
         // Two-call pattern for InitializeProcThreadAttributeList
         var size = IntPtr.Zero;
         InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref size);
@@ -108,7 +122,21 @@ public sealed class ProcessHost : IDisposable
                         ref startupInfo,
                         out _processInfo))
                 {
-                    throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateProcess failed.");
+                    // THE ERROR CODE IS THE DIAGNOSIS - do not drop it. This threw
+                    // "CreateProcess failed." for a whole release, and Win32Exception(code, message)
+                    // returns the MESSAGE from Message, not the system text, so every caller that
+                    // logged ex.Message logged those three words and nothing else. ERROR_FILE_NOT_FOUND,
+                    // ERROR_DIRECTORY and ERROR_NOT_ENOUGH_MEMORY are three different bugs with three
+                    // different fixes, and a clean-machine install failure (devthrottle_internal issue
+                    // #1050) took four eliminations to place because the log distinguished none of them.
+                    // The code, its system text, the command line and the working directory all go in
+                    // the message, so they reach the Director log AND the caller's error response.
+                    var error = Marshal.GetLastWin32Error();
+                    var systemText = new Win32Exception(error).Message;
+                    var detail = $"CreateProcess failed with Win32 error {error} ({systemText}). " +
+                                 $"commandLine={commandLine}, workingDir={workingDir ?? "(inherited)"}";
+                    FileLog.Write($"[ProcessHost] Start FAILED: {detail}");
+                    throw new Win32Exception(error, detail);
                 }
             }
             finally

--- a/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
+++ b/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
@@ -47,9 +47,12 @@ public static class AgentLaunchDefaults
     /// <see cref="ResolveDefaultArgs"/> takes the preset and model from.
     ///
     /// A kind with no entry, or an entry with a blank path, falls through to the per-type path in
-    /// <see cref="AgentOptions"/> exactly as before - that is the documented default for a machine
-    /// with no agent library, not a fallback that hides a failure. Callers that let the USER pick an
-    /// entry (the desktop New Session dialog) pass that entry's path directly and do not come here.
+    /// <see cref="AgentOptions"/> - the documented default for a machine with no agent library, which
+    /// is a real configuration (a developer with the agent on PATH), not a guess standing in for a
+    /// missing value. It can no longer end the way #1050 did either: an executable that resolves to
+    /// nothing is refused by name in <c>SessionManager.CreateSession</c>, with a sentence, before
+    /// CreateProcess is asked to launch it. Callers that let the USER pick an entry (the desktop New
+    /// Session dialog) pass that entry's path directly and do not come here.
     /// </summary>
     public static IAgent CreateAgentForKind(AgentKind agentKind, AgentOptions options)
     {

--- a/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
+++ b/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
@@ -25,9 +25,62 @@ namespace CcDirector.Core.Configuration;
 /// all, silently: a spawn asking for bypassPermissions=true got a Codex launched with an empty
 /// command line, sandboxed and prompting on every tool call, while the log said the default had been
 /// applied. It now covers every agent that HAS such a flag, and says plainly when one does not.
+///
+/// It also owns the EXECUTABLE for those callers (<see cref="CreateAgentForKind"/>), because the
+/// executable and the arguments have to come from the SAME agent entry. They did not, and that is
+/// devthrottle_internal issue #1050: a clean machine could not start a session with the agent its own
+/// wizard had just installed. The wizard records the installed binary's absolute path on the agent
+/// entry (<c>agent.entries[].executable_path</c>) and reports it as ready; nothing writes the legacy
+/// per-type <c>agent.claude_path</c> key any more, so <see cref="AgentOptions.ClaudePath"/> stayed at
+/// its default bare name "claude". The create path took the arguments from the entry and the
+/// executable from <see cref="AgentOptions"/>, so it handed CreateProcess a bare "claude" that does
+/// not resolve when the installer's <c>.local\bin</c> is not on the running Director's PATH - and the
+/// launch died with a bare "CreateProcess failed." The desktop New Session dialog never had the bug
+/// because it always passed the selected entry's path.
 /// </summary>
 public static class AgentLaunchDefaults
 {
+    /// <summary>
+    /// Build the agent for a caller that knows only the agent KIND - a Control API spawn, a handover
+    /// target, a workspace restore - so it launches the executable the machine actually has: the
+    /// path recorded on the configured agent entry, which is the same entry
+    /// <see cref="ResolveDefaultArgs"/> takes the preset and model from.
+    ///
+    /// A kind with no entry, or an entry with a blank path, falls through to the per-type path in
+    /// <see cref="AgentOptions"/> exactly as before - that is the documented default for a machine
+    /// with no agent library, not a fallback that hides a failure. Callers that let the USER pick an
+    /// entry (the desktop New Session dialog) pass that entry's path directly and do not come here.
+    /// </summary>
+    public static IAgent CreateAgentForKind(AgentKind agentKind, AgentOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        var entryPath = ResolveEntryExecutablePath(agentKind, options);
+        return AgentPluginRegistry.CreateAgentWithPathOverride(agentKind, options, entryPath);
+    }
+
+    /// <summary>
+    /// The executable path recorded on the configured agent entry for this kind (the first ENABLED
+    /// entry of that kind, then any entry of that kind - the same entry the desktop dialog
+    /// pre-selects), or null when there is no such entry or its path is blank.
+    /// </summary>
+    public static string? ResolveEntryExecutablePath(AgentKind agentKind, AgentOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        var entry = FindEntry(agentKind, options);
+        var path = entry?.ExecutablePath?.Trim();
+        if (string.IsNullOrEmpty(path))
+        {
+            FileLog.Write($"[AgentLaunchDefaults] ResolveEntryExecutablePath: {agentKind} has no configured entry path; " +
+                          "launching the per-type default from AgentOptions");
+            return null;
+        }
+
+        FileLog.Write($"[AgentLaunchDefaults] ResolveEntryExecutablePath: {agentKind} resolved from entry id={entry!.Id} to {path}");
+        return path;
+    }
+
     /// <summary>
     /// The default effective launch arguments for the given agent kind, matching what the desktop
     /// New Session dialog launches by default:
@@ -107,9 +160,7 @@ public static class AgentLaunchDefaults
     /// </summary>
     private static string ResolveEntryArgs(AgentKind agentKind, AgentOptions options)
     {
-        var entries = AgentEntryStore.LoadEntries(options);
-        var entry = entries.FirstOrDefault(e => e.Enabled && e.Type == agentKind)
-                    ?? entries.FirstOrDefault(e => e.Type == agentKind);
+        var entry = FindEntry(agentKind, options);
         if (entry is not null)
         {
             var argsFromEntry = entry.ToToolConfig().ResolveEffectiveCommandLineArguments();
@@ -120,5 +171,18 @@ public static class AgentLaunchDefaults
         var args = AgentToolConfig.Load(agentKind).ResolveEffectiveCommandLineArguments();
         FileLog.Write($"[AgentLaunchDefaults] ResolveEntryArgs: {agentKind} no configured entry; per-tool config args=\"{args}\"");
         return args;
+    }
+
+    /// <summary>
+    /// The configured agent-library entry a kind-only launch belongs to: the first ENABLED entry of
+    /// that kind, then any entry of that kind, mirroring what the desktop New Session dialog
+    /// pre-selects. ONE lookup for both the arguments and the executable, so the two can never come
+    /// from different entries again (issue #1050).
+    /// </summary>
+    private static AgentEntry? FindEntry(AgentKind agentKind, AgentOptions options)
+    {
+        var entries = AgentEntryStore.LoadEntries(options);
+        return entries.FirstOrDefault(e => e.Enabled && e.Type == agentKind)
+               ?? entries.FirstOrDefault(e => e.Type == agentKind);
     }
 }

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -142,6 +142,20 @@ public sealed class Session : IDisposable
     /// Defaults to ClaudeCode for sessions created via legacy code paths.</summary>
     public AgentKind AgentKind { get; internal set; } = AgentKind.ClaudeCode;
 
+    /// <summary>
+    /// The executable this session was actually launched with - the resolved path handed to
+    /// CreateProcess, after the agent entry's recorded path and any batch-shim wrapping have been
+    /// applied. Null for sessions that spawn no local process (embedded test backends, remote
+    /// backends).
+    ///
+    /// Recorded because it was not (devthrottle_internal issue #1050): a clean machine launched a
+    /// bare "claude" instead of the absolute path its own wizard had just recorded, and neither the
+    /// log nor the session said which executable had been tried, so the failure was
+    /// indistinguishable from a broken pseudo-console. This is the launch fact a test can pin and an
+    /// operator can read.
+    /// </summary>
+    public string? LaunchExecutable { get; internal set; }
+
     /// <summary>If this session was created as part of a group (issue #225), the shared
     /// group identity its members travel by; null for a solo session. Members of the same
     /// group sort adjacently and drag as one unit. Stamped at creation, immutable.</summary>

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -5,6 +5,7 @@ using CcDirector.Core.AgentPlugins;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Settings;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -704,15 +705,38 @@ public sealed class SessionManager : IDisposable
             // as a ".cmd" shim (e.g. npm-installed "opencode.cmd") would never be found from
             // the bare name "opencode". Resolving against PATH+PATHEXT yields the full
             // "...\opencode.cmd" path. CreateProcess still cannot execute a batch shim
-            // directly, so CommandLineLauncher wraps .cmd/.bat through cmd.exe. If the command
-            // cannot be resolved at all we keep the original so the launch fails loudly.
-            var resolvedExe = ExecutableResolver.Resolve(agent.ExecutablePath) ?? agent.ExecutablePath;
+            // directly, so CommandLineLauncher wraps .cmd/.bat through cmd.exe.
+            //
+            // A command that resolves to NOTHING is refused here, by name. It used to be passed
+            // through unchanged "so the launch fails loudly", and it did not fail loudly - it failed
+            // cryptically: devthrottle_internal issue #1050 handed CreateProcess a bare "claude" that
+            // was on no PATH and got back "CreateProcess failed." with no error code, no path, and
+            // nothing for the person to act on. The sentence below names the agent, the command that
+            // was tried, and what to do, and it travels all the way out as the caller's error.
+            var resolvedExe = ExecutableResolver.Resolve(agent.ExecutablePath);
+            if (resolvedExe is null)
+            {
+                var display = ToolDetectionService.DisplayName(agent.Kind);
+                throw new InvalidOperationException(
+                    $"{display} could not be started: the command \"{agent.ExecutablePath}\" is not a file on this " +
+                    "machine and was not found on this Director's PATH. Set this agent's executable path in " +
+                    $"Settings, Agents - or install {display} - and start the session again.");
+            }
             if (!string.Equals(resolvedExe, agent.ExecutablePath, StringComparison.OrdinalIgnoreCase))
                 _log?.Invoke($"Resolved agent command '{agent.ExecutablePath}' to '{resolvedExe}'");
 
             var (launchExe, launchArgs) = CommandLineLauncher.Build(resolvedExe, args);
             if (!string.Equals(launchExe, resolvedExe, StringComparison.OrdinalIgnoreCase))
                 _log?.Invoke($"Launching '{resolvedExe}' via shell: {launchExe} {launchArgs}");
+
+            // The whole launch spec, in the log the person reads when a session will not start, and in
+            // the line immediately before the attempt. Issue #1050 was diagnosed from the outside for
+            // an hour without this: the working RawCli path printed its executable and the failing
+            // Claude path printed none, so the one difference that mattered was the one thing invisible.
+            // Variable NAMES only - the injected set carries agent credentials.
+            _log?.Invoke($"Launching {agent.Kind}: exe={launchExe}, args={(string.IsNullOrEmpty(launchArgs) ? "(none)" : launchArgs)}, " +
+                         $"workingDir={repoPath}, injectedEnv={string.Join(",", envVars.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))}");
+            session.LaunchExecutable = launchExe;
 
             // Reserve the worktree BEFORE the process starts (inspection round 5). The reserve-write is
             // serialized against the reaper's remove by a machine-wide lock, so a reaper can never

--- a/src/CcDirector.Gateway.Tests/CleanInstallSessionLaunchTests.cs
+++ b/src/CcDirector.Gateway.Tests/CleanInstallSessionLaunchTests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The clean-machine install failure, at the seam it happened on (devthrottle_internal issue #1050).
+///
+/// On the first clean-machine walk of v1.8.7 the product could not start a session with the agent its
+/// OWN wizard had just installed. The wizard runs the official installer, which drops the binary in
+/// <c>~/.local\bin</c>; detection probes that location directly, so the wizard finds it and records
+/// its ABSOLUTE path on the agent entry (<c>agent.entries[].executable_path</c>) and reports
+/// "1 agent ready". But nothing writes the legacy per-type <c>agent.claude_path</c> key any more, so
+/// <see cref="AgentOptions.ClaudePath"/> stays at its bare default "claude" - and the Control API
+/// create path built the agent from <see cref="AgentOptions"/> alone. So the ARGUMENTS came from the
+/// entry and the EXECUTABLE came from somewhere else: CreateProcess was handed a bare "claude" that
+/// resolves on no clean machine, and the session died with "CreateProcess failed."
+///
+/// Every existing test passed because every test exercised the working seam - the desktop New Session
+/// dialog passes the selected entry's path explicitly, which is every path a developer takes.
+///
+/// THIS TEST PINS THE PROPERTY, NOT THE SYMPTOM. It asserts the RESOLVED EXECUTABLE the create path
+/// launched, and the expected value is a file inside the test's own temp folder, so no machine's PATH
+/// can make it pass by accident - which is exactly how "the session starts" would go green again the
+/// moment something put <c>.local\bin</c> on a PATH, while a clean machine stayed broken.
+///
+/// CC_DIRECTOR_ROOT is redirected to an isolated temp folder, so the seeded config, the agent entry
+/// and the Claude hook-settings file never touch the real machine. In the "DirectorRoot" collection,
+/// which serializes root-touching tests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class CleanInstallSessionLaunchTests : IDisposable
+{
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+    private const string DirectorId = "dir-1050-test";
+
+    /// <summary>
+    /// What the machine-level path is on a clean install: the bare default that nothing writes and
+    /// nothing can resolve once the wizard has installed the agent off PATH.
+    /// </summary>
+    private const string UnresolvableBareCommand = "claude-1050-not-installed";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _repo;
+    private readonly string _installedAgentExe;
+    private readonly string _otherEntryExe;
+    private readonly SessionManager _sm;
+
+    public CleanInstallSessionLaunchTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-1050-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _repo = Path.Combine(_root, "repo");
+        Directory.CreateDirectory(_repo);
+
+        // Stand in for the binary the wizard installed: a REAL executable at an absolute path in a
+        // directory that is on no PATH - the shape of C:\Users\qa\.local\bin\claude.exe. A copy of the
+        // platform shell is used because it is guaranteed to exist and to launch.
+        var onWindows = OperatingSystem.IsWindows();
+        var source = onWindows ? Path.Combine(Environment.SystemDirectory, "cmd.exe") : "/bin/sh";
+        var exeName = onWindows ? "claude.exe" : "claude";
+        _installedAgentExe = CopyShellTo(Path.Combine(_root, "local-bin"), exeName, source);
+        _otherEntryExe = CopyShellTo(Path.Combine(_root, "other-bin"), exeName, source);
+
+        // The config a clean machine has after the wizard's install-and-accept: an agent entry carrying
+        // the installed binary's absolute path, and no legacy per-type path key at all.
+        //
+        // TWO entries of the same kind on purpose. The first is disabled and carries a DIFFERENT path
+        // and a DIFFERENT preset; the enabled one is the entry every launch must read. With one entry
+        // there is no way to tell "the launch read the entry" from "the launch read some other source
+        // that happens to hold the same string" - and the defect was not a missing value, it was two
+        // halves of one record being read from two places. Two distinguishable entries make the pairing
+        // itself the assertion: the executable and the arguments have to name the SAME record.
+        Directory.CreateDirectory(CcStorage.Config());
+        File.WriteAllText(CcStorage.ConfigJson(), JsonSerializer.Serialize(new
+        {
+            agent = new
+            {
+                entries = new[]
+                {
+                    new
+                    {
+                        type = "ClaudeCode",
+                        enabled = false,
+                        executable_path = _otherEntryExe,
+                        preset_id = "Skip permissions",
+                        launch_mode = "Unattended",
+                    },
+                    new
+                    {
+                        type = "ClaudeCode",
+                        enabled = true,
+                        executable_path = _installedAgentExe,
+                        preset_id = "Standard",
+                        launch_mode = "Guided",
+                    },
+                },
+            },
+        }));
+
+        _sm = new SessionManager(new AgentOptions { ClaudePath = UnresolvableBareCommand });
+    }
+
+    /// <summary>
+    /// A real, launchable executable at an absolute path in a directory that is on no PATH - the shape
+    /// of C:\Users\qa\.local\bin\claude.exe. A copy of the platform shell, because it is guaranteed to
+    /// exist and to start.
+    /// </summary>
+    private static string CopyShellTo(string directory, string fileName, string shell)
+    {
+        Directory.CreateDirectory(directory);
+        var target = Path.Combine(directory, fileName);
+        File.Copy(shell, target);
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(target,
+                UnixFileMode.UserRead | UnixFileMode.UserExecute | UnixFileMode.UserWrite);
+        return target;
+    }
+
+    public void Dispose()
+    {
+        foreach (var session in _created)
+        {
+            try { session.Dispose(); } catch { /* best effort */ }
+        }
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private readonly List<Session> _created = new();
+
+    private Session CreateThroughControlApi()
+    {
+        var result = SessionCommandExecutor.Create(_sm, DirectorId, new DirectorCommand
+        {
+            Verb = "create",
+            PayloadJson = JsonSerializer.Serialize(new NewSessionRequest
+            {
+                RepoPath = _repo,
+                Agent = "ClaudeCode",
+                Name = "issue 1050 clean install launch",
+            }, Web),
+        });
+
+        Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+        var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson!, Web);
+        Assert.NotNull(dto);
+        var session = _sm.GetSession(Guid.Parse(dto!.SessionId));
+        Assert.NotNull(session);
+        _created.Add(session!);
+        return session!;
+    }
+
+    [Fact]
+    public void Create_LaunchesTheExecutableTheWizardRecordedOnTheAgentEntry()
+    {
+        // THE defect: the entry knows where the agent is, and the launch must use it. The bare
+        // machine-level command cannot resolve, so before the fix this create failed outright.
+        var session = CreateThroughControlApi();
+
+        Assert.Equal(_installedAgentExe, session.LaunchExecutable);
+    }
+
+    [Fact]
+    public void Create_DoesNotLaunchTheUnwritableBareMachineCommand()
+    {
+        // Stated on its own because the bare name is the failure. It must not reach the launcher when
+        // an entry records a real path - not as a first choice and not as a fallback.
+        var session = CreateThroughControlApi();
+
+        Assert.NotEqual(UnresolvableBareCommand, session.LaunchExecutable);
+        Assert.DoesNotContain(UnresolvableBareCommand, session.LaunchExecutable);
+    }
+
+    [Fact]
+    public void Create_TakesArgumentsAndExecutableFromTheSameEntry()
+    {
+        // THE ACTUAL DEFECT, as one assertion: the arguments and the executable must name ONE record.
+        // Two entries of this kind exist, each with its own path AND its own preset, so a launch that
+        // read them from two sources would pair the enabled entry's arguments with the other entry's
+        // binary (or with a machine-level path) and this would fail. Both halves must be the ENABLED
+        // entry's: the Standard preset's automatic permission mode, and the path beside it.
+        var session = CreateThroughControlApi();
+
+        Assert.Equal(_installedAgentExe, session.LaunchExecutable);
+        Assert.Contains("--permission-mode auto", session.ClaudeArgs ?? "");
+
+        // And not the other entry's pairing, which is what "read from two sources" would produce.
+        Assert.NotEqual(_otherEntryExe, session.LaunchExecutable);
+        Assert.DoesNotContain("--dangerously-skip-permissions", session.ClaudeArgs ?? "");
+    }
+}


### PR DESCRIPTION
Fixes the clean-machine defect in devthrottle_internal issue #1050: starting a session through the command line or the Control API failed with `CreateProcess failed.` for the agent the onboarding wizard had just installed and reported as ready.

## What was wrong

The wizard runs the official Claude Code installer, which puts the binary in the user's `.local\bin`. Detection probes that location directly, so the wizard finds it, records its **absolute path on the agent entry** (`agent.entries[].executable_path`) and reports "1 agent ready".

Nothing writes the legacy per-type `agent.claude_path` key any more, so `AgentOptions.ClaudePath` stays at its bare default `"claude"` - and the create path built the agent from `AgentOptions` alone. So the **arguments** came out of the entry and the **executable** came from somewhere else. `CreateProcess` was handed a bare `claude` that resolves on no clean machine.

Confirmed on the machine that produced it: the entry is present, its `executable_path` points at a file that exists, `agent.claude_path` is absent, and the line immediately before the failure is the executor resolving the **arguments** out of that very entry. Both halves come from one record in one operation and only one of them was used.

The desktop New Session dialog was never affected - it passes the selected entry's path explicitly. That is why every path a developer takes worked, and why every existing test passed.

## The fix, at the seam

Every launch that knows only the agent KIND now builds its agent through `AgentLaunchDefaults.CreateAgentForKind`, which reads the executable from the **same entry lookup** that already supplies the preset and the model. One record, one read, both halves. That covers the Control API create verb (the reported path), the handover target, and the desktop workspace-restore and quick-launch paths.

A command that resolves to nothing is now **refused by name** before `CreateProcess` sees it. It used to be passed through "so the launch fails loudly" and instead failed cryptically; the message now names the agent, the command that was tried, and what to do, and it travels out as the caller's error instead of a bare HTTP 500.

## Diagnosis, worth having whatever the next launch failure turns out to be

- **The Win32 error code**, its system text, the command line and the working directory all go into the `CreateProcess` failure message. It threw `CreateProcess failed.` for a whole release: `Win32Exception(code, message)` returns the *message* from `Message`, not the system text, so every caller that logged `ex.Message` logged three words that name no cause. File-not-found, bad-directory and out-of-memory are three different bugs and the log distinguished none of them.
- **The whole launch spec** - executable, arguments, working directory, and the NAMES of the injected environment variables - is logged immediately before the attempt, in the log a person reads when a session will not start. Values are never logged; that set carries agent credentials.
- **A session records the resolved executable** it was launched with, so the launch fact is inspectable rather than invisible. This is also what the tests assert on.

## Proof

The tests pin the property, not the symptom. `CleanInstallSessionLaunchTests` seeds **two** entries of the same kind - one disabled with a different path AND a different preset, one enabled - so a launch reading the two halves from two sources would pair the wrong binary with the right arguments and fail. The expected executable lives in the test's own temporary folder, where no machine's PATH can produce it by accident, so this cannot go green again because something put a directory on a PATH.

Verified red against the pre-fix lines, then green:

- create path, pre-fix: `Assert.Equal() Failure: Expected: Ok, Actual: Error` (three tests)
- `CreateProcess` message, pre-fix: `Assert.Contains() Failure ... String: "CreateProcess failed." Not found: "Win32 error 2"`
- unresolvable command, pre-fix: `Expected: typeof(InvalidOperationException), Actual: typeof(Win32Exception) ---- CreateProcess failed.`
- with the fix: 28 passed in the two new/extended classes, `CcDirector.Core.Tests` 3942 passed / 0 failed, whole solution builds clean.

## Deliberately not in scope

- The **blank entry path** fall-through in the desktop `CreateAgentForEntry` route is filed separately as devthrottle_internal issue #1056 (an upgrade-path hazard, latent on a wizard-installed agent). No new fall-back is introduced here, and the refusal above means a blank path can no longer end in a bare Win32 error.
- The headless agent invocations that read `AgentOptions.ClaudePath` directly (the wingman turn summaries and goal assessments) have the same "bare command on a clean machine" exposure by a different route. Not touched here; worth its own issue.
