### PR TITLE
Serve a tenant only its own missions, and stamp the owner at write time (#1039)

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -194,7 +194,10 @@ public sealed class ControlApiHost : IAsyncDisposable
     private TurnSummaryCache? _turnSummaryCache;
     // Mission records (mission-as-first-class-unit-of-work): a durable, file-backed store with no runtime
     // dependencies, so it is ready from construction (unlike the caches wired up in StartAsync).
-    private readonly Core.Sessions.MissionStore _missionStore = new();
+    // A Director runs on one person's machine and serves one owner, so its store is single-tenant: every
+    // record is Local's, including any written before missions carried an owner (#1039).
+    private readonly Core.Sessions.MissionStore _missionStore =
+        new(filePath: null, adoptUnattributedAs: Core.Tenancy.TenantId.Local);
     private SessionStatusWingman? _statusWingman;
     private ProactiveExplainService? _proactiveExplain;
     private TerminalStateDetector? _terminalStateDetector;

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -503,7 +503,7 @@ internal static class SessionCommandExecutor
             {
                 // Transitional bridge: resolve the name from the local Director MissionStore. Removed with
                 // the Director MissionStore in Phase 1.
-                var mission = services?.MissionStore?.Get(createMissionId);
+                var mission = services?.MissionStore?.Get(Core.Tenancy.TenantId.Local, createMissionId);
                 if (mission is null)
                     return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
                         $"unknown mission '{createMissionId}'. Create it first with POST /missions.");
@@ -781,7 +781,8 @@ internal static class SessionCommandExecutor
             return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
         }
 
-        var mission = services?.MissionStore?.Get(missionId);
+        // The Director's store is single-tenant - one machine, one owner - so Local is its whole world.
+        var mission = services?.MissionStore?.Get(Core.Tenancy.TenantId.Local, missionId);
         if (mission is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
                 $"unknown mission '{missionId}'. Create it first with POST /missions.");

--- a/src/CcDirector.Core.Tests/MissionStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Core.Tests/MissionStoreTenantPartitionTests.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The tenant partition of <see cref="MissionStore"/> (devthrottle_internal issue #1039).
+///
+/// One hosted Gateway process serves every account out of ONE missions.json. Before this partition,
+/// <c>List()</c> took no tenant and <c>Get()</c> resolved by bare id, so two accounts that shared nothing
+/// were served byte-identical mission lists on the deployed service - and a mission name is free text a
+/// person typed, so that disclosed what other customers were working on in their own words.
+///
+/// Every case here is written as an INVARIANT - the rows a tenant is served all belong to that tenant -
+/// rather than as "this particular id is absent". An absence test passes for the wrong reason as soon as
+/// the id changes shape; the invariant does not. And each refusal case is paired with a PERMITTED case in
+/// the same store, because a store that returned nothing to everybody would satisfy every refusal
+/// assertion here while being entirely broken.
+/// </summary>
+public class MissionStoreTenantPartitionTests
+{
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>A shared, multi-tenant store: unattributed rows belong to nobody (the hosted shape).</summary>
+    private static MissionStore Shared(string path) => new(path, adoptUnattributedAs: null);
+
+    private static string TempPath() =>
+        Path.Combine(Path.GetTempPath(), $"test_missions_tenant_{Guid.NewGuid()}.json");
+
+    private static void WithTempFile(Action<string> body)
+    {
+        var path = TempPath();
+        try { body(path); }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void List_ServesOnlyTheCallersOwnRows_AndTheOtherTenantStillSeesItsOwn()
+    {
+        WithTempFile(path =>
+        {
+            var store = Shared(path);
+            store.Create(TenantA, "Payments cutover for Northwind");
+            store.Create(TenantA, "Second A mission");
+            var bMission = store.Create(TenantB, "B's own mission");
+
+            var servedToB = store.List(TenantB);
+
+            // The invariant: every row B is served is B's. Not "A's id is absent" - this holds however the
+            // records are keyed, which is the check that would have caught this leak the first time.
+            Assert.All(servedToB, m => Assert.Equal(TenantB.Value, m.TenantId));
+
+            // The permitted half, in the same store and the same breath: B is genuinely served its own row.
+            // Without this, a store that returned an empty list to everyone would pass the assertion above.
+            Assert.Equal(new[] { bMission.MissionId }, servedToB.Select(m => m.MissionId));
+
+            // And symmetrically for A, so the partition is not just "B sees nothing".
+            var servedToA = store.List(TenantA);
+            Assert.All(servedToA, m => Assert.Equal(TenantA.Value, m.TenantId));
+            Assert.Equal(2, servedToA.Count);
+        });
+    }
+
+    [Fact]
+    public void Get_ByAnotherTenantsId_ResolvesToNothing_ButTheOwnerStillResolvesIt()
+    {
+        WithTempFile(path =>
+        {
+            var store = Shared(path);
+            var aMission = store.Create(TenantA, "Kickoff with Ana and Ravi");
+
+            // The refusal: naming the id is not a way to read the record.
+            Assert.Null(store.Get(TenantB, aMission.MissionId));
+
+            // The control: that same id, asked for by its OWNER, resolves. So the null above is a refusal
+            // and not a store that cannot find anything.
+            var owned = store.Get(TenantA, aMission.MissionId);
+            Assert.NotNull(owned);
+            Assert.Equal("Kickoff with Ana and Ravi", owned.MissionName);
+        });
+    }
+
+    [Fact]
+    public void Delete_CannotRemoveAnotherTenantsMission_ButTheOwnerCan()
+    {
+        WithTempFile(path =>
+        {
+            var store = Shared(path);
+            var aMission = store.Create(TenantA, "A's mission");
+
+            Assert.False(store.Delete(TenantB, aMission.MissionId));
+            Assert.NotNull(store.Get(TenantA, aMission.MissionId));   // still there - the write was refused
+
+            Assert.True(store.Delete(TenantA, aMission.MissionId));   // the permitted half
+            Assert.Null(store.Get(TenantA, aMission.MissionId));
+        });
+    }
+
+    [Fact]
+    public void Create_StampsTheCallersTenantOnTheRecord_AtWriteTime()
+    {
+        WithTempFile(path =>
+        {
+            var store = Shared(path);
+
+            var mission = store.Create(TenantA, "Stamped at write time");
+
+            Assert.Equal(TenantA.Value, mission.TenantId);
+
+            // Read the file rather than the returned object: a read-side filter over unattributed rows is a
+            // deferred leak, so the OWNER has to be on disk, in the persisted record.
+            var persisted = JsonSerializer.Deserialize<List<Mission>>(
+                File.ReadAllText(path), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+            Assert.Equal(TenantA.Value, Assert.Single(persisted).TenantId);
+        });
+    }
+
+    [Fact]
+    public void SharedStore_UnattributedRows_AreServedToNobody_AndAreNotDestroyed()
+    {
+        WithTempFile(path =>
+        {
+            // A row exactly as the deployed hosted Gateway holds it today: no owner, because it predates
+            // the stamp. It cannot be attributed after the fact, so the store must not guess.
+            File.WriteAllText(path, JsonSerializer.Serialize(new[]
+            {
+                new Mission
+                {
+                    MissionId = Guid.NewGuid(),
+                    MissionName = "legacy unattributed mission",
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    TenantId = null,
+                }
+            }));
+
+            var store = Shared(path);
+            var legacyId = JsonSerializer.Deserialize<List<Mission>>(File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })![0].MissionId;
+
+            Assert.Empty(store.List(TenantA));
+            Assert.Empty(store.List(TenantB));
+            Assert.Null(store.Get(TenantA, legacyId));
+            Assert.False(store.Delete(TenantA, legacyId));
+
+            // Quarantined, not deleted: the row is still on disk for whoever holds the deployment to
+            // inspect. Reading it back proves the store refused it rather than silently dropping it - which
+            // would look identical from the API and destroy the evidence.
+            var stillOnDisk = JsonSerializer.Deserialize<List<Mission>>(File.ReadAllText(path),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+            Assert.Equal("legacy unattributed mission", Assert.Single(stillOnDisk).MissionName);
+        });
+    }
+
+    [Fact]
+    public void SingleTenantStore_AdoptsUnattributedRows_SoSelfHostIsUnchanged()
+    {
+        WithTempFile(path =>
+        {
+            File.WriteAllText(path, JsonSerializer.Serialize(new[]
+            {
+                new Mission
+                {
+                    MissionId = Guid.NewGuid(),
+                    MissionName = "mission from before the stamp",
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    TenantId = null,
+                }
+            }));
+
+            // Self-host and the Director: exactly one tenant by construction, so an unattributed row is
+            // that tenant's. This is a fact about the deployment, not an inference about the row - and it
+            // is why an existing self-host install keeps listing the missions it already had.
+            var store = new MissionStore(path, adoptUnattributedAs: TenantId.Local);
+
+            var listed = store.List(TenantId.Local);
+            Assert.Equal("mission from before the stamp", Assert.Single(listed).MissionName);
+        });
+    }
+
+    [Fact]
+    public void SingleTenantAdoption_DoesNotLeakToAnotherTenant()
+    {
+        WithTempFile(path =>
+        {
+            File.WriteAllText(path, JsonSerializer.Serialize(new[]
+            {
+                new Mission
+                {
+                    MissionId = Guid.NewGuid(),
+                    MissionName = "adopted by Local only",
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    TenantId = null,
+                }
+            }));
+
+            var store = new MissionStore(path, adoptUnattributedAs: TenantId.Local);
+
+            // Adoption names ONE tenant. It is not "anyone may read unattributed rows".
+            Assert.Empty(store.List(TenantA));
+            Assert.Single(store.List(TenantId.Local));
+        });
+    }
+
+    [Fact]
+    public void EveryAccessor_RefusesAnInvalidTenant()
+    {
+        WithTempFile(path =>
+        {
+            var store = Shared(path);
+            var unset = default(TenantId);   // bypasses the validating constructor - Value is null
+
+            // A null Value must never reach the ownership comparison, where it would be compared against a
+            // row's owner and quietly decide something. Fail loud on every leg instead.
+            Assert.Throws<ArgumentException>(() => store.List(unset));
+            Assert.Throws<ArgumentException>(() => store.Get(unset, Guid.NewGuid()));
+            Assert.Throws<ArgumentException>(() => store.Delete(unset, Guid.NewGuid()));
+            Assert.Throws<ArgumentException>(() => store.Create(unset, "name"));
+        });
+    }
+}

--- a/src/CcDirector.Core.Tests/MissionStoreTests.cs
+++ b/src/CcDirector.Core.Tests/MissionStoreTests.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
 using Xunit;
 
 namespace CcDirector.Core.Tests;
@@ -9,24 +10,34 @@ namespace CcDirector.Core.Tests;
 /// throwaway temp file and asserts the create / get / list / delete API plus survival across a fresh store
 /// instance (the "survives a restart" guarantee), and the session-side MissionId/MissionName round-trip
 /// through <see cref="PersistedSession"/>.
+///
+/// These are the SINGLE-TENANT behaviours - one owner, everything Local - which is what a Director and a
+/// self-host Gateway are. The partitioning the store gained in #1039 is exercised separately in
+/// <see cref="MissionStoreTenantPartitionTests"/>.
 /// </summary>
 public class MissionStoreTests
 {
+    /// <summary>A single-tenant store: one owner, so unattributed rows are that owner's.</summary>
+    private static MissionStore NewStore(string path) => new(path, adoptUnattributedAs: TenantId.Local);
+
+    private static string TempPath() =>
+        Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+
     [Fact]
     public void Create_MintsIdAndPersists_GetReturnsIt()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        var tempFile = TempPath();
         try
         {
-            var store = new MissionStore(tempFile);
+            var store = NewStore(tempFile);
 
-            var mission = store.Create("Session Lifecycle");
+            var mission = store.Create(TenantId.Local, "Session Lifecycle");
 
             Assert.NotEqual(Guid.Empty, mission.MissionId);
             Assert.Equal("Session Lifecycle", mission.MissionName);
             Assert.Null(mission.ParentMissionId);
 
-            var fetched = store.Get(mission.MissionId);
+            var fetched = store.Get(TenantId.Local, mission.MissionId);
             Assert.NotNull(fetched);
             Assert.Equal(mission.MissionId, fetched.MissionId);
             Assert.Equal("Session Lifecycle", fetched.MissionName);
@@ -41,13 +52,13 @@ public class MissionStoreTests
     [Fact]
     public void Create_WithParent_NestsUnderIt()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        var tempFile = TempPath();
         try
         {
-            var store = new MissionStore(tempFile);
-            var parent = store.Create("Parent Mission");
+            var store = NewStore(tempFile);
+            var parent = store.Create(TenantId.Local, "Parent Mission");
 
-            var child = store.Create("Child Mission", parent.MissionId);
+            var child = store.Create(TenantId.Local, "Child Mission", parent.MissionId);
 
             Assert.Equal(parent.MissionId, child.ParentMissionId);
         }
@@ -61,21 +72,21 @@ public class MissionStoreTests
     [Fact]
     public void Create_BlankName_Throws()
     {
-        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
-        Assert.Throws<ArgumentException>(() => store.Create("   "));
+        var store = NewStore(TempPath());
+        Assert.Throws<ArgumentException>(() => store.Create(TenantId.Local, "   "));
     }
 
     [Fact]
     public void List_ReturnsEveryMission_OldestFirst()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        var tempFile = TempPath();
         try
         {
-            var store = new MissionStore(tempFile);
-            var first = store.Create("First");
-            var second = store.Create("Second");
+            var store = NewStore(tempFile);
+            var first = store.Create(TenantId.Local, "First");
+            var second = store.Create(TenantId.Local, "Second");
 
-            var all = store.List();
+            var all = store.List(TenantId.Local);
 
             Assert.Equal(2, all.Count);
             Assert.Equal(first.MissionId, all[0].MissionId);
@@ -91,25 +102,25 @@ public class MissionStoreTests
     [Fact]
     public void Get_UnknownId_ReturnsNull()
     {
-        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
-        Assert.Null(store.Get(Guid.NewGuid()));
+        var store = NewStore(TempPath());
+        Assert.Null(store.Get(TenantId.Local, Guid.NewGuid()));
     }
 
     [Fact]
     public void Missions_SurviveANewStoreInstance_PersistReload()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        var tempFile = TempPath();
         try
         {
-            var created = new MissionStore(tempFile).Create("Durable Mission");
+            var created = NewStore(tempFile).Create(TenantId.Local, "Durable Mission");
 
             // A brand-new store instance against the same file models a Director restart.
-            var reopened = new MissionStore(tempFile);
-            var fetched = reopened.Get(created.MissionId);
+            var reopened = NewStore(tempFile);
+            var fetched = reopened.Get(TenantId.Local, created.MissionId);
 
             Assert.NotNull(fetched);
             Assert.Equal("Durable Mission", fetched.MissionName);
-            Assert.Single(reopened.List());
+            Assert.Single(reopened.List(TenantId.Local));
         }
         finally
         {
@@ -121,17 +132,17 @@ public class MissionStoreTests
     [Fact]
     public void Delete_RemovesMission_AndReturnsTrue()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        var tempFile = TempPath();
         try
         {
-            var store = new MissionStore(tempFile);
-            var mission = store.Create("Doomed Mission");
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Doomed Mission");
 
-            var removed = store.Delete(mission.MissionId);
+            var removed = store.Delete(TenantId.Local, mission.MissionId);
 
             Assert.True(removed);
-            Assert.Null(store.Get(mission.MissionId));
-            Assert.Empty(store.List());
+            Assert.Null(store.Get(TenantId.Local, mission.MissionId));
+            Assert.Empty(store.List(TenantId.Local));
         }
         finally
         {
@@ -143,8 +154,8 @@ public class MissionStoreTests
     [Fact]
     public void Delete_UnknownId_ReturnsFalse()
     {
-        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
-        Assert.False(store.Delete(Guid.NewGuid()));
+        var store = NewStore(TempPath());
+        Assert.False(store.Delete(TenantId.Local, Guid.NewGuid()));
     }
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/Mission.cs
+++ b/src/CcDirector.Core/Sessions/Mission.cs
@@ -22,4 +22,16 @@ public sealed class Mission
 
     /// <summary>UTC timestamp the Mission was created. Used for stable list ordering.</summary>
     public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// The tenant that owns this Mission, stamped at creation from the CALLER's authenticated identity -
+    /// never from anything a client sends. Every read is filtered on it, so a mission is only ever served to
+    /// the tenant that wrote it.
+    ///
+    /// Null means UNATTRIBUTED: a record written before missions carried an owner. On a single-tenant
+    /// install there is exactly one tenant by construction, so <see cref="MissionStore"/> may be told to
+    /// adopt those rows as that tenant; where more than one tenant shares the store, an unattributed row
+    /// belongs to nobody and is served to nobody. See <see cref="MissionStore"/> for the rule.
+    /// </summary>
+    public string? TenantId { get; set; }
 }

--- a/src/CcDirector.Core/Sessions/MissionStore.cs
+++ b/src/CcDirector.Core/Sessions/MissionStore.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Sessions;
@@ -14,6 +15,24 @@ namespace CcDirector.Core.Sessions;
 ///
 /// Every mutating call reads, mutates, and rewrites the file under a single lock so concurrent Control API
 /// requests cannot interleave a half-written set.
+///
+/// PARTITIONED BY TENANT (devthrottle_internal issue #1039). One hosted Gateway process serves every
+/// account from ONE of these files, so a mission carries the tenant that created it and every accessor
+/// takes the tenant it is acting for. There is deliberately NO bare-id and NO unscoped accessor left on
+/// this type: a caller cannot reach another tenant's record because there is no method that would return
+/// one, rather than because each call site remembered to filter. The mission NAME is free text a person
+/// typed - customer and project names - so an unpartitioned list is a disclosure of what other accounts
+/// are working on, in their own words.
+///
+/// UNATTRIBUTED ROWS (<see cref="Mission.TenantId"/> null) are records written before missions carried an
+/// owner. They cannot be attributed after the fact, so the store never guesses:
+///  - Given an <c>adoptUnattributedAs</c> tenant, they are that tenant's. This is for a SINGLE-TENANT
+///    install (self-host, the Director), where there is exactly one tenant by construction - so this is a
+///    fact about the deployment, not an inference about the row.
+///  - Given null (the hosted Gateway, where the file is shared), they belong to NOBODY: they match no
+///    tenant, so they are never listed, never resolvable by id, and never deletable through this API.
+///    They stay on disk - quarantined, not destroyed - so whoever holds the deployment can still inspect
+///    or remove them out of band.
 /// </summary>
 public sealed class MissionStore
 {
@@ -25,27 +44,45 @@ public sealed class MissionStore
 
     private readonly object _lock = new();
 
+    /// <summary>
+    /// The tenant that owns rows written before missions carried an owner, or null to quarantine them.
+    /// See the type remarks - this is a statement about the DEPLOYMENT (one tenant, or many sharing the
+    /// file), decided once at construction where that is known, never inferred per row.
+    /// </summary>
+    private readonly TenantId? _adoptUnattributedAs;
+
     public string FilePath { get; }
 
-    public MissionStore(string? filePath = null)
+    /// <param name="filePath">Where the set is persisted. Null uses the Director's tool-config location.</param>
+    /// <param name="adoptUnattributedAs">
+    /// The owner of unattributed rows. Pass <see cref="TenantId.Local"/> on a single-tenant install; pass
+    /// null where more than one tenant shares the file, which quarantines them. It has no default on
+    /// purpose: a store that serves several tenants must not inherit a single-tenant answer by omission.
+    /// </param>
+    public MissionStore(string? filePath, TenantId? adoptUnattributedAs)
     {
+        _adoptUnattributedAs = adoptUnattributedAs;
         FilePath = filePath ?? Path.Combine(
             CcStorage.ToolConfig("director"),
             "missions.json");
-        FileLog.Write($"[MissionStore] Initialized: FilePath={FilePath}");
+        FileLog.Write($"[MissionStore] Initialized: FilePath={FilePath} " +
+                      $"unattributedRows={(adoptUnattributedAs is { } t ? $"adopted as {t.ToLogString()}" : "quarantined")}");
     }
 
     /// <summary>
-    /// Create and persist a new Mission with a freshly minted id. <paramref name="missionName"/> is
-    /// required (a blank name throws) and <paramref name="parentMissionId"/> nests it under a parent when
-    /// given. Returns the created record.
+    /// Create and persist a new Mission with a freshly minted id, OWNED BY <paramref name="tenant"/> -
+    /// which the caller resolves from its own authenticated identity, never from client input.
+    /// <paramref name="missionName"/> is required (a blank name throws) and <paramref name="parentMissionId"/>
+    /// nests it under a parent when given. Returns the created record.
     /// </summary>
-    public Mission Create(string missionName, Guid? parentMissionId = null)
+    public Mission Create(TenantId tenant, string missionName, Guid? parentMissionId = null)
     {
+        RequireValid(tenant);
         if (string.IsNullOrWhiteSpace(missionName))
             throw new ArgumentException("missionName is required", nameof(missionName));
 
-        FileLog.Write($"[MissionStore] Create: name=\"{missionName}\" parent={parentMissionId?.ToString() ?? "(none)"}");
+        FileLog.Write($"[MissionStore] Create: tenant={tenant.ToLogString()} name=\"{missionName}\" " +
+                      $"parent={parentMissionId?.ToString() ?? "(none)"}");
 
         var mission = new Mission
         {
@@ -53,6 +90,7 @@ public sealed class MissionStore
             MissionName = missionName.Trim(),
             ParentMissionId = parentMissionId,
             CreatedAt = DateTimeOffset.UtcNow,
+            TenantId = tenant.Value,
         };
 
         lock (_lock)
@@ -62,36 +100,70 @@ public sealed class MissionStore
             SaveAll(missions);
         }
 
-        FileLog.Write($"[MissionStore] Create: created mission {mission.MissionId}");
+        FileLog.Write($"[MissionStore] Create: created mission {mission.MissionId} for tenant {tenant.ToLogString()}");
         return mission;
     }
 
-    /// <summary>Return the Mission with the given id, or null when none exists.</summary>
-    public Mission? Get(Guid missionId)
+    /// <summary>
+    /// Return <paramref name="tenant"/>'s Mission with the given id, or null when that tenant has no such
+    /// mission. A mission another tenant owns is indistinguishable from one that does not exist, which is
+    /// the point: the id alone reaches nothing.
+    /// </summary>
+    public Mission? Get(TenantId tenant, Guid missionId)
     {
+        RequireValid(tenant);
         lock (_lock)
-            return LoadAll().FirstOrDefault(m => m.MissionId == missionId);
+            return LoadAll().FirstOrDefault(m => m.MissionId == missionId && OwnedBy(m, tenant));
     }
 
-    /// <summary>Return every stored Mission, oldest first.</summary>
-    public IReadOnlyList<Mission> List()
+    /// <summary>Return every Mission <paramref name="tenant"/> owns, oldest first.</summary>
+    public IReadOnlyList<Mission> List(TenantId tenant)
     {
+        RequireValid(tenant);
         lock (_lock)
-            return LoadAll().OrderBy(m => m.CreatedAt).ToList();
+            return LoadAll().Where(m => OwnedBy(m, tenant)).OrderBy(m => m.CreatedAt).ToList();
     }
 
-    /// <summary>Delete the Mission with the given id. Returns true when a record was removed.</summary>
-    public bool Delete(Guid missionId)
+    /// <summary>
+    /// Delete <paramref name="tenant"/>'s Mission with the given id. Returns true when a record was
+    /// removed - false both when no such mission exists and when it belongs to someone else.
+    /// </summary>
+    public bool Delete(TenantId tenant, Guid missionId)
     {
-        FileLog.Write($"[MissionStore] Delete: mission={missionId}");
+        RequireValid(tenant);
+        FileLog.Write($"[MissionStore] Delete: tenant={tenant.ToLogString()} mission={missionId}");
         lock (_lock)
         {
             var missions = LoadAll();
-            var removed = missions.RemoveAll(m => m.MissionId == missionId) > 0;
+            var removed = missions.RemoveAll(m => m.MissionId == missionId && OwnedBy(m, tenant)) > 0;
             if (removed)
                 SaveAll(missions);
             return removed;
         }
+    }
+
+    /// <summary>
+    /// The one ownership test every accessor above shares, so scoping cannot differ between them. A row
+    /// with an owner belongs to that owner; a row with none belongs to the adoption tenant, and to nobody
+    /// when there is none.
+    /// </summary>
+    private bool OwnedBy(Mission mission, TenantId tenant)
+    {
+        var owner = string.IsNullOrWhiteSpace(mission.TenantId)
+            ? _adoptUnattributedAs?.Value
+            : mission.TenantId;
+        return owner is not null && string.Equals(owner, tenant.Value, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Refuse a <c>default(TenantId)</c>. Every accessor is scoped by comparison against the caller's
+    /// tenant, so an invalid tenant must fail loudly here rather than compare its null Value against a
+    /// row and quietly decide something.
+    /// </summary>
+    private static void RequireValid(TenantId tenant)
+    {
+        if (!tenant.IsValid)
+            throw new ArgumentException("A MissionStore call needs a valid tenant.", nameof(tenant));
     }
 
     /// <summary>Read the full set from disk. An absent file is an empty set; a corrupt file fails loudly.</summary>

--- a/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
@@ -31,8 +31,10 @@ public sealed class MissionCommandTests
         return (sm, session);
     }
 
+    // The Director's store is single-tenant - one machine, one owner - so every record is Local's (#1039).
     private static MissionStore NewMissionStore() =>
-        new(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
+        new(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"),
+            adoptUnattributedAs: Core.Tenancy.TenantId.Local);
 
     private static DirectorCommand AttachCommand(string sid, Guid? missionId) => new()
     {
@@ -57,7 +59,7 @@ public sealed class MissionCommandTests
         try
         {
             var store = NewMissionStore();
-            var mission = store.Create("Session Lifecycle");
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
             var services = new SessionCommandServices { MissionStore = store };
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
@@ -98,7 +100,7 @@ public sealed class MissionCommandTests
         try
         {
             var store = NewMissionStore();
-            var mission = store.Create("Session Lifecycle");
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
             var services = new SessionCommandServices { MissionStore = store };
 
             await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
@@ -120,7 +122,7 @@ public sealed class MissionCommandTests
         try
         {
             var store = NewMissionStore();
-            var mission = store.Create("Session Lifecycle");
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
             var services = new SessionCommandServices { MissionStore = store };
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(Guid.NewGuid().ToString(), mission.MissionId), services);
@@ -152,7 +154,7 @@ public sealed class MissionCommandTests
         try
         {
             var store = NewMissionStore();
-            var mission = store.Create("Session Lifecycle");
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
             var services = new SessionCommandServices { MissionStore = store };
 
             var command = CreateCommand(new NewSessionRequest
@@ -233,7 +235,7 @@ public sealed class MissionCommandTests
         try
         {
             var store = NewMissionStore();
-            var mission = store.Create("Name From Director Store");
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Name From Director Store");
             var services = new SessionCommandServices { MissionStore = store };
 
             var command = CreateCommand(new NewSessionRequest

--- a/src/CcDirector.Gateway.Tests/MissionRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionRouteTenantScopingTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// devthrottle_internal issue #1039: the Gateway-native mission surface scoped to the CALLER's own tenant,
+/// proven over the REAL mapped routes and the REAL auth middleware, with two separately-enrolled accounts.
+///
+/// What was live on the deployed hosted image: <c>GET /missions</c> called <c>missions.List()</c> - no
+/// tenant argument at all - so two accounts created minutes apart, sharing nothing, were served
+/// BYTE-IDENTICAL mission lists. A mission name is free text a person typed, so the payload disclosed
+/// other customers' project and people names. <c>GET /missions/{mid}</c> resolved by bare id and
+/// <c>POST /missions</c> wrote with no owner, which is how the shared store came to hold several accounts'
+/// records in the first place.
+///
+/// HOW THESE CASES ARE WRITTEN, and it matters more than the count:
+///
+///  - The assertion is the INVARIANT - every record served to a caller belongs to that caller - not "this
+///    particular id is absent". The #1017 matrix nearly missed this leak because its cross-tenant check
+///    looked for a DEVICE ID inside the response, and a mission is not keyed by one, so it passed while the
+///    box handed over the whole list. A check that knows only one kind of identifier certifies every
+///    surface keyed by a different one.
+///  - Every refusal is paired with a PERMITTED request in the same test. A Gateway that refused everybody
+///    would satisfy every refusal assertion here while being completely broken, so a refusal on its own
+///    proves nothing.
+///  - <see cref="The_leak_detector_itself_detects_a_leak_when_there_is_one"/> is the SELF-TEST: it points
+///    the same structural comparison these tests refuse with at a record the caller genuinely owns and
+///    requires it to come out POSITIVE. If that ever goes green-by-absence, the detector cannot tell a
+///    refusal from a success and none of the other cases mean anything.
+///
+/// Revert-prove: put <c>missions.List()</c> / <c>missions.Get(missionId)</c> back and
+/// <see cref="A_missions_list_serves_only_the_callers_own_missions"/> and
+/// <see cref="A_mission_belonging_to_another_tenant_is_not_resolvable_by_id"/> both go RED.
+///
+/// The assembly disables test parallelization, so toggling CC_GATEWAY_HOSTED here is safe; it is reset in
+/// DisposeAsync.
+/// </summary>
+public sealed class MissionRouteTenantScopingTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-1039-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts enrolled through the product's own hosted enrollment, each atomically bound to its
+        // own canonically-minted tenant - the same shape the two throwaway signups in the field run had.
+        _keyA = HostedTestEnrollment.Enroll(
+            _gateway, "sub-alice", "alice@example.com", "dev-a", "MACHINE-A").DeviceKey;
+        _keyB = HostedTestEnrollment.Enroll(
+            _gateway, "sub-bob", "bob@example.com", "dev-b", "MACHINE-B").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task A_missions_list_serves_only_the_callers_own_missions()
+    {
+        var aMission = await CreateMission(_keyA, "Payments cutover for Northwind");
+        var bMission = await CreateMission(_keyB, "B's own unrelated mission");
+
+        var (aStatus, aBody) = await GetRaw("missions", _keyA);
+        var (bStatus, bBody) = await GetRaw("missions", _keyB);
+        Assert.Equal(HttpStatusCode.OK, aStatus);
+        Assert.Equal(HttpStatusCode.OK, bStatus);
+
+        // The leak as it was observed in the field: identical bodies to two unrelated accounts. This is the
+        // cheapest check there is and it needs no knowledge of what the surface is keyed by.
+        Assert.NotEqual(aBody, bBody);
+
+        // The invariant, structurally: no record of B's appears anywhere in A's payload, and vice versa.
+        Assert.False(ContainsMission(aBody, bMission), "tenant A was served tenant B's mission record");
+        Assert.False(ContainsMission(bBody, aMission), "tenant B was served tenant A's mission record");
+
+        // The permitted half: each account IS served its own mission. Without this a Gateway answering
+        // "[]" to everyone would pass every assertion above.
+        Assert.True(ContainsMission(aBody, aMission), "tenant A was not served its own mission");
+        Assert.True(ContainsMission(bBody, bMission), "tenant B was not served its own mission");
+
+        // And the list is exactly the caller's own set, by count as well as by content.
+        Assert.Equal(new[] { aMission.MissionId }, Parse(aBody).Select(m => m.MissionId).ToArray());
+        Assert.Equal(new[] { bMission.MissionId }, Parse(bBody).Select(m => m.MissionId).ToArray());
+    }
+
+    [Fact]
+    public async Task The_leak_detector_itself_detects_a_leak_when_there_is_one()
+    {
+        // THE SELF-TEST. Every refusal above is "ContainsMission(...) is false". That assertion is worth
+        // exactly as much as its ability to come out TRUE, so point it at a record the caller genuinely
+        // owns and require a positive. If this case ever fails, every other case in this file is passing on
+        // a detector that cannot see anything, and the file certifies nothing.
+        var aMission = await CreateMission(_keyA, "A mission the caller definitely owns");
+
+        var (_, aBody) = await GetRaw("missions", _keyA);
+
+        Assert.True(ContainsMission(aBody, aMission),
+            "the structural comparison failed to find a record that IS in the payload - it cannot tell a " +
+            "refusal from a success, so no refusal assertion in this file means anything");
+    }
+
+    [Fact]
+    public async Task A_mission_belonging_to_another_tenant_is_not_resolvable_by_id()
+    {
+        var aMission = await CreateMission(_keyA, "Kickoff with Ana and Ravi");
+
+        // The refusal: naming a valid id from another account reaches nothing. 404 rather than 403, so the
+        // id cannot even be probed for existence - "someone else has it" and "nobody has it" read alike.
+        var (foreignStatus, _) = await GetRaw($"missions/{aMission.MissionId}", _keyB);
+        Assert.Equal(HttpStatusCode.NotFound, foreignStatus);
+
+        // The control: that same id, asked for by its OWNER, resolves and carries the name. So the 404 is a
+        // refusal, not a route that resolves nothing for anybody.
+        var (ownStatus, ownBody) = await GetRaw($"missions/{aMission.MissionId}", _keyA);
+        Assert.Equal(HttpStatusCode.OK, ownStatus);
+        Assert.Contains("Kickoff with Ana and Ravi", ownBody);
+    }
+
+    [Fact]
+    public async Task A_created_mission_is_owned_by_its_creator_and_appears_for_nobody_else()
+    {
+        // The write side. A read-side filter alone would be a deferred leak: unattributed rows would keep
+        // accumulating behind it, which is how the shared store came to hold several accounts' missions.
+        var bMission = await CreateMission(_keyB, "written by B, owned by B");
+
+        var (_, aBody) = await GetRaw("missions", _keyA);
+        Assert.False(ContainsMission(aBody, bMission));
+
+        var (_, bBody) = await GetRaw("missions", _keyB);
+        Assert.True(ContainsMission(bBody, bMission));
+    }
+
+    [Fact]
+    public async Task Another_tenants_mission_cannot_be_named_as_a_parent()
+    {
+        // A parent is a reference INTO the mission set, so it resolves under the same scope as any other
+        // read. Otherwise the id would be a way to attach to - and imply the existence of - a record the
+        // caller cannot see.
+        var aMission = await CreateMission(_keyA, "A's root mission");
+
+        var resp = await PostMission(_keyB, new NewMissionRequest
+        {
+            MissionName = "B's child of A's mission",
+            ParentMissionId = aMission.MissionId,
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+
+        // The control: B nesting under its OWN mission is accepted, so the refusal above is about the
+        // owner and not about parents being rejected wholesale.
+        var bParent = await CreateMission(_keyB, "B's root mission");
+        var ok = await PostMission(_keyB, new NewMissionRequest
+        {
+            MissionName = "B's child of B's mission",
+            ParentMissionId = bParent.MissionId,
+        });
+        Assert.Equal(HttpStatusCode.Created, ok.StatusCode);
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The leak detector: does this payload contain THIS WHOLE RECORD? Structural rather than keyed on one
+    /// field, because the leak that got through #1017 got through precisely by not being keyed by the one
+    /// identifier the check knew about. Validated by
+    /// <see cref="The_leak_detector_itself_detects_a_leak_when_there_is_one"/> before any refusal here
+    /// relies on it.
+    /// </summary>
+    private static bool ContainsMission(string body, MissionDto mission) =>
+        Parse(body).Any(m => m.MissionId == mission.MissionId || m.MissionName == mission.MissionName);
+
+    private static List<MissionDto> Parse(string body) =>
+        JsonSerializer.Deserialize<List<MissionDto>>(body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new List<MissionDto>();
+
+    private async Task<MissionDto> CreateMission(string deviceKey, string name)
+    {
+        var resp = await PostMission(deviceKey, new NewMissionRequest { MissionName = name });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(dto);
+        return dto!;
+    }
+
+    private Task<HttpResponseMessage> PostMission(string deviceKey, NewMissionRequest body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "missions")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<(HttpStatusCode Status, string Body)> GetRaw(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        var resp = await _http.SendAsync(req);
+        return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+}
+
+/// <summary>
+/// The self-host control for #1039. Self-host is single-owner and is what the hosted partition must NOT
+/// change: one tenant, every mission its own, listed and resolvable exactly as before. Without this the
+/// partition could be "correct" by refusing the only user the product has.
+/// </summary>
+public sealed class MissionRouteSelfHostControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-1039-selfhost-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task The_single_owner_creates_lists_and_resolves_its_missions_unchanged()
+    {
+        var create = await _http.PostAsJsonAsync("missions",
+            new NewMissionRequest { MissionName = "Self-host mission" });
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+        var created = await create.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(created);
+
+        var list = await _http.GetFromJsonAsync<List<MissionDto>>("missions");
+        Assert.NotNull(list);
+        Assert.Contains(list!, m => m.MissionId == created!.MissionId);
+
+        var byId = await _http.GetFromJsonAsync<MissionDto>($"missions/{created!.MissionId}");
+        Assert.NotNull(byId);
+        Assert.Equal("Self-host mission", byId!.MissionName);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -231,11 +231,24 @@ internal static class GatewayEndpoints
         //   GET  /missions/{mid}  -> MissionDto | 404
         if (missions is not null)
         {
-            app.MapPost("/missions", (NewMissionRequest req) =>
+            app.MapPost("/missions", (NewMissionRequest req, HttpContext ctx) =>
             {
                 FileLog.Write($"[GatewayEndpoints] POST /missions: name=\"{req?.MissionName}\"");
                 if (req is null || string.IsNullOrWhiteSpace(req.MissionName))
                     return Results.BadRequest(new { error = "missionName is required" });
+
+                // #1039: stamp the CALLER's own tenant on the record at write time. A read-side filter
+                // alone would be a deferred leak - unattributed rows would keep accumulating behind it,
+                // which is exactly how the shared store came to hold several accounts' missions.
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
+
+                // A parent is a reference INTO the mission set, so it resolves under the same scope as any
+                // other read: naming another tenant's mission as a parent is not a way to reach it.
+                if (req.ParentMissionId is Guid parentId && missions.Get(tenant.Value, parentId) is null)
+                    return Results.BadRequest(new { error = $"unknown parent mission '{parentId}'" });
 
                 // Workflows mission (phase 4, issue #1771): a mission IS a run of the built-in
                 // "mission" workflow. The EXPECTED failure (mission workflow unrunnable) is checked
@@ -264,7 +277,7 @@ internal static class GatewayEndpoints
                     }
                 }
 
-                var mission = missions.Create(req.MissionName, req.ParentMissionId);
+                var mission = missions.Create(tenant.Value, req.MissionName, req.ParentMissionId);
                 var dto = ToMissionDto(mission);
                 if (workflowRuns is not null && missionWorkflowEnabled != false)
                 {
@@ -293,15 +306,33 @@ internal static class GatewayEndpoints
                 return Results.Json(dto, statusCode: StatusCodes.Status201Created);
             });
 
-            app.MapGet("/missions", () =>
-                Results.Json(missions.List().Select(ToMissionDto).ToList()));
+            // #1039: the list is the caller's OWN missions. It used to be missions.List() - every account's
+            // missions, served to every account, on one shared hosted store. A request that resolves to no
+            // tenant is DENIED (403), never served the Local partition.
+            app.MapGet("/missions", (HttpContext ctx) =>
+            {
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
 
-            app.MapGet("/missions/{mid}", (string mid) =>
+                return Results.Json(missions.List(tenant.Value).Select(ToMissionDto).ToList());
+            });
+
+            // #1039: resolve INSIDE the caller's own tenant. A mission id that belongs to another account
+            // answers 404 - the same answer as an id that does not exist - so an id cannot be probed for
+            // existence, let alone read.
+            app.MapGet("/missions/{mid}", (string mid, HttpContext ctx) =>
             {
                 if (!Guid.TryParse(mid, out var missionId))
                     return Results.BadRequest(new { error = "invalid mission id format" });
 
-                var mission = missions.Get(missionId);
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
+
+                var mission = missions.Get(tenant.Value, missionId);
                 return mission is null
                     ? Results.NotFound(new { error = "mission not found" })
                     : Results.Json(ToMissionDto(mission));

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -331,7 +331,11 @@ internal static class MachineEndpoints
             // here rather than forwarding it to a Director that no longer owns mission validation.
             if (req.MissionId is Guid spawnMissionId && missions is not null)
             {
-                var mission = missions.Get(spawnMissionId);
+                // #1039: resolve the mission in the CALLING tenant. This lookup was by bare id, so naming
+                // another account's mission id here stamped that account's mission NAME - free text a person
+                // typed - onto the caller's own session. It is the same disclosure GET /missions/{mid} was,
+                // reached through the spawn route instead, and the issue does not name it.
+                var mission = missions.Get(tenant, spawnMissionId);
                 if (mission is null)
                 {
                     FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: unknown mission {spawnMissionId}");

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -772,7 +772,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, at a Gateway-side file path
         // (CcStorage.Root(), the same location the cron and snooze stores use), NOT the Director's tool-config
         // missions.json. Reuses Core.Sessions.MissionStore unchanged.
-        Missions = new Core.Sessions.MissionStore(missionsPath ?? Path.Combine(CcStorage.Root(), "missions.json"));
+        //
+        // #1039: the store is partitioned by tenant, and the answer for rows written BEFORE it was differs by
+        // deployment. Self-host has exactly one tenant, so its existing missions are Local's and it keeps
+        // listing them unchanged. Hosted shares this one file across every account, so an unattributed row
+        // cannot be attributed after the fact and is quarantined - readable by nobody, left on disk. Decided
+        // from GatewayHostedMode.IsHosted, the same signal that picks the tenant context below.
+        Missions = new Core.Sessions.MissionStore(
+            missionsPath ?? Path.Combine(CcStorage.Root(), "missions.json"),
+            adoptUnattributedAs: GatewayHostedMode.IsHosted ? null : Core.Tenancy.TenantId.Local);
         StreamRegistry = new Streaming.GatewayStreamRegistry();
         InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
         _promptLog = new Prompts.GatewayPromptLog(promptLogPath);


### PR DESCRIPTION
Closes the live cross-tenant read on the hosted Gateway filed as devthrottle_internal #1039.

## What was serving

`GET /missions` called `missions.List()` - no tenant argument, no filter, no caller scope, behind
only the host-wide device-key gate. One hosted process serves every account out of one
`missions.json`, so every account was served every account's missions. Two accounts created minutes
apart through the public signup, sharing nothing, received **byte-identical** lists on
`sha256:8d38eb82...`. A mission name is free text a person typed; the observed sample carried a
customer project name and two people's first names.

`GET /missions/{mid}` resolved by bare id, and `POST /missions` wrote with no owner - which is how
the shared store came to hold several accounts' records in the first place.

## The fix

A `Mission` carries the tenant that created it, and `MissionStore` takes the tenant it is acting for
on every accessor. **There is deliberately no bare-id and no unscoped accessor left on the type**:
another tenant's record is unreachable because no method would return one, rather than because each
call site remembered to filter.

The routes resolve the caller's tenant from its authenticated device key - never from client input -
and deny (403) rather than fall back to the Local partition when none resolves. A foreign mission id
answers **404**, the same answer an unknown id gets, so an id cannot be probed for existence.

## A fourth leg the issue does not name

The mission-scoped spawn in `MachineEndpoints` looked `missions.Get(missionId)` up by bare id too, so
naming another account's mission id there stamped that account's mission **name** onto the caller's
own session. Same disclosure, reached through the spawn route instead. It is fixed here. A parent
mission id now resolves under the caller's scope for the same reason.

## Rows that predate the owner

They cannot be attributed after the fact, so the store never guesses:

* **Single-tenant install** (self-host, the Director): exactly one tenant by construction, so those
  rows are that tenant's. An existing install lists exactly what it listed before.
* **Shared store** (hosted): they belong to nobody - served to no one, resolvable by no one, and
  **left on disk rather than deleted**, so whoever holds the deployment can still inspect them.
  Removing them is a deployment action and is still open.

## The rest of #904's adjacent list, checked rather than assumed

#904 named six adjacent collections and recorded that nothing open covered them; that list was
carried nowhere, which is why this was predictable rather than surprising. Fixing only what #1039
names would repeat exactly that. Checked on `origin/main`:

| Route | State |
|---|---|
| `GET /missions` | **was unscoped - fixed here** |
| `GET /devices` | already scoped to the calling tenant |
| `GET /interrupted` | already scoped |
| `GET /launchers` | already scoped |
| `GET /diag/results` | already scoped, on both read and write |
| `GET /exes/list` | refused outright on hosted |

`/gateway/missions/notes` - the mission WHY, also free text - was checked too: it sits on the
database's global tenant filter and is partitioned.

## Proof

Assertions are **invariants** - every record served to a caller belongs to that caller - not "this
particular id is absent". An absence assertion is satisfied the moment an id changes shape, and
satisfied for free by a route that returns nothing to anybody. That is not hypothetical here: the
first cross-tenant check pointed at this surface looked for a *device id* in the response, and a
mission is not keyed by one, so it passed while the box handed over the whole list.

* 8 store-level partition cases, 6 HTTP two-tenant cases over the real routes and real auth
  middleware, plus a self-host control proving the single-owner path is unchanged.
* Every refusal is paired with a **permitted request in the same test** - a Gateway refusing
  everybody would satisfy every refusal assertion here while being broken.
* `The_leak_detector_itself_detects_a_leak_when_there_is_one` points the same structural comparison
  at a record the caller genuinely owns and requires a positive. If it ever goes green by absence,
  the detector cannot tell a refusal from a success and no other case in the file means anything.
* **Revert-proved both levels.** Restoring the unscoped accessors turns 3 of the 5 HTTP cases red;
  removing the ownership filter turns 5 of the 8 store cases red.

## What this does NOT prove

**The fix is not deployed.** At 2026-07-30T11:10Z the live service still reported
`{"status":"ok","version":"1.8.4","commit":"71f90ba"}` - the commit the leak was found on. This is a
claim about source code; the hosted release is a separate manual step, and the live claim needs the
two-tenant matrix re-run against the new digest afterwards.

The matrix is extended for that run in `devthrottle_internal` (`docs/qa/runs/2026-07-30-TEN2/`):
`/missions` is promoted from a supplementary probe to a **graded family** bound by the same validity
gates, the harness self-test gains a second probe on the mission refusal, and an offline mutation
test shows the family goes red against a leaking Gateway and green against a partitioned one.
