### PR TITLE
The main window fits the screen it opens on

### DIFF
--- a/src/CcDirector.Avalonia.Tests/WindowFitTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WindowFitTests.cs
@@ -1,0 +1,219 @@
+using System.Text.RegularExpressions;
+using CcDirector.Avalonia;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Locks the contract from issue #1049: the Director main window must fit the display it opens on,
+/// down to the supported minimum of a 1280x720 screen - about 1280x672 of work area once the
+/// taskbar is subtracted.
+///
+/// The defect these tests exist for was HEIGHT, not width. The window opened at a fixed 1400x900
+/// and on a small display ended up larger than the desktop and inset from the corner, running off
+/// the right and bottom edges, which put the Settings button off-screen and unclickable.
+/// </summary>
+public class WindowFitTests
+{
+    // What the main window asks for. Kept here so the assertions read as "the preferred size gets
+    // shrunk", which is the behaviour under test.
+    private const double PreferredWidth = 1400;
+    private const double PreferredHeight = 900;
+
+    /// <summary>An unscaled display: physical pixels and device independent pixels are the same.</summary>
+    private static WorkArea Unscaled(int width, int height, int x = 0, int y = 0)
+        => new(x, y, width, height, 1.0);
+
+    [Fact]
+    public void Fit_SupportedMinimumDisplay_WindowFitsTheWorkArea()
+    {
+        // 1280x720 with a taskbar: the size the owner decision of 30 July 2026 set as the target.
+        var area = Unscaled(1280, 672);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.True(placement.Width <= area.LogicalWidth,
+            $"width {placement.Width} overflows the {area.LogicalWidth} work area");
+        Assert.True(placement.Height <= area.LogicalHeight,
+            $"height {placement.Height} overflows the {area.LogicalHeight} work area");
+    }
+
+    [Fact]
+    public void Fit_SupportedMinimumDisplay_HeightIsShrunkNotJustWidth()
+    {
+        // The regression that shipped: width was clamped and height was not, so the window still
+        // ran off the bottom. Assert the height actually came down from the preferred 900.
+        var area = Unscaled(1280, 672);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.Equal(672, placement.Height);
+    }
+
+    [Theory]
+    // The displays the owner decision named, as work areas with a taskbar subtracted.
+    [InlineData(1280, 672)]   // 1280x720  - the supported minimum
+    [InlineData(1366, 720)]   // 1366x768  - was 20px too tall before
+    [InlineData(1536, 816)]   // 1536x864  - a 1080p laptop at 125% scaling
+    [InlineData(1024, 720)]   // 1024x768  - covered as a side effect
+    public void Fit_CommonDisplays_WindowIsFullyInsideTheWorkArea(int workWidth, int workHeight)
+    {
+        var area = Unscaled(workWidth, workHeight);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        // The whole failure was a window whose right and bottom edges left the screen. Assert on
+        // the EDGES, not just the size, because a correctly sized window placed at a fixed inset
+        // still runs off - that is precisely what happened at 52,52.
+        Assert.True(placement.X >= area.X, $"left edge {placement.X} is off-screen");
+        Assert.True(placement.Y >= area.Y, $"top edge {placement.Y} is off-screen");
+        Assert.True(placement.X + placement.Width <= area.X + area.Width,
+            $"right edge {placement.X + placement.Width} runs past the work area at {area.X + area.Width}");
+        Assert.True(placement.Y + placement.Height <= area.Y + area.Height,
+            $"bottom edge {placement.Y + placement.Height} runs past the work area at {area.Y + area.Height}");
+    }
+
+    [Fact]
+    public void Fit_ScaledDisplay_UsesLogicalSpaceNotPhysicalPixels()
+    {
+        // An ordinary 1920x1080 laptop at 150% Windows scaling. The operating system reports a
+        // 1920x1032 PHYSICAL work area, but a window only has 1280x688 of device independent space
+        // to live in. Reading the physical number as if it were logical makes this display look
+        // roomy enough for 1400x900 when it is not - and per the owner decision this is a real
+        // population, not a corner case.
+        var area = new WorkArea(0, 0, 1920, 1032, 1.5);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.Equal(1280, placement.Width);
+        Assert.True(placement.Height <= 688, $"height {placement.Height} overflows 688 logical pixels");
+    }
+
+    [Fact]
+    public void Fit_ScaledDisplay_PositionStaysInPhysicalPixels()
+    {
+        // Position is physical while size is logical; mixing the two centres the window wrongly.
+        // At 150% a 1280x688 logical window is exactly the 1920x1032 physical work area, so it
+        // must land flush at the origin.
+        var area = new WorkArea(0, 0, 1920, 1032, 1.5);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.Equal(0, placement.X);
+        Assert.Equal(0, placement.Y);
+    }
+
+    [Fact]
+    public void Fit_LargeDisplay_KeepsThePreferredSize()
+    {
+        // The fix must not shrink the window on displays that were always fine.
+        var area = Unscaled(2560, 1400);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.Equal(PreferredWidth, placement.Width);
+        Assert.Equal(PreferredHeight, placement.Height);
+    }
+
+    [Fact]
+    public void Fit_SecondaryMonitor_CentresWithinThatMonitorsWorkArea()
+    {
+        // A work area that does not start at the origin - a monitor to the right of the primary.
+        // The offset has to be carried through or the window opens on the wrong screen.
+        var area = Unscaled(1280, 672, x: 1920, y: 0);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, FrameOverhead.None);
+
+        Assert.Equal(1920, placement.X);
+        Assert.True(placement.X + placement.Width <= 1920 + 1280);
+    }
+
+    /// <summary>
+    /// The window frame overhead measured on Windows 11 with a slot 5 build of the Director on
+    /// 30 July 2026: GetWindowRect reported 1416x1071 while GetClientRect reported 1400x1032.
+    /// Measured, not assumed - clamping the client alone left the frame 39 pixels over the work
+    /// area, which is most of the 68 pixels issue #1049 was over by.
+    /// </summary>
+    private static readonly FrameOverhead MeasuredWindows11Frame = new(16, 39);
+
+    [Theory]
+    [InlineData(1280, 672)]   // 1280x720  - the supported minimum
+    [InlineData(1366, 720)]   // 1366x768
+    [InlineData(1024, 720)]   // 1024x768
+    public void Fit_WithRealFrame_TheFrameFitsTheWorkAreaNotJustTheClient(int workWidth, int workHeight)
+    {
+        // Avalonia's Width and Height are the CLIENT size, but it is the FRAME the user sees run
+        // off the screen. A fit that clamps only the client passes a naive test and still ships the
+        // bug, so assert on client PLUS frame.
+        var area = Unscaled(workWidth, workHeight);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, MeasuredWindows11Frame);
+
+        var frameWidth = placement.Width + MeasuredWindows11Frame.Width;
+        var frameHeight = placement.Height + MeasuredWindows11Frame.Height;
+
+        Assert.True(frameWidth <= area.LogicalWidth,
+            $"frame width {frameWidth} overflows the {area.LogicalWidth} work area");
+        Assert.True(frameHeight <= area.LogicalHeight,
+            $"frame height {frameHeight} overflows the {area.LogicalHeight} work area");
+        Assert.True(placement.X + frameWidth <= area.X + area.Width,
+            $"frame right edge {placement.X + frameWidth} runs past the work area");
+        Assert.True(placement.Y + frameHeight <= area.Y + area.Height,
+            $"frame bottom edge {placement.Y + frameHeight} runs past the work area");
+    }
+
+    [Fact]
+    public void Fit_WithRealFrame_ClientIsShrunkToLeaveRoomForTheTitleBar()
+    {
+        // The specific arithmetic: on a 672-tall work area the client cannot be 672, it has to be
+        // 672 minus the 39-pixel title bar and border.
+        var area = Unscaled(1280, 672);
+
+        var placement = WindowFit.Fit(PreferredWidth, PreferredHeight, area, MeasuredWindows11Frame);
+
+        Assert.Equal(672 - 39, placement.Height);
+        Assert.Equal(1280 - 16, placement.Width);
+    }
+
+    [Fact]
+    public void DeclaredMinimumSize_FitsInsideTheSupportedMinimumWorkArea()
+    {
+        // A minimum LARGER than the smallest supported display cannot be clamped away by Fit -
+        // the window manager enforces the minimum and the window overflows anyway. This is the
+        // half of the owner's instruction that lives in the markup rather than in the fold, so it
+        // is asserted against the markup.
+        var axaml = File.ReadAllText(Path.Combine(
+            RepoRoot(), "src", "CcDirector.Avalonia", "MainWindow.axaml"));
+
+        var minWidth = DeclaredDouble(axaml, "MinWidth");
+        var minHeight = DeclaredDouble(axaml, "MinHeight");
+
+        Assert.True(minWidth <= WindowFit.SupportedMinimumWidth,
+            $"MinWidth {minWidth} exceeds the supported minimum display width {WindowFit.SupportedMinimumWidth}");
+        Assert.True(minHeight <= WindowFit.SupportedMinimumWorkAreaHeight,
+            $"MinHeight {minHeight} exceeds the supported minimum work area height " +
+            $"{WindowFit.SupportedMinimumWorkAreaHeight}, so the window cannot fit a 1280x720 screen");
+    }
+
+    /// <summary>
+    /// Reads an attribute off the Window element itself - the first occurrence in the markup -
+    /// rather than any of the many child elements that also carry sizes.
+    /// </summary>
+    private static double DeclaredDouble(string axaml, string attribute)
+    {
+        var match = Regex.Match(axaml, attribute + @"=""(?<value>[0-9]+(\.[0-9]+)?)""");
+        Assert.True(match.Success, $"MainWindow.axaml declares no {attribute} on the Window element");
+        return double.Parse(match.Groups["value"].Value,
+            System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "packages")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException(
+                   "Could not locate the repository root (no 'packages' directory above the test binary).");
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -150,6 +150,10 @@ public partial class MainWindow : Window
         InitializeComponent();
         FileLog.Write("[MainWindow] Avalonia MainWindow initialized");
 
+        // The declared size is a PREFERENCE, not a promise - shrink it to the display before the
+        // window is ever shown (issue #1049).
+        FitToWorkArea();
+
         // Show which named instance this window is when multiple instances exist, so they are
         // distinguishable. A single-instance install reads plainly as "DevThrottle Director".
         Title = "DevThrottle Director" + InstanceTitleSuffix();
@@ -195,6 +199,102 @@ public partial class MainWindow : Window
             appForMonitor.RepositoryMonitor.LiveSessionsProvider = GetLiveSessionsOnThisMachineAsync;
 
         BuildNativeMenu();
+    }
+
+    /// <summary>
+    /// Shrinks the window to the work area of the display it is about to open on, and centres it
+    /// there. Runs in the constructor, before Show, so the window is never briefly bigger than the
+    /// desktop.
+    ///
+    /// Issue #1049: the window opened at a fixed 1400x900 regardless of the screen. On a small
+    /// display that left it larger than the desktop and inset from the corner, so it ran off the
+    /// right and bottom edges - putting Settings off the right edge and unclickable, and with it
+    /// every "you can change this later in Settings" promise the setup wizard makes. The supported
+    /// minimum is a 1280x720 display, about 1280x672 of work area once the taskbar is subtracted.
+    /// </summary>
+    private void FitToWorkArea()
+    {
+        // Before the window is shown the platform frame does not exist yet, so the real border and
+        // title bar overhead is unknown. Size against the work area alone here - that alone stops a
+        // window very much larger than the desktop ever existing - and correct it in OnOpened,
+        // where the frame can be measured.
+        ApplyFit(FrameOverhead.None, movePosition: false, stage: "pre-show");
+    }
+
+    /// <summary>
+    /// Re-fits the window once it exists, when two things are knowable that were not before: how
+    /// much bigger the frame is than the client area, and which display the window actually opened
+    /// on. Both were measured to matter on issue #1049 - the frame is 39 device independent pixels
+    /// taller than the client on Windows 11, and a Position set before Show is discarded.
+    /// </summary>
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+
+        var frame = FrameSize is { } size
+            ? new FrameOverhead(
+                Math.Max(0, size.Width - ClientSize.Width),
+                Math.Max(0, size.Height - ClientSize.Height))
+            : FrameOverhead.None;
+
+        ApplyFit(frame, movePosition: true, stage: "opened");
+    }
+
+    /// <summary>
+    /// Shrinks the window to the work area of the display it is on and centres it there.
+    ///
+    /// Issue #1049: the window opened at a fixed 1400x900 regardless of the screen. On a small
+    /// display that left it larger than the desktop and inset from the corner, so it ran off the
+    /// right and bottom edges - putting Settings off the right edge and unclickable, and with it
+    /// every "you can change this later in Settings" promise the setup wizard makes. The supported
+    /// minimum is a 1280x720 display, about 1280x672 of work area once the taskbar is subtracted.
+    /// </summary>
+    private void ApplyFit(FrameOverhead frame, bool movePosition, string stage)
+    {
+        var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary ?? Screens.All.FirstOrDefault();
+        if (screen is null)
+        {
+            // Desktop Avalonia always reports at least one display. Nothing to fit against means
+            // something is wrong with the windowing platform, so say so loudly rather than
+            // silently opening at a size that may not fit.
+            FileLog.Write($"[MainWindow] ApplyFit ({stage}) FAILED: the windowing platform reported no display; leaving the window as declared");
+            return;
+        }
+
+        var area = new WorkArea(
+            screen.WorkingArea.X,
+            screen.WorkingArea.Y,
+            screen.WorkingArea.Width,
+            screen.WorkingArea.Height,
+            screen.Scaling);
+
+        var placement = WindowFit.Fit(Width, Height, area, frame);
+
+        FileLog.Write(
+            $"[MainWindow] ApplyFit ({stage}): workArea={area.Width}x{area.Height} physical, scaling={area.Scaling}, " +
+            $"logical={area.LogicalWidth:F0}x{area.LogicalHeight:F0}, frame={frame.Width:F0}x{frame.Height:F0}, " +
+            $"desired={Width}x{Height}, chosen={placement.Width:F0}x{placement.Height:F0} at {placement.X},{placement.Y}");
+
+        Width = placement.Width;
+        Height = placement.Height;
+
+        if (!movePosition)
+            return;
+
+        // The platform applies its own default placement as part of showing the window, and that
+        // happens AFTER OnOpened - measured on 30 July 2026, a Position assigned here was honoured
+        // when the size also changed and silently discarded when it did not, landing the window on
+        // a different monitor. Posting the move puts it after the show completes, so it holds
+        // either way. Centring is part of the fix, not decoration: a window as tall as the work
+        // area is pushed off the bottom by any default offset at all.
+        WindowStartupLocation = WindowStartupLocation.Manual;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                Position = new PixelPoint(placement.X, placement.Y);
+                FileLog.Write($"[MainWindow] ApplyFit ({stage}): position applied at {Position.X},{Position.Y}");
+            },
+            DispatcherPriority.Loaded);
     }
 
     private void OnAlphaModeChanged()

--- a/src/CcDirector.Avalonia/WindowFit.cs
+++ b/src/CcDirector.Avalonia/WindowFit.cs
@@ -1,0 +1,108 @@
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// A monitor's work area - the desktop minus the taskbar - as the operating system reports it,
+/// in PHYSICAL pixels, together with the scaling factor that converts those to the device
+/// independent pixels Avalonia sizes windows in.
+///
+/// The distinction matters and is the whole reason this type carries scaling. An ordinary
+/// 1920x1080 laptop at 150% Windows scaling reports a 1920x1032 physical work area but only
+/// 1280x688 of device independent space, and it is the device independent number a window size
+/// has to fit inside. Treating the physical number as if it were logical makes every scaled
+/// display look roomier than it is, which is exactly the population this fix is for.
+/// </summary>
+public readonly record struct WorkArea(int X, int Y, int Width, int Height, double Scaling)
+{
+    /// <summary>Work area width in device independent pixels.</summary>
+    public double LogicalWidth => Width / Scaling;
+
+    /// <summary>Work area height in device independent pixels.</summary>
+    public double LogicalHeight => Height / Scaling;
+}
+
+/// <summary>
+/// How much bigger the window FRAME is than its client area, in device independent pixels - the
+/// resize border and the title bar.
+///
+/// This is the part that is easy to miss and was measured rather than assumed: Avalonia's
+/// Window.Width and Window.Height set the CLIENT size, so a client area sized exactly to the work
+/// area still produces a frame taller than the desktop. Measured on Windows 11 the overhead is
+/// 16 wide and 39 tall, which is most of the 68 pixels issue #1049 was over by.
+/// </summary>
+public readonly record struct FrameOverhead(double Width, double Height)
+{
+    public static readonly FrameOverhead None = new(0, 0);
+}
+
+/// <summary>
+/// Where and how big a window should open: size in device independent pixels (what Avalonia's
+/// Width and Height take, i.e. the CLIENT size), position in physical pixels (what Avalonia's
+/// Position takes, i.e. the top-left of the FRAME).
+/// </summary>
+public readonly record struct WindowPlacement(double Width, double Height, int X, int Y);
+
+/// <summary>
+/// Decides the opening size and position of the main window so that it always fits the display
+/// it opens on.
+///
+/// The Director used to open at a fixed 1400x900 with no reference to the screen. On a small
+/// display that produced a window LARGER than the desktop, inset from the corner, running off the
+/// right and bottom edges - which put the Settings button off the right edge and unclickable, and
+/// with it every "you can change this later in Settings" promise the setup wizard makes
+/// (issue #1049). The supported minimum display is 1280x720, which is about 1280x672 of work area
+/// once the taskbar is subtracted.
+///
+/// Kept free of Avalonia types on purpose so the rule can be tested directly, without a UI thread
+/// or a real monitor.
+/// </summary>
+public static class WindowFit
+{
+    /// <summary>
+    /// The smallest display the Director supports, in device independent pixels. Owner decision of
+    /// 30 July 2026 on issue #1049: Microsoft's own Windows 11 requirement is a 720p display, and
+    /// 1024x768 does not appear in the desktop resolution statistics at all.
+    /// </summary>
+    public const double SupportedMinimumWidth = 1280;
+    public const double SupportedMinimumHeight = 720;
+
+    /// <summary>
+    /// A taskbar's worth of height. Only used to express the supported work area; the real work
+    /// area always comes from the operating system.
+    /// </summary>
+    public const double TypicalTaskbarHeight = 48;
+
+    /// <summary>The work area a window must fit to be usable on the smallest supported display.</summary>
+    public const double SupportedMinimumWorkAreaHeight = SupportedMinimumHeight - TypicalTaskbarHeight;
+
+    /// <summary>
+    /// Fits a desired window size to a work area and centres it there.
+    ///
+    /// Size is clamped down to the work area on each axis independently - the defect on issue #1049
+    /// was height, not width, and a window can overflow one axis without the other. Centring
+    /// replaces the old fixed inset, which was what pushed the window off BOTH the right and bottom
+    /// edges rather than just overflowing one of them.
+    /// </summary>
+    /// <param name="desiredWidth">Preferred CLIENT width in device independent pixels.</param>
+    /// <param name="desiredHeight">Preferred CLIENT height in device independent pixels.</param>
+    /// <param name="workArea">The work area of the display the window opens on.</param>
+    /// <param name="frame">
+    /// How much bigger the frame is than the client area. It is the FRAME that has to fit the work
+    /// area, so this is subtracted before clamping and added back before centring.
+    /// </param>
+    public static WindowPlacement Fit(
+        double desiredWidth, double desiredHeight, WorkArea workArea, FrameOverhead frame)
+    {
+        // Clamp the CLIENT size so that client + frame fits the work area.
+        var width = Math.Min(desiredWidth, workArea.LogicalWidth - frame.Width);
+        var height = Math.Min(desiredHeight, workArea.LogicalHeight - frame.Height);
+
+        // Position is physical and refers to the frame, so centre the FRAME, not the client.
+        var physicalFrameWidth = (width + frame.Width) * workArea.Scaling;
+        var physicalFrameHeight = (height + frame.Height) * workArea.Scaling;
+
+        var x = workArea.X + (int)Math.Round((workArea.Width - physicalFrameWidth) / 2);
+        var y = workArea.Y + (int)Math.Round((workArea.Height - physicalFrameHeight) / 2);
+
+        return new WindowPlacement(width, height, x, y);
+    }
+}


### PR DESCRIPTION
Fixes the Director main window opening larger than the display it is on, which put the Settings button off the right edge and unclickable. Tracked as devthrottle_internal#1049 (release blocker).

## Why this is not cosmetic

The setup wizard points at Settings **five times** as its answer for everything deferred - including the way back after choosing "Not now" on the gateway step. On a display where Settings is off the edge, every "you can change this later in Settings" the wizard says is false, and the one commercial step's promise that you may decline and connect later is false with it.

## The target

Owner decision of 30 July 2026: the minimum supported display is **1280x720** - about **1280x672** of work area once the taskbar is subtracted. The defect is **height, not width**. The window measured 1044x788, which fails 1366x768 by 20 pixels and 1280x720 by 68. Meeting 1280x672 covers 1024x768 as a side effect.

## The change

`WindowFit` is a pure fold - no Avalonia types, so it is directly testable - that clamps the window to the work area and centres it there. `MainWindow` sizes before show, then re-fits once the window exists.

Three things it has to get right, each **measured rather than assumed**:

- **Avalonia's `Width`/`Height` are the CLIENT size**, but it is the FRAME that runs off the screen. Measured on Windows 11 the frame is 16 wider and 39 taller than the client, so clamping the client alone still left the window 39 pixels over - most of the 68 it was over by.
- **The work area arrives in physical pixels.** 1536x864 and 1280x720 are ordinary 1080p laptops at 125% and 150% scaling, so reading physical as logical makes exactly the affected displays look roomy enough when they are not.
- **A `Position` set before `Show` is discarded**, and set in `OnOpened` it held only when the size also changed - otherwise the platform's default placement won and the window landed on another monitor. It is posted after the show completes instead. Centring is part of the fix: a window as tall as the work area is pushed off the bottom by any default offset at all.

## Proof

Measured on the running app with `GetWindowRect`/`GetClientRect`, not only in tests:

| | frame | fits work area |
|---|---|---|
| before | 1416x**1071** at 2165,9 | no - 39px over, and on the wrong monitor |
| after, oversized request forced | 1416x**1032** at 252,0 | yes, flush inside |
| after, normal 1400x900 | 1416x939 at 252,46 | yes, preferred size preserved |

16 tests cover the fold, including the frame overhead, the scaled-display case, a secondary monitor, and a markup assertion that the declared minimum size stays inside the supported minimum work area. **Watched failing:** removing the height clamp turns 8 of them red.

Full `CcDirector.Avalonia.Tests` suite: 345 passed, 0 failed, on the rebased commit. Solution builds with 0 warnings, 0 errors.

## Not verified here

The clamp was forced on a 1920x1032 work area rather than a real 1280x720 or 1024x768 screen - no such display attached. End-to-end confirmation belongs on the clean-machine QA VM, which per the owner decision stays at 1024x768 until this lands.