### PR TITLE
Publish the release notes we wrote, and make a release latest only once it is complete

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -194,13 +194,28 @@ interface flow, but it is out of date in two ways that will cost you time:
 The version-bump commit therefore reaches `main` like any other change - through a
 pull request. That is how v1.1.0 shipped (pull request #1489).
 
-1. Open a pull request that bumps `Directory.Build.props` to the new version, titled
+1. Make sure `docs/public/release-notes/v<version>.md` is already merged to `main`.
+   The workflow publishes that file verbatim and FAILS if it is missing, so a tag
+   pushed without it burns a whole build and cannot be un-pushed.
+2. Open a pull request that bumps `Directory.Build.props` to the new version, titled
    `release: v<version> - <one-line summary>`. Merge it once it is green.
-2. Draft a GitHub release; create the tag `v<version>` on `main` at the merged bump
-   commit. Paste the canonical release notes as the body.
-3. The human clicks Publish. Pushing the tag triggers the Release workflow, which
-   builds the executable and attaches `cc-director.exe` to the release. Monitor the
-   Actions run.
+3. Create the tag `v<version>` on `main` at the merged bump commit and push it. That
+   is the last manual act. Monitor the Actions run.
+
+**Do NOT create or publish a GitHub release by hand, and do NOT paste the notes into
+the release body.** The workflow does both: it creates the release as a DRAFT, attaches
+every asset, and publishes it only once `release-manifest.json` is provably attached.
+
+Two defects live in the habit of doing it by hand, and both produce something that
+looks right to whoever reads it:
+
+- A release published before its assets exist is "latest" while being uninstallable.
+  Measured on v1.8.8: published 10:48:48Z, assets attached 10:54:11Z, and a launcher
+  that checked at 10:54:05Z failed. A failed update check renders exactly like being up
+  to date, so nobody notices (issue #1079). If you pre-create a published release, the
+  workflow attaches its assets to yours and the window comes straight back.
+- Pasting or generating the body by hand is why the page was right by accident rather
+  than by design; v1.8.7 shipped a list of internal pull-request titles (issue #1106).
 
 If you ever cut a tag before the bump commit is on `main`, reconcile it: push the
 tagged commit to a `release/v<version>` branch, open a pull request into `main`, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,6 +621,43 @@ jobs:
             exit 1
           fi
 
+      # The release page publishes OUR WRITTEN NOTES and nothing else.
+      #
+      # This workflow used to switch on the release action's own note GENERATION, which produced a
+      # list of internal pull-request titles. Every correct-looking release page up to v1.9.0 was
+      # a PERSON pasting docs/public/release-notes/<tag>.md over that list afterwards - so the page
+      # has been right by accident, not by design. v1.8.7 is the one that shipped as generated:
+      # four pull-request titles and a compare link, published to strangers. The switch is gone and
+      # a test in CcDirector.Core.Tests keeps it gone, by name.
+      #
+      # A missing notes file STOPS the release here. There is deliberately no fallback that
+      # generates a competing version nobody wrote: a plausible wrong page is worse than no page,
+      # because a page that looks like release notes does not get read.
+      - name: Resolve the written release notes
+        id: notes
+        run: |
+          NOTES="docs/public/release-notes/${GITHUB_REF_NAME}.md"
+          if [ ! -f "$NOTES" ]; then
+            echo "::error title=Release notes missing::$NOTES does not exist at tag $GITHUB_REF_NAME. Write the notes, commit them, and cut the tag again - this workflow does NOT generate release notes."
+            {
+              echo "## Release STOPPED: no written release notes"
+              echo ""
+              echo "Expected \`$NOTES\` at tag \`$GITHUB_REF_NAME\`."
+              echo ""
+              echo "The workflow publishes the notes we wrote and refuses to invent a substitute."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          # A file that exists but says nothing is the same defect wearing a different hat, so the
+          # floor is on CONTENT (non-whitespace characters), not on the file existing.
+          CHARS=$(tr -d '[:space:]' < "$NOTES" | wc -c)
+          if [ "$CHARS" -lt 200 ]; then
+            echo "::error title=Release notes empty::$NOTES has only $CHARS non-whitespace characters. That is a placeholder, not release notes."
+            exit 1
+          fi
+          echo "Publishing $NOTES ($CHARS non-whitespace characters)."
+          echo "path=$NOTES" >> "$GITHUB_OUTPUT"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
@@ -803,13 +840,62 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
+      # The release is created as a DRAFT with every asset already attached, and published by the
+      # step below. A draft is not "latest" and is not visible to /releases/latest, so no updater
+      # can see this version until it is COMPLETE: "latest" and "complete" become the same moment.
+      #
+      # Publishing first is what gave every release an update-failure window. Measured to the second
+      # on v1.8.8: published 10:48:48Z, assets attached 10:54:11Z - five minutes and twenty-three
+      # seconds in which /releases/latest named a version whose release-manifest.json did not exist.
+      # A launcher checked at 10:54:05Z, before the manifest existed, and failed outright. With hourly
+      # checks that is roughly one machine in eleven losing up to an hour, and a failed check used to
+      # render exactly like being up to date, so nobody noticed.
+      #
+      # draft: true is therefore load-bearing, not a preference. Do not set it back to false to
+      # "save a step" - the second step IS the publish.
+      - name: Create draft release with all assets
+        id: draft
         uses: softprops/action-gh-release@v3
         with:
           name: DevThrottle v${{ steps.version.outputs.version }}
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.path }}
           files: release-files/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish only once the manifest is provably attached. Every updater resolves
+      # release-manifest.json first and treats its absence as "this release is unusable", so a
+      # release published without it is a release nobody can install - and it would take the
+      # "latest" slot away from the previous working one.
+      # Addressed by release ID, not by tag: a DRAFT is not reachable through the by-tag endpoint
+      # (GitHub associates a draft with its tag only on publish), so a tag lookup here would be
+      # asking the wrong question and could answer about the wrong release entirely.
+      - name: Verify the manifest is attached, then publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.draft.outputs.id }}
+        run: |
+          if [ -z "$RELEASE_ID" ]; then
+            echo "::error title=No release id::The draft step produced no release id, so there is nothing to publish and no way to check what was attached."
+            exit 1
+          fi
+
+          ASSETS=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq '[.assets[].name] | join(" ")')
+          echo "Attached assets: $ASSETS"
+          case " $ASSETS " in
+            *" release-manifest.json "*)
+              ;;
+            *)
+              echo "::error title=Manifest not attached::Draft release $GITHUB_REF_NAME has no release-manifest.json. Refusing to publish - it would become 'latest' and no updater could install it."
+              exit 1
+              ;;
+          esac
+
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" -F draft=false >/dev/null
+          echo "Published $GITHUB_REF_NAME with all assets already attached."
+          {
+            echo "## Published"
+            echo "\`$GITHUB_REF_NAME\` left draft with every asset attached, so there is no window in which it is latest but incomplete."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -2,25 +2,41 @@
 
 ## Overview
 
-CC Director uses GitHub Actions to automate building, testing, and publishing releases. Releases are created entirely from the GitHub web UI -- no local commands required.
+GitHub Actions builds and publishes the release. **A person pushes a tag; nothing else.** The
+workflow creates the release page, attaches every asset, and only then publishes it.
 
 ## How to Release a New Version
 
-1. Go to https://github.com/example-org/devthrottle/releases
-2. Click **"Draft a new release"**
-3. In the **"Choose a tag"** dropdown, type a new tag (e.g., `v1.3.0`) and select **"Create new tag on publish"**
-4. Set the **Target** to `main`
-5. Enter a title (e.g., `CC Director v1.3.0`)
-6. Click **"Generate release notes"** to auto-populate from commits since the last tag
-7. Click **"Publish release"**
+1. **Write the release notes first** at `docs/public/release-notes/v<version>.md` and get them onto
+   `main`. This file IS the release page - it is published verbatim.
+2. Bump `<Version>` in `Directory.Build.props` (the single version source) and merge that to `main`.
+3. Create the tag `v<version>` on that merged commit and push it.
 
-GitHub Actions will automatically:
-- Install .NET 10 SDK
-- Run all unit tests
-- Build the single-file EXE using the 3-step workaround for .NET 10 bugs
-- Attach `cc-director.exe` to the release as a downloadable asset
+That is the whole procedure. The workflow then:
+
+- verifies the tag matches `Directory.Build.props`, and that the written notes exist and say
+  something;
+- builds every component for Windows and macOS and checks the asset list is complete;
+- creates the release **as a draft**, attaches all assets, and publishes it once the manifest is
+  provably attached.
 
 Monitor progress at: https://github.com/example-org/devthrottle/actions
+
+### Two things NOT to do, and why
+
+**Do not create or publish the release yourself in the web interface.** Publishing makes a release
+"latest" the instant you click, while the workflow's assets arrive minutes afterwards. Every updater
+that checks in between sees a newest version with no `release-manifest.json` and fails outright -
+measured on v1.8.8 at five minutes and twenty-three seconds, with a launcher failing six seconds
+before the assets landed. A failed update check used to look exactly like being up to date, so this
+went unnoticed for as long as the project has existed. Pushing the tag and leaving the release alone
+is what closes that window (issue #1079).
+
+**Do not use "Generate release notes".** It produces a list of internal pull-request titles, which
+is what v1.8.7 shipped to strangers. Every release page that looked right before v1.9.0 was a person
+pasting the written notes over that list afterwards - correct by accident. The workflow publishes
+`docs/public/release-notes/<tag>.md` and FAILS when it is absent; it will not invent a substitute,
+because a page that looks like release notes does not get read (issue #1106).
 
 ## Versioning
 
@@ -60,7 +76,9 @@ For local testing, `scripts/release.ps1` still works:
 .\scripts\release.ps1 -SelfContained    # Standalone (~150+ MB)
 ```
 
-Local builds use the version from `CcDirector.Wpf.csproj`. Only CI builds get the tag version.
+The version comes from `Directory.Build.props`, which is the single version source for every
+binary in the release (see `docs/architecture/VERSIONING.md`). The workflow fails the release if
+the tag and that file disagree.
 
 ## Previous Tags
 
@@ -72,4 +90,6 @@ Local builds use the version from `CcDirector.Wpf.csproj`. Only CI builds get th
 
 ## Implementation Status
 
-**Not yet implemented.** The GitHub Actions workflow (`.github/workflows/release.yml`) still needs to be created. See the implementation tasks for details.
+**Live.** `.github/workflows/release.yml` has built and published every release since v1.2.0. The
+"not yet implemented" note that stood here was left over from before the workflow existed and was
+plainly contradicted by every release page in the repository.

--- a/scripts/new-release.ps1
+++ b/scripts/new-release.ps1
@@ -85,6 +85,38 @@ if ($strayVersions) {
     exit 1
 }
 
+# --- Guard: the written release notes MUST exist before the tag does ---
+#
+# The release workflow publishes docs/public/release-notes/<tag>.md verbatim and FAILS when it is
+# absent - it will not generate a substitute, because a page of internal pull-request titles looks
+# like release notes and therefore ships unread. This guard is the same rule applied a minute
+# earlier, where it costs nothing: a tag that is already pushed cannot be un-pushed, and the
+# workflow's copy of the check can only fail AFTER the whole build has run.
+#
+# The working tree is clean by this point, so the notes file has to be committed already.
+$notesPath = Join-Path $repoRoot "docs\public\release-notes\$tagName.md"
+if (-not (Test-Path $notesPath)) {
+    Write-Host ""
+    Write-Host "ERROR: No written release notes for $tagName." -ForegroundColor Red
+    Write-Host "  Expected: $notesPath" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Write the notes, commit them, then run this script again. The release workflow" -ForegroundColor Yellow
+    Write-Host "publishes that file and refuses to invent a substitute." -ForegroundColor Yellow
+    Write-Host ""
+    exit 1
+}
+
+$notesChars = ((Get-Content $notesPath -Raw) -replace '\s', '').Length
+if ($notesChars -lt 200) {
+    Write-Host ""
+    Write-Host "ERROR: $notesPath has only $notesChars non-whitespace characters." -ForegroundColor Red
+    Write-Host "That is a placeholder, not release notes. The workflow applies the same floor." -ForegroundColor Red
+    Write-Host ""
+    exit 1
+}
+Write-Host ""
+Write-Host "Release notes: $notesPath ($notesChars characters)" -ForegroundColor Gray
+
 # --- Update the one file ---
 Write-Host ""
 Write-Host "Updating version to $newVersion..." -ForegroundColor Cyan

--- a/src/CcDirector.Core.Tests/ReleaseWorkflowContractTests.cs
+++ b/src/CcDirector.Core.Tests/ReleaseWorkflowContractTests.cs
@@ -1,0 +1,200 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// An architecture fitness function for the two things the release workflow got wrong, both of which
+/// produced something that LOOKED right to whoever read it.
+///
+/// 1. It published a generated list of internal pull-request titles instead of the release notes we
+///    wrote (issue #1106). v1.8.7 shipped that way: four pull-request titles and a compare link.
+///    Every correct-looking release page before it was a PERSON pasting
+///    docs/public/release-notes/&lt;tag&gt;.md over the generated list afterwards, so the page was right
+///    by accident. A page of pull-request titles looks like release notes, so nobody checks it.
+///
+/// 2. It published the release BEFORE attaching its assets (issue #1079), so every release had a
+///    window in which /releases/latest named a version whose release-manifest.json did not exist and
+///    every updater that checked inside it failed. Measured on v1.8.8: published 10:48:48Z, assets
+///    attached 10:54:11Z; a launcher checked at 10:54:05Z, six seconds early, and failed.
+///
+/// This is a C# test on purpose. CI runs `dotnet test` and nothing else, so a guard written in any
+/// other language would never run - and a guard nobody runs is not a guard. It reads the workflow as
+/// text, the same way MobileViewportContractTests pins the mobile shells.
+///
+/// Scope, stated rather than implied: this pins the MECHANISM in the workflow file. It cannot prove
+/// what a future GitHub Actions run does. It exists to stop the specific regressions that already
+/// shipped - somebody turning generated notes back on, or setting the release straight to published
+/// "to save a step".
+/// </summary>
+public sealed class ReleaseWorkflowContractTests
+{
+    private const string WorkflowPath = ".github/workflows/release.yml";
+    private const string ScriptPath = "scripts/new-release.ps1";
+    private const string NotesDir = "docs/public/release-notes";
+
+    private static string Workflow() => File.ReadAllText(Path.Combine(GetRepoRoot(), WorkflowPath));
+
+    [Fact]
+    public void Workflow_PublishesOurWrittenNotes_NotAGeneratedListOfPullRequestTitles()
+    {
+        var yml = Workflow();
+
+        // generate_release_notes is the exact switch that produced the v1.8.7 page. Even set to
+        // false it should not be here: its presence is an invitation to flip it back.
+        Assert.False(yml.Contains("generate_release_notes", StringComparison.Ordinal),
+            $"{WorkflowPath} mentions generate_release_notes again. That switch publishes a list of internal "
+            + "pull-request titles, which is what v1.8.7 shipped to strangers. The release body must come from "
+            + $"{NotesDir}/<tag>.md and nothing else.");
+
+        Assert.True(Regex.IsMatch(yml, @"body_path:\s*\$\{\{\s*steps\.notes\.outputs\.path\s*\}\}"),
+            $"{WorkflowPath} no longer sets body_path from the resolved notes step. Without it the release page "
+            + "carries whatever the action decides to invent.");
+
+        Assert.True(yml.Contains($"NOTES=\"{NotesDir}/${{GITHUB_REF_NAME}}.md\"", StringComparison.Ordinal),
+            $"{WorkflowPath} no longer resolves the notes file as {NotesDir}/<tag>.md. That path IS the contract - "
+            + "the release manager writes that file and the workflow publishes it verbatim.");
+    }
+
+    [Fact]
+    public void Workflow_StopsTheReleaseWhenTheWrittenNotesAreMissingOrEmpty()
+    {
+        var yml = Workflow();
+        var step = StepBody(yml, "Resolve the written release notes");
+        Assert.False(step is null, $"{WorkflowPath} no longer has a 'Resolve the written release notes' step. "
+            + "If it was renamed, update this test - do not delete the guard.");
+
+        // Absent file: must exit non-zero, not warn and carry on.
+        Assert.True(Regex.IsMatch(step!, @"if\s+\[\s+!\s+-f\s+""\$NOTES""\s+\]"),
+            "The notes step no longer tests that the file EXISTS.");
+        Assert.True(Regex.IsMatch(step!, @"Release notes missing[\s\S]*?exit 1"),
+            "A missing notes file no longer STOPS the release. An empty page that stops the release is safer than "
+            + "a confident wrong one that ships - that is the whole point of this guard.");
+
+        // Present but empty is the same defect wearing a different hat, so the floor is on content.
+        Assert.True(Regex.IsMatch(step!, @"Release notes empty[\s\S]*?exit 1"),
+            "A notes file that exists but says nothing no longer stops the release. A placeholder file would "
+            + "satisfy an existence check and publish a blank release page.");
+
+        // No fallback. The one rule that matters: never generate a competing version nobody wrote.
+        Assert.False(Regex.IsMatch(step!, @"\|\||else[\s\S]{0,200}(generate|gh api.*commits|git log)"),
+            "The notes step appears to fall back to generating notes. It must not: a plausible wrong page is "
+            + "worse than no page, because it does not get read.");
+    }
+
+    [Fact]
+    public void Workflow_AttachesEveryAssetToADraft_ThenPublishesInASeparateStep()
+    {
+        var yml = Workflow();
+
+        var draftStep = StepBody(yml, "Create draft release with all assets");
+        Assert.False(draftStep is null, $"{WorkflowPath} no longer has a 'Create draft release with all assets' step. "
+            + "The release must be assembled as a draft; a draft is not 'latest', so nothing can see it half-built.");
+
+        Assert.True(Regex.IsMatch(draftStep!, @"draft:\s*true"),
+            "The release is created with draft: false again. That is the #1079 defect exactly: publishing makes a "
+            + "release 'latest' instantly while its assets attach minutes later, and every updater that checks "
+            + "inside that window fails. Measured window on v1.8.8: 5m23s.");
+
+        Assert.True(Regex.IsMatch(draftStep!, @"files:\s*release-files/\*"),
+            "The draft step no longer attaches the assets, so publishing could not be the completing step.");
+
+        var publishStep = StepBody(yml, "Verify the manifest is attached, then publish");
+        Assert.False(publishStep is null, $"{WorkflowPath} no longer has the publish step. Creating a draft and never "
+            + "publishing it would ship nothing at all.");
+
+        Assert.True(publishStep!.Contains("release-manifest.json", StringComparison.Ordinal),
+            "The publish step no longer checks that release-manifest.json is attached. Every updater resolves the "
+            + "manifest first, so a release published without it is one nobody can install - and it takes the "
+            + "'latest' slot from the previous working release.");
+        Assert.True(Regex.IsMatch(publishStep!, @"Manifest not attached[\s\S]*?exit 1"),
+            "A draft with no manifest is no longer refused; it would be published anyway.");
+        Assert.True(Regex.IsMatch(publishStep!, @"--method PATCH[^\n]*releases/\$RELEASE_ID[^\n]*draft=false"),
+            "The publish step no longer takes the release out of draft, so the draft would never ship.");
+
+        // By ID, not by tag. GitHub associates a draft with its tag only on PUBLISH, so the by-tag
+        // endpoint cannot see this release yet - a tag lookup here asks a question about a different
+        // release (or none) and would read as an answer about this one.
+        Assert.True(publishStep!.Contains("steps.draft.outputs.id", StringComparison.Ordinal),
+            "The publish step no longer takes the release id from the draft step.");
+        Assert.True(Regex.IsMatch(publishStep!, @"if \[ -z ""\$RELEASE_ID"" \][\s\S]*?exit 1"),
+            "An empty release id no longer stops the step. It would then check the assets of nothing and "
+            + "publish nothing, while the run went green.");
+
+        // Order is the property that matters: assemble, then publish. Not the other way round.
+        Assert.True(yml.IndexOf("Create draft release with all assets", StringComparison.Ordinal)
+                    < yml.IndexOf("Verify the manifest is attached, then publish", StringComparison.Ordinal),
+            "The publish step runs BEFORE the assets are attached. That ordering is the defect.");
+    }
+
+    [Fact]
+    public void NewReleaseScript_RefusesToTagWhenTheWrittenNotesAreMissing()
+    {
+        var script = File.ReadAllText(Path.Combine(GetRepoRoot(), ScriptPath));
+
+        Assert.True(script.Contains(@"docs\public\release-notes\$tagName.md", StringComparison.Ordinal),
+            $"{ScriptPath} no longer looks for the written release notes. The workflow's copy of this check can "
+            + "only fail AFTER the tag is pushed and the whole build has run, and a pushed tag cannot be "
+            + "un-pushed. Checking here costs nothing.");
+
+        Assert.True(Regex.IsMatch(script, @"if \(-not \(Test-Path \$notesPath\)\)[\s\S]*?exit 1"),
+            $"{ScriptPath} no longer EXITS when the notes file is absent. Warning and continuing would push the tag.");
+
+        Assert.True(Regex.IsMatch(script, @"\$notesChars -lt 200[\s\S]*?exit 1"),
+            $"{ScriptPath} no longer rejects a placeholder notes file. The workflow applies a 200-character floor; "
+            + "these two must agree, or the script waves through exactly what the workflow will reject.");
+
+        // The guard has to run BEFORE the tag is created, or it is decoration.
+        var guardAt = script.IndexOf("$notesPath = Join-Path", StringComparison.Ordinal);
+        var tagAt = script.IndexOf("git -C $repoRoot tag $tagName", StringComparison.Ordinal);
+        Assert.True(guardAt > 0 && tagAt > 0 && guardAt < tagAt,
+            $"{ScriptPath} checks the release notes AFTER creating the tag. The point of the local guard is to fail "
+            + "while nothing has happened yet.");
+    }
+
+    /// <summary>
+    /// The floors in the two places must be the same number. Two guards for one rule drift apart by
+    /// default: the script waves a file through, the workflow rejects it, and the tag is already pushed.
+    /// </summary>
+    [Fact]
+    public void TheNotesContentFloor_IsTheSameNumberInBothGuards()
+    {
+        var yml = Workflow();
+        var script = File.ReadAllText(Path.Combine(GetRepoRoot(), ScriptPath));
+
+        var inWorkflow = Regex.Match(yml, @"CHARS""?\s*-lt\s+(\d+)");
+        Assert.True(inWorkflow.Success, $"Could not find the content floor in {WorkflowPath}.");
+        var inScript = Regex.Match(script, @"\$notesChars -lt (\d+)");
+        Assert.True(inScript.Success, $"Could not find the content floor in {ScriptPath}.");
+
+        Assert.Equal(inWorkflow.Groups[1].Value, inScript.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// Returns the text of a workflow step from its `- name:` line to the next step at the same
+    /// indentation, so an assertion about one step cannot be satisfied by text in another.
+    /// </summary>
+    private static string? StepBody(string yml, string stepName)
+    {
+        var marker = $"- name: {stepName}";
+        var start = yml.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0) return null;
+
+        var lineStart = yml.LastIndexOf('\n', start) + 1;
+        var indent = start - lineStart;
+        var rest = yml[(start + marker.Length)..];
+
+        // The next line that begins a step at the SAME indentation ends this one.
+        var next = Regex.Match(rest, $@"\n {{{indent}}}- name: ");
+        return next.Success ? rest[..next.Index] : rest;
+    }
+
+    private static string GetRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CcDirector.Gateway/GatewayService.cs
+++ b/src/CcDirector.Gateway/GatewayService.cs
@@ -246,18 +246,26 @@ public sealed class GatewayService : IDisposable
     private static async Task RunUpdateLoopAsync(CancellationToken ct)
     {
         var layout = InstallLayout.Default();
+
+        // Held across cycles: a release that is published but still uploading its assets is looked at
+        // again in MINUTES rather than at the next hourly cycle - the same policy the launcher uses,
+        // for the same reason (see ReleaseNotReadyRetry).
+        var notReady = new ReleaseNotReadyRetry();
+
         // Let the gateway settle before the first check; never compete with startup.
         try { await Task.Delay(TimeSpan.FromMinutes(2), ct); } catch (OperationCanceledException) { return; }
 
         while (!ct.IsCancellationRequested)
         {
             var cfg = AutoUpdateConfig.Load(layout);
+            TimeSpan? shortRetry = null;
             if (cfg.Enabled && OperatingSystem.IsWindows())
             {
                 try
                 {
                     var source = new ReleaseSource();
                     var release = await source.FetchLatestAsync(ct);
+                    notReady.Reset();
                     var version = await new GatewayUpdater(layout).CheckStageAndLaunchAsync(release, source, ct);
                     if (version is not null)
                     {
@@ -265,12 +273,20 @@ public sealed class GatewayService : IDisposable
                         return; // the detached helper POSTs /shutdown, swaps, and relaunches us
                     }
                 }
+                // Published but incomplete is NOT a failure - the release is fine and this check was
+                // early. Name it, and look again in minutes instead of at the next hourly cycle.
+                catch (ReleaseNotReadyException ex)
+                {
+                    shortRetry = notReady.NextDelay();
+                    FileLog.Write($"[GatewayService] {notReady.Describe(ex, shortRetry)}");
+                }
                 catch (Exception ex)
                 {
+                    notReady.Reset();
                     FileLog.Write($"[GatewayService] update check failed: {ex.Message}");
                 }
             }
-            try { await Task.Delay(cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1), ct); }
+            try { await Task.Delay(shortRetry ?? (cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1)), ct); }
             catch (OperationCanceledException) { break; }
         }
     }

--- a/src/CcDirector.Launcher/LauncherCore.cs
+++ b/src/CcDirector.Launcher/LauncherCore.cs
@@ -231,18 +231,25 @@ public sealed class LauncherCore : IAsyncDisposable
         var layout = InstallLayout.Default();
         var directorUpdates = new DirectorUpdateOwner(new DirectorSupervisor());
 
+        // Held across cycles: a release that is published but still uploading its assets is looked at
+        // again in MINUTES rather than at the next hourly cycle. This is the condition that cost a
+        // machine up to an hour of staleness for a window measured at 5m23s (v1.8.8).
+        var notReady = new ReleaseNotReadyRetry();
+
         // Let the launcher settle before the first check; never compete with startup.
         try { await Task.Delay(TimeSpan.FromMinutes(2), ct); } catch (OperationCanceledException) { return; }
 
         while (!ct.IsCancellationRequested)
         {
             var cfg = AutoUpdateConfig.Load(layout);
+            TimeSpan? shortRetry = null;
             if (cfg.Enabled && OperatingSystem.IsWindows())
             {
                 try
                 {
                     var source = new ReleaseSource();
                     var release = await source.FetchLatestAsync(ct);
+                    notReady.Reset();
                     var version = await new LauncherUpdater(layout).CheckStageAndLaunchAsync(release, source, ct);
                     if (version is not null)
                     {
@@ -250,8 +257,16 @@ public sealed class LauncherCore : IAsyncDisposable
                         return; // the detached helper POSTs /shutdown, swaps, and relaunches us
                     }
                 }
+                // Published but incomplete is NOT a failure, and it must not be logged as one: the
+                // release is fine and this check was simply early. Say so, and look again in minutes.
+                catch (ReleaseNotReadyException ex)
+                {
+                    shortRetry = notReady.NextDelay();
+                    FileLog.Write($"[LauncherCore] {notReady.Describe(ex, shortRetry)}");
+                }
                 catch (Exception ex)
                 {
+                    notReady.Reset();
                     FileLog.Write($"[LauncherCore] update check failed: {ex.Message}");
                 }
             }
@@ -272,7 +287,7 @@ public sealed class LauncherCore : IAsyncDisposable
                 }
             }
 
-            try { await Task.Delay(cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1), ct); }
+            try { await Task.Delay(shortRetry ?? (cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1)), ct); }
             catch (OperationCanceledException) { break; }
         }
     }

--- a/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
+++ b/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
@@ -231,6 +231,18 @@ public partial class MainWindow : Window
             NextButton.IsEnabled = true;
             return;
         }
+        // Installing during the minutes between a release being published and its files finishing
+        // upload is not an error, and must not read as one: the correct advice is "wait a moment and
+        // press Retry", not "could not fetch release info" (issue #1079).
+        catch (ReleaseNotReadyException ex)
+        {
+            SetupLog.Write($"[MainWindow] RunInstallAsync: prepare deferred (release not ready): {ex.Message}");
+            _installStep?.SetNotStarted();
+            _installStep?.SetStatus(ex.UserMessage());
+            NextButton.Content = "Retry";
+            NextButton.IsEnabled = true;
+            return;
+        }
         catch (Exception ex)
         {
             SetupLog.Write($"[MainWindow] RunInstallAsync: prepare FAILED: {ex.Message}");

--- a/tools/cc-director-setup-engine.Tests/ReleaseNotReadyTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ReleaseNotReadyTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The incomplete-release window (issue #1079): a release becomes "latest" when it is published, and
+/// its assets used to be attached minutes later. Measured on v1.8.8 - published 10:48:48Z, assets
+/// attached 10:54:11Z - and a launcher that checked at 10:54:05Z logged "update check failed" for a
+/// release that was perfectly fine.
+///
+/// These tests pin the two halves of the fix on the client side: the condition is CLASSIFIED (so a
+/// caller can tell "wait a few minutes" from "something is wrong"), and the wait is bounded (so a
+/// release that never completes does not get polled forever).
+/// </summary>
+public class ReleaseNotReadyTests
+{
+    /// <summary>Serves one canned JSON body for the release fetch; any second request is a failure.</summary>
+    private sealed class ReleaseJsonHandler(string json) : HttpMessageHandler
+    {
+        public List<string> Requested { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requested.Add(request.RequestUri!.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static string ReleaseJson(string tag, params string[] assetNames)
+    {
+        var assets = string.Join(",", assetNames.Select(n =>
+            $"{{\"name\":\"{n}\",\"browser_download_url\":\"https://release.test/{n}\"}}"));
+        return $"{{\"tag_name\":\"{tag}\",\"prerelease\":false,\"assets\":[{assets}]}}";
+    }
+
+    // ---- classification --------------------------------------------------
+
+    /// <summary>
+    /// The exact shape observed during the window: the release is published, some assets are already
+    /// attached, the manifest is not. It must come back as NOT READY - naming the release - rather
+    /// than as an unclassified failure that every caller then logs as "update check failed".
+    /// </summary>
+    [Fact]
+    public async Task FetchLatest_PublishedReleaseWithoutManifest_RaisesNotReadyNamingTheRelease()
+    {
+        var handler = new ReleaseJsonHandler(ReleaseJson("v1.8.8", "cc-director-win-x64.exe", "cc-launcher-win-x64.exe"));
+        var source = new ReleaseSource(new HttpClient(handler), new ReleaseInfoCache(NoCacheFile()));
+
+        var ex = await Assert.ThrowsAsync<ReleaseNotReadyException>(() => source.FetchLatestAsync(CancellationToken.None));
+
+        Assert.Equal("v1.8.8", ex.Tag);
+        Assert.Equal("release-manifest.json", ex.MissingAsset);
+        // The message has to say the release is being completed, not that something went wrong.
+        Assert.Contains("still being attached", ex.Message, StringComparison.Ordinal);
+        // And the user-facing wording must not read as an error.
+        Assert.Contains("Nothing is wrong", ex.UserMessage(), StringComparison.Ordinal);
+        Assert.Contains("1.8.8", ex.UserMessage(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A release with NO assets at all is the same condition seen a few seconds earlier in the window.
+    /// It must classify identically - the caller's decision is the same either way.
+    /// </summary>
+    [Fact]
+    public async Task FetchLatest_PublishedReleaseWithNoAssetsAtAll_RaisesNotReady()
+    {
+        var handler = new ReleaseJsonHandler(ReleaseJson("v1.9.1"));
+        var source = new ReleaseSource(new HttpClient(handler), new ReleaseInfoCache(NoCacheFile()));
+
+        var ex = await Assert.ThrowsAsync<ReleaseNotReadyException>(() => source.FetchLatestAsync(CancellationToken.None));
+        Assert.Equal("v1.9.1", ex.Tag);
+    }
+
+    /// <summary>
+    /// The guard has two failure directions, and this is the one that would make it useless: a
+    /// COMPLETE release must not be classified as not-ready. Without this the type would be a
+    /// permanent "wait a few minutes" that never installs anything.
+    /// </summary>
+    [Fact]
+    public async Task FetchLatest_CompleteRelease_DoesNotRaiseNotReady()
+    {
+        // The manifest fetch is served by the same handler, so it must parse as a manifest.
+        const string manifest = """
+            {"version":"1.9.1","tag":"v1.9.1","assets":{"cc-director-win-x64.exe":{"version":"1.9.1","size":10,"sha256":"ab","platform":"windows"}}}
+            """;
+        var handler = new ManifestThenReleaseHandler(
+            ReleaseJson("v1.9.1", "cc-director-win-x64.exe", "release-manifest.json"), manifest);
+        var source = new ReleaseSource(new HttpClient(handler), new ReleaseInfoCache(NoCacheFile()));
+
+        var resolved = await source.FetchLatestAsync(CancellationToken.None);
+
+        Assert.Equal("1.9.1", resolved.Manifest.Version);
+        Assert.True(resolved.DownloadUrls.ContainsKey("cc-director-win-x64.exe"));
+    }
+
+    /// <summary>Serves the release body for the API URL and the manifest body for the asset URL.</summary>
+    private sealed class ManifestThenReleaseHandler(string releaseJson, string manifestJson) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var body = request.RequestUri!.ToString().EndsWith("release-manifest.json", StringComparison.Ordinal)
+                ? manifestJson
+                : releaseJson;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    // ---- retry cadence ---------------------------------------------------
+
+    /// <summary>
+    /// The point of the policy: minutes, not the hourly cycle. With hourly checks and a
+    /// five-and-a-half minute window, a machine that checked inside it lost up to an hour.
+    /// </summary>
+    [Fact]
+    public void Retry_FirstNotReady_WaitsMinutesNotTheNormalCycle()
+    {
+        var policy = new ReleaseNotReadyRetry();
+
+        var delay = policy.NextDelay();
+
+        Assert.Equal(ReleaseNotReadyRetry.Interval, delay);
+        Assert.True(delay < TimeSpan.FromMinutes(10),
+            "the short retry must be on the scale of the window (minutes), not of the normal check cycle");
+    }
+
+    /// <summary>
+    /// Bounded on purpose: the allowance has to cover the measured 5m23s window with room to spare,
+    /// and then stop. A release still missing its manifest after a quarter of an hour is not a
+    /// publish window, it is a broken release, and polling it forever fixes nothing.
+    /// </summary>
+    [Fact]
+    public void Retry_CoversTheMeasuredWindowWithMargin_ThenGivesUp()
+    {
+        var policy = new ReleaseNotReadyRetry();
+        var covered = TimeSpan.Zero;
+
+        for (var i = 1; i <= ReleaseNotReadyRetry.MaxConsecutive; i++)
+        {
+            var delay = policy.NextDelay();
+            Assert.NotNull(delay);
+            covered += delay!.Value;
+            Assert.Equal(i, policy.Consecutive);
+        }
+
+        Assert.True(covered >= TimeSpan.FromMinutes(11),
+            $"the short-retry allowance covers only {covered.TotalMinutes:0} minutes; the window measured on "
+            + "v1.8.8 was 5m23s and this needs real margin over it");
+
+        // Allowance used up: the caller falls back to its normal interval.
+        Assert.Null(policy.NextDelay());
+        Assert.Null(policy.NextDelay());
+    }
+
+    /// <summary>
+    /// Per EPISODE, not a budget spent once for the life of the process. A launcher that runs for
+    /// weeks sees a publish window at every release; an exhausted counter would leave every release
+    /// after the first waiting out the full cycle.
+    /// </summary>
+    [Fact]
+    public void Retry_ResetOnAnyOtherOutcome_RestoresTheFullAllowance()
+    {
+        var policy = new ReleaseNotReadyRetry();
+        for (var i = 0; i < ReleaseNotReadyRetry.MaxConsecutive + 2; i++) policy.NextDelay();
+        Assert.Null(policy.NextDelay());
+
+        policy.Reset();
+
+        Assert.Equal(0, policy.Consecutive);
+        Assert.Equal(ReleaseNotReadyRetry.Interval, policy.NextDelay());
+    }
+
+    /// <summary>
+    /// "And SAY so." The log line is the only place a machine-tier update loop is visible, so it has
+    /// to name the release, say this is not a failure, and say when it will look again. The line it
+    /// replaced was "update check failed", which is none of those.
+    /// </summary>
+    [Fact]
+    public void Retry_Describe_SaysWhatHappenedAndWhatHappensNext()
+    {
+        var policy = new ReleaseNotReadyRetry();
+        var ex = new ReleaseNotReadyException("v1.8.8", "release-manifest.json");
+
+        var waiting = policy.Describe(ex, policy.NextDelay());
+        Assert.Contains("v1.8.8", waiting, StringComparison.Ordinal);
+        Assert.Contains("release-manifest.json", waiting, StringComparison.Ordinal);
+        Assert.Contains("NOT a failure", waiting, StringComparison.Ordinal);
+        Assert.Contains("3 minutes", waiting, StringComparison.Ordinal);
+        Assert.DoesNotContain("failed", waiting, StringComparison.OrdinalIgnoreCase);
+
+        // Giving up says something DIFFERENT, so the log distinguishes a window from a broken release.
+        var gaveUp = policy.Describe(ex, null);
+        Assert.Contains("STILL has no", gaveUp, StringComparison.Ordinal);
+        Assert.Contains("incomplete", gaveUp, StringComparison.Ordinal);
+    }
+
+    /// <summary>A cache file path in a throwaway directory, so no test reads the machine's real cache.</summary>
+    private static string NoCacheFile() =>
+        Path.Combine(Path.GetTempPath(), "cc-notready-" + Guid.NewGuid().ToString("N"), "release-info.json");
+}

--- a/tools/cc-director-setup-engine/ReleaseNotReadyException.cs
+++ b/tools/cc-director-setup-engine/ReleaseNotReadyException.cs
@@ -1,0 +1,42 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Raised when the release GitHub calls "latest" exists but is not yet USABLE: it carries no
+/// release-manifest.json, so there is nothing to resolve versions or checksums against.
+///
+/// This is a DIFFERENT condition from a failed fetch, and conflating the two is what made it
+/// invisible. It has one ordinary cause: a release becomes "latest" the moment it is published,
+/// and its assets used to be attached minutes afterwards. Measured on v1.8.8 - published
+/// 10:48:48Z, assets attached 10:54:11Z - a launcher checked at 10:54:05Z, six seconds before the
+/// manifest existed, and reported "update check failed". The release was fine; the check was
+/// simply early.
+///
+/// The workflow now attaches every asset to a DRAFT and publishes afterwards, so this window
+/// should no longer exist. This type survives that fix on purpose: it is the difference between
+/// "wait a few minutes, this will resolve itself" and "something is wrong", and a caller that
+/// cannot tell them apart has to guess. Both guesses made here were wrong - the launcher reported
+/// FAILED, and the Director's own updater (a separate code path, issue #1030) reported UP TO DATE.
+/// </summary>
+public sealed class ReleaseNotReadyException : Exception
+{
+    /// <summary>The tag of the release that is published but incomplete (for example "v1.8.8").</summary>
+    public string Tag { get; }
+
+    /// <summary>The asset that is missing. Always release-manifest.json today.</summary>
+    public string MissingAsset { get; }
+
+    public ReleaseNotReadyException(string tag, string missingAsset)
+        : base($"Release {tag} is published but has no {missingAsset} yet; its assets are still being attached.")
+    {
+        Tag = tag;
+        MissingAsset = missingAsset;
+    }
+
+    /// <summary>
+    /// The plain-English, ASCII-only message a user-facing surface shows. It says what is happening
+    /// and what happens next, so the state cannot be mistaken for either "up to date" or "broken".
+    /// </summary>
+    public string UserMessage() =>
+        $"Version {Tag.TrimStart('v', 'V')} has just been published and its download files are still " +
+        "being uploaded. Nothing is wrong - the update will be picked up automatically within a few minutes.";
+}

--- a/tools/cc-director-setup-engine/ReleaseNotReadyRetry.cs
+++ b/tools/cc-director-setup-engine/ReleaseNotReadyRetry.cs
@@ -1,0 +1,66 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// How long an update loop waits after finding the latest release published but incomplete
+/// (see <see cref="ReleaseNotReadyException"/>), instead of waiting out its normal cycle.
+///
+/// The problem this solves: the update check runs roughly hourly, and the incomplete-release
+/// window was measured at five and a half minutes. A machine that checked inside it lost up to an
+/// HOUR waiting for the next ordinary cycle, for a condition that resolves itself in minutes.
+///
+/// The cadence is deliberately bounded. Retrying for a quarter of an hour covers a window
+/// measured at 5m23s with room to spare; a release still missing its manifest after fifteen
+/// minutes is not a window any more, it is a broken release, and hammering GitHub every three
+/// minutes forever would neither fix it nor be polite. After that the loop returns to its normal
+/// interval - having said, in the log, exactly what it saw.
+///
+/// One policy object per loop, held across cycles: <see cref="NextDelay"/> on a not-ready result
+/// and <see cref="Reset"/> on any other outcome, so the allowance is per EPISODE rather than a
+/// budget the process spends once and never gets back.
+/// </summary>
+public sealed class ReleaseNotReadyRetry
+{
+    /// <summary>How long to wait before looking again while a release is still being completed.</summary>
+    public static readonly TimeSpan Interval = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// How many consecutive short retries are allowed before falling back to the normal cycle.
+    /// Five at three minutes is fifteen minutes of cover for a five-and-a-half minute window.
+    /// </summary>
+    public const int MaxConsecutive = 5;
+
+    private int _consecutive;
+
+    /// <summary>Consecutive not-ready results seen so far in this episode.</summary>
+    public int Consecutive => _consecutive;
+
+    /// <summary>
+    /// Records a not-ready result and returns how long to wait before looking again, or null when
+    /// the short-retry allowance for this episode is used up and the caller should fall back to its
+    /// normal interval.
+    /// </summary>
+    public TimeSpan? NextDelay()
+    {
+        _consecutive++;
+        return _consecutive <= MaxConsecutive ? Interval : null;
+    }
+
+    /// <summary>
+    /// Clears the episode. Called on every outcome that is NOT not-ready, so a later incomplete
+    /// release gets the full allowance again rather than inheriting an exhausted one.
+    /// </summary>
+    public void Reset() => _consecutive = 0;
+
+    /// <summary>
+    /// The log line for a not-ready result. It states the cause, the wait, and that nothing is
+    /// wrong - the three things missing from "update check failed", which is what this used to say.
+    /// </summary>
+    public string Describe(ReleaseNotReadyException ex, TimeSpan? delay) =>
+        delay is { } d
+            ? $"release {ex.Tag} is published but its {ex.MissingAsset} is not attached yet " +
+              $"(assets still uploading); NOT a failure - looking again in {d.TotalMinutes:0} minutes " +
+              $"(retry {_consecutive}/{MaxConsecutive})"
+            : $"release {ex.Tag} STILL has no {ex.MissingAsset} after {MaxConsecutive} short retries " +
+              $"({MaxConsecutive * Interval.TotalMinutes:0} minutes). That is no longer a publish window - " +
+              "the release looks incomplete. Falling back to the normal check interval.";
+}

--- a/tools/cc-director-setup-engine/ReleaseSource.cs
+++ b/tools/cc-director-setup-engine/ReleaseSource.cs
@@ -85,6 +85,10 @@ public sealed class ReleaseSource
     /// <see cref="GetReleaseBodyAsync"/>.
     /// </summary>
     /// <exception cref="GitHubRateLimitException">The fetch was rate-limited and retries were exhausted.</exception>
+    /// <exception cref="ReleaseNotReadyException">
+    /// The latest release is published but its release-manifest.json is not attached yet. Callers that
+    /// run on a loop should wait a few minutes and look again rather than treating this as a failure.
+    /// </exception>
     public async Task<ResolvedRelease> FetchLatestAsync(CancellationToken ct)
     {
         var url = $"https://api.github.com/repos/{GitHubRepositoryDefaults.Slug}/releases/latest";
@@ -264,8 +268,18 @@ public sealed class ReleaseSource
             }
         }
 
+        // A published release with no manifest is a release that is not FINISHED, and that is a
+        // different thing from a fetch that went wrong. It used to be raised as a bare
+        // InvalidOperationException, which every caller then logged as "update check failed" - so a
+        // check that was merely five minutes early was indistinguishable from a real fault. Classify
+        // it so a caller can wait it out and say so (see ReleaseNotReadyRetry). The Director's own
+        // updater has the same condition on its own code path; that half is issue #1030.
         if (manifestUrl is null)
-            throw new InvalidOperationException($"Latest release has no {ManifestAssetName} asset.");
+        {
+            var tag = root.TryGetProperty("tag_name", out var t) ? t.GetString() ?? "(untagged)" : "(untagged)";
+            EngineLog.Write($"[ReleaseSource] Release {tag} has {urls.Count} asset(s) but no {ManifestAssetName}; it is published but not complete.");
+            throw new ReleaseNotReadyException(tag, ManifestAssetName);
+        }
 
         var manifestJson = await _http.GetStringAsync(manifestUrl, ct);
         var manifest = ReleaseManifest.Parse(manifestJson);

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -348,6 +348,18 @@ public partial class MainWindow : Window
             NextButton.IsEnabled = true;
             return;
         }
+        // Installing during the minutes between a release being published and its files finishing
+        // upload is not an error, and must not read as one: the correct advice is "wait a moment and
+        // press Retry", not "could not fetch release info" (issue #1079).
+        catch (ReleaseNotReadyException ex)
+        {
+            SetupLog.Write($"[MainWindow] RunInstallAsync: prepare deferred (release not ready): {ex.Message}");
+            _installStep?.SetNotStarted();
+            _installStep?.SetStatus(ex.UserMessage());
+            NextButton.Content = "Retry";
+            NextButton.IsEnabled = true;
+            return;
+        }
         catch (Exception ex)
         {
             SetupLog.Write($"[MainWindow] RunInstallAsync: prepare FAILED: {ex.Message}");


### PR DESCRIPTION
Fixes two defects in the release workflow. They are one pull request because they are the same
file and the same shape: **both produced something that looked right to whoever read it**, so
neither was ever checked.

## The release page publishes our written notes (internal #1106)

The workflow switched on the release action's own note generation, which produces a list of
internal pull-request titles. Every correct-looking release page was a person pasting
`docs/public/release-notes/<tag>.md` over that list afterwards - right by accident, not by design.

Confirmed from the shipped pages rather than the code alone: **v1.8.7's release body is four
pull-request titles and a compare link**, published to strangers; v1.8.8 and v1.9.0 carry prose
that was set by hand.

The workflow now resolves `docs/public/release-notes/<tag>.md`, publishes it through `body_path`,
and **fails the release when it is absent** - or when it exists but holds fewer than 200
non-whitespace characters, because a placeholder would satisfy an existence check and publish a
blank page. There is deliberately no fallback that generates a competing version nobody wrote.

`scripts/new-release.ps1` applies the identical floor **before the tag is pushed**. The workflow's
copy can only fail after the whole build has run, and a pushed tag cannot be un-pushed.

## The release becomes "latest" only once it is complete (internal #1079)

Publishing made a release "latest" instantly while its assets attached minutes later, so every
release had a window in which `/releases/latest` named a version whose `release-manifest.json` did
not exist. Any updater checking inside it failed outright.

Measured on v1.8.8 from the GitHub API: published `10:48:48Z`, assets attached `10:54:11Z`. A
launcher checked at `10:54:05Z` - six seconds before the manifest existed - and logged
`update check failed`.

The release is now created **as a draft** with every asset attached, and published by a separate
step that first proves `release-manifest.json` is really there. A draft is not "latest", so
"latest" and "complete" become the same moment. The publish step addresses the release **by ID**,
not by tag: GitHub associates a draft with its tag only on publish, so a by-tag lookup would be
asking about a different release.

That closes the window at source. The machine-tier updaters also stop mistaking it for a fault, so
the state remains legible if a release ever stalls half-built:

- `ReleaseSource` raises a classified `ReleaseNotReadyException` (carrying the tag and the missing
  asset) instead of a bare `InvalidOperationException`.
- The launcher and the Gateway say so plainly and look again in **3 minutes** rather than at the
  next hourly cycle - **bounded to 5 consecutive retries**, because an unbounded short poll against
  a permanently manifest-less release never stops.
- Both setup wizards show "nothing is wrong, press Retry in a moment" instead of
  `ERROR: Could not fetch release info from GitHub`.

## The run-book was half the defect

`docs/Release-Process.md` told a human to click **"Generate release notes"** and then
**"Publish release"** - which is precisely how a published-but-empty release comes to exist, and
why v1.8.8 was published five and a half minutes before its assets. Both that document and the
release-manager skill now say: write the notes, merge the bump, push the tag, and **do not create
or publish the release by hand**. Pre-creating a published release would reintroduce the window
even with this workflow, since the assets would attach to it.

## Proof

- Five new tests in `ReleaseWorkflowContractTests` pin the mechanism in the workflow file - no
  generated notes, a guard that exits, a draft that carries the assets, a publish step that checks
  the manifest, and the same content floor in both guards. **All five go red against the workflow
  and script as they stand on `main`.** One of them caught the banned string in a comment written
  while making this change.
- Seven new tests in `ReleaseNotReadyTests` cover the classification in both directions - a
  published release with no manifest raises not-ready naming the release; a complete release does
  not - plus the retry cadence, its bound, its per-episode reset, and the wording of the log line.
- Full solution suite, setup engine (438), setup wizard (21) and setup CLI (32) all pass.

## Scope

The Director's own updater has this same condition on a separate code path and is being fixed
under internal #1030 by another change; this pull request deliberately touches none of
`UpdateService.cs`, `MainWindow.axaml.cs`, or `App.axaml.cs`. The two compose: once a release is
published only after its manifest is attached, the state that work surfaces simply stops occurring.
