### PR TITLE
Say when the fleet list is not the whole fleet

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -405,7 +405,14 @@ internal static class ControlEndpoints
         // omits cannot be named, so it cannot be interrupted, messaged or marked done. Issue #1019 - a card
         // that no tool could remove, with restarting the Director as the only remedy - was two independent
         // omissions from this one list.
-        app.MapGet("/fleet/sessions", async (CancellationToken ct) =>
+        //
+        // Issue #1051 - the other end of the same defect. The relayed roster DROPS an unreachable Director's
+        // sessions and still answers 200, so a caller cannot tell "that Director has no sessions" from "I
+        // could not reach it": absent reads identical to empty. `?envelope=true` answers with the roster AND
+        // a finished completeness verdict, so a caller that must not mistake a partial list for a whole one
+        // can say so. The bare array stays the default, because a Director that has not restarted yet still
+        // serves the old shape and the tools must keep working against it.
+        app.MapGet("/fleet/sessions", async (bool? envelope, CancellationToken ct) =>
         {
             // Omission one: EVERY session this Director is still holding belongs on the roster, including
             // crashed and exited-pending-reap rows. This store is the same store the desktop rail renders,
@@ -424,7 +431,6 @@ internal static class ControlEndpoints
             {
                 try
                 {
-                    var fleet = await gw.ListFleetSessionsAsync(ct);
                     // Omission two: the relayed list silently DROPS the sessions of a Director the Gateway
                     // cannot reach while still returning 200 (see GatewayClient.ListFleetSessionsAsync).
                     // A Director whose registration is failing therefore vanishes from its OWN fleet
@@ -433,10 +439,47 @@ internal static class ControlEndpoints
                     // authority on its own machine, so its rows go back in. The Gateway's copy WINS for any
                     // session it already knows: the session numbers and identity stamping it hands out are
                     // never overwritten here.
+                    //
+                    // Read posture, NOT the reaper's. The strict ListFleetSessionsWithReachabilityAsync throws
+                    // when the Gateway cannot vouch for completeness, which is correct for something that
+                    // deletes directories and wrong here: it would take `session list`, every target resolve,
+                    // cc-status and cc-history down against a version-skewed Gateway. This one returns null
+                    // reachability for "the Gateway did not say" and still serves the rows.
+                    var (fleet, reachability) = await gw.ReadFleetSessionsWithOptionalReachabilityAsync(ct);
                     var (roster, restored) = UnionOwnSessions(fleet, own);
                     if (restored.Count > 0)
                         FileLog.Write($"[ControlEndpoints] /fleet/sessions: the Gateway roster omitted {restored.Count} of this Director's own session(s); served from the local store: {string.Join(", ", restored)}");
-                    return Results.Json(roster);
+
+                    if (envelope != true)
+                        return Results.Json(roster);
+
+                    // The verdict is FOLDED HERE, not in the client. A caller must never have to decide what
+                    // "offline" means for completeness - that is the Gateway-owns-ruling rule, and the reason
+                    // the desktop rail renders pushed display state verbatim. The tools print these strings.
+                    //
+                    // Null reachability means the Gateway would not say, so rosterComplete is reported as NULL
+                    // - explicitly UNKNOWN, never true. Coalescing unknown to complete here would rebuild the
+                    // exact defect this issue is about, one layer up: absent reading identical to empty.
+                    bool? complete = null;
+                    string? incompleteReason = null;
+                    if (reachability is not null)
+                    {
+                        var folded = RosterCompleteness.Fold(reachability);
+                        complete = folded.Complete;
+                        incompleteReason = folded.Reason;
+                    }
+                    else
+                    {
+                        FileLog.Write("[ControlEndpoints] /fleet/sessions?envelope=true: the Gateway supplied no reachability; reporting completeness as UNKNOWN");
+                    }
+
+                    return Results.Json(new
+                    {
+                        sessions = roster,
+                        directors = reachability,
+                        rosterComplete = complete,
+                        rosterIncompleteReason = incompleteReason,
+                    });
                 }
                 catch (Exception ex)
                 {
@@ -446,7 +489,19 @@ internal static class ControlEndpoints
                 }
             }
 
-            return Results.Json(own);
+            if (envelope != true)
+                return Results.Json(own);
+
+            // Standalone: this Director is the whole fleet and it can see all of itself, so the roster is
+            // complete by construction. Saying so positively matters - a caller that treats "no reachability
+            // reported" as "might be incomplete" would otherwise warn forever on a single-machine setup.
+            return Results.Json(new
+            {
+                sessions = own,
+                directors = Array.Empty<DirectorReachabilityDto>(),
+                rosterComplete = true,
+                rosterIncompleteReason = (string?)null,
+            });
         });
 
         // GET /fleet/repositories + /fleet/worktrees - the repository/worktree directory (#510 phase C).

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -265,6 +265,73 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         return (env.Sessions, env.Directors);
     }
 
+    /// <summary>
+    /// The roster plus reachability WHEN THE GATEWAY SUPPLIES IT, for a READING caller (issue #1051).
+    ///
+    /// Deliberately a separate method from <see cref="ListFleetSessionsWithReachabilityAsync"/> rather than a
+    /// flag on it, because the two differ in ERROR POSTURE and that posture is the whole value of the other
+    /// one. The worktree reaper DELETES directories, so for it "I cannot confirm the roster is complete" must
+    /// be fatal - it fails closed and throws. A read-only listing has the opposite duty: turning a
+    /// degraded-but-usable answer into a total failure would take `session list`, every target resolve,
+    /// cc-status and cc-history down against a version-skewed Gateway, which is a far worse outcome than
+    /// showing the roster and saying completeness is unknown. Reusing the strict method here would have done
+    /// exactly that; weakening the strict method would have quietly disarmed the reaper's guard.
+    ///
+    /// So: reachability is NULL when the Gateway did not supply it - an older Gateway that ignores the
+    /// envelope query and answers with the bare array, or one that omits the field. Null means UNKNOWN and
+    /// callers must not read it as "complete"; that is the same absent-is-not-empty distinction this issue
+    /// exists to fix. A transport failure or a non-2xx is still a real failure and still throws.
+    /// </summary>
+    public async Task<(List<SessionDto> Sessions, List<DirectorReachabilityDto>? Reachability)>
+        ReadFleetSessionsWithOptionalReachabilityAsync(CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot list the fleet.");
+
+        FileLog.Write("[GatewayClient] ReadFleetSessionsWithOptionalReachabilityAsync: GET /sessions?envelope=true");
+        using var resp = await _http.GetAsync("sessions?envelope=true", ct);
+        if (!resp.IsSuccessStatusCode)
+            throw await RelayFailureAsync(resp, "GET /sessions?envelope=true", ct);
+
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        var parsed = ParseFleetBodyForDisplay(body);
+        FileLog.Write($"[GatewayClient] ReadFleetSessionsWithOptionalReachabilityAsync: {parsed.Sessions.Count} session(s), {(parsed.Reachability is null ? "NO" : parsed.Reachability.Count.ToString())} reachability record(s)");
+        return parsed;
+    }
+
+    /// <summary>
+    /// Split the /sessions body into rows plus OPTIONAL reachability, tolerating BOTH shapes the route can
+    /// answer with (issue #1051). Pure and separated from the request so the shape discrimination is
+    /// testable without a live Gateway - it is the part with a real failure mode, because an older Gateway
+    /// ignores the unknown envelope query parameter and answers with the plain array it always did.
+    ///
+    /// Reachability is null for "not supplied", which the caller must treat as UNKNOWN and never as complete.
+    /// A missing session list throws: that is a malformed answer, not a degraded one.
+    /// </summary>
+    internal static (List<SessionDto> Sessions, List<DirectorReachabilityDto>? Reachability)
+        ParseFleetBodyForDisplay(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            throw new InvalidOperationException("Gateway GET /sessions?envelope=true returned an empty body.");
+
+        using var doc = JsonDocument.Parse(body);
+
+        if (doc.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            var plain = JsonSerializer.Deserialize<List<SessionDto>>(body, JsonWebOptions) ?? new List<SessionDto>();
+            return (plain, null);
+        }
+
+        var env = JsonSerializer.Deserialize<SessionsEnvelope>(body, JsonWebOptions);
+        if (env?.Sessions is null)
+            throw new InvalidOperationException("Gateway GET /sessions?envelope=true omitted the session list.");
+
+        return (env.Sessions, env.Directors);
+    }
+
+    /// <summary>Web defaults (camelCase), matching what ReadFromJsonAsync uses elsewhere in this client.</summary>
+    private static readonly JsonSerializerOptions JsonWebOptions = new(JsonSerializerDefaults.Web);
+
     /// <summary>The /sessions?envelope=true response shape: the roster plus per-Director reachability.</summary>
     private sealed class SessionsEnvelope
     {

--- a/src/CcDirector.Core.Tests/RosterCompletenessFoldTests.cs
+++ b/src/CcDirector.Core.Tests/RosterCompletenessFoldTests.cs
@@ -1,0 +1,158 @@
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Issue #1051 - the other end of #1019's defect. The Gateway drops an unreachable Director's sessions from
+/// the roster and STILL ANSWERS 200, so a caller cannot tell "that Director has no sessions" from "I could
+/// not reach that Director": absent reads identical to empty. Since the roster is what every command line
+/// verb resolves a target against, a session on an unreachable machine is unnameable - the same failure
+/// #1019 fixed, one machine over.
+///
+/// These pin the fold that turns reachability into a verdict a tool prints verbatim. It lives in
+/// Gateway.Contracts beside SessionOrdering, not in each tool, because deciding what a reachability state
+/// MEANS is ruling rather than rendering, and three tools each deciding for themselves would drift.
+/// Testing it from here rather than Gateway.Tests is deliberate: it is a pure fold with no host, so it
+/// does not belong behind that suite's machine-wide serialisation lock.
+///
+/// The distinction that carries the whole design: OFFLINE drops a Director's sessions, so rows really are
+/// missing. WOBBLY does not - it is inside the grace window and its last-known-good sessions are still
+/// served, so the roster is whole and merely part-stale. Warning on wobbly would put a caveat on the most
+/// frequently run command in the tool for a case where nothing is missing, which trains the reader to
+/// ignore it - and then it is not there when offline finally happens.
+/// </summary>
+public sealed class RosterCompletenessFoldTests
+{
+    private static DirectorReachabilityDto R(
+        string state, string machine = "MACHINE_B", string id = "d2",
+        double? ageSeconds = null, string? error = null, DateTime? lastSeen = null)
+        => new()
+        {
+            DirectorId = id,
+            MachineName = machine,
+            State = state,
+            LastSeenAgeSeconds = ageSeconds,
+            LastSeenUtc = lastSeen,
+            Error = error,
+        };
+
+    [Fact]
+    public void AllOnline_isComplete_withNothingToSay()
+    {
+        var (complete, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateOnline, "MACHINE_A", "d1"),
+            R(DirectorReachabilityDto.StateOnline, "MACHINE_B", "d2"),
+        });
+
+        Assert.True(complete);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public void AnOfflineDirector_makesTheRosterIncomplete_andIsNamed()
+    {
+        // The reported shape. The caller must be able to say WHICH machine it could not see, because
+        // "give up, the session is gone" and "go and look at MACHINE_B" are opposite next steps.
+        var (complete, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateOnline, "MACHINE_A", "d1"),
+            R(DirectorReachabilityDto.StateOffline, "MACHINE_B", "d2", ageSeconds: 240, error: "director not connected to the tunnel"),
+        });
+
+        Assert.False(complete);
+        Assert.NotNull(reason);
+        Assert.Contains("MACHINE_B", reason);
+        Assert.Contains("missing from this list", reason);
+        Assert.Contains("director not connected to the tunnel", reason);
+        Assert.Contains("4m", reason);                        // the age, so "how stale" is answerable
+        Assert.DoesNotContain("MACHINE_A", reason);           // a reachable Director is never blamed
+    }
+
+    [Fact]
+    public void AWobblyDirector_isNOTreportedIncomplete_becauseItsSessionsAreStillServed()
+    {
+        // The load-bearing distinction. Wobbly keeps serving last-known-good rows, so nothing is missing
+        // and there is nothing to warn about. If this ever flips to incomplete, `session list` grows a
+        // permanent caveat on a healthy fleet and the warning stops meaning anything.
+        var (complete, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateWobbly, "MACHINE_B", "d2", ageSeconds: 12, error: "one poll missed"),
+        });
+
+        Assert.True(complete);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public void SeveralOfflineDirectors_areAllNamed_andCountedPlurally()
+    {
+        var (complete, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateOffline, "MACHINE_B", "d2"),
+            R(DirectorReachabilityDto.StateOffline, "MACHINE_C", "d3"),
+        });
+
+        Assert.False(complete);
+        Assert.Contains("2 Directors", reason);
+        Assert.Contains("MACHINE_B", reason);
+        Assert.Contains("MACHINE_C", reason);
+    }
+
+    [Fact]
+    public void OneOfflineDirector_readsSingular()
+    {
+        var (_, reason) = RosterCompleteness.Fold(new[] { R(DirectorReachabilityDto.StateOffline) });
+        Assert.Contains("1 Director could not be reached", reason);
+    }
+
+    [Fact]
+    public void ADirectorNeverReached_saysSo_ratherThanClaimingAnAge()
+    {
+        // No last-seen at all is different from "last seen a while ago", and inventing an age would be
+        // a fabricated number. Say "never reached".
+        var (complete, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateOffline, ageSeconds: null, lastSeen: null),
+        });
+
+        Assert.False(complete);
+        Assert.Contains("never reached", reason);
+    }
+
+    [Fact]
+    public void AnOfflineDirectorWithNoMachineName_fallsBackToItsId_soItIsStillIdentifiable()
+    {
+        var (_, reason) = RosterCompleteness.Fold(new[]
+        {
+            R(DirectorReachabilityDto.StateOffline, machine: "", id: "director-7"),
+        });
+
+        Assert.Contains("director-7", reason);
+    }
+
+    [Fact]
+    public void NoReachabilityReported_isTreatedAsComplete()
+    {
+        // The standalone floor: no Gateway, so no other Director can be hiding anything. An empty list
+        // here must NOT read as "might be incomplete", or a single-machine setup warns forever.
+        Assert.True(RosterCompleteness.Fold(Array.Empty<DirectorReachabilityDto>()).Complete);
+        Assert.True(RosterCompleteness.Fold(null).Complete);
+    }
+
+    [Fact]
+    public void StateMatching_isCaseInsensitive()
+    {
+        var (complete, _) = RosterCompleteness.Fold(new[] { R("OFFLINE") });
+        Assert.False(complete);
+    }
+
+    [Theory]
+    [InlineData(30, "30s")]
+    [InlineData(89, "89s")]
+    [InlineData(240, "4m")]
+    [InlineData(7200, "2h")]
+    public void Age_readsInTheCoarsestUsefulUnit(double seconds, string expected)
+        => Assert.Equal(expected, RosterCompleteness.DescribeAge(seconds));
+}

--- a/src/CcDirector.Gateway.Contracts/RosterCompleteness.cs
+++ b/src/CcDirector.Gateway.Contracts/RosterCompleteness.cs
@@ -1,0 +1,72 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Issue #1051: turn per-Director reachability into a COMPLETENESS VERDICT, in words a client prints
+/// verbatim.
+///
+/// The defect this exists for: the Gateway drops an unreachable Director's sessions from the roster and
+/// still answers 200, so a caller cannot tell "that Director has no sessions" from "I could not reach that
+/// Director". Absent reads identical to empty. Because the roster is what every command line verb resolves
+/// a target against, a session on an unreachable machine is unnameable - the same failure #1019 fixed for
+/// a crashed session, one machine over.
+///
+/// It lives HERE, beside <see cref="SessionOrdering"/>, for the same reason that does: deciding what a
+/// state MEANS is the single fold, and a client that rules for itself renders something plausible the
+/// moment it meets a state it did not expect. Three command line tools resolve against this roster, and
+/// three copies of this judgement would drift; one cannot.
+/// </summary>
+public static class RosterCompleteness
+{
+    /// <summary>
+    /// Whether the roster is the whole fleet, and if not, why - as a finished sentence.
+    ///
+    /// ONLY <see cref="DirectorReachabilityDto.StateOffline"/> counts as incomplete, and that distinction
+    /// carries the whole design. An offline Director has had its sessions DROPPED, so rows really are
+    /// missing. A <see cref="DirectorReachabilityDto.StateWobbly"/> one is inside the grace window and its
+    /// last-known-good sessions are STILL SERVED, so the roster is whole and merely part-stale. Reporting
+    /// wobbly as incomplete would put a caveat on the most frequently run command in the tool for a case
+    /// where nothing is missing - which teaches the reader to skip it, and then it is not read on the day
+    /// offline finally happens.
+    ///
+    /// An empty or absent list is COMPLETE, not unknown: that is the standalone floor, where there is no
+    /// Gateway and no other Director that could be hiding anything.
+    /// </summary>
+    public static (bool Complete, string? Reason) Fold(IReadOnlyList<DirectorReachabilityDto>? reachability)
+    {
+        if (reachability is null || reachability.Count == 0)
+            return (true, null);
+
+        var offline = reachability
+            .Where(r => string.Equals(r.State, DirectorReachabilityDto.StateOffline, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (offline.Count == 0)
+            return (true, null);
+
+        var named = offline.Select(r =>
+        {
+            var who = !string.IsNullOrWhiteSpace(r.MachineName) ? r.MachineName : r.DirectorId;
+            if (string.IsNullOrWhiteSpace(who))
+                who = "an unidentified Director";
+            // "never reached" and "last seen a while ago" are different facts, and inventing an age for
+            // the first would be a fabricated number. Say which one it is.
+            var age = r.LastSeenAgeSeconds is double secs and > 0
+                ? $", last seen {DescribeAge(secs)} ago"
+                : r.LastSeenUtc is null ? ", never reached" : "";
+            var why = !string.IsNullOrWhiteSpace(r.Error) ? $": {r.Error}" : "";
+            return $"{who}{age}{why}";
+        });
+
+        var count = offline.Count == 1
+            ? "1 Director could not be reached"
+            : $"{offline.Count} Directors could not be reached";
+        return (false, $"{count}, so its sessions are missing from this list - {string.Join("; ", named)}");
+    }
+
+    /// <summary>A coarse, human age for a last-seen gap. Deliberately vague - the precision is not the point.</summary>
+    public static string DescribeAge(double seconds)
+    {
+        if (seconds < 90) return $"{Math.Round(seconds)}s";
+        if (seconds < 5400) return $"{Math.Round(seconds / 60)}m";
+        return $"{Math.Round(seconds / 3600)}h";
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FleetBodyShapeToleranceTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetBodyShapeToleranceTests.cs
@@ -1,0 +1,104 @@
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1051. The Director now asks the Gateway for the reachability envelope so it can tell its command
+/// line callers whether the roster is the whole fleet. An OLDER Gateway ignores the unknown envelope query
+/// parameter and answers with the plain session array it always did - the hosted Gateway is deployed
+/// separately from the desktop app, so a newer Director meeting an older Gateway is an ordinary state, not
+/// an exotic one.
+///
+/// That is a real failure mode and it was nearly shipped as one: the first cut of this change reused
+/// <c>ListFleetSessionsWithReachabilityAsync</c>, which FAILS CLOSED and throws when the Gateway cannot
+/// vouch for completeness. That posture is correct for its own caller, the worktree reaper, which deletes
+/// directories - and catastrophic here, where it would have turned `session list`, every target resolve,
+/// cc-status and cc-history into a 502 against a version-skewed Gateway. Two callers, two postures, and
+/// these tests pin the reading one.
+///
+/// Null reachability means UNKNOWN, and the point of the whole issue is that unknown must never be read as
+/// complete: absent is not empty.
+/// </summary>
+public sealed class FleetBodyShapeToleranceTests
+{
+    [Fact]
+    public void TheEnvelopeShape_yieldsRowsAndReachability()
+    {
+        const string body = """
+        {
+          "sessions": [ { "sessionId": "aaaa", "name": "one" } ],
+          "directors": [ { "directorId": "d2", "machineName": "MACHINE_B", "state": "offline" } ]
+        }
+        """;
+
+        var (sessions, reachability) = GatewayClient.ParseFleetBodyForDisplay(body);
+
+        Assert.Single(sessions);
+        Assert.Equal("aaaa", sessions[0].SessionId);
+        Assert.NotNull(reachability);
+        Assert.Single(reachability!);
+        Assert.Equal("MACHINE_B", reachability![0].MachineName);
+        Assert.Equal("offline", reachability[0].State);
+    }
+
+    [Fact]
+    public void ThePlainArrayShape_fromAnOlderGateway_yieldsRowsAndUNKNOWNreachability()
+    {
+        // The compatibility case. The rows must still be served - refusing them would break every verb -
+        // and reachability must come back NULL so the caller reports completeness as unknown rather than
+        // claiming a completeness nobody vouched for.
+        const string body = """[ { "sessionId": "aaaa", "name": "one" }, { "sessionId": "bbbb" } ]""";
+
+        var (sessions, reachability) = GatewayClient.ParseFleetBodyForDisplay(body);
+
+        Assert.Equal(2, sessions.Count);
+        Assert.Null(reachability);
+    }
+
+    [Fact]
+    public void AnEnvelopeWithoutReachability_isUNKNOWN_notComplete()
+    {
+        // A version-skewed Gateway can answer the envelope shape while omitting the reachability array.
+        // Absent is not empty: an empty array would be an authoritative "no Directors are unreachable",
+        // and this is "it did not say".
+        const string body = """{ "sessions": [ { "sessionId": "aaaa" } ] }""";
+
+        var (sessions, reachability) = GatewayClient.ParseFleetBodyForDisplay(body);
+
+        Assert.Single(sessions);
+        Assert.Null(reachability);
+    }
+
+    [Fact]
+    public void AnEmptyReachabilityArray_isPreserved_asAnAuthoritativeNothingUnreachable()
+    {
+        // The other half of the distinction above, and the reason it cannot be collapsed: present-but-empty
+        // is a positive statement that the whole fleet was reachable.
+        const string body = """{ "sessions": [], "directors": [] }""";
+
+        var (sessions, reachability) = GatewayClient.ParseFleetBodyForDisplay(body);
+
+        Assert.Empty(sessions);
+        Assert.NotNull(reachability);
+        Assert.Empty(reachability!);
+    }
+
+    [Fact]
+    public void AnEnvelopeWithNoSessionList_throws_becauseThatIsMalformedNotDegraded()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => GatewayClient.ParseFleetBodyForDisplay("""{ "directors": [] }"""));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnEmptyBody_throws_ratherThanReadingAsAnEmptyFleet(string? body)
+    {
+        // An empty body is a broken answer. Treating it as "no sessions" would be the same class of error
+        // this whole issue is about - reporting absence as emptiness.
+        Assert.Throws<InvalidOperationException>(() => GatewayClient.ParseFleetBodyForDisplay(body));
+    }
+}

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -85,26 +85,41 @@ def _repo_name(repo: str) -> str:
     return repo.replace("\\", "/").rstrip("/").split("/")[-1] if repo else "-"
 
 
-def _get_sessions() -> List[Dict[str, Any]]:
+def _get_fleet() -> Tuple[List[Dict[str, Any]], Optional[bool], Optional[str]]:
+    """The fleet roster and its completeness verdict, with this tool's error posture (issue #1051).
+
+    The fetch itself is shared (director.get_fleet) so the three tools that resolve a target against
+    this roster cannot drift; only the "print and exit" behaviour is local.
+    """
     try:
-        sessions = director.get_json("fleet/sessions") or []
+        return director.get_fleet()
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
-    return sessions
+
+
+def _roster_caveat(complete: Optional[bool], reason: Optional[str]) -> str:
+    return director.roster_caveat(complete, reason)
 
 
 def _resolve_target(target: str, *, command_name: str) -> Dict[str, Any]:
-    sessions = _get_sessions()
+    sessions, complete, reason = _get_fleet()
     # Issue #821: the shared resolver now understands the three-digit session number (#820) as a
     # first-class target, preferring it over id-prefix / name matching, so message send / ask and
     # session rename all address a session by its number through this one call.
     matches = director.resolve_target(sessions, target)
     if not matches:
+        # Issue #1051: this is where a dropped Director does its real damage. "No session matches"
+        # reads as "that session does not exist", and for a session on a machine the Gateway could
+        # not reach that is simply false - the roster we searched never contained it. Say which we
+        # mean, because the two call for opposite next steps: give up, or go and look at machine B.
         console.print(
             f"[red]No session matches '{target}'.[/red] "
             "Run cc-devthrottle session list to see the fleet."
         )
+        caveat = _roster_caveat(complete, reason)
+        if caveat:
+            console.print(f"[yellow]The fleet list searched may be incomplete.[/yellow] {caveat}")
         raise typer.Exit(1)
     if len(matches) > 1:
         console.print(f"[yellow]'{target}' is ambiguous - {len(matches)} matches:[/yellow]")
@@ -135,16 +150,29 @@ def resolve_target_or_current(target: Optional[str]) -> str:
 
 def list_sessions(json_output: bool) -> None:
     """List every session running across the fleet."""
-    sessions = _get_sessions()
+    sessions, complete, reason = _get_fleet()
+    caveat = _roster_caveat(complete, reason)
 
     if json_output:
         # Plain print, not console.print: Rich wraps to 80 columns when stdout is not a TTY and
         # injects newlines into long values, producing invalid JSON for agents/pipes.
         print(json.dumps(sessions, indent=2))
+        # Issue #1051: the caveat goes to STDERR, never stdout. The shape of this output is depended
+        # on by agents and pipes, so it stays a bare array - but a caller acting on a partial roster
+        # still has to be told, and stderr reaches a human without corrupting the parse.
+        if caveat:
+            print(f"WARNING: the fleet list may be incomplete. {caveat}", file=sys.stderr)
         return
 
     if not sessions:
-        console.print("No sessions are running in the fleet.")
+        # Issue #1051, the worst sentence in the tool. "No sessions are running in the fleet" is a
+        # claim about the WHOLE FLEET, and an empty roster with an unreachable Director does not
+        # support it - the sessions may be running perfectly well on the machine we could not read.
+        # Absent is not empty, and only one of the two is worth saying out loud.
+        if caveat:
+            console.print(f"[yellow]No sessions were returned, but this is not the whole fleet.[/yellow] {caveat}")
+        else:
+            console.print("No sessions are running in the fleet.")
         return
 
     table = Table(show_header=True, header_style="bold", box=box.ASCII)
@@ -178,6 +206,10 @@ def list_sessions(json_output: bool) -> None:
         table.add_row(number_text, director.short_id(sid) + marker, name, machine, _repo_name(repo), status)
 
     console.print(table)
+    # Issue #1051: printed AFTER the table, so the rows the reader can trust come first and the
+    # qualification lands on what they have just read rather than being scrolled past above it.
+    if caveat:
+        console.print(f"[yellow]This is not the whole fleet.[/yellow] {caveat}")
 
 
 def whoami() -> None:
@@ -191,7 +223,10 @@ def whoami() -> None:
         raise typer.Exit(1)
 
     short = director.short_id(sid)
-    sessions = _get_sessions()
+    # Completeness is deliberately ignored here: whoami looks up THIS session, which lives on the
+    # Director being asked, and a Director always reports its own sessions (issue #1019). An
+    # unreachable Director elsewhere cannot hide the caller from itself.
+    sessions, _, _ = _get_fleet()
     me = next(
         (s for s in sessions if director.field(s, "sessionId", "SessionId").lower() == sid.lower()),
         None,
@@ -671,7 +706,11 @@ def _spawn_selftest(repo: str, command_args: str, name: str) -> str:
 
 
 def _fleet_ids() -> List[str]:
-    sessions = director.get_json("fleet/sessions") or []
+    # Goes through the one shared fetch so the selftest reads the same roster every verb does. The
+    # sessions it checks for are the ones it just spawned on THIS Director, which always reports its
+    # own (issue #1019), so completeness cannot hide them - but reading a different route than the
+    # rest of the tool is how a selftest ends up passing on a roster nobody else sees.
+    sessions, _, _ = director.get_fleet()
     return [director.field(s, "sessionId", "SessionId") for s in sessions]
 
 

--- a/tools/cc-devthrottle/tests/test_roster_completeness.py
+++ b/tools/cc-devthrottle/tests/test_roster_completeness.py
@@ -1,0 +1,214 @@
+"""Tests for issue #1051: the command line never presents a partial roster as the whole fleet.
+
+The Gateway drops an unreachable Director's sessions and still answers 200, so a short roster is
+indistinguishable from a complete one. Three sentences in these tools were flatly false in that state:
+
+  * "No session matches '<id>'" - it may exist perfectly well on the machine we could not read.
+  * "No sessions are running in the fleet" - a claim about the whole fleet from a partial list.
+  * "(no sessions running)" - the same claim in cc-status.
+
+Each reads as a fact about the world and was only ever a fact about the bytes that arrived. The two
+readings call for opposite next steps - give up, or go and look at that machine - which is exactly why
+the difference has to be said out loud.
+
+The verdict itself is folded on the Director (ControlEndpoints.FoldRosterCompleteness) and rendered
+here verbatim. These tests pin the rendering and the three-state handling, not the ruling.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cc_shared import director  # noqa: E402
+from src import session_ops  # noqa: E402
+
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+OFFLINE_REASON = "1 Director could not be reached, so its sessions are missing from this list - MACHINE_B, last seen 4m ago"
+
+
+@pytest.fixture
+def fleet(monkeypatch):
+    """Serve a chosen roster and completeness verdict, with no real HTTP."""
+
+    def serve(sessions, complete, reason=None):
+        monkeypatch.delenv("CC_SESSION_ID", raising=False)
+        monkeypatch.setattr(session_ops, "_get_fleet", lambda: (sessions, complete, reason))
+
+    return serve
+
+
+def _row():
+    return {"sessionId": SESSION_ID, "name": "worker", "machineName": "MACHINE_A",
+            "repoPath": r"D:\repo", "activityState": "Working"}
+
+
+# ===== the caveat itself: three states, and absent is not complete =====
+
+def test_a_complete_roster_says_nothing_extra():
+    assert director.roster_caveat(True, None) == ""
+
+
+def test_an_incomplete_roster_reports_the_directors_own_reason():
+    assert director.roster_caveat(False, OFFLINE_REASON) == OFFLINE_REASON
+
+
+def test_an_incomplete_roster_with_no_reason_still_warns():
+    # Never go silent just because the reason was missing - incomplete is the load-bearing fact.
+    assert "incomplete" in director.roster_caveat(False, None)
+
+
+def test_an_unknown_verdict_is_not_treated_as_complete():
+    # THE POINT OF THE WHOLE ISSUE, applied to ourselves. A Director that has not restarted since this
+    # was added serves the bare array and cannot vouch either way. Reading that silence as "complete"
+    # would rebuild the exact defect being fixed: absent reading identical to empty.
+    caveat = director.roster_caveat(None, None)
+    assert caveat != ""
+    assert "cannot confirm" in caveat
+
+
+# ===== "no session matches" must not imply "it does not exist" =====
+
+def test_failed_resolve_on_an_incomplete_roster_says_the_list_may_be_short(fleet, capsys):
+    fleet([], False, OFFLINE_REASON)
+
+    with pytest.raises(typer.Exit):
+        session_ops._resolve_target("abc123", command_name="cc-devthrottle session done")
+
+    out = capsys.readouterr().out
+    assert "No session matches" in out
+    assert "may be incomplete" in out
+    assert "MACHINE_B" in out        # names the machine to go and look at
+
+
+def test_failed_resolve_on_a_complete_roster_stays_terse(fleet, capsys):
+    # The counterpart: when the Director vouches for the roster, "no session matches" IS the whole truth
+    # and must not be padded with a hedge that would train the reader to ignore it.
+    fleet([], True, None)
+
+    with pytest.raises(typer.Exit):
+        session_ops._resolve_target("abc123", command_name="cc-devthrottle session done")
+
+    out = capsys.readouterr().out
+    assert "No session matches" in out
+    assert "may be incomplete" not in out
+
+
+# ===== "no sessions in the fleet" is a claim a partial list cannot support =====
+
+def test_empty_and_incomplete_does_not_claim_the_fleet_is_empty(fleet, capsys):
+    fleet([], False, OFFLINE_REASON)
+
+    session_ops.list_sessions(json_output=False)
+
+    out = capsys.readouterr().out
+    assert "not the whole fleet" in out
+    assert "No sessions are running in the fleet" not in out
+
+
+def test_empty_and_complete_still_says_the_fleet_is_empty(fleet, capsys):
+    fleet([], True, None)
+
+    session_ops.list_sessions(json_output=False)
+
+    assert "No sessions are running in the fleet" in capsys.readouterr().out
+
+
+def test_a_listed_roster_that_is_incomplete_is_qualified_after_the_table(fleet, capsys):
+    fleet([_row()], False, OFFLINE_REASON)
+
+    session_ops.list_sessions(json_output=False)
+
+    out = capsys.readouterr().out
+    assert "11111111" in out                 # the rows the reader can trust come first
+    assert "not the whole fleet" in out
+
+
+def test_a_listed_roster_that_is_complete_is_not_qualified(fleet, capsys):
+    fleet([_row()], True, None)
+
+    session_ops.list_sessions(json_output=False)
+
+    assert "not the whole fleet" not in capsys.readouterr().out
+
+
+# ===== the machine-readable path keeps its shape =====
+
+def test_json_output_stays_a_bare_array_and_warns_on_stderr(fleet, capsys):
+    # Agents and pipes parse stdout, so the shape must not change - but a caller acting on a partial
+    # roster still has to be told. stderr carries the warning without corrupting the parse.
+    import json
+
+    fleet([_row()], False, OFFLINE_REASON)
+
+    session_ops.list_sessions(json_output=True)
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)         # would raise if the warning had gone to stdout
+    assert isinstance(parsed, list)
+    assert parsed[0]["sessionId"] == SESSION_ID
+    assert "WARNING" in captured.err
+    assert "MACHINE_B" in captured.err
+
+
+def test_json_output_on_a_complete_roster_writes_nothing_to_stderr(fleet, capsys):
+    fleet([_row()], True, None)
+
+    session_ops.list_sessions(json_output=True)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# ===== the transport: an older Director cannot be mistaken for a vouching one =====
+
+def test_get_fleet_reads_the_envelope(monkeypatch):
+    monkeypatch.setattr(director, "get_json", lambda path: {
+        "sessions": [_row()],
+        "rosterComplete": False,
+        "rosterIncompleteReason": OFFLINE_REASON,
+    })
+
+    sessions, complete, reason = director.get_fleet()
+
+    assert len(sessions) == 1
+    assert complete is False
+    assert reason == OFFLINE_REASON
+
+
+def test_get_fleet_asks_for_the_envelope(monkeypatch):
+    seen = {}
+
+    def get_json(path):
+        seen["path"] = path
+        return {"sessions": [], "rosterComplete": True}
+
+    monkeypatch.setattr(director, "get_json", get_json)
+    director.get_fleet()
+
+    assert "envelope=true" in seen["path"]
+
+
+def test_get_fleet_tolerates_an_older_director_serving_a_bare_array(monkeypatch):
+    # A running Director is long-lived and the command line is invoked fresh, so a newer tool WILL meet
+    # an older Director. It must still work - and must report "cannot vouch", never "complete".
+    monkeypatch.setattr(director, "get_json", lambda path: [_row()])
+
+    sessions, complete, reason = director.get_fleet()
+
+    assert len(sessions) == 1
+    assert complete is None
+    assert reason is None
+
+
+def test_get_fleet_ignores_a_non_boolean_completeness_value(monkeypatch):
+    # A malformed field must degrade to "cannot vouch", not to a truthy string reading as complete.
+    monkeypatch.setattr(director, "get_json", lambda path: {"sessions": [], "rosterComplete": "yes"})
+
+    _, complete, _ = director.get_fleet()
+
+    assert complete is None

--- a/tools/cc-devthrottle/tests/test_session_compact.py
+++ b/tools/cc-devthrottle/tests/test_session_compact.py
@@ -29,8 +29,10 @@ def posted(monkeypatch):
         monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
         # An explicit target is resolved against the fleet roster; serve one rather than reaching for a
         # live Director.
-        monkeypatch.setattr(session_ops, "_get_sessions",
-                            lambda: [{"sessionId": SESSION_ID, "name": "stuck", "machineName": "M", "number": 114}])
+        # Patch the ONE fetch every resolve goes through. It reports the roster as complete, so these
+        # tests assert the compact verb and never trip over the incomplete-roster caveat (issue #1051).
+        monkeypatch.setattr(session_ops, "_get_fleet",
+                            lambda: ([{"sessionId": SESSION_ID, "name": "stuck", "machineName": "M", "number": 114}], True, None))
 
         def post_json(path, body, timeout=30):
             calls.append({"path": path, "body": body, "timeout": timeout})

--- a/tools/cc-history/src/cli.py
+++ b/tools/cc-history/src/cli.py
@@ -61,17 +61,20 @@ def _run(
 ) -> None:
     """Show the last N conversation messages of TARGET (works for Claude, Codex, and Pi sessions)."""
     try:
-        sessions = director.get_json("fleet/sessions") or []
+        sessions, complete, roster_reason = director.get_fleet()
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
 
     matches = director.resolve_target(sessions, target)
     if not matches:
-        console.print(
-            f"[red]No session matches '{target}'.[/red] "
-            "Run cc-devthrottle session list to see the fleet."
-        )
+        console.print(director.no_match_message(target))
+        # Issue #1051: an unreachable Director's sessions are dropped from the roster under a 200, so
+        # "no session matches" can mean "the list we searched never had it". Do not imply otherwise -
+        # "it does not exist" and "I could not see that machine" call for opposite next steps.
+        caveat = director.roster_caveat(complete, roster_reason)
+        if caveat:
+            console.print(f"[yellow]The fleet list searched may be incomplete.[/yellow] {caveat}")
         raise typer.Exit(1)
     if len(matches) > 1:
         console.print(f"[yellow]'{target}' is ambiguous - {len(matches)} matches.[/yellow] Use a longer id prefix.")

--- a/tools/cc-status/src/cli.py
+++ b/tools/cc-status/src/cli.py
@@ -40,23 +40,33 @@ def _run(
 ) -> None:
     """Show what fleet sessions are doing: activity state, agent, repo, and last status reason."""
     try:
-        sessions = director.get_json("fleet/sessions") or []
+        # Named roster_reason, not reason: the per-session loop below binds `reason` to a status reason.
+        sessions, complete, roster_reason = director.get_fleet()
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
+    # Issue #1051: an unreachable Director's sessions are dropped from the roster under a 200, so a
+    # short list looks exactly like a whole one. Everything below reports on what came back; this is
+    # what says whether that was the whole fleet.
+    caveat = director.roster_caveat(complete, roster_reason)
 
     if target.strip().lower() != "all":
         sessions = director.resolve_target(sessions, target)
         if not sessions:
-            console.print(
-                f"[red]No session matches '{target}'.[/red] "
-                "Run cc-devthrottle session list to see the fleet."
-            )
+            console.print(director.no_match_message(target))
+            # Not found, or not reached? The two call for opposite next steps, so never imply the first.
+            if caveat:
+                console.print(f"[yellow]The fleet list searched may be incomplete.[/yellow] {caveat}")
             raise typer.Exit(1)
 
     me = director.session_id()
     if not sessions:
-        console.print("(no sessions running)")
+        # "(no sessions running)" is a claim about the whole fleet that an incomplete roster cannot
+        # support - the sessions may be running fine on the machine we could not read (issue #1051).
+        if caveat:
+            console.print(f"[yellow](nothing came back, but this is not the whole fleet)[/yellow] {caveat}")
+        else:
+            console.print("(no sessions running)")
         return
 
     for s in sessions:
@@ -70,6 +80,9 @@ def _run(
         you = " [dim](you)[/dim]" if me and sid == me else ""
         console.print(f"[bold]{director.short_id(sid)}[/bold]{you}  {name}  [[cyan]{agent}[/cyan]]  [yellow]{state}[/yellow] - {reason}")
         console.print(f"    [dim]{machine}  {repo}[/dim]")
+
+    if caveat:
+        console.print(f"[yellow]This is not the whole fleet.[/yellow] {caveat}")
 
 
 def app() -> None:

--- a/tools/cc_shared/director.py
+++ b/tools/cc_shared/director.py
@@ -21,7 +21,7 @@ import os
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 class DirectorError(RuntimeError):
@@ -113,8 +113,52 @@ def delete(path: str, timeout: float = 30) -> Any:
     return _request("DELETE", path, None, timeout=timeout)
 
 
+def get_fleet() -> Tuple[List[Dict[str, Any]], Optional[bool], Optional[str]]:
+    """The fleet roster, plus whether the Director could vouch that it is COMPLETE (issue #1051).
+
+    The Gateway drops an unreachable Director's sessions and still answers 200, so a short roster is
+    indistinguishable from a whole one. Asking for the envelope returns the Director's folded verdict
+    alongside the rows; the verdict is computed there, never here, because deciding what a
+    reachability state MEANS is ruling and a client only renders.
+
+    Returns (sessions, complete, reason). `complete` is None for "the Director did not say" - and
+    None is NOT True: a Director that has not restarted since this was added still serves the bare
+    array, and reading its silence as a guarantee would reinstate the very defect this closes.
+
+    Lives here, not in one tool, because three tools resolve a target against this roster and each
+    used to print "No session matches" with no idea the list might be short. Three copies of that
+    judgement would drift; one cannot.
+    """
+    body = get_json("fleet/sessions?envelope=true") or []
+    if isinstance(body, list):
+        return body, None, None
+    sessions = body.get("sessions") or []
+    complete = body.get("rosterComplete")
+    reason = body.get("rosterIncompleteReason")
+    return sessions, (complete if isinstance(complete, bool) else None), reason
+
+
+def roster_caveat(complete: Optional[bool], reason: Optional[str]) -> str:
+    """The sentence to add when the roster might not be the whole fleet. Empty when it is (#1051)."""
+    if complete is True:
+        return ""
+    if complete is False:
+        return reason or "Part of the fleet could not be reached, so this list may be incomplete."
+    return "This Director cannot confirm the roster is complete, so a session may be missing from it."
+
+
+def no_match_message(target: str) -> str:
+    """The shared 'no session matches' line, so the three tools cannot drift on the wording."""
+    return (f"[red]No session matches '{target}'.[/red] "
+            "Run cc-devthrottle session list to see the fleet.")
+
+
 def field(dto: Dict[str, Any], *keys: str, default: str = "") -> str:
-    """Read the first present key from a session DTO, tolerating camelCase or PascalCase."""
+    """Read the first present key from a session DTO, tolerating camelCase or PascalCase.
+
+    Returns a STRING always - so never use it to read a boolean: `str(False)` is `"False"`, which is
+    truthy, and every row would test true. Read booleans straight off the dict instead.
+    """
     for key in keys:
         if key in dto and dto[key] is not None:
             return str(dto[key])


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1051. Follows thefrederiksen/devthrottle#2289 (#1019), which fixed the local half of the same defect.

> `devthrottle#1051` in this repository is an unrelated issue, so the link is fully qualified deliberately.

## The defect

`GET /sessions` on the Gateway **drops an unreachable Director's sessions and still answers 200.** A caller holding that response cannot tell:

* "that Director has no sessions", from
* "I could not reach that Director, and its sessions are missing from what you are holding".

**Absent reads identical to empty.** A 200 with a short list looks exactly like a 200 with a whole one, and nothing in the response says which arrived.

That roster is what every `cc-devthrottle` verb resolves a target against, so this is #1019's consequence one machine over: a session on an unreachable machine cannot be **named**, and a session that cannot be named cannot be interrupted, messaged, or marked done.

Three sentences were flatly false in that state:

| Said | When the roster was short |
|---|---|
| `No session matches '<id>'` | It may exist perfectly well on the machine we could not read |
| `No sessions are running in the fleet` | A claim about the whole fleet, from a partial list |
| `(no sessions running)` (cc-status) | The same claim again |

Each reads as a fact about the world and was only ever a fact about the bytes that arrived — and the two readings call for opposite next steps: give up, or go and look at machine B.

## What changed

`GET /fleet/sessions?envelope=true` answers with the roster **and a finished completeness verdict**; the three tools print it. The bare array stays the default shape, because a Director that has not restarted yet still serves it.

**Only `offline` counts as incomplete**, and that distinction carries the design. An offline Director has had its sessions dropped, so rows really are missing. A `wobbly` one is inside the grace window with its last-known-good sessions still served — the roster is whole, merely part-stale. Reporting wobbly as incomplete would put a caveat on the most frequently run command in the tool for a case where nothing is missing, which teaches the reader to skip it, and then it goes unread on the day offline finally happens.

## Three things worth a reviewer's attention

**1. The verdict is folded in `Gateway.Contracts`, beside `SessionOrdering` — not in each tool.** Deciding what a reachability state *means* is ruling, not rendering. Three tools each deciding for themselves would drift, and a client that rules for itself renders something plausible the moment it meets a state it did not expect. The shared fetch and wording also moved into `cc_shared/director.py`, so the "No session matches" line has one definition instead of three copies.

**2. Unknown is a third state and is never collapsed into complete.** A Director that predates this change serves the bare array and cannot vouch either way. Reading that silence as a guarantee of completeness would rebuild this very defect one layer up, so the tools say they *cannot confirm* rather than implying all is well. This is a real case, not a hypothetical: a running Director is long-lived and the command line is invoked fresh, so a newer tool will meet an older Director.

**3. The read path deliberately does NOT reuse `ListFleetSessionsWithReachabilityAsync`, and this is the near-miss worth reading.** My first cut did reuse it. That method **fails closed** — it throws when the Gateway cannot vouch for completeness. That posture is correct for its own caller, the worktree reaper, which deletes directories. It is catastrophic for a listing: against a Gateway that ignores the envelope query (the hosted Gateway is deployed separately from the desktop app, so version skew is ordinary) it would have turned `session list`, every target resolve, `cc-status` and `cc-history` into a 502.

So there are now two methods with two explicit postures, and the strict one is untouched — weakening it would have quietly disarmed the reaper's guard, which is a worse outcome than the bug being fixed here.

## Proof

**Fail-on-purpose, both halves.** These were run as mutations of the shipped code, not as a description of what the tests would do:

*The wobbly/offline distinction* — making `wobbly` count as incomplete (the plausible-but-wrong implementation) is caught by exactly one test, the one that exists for it:
```
Failed RosterCompletenessFoldTests.AWobblyDirector_isNOTreportedIncomplete_becauseItsSessionsAreStillServed
Total tests: 13   Passed: 12   Failed: 1
```

*The caveat itself* — making `roster_caveat` always return empty (the pre-fix behaviour, where a partial roster looks whole) is caught by seven:
```
FAILED test_an_incomplete_roster_reports_the_directors_own_reason
FAILED test_an_incomplete_roster_with_no_reason_still_warns
FAILED test_an_unknown_verdict_is_not_treated_as_complete
FAILED test_failed_resolve_on_an_incomplete_roster_says_the_list_may_be_short
FAILED test_empty_and_incomplete_does_not_claim_the_fleet_is_empty
FAILED test_a_listed_roster_that_is_incomplete_is_qualified_after_the_table
FAILED test_json_output_stays_a_bare_array_and_warns_on_stderr
7 failed, 166 passed
```

**Green:** 13 fold tests and `173 passed` across `tools/cc-devthrottle` (157 before, plus 16 added).

The fold tests live in `Core.Tests` rather than `Gateway.Tests` on purpose: it is a pure fold with no host, so it does not belong behind that suite's machine-wide serialisation lock, and it can be run and re-run while other worktrees hold that lock.

`--json` output keeps its bare-array shape — agents and pipes parse it — and the warning goes to **stderr**, so a partial roster is still announced without corrupting the parse. There is a test asserting stdout still parses as JSON.

### Not yet proven

`CcDirector.Gateway.Tests` has not run locally: another session holds its per-user suite lock, and that lock never breaks for a live holder. `FleetBodyShapeToleranceTests` (the array-vs-envelope shape tolerance, item 3 above) therefore has CI as its first observer. I will post the CI result here pass or fail, and this should not merge before it lands.
