### PR TITLE
release: v1.9.1 - the app stops feeling slow, buttons answer at once, and auto-update says where you are

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.0</Version>
+    <Version>1.9.1</Version>
   </PropertyGroup>
 
   <!--

--- a/docs/public/release-notes/v1.9.1.md
+++ b/docs/public/release-notes/v1.9.1.md
@@ -1,0 +1,149 @@
+## v1.9.1 - July 30, 2026
+
+The app stops getting slower as sessions pile up, buttons answer the moment you click them, and
+auto-update finally tells you which situation you are in. One number has been removed on purpose,
+and it is explained below rather than listed.
+
+### The context percentage is gone, and that is the fix
+
+The context gauge used to read something like "ctx 184k / 200k (92%)" in red. The used count was
+real. The number it was being divided by was not: DevThrottle guessed the size of the model's
+context window from the letters in the model name, and that guess is wrong on the model this
+product is most often run with. A session with roughly 800,000 tokens of room left was shown at 92
+percent in red, which pushes you to compact a session that has barely started.
+
+Adding the current model to that table would have cleared the screenshot and fixed nothing. A table
+of model facts is right the day it is written and wrong from the next model onwards, with no error
+and no warning - just a plausible wrong number on the screen.
+
+So the rule is now that DevThrottle only shows a context window the agent itself reported, and never
+one it worked out for itself. Where the agent reports it, you get the full gauge exactly as before -
+that is the case today with Codex, which reads the window out of its own session file. Where the
+agent does not report it yet, you get the raw token count with no percentage, no bar and no colour.
+That is the honest state: a missing number is an annoyance, a confident wrong one gets acted on.
+
+The percentage comes back for those agents as soon as we can ask them for their real window, which
+is being done as its own piece of work.
+
+### The app stops feeling slow as sessions accumulate
+
+Three costs that grew with every session you had open, measured before and after rather than judged
+by feel.
+
+- **The "receiving a dictation" check used to re-read the whole dictation store once per session,
+  every second, on the thread that paints the screen.** Against a store of 28 records that was 2.3
+  milliseconds a tick with one session open and 58 milliseconds a tick with twenty-seven. The store
+  is now read once per tick and every session asks that one answer, so the cost is the same whether
+  you have one session or fifty. The read also moved off the drawing thread, and a record that has
+  finished is read once and then left alone.
+- **Repository status was checked once per session instead of once per repository.** Two dozen
+  sessions spread over six working trees ran the same check ten times over on one tree. On the
+  reported machine that is 23 checks reduced to 6.
+- **Delivery records that no client will ever acknowledge are now cleared out.** They were kept
+  forever waiting for an acknowledgement that could never arrive - from a client that was
+  reinstalled, or simply never came back - so the store grew without limit. Records that are
+  genuinely finished are now retired after thirty days. Anything still owed to you is untouched.
+
+### Buttons answer immediately, once, and out loud
+
+Eleven buttons across the app broke one of two rules: nothing happened on screen until the work had
+already finished, and a second click started a second copy of the same operation.
+
+- **The Cockpit button used to sit silent for up to eight seconds.** It now says what it is doing
+  before it goes looking, waits four seconds rather than eight, and when it cannot reach your
+  gateway it tells you the address it tried and offers Retry instead of a bare OK. Clicking it
+  against an unreachable gateway used to stack up five identical error windows.
+- **Clicking twice no longer does the thing twice.** Compact and Clear context in particular -
+  three clicks used to buy three compactions, and compaction costs real money. The same applies to
+  Delete safe branches, Commit, Gateway scan, the workflow recorder, Screenshot Issue, Run one tool,
+  Stop turn and Interrupt.
+- **Buttons that fail now say so on the screen.** The workflow recorder, the branch delete and the
+  commit button previously reported failure only to a log file, so a failed recording left the
+  interface saying idle and a button that appeared to do nothing at all.
+- **Delete safe branches reports what it did.** It now shows progress and counts the branches it
+  refused to delete, which were previously invisible.
+
+### Auto-update says which situation you are in
+
+Auto-update has been working all along, but every state looked identical from the outside - a
+version number that did not change. Up to date, has not checked yet, downloading, downloaded and
+waiting, and a check that failed all looked the same.
+
+- **The update panel is now always on screen and always says which state you are in**: up to date
+  and when it last looked, checking, downloading, a build downloaded and waiting for your sessions
+  to finish, a check that failed and why, or an update that was installed and rolled back because it
+  did not start. The panel used to hide itself whenever there was nothing to report, which is
+  exactly when you want to look at it.
+- **It offers exactly one action, and only when that action can actually work.** "Install it now"
+  appears only when a build is staged, no session would be interrupted, and the launcher that
+  performs the restart is there to do it. When nothing can usefully be done, no button is offered
+  rather than one that would fail.
+- **Two situations that used to share one line are now separated.** A release that has not finished
+  publishing its downloads gets better on its own, so it says so and is retried within minutes. A
+  release that is complete but carries no build for your platform never gets better by waiting, so
+  it is reported instead of retried. Both used to say "up to date".
+
+### Setting up, and getting a clean machine onto the board
+
+- **The board and the setup wizard now give one answer about your coding agent.** On a clean machine
+  the wizard would install a coding agent and say "1 agent ready" while the board behind it said "No
+  coding agent found" with a Fix button, both reading the same machine. The board was answering a
+  narrower question and had computed its answer before the wizard ran. There is now a single
+  authority both screens read, and the board re-reads it whenever the fact changes.
+- **A clean install no longer reports its own successful setup as a failure.** A brand-new install
+  landed on the board in NEEDS ATTENTION after having set itself up correctly. When a tool really
+  does fail, the failure now arrives with its reason attached instead of sending you to a log that
+  never recorded one.
+- **Declining the account no longer takes your other options away.** On the wizard's gateway step,
+  cancelling a sign-in used to remove all three option cards, so "Not now" became unreachable and
+  there was no way to carry on through the remaining steps. DevThrottle installs and runs without an
+  account, and that step now keeps saying so: the failure is a message on the choice screen, and the
+  cards stay. Going back and forward no longer strands you on the cards-less version of the screen.
+- **That step is usable from the keyboard and by a screen reader.** The three options were images
+  that looked like controls; they are real controls now, so they take Tab, respond to the arrow keys
+  and Space, and announce themselves. Previously a keyboard user could reach exactly one of the
+  three.
+- **The setup walkthrough documentation now shows what you will actually see** - nine verified
+  screenshots covering all three installer screens and setup wizard steps 2 through 7.
+
+### A session that dies on a network blip gets itself going again
+
+Overnight on 21 July a session printed a name resolution error at 06:56 and sat dead until 09:32.
+Nothing was wrong with the agent, the machine or the work - the fault cleared itself in seconds and
+the session simply had nobody to type "continue" into it. Two hours and thirty-six minutes of build
+time were lost to that.
+
+DevThrottle now watches for a session that has stopped on a transient transport fault and resumes
+it: 45 seconds for the first attempt, then every fifteen minutes, escalating to you after eight
+tries rather than retrying forever. Rate limiting backs off to an hour.
+
+Three things it will never resume, because they need you: being out of allowance, a failed sign-in,
+and a full context window. Those raise a hand instead. It also cannot type into a session that is
+working, or into a session sitting at a menu where "continue" would pick an option, and it will not
+re-fire on a session it has already rescued. Every detection, wait, send and escalation is written
+down so you can see what it did. All of it can be switched off.
+
+### On the hosted service
+
+- **Your missions are served only to you.** The hosted gateway served every account's mission list to
+  every account. A mission name is free text somebody typed, so this disclosed what other people were
+  working on in their own words. Missions now carry the account that created them, another account's
+  mission is unreachable rather than merely filtered out, and looking up an unknown mission gives the
+  same answer as looking up somebody else's. Existing installs that are not shared - self-hosted and
+  the desktop Director - list exactly what they listed before.
+- **An update check no longer fails against a release that is still uploading.** Publishing used to
+  mark a release as the latest one instantly while its downloads arrived minutes later, so anything
+  that checked in between saw a newest version it could not install and simply failed. A release is
+  now only made the latest one once its downloads are provably attached, and the release page you
+  read is the notes we wrote rather than a list of internal change titles.
+
+### Smaller things
+
+- **The command line tools say when the list they are showing is not the whole fleet.** If a machine
+  cannot be reached its sessions are missing from the list, and that used to read exactly like that
+  machine having no sessions - so "No session matches" and "No sessions are running in the fleet"
+  could both be flatly untrue. They now say when a Director could not be reached.
+- **The move-session instructions the gateway hands out are the current ones.** Two copies had drifted
+  apart, and agents fetching the served copy were told to leave the original session running, which
+  is the opposite of what moving a session now does.
+- **cc-image no longer prints a non-plain-text character** when it shortens a table cell.


### PR DESCRIPTION
Version bump to 1.9.1 plus the written release notes at `docs/public/release-notes/v1.9.1.md`, which the release workflow publishes verbatim and refuses to substitute for.

Carries 21 commits since v1.9.0. Written for a user, in plain language.

Headline items: the setup wizard no longer takes your other gateway options away when a sign-in is cancelled, so declining the account still works; the board and the setup wizard now agree about whether a coding agent is installed; a clean install no longer reports its own successful setup as a failure; the app stops getting slower as sessions accumulate; buttons answer immediately instead of after eight seconds of silence; auto-update says which situation you are in; a session that dies on a network blip resumes itself; and the hosted service serves each account only its own missions.

The context percentage is EXPLAINED rather than listed, because it will otherwise read as a regression. It was computed against a context window derived from the model name, and that derivation is wrong on the model the fleet runs - a session with roughly 800,000 tokens of headroom showed 92 percent in red. The raw token count is a real measurement and stays; the percentage returns when the agent itself reports its window.

Not included: the download page telling you what to do when Windows holds the file. That page is not in this repository, so it is not part of this tag.