### PR TITLE
THROWAWAY fault-injection proof for #2298 - DO NOT MERGE

### DIFF
--- a/src/CcDirector.Avalonia.Tests/GatewayStepOptionsTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GatewayStepOptionsTests.cs
@@ -1,0 +1,238 @@
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Onboarding;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The gateway step's three options - Hosted, Self-hosted, Not now - must stay REACHABLE. All of them,
+/// by mouse and by keyboard, before a sign-in attempt and after one that failed or was cancelled.
+///
+/// That is not a styling preference. The step gives "Not now" equal prominence deliberately, because it
+/// is the no-account, local-only choice and the product installs and runs without an account; the source
+/// comment says a first screen reading as sign-up-to-continue "would change what the product is". Two
+/// separate mechanisms were quietly taking that promise back:
+///
+///   * #1070 - a cancelled sign-in swapped the whole choice view for a failure view, so all three cards
+///     vanished, and re-entering the step never reset the sub-view, so Back-then-forward brought the
+///     user back to the cards-less screen. No path declined the gateway and continued.
+///   * #1071 - the cards were Borders with handlers hung on them. A Border gets no automation peer, so
+///     they exposed no name, no pattern, and never entered the tab order: Tab cycled Back and Sign in
+///     and connect for ever, and a keyboard user could reach exactly one option (the pre-selected one).
+///
+/// THESE TESTS ASSERT THE INVARIANT, NOT THE INSTANCE. "Every option is still reachable" rather than
+/// "this particular card is present", because the defect is about the set, and a test naming one card
+/// would pass while another went missing.
+/// </summary>
+public class GatewayStepOptionsTests
+{
+    /// <summary>
+    /// Open the gateway step against a CLEAN machine, with config redirected to a throwaway root.
+    ///
+    /// This isolation is not boilerplate - without it these tests read the DEVELOPER'S OWN gateway. The
+    /// step calls AdoptExistingGateway on entry, which loads the real config.json, and on a machine that
+    /// already has a gateway the step opens on the connected view with the primary button reading
+    /// "Continue" instead of the choice cards. So the same code gave one answer on a clean CI runner and
+    /// another on this machine. A test whose verdict depends on whose laptop it runs on is not a check.
+    /// The assembly runs sequentially (TestParallelization), so the process-global variable is not raced.
+    /// </summary>
+    private static void WithCleanMachine(Action<FirstRunWizardDialog> body)
+    {
+        var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "cc-director-gateway-step-tests", Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        try
+        {
+            // Guard the isolation itself rather than assuming it: if a gateway is somehow configured in
+            // this temp root, every assertion below is about the wrong screen.
+            Assert.False(GatewayConfig.Load().IsEnabled, "the throwaway root is not clean, so the step will open on the connected view");
+
+            var dialog = new FirstRunWizardDialog(new AgentOptions());
+            dialog.ShowStepForTests(WizardStep.Gateway);
+            body(dialog);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", old);
+            try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// THE POSITIVE CONTROL FOR EVERY ASSERTION BELOW.
+    ///
+    /// A card that cannot be driven and a card that is not there look identical from a test, so before
+    /// trusting anything this file says about the cards, prove the instrument can SEE a control it should
+    /// see. The step's own primary button is known-good: it is a real Button, it is focusable, and it is
+    /// visible. If this fails, every other result in this file is meaningless rather than reassuring -
+    /// and in particular a "the cards are fine" green would be unearned.
+    /// </summary>
+    [AvaloniaFact]
+    public void Control_TheStepsOwnButtonsAreVisibleAndFocusable_SoAbsenceMeansSomething()
+    {
+        WithCleanMachine(dialog =>
+        {
+
+            Assert.True(dialog.GatewayPanel.IsVisible, "the gateway step itself is not showing - nothing below can be trusted");
+            Assert.True(dialog.PrimaryButton.IsVisible);
+            Assert.True(dialog.PrimaryButton.Focusable);
+            Assert.Equal(3, dialog.GatewayOptionCardsForTests.Count);
+        });
+    }
+
+    [AvaloniaFact]
+    public void EveryOption_IsARealControlWithAnAccessibleName_NotDecoratedText()
+    {
+        WithCleanMachine(dialog =>
+        {
+
+            foreach (var card in dialog.GatewayOptionCardsForTests)
+            {
+                // A real control, so it gets an automation peer at all. This is the whole of #1071: the
+                // markup already declared Focusable, KeyDown, GotFocus and a name on a Border, and none of
+                // it surfaced, because a Border is not a control no matter what you hang on it.
+                var option = Assert.IsAssignableFrom<RadioButton>(card);
+
+                // In the tab order, and named for a screen reader.
+                Assert.True(option.Focusable, $"{card.Name} is not focusable, so Tab cannot reach it");
+                Assert.True(option.IsTabStop, $"{card.Name} is not a tab stop");
+                Assert.False(string.IsNullOrWhiteSpace(AutomationProperties.GetName(option)),
+                    $"{card.Name} exposes no accessible name");
+            }
+        });
+    }
+
+    [AvaloniaFact]
+    public void EveryOption_IsOneOfASingleChoiceGroup_SoSelectionIsExposedAndExclusive()
+    {
+        WithCleanMachine(dialog =>
+        {
+            var cards = dialog.GatewayOptionCardsForTests;
+
+            // One group: that is what gives arrow-key movement between the options and a SelectionItem
+            // pattern a screen reader can read the selected state from. A Border carried no selected state
+            // at all, which is why it had to be smuggled into the accessible help text.
+            var groups = cards.Select(c => Assert.IsAssignableFrom<RadioButton>(c).GroupName).Distinct().ToList();
+            Assert.Single(groups);
+            Assert.False(string.IsNullOrWhiteSpace(groups[0]));
+
+            // Exclusive, and exactly one selected to begin with - a group where nothing is checked gives a
+            // keyboard user no entry point.
+            Assert.Single(cards, c => c is RadioButton { IsChecked: true });
+        });
+    }
+
+    [AvaloniaFact]
+    public void ChoosingAnyOption_MovesTheWizardsChoice_SoTheControlIsWiredNotJustPresent()
+    {
+        WithCleanMachine(dialog =>
+        {
+            // Reachable and inert is still broken. Drive each card the way the control itself is driven and
+            // assert the wizard's own choice followed - including "Not now", the option that was unreachable.
+            var cards = dialog.GatewayOptionCardsForTests;
+
+            var seen = new List<string>();
+            foreach (var card in cards)
+            {
+                Assert.IsAssignableFrom<RadioButton>(card).IsChecked = true;
+                seen.Add(dialog.GatewayChoiceForTests);
+            }
+
+            // Three cards, three DIFFERENT choices: proves each card is bound to its own option rather than
+            // all three landing on the same one.
+            Assert.Equal(3, seen.Distinct().Count());
+            Assert.Contains("NotNow", seen);
+        });
+    }
+
+    [AvaloniaFact]
+    public void ACancelledSignIn_LeavesEveryOptionReachable()
+    {
+        WithCleanMachine(dialog =>
+        {
+            // THE #1070 INVARIANT. Not "the cards are visible" for one named card - every option, still
+            // reachable, after the failure path has run.
+
+            dialog.ReportGatewayFailureForTests("Sign-in was cancelled.");
+
+            Assert.True(dialog.GatewayChoiceView.IsVisible, "the choice view was replaced, so the options are gone");
+            foreach (var card in dialog.GatewayOptionCardsForTests)
+            {
+                Assert.True(card.IsVisible, $"{card.Name} disappeared when the sign-in was cancelled");
+                Assert.True(card.Focusable, $"{card.Name} is no longer reachable by keyboard");
+            }
+
+            // And the reason is actually shown - otherwise this could pass by the failure never rendering.
+            Assert.True(dialog.GatewayFailBanner.IsVisible);
+            Assert.Contains("cancelled", dialog.GatewayFailText.Text ?? "", StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [AvaloniaFact]
+    public void ACancelledSignIn_DoesNotStickAcrossLeavingAndReenteringTheStep()
+    {
+        WithCleanMachine(dialog =>
+        {
+            // The second half of #1070, and the half that made it a trap rather than a glitch: Back went to
+            // Welcome, and coming forward again returned to the cancelled state with the cards still gone,
+            // because the step's own entry never set a sub-view.
+            dialog.ReportGatewayFailureForTests("Sign-in was cancelled.");
+
+            dialog.ShowStepForTests(WizardStep.Welcome);
+            dialog.ShowStepForTests(WizardStep.Gateway);
+
+            Assert.True(dialog.GatewayChoiceView.IsVisible);
+            Assert.All(dialog.GatewayOptionCardsForTests, card => Assert.True(card.IsVisible));
+            // The stale reason is gone too - a cancellation the user has navigated away from must not be
+            // re-presented as if it had just happened.
+            Assert.False(dialog.GatewayFailBanner.IsVisible);
+        });
+    }
+
+    [AvaloniaFact]
+    public void ACancelledSignIn_StillLetsTheUserDeclineTheGatewayAndContinue()
+    {
+        WithCleanMachine(dialog =>
+        {
+            // The consequence the issue is actually about, asserted end to end: after cancelling, the user
+            // can still choose "Not now" and the step offers to move on WITHOUT a gateway. Before the fix
+            // there was no path that declined the gateway and continued through the remaining six steps.
+            dialog.ReportGatewayFailureForTests("Sign-in was cancelled.");
+
+            var notNow = dialog.GatewayOptionCardsForTests.Single(c => c.Name == "GatewayNotNowCard");
+            Assert.IsAssignableFrom<RadioButton>(notNow).IsChecked = true;
+
+            Assert.Equal("NotNow", dialog.GatewayChoiceForTests);
+            Assert.True(dialog.PrimaryButton.IsEnabled);
+            Assert.Equal("Continue without a gateway", dialog.PrimaryButton.Content);
+        });
+    }
+
+    [AvaloniaFact]
+    public void TheFailureMessage_NamesNoControlThatIsNotOnTheScreen()
+    {
+        WithCleanMachine(dialog =>
+        {
+            // The cheap half of #1070. The cancelled state read: Sign-in was cancelled. Click "Sign in to
+            // DevThrottle" to try again. There is no control with that label anywhere in the product - it is
+            // the heading of the browser sign-in page, which at that moment is the thing the user just
+            // closed. Asserted over the WHOLE banner, message and guidance together, because either could
+            // reintroduce it.
+            dialog.ReportGatewayFailureForTests("Sign-in was cancelled.");
+
+            var bannerText = string.Join(" ", dialog.GatewayFailBanner
+                .GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Select(t => t.Text ?? ""));
+
+            Assert.DoesNotContain("Sign in to DevThrottle", bannerText, StringComparison.OrdinalIgnoreCase);
+            // Positive half, so this cannot pass by the banner being empty: it points at what IS there.
+            Assert.Contains("Not now", bannerText, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+}

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -167,6 +167,59 @@
             <Setter Property="HorizontalAlignment" Value="Center" />
             <Setter Property="Margin" Value="0,0,0,8" />
         </Style>
+
+        <!-- THE GATEWAY CHOICE CARDS ARE RADIO BUTTONS, NOT DECORATED BORDERS (issue #1071).
+             They were Borders carrying PointerPressed plus Focusable="True", KeyDown, GotFocus and an
+             AutomationProperties.Name - and NONE of it reached the accessibility tree. A Border is not a
+             control: it gets no automation peer, so it exposed no name and no pattern, and it never
+             entered the tab order. The full UIA dump was three unfocusable Text blobs in one unnamed
+             Pane, and ten Tab presses cycled Pane -> Back -> Sign in and connect for ever. The keyboard
+             and screen-reader support had been WRITTEN and was not SURFACED, which is why the markup
+             looked correct on inspection.
+             A RadioButton is the honest control for one-of-three: it brings the automation peer, the
+             accessible name, SelectionItem with a real selected state, the tab stop, arrow-key movement
+             inside the group, and Space to choose - none of which can be reproduced by hanging handlers
+             on a Border. The template below is the card; the radio glyph is deliberately not drawn. -->
+        <Style Selector="RadioButton.gatewayCard">
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Name="CardShell" Background="#FFFFFF" BorderBrush="#E6E8EC"
+                            BorderThickness="1" CornerRadius="10" Padding="16,13">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Stretch" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <!-- The chosen card. Selection is ALSO exposed natively now (SelectionItem / IsChecked), so it
+             no longer has to be smuggled into the accessible help text the way the Border version did. -->
+        <Style Selector="RadioButton.gatewayCard:checked /template/ Border#CardShell">
+            <Setter Property="BorderBrush" Value="#0066B8" />
+            <Setter Property="BorderThickness" Value="1.5" />
+            <Setter Property="Background" Value="#F2F8FD" />
+        </Style>
+        <!-- A visible focus ring. A keyboard user has to be able to SEE where they are before Space
+             commits the choice; without this the cards would be reachable and still unusable. -->
+        <Style Selector="RadioButton.gatewayCard:focus-visible /template/ Border#CardShell">
+            <Setter Property="BorderBrush" Value="#0066B8" />
+            <Setter Property="BorderThickness" Value="2" />
+        </Style>
+        <Style Selector="RadioButton.gatewayCard:pointerover /template/ Border#CardShell">
+            <Setter Property="BorderBrush" Value="#9CC4E4" />
+        </Style>
+        <!-- The recommended card is the dominant one: more room, a softer corner, a heavier selected
+             border. Prominence is a visual weighting only - every card is the same KIND of control, which
+             is what "Not now stays exactly as prominent" has to mean for a keyboard. -->
+        <Style Selector="RadioButton.gatewayCard.emphasized /template/ Border#CardShell">
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="22,20" />
+        </Style>
+        <Style Selector="RadioButton.gatewayCard.emphasized:checked /template/ Border#CardShell">
+            <Setter Property="BorderThickness" Value="2" />
+        </Style>
     </Window.Styles>
 
     <Grid Margin="44,32,44,24" RowDefinitions="Auto,*,Auto">
@@ -504,18 +557,38 @@
                                   MaxWidth="640" HorizontalAlignment="Center">
                     <StackPanel MaxWidth="600" Spacing="14"
                                 VerticalAlignment="Top" HorizontalAlignment="Stretch">
-                        <!-- Focusable and key-operable, with an accessible name. These three cards were
-                             bare Borders carrying only PointerPressed: not focusable, exposing no
-                             invoke pattern, and therefore unreachable by keyboard or screen reader -
-                             so choosing a gateway, the one commercial step in the product, could not
-                             be done without a mouse at all. -->
-                        <Border x:Name="GatewayHostedCard" Cursor="Hand" Focusable="True"
-                                AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
-                                Background="#F2F8FD" BorderBrush="#0066B8" BorderThickness="2"
-                                CornerRadius="12" Padding="22,20"
-                                KeyDown="GatewayCard_KeyDown"
-                                GotFocus="GatewayCard_GotFocus"
-                                PointerPressed="GatewayHostedCard_Pressed">
+                        <!-- A FAILED OR CANCELLED SIGN-IN IS A BANNER ON THIS VIEW, NOT A VIEW THAT
+                             REPLACES IT (issue #1070).
+                             It used to be its own exclusive sub-view, so cancelling a sign-in removed all
+                             three cards - and "Not now", the no-account option this screen gives equal
+                             prominence ON PURPOSE, became unreachable. The only ways out were completing a
+                             sign-in, abandoning the whole wizard from Welcome, or closing the window; Back
+                             went to Welcome and coming forward again returned to the cancelled state with
+                             the cards still gone, because re-entering the step never reset the sub-view.
+                             A failure is a thing that happened to one option. It is not a reason to
+                             withdraw the other two - least of all the one that needs no sign-in at all. -->
+                        <Border x:Name="GatewayFailBanner" IsVisible="False"
+                                Background="#FEF2F2" BorderBrush="#F5C2C2" BorderThickness="1"
+                                CornerRadius="10" Padding="16,13">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Name="GatewayFailText" FontSize="13.5" Foreground="#B42318"
+                                           TextWrapping="Wrap" />
+                                <!-- Points at what is ON THIS SCREEN, and at no named button - the
+                                     primary button's label changes with the selected card, so naming it
+                                     here would go stale the moment the user picks a different option.
+                                     The engine states what happened and nothing about buttons at all;
+                                     see GatewayAccountEnrollRunner. The old text told the user to click
+                                     "Sign in to DevThrottle", which is the heading of the browser page
+                                     they had just closed and is not a control anywhere in the product. -->
+                                <TextBlock FontSize="12.5" Foreground="#8A5C58" TextWrapping="Wrap"
+                                           Text="Your options below are unchanged - keep the hosted gateway selected to try signing in again, or choose another, including &quot;Not now&quot;, which needs no account." />
+                            </StackPanel>
+                        </Border>
+
+                        <RadioButton x:Name="GatewayHostedCard" GroupName="GatewayChoice"
+                                     Classes="gatewayCard emphasized" IsChecked="True"
+                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
+                                     IsCheckedChanged="GatewayCard_IsCheckedChanged">
                             <StackPanel Spacing="6">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
                                     <TextBlock Text="Hosted gateway" FontSize="17" FontWeight="Bold"
@@ -533,37 +606,31 @@
                                 <TextBlock FontSize="12.5" Foreground="#8A909A"
                                            Text="Part of Pro" />
                             </StackPanel>
-                        </Border>
+                        </RadioButton>
 
                         <Grid ColumnDefinitions="*,14,*">
-                            <Border Grid.Column="0" x:Name="GatewaySelfHostCard" Cursor="Hand" Focusable="True"
-                                    AutomationProperties.Name="Self-hosted gateway. Run your own gateway and join it. For advanced setups."
-                                    Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                                    CornerRadius="10" Padding="16,13"
-                                    KeyDown="GatewayCard_KeyDown"
-                                    GotFocus="GatewayCard_GotFocus"
-                                    PointerPressed="GatewaySelfHostCard_Pressed">
+                            <RadioButton Grid.Column="0" x:Name="GatewaySelfHostCard" GroupName="GatewayChoice"
+                                         Classes="gatewayCard"
+                                         AutomationProperties.Name="Self-hosted gateway. Run your own gateway and join it. For advanced setups."
+                                         IsCheckedChanged="GatewayCard_IsCheckedChanged">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Self-hosted gateway" FontSize="13.5" FontWeight="SemiBold"
                                                Foreground="#16181D" />
                                     <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#8A909A"
                                                Text="Run your own gateway and join it. For advanced setups." />
                                 </StackPanel>
-                            </Border>
-                            <Border Grid.Column="2" x:Name="GatewayNotNowCard" Cursor="Hand" Focusable="True"
-                                    AutomationProperties.Name="Not now. Local-only on this machine. Connect any time from Settings."
-                                    Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
-                                    CornerRadius="10" Padding="16,13"
-                                    KeyDown="GatewayCard_KeyDown"
-                                    GotFocus="GatewayCard_GotFocus"
-                                    PointerPressed="GatewayNotNowCard_Pressed">
+                            </RadioButton>
+                            <RadioButton Grid.Column="2" x:Name="GatewayNotNowCard" GroupName="GatewayChoice"
+                                         Classes="gatewayCard"
+                                         AutomationProperties.Name="Not now. Local-only on this machine. Connect any time from Settings."
+                                         IsCheckedChanged="GatewayCard_IsCheckedChanged">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Not now" FontSize="13.5" FontWeight="SemiBold"
                                                Foreground="#16181D" />
                                     <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#8A909A"
                                                Text="Local-only on this machine. Connect any time from Settings." />
                                 </StackPanel>
-                            </Border>
+                            </RadioButton>
                         </Grid>
                     </StackPanel>
                     </ScrollViewer>
@@ -598,14 +665,9 @@
                                 Click="GatewayChange_Click" />
                     </StackPanel>
 
-                    <!-- Failure view: plain-English reason, readable on white, with a retry. -->
-                    <StackPanel x:Name="GatewayFailedView" IsVisible="False" Spacing="12"
-                                VerticalAlignment="Center" HorizontalAlignment="Center" MaxWidth="480">
-                        <TextBlock x:Name="GatewayFailText" FontSize="14" Foreground="#DC2626"
-                                   TextWrapping="Wrap" TextAlignment="Center" />
-                        <Button Classes="dialogButton" Content="Try again" HorizontalAlignment="Center"
-                                Click="GatewayTryAgain_Click" />
-                    </StackPanel>
+                    <!-- There is deliberately NO separate failure view. The reason is rendered as
+                         GatewayFailBanner at the top of the choice view above, so a failure never costs
+                         the user the other two options (issue #1070). -->
 
                     <!-- Advanced view: the existing join-an-existing-gateway flow, for self-hosters. -->
                     <Grid x:Name="GatewayAdvancedView" IsVisible="False" RowDefinitions="Auto,*">

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -585,10 +585,15 @@
                             </StackPanel>
                         </Border>
 
-                        <RadioButton x:Name="GatewayHostedCard" GroupName="GatewayChoice"
-                                     Classes="gatewayCard emphasized" IsChecked="True"
-                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
-                                     IsCheckedChanged="GatewayCard_IsCheckedChanged">
+                        <!-- FAULT 4 (injected): back to a Border with Focusable + a name declared on it,
+                             exactly as the defect shipped. Expected to be caught by
+                             EveryOption_IsARealControlWithAnAccessibleName_NotDecoratedText,
+                             EveryOption_IsOneOfASingleChoiceGroup_SoSelectionIsExposedAndExclusive, and
+                             ChoosingAnyOption_MovesTheWizardsChoice_SoTheControlIsWiredNotJustPresent. -->
+                        <Border x:Name="GatewayHostedCard" Cursor="Hand" Focusable="True"
+                                AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
+                                Background="#F2F8FD" BorderBrush="#0066B8" BorderThickness="2"
+                                CornerRadius="12" Padding="22,20">
                             <StackPanel Spacing="6">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
                                     <TextBlock Text="Hosted gateway" FontSize="17" FontWeight="Bold"
@@ -606,31 +611,31 @@
                                 <TextBlock FontSize="12.5" Foreground="#8A909A"
                                            Text="Part of Pro" />
                             </StackPanel>
-                        </RadioButton>
+                        </Border>
 
                         <Grid ColumnDefinitions="*,14,*">
-                            <RadioButton Grid.Column="0" x:Name="GatewaySelfHostCard" GroupName="GatewayChoice"
-                                         Classes="gatewayCard"
-                                         AutomationProperties.Name="Self-hosted gateway. Run your own gateway and join it. For advanced setups."
-                                         IsCheckedChanged="GatewayCard_IsCheckedChanged">
+                            <Border Grid.Column="0" x:Name="GatewaySelfHostCard" Cursor="Hand" Focusable="True"
+                                    AutomationProperties.Name="Self-hosted gateway. Run your own gateway and join it. For advanced setups."
+                                    Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                                    CornerRadius="10" Padding="16,13">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Self-hosted gateway" FontSize="13.5" FontWeight="SemiBold"
                                                Foreground="#16181D" />
                                     <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#8A909A"
                                                Text="Run your own gateway and join it. For advanced setups." />
                                 </StackPanel>
-                            </RadioButton>
-                            <RadioButton Grid.Column="2" x:Name="GatewayNotNowCard" GroupName="GatewayChoice"
-                                         Classes="gatewayCard"
-                                         AutomationProperties.Name="Not now. Local-only on this machine. Connect any time from Settings."
-                                         IsCheckedChanged="GatewayCard_IsCheckedChanged">
+                            </Border>
+                            <Border Grid.Column="2" x:Name="GatewayNotNowCard" Cursor="Hand" Focusable="True"
+                                    AutomationProperties.Name="Not now. Local-only on this machine. Connect any time from Settings."
+                                    Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
+                                    CornerRadius="10" Padding="16,13">
                                 <StackPanel Spacing="3">
                                     <TextBlock Text="Not now" FontSize="13.5" FontWeight="SemiBold"
                                                Foreground="#16181D" />
                                     <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#8A909A"
                                                Text="Local-only on this machine. Connect any time from Settings." />
                                 </StackPanel>
-                            </RadioButton>
+                            </Border>
                         </Grid>
                     </StackPanel>
                     </ScrollViewer>

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -66,7 +66,7 @@ public partial class FirstRunWizardDialog : Window
     // True while RefreshGatewayChoiceUi is pushing _gatewayChoice INTO the cards' IsChecked. The cards
     // are RadioButtons now, so writing IsChecked raises IsCheckedChanged, which would call straight back
     // into the selection handler. One flag, set around the three writes, keeps the data flowing one way.
-    private bool _syncingGatewayCards;
+    private bool _syncingGatewayCards = false; // FAULT 4 (injected): nothing sets it now.
 
     // A gateway that is ALREADY configured when the step opens. Read once, from the saved config, so
     // a re-run does not ask the user to enroll a machine that is already enrolled. Before this,
@@ -393,7 +393,9 @@ public partial class FirstRunWizardDialog : Window
                 // is where the old cancelled state got STUCK: the step set no sub-view at all, so
                 // whichever one was last visible survived, and after a cancel that was the cards-less
                 // failure view (issue #1070).
-                ClearGatewayFailure();
+                // FAULT 2 (injected): ClearGatewayFailure() removed, so a previous attempt's banner
+                // survives leaving and re-entering the step. Expected to be caught by
+                // ACancelledSignIn_DoesNotStickAcrossLeavingAndReenteringTheStep.
                 AdoptExistingGateway();
                 RefreshGatewayChoiceUi();
                 break;
@@ -2186,17 +2188,8 @@ public partial class FirstRunWizardDialog : Window
     private void RefreshGatewayChoiceUi()
     {
         // Guard the round trip: setting IsChecked raises IsCheckedChanged, which calls back in here.
-        _syncingGatewayCards = true;
-        try
-        {
-            GatewayHostedCard.IsChecked = _gatewayChoice == GatewayChoice.Hosted;
-            GatewaySelfHostCard.IsChecked = _gatewayChoice == GatewayChoice.SelfHost;
-            GatewayNotNowCard.IsChecked = _gatewayChoice == GatewayChoice.NotNow;
-        }
-        finally
-        {
-            _syncingGatewayCards = false;
-        }
+        // FAULT 4 (injected): the cards are Borders again, so there is no checked state to push into
+        // them and nothing exposes the selection.
 
         PrimaryButton.Content = _gatewayConnected
             ? "Continue"
@@ -2227,6 +2220,7 @@ public partial class FirstRunWizardDialog : Window
         if (sender is not RadioButton card || card.IsChecked != true) return;
         if (!TryChoiceForCard(card, out var choice)) return;
         SelectGatewayChoice(choice);
+        // FAULT 4 (injected): nothing raises this any more - the Borders carry no handler.
     }
 
     private bool TryChoiceForCard(object? sender, out GatewayChoice choice)
@@ -2326,9 +2320,13 @@ public partial class FirstRunWizardDialog : Window
     /// </summary>
     private void ShowGatewayFailure(string message)
     {
+        // FAULT 1 (injected): the failure takes the choice view away, as the old exclusive failure view
+        // did. Expected to be caught by ACancelledSignIn_LeavesEveryOptionReachable and
+        // ACancelledSignIn_StillLetsTheUserDeclineTheGatewayAndContinue.
         GatewayFailText.Text = message;
         GatewayFailBanner.IsVisible = true;
         ShowGatewayView(GatewayChoiceView);
+        GatewayChoiceView.IsVisible = false;
         RefreshGatewayChoiceUi();
         PrimaryButton.IsEnabled = true;
     }

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -63,6 +63,11 @@ public partial class FirstRunWizardDialog : Window
     private bool _gatewayConnected;
     private CancellationTokenSource? _hostedEnrollCts;
 
+    // True while RefreshGatewayChoiceUi is pushing _gatewayChoice INTO the cards' IsChecked. The cards
+    // are RadioButtons now, so writing IsChecked raises IsCheckedChanged, which would call straight back
+    // into the selection handler. One flag, set around the three writes, keeps the data flowing one way.
+    private bool _syncingGatewayCards;
+
     // A gateway that is ALREADY configured when the step opens. Read once, from the saved config, so
     // a re-run does not ask the user to enroll a machine that is already enrolled. Before this,
     // _gatewayConnected was a this-run-only flag and the step always opened on the choice cards
@@ -383,6 +388,12 @@ public partial class FirstRunWizardDialog : Window
 
             case WizardStep.Gateway:
                 PrimaryButton.IsVisible = true;
+                // Re-entering the step drops a previous attempt's banner. Coming back to this screen
+                // must not re-present a cancellation the user has already navigated away from - and this
+                // is where the old cancelled state got STUCK: the step set no sub-view at all, so
+                // whichever one was last visible survived, and after a cancel that was the cards-less
+                // failure view (issue #1070).
+                ClearGatewayFailure();
                 AdoptExistingGateway();
                 RefreshGatewayChoiceUi();
                 break;
@@ -2163,13 +2174,29 @@ public partial class FirstRunWizardDialog : Window
         RefreshGatewayChoiceUi();
     }
 
-    /// <summary>Paint the three choice cards and the primary CTA from the current selection.</summary>
+    /// <summary>
+    /// Paint the primary CTA from the current selection, and keep the cards' checked state in step with
+    /// it.
+    ///
+    /// The card VISUALS are no longer set here. Selection is a real control state now
+    /// (<c>RadioButton.IsChecked</c>), so the accent border and tint come from the
+    /// <c>RadioButton.gatewayCard:checked</c> style, and the selected state reaches a screen reader
+    /// through the SelectionItem pattern instead of being smuggled into the accessible help text.
+    /// </summary>
     private void RefreshGatewayChoiceUi()
     {
-        // Card selection visuals: the chosen card carries the accent border + tint; the others rest.
-        StyleGatewayCard(GatewayHostedCard, _gatewayChoice == GatewayChoice.Hosted, emphasized: true);
-        StyleGatewayCard(GatewaySelfHostCard, _gatewayChoice == GatewayChoice.SelfHost, emphasized: false);
-        StyleGatewayCard(GatewayNotNowCard, _gatewayChoice == GatewayChoice.NotNow, emphasized: false);
+        // Guard the round trip: setting IsChecked raises IsCheckedChanged, which calls back in here.
+        _syncingGatewayCards = true;
+        try
+        {
+            GatewayHostedCard.IsChecked = _gatewayChoice == GatewayChoice.Hosted;
+            GatewaySelfHostCard.IsChecked = _gatewayChoice == GatewayChoice.SelfHost;
+            GatewayNotNowCard.IsChecked = _gatewayChoice == GatewayChoice.NotNow;
+        }
+        finally
+        {
+            _syncingGatewayCards = false;
+        }
 
         PrimaryButton.Content = _gatewayConnected
             ? "Continue"
@@ -2182,18 +2209,6 @@ public partial class FirstRunWizardDialog : Window
         PrimaryButton.IsEnabled = true;
     }
 
-    private static void StyleGatewayCard(Border card, bool selected, bool emphasized)
-    {
-        card.BorderBrush = Brush(selected ? "#0066B8" : "#E6E8EC");
-        card.BorderThickness = new global::Avalonia.Thickness(selected && emphasized ? 2 : selected ? 1.5 : 1);
-        card.Background = Brush(selected ? "#F2F8FD" : "#FFFFFF");
-
-        // The selection has to be readable without seeing the border. A Border is not a radio button
-        // and exposes no selected state, so the state is carried in the accessible help text - the one
-        // channel a screen reader will actually read out.
-        AutomationProperties.SetHelpText(card, selected ? "Selected" : "Not selected. Press Enter to choose it.");
-    }
-
     private void SelectGatewayChoice(GatewayChoice choice)
     {
         FileLog.Write($"[FirstRunWizardDialog] SelectGatewayChoice: {choice}");
@@ -2201,33 +2216,17 @@ public partial class FirstRunWizardDialog : Window
         RefreshGatewayChoiceUi();
     }
 
-    private void GatewayHostedCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.Hosted);
-    private void GatewaySelfHostCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.SelfHost);
-    private void GatewayNotNowCard_Pressed(object? sender, PointerPressedEventArgs e) => SelectGatewayChoice(GatewayChoice.NotNow);
-
     /// <summary>
-    /// Space or Enter picks the focused card - the keyboard equivalent of clicking it. Tab already
-    /// reaches the cards now that they are focusable; without this they could be reached and not used.
+    /// A card became the checked one - by mouse, by Space, or by an arrow key inside the group. One
+    /// handler for all three inputs, because a RadioButton makes them the same event; the Border version
+    /// needed a PointerPressed per card plus its own KeyDown, and still reached no keyboard at all.
     /// </summary>
-    private void GatewayCard_KeyDown(object? sender, KeyEventArgs e)
+    private void GatewayCard_IsCheckedChanged(object? sender, RoutedEventArgs e)
     {
-        if (e.Key is not (Key.Space or Key.Enter)) return;
-        if (!TryChoiceForCard(sender, out var choice)) return;
+        if (_syncingGatewayCards) return;
+        if (sender is not RadioButton card || card.IsChecked != true) return;
+        if (!TryChoiceForCard(card, out var choice)) return;
         SelectGatewayChoice(choice);
-        e.Handled = true;
-    }
-
-    /// <summary>
-    /// Focus alone does NOT change the choice. Tabbing through the options to read them must not
-    /// silently move the selection - a keyboard or screen-reader user has to be able to review all
-    /// three before committing, exactly as a mouse user can. Space or Enter is the commit.
-    /// </summary>
-    private void GatewayCard_GotFocus(object? sender, GotFocusEventArgs e)
-    {
-        // Announce what is focused and whether it is the current choice, since a Border exposes no
-        // selection state of its own.
-        if (TryChoiceForCard(sender, out var choice) && sender is Border card)
-            AutomationProperties.SetHelpText(card, choice == _gatewayChoice ? "Selected" : "Not selected. Press Enter to choose it.");
     }
 
     private bool TryChoiceForCard(object? sender, out GatewayChoice choice)
@@ -2239,13 +2238,12 @@ public partial class FirstRunWizardDialog : Window
         return false;
     }
 
-    /// <summary>Show exactly one of the gateway step's sub-views (choice / connecting / connected / failed / advanced).</summary>
+    /// <summary>Show exactly one of the gateway step's sub-views (choice / connecting / connected / advanced).</summary>
     private void ShowGatewayView(Control view)
     {
         GatewayChoiceView.IsVisible = view == GatewayChoiceView;
         GatewayConnectingView.IsVisible = view == GatewayConnectingView;
         GatewayConnectedView.IsVisible = view == GatewayConnectedView;
-        GatewayFailedView.IsVisible = view == GatewayFailedView;
         GatewayAdvancedView.IsVisible = view == GatewayAdvancedView;
     }
 
@@ -2258,6 +2256,9 @@ public partial class FirstRunWizardDialog : Window
     private async Task StartHostedEnrollAsync()
     {
         FileLog.Write("[FirstRunWizardDialog] StartHostedEnrollAsync");
+        // A new attempt supersedes the last one's reason; leaving it up would let a stale cancellation sit
+        // above a sign-in that is in flight right now.
+        ClearGatewayFailure();
         ShowGatewayView(GatewayConnectingView);
         PrimaryButton.IsEnabled = false;
 
@@ -2314,12 +2315,26 @@ public partial class FirstRunWizardDialog : Window
         }
     }
 
+    /// <summary>
+    /// Report a failed or cancelled gateway attempt WITHOUT taking the other options away (issue #1070).
+    ///
+    /// The banner is shown on the choice view and the choice view stays visible. That single change is
+    /// what makes the state recoverable: every card is still there, "Not now" included, so the user who
+    /// tried the recommended path and changed their mind can still decline the gateway and finish the
+    /// remaining six steps. It also ends the stickiness - the visible sub-view is the choice view, so
+    /// leaving the step and coming back cannot land on a cards-less screen.
+    /// </summary>
     private void ShowGatewayFailure(string message)
     {
         GatewayFailText.Text = message;
-        ShowGatewayView(GatewayFailedView);
+        GatewayFailBanner.IsVisible = true;
+        ShowGatewayView(GatewayChoiceView);
+        RefreshGatewayChoiceUi();
         PrimaryButton.IsEnabled = true;
     }
+
+    /// <summary>Drop a previous attempt's banner, so a stale reason cannot reappear two navigations later.</summary>
+    private void ClearGatewayFailure() => GatewayFailBanner.IsVisible = false;
 
     private void GatewayCancelSignIn_Click(object? sender, RoutedEventArgs e)
     {
@@ -2327,16 +2342,17 @@ public partial class FirstRunWizardDialog : Window
         _hostedEnrollCts?.Cancel();
     }
 
-    private void GatewayTryAgain_Click(object? sender, RoutedEventArgs e)
-    {
-        FileLog.Write("[FirstRunWizardDialog] GatewayTryAgain_Click");
-        ShowGatewayView(GatewayChoiceView);
-        RefreshGatewayChoiceUi();
-    }
+    // There is no GatewayTryAgain_Click any more. Its only caller was the failure view's "Try again"
+    // button, and that button was redundant the moment the failure became a banner ON the choice view:
+    // the primary button is already the retry and already says what it will do - "Sign in and connect"
+    // with the hosted card selected, which stays selected through a cancellation. A second button
+    // labelled "Try again" would either duplicate it or, worse, merely dismiss the message, which is a
+    // control that appears to act and does not.
 
     private void GatewayBackToOptions_Click(object? sender, RoutedEventArgs e)
     {
         FileLog.Write("[FirstRunWizardDialog] GatewayBackToOptions_Click");
+        ClearGatewayFailure();
         ShowGatewayView(GatewayChoiceView);
         RefreshGatewayChoiceUi();
     }
@@ -2607,6 +2623,36 @@ public partial class FirstRunWizardDialog : Window
 
     /// <summary>The wizard's current step, so a UI test can assert navigation moved as expected.</summary>
     internal WizardStep CurrentStepForTests => _model.Current;
+
+    /// <summary>Open a step exactly as navigation does, so a test can arrive at it without clicking through.</summary>
+    internal void ShowStepForTests(WizardStep step)
+    {
+        _model.GoTo(step);
+        ShowStep(step);
+    }
+
+    /// <summary>
+    /// Report a failed or cancelled gateway sign-in through the REAL failure path, so a test asserts what
+    /// a user would see. It drives <see cref="ShowGatewayFailure"/> itself rather than a copy of it - a
+    /// test that reproduced the rendering would pass while the product's own path stayed broken.
+    /// </summary>
+    internal void ReportGatewayFailureForTests(string message) => ShowGatewayFailure(message);
+
+    /// <summary>
+    /// The three gateway option cards, in the order they read on screen.
+    ///
+    /// Typed as <see cref="Control"/> ON PURPOSE, not as RadioButton. The seam must not presuppose the
+    /// fix: if it returned the fixed type, then putting the defect back - cards as plain Borders - would
+    /// stop the TEST PROJECT COMPILING, and "the build broke" is not the same evidence as "the test
+    /// failed". A check has to be able to observe the thing it rules out, so the assertion that these are
+    /// real controls belongs in the test, where it can go red, rather than in the signature, where it
+    /// would go unbuildable.
+    /// </summary>
+    internal IReadOnlyList<Control> GatewayOptionCardsForTests =>
+        new Control[] { GatewayHostedCard, GatewaySelfHostCard, GatewayNotNowCard };
+
+    /// <summary>Which gateway option is selected, named as the user would name it.</summary>
+    internal string GatewayChoiceForTests => _gatewayChoice.ToString();
 
     private static SolidColorBrush Brush(string hex) => new(Color.Parse(hex));
 }

--- a/tools/cc-director-setup-engine.Tests/GatewayAccountEnrollRunnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayAccountEnrollRunnerTests.cs
@@ -134,6 +134,51 @@ public class GatewayAccountEnrollRunnerTests
         Assert.Empty(reqs);
     }
 
+    /// <summary>
+    /// The cancel message must state what happened and NAME NO CONTROL (issue #1070).
+    ///
+    /// All three cancel paths used to end <c>Click "Sign in to DevThrottle" to try again</c>. No surface in
+    /// the product has a control with that label - it is the heading of the browser sign-in page, which at
+    /// the moment of a cancellation is exactly what the user just closed. And this engine cannot name a
+    /// button correctly even in principle: the wizard's gateway step offers "Try again" and "Sign in and
+    /// connect", the shared gateway panel offers "Sign in with DevThrottle". So the engine reports the
+    /// fact and each surface adds its own recovery wording next to its own buttons.
+    ///
+    /// Asserted on ALL THREE paths, because they carried three copies of the same sentence and fixing one
+    /// would have left the other two telling the user to click something that does not exist.
+    /// </summary>
+    [Fact]
+    public async Task EverySignInCancelledMessage_StatesTheFact_AndNamesNoButton()
+    {
+        var messages = new List<string?>();
+
+        var (verify, _, _) = BuildRunner(
+            _ => throw new InvalidOperationException("no HTTP expected"),
+            signIn: _ => throw new OperationCanceledException());
+        messages.Add((await verify.VerifyAndSaveAsync(GatewayUrl, DeviceId, MachineName, CancellationToken.None)).ErrorMessage);
+
+        var (discover, _, _) = BuildRunner(
+            _ => throw new InvalidOperationException("no HTTP expected"),
+            signIn: _ => throw new OperationCanceledException());
+        messages.Add((await discover.SignInAndDiscoverGatewaysAsync(CancellationToken.None)).ErrorMessage);
+
+        var (hosted, _, _) = BuildRunner(
+            _ => throw new InvalidOperationException("no HTTP expected"),
+            signIn: _ => throw new OperationCanceledException());
+        messages.Add((await hosted.SignInAndEnrollHostedAsync(DeviceId, MachineName, CancellationToken.None)).ErrorMessage);
+
+        Assert.Equal(3, messages.Count);
+        foreach (var message in messages)
+        {
+            // Positive first, so this cannot pass by a message going blank or a path stopping short of
+            // the cancellation: it still has to SAY the sign-in was cancelled.
+            Assert.Contains("Sign-in was cancelled", message);
+            Assert.DoesNotContain("Sign in to DevThrottle", message);
+            // No surface's button label belongs in an engine message, whichever one it is.
+            Assert.DoesNotContain("Click \"", message);
+        }
+    }
+
     [Fact]
     public async Task VerifyAndSaveAsync_SignInFailed_BlocksAndDoesNotPersist()
     {

--- a/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
+++ b/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
@@ -160,7 +160,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] VerifyAndSaveAsync: sign-in cancelled before a credential arrived");
             return OperationResult<MobileEnrollmentResponse>.Fail(
-                "Sign-in was cancelled.");
+                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
         }
         catch (Exception ex)
         {
@@ -203,7 +203,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] SignInAndDiscoverGatewaysAsync: sign-in cancelled before a credential arrived");
             return OperationResult<IReadOnlyList<DiscoveredGateway>>.Fail(
-                "Sign-in was cancelled.");
+                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
         }
         catch (Exception ex)
         {
@@ -341,7 +341,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: sign-in cancelled before a credential arrived");
             return OperationResult<MobileEnrollmentResponse>.Fail(
-                "Sign-in was cancelled.");
+                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
         }
         catch (Exception ex)
         {

--- a/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
+++ b/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using CcDirector.Core.Account;
@@ -53,6 +53,15 @@ public sealed record DiscoveredGateway(string Name, string EndpointUrl);
 /// installer step renders it and BLOCKS completion. The sign-in step, the HTTP handler, and the persist
 /// action are all injectable so the join logic is unit-testable with no browser, no network, and no disk.
 /// The captured access token and both device keys are NEVER written to the log (security rule DT-05).
+///
+/// THESE MESSAGES STATE THE FACT AND NAME NO CONTROL. This engine is shared by surfaces whose buttons
+/// are labelled differently - the wizard's gateway step offers "Try again" and "Sign in and connect",
+/// the shared gateway panel offers "Sign in with DevThrottle" - so any button name written here is
+/// wrong somewhere. All three cancel messages used to end <c>Click "Sign in to DevThrottle" to try
+/// again</c>, which was wrong EVERYWHERE: no surface has a control with that label. It is the heading of
+/// the browser sign-in page, which at the moment of a cancellation is precisely the thing the user just
+/// closed. So the engine reports WHAT HAPPENED and each surface adds its own recovery wording next to
+/// its own buttons (issue #1070).
 /// </summary>
 public sealed class GatewayAccountEnrollRunner
 {
@@ -151,7 +160,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] VerifyAndSaveAsync: sign-in cancelled before a credential arrived");
             return OperationResult<MobileEnrollmentResponse>.Fail(
-                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
+                "Sign-in was cancelled.");
         }
         catch (Exception ex)
         {
@@ -194,7 +203,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] SignInAndDiscoverGatewaysAsync: sign-in cancelled before a credential arrived");
             return OperationResult<IReadOnlyList<DiscoveredGateway>>.Fail(
-                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
+                "Sign-in was cancelled.");
         }
         catch (Exception ex)
         {
@@ -332,7 +341,7 @@ public sealed class GatewayAccountEnrollRunner
         {
             EngineLog.Write("[GatewayAccountEnrollRunner] SignInAndEnrollHostedAsync: sign-in cancelled before a credential arrived");
             return OperationResult<MobileEnrollmentResponse>.Fail(
-                "Sign-in was cancelled. Click \"Sign in to DevThrottle\" to try again.");
+                "Sign-in was cancelled.");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
**THROWAWAY - DO NOT MERGE, DO NOT REVIEW. This branch exists to be observed FAILING, then deleted.**

Revert proof for **#2298** (thefrederiksen/devthrottle_internal#1070 and #1071).

This is `origin/main` + pull request #2298's **tests**, with four faults injected into #2298's
**production** code. The tests are **byte-identical** to #2298 - `git diff fix/gateway-cards-1070-1071 HEAD
-- src/CcDirector.Avalonia.Tests tools/cc-director-setup-engine.Tests` is empty.

## Why fault injection and not a plain revert

A blanket `git checkout origin/main -- <production files>` does not work here, and calling it a revert would
misdescribe what ran. The old cards were `Border`s; restoring them changes the generated field types and the
**test project stops compiling**. A build error is not the same evidence as a failing test - it proves
nothing about whether the test can detect the defect. So the seam that hands the cards to the tests is typed
`Control` rather than `RadioButton`, and the faults are applied surgically so **every test still runs**.

| Fault | What it puts back | Issue |
| --- | --- | --- |
| 1 | `ShowGatewayFailure` hides the choice view, as the old exclusive failure view did - the cards vanish | #1070 |
| 2 | The step's entry no longer calls `ClearGatewayFailure`, so a stale banner survives leaving and re-entering | #1070 |
| 3 | All three engine cancel messages name a control again: `Click "Sign in to DevThrottle" to try again` | #1070 |
| 4 | The three cards go back to `Border`s carrying `Focusable` and an `AutomationProperties.Name` | #1071 |

## Predicted RED - 7 tests

`CcDirector.Avalonia.Tests.GatewayStepOptionsTests`
- `EveryOption_IsARealControlWithAnAccessibleName_NotDecoratedText` (F4)
- `EveryOption_IsOneOfASingleChoiceGroup_SoSelectionIsExposedAndExclusive` (F4)
- `ChoosingAnyOption_MovesTheWizardsChoice_SoTheControlIsWiredNotJustPresent` (F4)
- `ACancelledSignIn_StillLetsTheUserDeclineTheGatewayAndContinue` (F4)
- `ACancelledSignIn_LeavesEveryOptionReachable` (F1)
- `ACancelledSignIn_DoesNotStickAcrossLeavingAndReenteringTheStep` (F1 + F2)

`CcDirector.Setup.Engine.Tests.GatewayAccountEnrollRunnerTests`
- `EverySignInCancelledMessage_StatesTheFact_AndNamesNoButton` (F3)

## Predicted GREEN - 2 tests, and both matter

- **`Control_TheStepsOwnButtonsAreVisibleAndFocusable_SoAbsenceMeansSomething`** - THE POSITIVE CONTROL. It
  must stay green, because it is what proves the reds above are about the cards rather than about a harness
  that stopped seeing the screen at all. A card that cannot be driven and a card that is not there look
  identical from a test. **If this one goes red the run is void, not damning.**
- **`TheFailureMessage_NamesNoControlThatIsNotOnTheScreen`** - it guards the *banner's* own guidance text,
  which fault 3 does not touch; the engine string is guarded by the engine test instead. Predicted green so
  the limit of that test is on the record rather than discovered later.

Everything else must stay green: the other **313** Avalonia tests and the other **430** setup-engine tests.
A wide red means a broken harness, not four injected faults.
