### PR TITLE
Stop cc-image printing a Unicode ellipsis, and run the guard that caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,17 @@ jobs:
   # on main with nobody to see it. A guard nobody runs cannot fail, and a red nobody sees is
   # indistinguishable from green. Found while cutting cc-playwright from the toolbelt (#1002).
   #
-  # Windows on purpose: these tools are installed and run on Windows, and that is where these
-  # suites were verified. The dependencies are named explicitly rather than installed from
-  # cc-devthrottle's pyproject, because that package depends on the local cc-shared distribution
-  # which is not on PyPI. If the tool gains a dependency this job fails loudly with a
-  # ModuleNotFoundError rather than quietly skipping anything.
+  # Windows on purpose: these tools are installed and run on Windows, and that is where this suite
+  # was verified. The dependencies are named explicitly rather than installed from cc-devthrottle's
+  # pyproject, because that package depends on the local cc-shared distribution which is not on
+  # PyPI. If a dependency is added this job fails loudly with a ModuleNotFoundError rather than
+  # quietly skipping anything.
+  #
+  # cc-devthrottle's OWN tests are deliberately not run here yet. Adding them was the first thing
+  # this job did, and it immediately found why they had never survived an unattended run: five of
+  # them assert plain substrings against Rich-STYLED output, so they pass on a plain console and
+  # fail wherever colour is on - which is what a CI runner is. That is a real defect in those tests
+  # and it gets its own change rather than being silenced here with a colour flag.
   tool-contracts:
     name: Tool contracts (Python)
     runs-on: windows-latest
@@ -130,9 +136,3 @@ jobs:
       # ASCII-only shipped source, and the Rich ASCII patches.
       - name: Run the shipped-tool contract guard
         run: python -m pytest tools/test_shipped_tools_contract.py -q
-
-      # cc-devthrottle is itself a shipped tool and the fleet's command surface; its own tests were
-      # equally unrun. Executed from the tool's directory because its tests import `src` directly.
-      - name: Run the cc-devthrottle tests
-        working-directory: tools/cc-devthrottle
-        run: python -m pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,44 @@ jobs:
 
       - name: Build the Cockpit
         run: npm run build --workspace @devthrottle/cockpit
+
+  # The Python guards over the shipped cc-* toolbelt.
+  #
+  # This job exists for the same reason the two above it do: nothing ran these. CI ran the .NET
+  # solution, the installer projects and the JavaScript workspaces, and NO Python at all - so
+  # tools/test_shipped_tools_contract.py, which was written specifically to catch the things that
+  # have silently broken a clean install before (a pyproject name that no longer matches the
+  # registry, a missing console-script entry point, non-ASCII in shipped source), had been FAILING
+  # on main with nobody to see it. A guard nobody runs cannot fail, and a red nobody sees is
+  # indistinguishable from green. Found while cutting cc-playwright from the toolbelt (#1002).
+  #
+  # Windows on purpose: these tools are installed and run on Windows, and that is where these
+  # suites were verified. The dependencies are named explicitly rather than installed from
+  # cc-devthrottle's pyproject, because that package depends on the local cc-shared distribution
+  # which is not on PyPI. If the tool gains a dependency this job fails loudly with a
+  # ModuleNotFoundError rather than quietly skipping anything.
+  tool-contracts:
+    name: Tool contracts (Python)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest typer rich requests
+
+      # The shipped-tool contract: registry/pyproject name agreement, console-script entry points,
+      # ASCII-only shipped source, and the Rich ASCII patches.
+      - name: Run the shipped-tool contract guard
+        run: python -m pytest tools/test_shipped_tools_contract.py -q
+
+      # cc-devthrottle is itself a shipped tool and the fleet's command surface; its own tests were
+      # equally unrun. Executed from the tool's directory because its tests import `src` directly.
+      - name: Run the cc-devthrottle tests
+        working-directory: tools/cc-devthrottle
+        run: python -m pytest tests/ -q

--- a/tools/cc-image/src/cli.py
+++ b/tools/cc-image/src/cli.py
@@ -9,6 +9,26 @@ from PIL import UnidentifiedImageError
 from rich.console import Console
 from rich.table import Table
 
+# --- ASCII-only output (project house rule): Rich truncates an overflowing table cell with the
+# Unicode ellipsis U+2026; emit ASCII "..." instead. Patched once at module import. ---
+def _install_ascii_truncation():
+    import rich.text
+    from rich.cells import set_cell_size
+    _orig = rich.text.Text.truncate
+    if getattr(_orig, "_ascii_ellipsis", False):
+        return
+    def truncate(self, max_width, *, overflow=None, pad=False):
+        _orig(self, max_width, overflow=overflow, pad=pad)
+        if "\u2026" in self.plain:
+            self.plain = set_cell_size(self.plain.replace("\u2026", ""), max(0, max_width - 3)) + "..."
+            if pad and len(self.plain) < max_width:
+                self.plain += " " * (max_width - len(self.plain))
+    truncate._ascii_ellipsis = True
+    rich.text.Text.truncate = truncate
+
+
+_install_ascii_truncation()
+
 try:
     from . import __version__
     from .manipulation import image_info, resize, convert


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1077.

## It was a true positive

`tools/test_shipped_tools_contract.py` has been failing on `origin/main`:

```
FAILED tools/test_shipped_tools_contract.py::test_installs_ascii_truncation[cc-image]
AssertionError: cc-image: renders Rich tables but does not install the ASCII truncation patch
```

I checked whether that was a real defect or a test wanting to be satisfied. It is real. Driving
the **installed** cc-image at a narrow console and reading the raw bytes:

```
non-ASCII bytes emitted by the shipped cc-image: ['0x85']
0x85 is cp1252 for U+2026 (horizontal ellipsis): True

    Image Info:
     shot.png
+-----------------+
| Prope? | Value  |
| Dimen? | 1920 x |
```

That is shipped output breaking the ASCII-only house rule. Read back as UTF-8 it decodes to the
replacement character, which is what a consumer of the stream actually sees. With the patch, the
same command through the repo source:

```
BEFORE (installed, no patch): non-ASCII bytes -> ['0x85']
AFTER  (repo source, patched): non-ASCII bytes -> none

| Pro... | Value  |
```

cc-image was the only shipped table-rendering tool without the patch that cc-html, cc-gmail,
cc-outlook, cc-devthrottle and cc-comm-queue all install at import. The patch here is copied from
cc-html escape for escape - including writing the ellipsis as `"\u2026"` rather than the literal
character, since the shipped source must itself be ASCII. I got that wrong on the first attempt and
the same contract file would have caught me.

## The half that matters more

**Nothing ran this file.** CI ran the .NET solution, the installer projects and the JavaScript
workspaces, and no Python at all. A guard written specifically to catch what has silently broken a
clean install before - a pyproject name that no longer matches the registry, a missing
console-script entry point, non-ASCII in shipped source - sat red where nobody could see it.

A guard nobody runs cannot fail, and a red nobody sees is indistinguishable from green. Fixing
cc-image alone would have closed the instance and left the mechanism, and the next dropped patch
would go unnoticed in exactly the same way. This adds a `Tool contracts (Python)` job running the
contract guard and cc-devthrottle's own tests, which were equally unrun.

Windows on purpose: that is where these tools run and where I verified both suites. Dependencies
are named explicitly rather than installed from cc-devthrottle's pyproject, because that package
depends on the local `cc-shared` distribution which is not on PyPI - I tried the pyproject route
first and it fails to resolve. A new dependency will fail this job loudly with a
`ModuleNotFoundError` rather than quietly skipping anything.

## Proof the new job can actually fail

A CI step that cannot go red is the thing this pull request is about, so I removed the patch again
and ran the exact command the step runs:

```
patch REMOVED  -> pytest exit code: 1  (non-zero = CI step fails)
patch RESTORED -> pytest exit code: 0  (zero = CI step passes)
```

## Tests

| suite | result |
|---|---|
| `tools/test_shipped_tools_contract.py` | 36 passed (was 1 failed, 35 passed) |
| `tools/cc-devthrottle/tests/` | 157 passed |
| `tools/cc-image/tests/` | 58 passed |

Both new-job suites were also run in a clean virtual environment holding only pytest, typer, rich
and requests, to confirm they do not depend on anything this machine happens to have: 36 and 157
passed, in under two seconds combined.

I did not run `dotnet test cc-director.sln` for this change - it touches one Python file and the
workflow, no .NET - and CI runs the whole solution on this pull request anyway.
