### PR TITLE
Let the Director's own sentence reach the user instead of a status code

### DIFF
--- a/tools/cc_shared/director.py
+++ b/tools/cc_shared/director.py
@@ -59,14 +59,40 @@ def _token() -> Optional[str]:
     return None
 
 
-def _extract_error(body: str) -> Optional[str]:
+def _error_message(body: str, code: int) -> str:
+    """What the user reads when a Director call fails (issue #1062).
+
+    TWO body shapes arrive here and BOTH carry the sentence the Director wrote. Its own handlers
+    return `{"error": "..."}`. Anything that reaches ASP.NET's unhandled-exception page instead
+    returns problem-details, which puts the sentence in `detail` - and the old extractor read only
+    `error`, so every problem-details failure arrived as a bare status code. That is how the
+    refusal sentence added in #1050 - naming the agent, the command tried, and the two ways to fix
+    it - was written, travelled across HTTP intact, and was thrown away by the last component: the
+    user saw `HTTP 500 from the Director`, indistinguishable from the bug #1050 had just closed.
+    This is a SHARED helper, so the loss was never spawn-only; it applied to every command routed
+    through `_request` that hit an endpoint answering in problem-details.
+
+    problem-details `title` is deliberately NOT read as that sentence. It is a generic label - "An
+    error occurred while processing your request.", "Not Found" - that says LESS than the status
+    code it would have displaced, so promoting it would trade one uninformative line for a worse
+    one. It is worth showing beside the code, never instead of it.
+    """
+    status = f"HTTP {code} from the Director"
     try:
         obj = json.loads(body)
     except (ValueError, TypeError):
-        return None
-    if isinstance(obj, dict):
-        return obj.get("error") or obj.get("Error")
-    return None
+        return status
+    if not isinstance(obj, dict):
+        return status
+    for key in ("error", "Error", "detail", "Detail"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("title", "Title"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"{status}: {value.strip()}"
+    return status
 
 
 def _request(method: str, path: str, body: Optional[dict] = None, timeout: float = 30) -> Any:
@@ -90,7 +116,7 @@ def _request(method: str, path: str, body: Optional[dict] = None, timeout: float
             detail = err.read().decode("utf-8")
         except OSError:
             detail = ""
-        raise DirectorError(_extract_error(detail) or f"HTTP {err.code} from the Director") from err
+        raise DirectorError(_error_message(detail, err.code)) from err
     except urllib.error.URLError as err:
         raise DirectorError(
             f"Cannot reach the Director at {director_base_url()}: {err.reason}"

--- a/tools/cc_shared/tests/test_director.py
+++ b/tools/cc_shared/tests/test_director.py
@@ -1,12 +1,17 @@
 """Unit tests for the shared Director-API helpers used by the fleet-messaging tools (issue #705)."""
 
+import io
+import json
 import sys
+import urllib.error
 from pathlib import Path
 
 # Make cc_shared importable when tests run from the tools/ tree.
 _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
+
+import pytest  # noqa: E402
 
 from cc_shared import director  # noqa: E402
 
@@ -112,3 +117,96 @@ def test_resolve_target_name_unchanged_with_numbers_present():
     matches = director.resolve_target(SESSIONS, "docs")
     assert len(matches) == 1
     assert director.field(matches[0], "name", "Name") == "docs"
+
+
+# --- Issue #1062: the Director's sentence must reach the user, not the status code -------------
+#
+# The refusal sentence #1050 added is written by the Director, survives HTTP intact, and was then
+# discarded by this client because the extractor read only "error" while an unhandled exception
+# answers in ASP.NET problem-details, which carries it in "detail". These tests pin BOTH shapes, so
+# neither can be traded for the other, and the last two drive the real raise site rather than the
+# helper alone - a helper that returns the right string proves nothing if nobody calls it.
+
+# The body from the issue, verbatim: what POST /fleet/spawn actually returns for an unresolvable
+# agent command. Trimmed only of newlines.
+SPAWN_SENTENCE = (
+    'Claude Code could not be started: the command "definitely-not-an-agent-cli-9f3a" is not a '
+    "file on this machine and was not found on this Director's PATH. Set this agent's executable "
+    "path in Settings, Agents - or install Claude Code - and start the session again."
+)
+PROBLEM_DETAILS = json.dumps({
+    "type": "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+    "title": "An error occurred while processing your request.",
+    "status": 500,
+    "detail": SPAWN_SENTENCE,
+})
+
+
+def test_error_message_reads_problem_details_detail():
+    assert director._error_message(PROBLEM_DETAILS, 500) == SPAWN_SENTENCE
+
+
+def test_error_message_still_reads_the_directors_own_error_shape():
+    # The two shapes coexist in this API; fixing one must not cost the other.
+    body = json.dumps({"error": "toSessionId is required"})
+    assert director._error_message(body, 400) == "toSessionId is required"
+
+
+def test_error_message_prefers_error_over_detail_when_a_body_carries_both():
+    body = json.dumps({"error": "the specific one", "detail": "the generic one"})
+    assert director._error_message(body, 500) == "the specific one"
+
+
+def test_error_message_accepts_pascal_case_detail():
+    assert director._error_message(json.dumps({"Detail": "a sentence"}), 500) == "a sentence"
+
+
+def test_error_message_shows_a_generic_title_beside_the_code_not_instead_of_it():
+    # problem-details "title" says less than the status code, so promoting it would make the
+    # message worse. It is additive only.
+    body = json.dumps({"title": "Not Found", "status": 404})
+    assert director._error_message(body, 404) == "HTTP 404 from the Director: Not Found"
+
+
+@pytest.mark.parametrize("body", [
+    "",
+    "<html>a proxy error page</html>",
+    json.dumps(["not", "an", "object"]),
+    json.dumps({"status": 500}),
+    json.dumps({"error": "   ", "detail": ""}),  # present but empty: not a sentence
+])
+def test_error_message_falls_back_to_the_status_when_the_body_carries_no_sentence(body):
+    assert director._error_message(body, 500) == "HTTP 500 from the Director"
+
+
+def _http_error(code: int, body: str) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://127.0.0.1:1/fleet/spawn", code=code, msg="Internal Server Error",
+        hdrs=None, fp=io.BytesIO(body.encode("utf-8")),
+    )
+
+
+def test_request_surfaces_the_sentence_from_a_problem_details_response(monkeypatch):
+    """End to end through _request: this is the path every cc-devthrottle command takes."""
+    monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:1")
+    monkeypatch.setattr(director, "_token", lambda: None)
+    monkeypatch.setattr(director.urllib.request, "urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(_http_error(500, PROBLEM_DETAILS)))
+
+    with pytest.raises(director.DirectorError) as caught:
+        director.post_json("fleet/spawn", {"repoPath": "C:/x", "agent": "ClaudeCode"})
+
+    assert str(caught.value) == SPAWN_SENTENCE
+    assert "HTTP 500" not in str(caught.value)
+
+
+def test_request_still_reports_the_status_when_the_body_carries_no_sentence(monkeypatch):
+    monkeypatch.setenv("CC_DIRECTOR_API", "http://127.0.0.1:1")
+    monkeypatch.setattr(director, "_token", lambda: None)
+    monkeypatch.setattr(director.urllib.request, "urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(_http_error(502, "")))
+
+    with pytest.raises(director.DirectorError) as caught:
+        director.get_json("fleet/sessions")
+
+    assert str(caught.value) == "HTTP 502 from the Director"


### PR DESCRIPTION
`cc-devthrottle` printed `Error: HTTP 500 from the Director` for any failure that answered in ASP.NET problem-details, discarding the message the Director had written and sent intact.

## Cause

`tools/cc_shared/director.py` read only the `error` key. The Director's own handlers return `{"error": "..."}`, but anything that reaches ASP.NET's unhandled-exception page answers in problem-details, which puts the message in `detail`. The extractor found nothing and fell through to the status-only string.

The helper is shared, so this was never spawn-only: **every** command routed through `_request` lost its message the same way.

The visible cost: the refusal for an unresolvable agent - a sentence naming the agent, the command tried, and the two ways to fix it - was written, survived HTTP, and was thrown away by the last component. The user saw a bare status code, indistinguishable from the bug that refusal had just closed.

## Change

Read `detail` as well as `error` (both shapes are in use; neither is traded for the other).

problem-details `title` is deliberately **not** promoted to the message. It is a generic label - "An error occurred while processing your request.", "Not Found" - that says less than the status code it would replace, so promoting it would swap one uninformative line for a worse one. It is appended beside the code instead: `HTTP 404 from the Director: Not Found`.

## Proof at the user-visible layer

Against a live Director, which really does answer `Content-Type: application/problem+json` with the sentence in `detail`:

```
$ curl -i -X POST $CC_DIRECTOR_API/fleet/spawn -d '{...,"command":"definitely-not-an-agent-cli-9f3a"}'
HTTP/1.1 500 Internal Server Error
Content-Type: application/problem+json
{"type":"...","title":"An error occurred while processing your request.","status":500,"detail":"CreateProcess failed."}
```

Same command, same Director, the two clients:

```
BEFORE   Error: HTTP 500 from the Director
AFTER    Error: CreateProcess failed.
```

(The sentence differs from the one in the issue only because the Director running here is 1.8.6, whose message for this case is `CreateProcess failed.`. The field carrying it is the same `detail`.)

Neither attempt registered a session - the refusal throws before the session is added - and the fleet roster is unchanged.

## Tests

`tools/cc_shared/tests/test_director.py`: both body shapes, the PascalCase variants, the title-beside-the-code rule, and five bodies that carry no sentence at all. Two of them drive `_request` end to end rather than the helper alone, because a helper that returns the right string proves nothing if nobody calls it.

Confirmed failing on the pre-fix code with exactly the defect's output (`assert 'HTTP 500 from the Director' == 'Claude Code could not be started: ...'`), then passing. Full suite: 270 passed.

## Checked and deliberately left alone

- **The desktop New Session dialog does NOT have this defect.** It shows `_lastSessionCreateError`, which is the exception message in full, and there is no HTTP hop on that path.
- Three other desktop call sites (workspace restore, agent-template launch, hand-to-agent) drop a launch failure with no dialog at all. That is silence rather than a discarded detail - a different defect, filed separately rather than widened into this pull request.
- Six copies of `_gateway_message` in `tools/cc-devthrottle/src/*_ops.py` have the same `error`-only read, but they fall back to the raw response text, so the sentence is visible (as raw JSON) rather than lost. Ugly, not the same bug; noted, not changed here.

Closes devthrottle_internal#1062