### PR TITLE
Docs: quote the download page, and name the route that is not account-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Three ways to get it, all the same install:
 
 | | How |
 |---|---|
-| **Download it** | **[devthrottle.com/download](https://devthrottle.com/download)** -- pick your platform and run it. No sign-up. |
+| **Download it** | **[devthrottle.com/download](https://devthrottle.com/download)** -- the Windows installer, and the one-line install for macOS. *"Free, no account needed."* Go to `/download` directly; the home page's **Get started** button takes the account-first route instead. |
 | **By prompt** | Paste [one prompt](docs/install/install-prompt.md) into a coding agent you already have and it installs the Director for you, unattended. |
 | **From a release** | The same assets, direct: [latest release](https://github.com/thefrederiksen/devthrottle/releases/latest). |
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The gateway is what makes DevThrottle reachable beyond the one machine: your age
 | **Self-hosted gateway** | Run the gateway on your own machine and join it. Windows only, and it still needs a DevThrottle sign-in. For advanced setups. |
 | **Not now** | Local-only on this machine. Connect any time from Settings. |
 
-Either gateway needs a DevThrottle login -- with Google, GitHub, or an email and password. There is no bring-your-own-key: inference always routes through DevThrottle, which is exactly why connecting a gateway asks you to sign in.
+Either gateway needs a DevThrottle login -- Google, GitHub, or email. The email route sends you a sign-in link rather than asking for a password, so Google or GitHub is the quicker way in. There is no bring-your-own-key: inference always routes through DevThrottle, which is exactly why connecting a gateway asks you to sign in.
 
 <p align="center">
   <a href="https://devthrottle.com"><img src="https://img.shields.io/badge/Start%20free-devthrottle.com-2EA44F?style=for-the-badge" alt="Start free at devthrottle.com"></a>

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -31,7 +31,9 @@ There is **no install type to choose**. Every machine gets the same thing.
 
 ### Windows
 
-Download **DevThrottle Setup** from [devthrottle.com/download](https://devthrottle.com/download) -- no sign-up -- and run it. Three screens: **Welcome, Install, Complete**. There is nothing to decide on any of them.
+Download **DevThrottle Setup** from [devthrottle.com/download](https://devthrottle.com/download) and run it. Three screens: **Welcome, Install, Complete**. There is nothing to decide on any of them.
+
+Go to `/download` directly. It says *"Free, no account needed"* and means it. The home page's main **Get started** button takes the other route -- sign up first, download second -- so you will be asked for an account before you have downloaded anything.
 
 The same file is on the [latest release](https://github.com/thefrederiksen/devthrottle/releases/latest) as `devthrottle-setup-win-x64.exe` if you would rather take it straight from there.
 

--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -121,7 +121,7 @@ stop and say exactly what is needed. Do not work around it.
 
 | Command | What it does |
 |---|---|
-| `<installer> signin` | Opens a browser to sign in with Google, GitHub, or email (or create a free account). |
+| `<installer> signin` | Opens a browser to sign in with Google, GitHub, or email (or create a free account). The email route sends a sign-in link, not a password prompt. |
 | `<installer> enroll --hosted` | Signs in and joins DevThrottle's hosted gateway. |
 | `<installer> enroll --gateway <url>` | Joins a gateway you run yourself. Omit `--gateway` to find it from your account. |
 
@@ -254,7 +254,7 @@ The gateway is the inference engine, and it is what makes DevThrottle reachable 
 | **Self-hosted gateway** | Run the gateway on your own machine and join it. Windows only, needs the machine to stay on, and a DevThrottle sign-in all the same. For advanced setups. |
 | **Not now** | Local-only on this machine. Everything on the board still works. Connect any time from Settings. |
 
-Both gateways need a DevThrottle login -- Google, GitHub, or an email and password. There is no bring-your-own-key: inference always routes through DevThrottle, which is why a gateway asks who you are and installing does not.
+Both gateways need a DevThrottle login -- Google, GitHub, or email. The email route emails you a sign-in link instead of asking for a password, which means a trip to your inbox; Google or GitHub is one click. There is no bring-your-own-key: inference always routes through DevThrottle, which is why a gateway asks who you are and installing does not.
 
 ### Multi-Machine Setup (Remote Access)
 

--- a/docs/public/getting-started/04-setup-wizard-walkthrough.md
+++ b/docs/public/getting-started/04-setup-wizard-walkthrough.md
@@ -44,7 +44,13 @@ answer**.
 ### Getting it
 
 Download **DevThrottle Setup** from [devthrottle.com/download](https://devthrottle.com/download).
-There is no sign-up in front of the download.
+That page puts it better than this one can -- *"Download the Director. Free, no account needed"*, and
+of the sign-in that comes later, *"This is the moment you sign in - never before it."*
+
+> Go to `/download` directly. If you start at the DevThrottle home page instead, its main
+> **Get started** button takes the account-first route -- its own rail reads "1 Account, 2 Download" --
+> and you will be asked to sign up before you have downloaded anything. Nothing is wrong with that
+> route, but it is not the one this page describes.
 
 If you would rather verify the file yourself, take it from the
 [latest release](https://github.com/thefrederiksen/devthrottle/releases/latest) instead --

--- a/docs/public/getting-started/04-setup-wizard-walkthrough.md
+++ b/docs/public/getting-started/04-setup-wizard-walkthrough.md
@@ -167,9 +167,25 @@ Three cards:
 | **Self-hosted gateway** | Run your own gateway and join it. For advanced setups. |
 | **Not now** | Local-only on this machine. Connect any time from Settings. |
 
-The hosted card's button reads **Sign in and connect**. It opens your browser to sign in with
-**Google, GitHub, or email**, and the wizard continues on its own once you are done -- you do not
-come back and click anything.
+The hosted card's button reads **Sign in and connect**. It opens your browser, and the wizard waits:
+*"We opened your browser to sign you in with Google, GitHub, or email. This window continues
+automatically when you are done."* There is a **Cancel sign-in** link, and the primary button greys
+out while it waits.
+
+The browser page says what it is for -- *"Sign in to connect the Director on this machine"* -- and
+offers three ways in:
+
+| | What happens |
+|---|---|
+| **Continue with Google** | One click, if you are already signed in to Google in that browser. |
+| **Continue with GitHub** | The same. |
+| **Continue with email** | *"We'll email you a link to sign in - no password needed."* You get a **link**, not a password box. |
+
+**The email route sends you to your inbox, so pick Google or GitHub if you can.** There is no password
+field on that page at all -- even if you set a password when you created the account. Signing in by
+email means leaving the machine you are setting up, opening your mail, and clicking a link. On a
+freshly installed Windows box with no mail client configured, that means a second device. The wizard
+will wait as long as it takes, but "when you are done" can be a trip across the room.
 
 If you signed up on the website a moment ago, your browser still holds that session, and this step
 costs **zero clicks and about five seconds**: the tab says *"Signed in to DevThrottle. You can close


### PR DESCRIPTION
Follow-up to thefrederiksen/devthrottle#2287 (now merged). Small, three files.

## The sentence is true — and the page says it better

The clean-machine run walked `devthrottle.com/download` directly and settled the one claim it could not verify during the cross-check. Our wording was accurate; the page is stronger:

- *"Download the Director. Free, no account needed."*
- *"You only sign in later — when you connect a gateway."*
- Step 2: *"This is the moment you sign in — never before it."*

So it is quoted now rather than paraphrased. I verified it against production before writing it in, because it is a claim about a live page rather than about code.

## The more useful half is a distinction

Both of these are true, about different pages:

| Route | What a stranger gets |
|---|---|
| **`/download`** | No account wall. Download first, sign in later. |
| **Home page → Get started** | Sign-up first, download second. Its own rail reads "1 Account, 2 Download". |

Our pages point at `/download`, so what they said was accurate **about the route they name**. But a reader who lands on `devthrottle.com`, clicks the big button, and is asked to sign up concludes the documentation lied to them — and they will not blame the route, they will blame us.

All three pages now say to go to `/download` directly, and what happens if you do not.

## Also corrected

The README said `/download` lets you "pick your platform", which overstates it. The page carries the Windows installer and the one-line install for macOS.

## Worth someone's attention, not mine to decide

The install spine's first rule is *"Never put an account, email, or sign-up in front of the download."* The home page's **primary** call to action does exactly that. Documenting around it is the right move for a docs pull request; whether the funnel should change is a product call, and I have raised it separately rather than quietly encoding it as intended behaviour.

## Proof

- `/download` copy fetched from production and quoted verbatim.
- All three pages rendered to HTML.
- Docs only; no code touched.
