### PR TITLE
The board and the setup wizard now give one answer about your coding agent

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -55,6 +55,13 @@ public partial class FirstRunWizardDialog : Window
     private HashSet<AgentKind> _existingAgentTypes = new();
     private bool _agentScanRan;
 
+    // The agents this machine can actually launch, from the SAME scan the status board reads
+    // (AgentReadiness). The receipt and the board have to answer "do you have a coding agent" with one
+    // voice - issue #1047 is what it looks like when they do not - so the wording on this screen and on
+    // the Done receipt is driven from here rather than from the suggestion list alone. A suggestion is
+    // about what the wizard can ADD; this is about what the user HAS.
+    private IReadOnlyList<AgentReadinessFact> _agentReadiness = Array.Empty<AgentReadinessFact>();
+
     // The gateway step's three-way choice. Hosted is the recommended default, pre-selected per the
     // mockup: most users should sign in and be done. Self-host and Not-now are the quiet minority paths.
     private enum GatewayChoice { Hosted, SelfHost, NotNow }
@@ -559,18 +566,19 @@ public partial class FirstRunWizardDialog : Window
         SetAgentsPrimaryBusy(true);
         try
         {
-            var (suggestions, existing) = await Task.Run(() =>
+            var (suggestions, existing, presence) = await Task.Run(() =>
             {
                 var scanned = _toolModel.ScanSuggestions(_options);
                 var present = new HashSet<AgentKind>(AgentEntryStore.ReadCurrentEntries().Select(en => en.Type));
-                return (scanned, present);
+                return (scanned, present, AgentReadiness.Scan(_options));
             });
 
             _agentSuggestions = suggestions;
             _existingAgentTypes = existing;
+            _agentReadiness = presence;
             _agentScanRan = true;
 
-            var anyFound = suggestions.Any(s => s.Found) || existing.Count > 0;
+            var anyFound = presence.Any(f => f.Present);
             _model.SetAgentsFound(anyFound);
 
             // Draw what we have now, with the version cell still pending, so the list builds in front
@@ -585,7 +593,7 @@ public partial class FirstRunWizardDialog : Window
                 name => AgentsScanLine.Text = $"Checking {name}...");
             BuildAgentRows(suggestions, existing, versions);
 
-            var foundCount = suggestions.Count(s => s.Found);
+            var foundCount = presence.Count(f => f.Present);
             if (anyFound)
             {
                 AgentsTitle.Text = $"We found {foundCount} coding {(foundCount == 1 ? "agent" : "agents")}";
@@ -2387,10 +2395,12 @@ public partial class FirstRunWizardDialog : Window
     {
         DoneReceiptPanel.Children.Clear();
 
-        // Agents row.
-        var addedNames = _agentSuggestions
-            .Where(s => s.Found)
-            .Select(s => s.DisplayName)
+        // Agents row. Counted from the shared presence scan, which is the same fact the status board
+        // behind this wizard renders - so "1 agent ready" here and the board's agent row cannot be two
+        // different answers to one question (issue #1047).
+        var addedNames = _agentReadiness
+            .Where(f => f.Present)
+            .Select(f => f.DisplayName)
             .ToList();
         if (addedNames.Count > 0)
             DoneReceiptPanel.Children.Add(ReceiptRow(

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -305,6 +305,15 @@ public partial class MainWindow : Window
         HomeView.RepairToolsRequested += (_, _) => _ = RepairToolsAsync();
         HomeView.OpenSettingsRequested += (_, _) => BtnSettings_Click(this, new RoutedEventArgs());
         HomeView.GatewayClicked += (_, _) => OpenGatewayConnectionPanel();
+
+        // The agent readiness row is a READ of a fact that anything can change while this window is
+        // open - the first-run wizard, the Settings Agents tab, the Control API. Computing it once at
+        // startup is what let the board go on saying "No coding agent found" after the wizard had just
+        // installed one and written it (issue #1047). Re-read it whenever the store is written, so the
+        // board cannot be stale rather than merely being refreshed by someone who remembered to.
+        AgentEntryStore.EntriesChanged += OnAgentEntriesChanged;
+        Closed += (_, _) => AgentEntryStore.EntriesChanged -= OnAgentEntriesChanged;
+
         UpdateHomeVisibility();
 
         // Refresh the rail's relative time labels and the needs-you count every 15 seconds.
@@ -403,6 +412,15 @@ public partial class MainWindow : Window
         // thumbnails appear behind the wizard the moment the folder is confirmed.
         var dialog = new FirstRunWizardDialog(options, ReloadScreenshotsPanelAsync);
         await dialog.ShowDialog<bool?>(this);
+
+        // The wizard installs agents AND tools, so every readiness fact behind the board may have moved
+        // while it was open. Re-read all of them before the user sees the board - arriving at a screen
+        // that contradicts the receipt they just read is the whole of issue #1047. The tool-health cache
+        // is dropped too, or the tools row would keep reporting the pre-wizard run.
+        FileLog.Write("[MainWindow] OpenFirstRunWizardAsync: wizard closed, re-reading readiness");
+        _lastToolHealth = null;
+        UpdateHomeVisibility();
+
         return dialog.WantsNewSession;
     }
 
@@ -934,6 +952,18 @@ public partial class MainWindow : Window
            || RepositoriesOverlay.IsVisible;
 
     /// <summary>
+    /// The configured agents changed (wizard, Settings, or Control API) - re-read the readiness facts
+    /// so the board agrees with whatever just wrote them. Raised on the writer's thread, so it hops to
+    /// the interface thread; going through <see cref="UpdateHomeVisibility"/> keeps the "only refresh
+    /// what is actually on screen" rule in one place.
+    /// </summary>
+    private void OnAgentEntriesChanged()
+    {
+        FileLog.Write("[MainWindow] OnAgentEntriesChanged: agent store written, re-reading readiness");
+        Dispatcher.UIThread.Post(UpdateHomeVisibility);
+    }
+
+    /// <summary>
     /// Show the full-screen home page exactly when this Director has zero sessions - it is
     /// the "nothing is running, here is the state, start something" screen. The window menu
     /// bar stays; the toolbar is hidden so only the home shows beneath it. The home appears
@@ -975,14 +1005,12 @@ public partial class MainWindow : Window
 
             var facts = await Task.Run<(List<AgentCliFact> clis, int built, int total, List<string> missing)>(() =>
             {
-                var detector = new ToolDetectionService();
-                var clis = ToolDetectionService.SupportedTools.Select(tool =>
-                {
-                    var det = detector.DetectTool(tool, options);
-                    var validation = ToolDetectionService.ReadValidationStatus(tool, options);
-                    var version = validation?.Ok == true ? validation.Version : null;
-                    return new AgentCliFact(ToolDetectionService.DisplayName(tool), det.Found, version);
-                }).ToList();
+                // ONE authority for "does this machine have a coding agent" - the same scan the
+                // first-run wizard reads, so the board and the wizard's receipt cannot answer the
+                // same question differently (issue #1047).
+                var clis = AgentReadiness.Scan(options)
+                    .Select(f => new AgentCliFact(f.DisplayName, f.Present, f.Version))
+                    .ToList();
 
                 // Only consider tools this install is EXPECTED to provide (shim, built, or on PATH); tools
                 // never installed here (extras tier, other bundles, manifest drift) must not raise a warning.

--- a/src/CcDirector.Core.Tests/Agents/AgentReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/Agents/AgentReadinessTests.cs
@@ -1,0 +1,202 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Agents;
+
+/// <summary>
+/// The two surfaces that tell a user whether they have a coding agent - the status board's readiness
+/// row and the first-run wizard's receipt - must give ONE answer (devthrottle_internal issue #1047:
+/// the wizard said "1 agent ready" and the board said "No coding agent found", on the same machine,
+/// seconds apart). These tests pin the shared answer.
+///
+/// The detector is injected. With the real one, a developer machine with Claude Code installed would
+/// make every case pass by accident - the "present" assertion would be true for the wrong reason and
+/// the "absent" assertion could never fail. Here the machine's real agents are invisible, so what is
+/// being tested is the rule and not the host.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class AgentReadinessTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    /// <summary>A machine where detection resolves nothing at all: no PATH hit, no known install location.</summary>
+    private static readonly AgentReadiness.InstalledToolProbe NothingInstalled = (_, _) => null;
+
+    public AgentReadinessTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-agentpresence-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static void SeedConfig(string json)
+    {
+        var path = CcStorage.ConfigJson();
+        var dir = Path.GetDirectoryName(path);
+        Assert.NotNull(dir);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(path, json);
+    }
+
+    /// <summary>A real, existing executable inside the test's own root - never something the host provides.</summary>
+    private string WriteFakeAgentExecutable(string name)
+    {
+        var dir = Path.Combine(_root, "fake-agent");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name);
+        File.WriteAllText(path, "@echo off");
+        return path;
+    }
+
+    [Fact]
+    public void Scan_AgentInstalledOffPathButRecordedAsAnEntry_ReportsPresent()
+    {
+        // The clean-machine case the issue was found on: the wizard runs the official installer, which
+        // drops the binary somewhere this process's PATH does not cover, and records its ABSOLUTE path
+        // on the agent entry. The user can launch it, so every surface must say they have an agent.
+        var exe = WriteFakeAgentExecutable("claude.cmd");
+        SeedConfig($$"""
+        {
+          "agent": {
+            "entries": [
+              {
+                "id": "e1",
+                "display_name": "Claude Code",
+                "type": "ClaudeCode",
+                "enabled": true,
+                "executable_path": {{System.Text.Json.JsonSerializer.Serialize(exe)}}
+              }
+            ]
+          }
+        }
+        """);
+
+        var facts = AgentReadiness.Scan(new AgentOptions(), NothingInstalled);
+
+        var claude = facts.Single(f => f.Tool == AgentKind.ClaudeCode);
+        Assert.True(claude.Present);
+        Assert.Equal(AgentReadinessSource.ConfiguredEntry, claude.Source);
+        Assert.Equal(exe, claude.ResolvedPath, ignoreCase: true);
+        Assert.Contains(facts, f => f.Present);
+    }
+
+    [Fact]
+    public void Scan_EntryPointingAtAnExecutableThatIsNotThere_ReportsAbsent()
+    {
+        // The other direction of the same untruth. An entry left behind after the agent was uninstalled
+        // is not an agent, and calling it one would put a green row in front of a user who cannot start
+        // anything. The entry's path is RESOLVED, never taken on trust.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              {
+                "id": "e1",
+                "display_name": "Claude Code",
+                "type": "ClaudeCode",
+                "enabled": true,
+                "executable_path": "C:/nowhere/claude-that-was-uninstalled.cmd"
+              }
+            ]
+          }
+        }
+        """);
+
+        var facts = AgentReadiness.Scan(new AgentOptions(), NothingInstalled);
+
+        Assert.All(facts, f => Assert.False(f.Present));
+        Assert.All(facts, f => Assert.Equal(AgentReadinessSource.NotFound, f.Source));
+    }
+
+    [Fact]
+    public void Scan_DisabledEntry_ReportsAbsent()
+    {
+        // A disabled entry is one the user has said they do not want launched. It must not prop up the
+        // readiness row.
+        var exe = WriteFakeAgentExecutable("codex.cmd");
+        SeedConfig($$"""
+        {
+          "agent": {
+            "entries": [
+              {
+                "id": "e1",
+                "display_name": "Codex",
+                "type": "Codex",
+                "enabled": false,
+                "executable_path": {{System.Text.Json.JsonSerializer.Serialize(exe)}}
+              }
+            ]
+          }
+        }
+        """);
+
+        var facts = AgentReadiness.Scan(new AgentOptions(), NothingInstalled);
+
+        Assert.False(facts.Single(f => f.Tool == AgentKind.Codex).Present);
+    }
+
+    [Fact]
+    public void Scan_NoEntriesAndNothingInstalled_ReportsAbsentForEveryTool()
+    {
+        // The genuinely empty machine still has to report empty - the added entry rule must not turn
+        // every scan green.
+        SeedConfig("""{ "agent": { "entries": [] } }""");
+
+        var facts = AgentReadiness.Scan(new AgentOptions(), NothingInstalled);
+
+        Assert.NotEmpty(facts);
+        Assert.All(facts, f => Assert.False(f.Present));
+    }
+
+    [Fact]
+    public void Scan_DetectedTool_PrefersDetectionAndReportsItsPath()
+    {
+        // Detection still wins when it resolves: the resolved path is what the surfaces show.
+        var exe = WriteFakeAgentExecutable("detected-claude.cmd");
+        SeedConfig("""{ "agent": { "entries": [] } }""");
+
+        var facts = AgentReadiness.Scan(
+            new AgentOptions(),
+            (tool, _) => tool == AgentKind.ClaudeCode ? exe : null);
+
+        var claude = facts.Single(f => f.Tool == AgentKind.ClaudeCode);
+        Assert.True(claude.Present);
+        Assert.Equal(AgentReadinessSource.Detected, claude.Source);
+        Assert.Equal(exe, claude.ResolvedPath);
+    }
+
+    [Fact]
+    public void SaveEntries_RaisesEntriesChanged()
+    {
+        // The wire that stops the board holding a startup answer: every writer goes through SaveEntries,
+        // so one subscription there catches the wizard, the Settings tab and the Control API alike.
+        SeedConfig("""{ }""");
+
+        var raised = 0;
+        void Handler() => raised++;
+
+        AgentEntryStore.EntriesChanged += Handler;
+        try
+        {
+            AgentEntryStore.SaveEntries(new List<AgentEntry>
+            {
+                new() { DisplayName = "Claude Code", Type = AgentKind.ClaudeCode, ExecutablePath = "claude" },
+            });
+        }
+        finally
+        {
+            AgentEntryStore.EntriesChanged -= Handler;
+        }
+
+        Assert.Equal(1, raised);
+    }
+}

--- a/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
@@ -60,7 +60,7 @@ public class HomeStatusBuilderTests
 
         var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
-        Assert.Equal("Codex 0.21.0 - on PATH", clis.Detail);
+        Assert.Equal("Codex 0.21.0 - ready", clis.Detail);
         Assert.Equal(HomeCheckAction.None, clis.Action);
     }
 
@@ -73,7 +73,7 @@ public class HomeStatusBuilderTests
 
         var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
-        Assert.Equal("Claude Code 2.1.177, Codex - on PATH", clis.Detail);
+        Assert.Equal("Claude Code 2.1.177, Codex - ready", clis.Detail);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class HomeStatusBuilderTests
             new[] { Cli("Claude Code", true, "2.1.177 (Claude Code)") },
             toolsBuilt: 31, toolsTotal: 31);
 
-        Assert.Equal("Claude Code 2.1.177 - on PATH", Row(status, HomeStatusBuilder.AgentRowTitle).Detail);
+        Assert.Equal("Claude Code 2.1.177 - ready", Row(status, HomeStatusBuilder.AgentRowTitle).Detail);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class HomeStatusBuilderTests
 
         var clis = Row(status, HomeStatusBuilder.AgentRowTitle);
         Assert.Equal(HomeCheckLevel.Ok, clis.Level);
-        Assert.Equal("Claude Code - on PATH", clis.Detail);
+        Assert.Equal("Claude Code - ready", clis.Detail);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Agents/AgentReadiness.cs
+++ b/src/CcDirector.Core/Agents/AgentReadiness.cs
@@ -1,0 +1,134 @@
+using CcDirector.Core.AgentPlugins;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Settings;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Agents;
+
+/// <summary>How this machine knows about an agent CLI.</summary>
+public enum AgentReadinessSource
+{
+    /// <summary>Nothing found: no executable resolved and no usable configured entry.</summary>
+    NotFound,
+
+    /// <summary>Resolved by <see cref="ToolDetectionService"/> - on PATH, the configured path, or a known install location.</summary>
+    Detected,
+
+    /// <summary>Not resolvable by detection, but the user has an enabled agent entry whose executable exists.</summary>
+    ConfiguredEntry,
+}
+
+/// <summary>
+/// One agent CLI's presence on this machine: whether it is usable, where it resolved, how it was
+/// found, and the last version it reported.
+/// </summary>
+public sealed record AgentReadinessFact(
+    AgentKind Tool,
+    string DisplayName,
+    bool Present,
+    string ResolvedPath,
+    string? Version,
+    AgentReadinessSource Source);
+
+/// <summary>
+/// THE one answer to "does this machine have a usable coding agent". Every surface that shows the
+/// user that fact - the status board's readiness row and the first-run wizard - reads it from here,
+/// so they cannot give different answers to the same question (devthrottle_internal issue #1047,
+/// where the wizard's receipt said "1 agent ready" and the board said "No coding agent found").
+///
+/// An agent counts as present when EITHER of two things is true, because both mean the user can
+/// launch it:
+/// <list type="bullet">
+/// <item>detection resolves an executable - on PATH, at the configured path, or at a known install
+/// location (this is what the wizard's scan reports); or</item>
+/// <item>the user has an ENABLED entry in <c>agent.entries</c> whose executable actually exists.
+/// The wizard records an absolute path there after installing an agent, and the New Session picker
+/// launches from it, so an entry that resolves IS a working agent even when nothing puts it on this
+/// process's PATH - which is exactly the clean-machine case (the official Claude installer drops the
+/// binary in <c>~/.local\bin</c> and the running Director's PATH predates it).</item>
+/// </list>
+/// The entry's path is resolved, never trusted: an entry left pointing at a deleted executable is not
+/// an agent, and reporting it as one would be the same untruth in the other direction.
+/// </summary>
+public static class AgentReadiness
+{
+    /// <summary>
+    /// Resolves a tool to an executable path, or null when it is not installed. Injected so tests can
+    /// scan a known machine state instead of whatever agent CLIs the test machine happens to have -
+    /// with the real detector, a developer box with Claude Code installed passes every case by accident.
+    /// </summary>
+    internal delegate string? InstalledToolProbe(AgentKind tool, AgentOptions options);
+
+    /// <summary>Production probe: ask <see cref="ToolDetectionService"/>.</summary>
+    private static string? DefaultDetect(AgentKind tool, AgentOptions options)
+    {
+        var result = new ToolDetectionService().DetectTool(tool, options);
+        return result.Found ? result.ResolvedPath : null;
+    }
+
+    /// <summary>
+    /// Scan every built-in agent CLI and report its presence on this machine. One fact per tool,
+    /// in registry order, so a caller can both count what is usable and name it. Does file and PATH
+    /// probing - callers run it off the interface thread.
+    /// </summary>
+    public static IReadOnlyList<AgentReadinessFact> Scan(AgentOptions options)
+        => Scan(options, DefaultDetect);
+
+    internal static IReadOnlyList<AgentReadinessFact> Scan(AgentOptions options, InstalledToolProbe detect)
+    {
+        FileLog.Write("[AgentReadiness] Scan");
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (detect is null) throw new ArgumentNullException(nameof(detect));
+
+        var entries = AgentEntryStore.ReadCurrentEntries();
+        var facts = new List<AgentReadinessFact>();
+
+        foreach (var plugin in AgentPluginRegistry.BuiltIns)
+        {
+            var validation = ToolDetectionService.ReadValidationStatus(plugin.Kind, options);
+            var version = validation?.Ok == true ? validation.Version : null;
+
+            var detected = detect(plugin.Kind, options);
+            if (!string.IsNullOrWhiteSpace(detected))
+            {
+                facts.Add(new AgentReadinessFact(
+                    plugin.Kind, plugin.DisplayName, true, detected!, version, AgentReadinessSource.Detected));
+                continue;
+            }
+
+            var configured = ResolveConfiguredEntry(entries, plugin.Kind);
+            if (configured is not null)
+            {
+                FileLog.Write($"[AgentReadiness] Scan: tool={plugin.Kind} present via configured entry at {configured}");
+                facts.Add(new AgentReadinessFact(
+                    plugin.Kind, plugin.DisplayName, true, configured, version, AgentReadinessSource.ConfiguredEntry));
+                continue;
+            }
+
+            facts.Add(new AgentReadinessFact(
+                plugin.Kind, plugin.DisplayName, false, "", null, AgentReadinessSource.NotFound));
+        }
+
+        FileLog.Write($"[AgentReadiness] Scan: present={facts.Count(f => f.Present)} of {facts.Count}");
+        return facts;
+    }
+
+    /// <summary>
+    /// The first enabled entry of this type whose executable actually exists on disk, or null.
+    /// A disabled entry is deliberately excluded - the user has said they do not want to launch it.
+    /// </summary>
+    private static string? ResolveConfiguredEntry(IReadOnlyList<AgentEntry> entries, AgentKind tool)
+    {
+        foreach (var entry in entries)
+        {
+            if (entry.Type != tool || !entry.Enabled || string.IsNullOrWhiteSpace(entry.ExecutablePath))
+                continue;
+
+            var resolved = ExecutableResolver.Resolve(entry.ExecutablePath);
+            if (resolved is not null)
+                return resolved;
+        }
+
+        return null;
+    }
+}

--- a/src/CcDirector.Core/Configuration/AgentEntry.cs
+++ b/src/CcDirector.Core/Configuration/AgentEntry.cs
@@ -173,9 +173,23 @@ public static class AgentEntryStore
     }
 
     /// <summary>
+    /// Raised after the entries have been written, so every surface showing "do I have a coding
+    /// agent" re-reads the fact instead of holding the answer it computed at startup
+    /// (devthrottle_internal issue #1047: the wizard installed an agent and wrote it here, and the
+    /// status board went on saying "No coding agent found" because nothing told it the fact had
+    /// changed). Every writer - the first-run wizard, the Settings Agents tab and the Control API -
+    /// goes through this one method, so subscribing here catches all of them rather than relying on
+    /// each caller remembering to announce itself.
+    ///
+    /// Raised on the calling thread; interface subscribers marshal to their own thread.
+    /// </summary>
+    public static event Action? EntriesChanged;
+
+    /// <summary>
     /// Persist the ordered entries to <c>config.json</c> under <c>agent.entries</c>. The array is
     /// REPLACED wholesale (MergePatch replaces arrays), so removing/reordering takes effect; all
-    /// other config sections are left exactly as they were.
+    /// other config sections are left exactly as they were. Raises <see cref="EntriesChanged"/>
+    /// once the write has landed.
     /// </summary>
     public static void SaveEntries(IReadOnlyList<AgentEntry> entries)
     {
@@ -191,6 +205,9 @@ public static class AgentEntryStore
             ["agent"] = new JsonObject { ["entries"] = array }
         };
         CcDirectorConfigService.MergePatch(patch);
+
+        FileLog.Write("[AgentEntryStore] SaveEntries: raising EntriesChanged");
+        EntriesChanged?.Invoke();
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -161,9 +161,13 @@ public static class HomeStatusBuilder
                 "No coding agent found - install Claude Code, Codex, Pi, Gemini, or OpenCode",
                 HomeCheckAction.OpenSettings);
 
+        // "ready", not "on PATH". An agent counts when it is launchable, and being on PATH is only one
+        // of the ways it can be - the wizard records an absolute path for an agent it installed off
+        // PATH, and that agent is just as usable. Naming a mechanism the row does not actually know
+        // would be a small lie in the same family as the one this row was fixed for (issue #1047).
         var names = installed.Select(CliLabel);
         return new HomeCheck(AgentRowTitle, HomeCheckLevel.Ok,
-            $"{string.Join(", ", names)} - on PATH", HomeCheckAction.None);
+            $"{string.Join(", ", names)} - ready", HomeCheckAction.None);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1047 (release blocker, found on the clean-machine walk of v1.8.7).

## What was wrong

The first-run wizard installed Claude Code, its receipt said **"1 agent ready"**, and the board it
dropped the user onto said **"No coding agent found"** in red, with a Fix button. Same machine, same
minute, opposite answers.

I read both sides before touching either, because the two possible causes have opposite fixes. The
wizard was telling the truth: the agent is installed, version-checked and written to the agent list.
The board was wrong, for two separate reasons that both had to go.

**1. The board never re-read the fact.** Its readiness is computed once, when the window opens. On the
reported run that answer was taken at 00:19, eighteen minutes before the wizard installed anything, and
nothing re-evaluated it afterwards - the only things that trigger a re-read are the window opening, the
session count crossing zero, and an in-window overlay opening or closing. A modal wizard is none of those.

**2. The board asked a narrower question than the wizard.** It counted only agents that resolve on PATH
or at a known install location, and ignored `agent.entries` entirely - the list the wizard writes, where
an installed agent records its absolute path, and the list the New Session picker actually launches from.
That is precisely the clean-machine case: the official installer drops the binary in `~/.local\bin` and
the running Director's PATH predates it (the same seam as #1050).

Fixing only the first would have left the board "fixed by timing" - green on a fast machine, back on a
slow one, and still wrong for anyone who configures an agent by hand.

## What changed

- **`AgentReadiness.Scan` (new, Core)** is now the one authority for "does this machine have a usable
  coding agent". An agent counts when detection resolves it **or** when an enabled entry's executable
  actually exists. The entry's path is resolved, never trusted - an entry left pointing at an uninstalled
  agent is not an agent, and reporting it as one would be the same untruth in the other direction.
- **The board, the wizard's Agents screen and the wizard's Done receipt all read it**, so they agree by
  construction instead of by timing.
- **`AgentEntryStore` raises `EntriesChanged`** after every write, and the board subscribes. Every writer -
  the wizard, the Settings Agents tab, the Control API - goes through that one method, so the board
  re-reads whenever the fact moves rather than depending on each writer remembering to poke it.
- The board also re-reads when the wizard closes, since the wizard changes the tool facts too.

## Reproduced first, in the running product

Isolated Director (own `CC_DIRECTOR_ROOT`, scrubbed environment), agent added through the Control API -
the same in-process `SaveEntries` call the wizard makes.

Before, the log after the write is empty - the board does not react at all:

```
10:08:58.064 [AgentEntryStore] SaveEntries: count=4
10:08:58.076 [AgentsEndpoint] POST /settings/agents: added id=..., type=Codex
10:08:58.083 [ControlApiHost] POST /settings/agents -> 201
(nothing further - no re-evaluation of any kind)
```

After:

```
10:25:04.513 [AgentEntryStore] SaveEntries: raising EntriesChanged
10:25:04.513 [MainWindow] OnAgentEntriesChanged: agent store written, re-reading readiness
10:25:04.513 [MainWindow] UpdateHomeVisibility: showHome=True ...
10:25:04.543 [AgentReadiness] Scan: tool=Codex present via configured entry at ...\my-agent.cmd
10:25:04.555 [AgentReadiness] Scan: present=4 of 8      (was 3 of 8)
10:25:54.984 [MainWindow] OpenFirstRunWizardAsync: wizard closed, re-reading readiness
```

That exercises all three wires: the store event, the wizard-close refresh, and an agent counted from a
configured entry that detection cannot resolve.

## Tests

Six tests in `AgentReadinessTests`, with the detector injected - with the real one, any developer machine
with an agent installed would pass every case by accident and the absent-cases could never fail. They pin
both directions: an off-PATH agent recorded as an entry is present; an entry pointing at a missing
executable, a disabled entry, and a genuinely empty machine are all absent.

`Scan_AgentInstalledOffPathButRecordedAsAnEntry_ReportsPresent` was confirmed to fail under the old rule
(the configured-entry branch disabled) and pass with it - it fails for the reason it claims to.

Core suite 4003 passed / 8 skipped, Avalonia suite 321 passed.

## Not verified here

The user-visible red-to-green flip of the board's agent row needs a machine with **no** agent installed
anywhere; this machine has several at known locations, so detection finds them however the environment is
scrubbed. The symptom itself is evidenced by the QA run's screenshots; what I reproduced and fixed live is
the mechanism behind it. A clean-VM pass is still the right final check.

Also unchanged: `tools/cc-director-setup-engine` has its own separate `AgentPresence` answering a similar
question for the installer. It is a third surface and out of scope here, but worth a look before the next
clean-machine walk.