### PR TITLE
fix(gateway): retire dictation tombstones the client will never acknowledge

### DIFF
--- a/src/CcDirector.Gateway.Tests/DictationTombstoneSweepWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTombstoneSweepWiringTests.cs
@@ -1,0 +1,142 @@
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Dictation delivery tombstones are bounded IN PRODUCTION, and the bound touches ONLY the records it is
+/// allowed to touch (issue #1111).
+///
+/// WHY IT BOOTS A REAL GATEWAY. The designed retirement path for a terminal record is a client ack, and it
+/// works - but an ack that will never come (a client that dropped its queue, was reinstalled, or simply never
+/// returned) left its tombstone immortal, so the store grew without any ceiling. That was observed live: 28
+/// records, every one DELIVERED, the oldest three weeks old. A test that CALLS the sweep cannot detect that,
+/// because it passes whether or not anything in production runs it - which is exactly how this root grew
+/// unbounded while looking covered, and the same trap its voice-turn sibling fell into. So this test never
+/// calls the sweep. It writes records on disk, starts a real <see cref="GatewayHost"/>, and waits for the
+/// Gateway to retire the right one on its own.
+///
+/// WHAT MUST SURVIVE MATTERS MORE THAN WHAT IS REMOVED. This sweep is deliberately not
+/// <see cref="VoiceUploadStore.SweepAbandoned"/>, which deletes any aged upload directory without reading
+/// its state. A PENDING record holds a live session lock and guards audio still owed, and FAILED can be
+/// restored to PENDING by ClearFailed - so age-deleting either would silently unlock a session or drop a
+/// dictation. Those assertions are the point of this test, not the deletion.
+///
+/// Only the SCHEDULE is compressed. The thirty-day age cut-off is production's own, and the records are aged
+/// into the past on disk, so what runs here is the deployed retention rule rather than a shortened copy.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class DictationTombstoneSweepWiringTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+
+    private GatewayHost? _gateway;
+    private string? _originalRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-tombstone-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-tombstone-instances-" + Guid.NewGuid().ToString("N"));
+
+    public Task InitializeAsync()
+    {
+        _originalRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        GatewayHost.DictationTombstoneSweepScheduleForTests = null;
+        if (_gateway is not null) await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _originalRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    [Fact]
+    public async Task RunningGateway_RetiresOldDeliveredTombstone_ButNeverPendingFailedOrFresh()
+    {
+        var root = CcStorage.DictationUploads();
+        var old = DateTime.UtcNow.AddDays(-31);   // past the thirty-day production cut-off
+        var recent = DateTime.UtcNow.AddDays(-2); // well inside it
+
+        // The live defect: a DELIVERED record whose client never acknowledged it. Nothing else can ever
+        // retire this, so without the sweep it is immortal.
+        var deliveredOld = WriteRecord(root, "Delivered", old);
+        // ABANDONED is terminal too, and equally unacknowledgeable once the client is gone.
+        var abandonedOld = WriteRecord(root, "Abandoned", old);
+
+        // ---- everything below must SURVIVE, however old ----
+
+        // PENDING holds a live session lock and audio still owed. Age-deleting it would silently un-orange a
+        // session and drop a dictation that was still coming. This is the assertion that separates this
+        // sweep from the blunt age sweep next door.
+        var pendingOld = WriteRecord(root, "Pending", old);
+        // FAILED is explicitly NOT terminal - ClearFailed can restore it to PENDING.
+        var failedOld = WriteRecord(root, "Failed", old);
+        // Inside the window: the client may still legitimately re-drive this id.
+        var deliveredFresh = WriteRecord(root, "Delivered", recent);
+        // Unreadable: a half-written marker is never proof of anything, so it is left alone.
+        var corruptOld = Path.Combine(root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(corruptOld);
+        File.WriteAllText(Path.Combine(corruptOld, "record.json"), "{ not valid json");
+        Directory.SetLastWriteTimeUtc(corruptOld, old);
+        // The partition container is not an upload; deleting it would take every tenant's records with it.
+        var tenantsDir = Path.Combine(root, VoiceUploadStore.TenantPartitionDirectoryName);
+        Directory.CreateDirectory(tenantsDir);
+        Directory.SetLastWriteTimeUtc(tenantsDir, old);
+
+        GatewayHost.DictationTombstoneSweepScheduleForTests = TimeSpan.FromMilliseconds(150);
+        _gateway = new GatewayHost(
+            port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: false,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        var swept = await WaitUntilGone(deliveredOld, TimeSpan.FromSeconds(20));
+
+        Assert.True(swept, $"the running Gateway never retired the stale DELIVERED tombstone at {deliveredOld} - " +
+            "nothing in production is running the tombstone sweep");
+        Assert.False(Directory.Exists(abandonedOld), "a stale ABANDONED tombstone was not retired");
+
+        Assert.True(Directory.Exists(pendingOld),
+            "the sweep deleted a PENDING record - that silently unlocks a session and drops audio still owed");
+        Assert.True(Directory.Exists(failedOld),
+            "the sweep deleted a FAILED record, which ClearFailed can still restore to PENDING");
+        Assert.True(Directory.Exists(deliveredFresh),
+            "the sweep deleted a tombstone inside the retention window, weakening the de-dupe guarantee");
+        Assert.True(Directory.Exists(corruptOld),
+            "the sweep deleted a record it could not read - an unreadable marker proves nothing");
+        Assert.True(Directory.Exists(tenantsDir), "the sweep deleted the per-tenant partition container");
+    }
+
+    // ===== helpers =================================================================================
+
+    /// <summary>
+    /// Write one delivery record in the exact on-disk shape the Gateway writes, and age the directory - the
+    /// signal the sweep judges by - to a chosen point in the past.
+    /// </summary>
+    private static string WriteRecord(string root, string state, DateTime lastWriteUtc)
+    {
+        var dir = Path.Combine(root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "record.json"),
+            $"{{\"State\":\"{state}\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\"," +
+            $"\"Reason\":null,\"SessionId\":\"{Guid.NewGuid()}\"}}");
+        Directory.SetLastWriteTimeUtc(dir, lastWriteUtc);
+        return dir;
+    }
+
+    private static async Task<bool> WaitUntilGone(string dir, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!Directory.Exists(dir)) return true;
+            await Task.Delay(100);
+        }
+        return !Directory.Exists(dir);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -557,6 +557,33 @@ public sealed class GatewayHost : IAsyncDisposable
     /// the timer turns it red.
     /// </summary>
     internal static TimeSpan? VoiceTurnUploadSweepScheduleForTests;
+
+    // Dictation tombstone retention (issue #1111). Distinct from the voice-turn sweep above in BOTH numbers
+    // and in what it is allowed to touch: this one deletes only DELIVERED/ABANDONED records, never a PENDING
+    // one, and it exists solely to bound tombstones whose client acknowledgment will never arrive.
+    private System.Threading.Timer? _dictationTombstoneSweepTimer;
+    private static readonly TimeSpan DictationTombstoneSweepInterval = TimeSpan.FromHours(6);
+    // WHY THIRTY DAYS, and why so much longer than the four hours next door. These two roots hold opposite
+    // things. The voice-turn root holds RECORDED AUDIO that nothing else will ever remove, so its bound is a
+    // privacy ceiling and wants to be tight. A dictation tombstone holds no audio at all - the bytes are
+    // discarded when the record turns terminal - it is a few hundred bytes whose only job is to stop a
+    // client re-driving an upload id it already delivered. So the risk here is inverted: deleting too EARLY
+    // silently re-opens the door to a duplicate dictation, while keeping too long costs almost nothing.
+    //
+    // The number therefore comes from the client, not from the disk. A client holds its on-device copy until
+    // it sees a terminal outcome and acks; a phone that is offline, out of battery, or simply not opened
+    // might not come back for days. Thirty days is an order of magnitude beyond any plausible return, so no
+    // client that could still re-drive an id is affected, while a tombstone nobody will ever ack stops being
+    // immortal. The ack remains the real retirement path and retires records in seconds; this only catches
+    // what the ack has permanently lost.
+    private static readonly TimeSpan DictationTombstoneMaxAge = TimeSpan.FromDays(30);
+    /// <summary>
+    /// Test seam: overrides the dictation tombstone sweep schedule (first tick and period). Null in
+    /// production, assigned only by tests. It exists for the same reason its voice-turn sibling does - the
+    /// sweep method having its own unit test proves nothing about whether anything CALLS it, which is
+    /// precisely how this root grew unbounded while looking covered.
+    /// </summary>
+    internal static TimeSpan? DictationTombstoneSweepScheduleForTests;
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
@@ -618,8 +645,10 @@ public sealed class GatewayHost : IAsyncDisposable
     // Durable dictation upload staging (issue #1006): the phone streams recorded audio here in chunks;
     // the Gateway assembles, transcribes, and injects the turn itself. Each upload id carries a durable
     // delivery record (issue #1183): PENDING chunks are retained until delivered/abandoned, and the
-    // terminal tombstone de-dupes the upload id forever until the client acknowledges it - so there is no
-    // age sweep for dictation staging (only the unrelated voice-turn staging is age-swept).
+    // terminal tombstone de-dupes the upload id until the client acknowledges it. PENDING is never age-swept
+    // here - it holds a live session lock and audio still owed. Issue #1111 added the one bound that does
+    // apply: SweepResolvedTombstones retires TERMINAL records whose acknowledgment will never come, on a
+    // thirty-day backstop, because otherwise a client that never returns leaves its tombstone immortal.
     // The tenant is named here because the store REQUIRES one - there is no constructor that picks a
     // partition on the author's behalf. This is the BASE handle only: the dictation endpoint re-scopes it
     // with ForTenant to the tenant it resolved from the authenticated device key, and does its work solely
@@ -3065,6 +3094,32 @@ public sealed class GatewayHost : IAsyncDisposable
             $"{voiceTurnUploadSchedule.TotalMinutes:0.###}min, removing staging idle longer than " +
             $"{VoiceTurnUploadMaxAge.TotalHours:0.###}h");
 
+        // Dictation tombstone retention (issue #1111). The client ack is what normally retires a terminal
+        // record, and it does so within seconds; this only bounds the ones whose ack will NEVER arrive -
+        // a client that dropped its queue, was reinstalled, or never came back. Without it those records are
+        // immortal and the store grows forever, which is what was observed live (28 records, all DELIVERED,
+        // the oldest three weeks old). Per-tenant for the same reason the sweep above is: the pass does not
+        // descend into the partition container, so sweeping only the base handle would leave every hosted
+        // tenant's tombstones unbounded. Self-host runs exactly one Local pass over the base root.
+        var dictationTombstoneSchedule = DictationTombstoneSweepScheduleForTests ?? DictationTombstoneSweepInterval;
+        _dictationTombstoneSweepTimer = new System.Threading.Timer(
+            _ =>
+            {
+                try
+                {
+                    _tenantPass.ForEachTenant(() =>
+                    {
+                        if (_tenantPass.Current is not { } tenant) return; // deny: no scope -> sweep nothing
+                        _dictationUploads.ForTenant(tenant).SweepResolvedTombstones(DictationTombstoneMaxAge);
+                    });
+                }
+                catch (Exception ex) { FileLog.Write($"[GatewayHost] dictation tombstone sweep error: {ex.Message}"); }
+            },
+            null, dictationTombstoneSchedule, dictationTombstoneSchedule);
+        FileLog.Write($"[GatewayHost] dictation tombstone sweep started: every " +
+            $"{dictationTombstoneSchedule.TotalHours:0.###}h, retiring unacknowledged terminal records older " +
+            $"than {DictationTombstoneMaxAge.TotalDays:0.###} days (PENDING is never swept)");
+
         // Issue #640: start the Gateway-owned background token refresh. Start() returns immediately (the
         // first sweep runs after a short delay), so this never blocks startup. When the cached access
         // token has expired and a refresh endpoint is configured, the sweep exchanges the refresh token
@@ -3555,6 +3610,8 @@ public sealed class GatewayHost : IAsyncDisposable
         _displayStateSweepTimer = null;
         try { _voiceTurnUploadSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice-turn upload sweep timer dispose error: {ex.Message}"); }
         _voiceTurnUploadSweepTimer = null;
+        try { _dictationTombstoneSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] dictation tombstone sweep timer dispose error: {ex.Message}"); }
+        _dictationTombstoneSweepTimer = null;
 
 
         // Issue #640: stop the background token refresh timer.

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -423,6 +423,93 @@ public sealed class VoiceUploadStore
     }
 
     /// <summary>
+    /// Retire TERMINAL tombstones (DELIVERED / ABANDONED) that no client ever acknowledged and that are older
+    /// than <paramref name="maxAge"/> (issue #1111).
+    ///
+    /// WHY THIS EXISTS, GIVEN THE RULE RIGHT ABOVE IT. <see cref="Acknowledge"/> is the designed retirement
+    /// path and the record comment states the tombstone is retired "only on a real client ack, never by age".
+    /// That is correct for an ack that is merely LATE - a lost ack should not race a delete, and the client
+    /// re-acks after a re-complete. What it has no answer for is an ack that will NEVER come: a client that
+    /// dropped its queue, was reinstalled, or simply never returned. Those tombstones are unreachable by the
+    /// only mechanism that can retire them, so the store grows without any ceiling at all. Observed live: 28
+    /// records, every one DELIVERED, the oldest three weeks old, none of them acknowledgeable by anything.
+    /// This is the backstop for that case ONLY - it does not replace the ack, it bounds what the ack abandons.
+    ///
+    /// WHY IT IS NOT <see cref="SweepAbandoned"/>. That sweep deletes ANY canonical upload directory past the
+    /// age, without reading its state. On the voice-turn staging root that is right, because idle IS abandoned
+    /// there. On this root it would be wrong and dangerous: a PENDING record holds a live session lock and
+    /// guards audio still queued for delivery, so age-deleting one would silently unlock a session and drop a
+    /// dictation that was still owed. FAILED is likewise not terminal - <c>ClearFailed</c> can restore it to
+    /// PENDING. So this method admits ONLY the two genuinely-final states and leaves everything else alone
+    /// forever, however old. A stuck PENDING is a different bug and must stay visible rather than be tidied
+    /// away by a cleanup that was never asked to make that judgement.
+    ///
+    /// THE DE-DUPE GUARANTEE. A tombstone stops a delivered id re-injecting if a client re-drives it. Deleting
+    /// one after <paramref name="maxAge"/> only weakens that for a client returning after the whole window,
+    /// which is why the caller sets it far beyond any real retry (see the constant at the call site) rather
+    /// than to a tidy round number. Inside the window nothing changes.
+    ///
+    /// State and age are BOTH re-read inside the per-upload gate immediately before the delete, so a
+    /// concurrent ack, re-complete, or resurrection cannot be interleaved between the check and the delete.
+    /// Anything unreadable, half-written, or of an unrecognised shape SURVIVES - the same positive-admit
+    /// discipline as the sweep above, because a false delete here is unrecoverable audio state.
+    /// </summary>
+    public int SweepResolvedTombstones(TimeSpan maxAge)
+    {
+        var removed = 0;
+        var cutoff = DateTime.UtcNow - maxAge;
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(_root))
+            {
+                var name = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+                // POSITIVELY ADMIT, exactly as SweepAbandoned does: only a canonical upload id is a candidate.
+                // The tenants container and the legacy quarantine are not canonical names, so both survive.
+                if (!IsCanonicalUploadDirName(name)) continue;
+
+                WithRecordLock(name, () =>
+                {
+                    try
+                    {
+                        if (!Directory.Exists(dir)) return;
+
+                        // Re-read INSIDE the gate: an ack may have retired it, or a re-complete rewritten it,
+                        // since the enumeration above.
+                        var record = ReadRecordFile(RecordPath(dir));
+                        if (record is null) return;                     // no marker, or unreadable: leave it
+                        if (!IsRetirableTombstone(record.State)) return; // PENDING / FAILED are never aged out
+                        if (Directory.GetLastWriteTimeUtc(dir) >= cutoff) return;
+
+                        Directory.Delete(dir, recursive: true);
+                        removed++;
+                        FileLog.Write($"[VoiceUploadStore] SweepResolvedTombstones retired uploadId={name} " +
+                            $"state={record.State} (never acknowledged, older than {maxAge})");
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[VoiceUploadStore] SweepResolvedTombstones dir={dir} failed: {ex.Message}");
+                    }
+                });
+            }
+            if (removed > 0)
+                FileLog.Write($"[VoiceUploadStore] SweepResolvedTombstones removed={removed} older than {maxAge}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] SweepResolvedTombstones failed: {ex.Message}");
+        }
+        return removed;
+    }
+
+    /// <summary>
+    /// The only two states this cleanup may retire. Written as an explicit allow-list rather than "not
+    /// PENDING" so a state added later is NOT swept by default - it has to be admitted deliberately.
+    /// </summary>
+    private static bool IsRetirableTombstone(DictationDeliveryState state)
+        => state is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned;
+
+    /// <summary>
     /// Create the staging directory for an upload if it does not exist and stamp its last-activity signal to
     /// now, ATOMICALLY under the upload's gate. This is the one place activity is recorded, so every caller
     /// that represents a live client (register, a resume, a chunk, an assemble) refreshes the same signal the


### PR DESCRIPTION
Second item from devthrottle_internal#1111 (item 1c): the dictation marker store grows forever.

## What is actually wrong

The designed retirement path for a terminal delivery record is a client ack, and **it works** - the log
shows it retiring records within seconds. So this is not a broken ack.

The gap is an ack that will **never** arrive. A client that dropped its queue, was reinstalled, or
simply never came back leaves a record that nothing can ever retire. The code says as much - "if the
ack is lost the tombstone simply persists" - and accepts it. What it did not account for is that
"persists" means forever, with no ceiling.

Observed live: **28 records, every one DELIVERED, oldest three weeks old**, none acknowledgeable by
anything.

## Why not just use SweepAbandoned

It already exists and would have been a one-line wiring change. It is also the wrong tool, and
dangerously so.

`SweepAbandoned` deletes any aged upload directory **without reading its state**. On the voice-turn
staging root that is correct - idle genuinely means abandoned. On this root a `PENDING` record holds a
live session lock and guards audio still owed for delivery, so age-deleting one would silently unlock
a session and drop a dictation the user was still waiting on. `FAILED` is not terminal either -
`ClearFailed` restores it to `PENDING`.

So `SweepResolvedTombstones` admits only `DELIVERED` and `ABANDONED`, written as an explicit
allow-list rather than "not PENDING" so a state added later is not swept by default. Anything
unreadable, half-written, or of an unrecognised shape survives. State and age are both re-read inside
the per-upload gate immediately before the delete, so a concurrent ack or re-complete cannot be
interleaved.

## The thirty days

Set from the client, not the disk. A tombstone holds no audio - the bytes are discarded when the
record turns terminal - so keeping one costs a few hundred bytes, while deleting one early re-opens
the door to a duplicate dictation. The risk is asymmetric, so the number is an order of magnitude
beyond any plausible client return rather than a tidy round figure.

## A written rule this amends

The record comment says the tombstone is "retired only on a real client ack, **never by age**". I did
not want to quietly contradict that, so: it is correct for an ack that is merely LATE, and nothing
about that case changes. It simply had no answer for an ack that is never coming. Both the record
comment and the store field comment are updated to say so rather than left to disagree with the code.

## The test

It boots a real Gateway and waits for it to retire a stale record on its own. The sweep having its own
unit test proves nothing about whether anything **calls** it - which is exactly how this root grew
unbounded while looking covered, and the trap its voice-turn sibling already fell into.

The assertions are weighted toward what must **survive**: PENDING, FAILED, a fresh tombstone, an
unreadable marker, and the tenant partition container. Removing the stale record is the easy half.

Note: local verification was blocked - three concurrent sessions on this machine held the
`CcDirector.Gateway.Tests` lock continuously, so the suite never got to run here. CI is the gate.