### PR TITLE
perf(director): read the dictation marker store once a tick, not once per session

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -335,17 +335,24 @@ public partial class MainWindow : Window
         _sessionGitTimer.Start();
 
         // Issue #1181, Task 3b: refresh each session's "receiving a dictation" flag once a second so the
-        // rail can paint it orange while a phone dictation is inbound. One cheap disk read per session per
-        // tick (the durable marker), NOT per render; the Session raises a change event only when it flips,
-        // so the rail repaints just on the edges. (Task 4 will additionally compute this at the Gateway so
-        // the phone and cockpit show the same state.)
+        // rail can paint it orange while a phone dictation is inbound. The Session raises a change event
+        // only when it flips, so the rail repaints just on the edges. (Task 4 will additionally compute
+        // this at the Gateway so the phone and cockpit show the same state.)
+        //
+        // Issue #1111: read the marker store ONCE per tick, not once per tick PER SESSION. Asking each
+        // session separately re-enumerated the store and re-read every marker for each one, so the work
+        // was sessions x markers - hundreds of file reads a second on the UI thread at two dozen sessions,
+        // every one of them re-deriving the same store-wide answer. The set is read once here and each
+        // session is then asked against it for free, so this tick costs the same whether one session is
+        // open or fifty.
         _dictationLockTimer = new global::Avalonia.Threading.DispatcherTimer
         {
             Interval = TimeSpan.FromSeconds(1),
         };
         _dictationLockTimer.Tick += (_, _) =>
         {
-            foreach (var vm in _sessions) vm.Session.RefreshReceivingDictation();
+            var lockedSessionIds = Session.DictationLockedIds();
+            foreach (var vm in _sessions) vm.Session.RefreshReceivingDictation(lockedSessionIds);
         };
         _dictationLockTimer.Start();
 

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -582,6 +582,11 @@ public sealed class ControlApiHost : IAsyncDisposable
         // and control-API send paths. Idempotent to set on each start.
         Core.Sessions.Session.DictationLockCheck = id => Core.Sessions.DictationLockReader.IsSessionLocked(id);
 
+        // Issue #1111: the same projection, read in ONE pass, for the roster's per-tick refresh of every
+        // session. Wired from the same reader as the line above so the two can never disagree about a
+        // marker; the single-session hook stays for the single-session question.
+        Core.Sessions.Session.DictationLockedIdsCheck = () => Core.Sessions.DictationLockReader.LockedSessionIds();
+
         // Issue #1357: the signed-in DevThrottle user for a session's preamble. The account credential
         // lives on the Gateway (issue #651), so this reads GET /account/status (email + provider +
         // nickname) through a short-lived cache. GatewayConfig.Load is re-read each resolve so a settings

--- a/src/CcDirector.Core.Tests/Sessions/DictationLockReaderTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/DictationLockReaderTests.cs
@@ -105,4 +105,86 @@ public sealed class DictationLockReaderTests : IDisposable
         WriteMarker(Guid.NewGuid().ToString("N"), "Pending", Guid.NewGuid().ToString());
         Assert.False(DictationLockReader.IsSessionLocked(_root, ""));
     }
+
+    // ---- LockedSessionIds: the bulk read behind the roster's per-tick refresh (issue #1111) ----
+    //
+    // The bulk read exists ONLY to stop the roster re-reading the whole marker store once per session per
+    // second. It is therefore worth nothing unless it gives the SAME answer as the single-session read it
+    // replaces at the call site - so the tests below mirror the cases above, and the last one asserts the
+    // agreement directly rather than trusting that the two implementations were kept in step by hand.
+
+    [Fact]
+    public void LockedSessionIds_ReturnsEveryPendingSession_InOnePass()
+    {
+        var a = Guid.NewGuid().ToString();
+        var b = Guid.NewGuid().ToString();
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", a);
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", b);
+
+        var locked = DictationLockReader.LockedSessionIds(_root);
+
+        Assert.Equal(2, locked.Count);
+        Assert.Contains(a, locked);
+        Assert.Contains(b, locked);
+    }
+
+    [Theory]
+    [InlineData("Delivered")]
+    [InlineData("Abandoned")]
+    [InlineData("Failed")]
+    public void LockedSessionIds_NonPendingMarker_ContributesNoLock(string terminalState)
+    {
+        // The live failure this fixes: a store full of terminal tombstones nobody purges. They must cost a
+        // read and contribute nothing, never a lock.
+        WriteMarker(Guid.NewGuid().ToString("N"), terminalState, Guid.NewGuid().ToString());
+
+        Assert.Empty(DictationLockReader.LockedSessionIds(_root));
+    }
+
+    [Fact]
+    public void LockedSessionIds_IsCaseInsensitive_LikeTheSingleSessionRead()
+    {
+        var sid = Guid.NewGuid().ToString().ToUpperInvariant();
+        WriteMarker(Guid.NewGuid().ToString("N"), "pending", sid);
+
+        Assert.Contains(sid.ToLowerInvariant(), DictationLockReader.LockedSessionIds(_root));
+    }
+
+    [Fact]
+    public void LockedSessionIds_MissingRootOrGarbageMarker_FailsOpen()
+    {
+        Assert.Empty(DictationLockReader.LockedSessionIds(Path.Combine(_root, "does-not-exist")));
+
+        var dir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "record.json"), "{ not valid json");
+
+        // Same posture as IsSessionLocked: a corrupt marker is skipped, never a phantom lock.
+        Assert.Empty(DictationLockReader.LockedSessionIds(_root));
+    }
+
+    [Fact]
+    public void LockedSessionIds_AgreesWithIsSessionLocked_ForEverySession()
+    {
+        // A store shaped like a real one: one live dictation among a pile of terminal tombstones, plus a
+        // corrupt marker and a session that has never dictated. Whatever the answer is per session, the two
+        // reads must give it identically - that agreement is the whole licence to swap one for the other.
+        var pending = Guid.NewGuid().ToString();
+        var delivered = Guid.NewGuid().ToString();
+        var neverSeen = Guid.NewGuid().ToString();
+
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", pending);
+        WriteMarker(Guid.NewGuid().ToString("N"), "Delivered", delivered);
+        WriteMarker(Guid.NewGuid().ToString("N"), "Abandoned", delivered);
+        var corrupt = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(corrupt);
+        File.WriteAllText(Path.Combine(corrupt, "record.json"), "{ half written");
+
+        var locked = DictationLockReader.LockedSessionIds(_root);
+
+        foreach (var sid in new[] { pending, delivered, neverSeen })
+        {
+            Assert.Equal(DictationLockReader.IsSessionLocked(_root, sid), locked.Contains(sid));
+        }
+    }
 }

--- a/src/CcDirector.Core.Tests/Sessions/DictationRosterRefreshCostTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/DictationRosterRefreshCostTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// Issue #1111: the roster's "receiving a dictation" refresh must cost the SAME whether one session is
+/// open or fifty.
+///
+/// The original loop asked each session separately, and each ask re-enumerated the whole dictation-uploads
+/// store and re-read every marker in it. So a one-second timer did (sessions x markers) file reads per
+/// second on the UI thread - hundreds of them on a Director holding two dozen sessions, every one of them
+/// re-deriving the same store-wide answer. The fix reads the store ONCE per tick and asks the resulting
+/// set per session.
+///
+/// This is pinned as source text rather than behaviour because the defect is not a wrong answer - the old
+/// code returned exactly the right one. The defect is WHERE the read happens: inside the loop instead of
+/// above it. No assertion on the result can tell those apart, so the loop itself is the thing under test.
+/// The DoesNotContain is the live half: restoring the per-session call reddens this test.
+/// </summary>
+public sealed class DictationRosterRefreshCostTests
+{
+    [Fact]
+    public void Roster_refresh_reads_the_marker_store_once_per_tick_not_once_per_session()
+    {
+        var main = File.ReadAllText(Path.Combine(RepoRoot(), "src", "CcDirector.Avalonia", "MainWindow.axaml.cs"));
+
+        // Read once, ABOVE the loop.
+        Assert.Contains("var lockedSessionIds = Session.DictationLockedIds();", main);
+
+        // Then ask the set per session - no disk in the loop body.
+        Assert.Contains(
+            "foreach (var vm in _sessions) vm.Session.RefreshReceivingDictation(lockedSessionIds);",
+            main);
+
+        // The regression itself: the parameterless overload goes back to disk for ONE session, so calling it
+        // per session in a loop is precisely the cost this issue removed. It stays on Session for a caller
+        // refreshing a single session, but it must not reappear in the roster's tick.
+        Assert.DoesNotContain("vm.Session.RefreshReceivingDictation();", main);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root from " + AppContext.BaseDirectory);
+    }
+}

--- a/src/CcDirector.Core/Sessions/DictationLockReader.cs
+++ b/src/CcDirector.Core/Sessions/DictationLockReader.cs
@@ -74,6 +74,60 @@ public static class DictationLockReader
         return false;
     }
 
+    /// <summary>
+    /// Every session id with an inbound dictation, from ONE pass over the uploads root. Reads the
+    /// production root (<see cref="CcStorage.DictationUploads"/>).
+    /// </summary>
+    public static IReadOnlySet<string> LockedSessionIds()
+        => LockedSessionIds(CcStorage.DictationUploads());
+
+    /// <summary>
+    /// The bulk read behind the roster's "receiving a dictation" paint (issue #1111). Asking
+    /// <see cref="IsSessionLocked(Guid)"/> once per session re-enumerated this directory and re-read
+    /// every marker once per session, so a Director holding two dozen sessions did hundreds of file
+    /// reads a second to answer one question whose answer is the SAME for every session in a tick.
+    /// This answers it once: one enumeration, each marker read exactly once, and the caller then asks
+    /// the returned set per session for free.
+    ///
+    /// Deliberately NOT a replacement for <see cref="IsSessionLocked(string, string)"/>. That one stays
+    /// as it is: it is the single-session question, and callers depending on its exact posture keep it
+    /// unchanged. This method matches that posture rather than inventing a new one - it FAILS OPEN the
+    /// same way (an unreadable root or a half-written marker contributes no lock, never a false lock),
+    /// so the two can never disagree about a marker they both managed to read.
+    ///
+    /// Returns an ordinal-ignore-case set because the marker's session id is compared case-insensitively
+    /// by the single-session path, and a caller passing a <c>Guid.ToString()</c> must get the same answer.
+    /// </summary>
+    public static IReadOnlySet<string> LockedSessionIds(string uploadsRoot)
+    {
+        var locked = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        string[] dirs;
+        try
+        {
+            if (!Directory.Exists(uploadsRoot)) return locked;
+            dirs = Directory.GetDirectories(uploadsRoot);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationLockReader] enumerate {uploadsRoot} failed: {ex.Message}");
+            return locked;
+        }
+
+        foreach (var dir in dirs)
+        {
+            var marker = ReadMarker(Path.Combine(dir, "record.json"));
+            if (marker is null) continue;
+            if (string.Equals(marker.State, "Pending", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(marker.SessionId))
+            {
+                locked.Add(marker.SessionId);
+            }
+        }
+
+        return locked;
+    }
+
     private static Marker? ReadMarker(string path)
     {
         try

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -2259,6 +2259,29 @@ public sealed class Session : IDisposable
     public static Func<Guid, bool>? DictationLockCheck { get; set; }
 
     /// <summary>
+    /// Host-injected BULK form of <see cref="DictationLockCheck"/>: every session id currently holding an
+    /// inbound dictation, read in one pass (issue #1111). Wired by the Director host alongside the
+    /// single-session hook; left null (nothing locked) elsewhere and in unit tests, exactly like its
+    /// sibling. Exists because the roster asks this question of EVERY session on a one-second timer, and
+    /// the single-session hook re-reads the whole marker store per session - work that grows with the
+    /// session count to answer a question with one store-wide answer per tick.
+    /// Tests that set it must reset it to null in teardown.
+    /// </summary>
+    public static Func<IReadOnlySet<string>>? DictationLockedIdsCheck { get; set; }
+
+    /// <summary>
+    /// The set of session ids with an inbound dictation, for a caller about to ask on behalf of many
+    /// sessions at once. Empty when no host wired <see cref="DictationLockedIdsCheck"/> - the same
+    /// "nothing is locked" answer <see cref="IsDictationLocked"/> gives in that case, so the bulk and
+    /// single-session paths agree on an unwired host instead of disagreeing.
+    /// </summary>
+    public static IReadOnlySet<string> DictationLockedIds()
+        => DictationLockedIdsCheck?.Invoke() ?? EmptyLockedIds;
+
+    private static readonly IReadOnlySet<string> EmptyLockedIds =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// True when a dictation is inbound to THIS session, so a human send into it is refused (issue
     /// #1181, Task 3b). A pure projection of the durable PENDING delivery marker via the host-injected
     /// <see cref="DictationLockCheck"/>; false when no host wired the check. This is the single
@@ -2287,8 +2310,21 @@ public sealed class Session : IDisposable
     /// so the disk read happens once per tick, not once per render.
     /// </summary>
     public void RefreshReceivingDictation()
+        => ApplyReceivingDictation(IsDictationLocked);
+
+    /// <summary>
+    /// The same refresh for a caller updating MANY sessions in one tick: it has already read the whole
+    /// marker store once (<see cref="DictationLockedIds"/>), so this asks that set instead of going back
+    /// to disk for this one session (issue #1111). Same result as <see cref="RefreshReceivingDictation()"/>
+    /// - both compare against the PENDING markers - but the disk read happens once per TICK rather than
+    /// once per tick per SESSION, so the cost of the roster's one-second refresh stops scaling with how
+    /// many sessions are open.
+    /// </summary>
+    public void RefreshReceivingDictation(IReadOnlySet<string> lockedSessionIds)
+        => ApplyReceivingDictation(lockedSessionIds.Contains(Id.ToString()));
+
+    private void ApplyReceivingDictation(bool now)
     {
-        var now = IsDictationLocked;
         if (now == _isReceivingDictation) return;
         _isReceivingDictation = now;
         FileLog.Write($"[Session] IsReceivingDictation -> {now}: session={Id}");


### PR DESCRIPTION
Fixes the biggest item in devthrottle_internal#1111: the Director getting slower with every session
you open.

## The defect

The roster refreshes each session's "receiving a dictation" flag on a one-second timer. It asked
each session separately, and every ask re-enumerated the whole dictation-uploads store and re-read
every marker in it. So the work per tick was `sessions x markers`.

Measured on a live Director: 27 sessions against a store of 28 markers is roughly **750 file reads
and JSON parses per second**, synchronously on the UI thread. Every one of those reads re-derives
the same store-wide answer - 26 of the 27 scans in a tick are exact duplicates of the first.

Two aggravating facts from the live machine: not one of the 28 markers was `Pending` (they are all
finished tombstones nobody purges, the oldest three weeks old), and the cost grows with both numbers
forever.

## The change

`DictationLockReader.LockedSessionIds` does one pass and returns the set of session ids with a
Pending marker. The timer reads that set above the loop; each session is then asked against the set
for free. The tick now costs the same whether one session is open or fifty.

`IsSessionLocked` is deliberately untouched - it is still the single-session question, with its
existing fail-open posture. The bulk read matches that posture rather than inventing a new one, and
`LockedSessionIds_AgreesWithIsSessionLocked_ForEverySession` asserts the two give identical answers
per session so they cannot drift apart. The parameterless `RefreshReceivingDictation()` also stays,
for a caller refreshing a single session.

## On the test

The defect was never a wrong answer - the old code returned exactly the right one. The defect is
WHERE the read happens: inside the loop instead of above it. No assertion on the result can tell
those apart, so the timer body itself is pinned as source text in
`DictationRosterRefreshCostTests`.

I revert-proved it rather than assume it works: restoring the per-session call makes that test fail,
and restoring the fix makes it pass again. A guard that cannot fail is not a guard.

## Scope

Deliberately just this one change. The rest of #1111 - moving the read off the UI thread, the git
status probes that fan out per session instead of per repository, and the unnormalized `RepoPath`
that would defeat that dedup - is left for follow-ups, at the owner's direction, so the immediate
relief lands on its own.

## Not fixed here, but found while reading

The doc comment on `Session.IsDictationLocked` says it is the checkpoint that refuses a human send
while a dictation is inbound. It is not: the only consumer of that property is the roster's refresh.
The enforcement genuinely lives at the Gateway's front door. Worth reconciling the comment with the
code separately - I left it alone rather than change behaviour in a performance fix.
