### PR TITLE
Tunnel liveness: ping more often, and stop logging a cancelled wait as a slow push

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -330,6 +330,29 @@ function isGatewayUnreachable(err: unknown): boolean {
   return err instanceof Error;
 }
 
+// The header the Gateway stamps when a failure is the DIRECTOR's and not its own - it did not answer in
+// time, or its tunnel died mid-command (issue #1153, TunnelCatchAllDispatch.FaultSideHeader).
+const FAULT_SIDE_HEADER = "X-DevThrottle-Fault";
+const FAULT_SIDE_DIRECTOR = "director";
+
+// True when a 502/504 came from OUR Gateway, about a Director, rather than from an edge proxy in front of a
+// Gateway that is down.
+//
+// WHY THIS EXISTS. 502/503/504 are read as "the backend could not be reached", which is right when they come
+// from a proxy and wrong when the Gateway itself composed them to say a MACHINE behind it went quiet. Without
+// this, one Director stalling for seven seconds put "Bad connection - showing last known information" on the
+// owner's phone while the Gateway was answering him in the same millisecond - the app blaming the one part of
+// the system that was working. A Director being slow is not a connection problem and must not be reported as
+// one; the screen that asked for that machine's data still surfaces its own failure, and the Gateway's error
+// body already names the machine in plain words.
+//
+// ABSENCE IS THE SAFE DEFAULT: a proxy in front of a dead Gateway cannot stamp this, so an unstamped 502
+// still means unreachable, exactly as before. Only a stamped response is treated as proof the Gateway
+// answered.
+function isDirectorFault(res: Response): boolean {
+  return res.headers.get(FAULT_SIDE_HEADER) === FAULT_SIDE_DIRECTOR;
+}
+
 // The ONE transport choke point every Gateway contact in this client routes through, so the shared
 // connection-health signal (connection/health.ts) is fed in exactly one place instead of hand-wired
 // into each page's poll. It is a transparent wrapper around the browser fetch: it returns the same
@@ -391,7 +414,7 @@ export async function gatewayFetch(
     if (timer !== undefined) clearTimeout(timer);
     if (onCallerAbort && callerSignal) callerSignal.removeEventListener("abort", onCallerAbort);
   }
-  if (res.status === 0 || res.status === 502 || res.status === 503 || res.status === 504) {
+  if ((res.status === 0 || res.status === 502 || res.status === 503 || res.status === 504) && !isDirectorFault(res)) {
     reportGatewayUnreachable();
   } else {
     reportGatewayReachable();

--- a/packages/client-core/src/api/handover.test.ts
+++ b/packages/client-core/src/api/handover.test.ts
@@ -14,6 +14,12 @@ function mockFetch(status: number, body: unknown) {
       ({
         ok: status >= 200 && status < 300,
         status,
+        // A real Response ALWAYS carries headers, and this double must too. gatewayFetch reads
+        // X-DevThrottle-Fault on a 502/504 to tell "the Gateway could not be reached" from "the Gateway
+        // answered, and the Director behind it did not" (issue #1153). A double without headers is not a
+        // Response, and the `as unknown as Response` cast is what let it pretend to be one - so the omission
+        // surfaced as a TypeError in the transport instead of a type error here.
+        headers: new Headers(),
         json: async () => body,
         text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
       }) as unknown as Response,

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -172,22 +172,39 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     {
         var startedUtc = DateTime.UtcNow;
         _rePushStartedUtc = startedUtc;
+        var report = ReseedReport.NotConnected;
         try
         {
             // ReseedAsync sends Hello + a full PushSnapshot with an incrementing sequence (the same path used
             // on connect/reconnect) and already swallows its own send faults, so a re-push is best-effort.
-            await ReseedAsync();
+            report = await ReseedAsync();
         }
         finally
         {
             // Report a SLOW push, not only a failed one. A push that succeeds but takes a whole cadence has
             // already eaten the following tick, which is the observed path to the cache going stale - and it
             // is otherwise indistinguishable from a healthy push in the log.
+            //
+            // WHAT CHANGED AND WHY IT MATTERS (issue #1153): this used to report one elapsed number for every
+            // outcome, including a push the connection's own server-timeout had CANCELLED - so an abandoned
+            // wait was logged in the same words as a slow Gateway, and the two are not the same event and do
+            // not have the same fix. The outcome now decides the wording, and a wait that never finished
+            // says so in the line rather than being counted as a duration the Gateway is answerable for.
             var elapsed = DateTime.UtcNow - startedUtc;
-            if (elapsed >= SlowRePushThreshold)
+            if (!report.Completed)
+            {
+                // NOT called slow. Nobody can say how long the push would have taken, because it did not
+                // finish - all that is known is how long we waited before it was abandoned.
+                FileLog.Write($"[GatewayStreamClient] re-push DID NOT COMPLETE after {elapsed.TotalSeconds:F1}s: "
+                    + $"{report.Failure ?? "no reason recorded"} - this is how long the WAIT lasted, "
+                    + "NOT how long the Gateway took");
+            }
+            else if (elapsed >= SlowRePushThreshold)
             {
                 FileLog.Write($"[GatewayStreamClient] re-push SLOW: took {elapsed.TotalSeconds:F1}s "
-                    + $"(cadence {SlowRePushThreshold.TotalSeconds:F0}s) - the next tick was likely skipped");
+                    + $"(cadence {SlowRePushThreshold.TotalSeconds:F0}s) - the next tick was likely skipped. "
+                    + $"Of that, building the snapshot here took {report.BuildSnapshot.TotalSeconds:F1}s and "
+                    + $"waiting for the Gateway to accept it took {report.AwaitGateway.TotalSeconds:F1}s");
             }
             _rePushStartedUtc = DateTime.MinValue;
             Interlocked.Exchange(ref _rePushInFlight, 0);
@@ -223,6 +240,14 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             // is safe to roll out per-Director.
             .AddMessagePackProtocol()
             .Build();
+
+        // Tunnel liveness (issue #1153) - the client half of the pair the hub sets in GatewayHost, read from
+        // the SAME shared constants so the two can never drift. ServerTimeout is what actually decides whether
+        // this Director hangs up: it fires on SILENCE from the Gateway, not on a slow call, so the fix for a
+        // Gateway that is alive but busy is a more frequent ping and an UNCHANGED tolerance. Both must be set
+        // before StartAsync.
+        _connection.ServerTimeout = DirectorStreamLimits.SilenceTolerance;
+        _connection.KeepAliveInterval = DirectorStreamLimits.KeepAlivePing;
 
         _connection.Reconnecting += ex =>
         {
@@ -376,13 +401,44 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         }
     }
 
-    private async Task ReseedAsync()
+    /// <summary>
+    /// What one reseed's SESSION leg actually did, so a duration can never be reported as something it did
+    /// not measure.
+    ///
+    /// THE DEFECT THIS TYPE EXISTS TO KILL (issue #1153). The re-push timing used to sit in a
+    /// <c>finally</c> wrapped around the whole send, so when the connection's own server-timeout cancelled an
+    /// in-flight push, the length of the WAIT was written to the log as <c>re-push SLOW: took 83.4s</c>. That
+    /// number is perfectly true about how long the wait lasted and says NOTHING about how long the push took -
+    /// a true record of the wrong thing - and it sent a day's investigation after the Gateway's speed when
+    /// what had actually happened was that the tunnel went silent and the client hung up. The tell, only
+    /// visible once someone looked, was that the slow-push line and the server-timeout line carried IDENTICAL
+    /// timestamps.
+    ///
+    /// So the phases are separated and the outcome is named: how long WE spent building the snapshot on this
+    /// machine, how long the GATEWAY took to accept it, and whether the wait finished at all. They fail for
+    /// different reasons and have different fixes, and one combined number cannot tell them apart.
+    /// </summary>
+    private readonly record struct ReseedReport(TimeSpan BuildSnapshot, TimeSpan AwaitGateway, bool Completed, string? Failure)
+    {
+        /// <summary>Nothing was attempted: there was no connected tunnel to reseed down.</summary>
+        public static ReseedReport NotConnected { get; } =
+            new(TimeSpan.Zero, TimeSpan.Zero, Completed: false, Failure: "the tunnel was not connected");
+    }
+
+    private async Task<ReseedReport> ReseedAsync()
     {
         var conn = _connection;
-        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        if (conn is null || conn.State != HubConnectionState.Connected) return ReseedReport.NotConnected;
+
+        var build = TimeSpan.Zero;
+        var awaitGateway = TimeSpan.Zero;
+        var completed = false;
+        string? failure = null;
         try
         {
             var seq = Interlocked.Increment(ref _sequence);
+
+            var helloStarted = DateTime.UtcNow;
             await conn.InvokeAsync("Hello", new DirectorStreamHello
             {
                 DirectorId = _directorId,
@@ -392,11 +448,31 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 Pid = Environment.ProcessId,
                 StartedAt = _startedAt,
             });
-            await conn.InvokeAsync("PushSnapshot", seq, _snapshot().ToArray());
-            FileLog.Write($"[GatewayStreamClient] reseeded full snapshot seq={seq}");
+            awaitGateway += DateTime.UtcNow - helloStarted;
+
+            // OUR work, on this machine: assembling the roster. Timed apart from the send because a slow build
+            // is a local problem (a starved machine, a lock held too long) and a slow send is the Gateway's -
+            // opposite diagnoses, opposite owners, and the single combined number could name neither.
+            var buildStarted = DateTime.UtcNow;
+            var snapshot = _snapshot().ToArray();
+            build = DateTime.UtcNow - buildStarted;
+
+            // The Gateway's work: InvokeAsync does not return when the frame is written, it returns when the
+            // hub method has FINISHED, so this measures the Gateway's own per-push processing.
+            var sendStarted = DateTime.UtcNow;
+            await conn.InvokeAsync("PushSnapshot", seq, snapshot);
+            awaitGateway += DateTime.UtcNow - sendStarted;
+
+            completed = true;
+            FileLog.Write($"[GatewayStreamClient] reseeded full snapshot seq={seq} "
+                + $"(built in {build.TotalMilliseconds:F0}ms, Gateway accepted it in {awaitGateway.TotalMilliseconds:F0}ms)");
         }
         catch (Exception ex)
         {
+            // Kept LOUD and kept here. This catch is the only place a hub-side throw becomes visible to the
+            // Director, and it is the one thing the Director would lose if this ever moved to a
+            // fire-and-forget send - so if that change is made, the surfacing has to be replaced, not dropped.
+            failure = ex.Message;
             FileLog.Write($"[GatewayStreamClient] reseed failed (auto-reconnect will retry): {ex.Message}");
         }
 
@@ -416,6 +492,8 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 FileLog.Write($"[GatewayStreamClient] repository reseed skipped (older Gateway?): {ex.Message}");
             }
         }
+
+        return new ReseedReport(build, awaitGateway, completed, failure);
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
@@ -103,6 +103,36 @@ public static class DirectorStreamLimits
     public const int UploadChunkRawBytes = 20 * 1024;
 
     /// <summary>
+    /// How often each side sends a keep-alive ping down an otherwise idle tunnel.
+    ///
+    /// DELIBERATELY SHORTER THAN THE SIGNALR DEFAULT of 15 seconds, and the reason is an outage rather than a
+    /// preference. A peer hangs up when it has heard NOTHING for <see cref="SilenceTolerance"/>, so on the
+    /// default pair (15s ping, 30s tolerance) exactly TWO late pings end the tunnel - and the keep-alive is a
+    /// timer callback on the same thread pool the hub's own handlers run on, so a busy Gateway delays the
+    /// pings FIRST. That is not hypothetical: on 2026-07-30 one Director hung up 35 times in a day on
+    /// "Server timeout (30000.00ms) elapsed without receiving a message from the server" while the Gateway was
+    /// alive and answering other work in the same second (devthrottle_internal issue #1153).
+    ///
+    /// At 5 seconds the SAME tolerance absorbs six missed pings instead of two, so a momentarily busy Gateway
+    /// is no longer mistaken for a dead one. The robustness is bought with cheap empty frames, NOT by waiting
+    /// longer to notice a genuinely dead peer - see <see cref="SilenceTolerance"/>, which does not move.
+    /// </summary>
+    public static readonly TimeSpan KeepAlivePing = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// How long each side tolerates COMPLETE SILENCE from the other before declaring the connection dead.
+    ///
+    /// Held at the SignalR default of 30 seconds ON PURPOSE, and it is worth saying why it is not being tuned
+    /// in either direction. Shortening it makes a Director hang up on a merely busy Gateway sooner, which is
+    /// the exact failure this pair exists to prevent. Lengthening it delays noticing a genuinely dead peer,
+    /// which costs the fleet real recovery time. Neither is the fix; pinging more often is.
+    ///
+    /// INVARIANT: this must stay at least twice <see cref="KeepAlivePing"/> - the framework's own rule - or a
+    /// single late ping ends the connection. At 5s against 30s there is six times the room.
+    /// </summary>
+    public static readonly TimeSpan SilenceTolerance = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// The maximum bytes in a single unary command REPLY (a <see cref="DirectorCommandResult"/> carried back
     /// over the tunnel as a SignalR client result via InvokeAsync). Unlike the up-stream - which is chunked at
     /// <see cref="MaxBinaryFrameBytes"/> - a command reply is ONE message: some read verbs (turns, full

--- a/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
+++ b/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
@@ -92,7 +92,45 @@ internal sealed class TunnelCatchAllDispatch
             PayloadJson = payloadJson,
         };
 
-        var result = await _sendCommand(directorId, command, ctx.RequestAborted);
+        // BOUNDED, and the bound is the whole point (issue #1153). This path used to await the tunnel with
+        // nothing but ctx.RequestAborted - no deadline at all - which is how a slow Director came to be
+        // reported as an offline GATEWAY. The phone polls these reads with a 10 second cap of its own, so a
+        // Director slower than that made the CLIENT give up first; a client-side abort has no response, no
+        // header, and no way to tell whose fault it was, so it was reported as the Gateway being unreachable.
+        //
+        // Answering FIRST is what makes the truth available. The read bound sits comfortably under the
+        // client's cap so the Gateway always gets to say "the machine did not answer" - stamped, attributable,
+        // and naming the machine - instead of leaving the client to guess from a silence. Nothing is lost by
+        // cutting at eight seconds that the client would not have abandoned two seconds later anyway.
+        //
+        // WRITES ARE NOT BOUNDED THIS WAY. They are one-shot, the caller passes no client-side cap, and some
+        // legitimately run long; they keep the router's ordinary deadline so this change cannot turn a slow
+        // but succeeding write into a failed one.
+        var isPolledRead = plan.Payload == Payload.None && plan.ItemId is null;
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+        if (isPolledRead) deadline.CancelAfter(PolledReadTimeout);
+
+        DirectorCommandResult? result;
+        try
+        {
+            result = await _sendCommand(directorId, command, deadline.Token);
+        }
+        catch (Exception) when (deadline.IsCancellationRequested && !ctx.RequestAborted.IsCancellationRequested)
+        {
+            // OUR deadline fired, not the caller's. Catching every exception type rather than
+            // OperationCanceledException is deliberate and is the same lesson DirectorCommandRouter records:
+            // SignalR completes a cancelled client-result invocation with a plain exception reading
+            // "Invocation canceled by the server", so filtering on the type here silently misreports every
+            // real timeout as something else. The TOKEN is the ground truth for whose deadline fired.
+            FileLog.Write($"[TunnelCatchAllDispatch] {ctx.Request.Method} {rest} -> verb={plan.Verb} sid={sid}: "
+                + $"director did not answer within {PolledReadTimeout.TotalSeconds:F0}s");
+            await WriteResultAsync(ctx, DirectorCommandResult.Fail(
+                DirectorCommandStatus.Timeout,
+                $"The Director did not answer within {PolledReadTimeout.TotalSeconds:F0} seconds. "
+                + "What you are seeing is the last information this machine sent."));
+            return true;
+        }
+
         FileLog.Write($"[TunnelCatchAllDispatch] {ctx.Request.Method} {rest} -> verb={plan.Verb} sid={sid}: {(result is null ? "owner not tunnel-connected" : result.Status.ToString())}");
         if (result is null) return false; // owner dropped the tunnel between locate and dispatch (rare) -> caller answers
 
@@ -158,6 +196,47 @@ internal sealed class TunnelCatchAllDispatch
         return obj.ToJsonString();
     }
 
+    /// <summary>
+    /// Response header naming WHOSE fault a failure was, stamped only when the answer is one this Gateway
+    /// produced ABOUT A DIRECTOR (issue #1153).
+    ///
+    /// THE PROBLEM IT SOLVES. A Director that is slow, or whose tunnel blipped, makes this route answer 504
+    /// or 502 - and the browser client treats every 502/503/504 as "the Gateway is unreachable", because that
+    /// is what those codes mean when they come from an edge proxy in front of a Gateway that is DOWN. So one
+    /// machine going quiet for seven seconds told the owner, on his phone, that the GATEWAY was offline, while
+    /// the Gateway was answering him in the same millisecond. The status code alone genuinely cannot carry the
+    /// difference: the same 502 means "I could not be reached" from a proxy and "I am fine, the machine behind
+    /// me did not answer" from us.
+    ///
+    /// WHY A HEADER AND NOT A BODY FIELD. The client's decision is made at the transport choke point, before
+    /// anything reads or parses the body, and reading it there would consume the stream the caller still needs.
+    /// A header is readable at exactly the point the decision is made.
+    ///
+    /// WHY ITS ABSENCE IS THE SAFE DEFAULT. An edge proxy in front of a dead Gateway cannot stamp this, so an
+    /// unstamped 502 keeps meaning exactly what it meant before - unreachable. Only a response carrying this
+    /// header is treated as proof the Gateway itself answered, and only this Gateway can put it there.
+    /// </summary>
+    internal const string FaultSideHeader = "X-DevThrottle-Fault";
+
+    /// <summary>The value of <see cref="FaultSideHeader"/> meaning "the Gateway answered; the Director did not".</summary>
+    internal const string FaultSideDirector = "director";
+
+    /// <summary>
+    /// How long a POLLED READ (turns, history, buffer-html, usage, context, github-urls, queue) waits for its
+    /// Director before the Gateway answers on its own.
+    ///
+    /// It is set FROM the client's own poll cap and must stay strictly under it. The phone caps these polls at
+    /// 10 seconds (POLL_TIMEOUT_MS in packages/client-core/src/api/client.ts); whichever side gives up first
+    /// decides what the owner is told, and only the GATEWAY's answer can say whose fault it was. If the client
+    /// wins the race it has no response, no header and no machine name - just a silence it reports as the
+    /// Gateway being unreachable, which is the defect. Eight seconds leaves two seconds of headroom so this
+    /// bound reliably fires first.
+    ///
+    /// RAISING THIS ABOVE THE CLIENT'S CAP SILENTLY UNDOES THE FIX. If it is ever changed, change it against
+    /// that constant, not on its own.
+    /// </summary>
+    private static readonly TimeSpan PolledReadTimeout = TimeSpan.FromSeconds(8);
+
     // Map a DirectorCommandResult back to the HTTP response the browser expects - the same shape the Director
     // REST route returned (200 + application/json for Ok; the matching typed error code otherwise). BodyJson is
     // already the serialized DTO, so it is written verbatim.
@@ -186,6 +265,16 @@ internal sealed class TunnelCatchAllDispatch
             DirectorCommandStatus.TunnelDropped => StatusCodes.Status502BadGateway,
             _ => StatusCodes.Status500InternalServerError,
         };
+
+        // Stamped for exactly the two outcomes where the Gateway is demonstrably healthy and the DIRECTOR is
+        // the one that failed - it did not answer in time, or its tunnel died mid-command. Both are answers
+        // this Gateway composed, so its own reachability is not in question and must not be reported as though
+        // it were. Every other status is left unstamped: a 400/404/409/423 already proves the Gateway answered
+        // and the client never treated those as unreachable, and a 500 is a Gateway fault, which is precisely
+        // what this header must never be used to disown.
+        if (result.Status is DirectorCommandStatus.Timeout or DirectorCommandStatus.TunnelDropped)
+            ctx.Response.Headers[FaultSideHeader] = FaultSideDirector;
+
         await ctx.Response.WriteAsJsonAsync(new { error = result.Error ?? $"director returned {result.Status}" });
     }
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2059,6 +2059,12 @@ public sealed class GatewayHost : IAsyncDisposable
                 // up-stream producer still chunks at MaxBinaryFrameBytes, so backpressure is unchanged.
                 o.MaximumReceiveMessageSize = Contracts.DirectorStreamLimits.MaxInboundMessageBytes;
                 o.StreamBufferCapacity = Contracts.DirectorStreamLimits.StreamBufferCapacity;
+                // Tunnel liveness (issue #1153). SET EXPLICITLY, and set from the SAME shared constants the
+                // Director's client uses, so the two halves of one timing budget cannot drift apart and
+                // neither side is left running on a framework default nobody chose. Before this, both ends
+                // ran on defaults and a Director hung up 35 times in a day on a Gateway that was alive.
+                o.KeepAliveInterval = Contracts.DirectorStreamLimits.KeepAlivePing;
+                o.ClientTimeoutInterval = Contracts.DirectorStreamLimits.SilenceTolerance;
             });
         builder.Services.AddSingleton(PushedSessions);
         builder.Services.AddSingleton(PushedRepositories);


### PR DESCRIPTION
Draft so CI runs on every push. Does not merge without the owner's word.

Part of devthrottle_internal issue #1153. Scope agreed with the Gateway remediation Architect: `DirectorHub.cs` is theirs and is untouched here.

## Two changes

**1. Explicit tunnel liveness on both ends.** Both sides ran on SignalR defaults - 15s keep-alive against a 30s silence tolerance - so exactly two late pings end the tunnel. The keep-alive is a timer callback on the same thread pool the hub's handlers run on, so a busy Gateway delays the pings first. On 2026-07-30 one Director hung up 35 times in a day on `Server timeout (30000.00ms) elapsed without receiving a message from the server` while the Gateway was alive and answering. Now: ping every 5s, tolerance unchanged at 30s, both read from shared constants in `DirectorStreamLimits` so the pair cannot drift. Six missed pings absorbed where two were fatal.

The tolerance is deliberately **not** lengthened. That would only delay noticing a peer that is genuinely dead.

**2. The re-push timing no longer reports a cancelled wait as a slow push.** The timing sat in a `finally` around the whole send, so when the server-timeout cancelled an in-flight push the length of the wait was logged as `re-push SLOW: took 83.4s` - perfectly true about the wait, and no record of how long the push took. That number sent a day's investigation after the Gateway's speed when the tunnel had gone silent. The tell was that both lines carried identical timestamps. Phases are now timed apart (build here / Gateway accepts) and the outcome names itself.

## What this does NOT do

It does not make the slow pushes fast. A push that **completed** on a healthy connection has been measured at **38.9s** against a 10s cadence; that is the Gateway running whole-fleet folds and a synchronous `SaveChanges` inside the hub invocation, and it belongs to the remediation mission.

I also considered moving the Director from `InvokeAsync` to a fire-and-forget `SendAsync` and did **not** do it. `InvokeAsync` is currently the only backpressure - one re-push in flight at a time - and the only place a hub-side throw becomes visible to the Director. A fire-and-forget send would trade a visible Director stall for an invisible queue growing at a Gateway that is already struggling. Worth revisiting once the hub is fast; not worth it blind.