### PR TITLE
Compare worktree paths the way the monitor does, so a linked temporary directory is not a red test

### DIFF
--- a/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
+++ b/src/CcDirector.Core.Tests/RepositoryMonitorTests.cs
@@ -268,11 +268,21 @@ public class RepositoryMonitorTests
 
             await monitor.RecomputeOneAsync(wt); // the watcher hands over a linked-worktree path
 
+            // Compare paths the way the monitor itself does. This used to use Path.GetFullPath,
+            // which resolves "." and ".." but NOT junctions or symbolic links, while the primary
+            // path arrives here from git (rev-parse --git-common-dir), which reports the RESOLVED
+            // real path. On any machine whose temporary directory is reached through a junction or
+            // a symbolic link the two spellings name the same directory and the string comparison
+            // still failed - a red that said "the monitor stored the wrong path" when the monitor
+            // was right and only the assertion was too literal. NormalizePath is the production
+            // canonicalizer (it follows links via GetFinalPathNameByHandle) and is what keys the
+            // model, so asserting through it tests the promise the monitor actually makes.
             lock (computedPaths)
                 Assert.All(computedPaths, p => Assert.Equal(
-                    System.IO.Path.GetFullPath(primary), System.IO.Path.GetFullPath(p)));
+                    WorktreeReaperService.NormalizePath(primary), WorktreeReaperService.NormalizePath(p)));
             var entry = Assert.Single(monitor.Snapshot());
-            Assert.Equal(System.IO.Path.GetFullPath(primary), System.IO.Path.GetFullPath(entry.Path));
+            Assert.Equal(
+                WorktreeReaperService.NormalizePath(primary), WorktreeReaperService.NormalizePath(entry.Path));
         }
         finally
         {


### PR DESCRIPTION
Closes the code side of thefrederiksen/devthrottle_internal#990 - `RepositoryMonitorTests.RecomputeOne_LinkedWorktreePath_RecomputesThePrimaryEntry` reported red on `origin/main` in an untouched checkout.

## What it turned out to be

It is environment-dependent, exactly as the issue suspected, and the environment condition is a **temporary directory reached through a junction or a symbolic link**.

The test builds its expected path from `Path.GetTempPath()` and compares with `Path.GetFullPath`, which resolves `.` and `..` but does **not** follow links. The path it compares against comes from git (`rev-parse --path-format=absolute --git-common-dir`), which reports the **resolved real** path. Two spellings of one directory, one literal string comparison, deterministic red on such a machine and green on every other one - which is precisely why it looked unexplained.

**The monitor was right the whole time.** It keys the model with `WorktreeReaperService.NormalizePath`, which follows links through `GetFinalPathNameByHandle`, so a linked-worktree path does recompute the primary checkout and does store exactly one entry. Only the assertion was too literal. It now asserts through that same canonicalizer, so it tests the promise the monitor actually makes rather than a stricter one it never made.

No production code changes. One test file, assertions only.

## Evidence

A positive control first, because an absence is only evidence once the instrument has been shown able to see the thing:

1. **Reproduced on unmodified `main`.** With the temporary directory pointed at a junction, the test fails:
   ```
   Expected: ...\ReposFred\ccd-temp-junction\ccd-canon-3d...
   Actual:   ...\ReposFred\ccd-temp-real\ccd-canon-3da177...
   ```
   The same directory under its real name.
2. **Green with this change behind the junction, and green with an ordinary temporary directory.** The `Assert.Single` also passes behind the junction, which is the evidence that the monitor stores one entry and not two - that assertion never got to run before, because the path comparison failed first.
3. **Still red when the behaviour is broken.** Forcing the linked-worktree canonicalization off (`gitIsFile = false`) fails the test with the assertion it exists for, both before and after this change. Relaxing the comparison did not leave behind a test that cannot go red.

For the record, on this machine and on CI the test was already green: it passes alone, it passes in a full `CcDirector.Core.Tests` run (2404 passed, 0 failed, 6 skipped), and CI is green on `8496b3018`. `RepositoryMonitor.cs`, its tests, and `GitCommandRunner.cs` have not changed since 2026-07-24, three days before the issue was filed, so nothing quietly fixed it in between. The reported red is reproducible only under the link condition above.

## One observation, deliberately not changed here

After a recompute through a linked worktree, the stored `RepositoryStatus.Path` carries git's resolved spelling, while the entry created by the scan carried the unresolved one. The model **key** is canonical either way, so there is no duplicate row and nothing is misfiled - the displayed string can just change spelling after a recompute on a linked path. That is cosmetic, I have not seen it cause harm, and fixing it here would be a change to production behaviour on the back of an unobserved problem. Noting it so it is not lost.
