### PR TITLE
Assert what the user reads, not how Rich painted it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
   # PyPI. If a dependency is added this job fails loudly with a ModuleNotFoundError rather than
   # quietly skipping anything.
   #
-  # cc-devthrottle's OWN tests are deliberately not run here yet. Adding them was the first thing
-  # this job did, and it immediately found why they had never survived an unattended run: five of
-  # them assert plain substrings against Rich-STYLED output, so they pass on a plain console and
-  # fail wherever colour is on - which is what a CI runner is. That is a real defect in those tests
-  # and it gets its own change rather than being silenced here with a colour flag.
+  # cc-devthrottle's own tests run here too. Adding them was the first thing this job did, and it
+  # immediately found why they had never survived an unattended run: five asserted plain substrings
+  # against Rich-STYLED output, so they passed on a plain console and failed wherever colour is on -
+  # which is what a runner is. Those assertions now compare TEXT rather than rendering (#1082), and
+  # the suite is required to be green both with colour and without.
   tool-contracts:
     name: Tool contracts (Python)
     runs-on: windows-latest
@@ -136,3 +136,13 @@ jobs:
       # ASCII-only shipped source, and the Rich ASCII patches.
       - name: Run the shipped-tool contract guard
         run: python -m pytest tools/test_shipped_tools_contract.py -q
+
+      # cc-devthrottle is itself a shipped tool and the fleet's command surface; its own tests were
+      # equally unrun. Executed from the tool's directory because its tests import `src` directly.
+      # FORCE_COLOR is set deliberately: the defect these tests carried only appears when Rich
+      # styles its output, so running them the safe way would re-hide exactly what this job caught.
+      - name: Run the cc-devthrottle tests
+        working-directory: tools/cc-devthrottle
+        env:
+          FORCE_COLOR: "1"
+        run: python -m pytest tests/ -q

--- a/tools/cc-devthrottle/tests/conftest.py
+++ b/tools/cc-devthrottle/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared helpers for the cc-devthrottle tests.
+
+WHY THIS EXISTS. These tests drive the command-line surface through Typer's CliRunner and then
+assert on what the user would read: that `--subject` is offered, that a summary says "900
+directories", that an error message survives intact. Rich renders that output with STYLE, so the
+captured text carries ANSI escape sequences threaded through it, and a plain `in` check against a
+styled string can miss a substring that is plainly on the screen:
+
+    assert '--subject' in '\x1b[1m ... \x1b[0m\x1b[1;36m--subject\x1b[0m ...'   # False
+
+Whether styling is on depends on the environment, not on the code under test. Locally, with output
+captured to a buffer, Rich usually renders plain and the assertions pass; on a continuous
+integration runner colour is on and they fail. Five of these tests had never been run anywhere but
+a developer's console, so nobody had seen it (issue #1082, found by the job added in #1077).
+
+The fix is to assert against the TEXT rather than the rendering. `plain` strips the escape
+sequences, so the assertion means the same thing wherever it runs. It deliberately does not turn
+colour off: forcing a plain console would make these particular tests pass while leaving the next
+one written the same way just as fragile, and it would depend on knowing exactly which environment
+variable a given runner uses to enable colour.
+"""
+
+import re
+
+import pytest
+
+# Control Sequence Introducer colour/style codes: ESC [ ... m. That is the whole of what Rich emits
+# for styling here; cursor movement and the like do not appear in captured CliRunner output.
+_ANSI_STYLE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Return `text` with ANSI style sequences removed, leaving what a reader actually sees."""
+    return _ANSI_STYLE.sub("", text)
+
+
+@pytest.fixture
+def plain():
+    """Strip ANSI styling from captured command output before asserting on it."""
+    return strip_ansi

--- a/tools/cc-devthrottle/tests/test_email_cli.py
+++ b/tools/cc-devthrottle/tests/test_email_cli.py
@@ -37,13 +37,16 @@ def test_owner_send_passes_subject_and_body():
     assert "Sent" in result.output
 
 
-def test_owner_has_no_recipient_option():
+def test_owner_has_no_recipient_option(plain):
     result = runner.invoke(app, ["email", "owner", "--help"])
     assert result.exit_code == 0
-    assert "--subject" in result.output
-    assert "--attach" in result.output
-    assert "--to" not in result.output
-    assert "--recipient" not in result.output
+    # Asserted against the text, not the rendering: Rich styles the help panel, so the raw capture
+    # threads escape sequences through the option names (see tests/conftest.py).
+    help_text = plain(result.output)
+    assert "--subject" in help_text
+    assert "--attach" in help_text
+    assert "--to" not in help_text
+    assert "--recipient" not in help_text
 
 
 def test_owner_requires_a_body_or_attachment():

--- a/tools/cc-devthrottle/tests/test_machine_ops.py
+++ b/tools/cc-devthrottle/tests/test_machine_ops.py
@@ -82,7 +82,7 @@ def test_apps_reports_an_incomplete_catalogue_rather_than_a_short_one(stub_get):
     assert "incomplete" in result.output
 
 
-def test_files_shows_the_hits_and_where_it_searched(stub_get):
+def test_files_shows_the_hits_and_where_it_searched(stub_get, plain):
     stub_get["payload"] = {
         "files": [{"name": "deck.pptx", "path": r"D:\Work\deck.pptx", "sizeBytes": 2048,
                    "modifiedUtc": "2026-07-01T10:00:00Z"}],
@@ -94,8 +94,10 @@ def test_files_shows_the_hits_and_where_it_searched(stub_get):
     result = runner.invoke(app, ["machine", "files", "SOREN_NORTH", "*.pptx"])
 
     assert result.exit_code == 0
-    assert "deck.pptx" in result.output
-    assert "900 directories" in result.output
+    # Rich styles the results table, so assert on the text rather than the rendering (conftest.py).
+    output = plain(result.output)
+    assert "deck.pptx" in output
+    assert "900 directories" in output
 
 
 def test_files_stopped_at_the_result_limit_says_so_and_says_what_to_change(stub_get):
@@ -129,7 +131,7 @@ def test_files_stopped_at_the_time_limit_advises_more_time_not_a_narrower_search
     assert "--seconds" in result.output
 
 
-def test_files_reports_directories_it_could_not_read(stub_get):
+def test_files_reports_directories_it_could_not_read(stub_get, plain):
     stub_get["payload"] = {
         "files": [], "truncated": False, "directoriesVisited": 5,
         "elapsedMilliseconds": 10, "unreadableDirectories": 42,
@@ -137,7 +139,7 @@ def test_files_reports_directories_it_could_not_read(stub_get):
 
     result = runner.invoke(app, ["machine", "files", "SOREN_NORTH", "*.txt"])
 
-    assert "42 directories could not be read" in result.output
+    assert "42 directories could not be read" in plain(result.output)
 
 
 def test_files_passes_the_time_limit_through_as_milliseconds(stub_get):

--- a/tools/cc-devthrottle/tests/test_session_buffer.py
+++ b/tools/cc-devthrottle/tests/test_session_buffer.py
@@ -76,7 +76,7 @@ def test_a_style_shaped_token_is_not_eaten(buffer_text, capsys):
     assert capsys.readouterr().out == text + "\n"
 
 
-def test_the_error_branch_does_not_crash_on_the_servers_error_text(buffer_text, monkeypatch, capsys):
+def test_the_error_branch_does_not_crash_on_the_servers_error_text(buffer_text, monkeypatch, capsys, plain):
     # The failure branch had the SAME defect as the success branch it reports on: the error text comes
     # from the server and can quote a path or a fragment of the session's own output, and it was
     # interpolated straight into Rich markup. A closing-tag-shaped token in it raised MarkupError - a
@@ -91,7 +91,7 @@ def test_the_error_branch_does_not_crash_on_the_servers_error_text(buffer_text, 
     with pytest.raises(typer.Exit):
         session_ops.read_session_buffer(None)
 
-    out = capsys.readouterr().out
+    out = plain(capsys.readouterr().out)
     assert "no session at [/tmp/x] on that Director" in out   # reported literally, not swallowed
     assert "Error:" in out                                     # and still human-readable
 

--- a/tools/cc-devthrottle/tests/test_session_compact.py
+++ b/tools/cc-devthrottle/tests/test_session_compact.py
@@ -151,7 +151,7 @@ def test_a_failure_is_reported_and_exits_nonzero(posted, monkeypatch, capsys):
     assert "director returned Timeout" in capsys.readouterr().out
 
 
-def test_a_bracketed_error_does_not_crash_the_verb(posted, monkeypatch, capsys):
+def test_a_bracketed_error_does_not_crash_the_verb(posted, monkeypatch, capsys, plain):
     # The server's error text can quote a path or a fragment of the session's own output. Interpolated
     # raw into Rich markup, a token like [/tmp/x] raises MarkupError out of the branch whose only job is
     # to explain a failure - the same defect already fixed for the buffer verb.
@@ -165,7 +165,7 @@ def test_a_bracketed_error_does_not_crash_the_verb(posted, monkeypatch, capsys):
     with pytest.raises(typer.Exit):
         session_ops.compact_session(None, "continue")
 
-    assert "no session at [/tmp/x] on that Director" in capsys.readouterr().out
+    assert "no session at [/tmp/x] on that Director" in plain(capsys.readouterr().out)
 
 
 def test_the_actions_are_discoverable_with_their_command_lines():


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1082.

**Stacked on #2300**, which adds the `Tool contracts (Python)` job this restores a step to. Review or merge that one first; until it lands, the diff here shows its commits too.

## What was wrong

Five cc-devthrottle tests asserted plain substrings against Rich-**styled** output - `"--subject"` in a help panel, `"900 directories"` in a results table, an error message quoted back. Rich threads ANSI escape sequences through that text, so an `in` check misses a substring that is plainly on the screen:

```
assert '--subject' in '\x1b[1m ... \x1b[1;36m--subject\x1b[0m ...'   ->  False
```

Whether styling is on is a property of the **environment**, not of the code under test. Captured to a buffer on a developer's console Rich usually renders plain and these passed; on a runner colour is on and they fail. They had never run anywhere but a console, so nobody had seen it - the same hole as the guard that found them (#1077): a suite nobody runs tells you nothing about whether it works.

## The fix, and the one I did not take

The assertions now compare **text**, through a `plain` fixture in a new `tests/conftest.py`.

I deliberately did **not** fix this by forcing colour off in the job. That would make these five pass while leaving the next test written the same way just as fragile, and it depends on knowing which variable a given runner uses to switch colour on - which I have not established, and did not want to guess at. Stripping the escapes is correct whatever the reason colour is on.

Two of the changed assertions are negative (`"--to" not in ...`). Those get **stronger**: a styled occurrence could previously have slipped past the check.

## The CI step comes back, running the harder condition

`FORCE_COLOR: "1"` is set on the restored step on purpose. Running these the safe way would re-hide exactly what the job caught, so CI now exercises the condition that failed rather than the one that passes.

## Proof

Green **both** ways, which had never been true before:

| condition | result |
|---|---|
| `FORCE_COLOR=1` (what CI now runs) | 157 passed |
| no colour | 157 passed |
| `tools/test_shipped_tools_contract.py` | 36 passed |

Run in a clean virtual environment holding only pytest, typer, rich and requests, so this does not lean on anything a particular machine happens to have.

And the assertions still discriminate - stripping escapes did not make them pass on anything. Changing one expectation to `"901 directories"` fails as it should:

```
with a deliberately WRONG expectation: 1 failed, 10 passed
restored:                              11 passed
```

No .NET or web code is touched.
