### PR TITLE
A clean install no longer reports its own successful setup as a failure

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -104,6 +104,9 @@ public partial class FirstRunWizardDialog : Window
     private bool _toolsRepairing;
     private bool _toolsStalled;
     private const int ToolsStallSeconds = 45;
+    // Guards the one-at-a-time shared health run this screen starts (issue #1045). The Director's board
+    // may already have run it; if so the snapshot is there and this screen just renders it.
+    private bool _toolsHealthRunInFlight;
 
     // Code step: the ROOT DIRECTORY store - the registered base folders the repository model scans.
     // It is NOT what New Session reads; New Session reads the repository registry and, since this
@@ -900,10 +903,17 @@ public partial class FirstRunWizardDialog : Window
     // ---- Tools step (the toolbelt, maintained automatically) ---------------------------------------
 
     /// <summary>
-    /// Render the toolbelt from the embedded manifest catalog: every shipped tool with its one-line
-    /// description and a Ready / Installing pill. All ready ends the story in one glance; anything
-    /// still installing starts a light poll so the rows flip to Ready live while the user watches -
-    /// the promise ("maintenance is our job now") demonstrated, not described.
+    /// Render the toolbelt: every shipped tool with its one-line description and a pill saying what is
+    /// actually known about it. All working ends the story in one glance; anything still installing starts
+    /// a light poll so the rows flip live while the user watches - the promise ("maintenance is our job
+    /// now") demonstrated, not described.
+    ///
+    /// The pill reports the SAME check the Director's board reports (<see cref="ToolHealthProbe"/>), and
+    /// says "Checking" until that check has an answer. It used to read the catalog - a presence check -
+    /// and render "Ready" under "All 9 tools are installed and up to date", while the board, minutes
+    /// later and from the same install, named cc-pdf as failing. Both were true about the question each
+    /// had asked; neither said which question that was, so the pair simply contradicted each other in
+    /// front of a new user (issue #1045). A screen with no verdict yet says so.
     /// </summary>
     private async Task RefreshToolsScreenAsync()
     {
@@ -933,43 +943,36 @@ public partial class FirstRunWizardDialog : Window
             // Recorded so the Done receipt reports the same three states this screen does.
             _toolsStalled = stalled;
 
+            // Everything this screen says is decided once, in ToolsScreenFold - rows and status line
+            // together, from the catalog and the shared verdict. The view below only paints it.
+            if (missingCount == 0) StartToolsHealthRunIfNeeded();
+            var view = ToolsScreenFold.Fold(
+                catalog.Select(t => new ToolsScreenInput(t.Name, t.Description, t.IsAvailable)).ToList(),
+                stalled,
+                ToolHealthProbe.Last); // null is "not judged yet", never "fine"
+
             ToolsListPanel.Children.Clear();
-            foreach (var tool in catalog)
+            foreach (var row in view.Rows)
             {
-                var state = tool.IsAvailable ? RowState.Ready
-                    : stalled ? RowState.NeedsYou
-                    : RowState.Working;
-                var detail = tool.IsAvailable || !stalled
-                    ? tool.Description
-                    : $"{tool.Description} - this one did not install";
-                ToolsListPanel.Children.Add(AgentRow(tool.Name, detail, state));
+                var state = row.Verdict switch
+                {
+                    ToolRowVerdict.Working => RowState.Ready,
+                    ToolRowVerdict.NotWorking or ToolRowVerdict.NotInstalled => RowState.NeedsYou,
+                    _ => RowState.Working, // Installing / Checking - both are work in progress
+                };
+                ToolsListPanel.Children.Add(AgentRow(row.Name, row.Detail, state));
             }
 
-            ToolsFixPanel.IsVisible = stalled;
-
-            if (missingCount == 0)
+            ToolsFixPanel.IsVisible = view.OfferRepair;
+            ToolsStatusText.Text = view.StatusText;
+            ToolsStatusText.Foreground = view.Tone switch
             {
-                ToolsStatusText.Text = $"All {_toolsTotalCount} tools are installed and up to date.";
-                ToolsStatusText.Foreground = Brush("#1A7F37");
-                _toolsWaitStartedUtc = null;
-                StopToolsPoll();
-            }
-            else if (stalled)
-            {
-                ToolsStatusText.Text = missingCount == 1
-                    ? "1 tool did not install. Repairing takes about a minute - you can continue while it runs."
-                    : $"{missingCount} tools did not install. Repairing takes about a minute - you can continue while it runs.";
-                ToolsStatusText.Foreground = Brush("#DC2626");
-                StopToolsPoll();
-            }
-            else
-            {
-                // Both halves of the trade, so continuing is an informed choice rather than a guess.
-                ToolsStatusText.Text =
-                    $"{_toolsReadyCount} of {_toolsTotalCount} ready. Wait here and all of them will be working before you finish. Continue and DevThrottle finishes the rest in the background on its own.";
-                ToolsStatusText.Foreground = Brush("#0066B8");
-                StartToolsPoll();
-            }
+                ToolsScreenTone.Good => Brush("#1A7F37"),
+                ToolsScreenTone.Bad => Brush("#DC2626"),
+                _ => Brush("#0066B8"),
+            };
+            if (missingCount == 0) _toolsWaitStartedUtc = null;
+            if (view.KeepPolling) StartToolsPoll(); else StopToolsPoll();
         }
         catch (Exception ex)
         {
@@ -977,6 +980,33 @@ public partial class FirstRunWizardDialog : Window
             ToolsStatusText.Text = $"Could not read the tool catalog: {ex.Message}";
             ToolsStatusText.Foreground = Brush("#DC2626");
         }
+    }
+
+    /// <summary>
+    /// Start the shared health run once, in the background, if nothing has judged the tools yet. The
+    /// screen stays responsive: the rows say "Checking" meanwhile and the existing poll redraws them the
+    /// moment a verdict lands. Whichever surface gets there first, both then read the same answer.
+    /// </summary>
+    private void StartToolsHealthRunIfNeeded()
+    {
+        if (_toolsHealthRunInFlight || ToolHealthProbe.Last is not null) return;
+        _toolsHealthRunInFlight = true;
+        FileLog.Write("[FirstRunWizardDialog] starting the shared tool health run");
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await ToolHealthProbe.RunAsync();
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[FirstRunWizardDialog] tool health run FAILED: {ex.Message}");
+            }
+            finally
+            {
+                _toolsHealthRunInFlight = false;
+            }
+        });
     }
 
     /// <summary>
@@ -1002,6 +1032,9 @@ public partial class FirstRunWizardDialog : Window
             FileLog.Write($"[FirstRunWizardDialog] BtnFixTools_Click: success={result.Success}, msg={result.Message}");
 
             _toolsRepairing = false;
+            // The tools on disk just changed, so the shared verdict is stale by definition - drop it and
+            // let the next render re-judge rather than showing a pre-repair answer as a post-repair one.
+            ToolHealthProbe.Invalidate();
             // A repair takes about a minute. The user may well have closed the wizard in the meantime;
             // the repair still ran and still mattered, but there is no screen left to report it on.
             if (_closed) return;
@@ -1012,10 +1045,14 @@ public partial class FirstRunWizardDialog : Window
                 _toolsWaitStartedUtc = null;
                 ToolsFixProgress.Text = "Repair finished. Checking the tools again...";
                 await RefreshToolsScreenAsync();
-                if (_toolsReadyCount == _toolsTotalCount)
-                    ToolsFixProgress.IsVisible = false;
-                else
+                // "All present" is not "all working", and this line used to treat them as the same thing -
+                // it hid itself the moment every tool was back on disk, even if one still did not run
+                // (issue #1045). The status line the fold just wrote carries the real outcome, so the only
+                // honest thing to do here is stand down when there is nothing left to add.
+                if (_toolsReadyCount < _toolsTotalCount)
                     ToolsFixProgress.Text = "The repair ran but some tools are still missing. Continue - DevThrottle keeps retrying in the background - or see the tools documentation below.";
+                else
+                    ToolsFixProgress.IsVisible = false;
             }
             else
             {
@@ -2441,11 +2478,26 @@ public partial class FirstRunWizardDialog : Window
         // Tools row (only when the Tools screen was seen, so the numbers are real).
         if (_toolsTotalCount > 0)
         {
-            // Three states here, not two, because the Tools screen has three. Reducing a tool that
+            // Four states here, not two, because the Tools screen has four. Reducing a tool that
             // FAILED to install back to "installing - finishes on its own" would repeat on the last
             // screen the exact false promise the third state was added to remove, and would contradict
-            // the screen the user saw two steps earlier.
-            if (_toolsReadyCount == _toolsTotalCount)
+            // the screen the user saw two steps earlier. The fourth is the one this receipt used to get
+            // wrong in the other direction: it read the same presence count the Tools step read and
+            // called it "tools ready", so a tool that was installed and did not work was signed off as
+            // ready on the final screen of onboarding (issue #1045).
+            var doneFailures = ToolHealthProbe.Last?.Summary.Failures ?? Array.Empty<ToolFailure>();
+            if (_toolsReadyCount == _toolsTotalCount && doneFailures.Count > 0)
+            {
+                var shown = string.Join(", ", doneFailures.Take(2).Select(f => f.ToString()));
+                if (doneFailures.Count > 2) shown += $", +{doneFailures.Count - 2} more";
+                DoneReceiptPanel.Children.Add(ReceiptRow(
+                    doneFailures.Count == 1
+                        ? $"{_toolsTotalCount} tools installed, 1 not working"
+                        : $"{_toolsTotalCount} tools installed, {doneFailures.Count} not working",
+                    $"{shown} - repair from Settings > Tools",
+                    RowState.NeedsYou));
+            }
+            else if (_toolsReadyCount == _toolsTotalCount)
                 DoneReceiptPanel.Children.Add(ReceiptRow(
                     $"{_toolsTotalCount} tools ready", "Installed and kept current automatically", done: true));
             else if (_toolsStalled)

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1067,6 +1067,7 @@ public partial class MainWindow : Window
         {
             _repairingTools = false;
             _lastToolHealth = null; // the tools changed - re-run the health check on the next refresh
+            CcDirector.Core.Tools.ToolHealthProbe.Invalidate(); // and let every surface re-read it
             await RefreshHomeAsync();
         }
     }
@@ -1109,36 +1110,24 @@ public partial class MainWindow : Window
         _toolHealthRunning = true;
         try
         {
+            // ONE health check, shared with the first-run wizard (issue #1045): ToolHealthProbe runs the
+            // checks, publishes the snapshot, and logs each failure WITH its reason, so no surface has to
+            // invent an answer and no failure arrives without one.
             var (summary, basePythonBroken) = await Task.Run(async () =>
             {
-                var catalog = new ToolCatalogService().GetCatalog();
-                var runner = new ToolTestRunner();
-                using var gate = new System.Threading.SemaphoreSlim(Math.Max(1, Environment.ProcessorCount - 1));
-                var inputs = await Task.WhenAll(catalog.Select(async d =>
-                {
-                    // Availability (PATH or bundled bin), not bin-only IsBuilt, decides whether the tool
-                    // can run its checks (issue #448). A PATH-only tool's BinaryPath is its PATH-resolved exe.
-                    if (!d.IsAvailable)
-                        return new CcDirector.Core.Tools.ToolHealthInput(d.Name, false, d.IsExpected, false);
-                    await gate.WaitAsync();
-                    try
-                    {
-                        var results = await runner.RunAllForToolAsync(d);
-                        return new CcDirector.Core.Tools.ToolHealthInput(d.Name, true, d.IsExpected, results.All(r => r.Passed));
-                    }
-                    finally { gate.Release(); }
-                }));
+                var snapshot = await CcDirector.Core.Tools.ToolHealthProbe.RunAsync();
                 // Probe the shared base Python directly. Every Python cc-* tool delegates to it, so if it is
                 // hollow (present but cannot import its standard library) they ALL fail at once - a single,
                 // repairable runtime failure the per-tool breakdown would otherwise show as N unrelated fails.
                 var pyBroken = !CcDirector.Setup.Engine.PythonRuntimeProbe.IsBasePythonHealthy(
                     CcDirector.Setup.Engine.InstallLayout.Default());
-                return (summary: CcDirector.Core.Tools.ToolHealthSummary.From(inputs), basePythonBroken: pyBroken);
+                return (summary: snapshot.Summary, basePythonBroken: pyBroken);
             });
 
             _lastToolHealth = summary;
             _lastBasePythonBroken = basePythonBroken;
-            FileLog.Write($"[MainWindow] tool health: pass={summary.Pass}, fail={summary.Fail}, notBuilt={summary.NotBuilt}, broken={summary.Broken}, basePythonBroken={basePythonBroken}");
+            FileLog.Write($"[MainWindow] tool health: pass={summary.Pass}, fail={summary.Fail}, notBuilt={summary.NotBuilt}, broken={summary.Broken}, basePythonBroken={basePythonBroken}" +
+                          (summary.Failures.Count == 0 ? "" : $", failing: {string.Join("; ", summary.Failures)}"));
 
             // Same rule as the fast path: a broken runtime that the automatic self-heal below is about
             // to repair is unfinished setup, not a fault, and is painted as progress rather than red.
@@ -1180,33 +1169,23 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Evaluate the active cc-* tools indicator (issue #829) against the latest health snapshot and, when
-    /// warranted, start an automatic reconcile. "Drift" is the existing warning condition (the tools row is
-    /// not green) OR - when auto-update is on - reconcile-detectable drift (a missing shim, an orphaned legacy
-    /// alias shim, a broken venv) that the row alone would not show. When auto-update is OFF the indicator
-    /// behaves exactly as it did before this issue: a passive warning on the row, no auto-reconcile. Starting
-    /// a reconcile is debounced (one in flight) and cooldown-gated (backoff between attempts) so the badge
-    /// never thrashes the reconcile engine.
+    /// warranted, start an automatic reconcile. What counts as a problem, and which kind, is decided by
+    /// <see cref="ClassifyToolsProblemAsync"/>: only drift a reconcile can actually correct starts one, and
+    /// a tool that is installed but failing is reported rather than looped on (issue #1045). When
+    /// auto-update is OFF the indicator behaves exactly as it did before issue #829: a passive warning on
+    /// the row, no auto-reconcile. Starting a reconcile is debounced (one in flight) and cooldown-gated
+    /// (backoff between attempts) so the badge never thrashes the reconcile engine.
     /// </summary>
     private async Task DriveToolsSyncAsync()
     {
-        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
-        var healthDrift = toolsCheck is not null && toolsCheck.Level != HomeCheckLevel.Ok;
         var enabled = ToolAutoUpdateSetting.Get();
-
-        // Probe the reconciler only when auto-update is on and the row itself is green - that is the only case
-        // where reconcile-detectable drift would otherwise go unseen. The probe is pure reads, run off the UI
-        // thread. When auto-update is off we use ONLY the row signal, preserving the pre-issue passive behavior.
-        var hasDrift = healthDrift;
-        if (enabled && !healthDrift && !_toolsReconcileInFlight)
-        {
-            hasDrift = await Task.Run(() =>
-                new CcDirector.Setup.Engine.ToolReconciler(CcDirector.Setup.Engine.InstallLayout.Default()).HasDrift());
-        }
+        var (reconcilableDrift, unreconcilableFault) = await ClassifyToolsProblemAsync(probeReconciler: enabled);
 
         var previousState = _toolsSync.State;
-        var decision = _toolsSync.Evaluate(hasDrift, enabled, _toolsReconcileInFlight);
+        var decision = _toolsSync.Evaluate(reconcilableDrift, unreconcilableFault, enabled, _toolsReconcileInFlight);
         if (decision.State != previousState)
-            FileLog.Write($"[MainWindow] tools indicator state: {previousState} -> {decision.State} (drift={hasDrift}, autoUpdate={enabled})");
+            FileLog.Write($"[MainWindow] tools indicator state: {previousState} -> {decision.State} " +
+                          $"(reconcilableDrift={reconcilableDrift}, toolFault={unreconcilableFault}, autoUpdate={enabled})");
 
         UpdateToolsIndicator();
 
@@ -1219,6 +1198,47 @@ public partial class MainWindow : Window
         {
             StartToolsReconcile();
         }
+    }
+
+    /// <summary>
+    /// Split the tools problem into the two things it can be, because they want opposite responses
+    /// (issue #1045):
+    ///
+    ///   reconcilable drift - a missing shim, an orphaned legacy alias, a broken or absent shared venv, a
+    ///     tool the install was meant to provide but did not. <c>ToolReconciler</c> has a mechanism for
+    ///     each of these, so an automatic attempt is warranted.
+    ///   an unreconcilable tool fault - the tool IS installed, its shim is there, the venv is healthy, and
+    ///     it still fails its own check. No reconcile touches this. Feeding it to one anyway is how a clean
+    ///     install came to run three reconciles that each correctly reported in-sync, count all three as
+    ///     ineffective, and land on a red badge that named no reason.
+    ///
+    /// <paramref name="probeReconciler"/> gates the extra read-only <c>HasDrift</c> probe: it is worth
+    /// running when we would act on the answer (auto-update on, or judging a reconcile that just finished)
+    /// and not otherwise. It is skipped while a reconcile is in flight - it would be reading a moving target.
+    /// </summary>
+    private async Task<(bool ReconcilableDrift, bool UnreconcilableFault)> ClassifyToolsProblemAsync(bool probeReconciler)
+    {
+        var health = _lastToolHealth;
+
+        // A tool missing from the install is repairable drift; a tool present-but-failing is not. Before the
+        // first health run there is no verdict, so fall back to the tools row: unjudged is not a pass, and
+        // whatever it reports is treated as reconcilable so the existing self-heal still fires.
+        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
+        var rowNotOk = toolsCheck is not null && toolsCheck.Level != HomeCheckLevel.Ok;
+        var reconcilableDrift = health is { } h ? h.HasMissingTool : rowNotOk;
+        var unreconcilableFault = health is { } h2 && h2.HasFailingTool;
+
+        // The shared base Python being hollow takes every Python tool down at once and IS repairable, so it
+        // counts as drift rather than a per-tool fault.
+        if (_lastBasePythonBroken) reconcilableDrift = true;
+
+        if (probeReconciler && !reconcilableDrift && !_toolsReconcileInFlight)
+        {
+            reconcilableDrift = await Task.Run(() =>
+                new CcDirector.Setup.Engine.ToolReconciler(CcDirector.Setup.Engine.InstallLayout.Default()).HasDrift());
+        }
+
+        return (reconcilableDrift, unreconcilableFault);
     }
 
     /// <summary>
@@ -1264,30 +1284,38 @@ public partial class MainWindow : Window
         // Re-probe health so we judge against the post-reconcile reality (driveSync:false - we record the
         // outcome here rather than letting the snapshot path start another reconcile).
         _lastToolHealth = null;
+        CcDirector.Core.Tools.ToolHealthProbe.Invalidate();
         await RefreshToolHealthAsync(force: true, driveSync: false);
 
-        var toolsCheck = _lastHomeStatus?.Checks.FirstOrDefault(c => c.Title == HomeStatusBuilder.ToolsRowTitle);
-        var healthDrift = toolsCheck is not null && toolsCheck.Level != HomeCheckLevel.Ok;
-        var reconcilerDrift = await Task.Run(() =>
-            new CcDirector.Setup.Engine.ToolReconciler(CcDirector.Setup.Engine.InstallLayout.Default()).HasDrift());
-        var driftRemains = healthDrift || reconcilerDrift;
+        // Judge the reconcile against the drift a reconcile is FOR. A tool that is installed and still
+        // fails its own check was never this pass's job (see ClassifyToolsProblemAsync), so counting it
+        // against the attempt made the reconcile look ineffective when it had nothing left to do.
+        var (reconcilableDrift, unreconcilableFault) = await ClassifyToolsProblemAsync(probeReconciler: true);
+        var reconcileFailed = outcome == CcDirector.Setup.Engine.ReconcileOutcome.Failed;
 
         var previousState = _toolsSync.State;
-        if (outcome != CcDirector.Setup.Engine.ReconcileOutcome.Failed && !driftRemains)
-        {
-            _toolsSync.OnReconcileSucceeded();
-            _toolsReconcileCooldownUntil = DateTime.MinValue;
-            FileLog.Write($"[MainWindow] tools indicator state: {previousState} -> {_toolsSync.State} (reconcile resolved drift)");
-        }
-        else
-        {
-            _toolsSync.OnReconcileFailed();
-            FileLog.Write($"[MainWindow] tools indicator state: {previousState} -> {_toolsSync.State} " +
-                          $"(reconcile ineffective; failures={_toolsSync.ConsecutiveFailures}, outcome={outcome}, driftRemains={driftRemains})");
+        // One entry point, and it takes the drift verdict - so there is no way to record success while the
+        // drift this pass was reconciling is still standing (issue #1045).
+        _toolsSync.OnReconcileFinished(reconcileFailed, reconcilableDrift);
 
-            if (_toolsSync.State == ToolsIndicatorState.Syncing)
-                ScheduleToolsReconcileRetry();
+        if (_toolsSync.State == ToolsIndicatorState.InSync && unreconcilableFault)
+        {
+            // The layout is now correct and a tool still does not work. That is a real to-do, not a sync
+            // problem: say so once, rather than retrying a reconcile that has nothing left to correct.
+            _toolsSync.OnUnreconcilableFault();
         }
+
+        var failing = _lastToolHealth is { } h && h.Failures.Count > 0
+            ? $", failing: {string.Join("; ", h.Failures)}"
+            : "";
+        FileLog.Write($"[MainWindow] tools indicator state: {previousState} -> {_toolsSync.State} " +
+                      $"(reconcile outcome={outcome}, reconcilableDrift={reconcilableDrift}, toolFault={unreconcilableFault}, " +
+                      $"ineffectiveAttempts={_toolsSync.ConsecutiveFailures}/{ToolsSyncStateMachine.MaxReconcileAttempts}{failing})");
+
+        if (_toolsSync.State == ToolsIndicatorState.InSync)
+            _toolsReconcileCooldownUntil = DateTime.MinValue;
+        else if (_toolsSync.State == ToolsIndicatorState.Syncing)
+            ScheduleToolsReconcileRetry();
 
         UpdateToolsIndicator();
     }
@@ -1415,8 +1443,11 @@ public partial class MainWindow : Window
                 ToolsIndicatorSub.Text = string.IsNullOrEmpty(detail) ? "click to open Settings and repair" : detail;
                 ToolsIndicatorSub.Foreground = AttentionRedSub;
                 ToolsIndicatorSpinner.IsVisible = false;
+                // Not "automatic sync did not resolve it": red is now also reached for a tool that is
+                // installed and simply does not work, where no sync was ever the right answer and none
+                // was attempted. The sub-label above carries the specific reason (issue #1045).
                 ToolTip.SetTip(ToolsIndicator,
-                    "Automatic tool sync did not resolve the problem.\nClick to open Settings and repair the tools.");
+                    "The DevThrottle tools are not all working.\nClick to open Settings and repair the tools.");
                 break;
 
             case ToolsIndicatorState.Warning:

--- a/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
@@ -185,7 +185,7 @@ public class HomeStatusBuilderTests
     [Fact]
     public void Build_ToolHealthWithFailure_ShowsBreakdownWarnsAndOffersRepair()
     {
-        var health = new ToolHealthSummary(24, 1, 4,0, new[] { "cc-foo" });
+        var health = new ToolHealthSummary(24, 1, 4, 0, new[] { new ToolFailure("cc-foo", "smoke check: exit 1") });
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
         var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
@@ -203,7 +203,7 @@ public class HomeStatusBuilderTests
     {
         // The home must show the true picture: any not-built tool warns and routes to the Tools page,
         // rather than reading "all systems go" while tools are missing.
-        var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<string>());
+        var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<ToolFailure>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
         var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
@@ -215,7 +215,7 @@ public class HomeStatusBuilderTests
     [Fact]
     public void Build_ToolHealthAllPassing_IsGreen()
     {
-        var health = new ToolHealthSummary(28, 0, 0, 0, Array.Empty<string>());
+        var health = new ToolHealthSummary(28, 0, 0, 0, Array.Empty<ToolFailure>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
         var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
@@ -226,7 +226,7 @@ public class HomeStatusBuilderTests
     [Fact]
     public void Build_ToolHealthBroken_OffersRepair()
     {
-        var health = new ToolHealthSummary(24, 0, 1,1, Array.Empty<string>());
+        var health = new ToolHealthSummary(24, 0, 1,1, Array.Empty<ToolFailure>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
         var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);
@@ -240,7 +240,7 @@ public class HomeStatusBuilderTests
         // The shared base Python is hollow - present but unable to import its standard library - so every
         // Python cc-* tool fails at once. The row must be red, name the runtime problem, and offer a real
         // repair (not a navigate-to-Tools) so one click re-provisions the runtime (issue #995).
-        var health = new ToolHealthSummary(0, 9, 0, 0, new[] { "cc-vault", "cc-html", "cc-pdf" });
+        var health = new ToolHealthSummary(0, 9, 0, 0, new[] { new ToolFailure("cc-vault", "version check: exit 1"), new ToolFailure("cc-html", "version check: exit 1"), new ToolFailure("cc-pdf", "version check: exit 1") });
         var status = HomeStatusBuilder.Build(
             new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health, basePythonBroken: true);
 
@@ -255,7 +255,7 @@ public class HomeStatusBuilderTests
     {
         // Regression guard for the routing change: a not-built-ONLY state (no failing built tool, nothing
         // broken) is optional tools, not a repairable failure - it must still route to the Tools page.
-        var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<string>());
+        var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<ToolFailure>());
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
 
         var tools = Row(status, HomeStatusBuilder.ToolsRowTitle);

--- a/src/CcDirector.Core.Tests/ToolHealthTests.cs
+++ b/src/CcDirector.Core.Tests/ToolHealthTests.cs
@@ -58,4 +58,59 @@ public class ToolHealthTests
         Assert.Equal(1, s.Broken);
         Assert.True(s.HasProblem); // a broken (expected-but-missing) tool alarms even with no failures
     }
+
+    // ---- Issue #1045: the failure carries its reason, and the two kinds of problem are told apart ----
+
+    [Fact]
+    public void From_FailingTool_KeepsTheReasonItGave()
+    {
+        // "1 fail" alone sent a reader to a log that had kept no record of why. The reason travels WITH
+        // the count now, because the runner already knew it and throwing it away cost a machine rebuild.
+        var s = ToolHealthSummary.From(new[]
+        {
+            Built("cc-html", true),
+            new ToolHealthInput("cc-pdf", true, true, false, "smoke check: timed out after 90s"),
+        });
+
+        var failure = Assert.Single(s.Failures);
+        Assert.Equal("cc-pdf", failure.Name);
+        Assert.Equal("smoke check: timed out after 90s", failure.Reason);
+        Assert.Equal("cc-pdf (smoke check: timed out after 90s)", failure.ToString());
+    }
+
+    [Fact]
+    public void From_ToolPresentButFailing_IsAFaultNotSomethingToReconcile()
+    {
+        // The tool is installed and its own check failed. A reconcile writes shims and rebuilds venvs; it
+        // has no mechanism for this, so it must not be reported as drift to retry.
+        var s = ToolHealthSummary.From(new[]
+        {
+            Built("cc-html", true),
+            new ToolHealthInput("cc-pdf", true, true, false, "smoke check: exit 1"),
+        });
+
+        Assert.True(s.HasFailingTool);
+        Assert.False(s.HasMissingTool);
+    }
+
+    [Fact]
+    public void From_ToolMissing_IsReconcilableDrift()
+    {
+        // A half-install IS a reconcile's job - it writes the shim, or rebuilds the venv behind it.
+        var s = ToolHealthSummary.From(new[] { Built("cc-html", true), NotBuilt("cc-pdf", expected: true) });
+
+        Assert.True(s.HasMissingTool);
+        Assert.False(s.HasFailingTool);
+    }
+
+    [Fact]
+    public void From_NoFailureReasonRecorded_StillNamesTheTool()
+    {
+        // A missing reason must degrade to the bare name, never to an empty row that hides the failure.
+        var s = ToolHealthSummary.From(new[] { Built("cc-pdf", false) });
+
+        var failure = Assert.Single(s.Failures);
+        Assert.Equal("cc-pdf", failure.ToString());
+        Assert.Equal(new[] { "cc-pdf" }, s.Failing);
+    }
 }

--- a/src/CcDirector.Core.Tests/Tools/ToolsScreenFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Tools/ToolsScreenFoldTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Core.Tools;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Tools;
+
+/// <summary>
+/// The setup wizard's Tools step says one thing about nine tools, and the Director's board says another
+/// about the same nine at the same moment - that was issue #1045, and these cases pin the rule that
+/// makes it impossible: a screen may only assert the question it has evidence for, and no evidence
+/// renders as CHECKING, never as a pass.
+/// </summary>
+public class ToolsScreenFoldTests
+{
+    private static ToolsScreenInput Tool(string name, bool available = true)
+        => new(name, $"{name} does a thing", available);
+
+    private static ToolHealthSnapshot Snapshot(params ToolCheckOutcome[] outcomes)
+    {
+        var inputs = outcomes.Select(o => new ToolHealthInput(
+            o.Name,
+            IsBuilt: o.Verdict != ToolVerdict.NotInstalled,
+            IsExpected: true,
+            Passed: o.Verdict == ToolVerdict.Working,
+            FailureReason: o.Verdict == ToolVerdict.NotWorking ? o.Detail : null));
+        return new ToolHealthSnapshot(ToolHealthSummary.From(inputs), outcomes, DateTime.UtcNow);
+    }
+
+    private static ToolsScreenRow Row(ToolsScreenView view, string name)
+        => view.Rows.Single(r => r.Name == name);
+
+    [Fact]
+    public void Fold_InstalledButNotYetChecked_SaysCheckingAndClaimsNothingAboutWorking()
+    {
+        // The whole defect in one case: everything is on disk and nothing has been run. The old screen
+        // said "Ready" and "All 9 tools are installed and up to date" from exactly this state.
+        var view = ToolsScreenFold.Fold(new[] { Tool("cc-pdf"), Tool("cc-html") }, stalled: false, health: null);
+
+        Assert.All(view.Rows, r => Assert.Equal(ToolRowVerdict.Checking, r.Verdict));
+        Assert.Contains("installed", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Checking", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("up to date", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("working", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.True(view.KeepPolling); // the answer is still coming - keep looking for it
+    }
+
+    [Fact]
+    public void Fold_InstalledAndFailing_NamesTheToolAndItsReason_NeverReady()
+    {
+        // The exact disagreement from the clean-machine run: cc-pdf present, cc-pdf failing. One surface
+        // called it Ready. Here it cannot.
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("cc-pdf"), Tool("cc-html") },
+            stalled: false,
+            Snapshot(
+                new ToolCheckOutcome("cc-pdf", ToolVerdict.NotWorking, "smoke check: timed out after 90s"),
+                new ToolCheckOutcome("cc-html", ToolVerdict.Working, "all checks passed")));
+
+        Assert.Equal(ToolRowVerdict.NotWorking, Row(view, "cc-pdf").Verdict);
+        Assert.Contains("timed out after 90s", Row(view, "cc-pdf").Detail);
+        Assert.Equal(ToolRowVerdict.Working, Row(view, "cc-html").Verdict);
+
+        Assert.Equal(ToolsScreenTone.Bad, view.Tone);
+        Assert.Contains("cc-pdf", view.StatusText);
+        Assert.Contains("not working", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.True(view.OfferRepair);
+    }
+
+    [Fact]
+    public void Fold_InstalledAndAllPassing_IsTheOnlyStateThatClaimsWorking()
+    {
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("cc-pdf"), Tool("cc-html") },
+            stalled: false,
+            Snapshot(
+                new ToolCheckOutcome("cc-pdf", ToolVerdict.Working, "all checks passed"),
+                new ToolCheckOutcome("cc-html", ToolVerdict.Working, "all checks passed")));
+
+        Assert.All(view.Rows, r => Assert.Equal(ToolRowVerdict.Working, r.Verdict));
+        Assert.Equal(ToolsScreenTone.Good, view.Tone);
+        Assert.Contains("working", view.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.False(view.OfferRepair);
+        Assert.False(view.KeepPolling);
+    }
+
+    [Fact]
+    public void Fold_StillInstalling_IsProgressNotFailure()
+    {
+        // A brand-new machine finishing its first setup is not a fault. Preserved from before #1045.
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("cc-pdf"), Tool("cc-html", available: false) },
+            stalled: false,
+            health: null);
+
+        Assert.Equal(ToolRowVerdict.Installing, Row(view, "cc-html").Verdict);
+        Assert.Equal(ToolsScreenTone.Progress, view.Tone);
+        Assert.False(view.OfferRepair);
+        Assert.True(view.KeepPolling);
+    }
+
+    [Fact]
+    public void Fold_StalledMissingTool_StopsPromisingAndOffersRepair()
+    {
+        // Past the stall window, "installing" is a promise the screen cannot keep. Preserved from before.
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("cc-pdf"), Tool("cc-html", available: false) },
+            stalled: true,
+            health: null);
+
+        Assert.Equal(ToolRowVerdict.NotInstalled, Row(view, "cc-html").Verdict);
+        Assert.Contains("did not install", Row(view, "cc-html").Detail);
+        Assert.Equal(ToolsScreenTone.Bad, view.Tone);
+        Assert.True(view.OfferRepair);
+        Assert.False(view.KeepPolling);
+    }
+
+    [Fact]
+    public void Fold_SnapshotMissingATool_TreatsItAsUncheckedNotPassing()
+    {
+        // A snapshot that does not mention a tool says nothing about it. The fold must not read that
+        // silence as a pass - the same "no evidence is not a green" rule, in its quietest form.
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("cc-pdf"), Tool("cc-word") },
+            stalled: false,
+            Snapshot(new ToolCheckOutcome("cc-pdf", ToolVerdict.Working, "all checks passed")));
+
+        Assert.Equal(ToolRowVerdict.Checking, Row(view, "cc-word").Verdict);
+    }
+
+    [Fact]
+    public void Fold_ManyFailures_SummarisesWithoutHidingTheCount()
+    {
+        var view = ToolsScreenFold.Fold(
+            new[] { Tool("a"), Tool("b"), Tool("c") },
+            stalled: false,
+            Snapshot(
+                new ToolCheckOutcome("a", ToolVerdict.NotWorking, "version check: exit 1"),
+                new ToolCheckOutcome("b", ToolVerdict.NotWorking, "version check: exit 1"),
+                new ToolCheckOutcome("c", ToolVerdict.NotWorking, "version check: exit 1")));
+
+        Assert.Contains("3 are not working", view.StatusText);
+        Assert.Contains("+1 more", view.StatusText); // truncated for width, but the count is still stated
+    }
+}

--- a/src/CcDirector.Core.Tests/Tools/ToolsSyncStateMachineTests.cs
+++ b/src/CcDirector.Core.Tests/Tools/ToolsSyncStateMachineTests.cs
@@ -9,6 +9,11 @@ namespace CcDirector.Core.Tests.Tools;
 /// Green -> Orange (syncing) -> Green normal cycle, the repeated-failure escalation to red, the
 /// auto-update opt-out passive warning, the one-in-flight debounce, and the exponential backoff
 /// schedule. No Avalonia, no I/O.
+///
+/// Issue #1045 reshaped two things here, and the cases at the bottom of the file pin both:
+///   - reporting an attempt takes the post-reconcile drift verdict, so "succeeded" cannot be
+///     asserted while drift stands;
+///   - a tool fault a reconcile cannot repair is a separate input from drift a reconcile can.
 /// </summary>
 public class ToolsSyncStateMachineTests
 {
@@ -17,7 +22,7 @@ public class ToolsSyncStateMachineTests
     {
         var sm = new ToolsSyncStateMachine();
 
-        var d = sm.Evaluate(hasDrift: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        var d = sm.Evaluate(reconcilableDrift: false, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
         Assert.Equal(ToolsIndicatorState.InSync, d.State);
         Assert.False(d.ShouldReconcile);
@@ -28,7 +33,7 @@ public class ToolsSyncStateMachineTests
     {
         var sm = new ToolsSyncStateMachine();
 
-        var d = sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
         Assert.Equal(ToolsIndicatorState.Syncing, d.State);
         Assert.True(d.ShouldReconcile);
@@ -40,7 +45,7 @@ public class ToolsSyncStateMachineTests
         var sm = new ToolsSyncStateMachine();
 
         // Debounce: one reconcile at a time - the badge stays orange but no second reconcile is started.
-        var d = sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: true);
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: true);
 
         Assert.Equal(ToolsIndicatorState.Syncing, d.State);
         Assert.False(d.ShouldReconcile);
@@ -51,45 +56,45 @@ public class ToolsSyncStateMachineTests
     {
         var sm = new ToolsSyncStateMachine();
 
-        var d = sm.Evaluate(hasDrift: true, autoUpdateEnabled: false, reconcileInFlight: false);
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: false, reconcileInFlight: false);
 
         Assert.Equal(ToolsIndicatorState.Warning, d.State);
         Assert.False(d.ShouldReconcile);
     }
 
     [Fact]
-    public void OnReconcileSucceeded_ReturnsToInSyncAndClearsFailures()
+    public void OnReconcileFinished_NoFailureAndDriftGone_ReturnsToInSyncAndClearsFailures()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
-        sm.OnReconcileFailed(); // one prior failure on the books
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true); // one prior failure on the books
 
-        sm.OnReconcileSucceeded();
+        sm.OnReconcileFinished(reconcileFailed: false, driftRemains: false);
 
         Assert.Equal(ToolsIndicatorState.InSync, sm.State);
         Assert.Equal(0, sm.ConsecutiveFailures);
     }
 
     [Fact]
-    public void OnReconcileFailed_BelowCeiling_StaysSyncing()
+    public void OnReconcileFinished_BelowCeiling_StaysSyncing()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
-        sm.OnReconcileFailed();
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
 
         Assert.Equal(1, sm.ConsecutiveFailures);
         Assert.Equal(ToolsIndicatorState.Syncing, sm.State);
     }
 
     [Fact]
-    public void OnReconcileFailed_AtCeiling_EscalatesToNeedsAttention()
+    public void OnReconcileFinished_AtCeiling_EscalatesToNeedsAttention()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
         for (var i = 0; i < ToolsSyncStateMachine.MaxReconcileAttempts; i++)
-            sm.OnReconcileFailed();
+            sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
 
         Assert.Equal(ToolsSyncStateMachine.MaxReconcileAttempts, sm.ConsecutiveFailures);
         Assert.Equal(ToolsIndicatorState.NeedsAttention, sm.State);
@@ -99,12 +104,12 @@ public class ToolsSyncStateMachineTests
     public void Evaluate_DriftEnabledAtCeiling_StaysRedAndStopsRetrying()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
         for (var i = 0; i < ToolsSyncStateMachine.MaxReconcileAttempts; i++)
-            sm.OnReconcileFailed();
+            sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
 
         // A fresh snapshot with drift still present must NOT ask for another reconcile - the ceiling holds.
-        var d = sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
         Assert.Equal(ToolsIndicatorState.NeedsAttention, d.State);
         Assert.False(d.ShouldReconcile);
@@ -114,17 +119,17 @@ public class ToolsSyncStateMachineTests
     public void Evaluate_DriftClearsAfterFailures_ResetsToInSyncAndForgetsFailures()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
-        sm.OnReconcileFailed();
-        sm.OnReconcileFailed();
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
 
         // The drift resolves (e.g. another Director fixed it): the badge clears and the budget resets.
-        var resolved = sm.Evaluate(hasDrift: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        var resolved = sm.Evaluate(reconcilableDrift: false, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
         Assert.Equal(ToolsIndicatorState.InSync, resolved.State);
         Assert.Equal(0, sm.ConsecutiveFailures);
 
         // A brand-new drift gets a fresh full attempt budget rather than inheriting the old failures.
-        var fresh = sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        var fresh = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
         Assert.Equal(ToolsIndicatorState.Syncing, fresh.State);
         Assert.True(fresh.ShouldReconcile);
     }
@@ -133,10 +138,10 @@ public class ToolsSyncStateMachineTests
     public void Evaluate_AutoUpdateDisabled_ClearsAnyPriorFailureBudget()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
-        sm.OnReconcileFailed();
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
 
-        var d = sm.Evaluate(hasDrift: true, autoUpdateEnabled: false, reconcileInFlight: false);
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: false, reconcileInFlight: false);
 
         Assert.Equal(ToolsIndicatorState.Warning, d.State);
         Assert.Equal(0, sm.ConsecutiveFailures);
@@ -146,11 +151,11 @@ public class ToolsSyncStateMachineTests
     public void NextBackoff_GrowsExponentiallyWithConsecutiveFailures()
     {
         var sm = new ToolsSyncStateMachine();
-        sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
 
-        sm.OnReconcileFailed();
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
         var first = sm.NextBackoff();
-        sm.OnReconcileFailed();
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: true);
         var second = sm.NextBackoff();
 
         Assert.Equal(ToolsSyncStateMachine.BaseBackoff, first);
@@ -164,15 +169,90 @@ public class ToolsSyncStateMachineTests
 
         // Green at rest.
         Assert.Equal(ToolsIndicatorState.InSync,
-            sm.Evaluate(hasDrift: false, autoUpdateEnabled: true, reconcileInFlight: false).State);
+            sm.Evaluate(reconcilableDrift: false, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false).State);
 
         // Drift -> orange + reconcile.
-        var drift = sm.Evaluate(hasDrift: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        var drift = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
         Assert.Equal(ToolsIndicatorState.Syncing, drift.State);
         Assert.True(drift.ShouldReconcile);
 
         // Reconcile fixes it -> back to green.
-        sm.OnReconcileSucceeded();
+        sm.OnReconcileFinished(reconcileFailed: false, driftRemains: false);
         Assert.Equal(ToolsIndicatorState.InSync, sm.State);
+    }
+
+    // ---- Issue #1045: in-sync must be unreachable while drift stands ---------------------------------
+
+    [Fact]
+    public void OnReconcileFinished_ReconcileReportsSuccessButDriftRemains_IsNotInSync()
+    {
+        // The exact contradiction from the clean-install log: the reconcile reported no failure, and the
+        // drift it was reconciling was still there. There is no argument list that calls that in-sync.
+        var sm = new ToolsSyncStateMachine();
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+
+        sm.OnReconcileFinished(reconcileFailed: false, driftRemains: true);
+
+        Assert.NotEqual(ToolsIndicatorState.InSync, sm.State);
+        Assert.Equal(1, sm.ConsecutiveFailures);
+    }
+
+    [Fact]
+    public void OnReconcileFinished_ReconcileFailedButDriftGone_IsNotInSync()
+    {
+        // The other direction of the same rule: a reconcile that errored does not get to claim green just
+        // because the drift happened to clear (another Director may have fixed it mid-flight).
+        var sm = new ToolsSyncStateMachine();
+        sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+
+        sm.OnReconcileFinished(reconcileFailed: true, driftRemains: false);
+
+        Assert.NotEqual(ToolsIndicatorState.InSync, sm.State);
+    }
+
+    // ---- Issue #1045: a fault no reconcile can repair does not spend the attempt budget --------------
+
+    [Fact]
+    public void Evaluate_ToolFaultWithNoReconcilableDrift_GoesStraightToNeedsAttention()
+    {
+        // cc-pdf installed, shimmed, venv healthy, and failing its own smoke check. Reconciling that three
+        // times over is three guaranteed no-ops; the honest answer is the red to-do, first time.
+        var sm = new ToolsSyncStateMachine();
+
+        var d = sm.Evaluate(reconcilableDrift: false, unreconcilableFault: true, autoUpdateEnabled: true, reconcileInFlight: false);
+
+        Assert.Equal(ToolsIndicatorState.NeedsAttention, d.State);
+        Assert.False(d.ShouldReconcile);
+    }
+
+    [Fact]
+    public void Evaluate_ToolFaultAlongsideReconcilableDrift_StillReconcilesFirst()
+    {
+        // A half-installed toolbelt can present as both. The reconcile is worth running, so drift wins and
+        // the fault is judged again on the far side of it.
+        var sm = new ToolsSyncStateMachine();
+
+        var d = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: true, autoUpdateEnabled: true, reconcileInFlight: false);
+
+        Assert.Equal(ToolsIndicatorState.Syncing, d.State);
+        Assert.True(d.ShouldReconcile);
+    }
+
+    [Fact]
+    public void Evaluate_ToolFaultThenResolved_ReturnsToGreenWithAFreshBudget()
+    {
+        // The red state must not be a one-way door: once the tool works again the badge clears, and a later
+        // drift gets its full attempt budget rather than inheriting the fault's spent one.
+        var sm = new ToolsSyncStateMachine();
+        sm.Evaluate(reconcilableDrift: false, unreconcilableFault: true, autoUpdateEnabled: true, reconcileInFlight: false);
+        Assert.Equal(ToolsIndicatorState.NeedsAttention, sm.State);
+
+        var resolved = sm.Evaluate(reconcilableDrift: false, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        Assert.Equal(ToolsIndicatorState.InSync, resolved.State);
+        Assert.Equal(0, sm.ConsecutiveFailures);
+
+        var fresh = sm.Evaluate(reconcilableDrift: true, unreconcilableFault: false, autoUpdateEnabled: true, reconcileInFlight: false);
+        Assert.Equal(ToolsIndicatorState.Syncing, fresh.State);
+        Assert.True(fresh.ShouldReconcile);
     }
 }

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -138,10 +138,13 @@ public static class HomeStatusBuilder
         if (!h.HasProblem)
             return new HomeCheck(ToolsRowTitle, HomeCheckLevel.Ok, detail, HomeCheckAction.None);
 
-        if (h.Failing.Count > 0)
+        // Name the failing tools WITH the reason each one gave. "1 fail - failing: cc-pdf" sends the reader
+        // to a log that kept no record of why; "failing: cc-pdf (smoke check: timed out after 90s)" is a
+        // fact they can act on, and it is free - the runner already knows it (issue #1045).
+        if (h.Failures.Count > 0)
         {
-            var shown = string.Join(", ", h.Failing.Take(3));
-            if (h.Failing.Count > 3) shown += $", +{h.Failing.Count - 3} more";
+            var shown = string.Join(", ", h.Failures.Take(2).Select(f => f.ToString()));
+            if (h.Failures.Count > 2) shown += $", +{h.Failures.Count - 2} more";
             detail += $" - failing: {shown}";
         }
 

--- a/src/CcDirector.Core/Tools/ToolHealth.cs
+++ b/src/CcDirector.Core/Tools/ToolHealth.cs
@@ -4,9 +4,25 @@ namespace CcDirector.Core.Tools;
 /// One tool's inputs for the home tool-health roll-up. <see cref="Passed"/> is only meaningful when
 /// <see cref="IsBuilt"/> is true (a not-built tool ran no tests). <see cref="IsExpected"/> marks a tool
 /// this install was meant to provide (shim or built), so a not-built-but-expected tool is a repairable
-/// half-install rather than an optional/never-installed one.
+/// half-install rather than an optional/never-installed one. <see cref="FailureReason"/> carries WHY the
+/// tool failed - which check, and what it said - so the failure travels with the count instead of being
+/// discarded (issue #1045).
 /// </summary>
-public readonly record struct ToolHealthInput(string Name, bool IsBuilt, bool IsExpected, bool Passed);
+public readonly record struct ToolHealthInput(
+    string Name, bool IsBuilt, bool IsExpected, bool Passed, string? FailureReason = null);
+
+/// <summary>
+/// A tool that failed its checks, with the reason attached: which check failed and what it reported
+/// (an exit code, a timeout, a missing expected string). The reason is the whole point - "1 fail" tells
+/// a user nothing they can act on, and told us nothing when a clean install reported cc-pdf failing and
+/// the log had kept no record of why.
+/// </summary>
+public sealed record ToolFailure(string Name, string Reason)
+{
+    /// <summary>"cc-pdf (smoke check: timed out after 90s)", or just the name when no reason was captured.</summary>
+    public override string ToString()
+        => string.IsNullOrWhiteSpace(Reason) ? Name : $"{Name} ({Reason})";
+}
 
 /// <summary>
 /// Aggregate cc-* tool health for the home readiness: how many built tools pass their checks, how many
@@ -15,10 +31,13 @@ public readonly record struct ToolHealthInput(string Name, bool IsBuilt, bool Is
 /// problems (a failing built tool or a broken one); optional not-built tools are shown but stay quiet.
 /// </summary>
 public sealed record ToolHealthSummary(
-    int Pass, int Fail, int NotBuilt, int Broken, IReadOnlyList<string> Failing)
+    int Pass, int Fail, int NotBuilt, int Broken, IReadOnlyList<ToolFailure> Failures)
 {
     /// <summary>Total tools considered (pass + fail + not-built).</summary>
     public int Total => Pass + Fail + NotBuilt;
+
+    /// <summary>The names of the failing tools, without their reasons.</summary>
+    public IReadOnlyList<string> Failing => Failures.Select(f => f.Name).ToList();
 
     /// <summary>
     /// True when the home should warn: ANY tool that is not passing - a built tool whose test failed, or
@@ -27,10 +46,24 @@ public sealed record ToolHealthSummary(
     /// </summary>
     public bool HasProblem => Fail > 0 || NotBuilt > 0;
 
+    /// <summary>
+    /// True when a tool is missing from the install - absent, or present as a shim with no binary behind
+    /// it. This IS repairable by a reconcile (it writes the shim, or rebuilds the venv), so it is the half
+    /// of a problem that warrants an automatic attempt.
+    /// </summary>
+    public bool HasMissingTool => NotBuilt > 0 || Broken > 0;
+
+    /// <summary>
+    /// True when a tool that IS installed fails its own checks. A reconcile has no mechanism for this -
+    /// the shim is there, the binary is there, the venv is healthy, and the tool still does not work - so
+    /// retrying one changes nothing. It is a to-do to report with its reason, not drift to loop on.
+    /// </summary>
+    public bool HasFailingTool => Fail > 0;
+
     public static ToolHealthSummary From(IEnumerable<ToolHealthInput> inputs)
     {
         int pass = 0, fail = 0, notBuilt = 0, broken = 0;
-        var failing = new List<string>();
+        var failures = new List<ToolFailure>();
         foreach (var t in inputs)
         {
             if (!t.IsBuilt)
@@ -40,8 +73,8 @@ public sealed record ToolHealthSummary(
                 continue;
             }
             if (t.Passed) pass++;
-            else { fail++; failing.Add(t.Name); }
+            else { fail++; failures.Add(new ToolFailure(t.Name, t.FailureReason ?? "")); }
         }
-        return new ToolHealthSummary(pass, fail, notBuilt, broken, failing);
+        return new ToolHealthSummary(pass, fail, notBuilt, broken, failures);
     }
 }

--- a/src/CcDirector.Core/Tools/ToolHealthProbe.cs
+++ b/src/CcDirector.Core/Tools/ToolHealthProbe.cs
@@ -1,0 +1,208 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Tools;
+
+/// <summary>What the health run concluded about one tool.</summary>
+public enum ToolVerdict
+{
+    /// <summary>The health run has not judged this tool yet.</summary>
+    Unchecked,
+
+    /// <summary>The tool is not installed here, so no checks were run against it.</summary>
+    NotInstalled,
+
+    /// <summary>Every declared check passed.</summary>
+    Working,
+
+    /// <summary>The tool is installed but a declared check failed. <see cref="ToolCheckOutcome.Detail"/> says which.</summary>
+    NotWorking,
+}
+
+/// <summary>One tool's verdict from a health run, with the human-readable reason behind it.</summary>
+public sealed record ToolCheckOutcome(string Name, ToolVerdict Verdict, string Detail);
+
+/// <summary>
+/// The result of one full health run: the roll-up every surface shows, plus the per-tool verdicts, plus
+/// when it was taken.
+/// </summary>
+public sealed record ToolHealthSnapshot(
+    ToolHealthSummary Summary, IReadOnlyList<ToolCheckOutcome> Tools, DateTime TakenUtc);
+
+/// <summary>
+/// Runs every shipped tool's declared checks and rolls them up - the ONE place that answers "do the
+/// tools work?", and the one snapshot every surface reads.
+///
+/// It exists because the answer used to be computed in one surface and guessed at in another (issue
+/// #1045). The Director's board ran these checks and reported cc-pdf failing; the first-run wizard read
+/// only the catalog - a presence check - and rendered it as "Ready" under the heading "All 9 tools are
+/// installed and up to date". Both were describing the same nine tools at the same moment, in opposite
+/// terms, because they were asking different questions and labelling both answers the same way. A
+/// surface that has no verdict must say so ("checking"), not supply a cheerful one of its own.
+/// </summary>
+public static class ToolHealthProbe
+{
+    private static readonly object Gate = new();
+    private static ToolHealthSnapshot? _last;
+    private static Task<ToolHealthSnapshot>? _inFlight;
+    // Bumped by Invalidate. A run that started before the tools on disk changed is answering a question
+    // about a machine that no longer exists, so it must neither be published nor joined by a later caller.
+    private static int _generation;
+
+    /// <summary>
+    /// The most recent completed health run, or null when none has finished yet. Null means "not judged
+    /// yet" and must be rendered as such - never as a pass.
+    /// </summary>
+    public static ToolHealthSnapshot? Last
+    {
+        get { lock (Gate) return _last; }
+    }
+
+    /// <summary>
+    /// Discard the cached verdict so the next run re-judges from scratch. Call this whenever the tools on
+    /// disk change (a repair, a reconcile) - a verdict taken before that change is about a different
+    /// machine. It also detaches any run already in flight, so a caller that arrives immediately after a
+    /// repair starts a FRESH run rather than joining the one that was mid-way through measuring the
+    /// pre-repair state and would have handed back its answer as though it were the post-repair one.
+    /// </summary>
+    public static void Invalidate()
+    {
+        lock (Gate)
+        {
+            _last = null;
+            _inFlight = null;
+            _generation++;
+        }
+        FileLog.Write("[ToolHealthProbe] snapshot invalidated");
+    }
+
+    /// <summary>
+    /// Run every tool's declared checks and publish the snapshot. Bounded concurrency: tools are process
+    /// launches, and a first run on a fresh install is the slowest they ever are. A tool that is not
+    /// available runs no checks and is reported as not installed.
+    ///
+    /// Concurrent callers share ONE run rather than each starting their own. On first launch the board and
+    /// the setup wizard both want this answer at the same moment; two runs would be eighteen cold process
+    /// launches racing each other on the slowest machine state there is, and could hand the two surfaces
+    /// two different answers - the disagreement this whole seam exists to prevent.
+    /// </summary>
+    public static Task<ToolHealthSnapshot> RunAsync(CancellationToken ct = default)
+    {
+        lock (Gate)
+        {
+            if (_inFlight is { } running)
+            {
+                FileLog.Write("[ToolHealthProbe] RunAsync: joining the health run already in flight");
+                return running;
+            }
+            // Task.Run so the catalog read (synchronous file I/O) never runs while this lock is held, and
+            // never on a caller's UI thread.
+            var generation = _generation;
+            var started = Task.Run(() => RunCoreAsync(generation, ct), ct);
+            _inFlight = started;
+            return started;
+        }
+    }
+
+    private static async Task<ToolHealthSnapshot> RunCoreAsync(int generation, CancellationToken ct)
+    {
+        try
+        {
+            var snapshot = await RunUncoalescedAsync(ct);
+            lock (Gate)
+            {
+                if (generation == _generation)
+                {
+                    _last = snapshot;
+                }
+                else
+                {
+                    // The tools changed under this run. Its answer describes the machine as it was before
+                    // that change, so publishing it would put a stale verdict on every surface.
+                    FileLog.Write("[ToolHealthProbe] discarding a health run that the tools changed underneath");
+                }
+            }
+            return snapshot;
+        }
+        finally
+        {
+            lock (Gate)
+            {
+                if (generation == _generation) _inFlight = null;
+            }
+        }
+    }
+
+    private static async Task<ToolHealthSnapshot> RunUncoalescedAsync(CancellationToken ct)
+    {
+        FileLog.Write("[ToolHealthProbe] RunAsync: starting a full tool health run");
+        var catalog = new ToolCatalogService().GetCatalog();
+        var runner = new ToolTestRunner();
+        using var gate = new SemaphoreSlim(Math.Max(1, Environment.ProcessorCount - 1));
+
+        var outcomes = await Task.WhenAll(catalog.Select(async descriptor =>
+        {
+            // Availability (PATH or bundled bin), not bin-only IsBuilt, decides whether the tool can run
+            // its checks (issue #448). A PATH-only tool's BinaryPath is its PATH-resolved exe.
+            if (!descriptor.IsAvailable)
+            {
+                return (input: new ToolHealthInput(descriptor.Name, false, descriptor.IsExpected, false),
+                        outcome: new ToolCheckOutcome(descriptor.Name, ToolVerdict.NotInstalled, "not installed here"));
+            }
+
+            await gate.WaitAsync(ct);
+            try
+            {
+                var results = await runner.RunAllForToolAsync(descriptor, ct);
+                var firstFailure = results.FirstOrDefault(r => !r.Passed);
+                if (firstFailure is null)
+                {
+                    return (input: new ToolHealthInput(descriptor.Name, true, descriptor.IsExpected, true),
+                            outcome: new ToolCheckOutcome(descriptor.Name, ToolVerdict.Working, "all checks passed"));
+                }
+
+                var reason = DescribeFailure(firstFailure);
+                // Log the reason HERE, where it is known. Reporting "1 fail" and dropping the cause is
+                // what made the clean-install cc-pdf failure undiagnosable from the log it left behind.
+                FileLog.Write($"[ToolHealthProbe] {descriptor.Name} FAILED: {reason}" +
+                              DescribeOutput(firstFailure));
+                return (input: new ToolHealthInput(descriptor.Name, true, descriptor.IsExpected, false, reason),
+                        outcome: new ToolCheckOutcome(descriptor.Name, ToolVerdict.NotWorking, reason));
+            }
+            finally { gate.Release(); }
+        }));
+
+        var summary = ToolHealthSummary.From(outcomes.Select(o => o.input));
+        var snapshot = new ToolHealthSnapshot(summary, outcomes.Select(o => o.outcome).ToList(), DateTime.UtcNow);
+
+        FileLog.Write($"[ToolHealthProbe] RunAsync done: pass={summary.Pass}, fail={summary.Fail}, " +
+                      $"notBuilt={summary.NotBuilt}, broken={summary.Broken}" +
+                      (summary.Failures.Count == 0 ? "" : $", failing: {string.Join("; ", summary.Failures)}"));
+        return snapshot;
+    }
+
+    /// <summary>
+    /// One line naming WHICH check failed and what it reported, e.g. "smoke check: timed out after 90s"
+    /// or "version check: exit 1". This is the string the board row, the wizard row, and the log all show.
+    /// </summary>
+    private static string DescribeFailure(ToolTestResult result)
+    {
+        var check = result.Kind switch
+        {
+            ToolTestKind.OnPath => "binary missing",
+            ToolTestKind.Version => "version check",
+            ToolTestKind.Smoke => "smoke check",
+            _ => result.Kind.ToString(),
+        };
+        return string.IsNullOrWhiteSpace(result.Message) ? check : $"{check}: {result.Message}";
+    }
+
+    /// <summary>The tool's own output on a failure, trimmed to one readable line for the log.</summary>
+    private static string DescribeOutput(ToolTestResult result)
+    {
+        var text = !string.IsNullOrWhiteSpace(result.Stderr) ? result.Stderr : result.Stdout;
+        if (string.IsNullOrWhiteSpace(text)) return "";
+        var oneLine = text.Replace("\r", " ").Replace("\n", " ").Trim();
+        if (oneLine.Length > 300) oneLine = oneLine[..300] + "...";
+        return $" | output: {oneLine}";
+    }
+}

--- a/src/CcDirector.Core/Tools/ToolsScreenFold.cs
+++ b/src/CcDirector.Core/Tools/ToolsScreenFold.cs
@@ -1,0 +1,134 @@
+namespace CcDirector.Core.Tools;
+
+/// <summary>What the setup wizard's Tools step should say about one tool.</summary>
+public enum ToolRowVerdict
+{
+    /// <summary>Not on disk yet, and still within the window where that is expected.</summary>
+    Installing,
+
+    /// <summary>Not on disk, and past the point where "installing" is an honest thing to say.</summary>
+    NotInstalled,
+
+    /// <summary>On disk. Whether it RUNS has not been answered yet - so the screen must not claim it does.</summary>
+    Checking,
+
+    /// <summary>On disk and every declared check passed.</summary>
+    Working,
+
+    /// <summary>On disk and a declared check failed. <see cref="ToolsScreenRow.Detail"/> says which.</summary>
+    NotWorking,
+}
+
+/// <summary>How the step's status line should read.</summary>
+public enum ToolsScreenTone
+{
+    Progress,
+    Good,
+    Bad,
+}
+
+/// <summary>One rendered row of the Tools step.</summary>
+public sealed record ToolsScreenRow(string Name, ToolRowVerdict Verdict, string Detail);
+
+/// <summary>Everything the Tools step renders, decided in one place.</summary>
+public sealed record ToolsScreenView(
+    IReadOnlyList<ToolsScreenRow> Rows,
+    string StatusText,
+    ToolsScreenTone Tone,
+    bool OfferRepair,
+    bool KeepPolling);
+
+/// <summary>One tool as the wizard knows it before any verdict: its name, its blurb, and whether it is on disk.</summary>
+public readonly record struct ToolsScreenInput(string Name, string Description, bool IsAvailable);
+
+/// <summary>
+/// Decides what the first-run wizard's Tools step says - every row and the status line - from the
+/// catalog (what is on disk) and the shared health snapshot (whether it works).
+///
+/// It is a fold rather than a handful of conditionals in the view because of what the view did with
+/// them (issue #1045). It had only the catalog, which answers "is it here?", and it rendered that
+/// answer as "Ready" beneath the heading "All 9 tools are installed and up to date" - a claim about
+/// working, made from evidence about presence. Minutes later the Director's board ran the actual checks
+/// and named cc-pdf as failing. Two screens of one product, one install, opposite claims, and a new
+/// user could see both inside a minute.
+///
+/// The rule this encodes: presence and function are different questions, a screen may only assert the
+/// one it has evidence for, and "no answer yet" renders as CHECKING - never as a pass.
+/// </summary>
+public static class ToolsScreenFold
+{
+    public static ToolsScreenView Fold(
+        IReadOnlyList<ToolsScreenInput> tools, bool stalled, ToolHealthSnapshot? health)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+
+        var verdicts = health?.Tools.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
+        var rows = new List<ToolsScreenRow>(tools.Count);
+
+        foreach (var tool in tools)
+        {
+            if (!tool.IsAvailable)
+            {
+                rows.Add(stalled
+                    ? new ToolsScreenRow(tool.Name, ToolRowVerdict.NotInstalled, $"{tool.Description} - this one did not install")
+                    : new ToolsScreenRow(tool.Name, ToolRowVerdict.Installing, tool.Description));
+                continue;
+            }
+
+            var outcome = verdicts is not null && verdicts.TryGetValue(tool.Name, out var v) ? v : null;
+            rows.Add(outcome?.Verdict switch
+            {
+                ToolVerdict.Working => new ToolsScreenRow(tool.Name, ToolRowVerdict.Working, tool.Description),
+                ToolVerdict.NotWorking => new ToolsScreenRow(tool.Name, ToolRowVerdict.NotWorking, $"{tool.Description} - {outcome.Detail}"),
+                // Installed, unjudged. The honest row is "checking", which is what this whole fold is for.
+                _ => new ToolsScreenRow(tool.Name, ToolRowVerdict.Checking, $"{tool.Description} - installed, checking that it runs"),
+            });
+        }
+
+        var total = tools.Count;
+        var installed = tools.Count(t => t.IsAvailable);
+        var missing = total - installed;
+        var failures = health?.Summary.Failures ?? Array.Empty<ToolFailure>();
+
+        if (missing > 0 && stalled)
+        {
+            return new ToolsScreenView(rows,
+                missing == 1
+                    ? "1 tool did not install. Repairing takes about a minute - you can continue while it runs."
+                    : $"{missing} tools did not install. Repairing takes about a minute - you can continue while it runs.",
+                ToolsScreenTone.Bad, OfferRepair: true, KeepPolling: false);
+        }
+
+        if (missing > 0)
+        {
+            // Both halves of the trade, so continuing is an informed choice rather than a guess.
+            return new ToolsScreenView(rows,
+                $"{installed} of {total} installed. Wait here and all of them will be working before you finish. " +
+                "Continue and DevThrottle finishes the rest in the background on its own.",
+                ToolsScreenTone.Progress, OfferRepair: false, KeepPolling: true);
+        }
+
+        if (health is null)
+        {
+            // Everything is on disk and nothing has run them. Say precisely that much and no more.
+            return new ToolsScreenView(rows,
+                $"All {total} tools are installed. Checking that each one runs...",
+                ToolsScreenTone.Progress, OfferRepair: false, KeepPolling: true);
+        }
+
+        if (failures.Count > 0)
+        {
+            var shown = string.Join(", ", failures.Take(2).Select(f => f.ToString()));
+            if (failures.Count > 2) shown += $", +{failures.Count - 2} more";
+            return new ToolsScreenView(rows,
+                failures.Count == 1
+                    ? $"All {total} tools are installed, but one is not working: {shown}. Repairing takes about a minute - you can continue while it runs."
+                    : $"All {total} tools are installed, but {failures.Count} are not working: {shown}. Repairing takes about a minute - you can continue while it runs.",
+                ToolsScreenTone.Bad, OfferRepair: true, KeepPolling: false);
+        }
+
+        return new ToolsScreenView(rows,
+            $"All {total} tools are installed and working.",
+            ToolsScreenTone.Good, OfferRepair: false, KeepPolling: false);
+    }
+}

--- a/src/CcDirector.Core/Tools/ToolsSyncStateMachine.cs
+++ b/src/CcDirector.Core/Tools/ToolsSyncStateMachine.cs
@@ -9,11 +9,11 @@ namespace CcDirector.Core.Tools;
 ///   InSync   -> tools are healthy; the badge hides (the green / all-clear case).
 ///   Syncing  -> drift was found and a reconcile is running to fix it (orange "Syncing tools...").
 ///   Warning  -> drift exists but auto-update is OFF; the legacy passive amber warning, click = Settings.
-///   NeedsAttention -> reconcile failed repeatedly; red "Tools need attention", a real clickable to-do.
+///   NeedsAttention -> red "Tools need attention", a real clickable to-do.
 ///
-/// The normal cycle is Green -> Orange (syncing) -> Green (resolved). Red is only reached after a
-/// bounded number of failed/ineffective reconcile attempts; it is the single case that stays a
-/// user-facing to-do.
+/// The normal cycle is Green -> Orange (syncing) -> Green (resolved). Red is reached two ways: after a
+/// bounded number of failed or ineffective reconcile attempts, or immediately for a tool fault no
+/// reconcile can repair (issue #1045). It is the single case that stays a user-facing to-do.
 /// </summary>
 public enum ToolsIndicatorState
 {
@@ -26,7 +26,10 @@ public enum ToolsIndicatorState
     /// <summary>Drift exists but auto-update is off. The legacy passive amber warning (click opens Settings).</summary>
     Warning,
 
-    /// <summary>Reconcile failed repeatedly. Red "Tools need attention" (a real, clickable to-do).</summary>
+    /// <summary>
+    /// Red "Tools need attention" (a real, clickable to-do): reconcile failed repeatedly, or a tool is
+    /// installed and failing its own check, which no reconcile can repair.
+    /// </summary>
     NeedsAttention,
 }
 
@@ -68,13 +71,23 @@ public sealed class ToolsSyncStateMachine
 
     /// <summary>
     /// Decide the indicator state for a fresh health snapshot and whether a reconcile should start now.
+    ///
+    /// The two problem inputs are deliberately separate, because they call for opposite responses and
+    /// were previously collapsed into one "hasDrift" flag (issue #1045). Feeding a tool's failing smoke
+    /// check into the reconciler asked a layout repair to fix something it has no mechanism for: the
+    /// reconcile correctly reported in-sync, the tool went on failing, and the ineffective-attempt count
+    /// climbed to the ceiling - three no-op reconciles ending in a red badge that named no reason.
     /// </summary>
-    /// <param name="hasDrift">True when the cc-* tools row is not green (the today-warning condition).</param>
+    /// <param name="reconcilableDrift">Drift a reconcile can actually correct: a missing shim, an orphaned
+    /// legacy alias, a broken or absent shared venv, a half-installed tool.</param>
+    /// <param name="unreconcilableFault">A tool that is installed and backed by a healthy venv but whose own
+    /// check fails. No reconcile will move this; it is a to-do for the user, reported with its reason.</param>
     /// <param name="autoUpdateEnabled">The effective <c>tools.autoUpdate.enabled</c> value.</param>
     /// <param name="reconcileInFlight">True when a reconcile this machine started has not finished yet.</param>
-    public ToolsSyncDecision Evaluate(bool hasDrift, bool autoUpdateEnabled, bool reconcileInFlight)
+    public ToolsSyncDecision Evaluate(
+        bool reconcilableDrift, bool unreconcilableFault, bool autoUpdateEnabled, bool reconcileInFlight)
     {
-        if (!hasDrift)
+        if (!reconcilableDrift && !unreconcilableFault)
         {
             // Resolved (or never drifted): back to green and forget past failures so the next drift
             // starts a fresh attempt budget.
@@ -92,7 +105,15 @@ public sealed class ToolsSyncStateMachine
             return new ToolsSyncDecision(State, ShouldReconcile: false);
         }
 
-        // Drift + auto-update on.
+        if (!reconcilableDrift)
+        {
+            // A tool fault with nothing to reconcile. Do not spend the attempt budget on reconciles that
+            // are each a guaranteed no-op - go straight to the red to-do, which names the tool and why.
+            OnUnreconcilableFault();
+            return new ToolsSyncDecision(State, ShouldReconcile: false);
+        }
+
+        // Reconcilable drift + auto-update on.
         if (ConsecutiveFailures >= MaxReconcileAttempts)
         {
             // Retry ceiling hit: stay red and stop auto-retrying. The user can still click to open Settings.
@@ -107,25 +128,45 @@ public sealed class ToolsSyncStateMachine
     }
 
     /// <summary>
-    /// Record that a reconcile attempt resolved the drift: clear the failure count and return to green.
+    /// Record the outcome of one reconcile attempt. This is the ONLY way to report an attempt, and it
+    /// takes the post-reconcile drift verdict as an argument, so "the reconcile succeeded" is not a thing
+    /// a caller can assert on its own - success means the reconcile did not fail AND the drift it was
+    /// reconciling is gone. Anything else is an ineffective attempt: the failure count rises and the badge
+    /// stays orange for a retry after <see cref="NextBackoff"/>, or falls to red once the ceiling is hit.
+    ///
+    /// The split matters (issue #1045). The old shape had a bare <c>OnReconcileSucceeded()</c> beside a
+    /// bare <c>OnReconcileFailed()</c> and left it to the caller to check drift before choosing - so the
+    /// rule that decides the whole indicator lived outside the thing that owns the indicator's state, and
+    /// a caller that forgot the check could report green over standing drift. Here it cannot: there is no
+    /// argument list that says in-sync while <paramref name="driftRemains"/> is true.
     /// </summary>
-    public void OnReconcileSucceeded()
+    /// <param name="reconcileFailed">True when the reconcile itself errored or reported failure.</param>
+    /// <param name="driftRemains">True when drift is STILL present after the reconcile ran.</param>
+    public void OnReconcileFinished(bool reconcileFailed, bool driftRemains)
     {
-        ConsecutiveFailures = 0;
-        State = ToolsIndicatorState.InSync;
-    }
+        if (!reconcileFailed && !driftRemains)
+        {
+            ConsecutiveFailures = 0;
+            State = ToolsIndicatorState.InSync;
+            return;
+        }
 
-    /// <summary>
-    /// Record a failed/ineffective reconcile attempt (it errored, or it ran but drift still remains).
-    /// Increments the failure count and escalates to red once the ceiling is reached; otherwise it stays
-    /// orange so the caller can retry after <see cref="NextBackoff"/>.
-    /// </summary>
-    public void OnReconcileFailed()
-    {
         ConsecutiveFailures++;
         State = ConsecutiveFailures >= MaxReconcileAttempts
             ? ToolsIndicatorState.NeedsAttention
             : ToolsIndicatorState.Syncing;
+    }
+
+    /// <summary>
+    /// Record a fault that a reconcile cannot repair: a tool that is installed, shimmed, and backed by a
+    /// healthy venv, but whose own check fails. There is no drift for the reconciler to correct, so
+    /// retrying it is pure noise - the machine goes straight to the red, user-facing to-do instead of
+    /// spending the attempt budget on three reconciles that are each a guaranteed no-op (issue #1045).
+    /// </summary>
+    public void OnUnreconcilableFault()
+    {
+        ConsecutiveFailures = MaxReconcileAttempts; // the budget is spent: retrying cannot help
+        State = ToolsIndicatorState.NeedsAttention;
     }
 
     /// <summary>

--- a/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
@@ -458,4 +458,119 @@ public sealed class ToolReconcilerTests : IDisposable
 
         Assert.True(new ToolReconciler(_layout).HasDrift());
     }
+
+    // ---- The heavy repair must survive a real thread hop (issue #1045) ---------------------------------
+    //
+    // Every other heavy-repair double in this file returns Task.FromResult, so the await inside the
+    // reconciler's mutex-guarded block completes SYNCHRONOUSLY and the mutex is released by the same
+    // thread that took it. The real heavy repair downloads a release and runs pip - it always yields, and
+    // its continuation resumes on an arbitrary thread-pool thread. A Windows named mutex has thread
+    // affinity, so releasing it there threw "Object synchronization method was called from an
+    // unsynchronized block of code", the reconciler's catch turned that into ReconcileOutcome.Failed, and
+    // a clean install reported its own successful first-run provision as a failure. The doubles below
+    // yield for real, which is the only thing the older ones do not do.
+
+    /// <summary>
+    /// A heavy-repair delegate whose task is completed by a DIFFERENT, explicitly-created thread. The
+    /// TaskCompletionSource deliberately does NOT use RunContinuationsAsynchronously, so the awaiting
+    /// continuation inside the reconciler runs inline on that foreign thread - which is what makes the
+    /// thread hop deterministic rather than a race the test might win by luck. (A plain
+    /// <c>await Task.Delay</c> is not enough: it schedules the continuation back through the test
+    /// runner's synchronization context and can land on the original thread, so a double built that way
+    /// passes against the broken code and detects nothing.)
+    /// </summary>
+    private sealed class ForeignThreadHeavyRepair
+    {
+        private readonly InstallLayout _layout;
+        public int Calls { get; private set; }
+        public int EnteredOnThreadId { get; private set; }
+        public int CompletedOnThreadId { get; private set; }
+        public ForeignThreadHeavyRepair(InstallLayout layout) => _layout = layout;
+
+        public Task<PythonToolsResult> InvokeAsync(CancellationToken ct)
+        {
+            Calls++;
+            EnteredOnThreadId = Environment.CurrentManagedThreadId;
+            var tcs = new TaskCompletionSource<PythonToolsResult>();
+            var worker = new Thread(() =>
+            {
+                CompletedOnThreadId = Environment.CurrentManagedThreadId;
+                Directory.CreateDirectory(_layout.PyenvScriptsDir);
+                File.WriteAllText(PythonToolsInstaller.ConsoleScriptPath(_layout, "cc-pdf"), "fake-exe");
+                new PythonToolsInstaller(_layout).WriteShims(new[] { "cc-pdf" });
+                var manifest = InstalledManifest.Load(_layout);
+                manifest.Set(PythonToolsInstaller.ComponentId, "1.0.0");
+                manifest.Save(_layout);
+                PythonToolsState.SaveScripts(_layout, new[] { "cc-pdf" });
+                tcs.SetResult(new PythonToolsResult(true, "provisioned", Array.Empty<string>(), 1, "1.0.0"));
+            })
+            { IsBackground = true, Name = "foreign-heavy-repair" };
+            worker.Start();
+            return tcs.Task;
+        }
+    }
+
+    /// <summary>
+    /// Run a reconcile the way the Director does - inside <c>Task.Run</c>, with no synchronization context -
+    /// so awaited continuations resume wherever the runtime puts them rather than being marshalled back by
+    /// the test runner.
+    /// </summary>
+    private static Task<ReconcileResult> ReconcileOffContextAsync(ToolReconciler reconciler)
+        => Task.Run(() => reconciler.ReconcileAsync());
+
+    [Fact]
+    public async Task ReconcileAsync_FirstRunProvision_HeavyRepairResumesOnAnotherThread_ReportsReconciled()
+    {
+        // Nothing on disk at all - the clean-install state, which escalates to the from-nothing provision.
+        var heavy = new ForeignThreadHeavyRepair(_layout);
+
+        var result = await ReconcileOffContextAsync(new ToolReconciler(_layout, heavy.InvokeAsync));
+
+        Assert.Equal(1, heavy.Calls);
+        Assert.NotEqual(heavy.EnteredOnThreadId, heavy.CompletedOnThreadId); // the hop really happened
+        Assert.Null(result.Error);
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.Contains(result.Actions, a => a.Contains("first run", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_BrokenVenv_HeavyRepairResumesOnAnotherThread_ReportsReconciled()
+    {
+        // A recorded bundle whose venv lost a console script - the repair escalation, also mutex-guarded.
+        RecordBundleInstalled();
+        RecordExpectedScripts("cc-pdf");
+        var heavy = new ForeignThreadHeavyRepair(_layout);
+
+        var result = await ReconcileOffContextAsync(new ToolReconciler(_layout, heavy.InvokeAsync));
+
+        Assert.Equal(1, heavy.Calls);
+        Assert.NotEqual(heavy.EnteredOnThreadId, heavy.CompletedOnThreadId);
+        Assert.Null(result.Error);
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_HeavyRepairResumesOnAnotherThread_MutexIsReleasedForTheNextCaller()
+    {
+        // The release must actually happen, not merely not-throw: a mutex left held (or abandoned by a
+        // failed release) would block or corrupt the next Director's reconcile.
+        var heavy = new ForeignThreadHeavyRepair(_layout);
+        await ReconcileOffContextAsync(new ToolReconciler(_layout, heavy.InvokeAsync));
+
+        using var mutex = new Mutex(initiallyOwned: false, ToolReconciler.HeavyRepairMutexName, out _);
+        var acquired = false;
+        try
+        {
+            acquired = mutex.WaitOne(TimeSpan.FromSeconds(1));
+            Assert.True(acquired, "the heavy-repair mutex was still held after the reconcile returned");
+        }
+        catch (AbandonedMutexException)
+        {
+            Assert.Fail("the heavy-repair mutex was abandoned - it was never released by its owning thread");
+        }
+        finally
+        {
+            if (acquired) mutex.ReleaseMutex();
+        }
+    }
 }

--- a/tools/cc-director-setup-engine/ToolReconciler.cs
+++ b/tools/cc-director-setup-engine/ToolReconciler.cs
@@ -263,39 +263,76 @@ public sealed class ToolReconciler
     /// holder. <paramref name="logReason"/> and <paramref name="successAction"/> tailor the wording so the log
     /// and the reported action distinguish a repair from a first-run provision.
     /// </summary>
-    private async Task<ReconcileResult?> EscalateHeavyRepairAsync(
+    private Task<ReconcileResult?> EscalateHeavyRepairAsync(
         List<string> actions, CancellationToken ct, string logReason, string successAction)
     {
-        using var mutex = new Mutex(initiallyOwned: false, HeavyRepairMutexName, out _);
-        var held = false;
-        try
+        // A Windows named mutex has THREAD AFFINITY: only the thread that took it may release it. The
+        // guarded work is asynchronous, and an await resumes on whatever thread the runtime picks - so
+        // taking the mutex, awaiting, and releasing inline meant ReleaseMutex ran on a different thread
+        // and threw "Object synchronization method was called from an unsynchronized block of code".
+        // ReconcileAsync's catch turned that into ReconcileOutcome.Failed, so a clean install reported
+        // its own SUCCESSFUL first-run provision as a failure and burned a reconcile attempt on it
+        // (issue #1045). Owning the mutex for the whole critical section on ONE dedicated thread is the
+        // fix: the release is guaranteed to run where the acquire did, and the abandonment recovery a
+        // named mutex gives us across Directors is preserved.
+        return RunOwningOneThreadAsync<ReconcileResult?>(() =>
         {
-            try { held = mutex.WaitOne(TimeSpan.Zero); }
-            catch (AbandonedMutexException) { held = true; } // a prior holder died; we now own it
-
-            if (!held)
+            using var mutex = new Mutex(initiallyOwned: false, HeavyRepairMutexName, out _);
+            var held = false;
+            try
             {
-                FileLog.Write("[ToolReconciler] reconcile skipped - another Director is reconciling");
-                actions.Add("heavy venv work skipped - another Director is reconciling");
+                try { held = mutex.WaitOne(TimeSpan.Zero); }
+                catch (AbandonedMutexException) { held = true; } // a prior holder died; we now own it
+
+                if (!held)
+                {
+                    FileLog.Write("[ToolReconciler] reconcile skipped - another Director is reconciling");
+                    actions.Add("heavy venv work skipped - another Director is reconciling");
+                    return null;
+                }
+
+                FileLog.Write($"[ToolReconciler] {logReason}");
+                // Blocking is correct here and cannot deadlock: this dedicated thread exists only to own
+                // the mutex, it belongs to no pool, and it holds no other lock.
+                var repair = _heavyRepairAsync(ct).GetAwaiter().GetResult();
+                if (!repair.Success)
+                {
+                    FileLog.Write($"[ToolReconciler] heavy venv work FAILED: {repair.Message}");
+                    return new ReconcileResult(ReconcileOutcome.Failed, actions, repair.Message);
+                }
+
+                FileLog.Write($"[ToolReconciler] heavy venv work succeeded: {repair.Message}");
+                actions.Add($"{successAction} ({repair.Message})");
                 return null;
             }
-
-            FileLog.Write($"[ToolReconciler] {logReason}");
-            var repair = await _heavyRepairAsync(ct);
-            if (!repair.Success)
+            finally
             {
-                FileLog.Write($"[ToolReconciler] heavy venv work FAILED: {repair.Message}");
-                return new ReconcileResult(ReconcileOutcome.Failed, actions, repair.Message);
+                if (held) mutex.ReleaseMutex();
             }
+        });
+    }
 
-            FileLog.Write($"[ToolReconciler] heavy venv work succeeded: {repair.Message}");
-            actions.Add($"{successAction} ({repair.Message})");
-            return null;
-        }
-        finally
+    /// <summary>
+    /// Run <paramref name="work"/> start-to-finish on one dedicated thread and surface its result (or its
+    /// exception) as a task. Used for the named-mutex critical section, which must be acquired and released
+    /// by the same thread; a thread-pool thread will not do, because the pool is free to run the work's
+    /// continuations elsewhere. The thread is created per call and is background, so it never keeps the
+    /// process alive.
+    /// </summary>
+    private static Task<T> RunOwningOneThreadAsync<T>(Func<T> work)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
         {
-            if (held) mutex.ReleaseMutex();
-        }
+            try { completion.SetResult(work()); }
+            catch (Exception ex) { completion.SetException(ex); }
+        })
+        {
+            IsBackground = true,
+            Name = "cc-director-tool-reconcile",
+        };
+        thread.Start();
+        return completion.Task;
     }
 
     /// <summary>

--- a/tools/cc-pdf/src/cli.py
+++ b/tools/cc-pdf/src/cli.py
@@ -34,13 +34,27 @@ try:
     from . import __version__
     from .html_generator import generate_html, embed_images_as_base64, AssetEmbedError
     from .pdf_converter import convert_to_pdf
-    from .md_converter import convert_pdf_to_markdown
 except ImportError:
     # Frozen executable mode - use absolute imports
     from src import __version__
     from src.html_generator import generate_html, embed_images_as_base64, AssetEmbedError
     from src.pdf_converter import convert_to_pdf
-    from src.md_converter import convert_pdf_to_markdown
+
+
+def _load_pdf_to_markdown():
+    """Import the PDF-to-Markdown converter, which is the only thing here that needs PyMuPDF.
+
+    PyMuPDF is a 53 MB native extension. Importing it at module load made EVERY cc-pdf invocation
+    pay for it - including ``--version`` and ``--themes``, which are the two commands the Director's
+    tool health check runs and which need nothing from it. Loading it inside the one command that
+    uses it keeps the health check off the heaviest import in the toolbelt, where a cold first run
+    on a fresh install is at its slowest and an antivirus is scanning the file for the first time.
+    """
+    try:
+        from .md_converter import convert_pdf_to_markdown
+    except ImportError:
+        from src.md_converter import convert_pdf_to_markdown
+    return convert_pdf_to_markdown
 
 # Import shared modules - handle both package and frozen modes
 try:
@@ -315,7 +329,7 @@ def to_markdown(
         _progress(f"[blue]Reading:[/blue] {input_file}", quiet)
 
         _progress("[blue]Converting:[/blue] PDF to Markdown", quiet)
-        markdown = convert_pdf_to_markdown(input_file, output, force=force)
+        markdown = _load_pdf_to_markdown()(input_file, output, force=force)
 
         _progress(f"[blue]Writing:[/blue] {output}", quiet)
         output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes the two defects behind internal issue #1045: a clean install of v1.8.7 landing on the board in
NEEDS ATTENTION, and a reconcile that reported `InSync` while `driftRemains=True`.

## What I actually reproduced

I could NOT reproduce cc-pdf failing. I built a rig that points `CC_DIRECTOR_ROOT` at an empty
directory, runs the reconciler's from-nothing provision (the real clean-install path: fetch the
release, build the shared venv, pip install the bundle), and then runs the exact health checks the
Director runs, printing every result. On a freshly provisioned bundle all eight shipped tools passed,
cc-pdf included.

What that rig DID reproduce, on the first run and every run, is a defect nobody had named:

```
reconcile: outcome=Failed, actions=0, error=Object synchronization method was called from an
unsynchronized block of code., 143s
catalog   : 8 tools, 8 built, 8 available
tool health: pass=8, fail=0
```

The provision fully succeeded - every tool built, every check green - and the reconcile reported
`Failed`.

## Root cause

`ToolReconciler.EscalateHeavyRepairAsync` took a Windows named mutex, awaited the heavy repair, and
released the mutex. A Windows named mutex has thread affinity: only the thread that took it may
release it. The `await` resumes on whatever thread the runtime picks, so `ReleaseMutex` ran on the
wrong thread and threw. `ReconcileAsync`'s catch turned that into `ReconcileOutcome.Failed`.

Every heavy escalation was affected - the first-run provision AND the broken-venv repair. The heavy
path could never report success.

The existing tests missed it because every heavy-repair test double returns `Task.FromResult`. A
completed task makes the `await` finish synchronously on the same thread, so the release succeeds and
the test passes. The doubles removed the exact property under test.

That also explains the log line in the issue. On a clean install: attempt 1 provisions the bundle,
succeeds, and reports `Failed` (this bug); attempts 2 and 3 find nothing to reconcile and honestly
report `InSync` while cc-pdf still fails its own check. Three ineffective attempts, and the badge
falls to red.

## The status defect, treated separately

`outcome=InSync, driftRemains=True` was two different questions printed under one word, and a rule
living outside the thing it governs.

- `ToolsSyncStateMachine` had a bare `OnReconcileSucceeded()` next to a bare `OnReconcileFailed()`,
  and left it to the caller to check drift before picking one. Success was a thing a caller could
  simply assert. It is now one method, `OnReconcileFinished(reconcileFailed, driftRemains)`, which
  takes the drift verdict as an argument - there is no argument list that says in-sync while drift
  stands.
- The reconcile was being driven by a tool's failing smoke check. A reconcile writes shims, purges
  orphaned aliases, and rebuilds venvs; it has no mechanism for a tool that is installed, shimmed,
  venv-healthy, and simply does not run. Three reconciles were each a guaranteed no-op. The two are
  now separate inputs: reconcilable drift starts a reconcile, an unreconcilable tool fault goes
  straight to the red to-do and names itself.
- `failures=3` beside `fail=1` were two different populations. The log now says
  `ineffectiveAttempts=3/3` and prints the drift sources separately.

## Making the failing state the one you get for free

The runner knew cc-pdf's exit code, its message, its stdout and its stderr, and threw all four away;
the board printed `1 fail - failing: cc-pdf` and the log kept no record of why. Diagnosing it needed
another clean machine.

The reason now travels with the count. `ToolHealthProbe` logs each failure with its cause and output
at the moment it is known, and the board row reads
`8 pass - 1 fail - failing: cc-pdf (smoke check: timed out after 90s)`.

## The three surfaces that disagreed

The wizard's Tools step, the wizard's Done receipt, and the board were asking different questions and
labelling all three answers the same way. The wizard read the catalog - a presence check - and
rendered it as "Ready" under "All 9 tools are installed and up to date"; the board ran the checks and
named cc-pdf as failing.

All three now read one shared verdict (`ToolHealthProbe`), and the wizard's ruling moved out of the
view into a pure fold (`ToolsScreenFold`). No verdict yet renders as "Checking" - never as a pass.
"All N tools are installed" is now said only when that is the claim being made; "and working" only
once something has run them.

## cc-pdf itself

Not a proven cause - I could not reproduce the failure, and I am not going to write a cause I did not
observe. What I did do is remove the one thing that made cc-pdf uniquely fragile on exactly the two
commands the health check runs: it imported PyMuPDF, a 53 MB native extension, at CLI load, so
`--version` and `--themes` both paid for it despite needing nothing from it. That import is now
deferred into the single command that uses it. Verified in a freshly provisioned venv: PyMuPDF no
longer loads for `--version`/`--themes`, and the markdown-to-PDF and PDF-to-markdown round trip still
works.

If cc-pdf fails again, the log will say why.

## Tests

- Three new reconciler cases drive the heavy repair through a real thread hop. The first version of
  this detector used `await Task.Delay` and PASSED against the broken code - the test runner's
  synchronization context marshalled the continuation back to the original thread. The committed
  version completes the task from an explicitly-created thread with an inline continuation, and fails
  against the broken code with the exact production error.
- State machine cases pin both directions of the new invariant, plus the tool-fault path.
- `ToolHealthSummary` cases pin that a failure keeps its reason, and that missing-tool and
  failing-tool are told apart.
- `ToolsScreenFoldTests` pins the contradiction from the issue: installed-but-unchecked renders as
  Checking and asserts nothing about working; installed-and-failing names the tool and its reason and
  can never render Ready.

Closes thefrederiksen/devthrottle_internal#1045
