### PR TITLE
Serialise every workflow that touches the hosted Gateway behind one concurrency group

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -33,20 +33,39 @@ on:
   # The branch/tag picked when starting the run is the commit that ships.
   workflow_dispatch:
 
-# A second release WAITS for the one in flight. It must never cancel it (issue #2222).
+# SERIALISATION. Everything that touches the live hosted Gateway - this deploy, the rollback
+# (rollback-hosted-gateway.yml) and the slot provisioning/cleanup (provision-hosted-gateway-slots.yml)
+# - shares the ONE group named below. Only one of them can run at a time; the rest queue.
 #
-# This used to be cancel-in-progress: true, on the reasoning that the cancel is safe during the
+# Why one group and not one per workflow: production and staging mount the SAME Azure Files share at
+# /home/gateway/cc-director, so any two of these running at once puts two containers on one set of
+# files. On 2026-07-30 a swap overlapped two containers for 144 seconds, which corrupted the SQLite
+# statistics database on that share; GET /sessions then returned HTTP 500 for 32 minutes across the
+# Cockpit, the phone and the command line. Every previous deploy had been rolling the same dice.
+# A deploy racing a rollback, or a deploy racing the provisioning job that starts and stops the
+# staging slot, is the same hazard with more moving parts.
+#
+# Why cancel-in-progress is FALSE. A second release WAITS for the one in flight; it must never cancel
+# it (issue #2222). This used to be true, on the reasoning that the cancel is safe during the
 # ~5-minute build because nothing live has changed yet. That reasoning only holds if the cancel
 # lands during the build, and there is no way to promise it does. On 2026-07-27 one landed INSIDE
 # "Deploy the new image to the staging slot and warm it" - after the staging slot had been started
 # and before anything could stop it. The stop step is skipped on a cancelled run, so the slot was
 # abandoned RUNNING: two Gateway containers on one worker for ten minutes, unattended, with the app
 # degraded the whole time. No probe failed and /healthz never dropped, so nothing caught it.
+# Cancelling a half-finished swap is worse than queueing behind it.
 #
 # Waiting costs a few minutes of build time. Cancelling costs an abandoned slot and a degraded
 # production service. Queue.
+#
+# The cost this accepts: a deploy holds the group for its full run, including the ten-minute
+# post-swap watch, so an emergency swap-back started during a deploy queues behind it. If a rollback
+# is genuinely needed NOW, cancel the deploy run in the Actions user interface first - that releases
+# the group and the rollback starts. Queueing is the right default because the common case is a
+# rollback started against a deploy that is still mid-swap, where running both at once is what
+# breaks production.
 concurrency:
-  group: deploy-hosted-gateway
+  group: hosted-gateway-production
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/provision-hosted-gateway-slots.yml
+++ b/.github/workflows/provision-hosted-gateway-slots.yml
@@ -29,6 +29,19 @@ on:
         required: false
         default: S1
 
+# SERIALISATION. Shares ONE group with deploy-hosted-gateway.yml and rollback-hosted-gateway.yml.
+# This workflow creates the staging slot, mounts the shared Azure Files share on it, changes app
+# settings and STOPS the slot - all of which fight a deploy or a rollback that is starting, swapping
+# or stopping that same slot. Production and staging mount the SAME share, so two of these running at
+# once puts two containers on one set of files; that is what corrupted the statistics database and
+# took GET /sessions down for 32 minutes on 2026-07-30.
+#
+# cancel-in-progress is FALSE: whatever is already in flight finishes first. Cancelling a
+# half-finished swap is worse than queueing behind it.
+concurrency:
+  group: hosted-gateway-production
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/rollback-hosted-gateway.yml
+++ b/.github/workflows/rollback-hosted-gateway.yml
@@ -28,6 +28,19 @@ on:
         required: false
         default: B1
 
+# SERIALISATION. Shares ONE group with deploy-hosted-gateway.yml and
+# provision-hosted-gateway-slots.yml, so a rollback can never run while a deploy or the slot
+# provisioning is in flight. Production and staging mount the SAME Azure Files share, so two of
+# these at once means two containers writing one set of files - the mechanism that corrupted the
+# statistics database and took GET /sessions down for 32 minutes on 2026-07-30.
+#
+# cancel-in-progress is FALSE: a swap-back that arrives while a deploy is mid-swap must WAIT, not
+# cut the deploy off half-finished. If the rollback is needed immediately, cancel the deploy run in
+# the Actions user interface - that releases the group and this run starts.
+concurrency:
+  group: hosted-gateway-production
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
Production and staging mount the same Azure Files share at `/home/gateway/cc-director`, so any two workflows that drive those slots put two containers on one set of files. On 2026-07-30 a slot swap overlapped two containers for 144 seconds, which corrupted the SQLite statistics database on that share; `GET /sessions` then returned HTTP 500 for 32 minutes across the Cockpit, the phone and the command line tools. Every previous deploy had been rolling the same dice.

The deploy already had its own concurrency group. The rollback and the slot provisioning job had none, so either could run while a deploy was mid-flight. This puts all three in one group, `hosted-gateway-production`, with `cancel-in-progress: false` so a second run queues rather than cancelling a half-finished swap.

**What this does not do.** It does not make a deploy safe. The warmed-slot-swap design inherently runs two containers against one share while the new image boots and warms - that is the deploy working as designed, and it is closed by moving the statistics store off the share, not by any concurrency group.

**Not verified:** two deploys were not run against each other, so queueing is unproven in practice. What is proven is that all three workflows parse and resolve to one group string.

**Known cost, being addressed next:** a deploy holds the group for its full run including the passive ten-minute post-swap watch, so an emergency swap-back started during a deploy queues behind it. A follow-up moves the group to the mutating job so the passive watch does not hold the emergency brake.

Incident record: `docs/incidents/gateway-roster-500-2026-07-30.md`.