### PR TITLE
Supersede an older CI run on a pull request, never on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+# One run per workflow per branch, and supersede an older run ONLY on a pull request.
+#
+# Why the asymmetry, because getting it the other way round is the expensive mistake. On a pull request
+# the head commit is the only one anyone acts on, so an older run for a commit that has already been
+# pushed past is spending a runner on an answer nobody will read - cancelling it is right. On a push to
+# main, EVERY commit must keep its own verification: cancelling there would leave main commits
+# permanently unverified, and a green that belongs to a specific commit is the whole point of having CI
+# rather than a memory of a run.
+#
+# Added after a draft pull request queued six simultaneous runs on one branch, none of which superseded
+# any other, so the answer everybody was waiting for kept being pushed further out by the very commits
+# that were waiting on it. When a resource serialises, parallelism converts into latency rather than
+# throughput, and the cost lands on whoever is waiting rather than on whoever is holding.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: Build & Test (.NET)


### PR DESCRIPTION
One run per workflow per branch, and an older run is superseded **only on a pull request**.

## Why

A draft pull request queued six simultaneous CI runs on one branch, none of which superseded any other. The whole-solution answer everybody was waiting for kept being pushed further out by the very commits that were waiting on it.

The general form, since this is the third time today the same shape has cost us: **when a resource serialises, parallelism converts into latency rather than throughput** - and the cost lands on whoever is waiting rather than on whoever is holding, which is why nobody notices they are the problem.

## The asymmetry is the point

- **Pull request -> cancel in progress.** The head commit is the only one anyone acts on. An older run for a commit that has already been pushed past is spending a runner on an answer nobody will read.
- **Push to main -> never cancel.** Every commit on main must keep its own verification. Cancelling there would leave main commits permanently unverified, and a green that belongs to a *specific commit* is the reason to have CI at all rather than a memory of a run.

Getting this the other way round is the expensive mistake, and setting the cancel flag once for both events is the reasonable-looking way to make it. It would not fail loudly - main would simply accumulate commits nobody ever verified. The reasoning is written into the workflow file for that reason.

## Scope

One file, one block. No job, step, trigger or matrix is changed. It affects the shared pipeline for every session in this repository, which is why it is on its own branch rather than folded into a feature branch.
