### PR TITLE
Installer: wait for the launcher to be ready instead of calling it dead at 20 seconds

### DIFF
--- a/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml
+++ b/tools/cc-director-setup-avalonia/Steps/InstallStep.axaml
@@ -8,19 +8,27 @@
                        Foreground="White"
                        FontSize="22"
                        FontWeight="SemiBold" />
-            <StackPanel Orientation="Horizontal" Margin="0,8,0,20">
+            <!-- The status line WRAPS, for the same reason it does on Windows (issue #1152): inside a
+                 horizontal StackPanel the text is measured with infinite width and then clipped at the
+                 window edge, so a failure message loses its tail - the log path - exactly when the user
+                 needs it. Fixed on both wizards, because one screen set means one correction. -->
+            <Grid ColumnDefinitions="*,Auto" Margin="0,8,0,20">
                 <TextBlock x:Name="StatusText"
+                           Grid.Column="0"
                            Text="Preparing..."
                            Foreground="#CCCCCC"
                            FontSize="13"
+                           TextWrapping="Wrap"
                            VerticalAlignment="Center" />
                 <Button x:Name="RepairButton"
+                        Grid.Column="1"
                         Content="Repair"
                         Classes="primary"
                         Width="90" Margin="16,0,0,0"
+                        VerticalAlignment="Center"
                         Click="RepairButton_Click"
                         IsVisible="False" />
-            </StackPanel>
+            </Grid>
         </StackPanel>
 
         <!-- Log location + report (visible DURING install, so a stuck/hung run can still be reported). -->

--- a/tools/cc-director-setup-engine.Tests/LauncherReadinessWaitTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherReadinessWaitTests.cs
@@ -25,11 +25,16 @@ public sealed class LauncherReadinessWaitTests
     private static readonly TimeSpan Instant = TimeSpan.FromMilliseconds(1);
 
     /// <summary>
-    /// The incident, as data. The launcher stays silent for far more polls than the old wait allowed,
-    /// then answers from the process the installer started - and the wait must report it HEALTHY.
+    /// The incident, as data. The launcher stays silent for sixty polls - at the installer's
+    /// one-second cadence that is a minute, well past the thirty-seven seconds measured in the
+    /// incident and three times what the old twenty-second allowance permitted - and then answers from
+    /// the process the installer started. The wait must report HEALTHY.
     ///
-    /// Revert-proof: put a fixed clock back in front of the condition and this goes red, because the
-    /// answer arrives after the point at which the old code had already given up.
+    /// Stated plainly, because a test that cannot fail is worse than no test: the poll interval is
+    /// compressed here, so this pins the SHAPE (a late answer is still a healthy one, and the loop
+    /// does not stop early on some clock of its own). What pins the incident's actual number is
+    /// <see cref="TheInstallersCeiling_IsFarBeyondTheColdStartThatWasCalledDead"/>, which reads the
+    /// ceiling the installer really uses.
     /// </summary>
     [Fact]
     public async Task ASlowFirstStartThatEventuallyAnswers_IsHealthy_NotFailed()
@@ -87,13 +92,13 @@ public sealed class LauncherReadinessWaitTests
         var started = DateTime.UtcNow;
         var result = await LauncherHealthProbe.WaitForReadyAsync(
             http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
-            starterIsRunning: () => ++polls < 3, ceiling: TimeSpan.FromMinutes(10), ct: default,
+            starterIsRunning: () => ++polls < 3, ceiling: TimeSpan.FromSeconds(30), ct: default,
             pollInterval: Instant);
         var elapsed = DateTime.UtcNow - started;
 
         Assert.Equal(LauncherWaitStop.StarterExited, result.Stop);
         Assert.Null(result.Health);
-        Assert.True(elapsed < TimeSpan.FromSeconds(20),
+        Assert.True(elapsed < TimeSpan.FromSeconds(5),
             $"The wait took {elapsed} for a process that had already exited - it waited out the ceiling instead of the condition.");
     }
 

--- a/tools/cc-director-setup-engine.Tests/LauncherReadinessWaitTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherReadinessWaitTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The installer must wait for the launcher to be READY, not for a clock to run out.
+///
+/// This is the guard for issue #1152. On a clean Windows 11 machine the installer allowed about twenty
+/// seconds for the launcher to answer, then painted a red ERROR and a Failed row on the last screen of
+/// a first install. The launcher had not failed: while that error was on screen, port 7900 answered
+/// 200 with ok:true from the very process the installer had started. cc-launcher.exe is a ~134 MB
+/// single-file binary that unpacks itself on first run, so it is slow exactly once - on the machine
+/// where a first-time user is watching. Pressing Retry completed the install with no error at all.
+///
+/// A bigger fixed number would be the same defect with a longer fuse, so what is pinned here is the
+/// SHAPE: keep waiting while the started process is alive and the port has not answered, and stop at
+/// once when the started process is gone, because then no answer is ever coming.
+/// </summary>
+public sealed class LauncherReadinessWaitTests
+{
+    private const string HealthyBody = """{"ok":true,"version":"1.9.0","pid":11216,"uptimeS":4}""";
+    private const string Url = "http://127.0.0.1:7900/healthz";
+    private static readonly TimeSpan Instant = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>
+    /// The incident, as data. The launcher stays silent for far more polls than the old wait allowed,
+    /// then answers from the process the installer started - and the wait must report it HEALTHY.
+    ///
+    /// Revert-proof: put a fixed clock back in front of the condition and this goes red, because the
+    /// answer arrives after the point at which the old code had already given up.
+    /// </summary>
+    [Fact]
+    public async Task ASlowFirstStartThatEventuallyAnswers_IsHealthy_NotFailed()
+    {
+        // Silent for 60 polls - three times the old twenty-second allowance at its one-second cadence.
+        var handler = new ScriptedHealth(silentPolls: 60, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => true, ceiling: TimeSpan.FromMinutes(5), ct: default,
+            pollInterval: Instant);
+
+        Assert.Equal(LauncherWaitStop.Healthy, result.Stop);
+        Assert.Equal(11216, result.Health!.Pid);
+        Assert.Equal(61, handler.Attempts);
+    }
+
+    /// <summary>
+    /// The other half of the rule: a launcher that is merely slow keeps being waited for. While the
+    /// process is alive and the ceiling has not elapsed, the wait keeps polling - it does not stop on
+    /// any smaller clock of its own.
+    /// </summary>
+    [Fact]
+    public async Task WhileTheStartedProcessIsAlive_ThePollingContinuesToTheCeiling()
+    {
+        var handler = new ScriptedHealth(silentPolls: int.MaxValue, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => true, ceiling: TimeSpan.FromMilliseconds(1500), ct: default,
+            pollInterval: Instant);
+
+        Assert.Equal(LauncherWaitStop.CeilingReached, result.Stop);
+        Assert.Null(result.Health);
+        Assert.True(handler.Attempts > 20,
+            $"Only {handler.Attempts} polls before the wait ended - it stopped on something other than the ceiling.");
+    }
+
+    /// <summary>
+    /// "Give up only when something is genuinely wrong." A process that has exited will never answer,
+    /// so the wait ends immediately rather than burning a five-minute ceiling on a certainty.
+    ///
+    /// Revert-proof: drop the liveness term and this hangs for the whole ceiling, so it goes red on the
+    /// elapsed-time assertion rather than passing slowly.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheStartedProcessExits_TheWaitStopsAtOnce()
+    {
+        var handler = new ScriptedHealth(silentPolls: int.MaxValue, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+        var polls = 0;
+
+        var started = DateTime.UtcNow;
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => ++polls < 3, ceiling: TimeSpan.FromMinutes(10), ct: default,
+            pollInterval: Instant);
+        var elapsed = DateTime.UtcNow - started;
+
+        Assert.Equal(LauncherWaitStop.StarterExited, result.Stop);
+        Assert.Null(result.Health);
+        Assert.True(elapsed < TimeSpan.FromSeconds(20),
+            $"The wait took {elapsed} for a process that had already exited - it waited out the ceiling instead of the condition.");
+    }
+
+    /// <summary>
+    /// A launcher that answers and then exits was still healthy. Liveness is read AFTER the poll, so
+    /// the certifying answer wins over a process that has since gone away.
+    /// </summary>
+    [Fact]
+    public async Task AnAnswerThatCertifies_WinsOverAProcessThatHasSinceExited()
+    {
+        var handler = new ScriptedHealth(silentPolls: 0, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => false, ceiling: TimeSpan.FromMinutes(5), ct: default,
+            pollInterval: Instant);
+
+        Assert.Equal(LauncherWaitStop.Healthy, result.Stop);
+    }
+
+    /// <summary>
+    /// Waiting longer must not weaken the identity rule from issue #2042: a stranger on the port is
+    /// still polled past (the real launcher may yet take the port) and still reported as what answered,
+    /// never as a certified install.
+    /// </summary>
+    [Fact]
+    public async Task AStrangerOnThePort_NeverCertifies_AndIsReportedAsWhatAnswered()
+    {
+        var handler = new ScriptedHealth(silentPolls: 0,
+            thenBody: """{"ok":true,"version":"1.9.0","pid":34084,"uptimeS":9461}""");
+        using var http = new HttpClient(handler);
+
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => true, ceiling: TimeSpan.FromMilliseconds(300), ct: default,
+            pollInterval: Instant);
+
+        Assert.Equal(LauncherWaitStop.CeilingReached, result.Stop);
+        Assert.Equal(34084, result.Health!.Pid);
+    }
+
+    [Fact]
+    public async Task ACancelledInstall_SaysSo_RatherThanBlamingTheLauncher()
+    {
+        var handler = new ScriptedHealth(silentPolls: int.MaxValue, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        var result = await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => true, ceiling: TimeSpan.FromMinutes(10), ct: cts.Token,
+            pollInterval: Instant);
+
+        Assert.Equal(LauncherWaitStop.Cancelled, result.Stop);
+    }
+
+    /// <summary>
+    /// The caller can tell the user this is a slow start rather than a frozen screen: every poll that
+    /// did not certify reports the elapsed time back.
+    /// </summary>
+    [Fact]
+    public async Task WhileWaiting_TheCallerIsToldHowLongItHasBeen()
+    {
+        var handler = new ScriptedHealth(silentPolls: 5, thenBody: HealthyBody);
+        using var http = new HttpClient(handler);
+        var notes = new List<TimeSpan>();
+
+        await LauncherHealthProbe.WaitForReadyAsync(
+            http, Url, expectedVersion: "1.9.0", expectedPid: 11216,
+            starterIsRunning: () => true, ceiling: TimeSpan.FromMinutes(5), ct: default,
+            pollInterval: Instant, onStillWaiting: notes.Add);
+
+        Assert.Equal(5, notes.Count);
+    }
+
+    /// <summary>
+    /// The ceiling the Windows installer actually uses. It is a backstop for a wedged launcher, so it
+    /// must sit far above any plausible cold first start - the twenty seconds that failed a clean
+    /// install must not be able to creep back in as "generous enough".
+    /// </summary>
+    [Fact]
+    public void TheInstallersCeiling_IsFarBeyondTheColdStartThatWasCalledDead() =>
+        Assert.True(LauncherTrayInstaller.FirstStartHealthCeiling >= TimeSpan.FromMinutes(3),
+            $"The launcher readiness ceiling is {LauncherTrayInstaller.FirstStartHealthCeiling}. A clean "
+            + "install was already failed at 20 seconds while the launcher was healthy (#1152).");
+
+    /// <summary>A launcher that answers only after a scripted number of silent polls, counting attempts.</summary>
+    private sealed class ScriptedHealth(int silentPolls, string thenBody) : HttpMessageHandler
+    {
+        public int Attempts { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Attempts++;
+            // A port nothing is listening on refuses the connection; that is what a cold start looks like.
+            if (Attempts <= silentPolls) throw new HttpRequestException("connection refused");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(thenBody),
+            });
+        }
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherHealthProbe.cs
+++ b/tools/cc-director-setup-engine/LauncherHealthProbe.cs
@@ -5,6 +5,27 @@ namespace CcDirector.Setup.Engine;
 /// <summary>One /healthz answer from a launcher: liveness plus IDENTITY (version, process id).</summary>
 public sealed record LauncherHealth(bool Ok, string? Version, int Pid);
 
+/// <summary>Why a readiness wait stopped. "Not ready yet" and "never going to be ready" are
+/// different facts and the caller has to be able to tell them apart.</summary>
+public enum LauncherWaitStop
+{
+    /// <summary>The launcher answered and the answer certifies this install. The only good end.</summary>
+    Healthy,
+
+    /// <summary>The process the caller started is gone, so no answer is ever coming from it.</summary>
+    StarterExited,
+
+    /// <summary>The process is still running but the ceiling elapsed without a certifying answer.</summary>
+    CeilingReached,
+
+    /// <summary>The caller cancelled the wait.</summary>
+    Cancelled,
+}
+
+/// <summary>The end of a readiness wait: the last answer seen (null when nothing ever answered) and
+/// why the waiting stopped.</summary>
+public sealed record LauncherWaitResult(LauncherHealth? Health, LauncherWaitStop Stop);
+
 /// <summary>
 /// Polls a launcher's /healthz until the answering launcher is provably the one just installed
 /// (issue #2042). The old check accepted ANY 200 from the fixed port - so on a machine where a
@@ -39,11 +60,61 @@ public static class LauncherHealthProbe
         HttpClient http, string healthUrl, string? expectedVersion, TimeSpan timeout, CancellationToken ct,
         int expectedPid = 0)
     {
+        var result = await WaitForReadyAsync(
+            http, healthUrl, expectedVersion, expectedPid, static () => true, timeout, ct);
+        return result.Health;
+    }
+
+    /// <summary>
+    /// Wait for the launcher to become ready on the CONDITION rather than on a clock: poll /healthz
+    /// until it certifies this install, and stop early only when something is genuinely wrong - the
+    /// process the caller started is no longer running, so nothing is ever going to answer for it.
+    ///
+    /// This exists because a fixed clock reported a healthy install as a failure (issue #1152). On a
+    /// clean Windows 11 machine the installer allowed about twenty seconds, called the launcher dead,
+    /// and painted a red ERROR and a Failed row - while /healthz on that exact port answered 200 with
+    /// ok:true from the process the installer had started. cc-launcher.exe is a ~134 MB single-file
+    /// binary that unpacks itself on first run, so it is slow exactly once: on the machine where a
+    /// first-time user is watching. A bigger fixed number is the same defect with a longer fuse, and
+    /// the next slow machine walks into it.
+    ///
+    /// So the ceiling is a backstop for a genuine hang, not the thing that decides the verdict. The
+    /// verdict is the port answering.
+    /// </summary>
+    /// <param name="expectedPid">The process the caller started, or 0 when it has none to expect.</param>
+    /// <param name="starterIsRunning">
+    /// True while the process the caller started is still alive. Returning false ends the wait at once:
+    /// a launcher that has exited will never answer, and waiting out the ceiling only delays a failure
+    /// that is already certain.
+    /// </param>
+    /// <param name="ceiling">The backstop for a process that is alive but wedged.</param>
+    /// <param name="onStillWaiting">
+    /// Called after each poll that did not certify, with the elapsed time, so a caller can tell the
+    /// user this is a slow first start rather than a frozen screen.
+    /// </param>
+    public static async Task<LauncherWaitResult> WaitForReadyAsync(
+        HttpClient http,
+        string healthUrl,
+        string? expectedVersion,
+        int expectedPid,
+        Func<bool> starterIsRunning,
+        TimeSpan ceiling,
+        CancellationToken ct,
+        TimeSpan? pollInterval = null,
+        Action<TimeSpan>? onStillWaiting = null)
+    {
         ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(starterIsRunning);
+
+        var interval = pollInterval ?? TimeSpan.FromSeconds(1);
+        var started = DateTime.UtcNow;
+        var deadline = started + ceiling;
         LauncherHealth? last = null;
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+
+        while (true)
         {
+            if (ct.IsCancellationRequested) return new LauncherWaitResult(last, LauncherWaitStop.Cancelled);
+
             try
             {
                 using var resp = await http.GetAsync(healthUrl, ct);
@@ -51,16 +122,25 @@ public static class LauncherHealthProbe
                 {
                     last = Parse(await resp.Content.ReadAsStringAsync(ct));
                     if (Certifies(last, expectedVersion, expectedPid))
-                        return last;
+                        return new LauncherWaitResult(last, LauncherWaitStop.Healthy);
                 }
             }
             catch
             {
-                // not up yet
+                // Not up yet. On a first start the port is not even listening, so this is the normal
+                // shape of a cold start rather than a symptom of anything.
             }
-            try { await Task.Delay(1000, ct); } catch (OperationCanceledException) { return last; }
+
+            // Ask AFTER polling, so a launcher that answered and then exited still counts as healthy.
+            if (!starterIsRunning()) return new LauncherWaitResult(last, LauncherWaitStop.StarterExited);
+
+            var elapsed = DateTime.UtcNow - started;
+            if (DateTime.UtcNow >= deadline) return new LauncherWaitResult(last, LauncherWaitStop.CeilingReached);
+            onStillWaiting?.Invoke(elapsed);
+
+            try { await Task.Delay(interval, ct); }
+            catch (OperationCanceledException) { return new LauncherWaitResult(last, LauncherWaitStop.Cancelled); }
         }
-        return last;
     }
 
     /// <summary>True when the answer certifies the install: ok, version-matched when one was expected,

--- a/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
+++ b/tools/cc-director-setup-engine/LauncherTrayInstaller.cs
@@ -31,6 +31,21 @@ public sealed class LauncherTrayInstaller
     /// <summary>The arguments the installed tray app runs with: managed mode runs the self-update check.</summary>
     public const string InstalledArguments = "--managed";
 
+    /// <summary>
+    /// The backstop for a launcher that is running but never answers. It is deliberately far beyond any
+    /// plausible first start: the wait ends when the port answers or when the started process is gone,
+    /// so a generous ceiling costs nothing in the broken case and stops a slow machine being called
+    /// broken in the healthy one. Twenty seconds was the number that failed a clean install (#1152) and
+    /// the process it declared dead was answering 200 the whole time.
+    /// </summary>
+    public static readonly TimeSpan FirstStartHealthCeiling = TimeSpan.FromMinutes(5);
+
+    /// <summary>How long a first start may take before the user is told it is a slow start, not a hang.</summary>
+    private static readonly TimeSpan SayItIsSlowAfter = TimeSpan.FromSeconds(8);
+
+    /// <summary>How often that reassurance is repeated while the wait continues.</summary>
+    private static readonly TimeSpan RepeatTheReassuranceEvery = TimeSpan.FromSeconds(5);
+
     private readonly InstallLayout _layout;
     private readonly HttpClient _http;
 
@@ -45,8 +60,13 @@ public sealed class LauncherTrayInstaller
     /// autostart-registered. The Launcher exe must already be placed (by the UpdateRunner) at
     /// <see cref="InstallLayout.PathFor"/> for the Launcher component.
     /// </summary>
+    /// <param name="progress">
+    /// Optional running commentary for the caller's screen while the launcher is still starting. A cold
+    /// first start of a 134 MB single-file binary can take a while, and a screen that says nothing for
+    /// that long reads as frozen.
+    /// </param>
     [SupportedOSPlatform("windows")]
-    public async Task<LauncherInstallResult> InstallAsync(CancellationToken ct = default)
+    public async Task<LauncherInstallResult> InstallAsync(CancellationToken ct = default, IProgress<string>? progress = null)
     {
         var steps = new List<string>();
         EngineLog.Write("[LauncherTrayInstaller] InstallAsync begin");
@@ -63,38 +83,69 @@ public sealed class LauncherTrayInstaller
         // 2. Start the tray app. It registers its own HKCU Run-key autostart (pointing at itself with
         // the same arguments) on startup, so install-time registration and app self-registration can
         // never disagree.
-        int startedPid;
+        Process started;
         try
         {
             var psi = BuildTrayLaunchInfo(launcherExe, _layout.LauncherDir);
-            using var p = Process.Start(psi)
+            started = Process.Start(psi)
                 ?? throw new InvalidOperationException("Process.Start returned null");
-            startedPid = p.Id;
-            steps.Add($"started Launcher tray app pid={p.Id} ({InstalledArguments})");
+            steps.Add($"started Launcher tray app pid={started.Id} ({InstalledArguments})");
         }
         catch (Exception ex)
         {
             return Fail(steps, $"Failed to start the Launcher tray app: {ex.Message}");
         }
 
-        // 3. Wait for health - identity-verified: the answer must come from THE PROCESS WE JUST
-        // STARTED, not from whatever holds the port. Version alone could not do this: build metadata
-        // is stripped when versions are compared, so an orphan reporting "1.8.4+abc" and a freshly
-        // placed "1.8.4" matched, and a same-version reinstall certified against the orphan.
+        // 3. Wait for readiness. Two things are being checked at once, and both matter.
+        //
+        // IDENTITY: the answer must come from THE PROCESS WE JUST STARTED, not from whatever holds the
+        // port. Version alone could not do this - build metadata is stripped when versions are compared,
+        // so an orphan reporting "1.8.4+abc" and a freshly placed "1.8.4" matched, and a same-version
+        // reinstall certified against the orphan.
+        //
+        // READINESS: the wait ends on the CONDITION, not on a clock. A fixed twenty seconds, tuned on a
+        // warm developer machine, declared this install failed on a clean Windows 11 machine while the
+        // launcher was still unpacking - and the port it said had never answered was answering 200 with
+        // ok:true from the very process this installer started (issue #1152). So the wait now ends when
+        // the launcher answers, or when the process we started is gone; the ceiling is only a backstop
+        // for a launcher that is alive and wedged.
         var expectedVersion = new InstalledStateReader(_layout).Read(ComponentRegistry.Launcher).Version;
-        var health = await LauncherHealthProbe.WaitForHealthyAsync(
-            _http, $"http://127.0.0.1:{LauncherDefaultPort}/healthz", expectedVersion, TimeSpan.FromSeconds(20), ct,
-            expectedPid: startedPid);
-        var up = LauncherHealthProbe.Certifies(health, expectedVersion, startedPid);
-        steps.Add(health is null
-            ? $"launcher healthz on {LauncherDefaultPort}: no response"
-            : up
-                ? $"launcher healthz on {LauncherDefaultPort}: OK (version {health.Version ?? "unversioned"}, process id {health.Pid})"
-                : $"launcher healthz on {LauncherDefaultPort}: answered by process id {health.Pid} (version {health.Version ?? "unknown"}), not the process {startedPid} this install started");
+        var startedPid = started.Id;
+        LauncherWaitResult wait;
+        try
+        {
+            var lastNote = TimeSpan.Zero;
+            wait = await LauncherHealthProbe.WaitForReadyAsync(
+                _http,
+                $"http://127.0.0.1:{LauncherDefaultPort}/healthz",
+                expectedVersion,
+                startedPid,
+                () => StarterIsRunning(started),
+                FirstStartHealthCeiling,
+                ct,
+                onStillWaiting: elapsed =>
+                {
+                    if (elapsed < SayItIsSlowAfter || elapsed - lastNote < RepeatTheReassuranceEvery) return;
+                    lastNote = elapsed;
+                    progress?.Report(
+                        "Starting the Launcher tray app. Its first start unpacks a large file and is slow "
+                        + $"only once - still waiting after {(int)elapsed.TotalSeconds} seconds...");
+                });
+        }
+        finally
+        {
+            started.Dispose();
+        }
+
+        var health = wait.Health;
+        var up = wait.Stop == LauncherWaitStop.Healthy;
+        steps.Add(up
+            ? $"launcher healthz on {LauncherDefaultPort}: OK (version {health!.Version ?? "unversioned"}, process id {health.Pid})"
+            : health is null
+                ? $"launcher healthz on {LauncherDefaultPort}: no response ({DescribeStop(wait.Stop)})"
+                : $"launcher healthz on {LauncherDefaultPort}: answered by process id {health.Pid} (version {health.Version ?? "unknown"}), ok={health.Ok} ({DescribeStop(wait.Stop)})");
         if (!up)
-            return Fail(steps, health is null
-                ? $"Launcher tray app started but did not answer on {LauncherDefaultPort}. Check {_layout.LogsDir}."
-                : $"A launcher is answering on port {LauncherDefaultPort}, but it is process {health.Pid} reporting version {health.Version ?? "unknown"} - not the process {startedPid} this install started. Refusing to certify: another launcher instance holds the port. Check {_layout.LogsDir}.");
+            return Fail(steps, DescribeFailure(wait, startedPid, expectedVersion));
 
         // 4. Verify the autostart Run key (written by the app on startup).
         var registered = LauncherAutostart.IsRegistered();
@@ -104,6 +155,61 @@ public sealed class LauncherTrayInstaller
 
         EngineLog.Write("[LauncherTrayInstaller] InstallAsync success");
         return new LauncherInstallResult(true, $"Launcher tray app installed and running on {LauncherDefaultPort}.", steps);
+    }
+
+    /// <summary>
+    /// Is the launcher we started still alive? This is the fact that separates "not ready yet" from
+    /// "never going to be ready".
+    ///
+    /// When the state cannot be read at all, the answer is "still running". That keeps the wait going
+    /// to its ceiling instead of ending it early, which is the safe direction: reporting a healthy
+    /// launcher as failed is the defect this whole wait exists to stop, and the ceiling still bounds it.
+    /// </summary>
+    private static bool StarterIsRunning(Process started)
+    {
+        try { return !started.HasExited; }
+        catch (Exception ex)
+        {
+            EngineLog.Write($"[LauncherTrayInstaller] could not read the started launcher's process state: {ex.Message}");
+            return true;
+        }
+    }
+
+    /// <summary>The reason the wait ended, for the log line that records it.</summary>
+    private static string DescribeStop(LauncherWaitStop stop) => stop switch
+    {
+        LauncherWaitStop.Healthy => "certified",
+        LauncherWaitStop.StarterExited => "the process this install started has exited",
+        LauncherWaitStop.CeilingReached => "still running but silent when the wait ceiling elapsed",
+        LauncherWaitStop.Cancelled => "the install was cancelled",
+        _ => stop.ToString(),
+    };
+
+    /// <summary>
+    /// What to tell the user. Each end of the wait is a different fact and deserves a different
+    /// sentence: a launcher that died is not a launcher that is slow, and neither is a stranger holding
+    /// the port. Every one of them names the log directory, because that is the only actionable part.
+    /// </summary>
+    private string DescribeFailure(LauncherWaitResult wait, int startedPid, string? expectedVersion)
+    {
+        var health = wait.Health;
+        var logs = _layout.LogsDir;
+
+        if (wait.Stop == LauncherWaitStop.Cancelled)
+            return $"Waiting for the Launcher tray app on port {LauncherDefaultPort} was cancelled. Check {logs}.";
+
+        if (health is null)
+            return wait.Stop == LauncherWaitStop.StarterExited
+                ? $"The Launcher tray app started as process {startedPid} but exited before it answered on port {LauncherDefaultPort}. Check {logs}."
+                : $"The Launcher tray app is still running as process {startedPid} but did not answer on port {LauncherDefaultPort} within {(int)FirstStartHealthCeiling.TotalMinutes} minutes. Check {logs}.";
+
+        if (health.Pid == startedPid)
+            return $"The Launcher tray app (process {startedPid}) answered on port {LauncherDefaultPort} but did not report itself healthy"
+                   + (LauncherHealthProbe.VersionMatches(expectedVersion, health.Version)
+                       ? $" (ok={health.Ok}). Check {logs}."
+                       : $": it reports version {health.Version ?? "unknown"}, not the freshly installed {expectedVersion}. Check {logs}.");
+
+        return $"A launcher is answering on port {LauncherDefaultPort}, but it is process {health.Pid} reporting version {health.Version ?? "unknown"} - not the process {startedPid} this install started. Refusing to certify: another launcher instance holds the port. Check {logs}.";
     }
 
     /// <summary>
@@ -154,25 +260,6 @@ public sealed class LauncherTrayInstaller
             finally { p.Dispose(); }
         }
         if (stopped > 0) steps.Add($"stopped {stopped} running installed Launcher process(es)");
-    }
-
-    private async Task<bool> WaitForHttpAsync(string url, TimeSpan timeout, CancellationToken ct)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
-        {
-            try
-            {
-                using var resp = await _http.GetAsync(url, ct);
-                if (resp.IsSuccessStatusCode) return true;
-            }
-            catch
-            {
-                // not up yet
-            }
-            try { await Task.Delay(1000, ct); } catch (OperationCanceledException) { return false; }
-        }
-        return false;
     }
 
     private static LauncherInstallResult Fail(List<string> steps, string message)

--- a/tools/cc-director-setup.Tests/InstallStatusLineRenderTests.cs
+++ b/tools/cc-director-setup.Tests/InstallStatusLineRenderTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using CcDirectorSetup.Steps;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// The markup guard next door checks the ATTRIBUTES. This one renders the real Windows install step
+/// and measures the actual failure message, because the defect in issue #1152 was something a person
+/// SAW: the sentence stopped at "Check C:" and the log path - the only actionable part - was gone.
+///
+/// The message used here is the one from the incident, so the case is the real one rather than a
+/// convenient long string. The test first proves the message genuinely does not fit on one line at
+/// the wizard's width (otherwise it would pass while proving nothing), then proves the control wrapped
+/// it instead of running off the edge.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public sealed class InstallStatusLineRenderTests
+{
+    private readonly WpfStaFixture _wpf;
+
+    public InstallStatusLineRenderTests(WpfStaFixture wpf) => _wpf = wpf;
+
+    /// <summary>The install step's content width inside the 900-pixel wizard window.</summary>
+    private const double ContentWidth = 828;
+
+    /// <summary>The failure text from the incident, with the log path that used to be cut off.</summary>
+    private const string TheFailure =
+        "ERROR: Launcher tray app failed to start. The Launcher tray app is still running as process "
+        + "11216 but did not answer on port 7900 within 5 minutes. "
+        + @"Check C:\Users\qa\AppData\Local\cc-director\logs.";
+
+    [Fact]
+    public void TheLauncherFailureMessage_WrapsInsteadOfBeingClippedAtTheWindowEdge()
+    {
+        _wpf.Run(() =>
+        {
+            var step = BuildRenderedStep(TheFailure, out var status);
+
+            // The case has to be real: this message cannot fit on one line at the wizard's width.
+            var oneLineWidth = UnwrappedWidth(status, TheFailure);
+            Assert.True(oneLineWidth > ContentWidth,
+                $"The message measures {oneLineWidth:F0}px on one line but the step is {ContentWidth}px wide, "
+                + "so this test would pass without wrapping anything. Pick a message that really overflows.");
+
+            // Wrapped, not clipped: it took more than one line and it stayed inside the step.
+            var lineHeight = UnwrappedHeight(status);
+            Assert.True(status.ActualHeight > lineHeight * 1.5,
+                $"The status line rendered {status.ActualHeight:F0}px high - one line of {lineHeight:F0}px. "
+                + "The message is being cut off at the window edge instead of wrapping (#1152).");
+            Assert.True(status.ActualWidth <= ContentWidth + 1,
+                $"The status line is {status.ActualWidth:F0}px wide inside a {ContentWidth}px step - it overflows.");
+
+            GC.KeepAlive(step);
+        });
+    }
+
+    /// <summary>
+    /// The Repair button still sits beside the status line rather than under it, so making the text
+    /// wrap did not quietly rearrange the screen for every other message.
+    /// </summary>
+    [Fact]
+    public void AShortStatus_StillLeavesTheRepairButtonBesideIt()
+    {
+        _wpf.Run(() =>
+        {
+            var step = BuildRenderedStep("Preparing...", out var status);
+            var repair = (Button)step.FindName("RepairButton");
+            repair.Visibility = Visibility.Visible;
+            step.UpdateLayout();
+
+            var statusTop = status.TranslatePoint(new Point(0, 0), step).Y;
+            var repairTop = repair.TranslatePoint(new Point(0, 0), step).Y;
+            var repairLeft = repair.TranslatePoint(new Point(0, 0), step).X;
+
+            Assert.True(Math.Abs(statusTop - repairTop) < repair.ActualHeight,
+                "The Repair button dropped onto its own row instead of staying beside the status text.");
+            Assert.True(repairLeft > status.ActualWidth,
+                "The Repair button is no longer to the right of the status text.");
+        });
+    }
+
+    private static InstallStep BuildRenderedStep(string statusText, out TextBlock status)
+    {
+        var step = new InstallStep();
+        step.SetStatus(statusText);
+
+        var host = new Border { Width = ContentWidth, Child = step };
+        host.Measure(new Size(ContentWidth, 600));
+        host.Arrange(new Rect(0, 0, ContentWidth, 600));
+        host.UpdateLayout();
+
+        status = (TextBlock)step.FindName("StatusText");
+        return step;
+    }
+
+    /// <summary>How wide this text would be if nothing wrapped it.</summary>
+    private static double UnwrappedWidth(TextBlock like, string text) => Format(like, text).Width;
+
+    /// <summary>The height of a single line in this control's typeface and size.</summary>
+    private static double UnwrappedHeight(TextBlock like) => Format(like, "Ag").Height;
+
+    private static FormattedText Format(TextBlock like, string text) =>
+        new(text,
+            CultureInfo.CurrentCulture,
+            FlowDirection.LeftToRight,
+            new Typeface(like.FontFamily, like.FontStyle, like.FontWeight, like.FontStretch),
+            like.FontSize,
+            Brushes.White,
+            VisualTreeHelper.GetDpi(like).PixelsPerDip);
+}

--- a/tools/cc-director-setup.Tests/InstallStatusLineWrapsTests.cs
+++ b/tools/cc-director-setup.Tests/InstallStatusLineWrapsTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// The install screen's status line must WRAP, on both wizards.
+///
+/// This is the second half of issue #1152. When the launcher step failed, the screen said:
+///
+///     ERROR: Launcher tray app failed to start. Launcher tray app started but did not answer on
+///     7900. Check C:
+///
+/// and stopped there - clipped at the window's right edge, exactly where the log path began. The log
+/// path is the only actionable part of that sentence, so the message told the user to check a file
+/// without saying which one. A failure message whose one instruction is truncated is worse than no
+/// instruction: it looks like the product tried to help and could not finish the sentence.
+///
+/// The cause was layout, not text. The status TextBlock sat in a horizontal StackPanel, which measures
+/// its children with infinite width, so wrapping can never happen and anything too long is simply cut
+/// off at the window edge. Both wizards had the same markup, so both are checked here.
+///
+/// Revert-proof: put StatusText back in a horizontal StackPanel, or drop its TextWrapping, and this
+/// goes red.
+/// </summary>
+public sealed class InstallStatusLineWrapsTests
+{
+    [Fact]
+    public void BothWizards_StatusLineWraps()
+    {
+        var root = FindRepoRoot();
+        var checkedFiles = 0;
+
+        foreach (var markup in InstallStepMarkup(root))
+        {
+            checkedFiles++;
+            var text = File.ReadAllText(markup);
+            var element = ElementDeclaring(text, "StatusText");
+
+            Assert.True(element is not null, $"{markup} has no StatusText element to check.");
+            Assert.Contains("TextWrapping=\"Wrap\"", element!, StringComparison.Ordinal);
+        }
+
+        Assert.Equal(2, checkedFiles);
+    }
+
+    /// <summary>
+    /// The layout, not just the attribute. TextWrapping is ignored inside a horizontal StackPanel -
+    /// children are measured with infinite width there - so the wrapping attribute alone would be a
+    /// guard that passes while the text still clips.
+    /// </summary>
+    [Fact]
+    public void BothWizards_StatusLineIsNotInsideAHorizontalStackPanel()
+    {
+        var root = FindRepoRoot();
+
+        foreach (var markup in InstallStepMarkup(root))
+        {
+            var text = File.ReadAllText(markup);
+            var before = text[..text.IndexOf("x:Name=\"StatusText\"", StringComparison.Ordinal)];
+            var openPanels = Regex.Matches(before, "<(StackPanel|Grid)\\b[^>]*>", RegexOptions.Singleline)
+                .Select(m => m.Value)
+                .Where(v => !v.EndsWith("/>", StringComparison.Ordinal))
+                .ToList();
+            var closedPanels = Regex.Matches(before, "</(StackPanel|Grid)>").Count;
+            var enclosing = openPanels.Skip(closedPanels).LastOrDefault();
+
+            Assert.True(enclosing is not null, $"{markup}: could not find the panel holding StatusText.");
+            Assert.DoesNotContain("Orientation=\"Horizontal\"", enclosing!, StringComparison.Ordinal);
+        }
+    }
+
+    private static IEnumerable<string> InstallStepMarkup(string root)
+    {
+        yield return Path.Combine(root, "tools", "cc-director-setup", "Steps", "InstallStep.xaml");
+        yield return Path.Combine(root, "tools", "cc-director-setup-avalonia", "Steps", "InstallStep.axaml");
+    }
+
+    /// <summary>The whole opening tag of the element that declares <paramref name="name"/>.</summary>
+    private static string? ElementDeclaring(string markup, string name)
+    {
+        var at = markup.IndexOf($"x:Name=\"{name}\"", StringComparison.Ordinal);
+        if (at < 0) return null;
+        var open = markup.LastIndexOf('<', at);
+        var close = markup.IndexOf('>', at);
+        return open < 0 || close < 0 ? null : markup[open..close];
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "tools", "cc-director-setup-avalonia")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the repo root (tools/cc-director-setup-avalonia) walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/tools/cc-director-setup.Tests/WelcomeStepTests.cs
+++ b/tools/cc-director-setup.Tests/WelcomeStepTests.cs
@@ -1,7 +1,5 @@
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Threading;
 using CcDirector.Setup.Engine;
 using CcDirectorSetup.Steps;
 using Xunit;
@@ -19,7 +17,8 @@ namespace CcDirectorSetup.Tests;
 /// resources loaded (resource lookup is thread-affine, so every control must be built on the thread
 /// that owns the Application). The shared thread is provided by <see cref="WpfStaFixture"/>.
 /// </summary>
-public sealed class WelcomeStepTests : IClassFixture<WpfStaFixture>
+[Collection(WpfCollection.Name)]
+public sealed class WelcomeStepTests
 {
     private readonly WpfStaFixture _wpf;
 
@@ -88,77 +87,5 @@ public sealed class WelcomeStepTests : IClassFixture<WpfStaFixture>
         var b = step.FindName(name) as Button;
         Assert.NotNull(b);
         return b!;
-    }
-}
-
-/// <summary>
-/// A single, long-lived STA thread that owns one <see cref="Application"/> with App.xaml's resources
-/// loaded, plus a <see cref="Dispatcher"/> to marshal work onto it. WPF resource resolution is
-/// thread-affine, so every WelcomeStep must be constructed on the one thread that created the
-/// Application - this fixture is that thread. Shared across the test class via IClassFixture so the
-/// Application (a per-process singleton) is created exactly once.
-/// </summary>
-public sealed class WpfStaFixture : IDisposable
-{
-    private readonly Thread _thread;
-    private Dispatcher? _dispatcher;
-    private readonly ManualResetEventSlim _ready = new(false);
-
-    public WpfStaFixture()
-    {
-        _thread = new Thread(() =>
-        {
-            // One Application per process. The Welcome step's XAML binds the App-level brushes by key
-            // (StaticResource AccentBrush etc.); in a unit test there is no App.xaml-driven startup, so
-            // we register exactly those brushes into Application.Resources here. The values mirror
-            // App.xaml; only the keys the step actually binds are needed for it to construct.
-            if (Application.Current == null)
-            {
-                var app = new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-                AddBrush(app, "TextForeground", "#CCCCCC");
-                AddBrush(app, "AccentBrush", "#007ACC");
-                AddBrush(app, "DimText", "#888888");
-                AddBrush(app, "MutedText", "#666666");
-                AddBrush(app, "StepInactive", "#3C3C3C");
-                AddBrush(app, "ErrorBrush", "#CC4444");
-                AddBrush(app, "ButtonBackground", "#3C3C3C");
-                AddBrush(app, "ButtonHover", "#505050");
-
-                // The Uninstall button in the step references the DangerButton style by key at parse
-                // time (it is only shown in update mode, but the reference is resolved when the XAML
-                // loads). A minimal Button style under that key is enough for the step to construct.
-                app.Resources["DangerButton"] = new Style(typeof(Button));
-            }
-
-            _dispatcher = Dispatcher.CurrentDispatcher;
-            _ready.Set();
-            Dispatcher.Run();
-        });
-        _thread.SetApartmentState(ApartmentState.STA);
-        _thread.IsBackground = true;
-        _thread.Start();
-        _ready.Wait();
-    }
-
-    private static void AddBrush(Application app, string key, string hex) =>
-        app.Resources[key] = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
-
-    /// <summary>Run <paramref name="body"/> synchronously on the STA thread, surfacing any exception.</summary>
-    public void Run(Action body)
-    {
-        Exception? captured = null;
-        _dispatcher!.Invoke(() =>
-        {
-            try { body(); }
-            catch (Exception ex) { captured = ex; }
-        });
-        if (captured != null)
-            throw new Xunit.Sdk.XunitException($"WPF STA body failed: {captured}");
-    }
-
-    public void Dispose()
-    {
-        _dispatcher?.InvokeShutdown();
-        _ready.Dispose();
     }
 }

--- a/tools/cc-director-setup.Tests/WpfStaFixture.cs
+++ b/tools/cc-director-setup.Tests/WpfStaFixture.cs
@@ -1,0 +1,75 @@
+using System.Windows;
+using System.Windows.Threading;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// A single, long-lived STA thread that owns the one <see cref="Application"/> this process may have,
+/// with the wizard's REAL App.xaml resources loaded. WPF resource resolution is thread-affine, so
+/// every control under test must be constructed on the thread that created the Application.
+///
+/// It loads App.xaml rather than re-declaring the brushes it needs. A hand-written copy of those
+/// values cannot receive a correction: change a brush or add a style in App.xaml and the copy silently
+/// keeps the old one, so a step that constructs here can still fail to construct in the product.
+/// </summary>
+public sealed class WpfStaFixture : IDisposable
+{
+    private readonly Thread _thread;
+    private Dispatcher? _dispatcher;
+    private readonly ManualResetEventSlim _ready = new(false);
+
+    public WpfStaFixture()
+    {
+        _thread = new Thread(() =>
+        {
+            // One Application per process, and .NET throws on a second one. The generated
+            // InitializeComponent is what loads App.xaml's resources; only the wizard's own entry point
+            // calls it normally, so it is called here.
+            if (Application.Current is null)
+            {
+                var app = new CcDirectorSetup.App { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+                app.InitializeComponent();
+            }
+
+            _dispatcher = Dispatcher.CurrentDispatcher;
+            _ready.Set();
+            Dispatcher.Run();
+        });
+        _thread.SetApartmentState(ApartmentState.STA);
+        _thread.IsBackground = true;
+        _thread.Start();
+        _ready.Wait();
+    }
+
+    /// <summary>Run <paramref name="body"/> synchronously on the STA thread, surfacing any exception.</summary>
+    public void Run(Action body)
+    {
+        Exception? captured = null;
+        _dispatcher!.Invoke(() =>
+        {
+            try { body(); }
+            catch (Exception ex) { captured = ex; }
+        });
+        if (captured != null)
+            throw new Xunit.Sdk.XunitException($"WPF STA body failed: {captured}");
+    }
+
+    public void Dispose()
+    {
+        _dispatcher?.InvokeShutdown();
+        _ready.Dispose();
+    }
+}
+
+/// <summary>
+/// Every test class that builds WPF controls joins this collection, so they share ONE fixture and run
+/// one at a time. A per-class fixture would build a second <see cref="Application"/> the moment a
+/// second class needed one, and .NET refuses that - which crashed the whole test host rather than
+/// failing a test.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class WpfCollection : ICollectionFixture<WpfStaFixture>
+{
+    public const string Name = "wpf";
+}

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -499,7 +499,11 @@ public partial class MainWindow : Window
         _installStep?.SetLauncherStarting();
         try
         {
-            var result = await new LauncherTrayInstaller(InstallLayout.Default()).InstallAsync();
+            // The status line carries the wait's own commentary. A cold first start of the launcher can
+            // run well past a minute while it unpacks itself, and a screen that says nothing for that
+            // long reads as frozen - which is how a slow start came to look like a failed one (#1152).
+            var progress = new Progress<string>(note => _installStep?.SetStatus(note));
+            var result = await new LauncherTrayInstaller(InstallLayout.Default()).InstallAsync(progress: progress);
             foreach (var s in result.Steps) SetupLog.Write($"[MainWindow]   launcher: {s}");
             SetupLog.Write($"[MainWindow] launcher start success={result.Success}: {result.Message}");
             if (result.Success)

--- a/tools/cc-director-setup/Steps/InstallStep.xaml
+++ b/tools/cc-director-setup/Steps/InstallStep.xaml
@@ -8,19 +8,32 @@
                        Foreground="White"
                        FontSize="22"
                        FontWeight="SemiBold" />
-            <StackPanel Orientation="Horizontal" Margin="0,8,0,20">
+            <!-- The status line WRAPS. It used to be a horizontal StackPanel, which gives its children
+                 infinite width and then clips them at the window edge, so the launcher failure read
+                 "...did not answer on 7900. Check C:" - cut off exactly where the log path, the only
+                 actionable part of the sentence, began (issue #1152). A Grid with a starred column
+                 gives the text the width it actually has, and it wraps instead of disappearing. -->
+            <Grid Margin="0,8,0,20">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
                 <TextBlock x:Name="StatusText"
+                           Grid.Column="0"
                            Text="Preparing..."
                            Foreground="{StaticResource TextForeground}"
                            FontSize="13"
+                           TextWrapping="Wrap"
                            VerticalAlignment="Center" />
                 <Button x:Name="RepairButton"
+                        Grid.Column="1"
                         Content="Repair"
                         Width="90" Margin="16,0,0,0"
+                        VerticalAlignment="Center"
                         Style="{StaticResource PrimaryButton}"
                         Click="RepairButton_Click"
                         Visibility="Collapsed" />
-            </StackPanel>
+            </Grid>
         </StackPanel>
 
         <!-- Log location + report (visible DURING install, so a stuck/hung run can still be reported). -->


### PR DESCRIPTION
Fixes the clean-install defect reported as devthrottle_internal issue 1152.

## The defect

A first install on a clean Windows 11 machine ended on a red ERROR with the Launcher row marked
Failed and the message "Launcher tray app started but did not answer on 7900". While that error was
on screen, port 7900 answered 200 with `ok:true` from process 11216 - the very process the installer
had started. Pressing Retry completed the install with no error at all.

The launcher had not failed. It was still starting. `cc-launcher.exe` is a ~134 MB single-file binary
that unpacks itself on first run, so it is slow exactly once: on the machine where a first-time user
is watching. The installer allowed a fixed twenty seconds, tuned on a warm developer machine, and
treated the end of that clock as a verdict.

## What changed

**The wait ends on a fact, not a clock.** `LauncherHealthProbe.WaitForReadyAsync` polls until the
launcher answers and certifies the install, and gives up early only when something is genuinely
wrong: the process this install started is gone, so no answer is ever coming. The five-minute
ceiling is a backstop for a launcher that is alive and wedged - it is not what decides the verdict.
Raising the old number instead would have been the same defect with a longer fuse.

Each way the wait can end now gets its own sentence, instead of one blanket "did not answer":
exited before answering, still running but silent at the ceiling, answered but not healthy, or a
stranger holding the port. The identity rule from the earlier orphan-launcher work is untouched - an
answer from a process this install did not start still never certifies it.

**The screen no longer looks frozen while a slow first start is under way.** After eight seconds the
status line says the launcher's first start unpacks a large file and reports the elapsed seconds.

**The error text no longer gets clipped.** The message was cut off at `Check C:` - exactly where the
log path, the only actionable part of the sentence, began. The status line sat in a horizontal
StackPanel, which measures its children with infinite width so wrapping can never happen and the
overflow is simply cut at the window edge. It is a Grid with a starred column now, on both wizards,
because the same markup was in both.

## Proof

Every guard was checked by injecting the fault and confirming it goes red first:

| Fault injected | Goes red |
| --- | --- |
| Ceiling back to 20 seconds | `TheInstallersCeiling_IsFarBeyondTheColdStartThatWasCalledDead` |
| Liveness term deleted from the wait | `WhenTheStartedProcessExits_TheWaitStopsAtOnce` (33s run instead of 50ms) |
| `TextWrapping` removed | markup guard, and the rendering test with "rendered 17px high - one line of 17px" |
| Horizontal StackPanel restored | markup guard (enclosing-panel check) |

The rendering test builds the real Windows install step at the wizard's content width, sets the
actual failure message, and measures it - it first proves the message genuinely cannot fit on one
line, so it cannot pass while proving nothing.

Test runs, all local: setup engine 449 passed, Windows wizard 25 passed, setup command line 32
passed, launcher 85 passed. Whole solution builds with zero warnings.

## Not covered, stated plainly

- **Not re-walked on a clean machine.** This is proven by unit and rendering tests, not by a fresh
  virtual machine install. The clean-machine seat walking v1.9.1 is the right place to confirm the
  screen a first-time user actually sees.
- **The macOS installer keeps its fixed twenty-second wait.** It is the same shape and could hit the
  same defect, but launchd owns the process there and can restart it under a new process id, so the
  liveness term is not straightforwardly the same fact. Only the wrapping fix was applied to that
  wizard. Worth its own look.
- The heading still reads "Installing" above a red ERROR - that is issue 1043 and is untouched here.
