### PR TITLE
Record the Director memory investigation and commit the analysis tools

### DIFF
--- a/docs/incidents/2026-07-30-director-memory-investigation.md
+++ b/docs/incidents/2026-07-30-director-memory-investigation.md
@@ -1,0 +1,341 @@
+# Director memory investigation - SOREN_NORTH - 2026-07-30
+
+Machine: SOREN_NORTH, 63.78 GB installed, Windows 11 Enterprise 26200.
+Investigated because the machine was sitting at ~53 GB used with many agent sessions running.
+
+**Headline: the sessions were not the problem. Two things were - a leaked microphone
+recorder inside the Director holding 7.5 GB, and a pile of orphaned build servers holding
+another 5-16 GB. Both are fixable, and one of them is a product defect that also explains
+our microphone contention problems.**
+
+The product defect is tracked as issue #2333 and is marked release-blocking.
+
+---
+
+## 1. Starting state
+
+| Measure | Value |
+|---|---|
+| Physical installed | 63.78 GB |
+| Physical in use | 53.1 GB (84%) |
+| Committed | 82.8 GB of a 105.78 GB limit |
+| **Commit peak this boot** | **106.28 GB - the machine had already hit its ceiling** |
+| Processes / threads / handles | 805 / 11,418 / 338,152 |
+
+The commit peak is the number that mattered. Physical pressure shows as slowness; hitting
+the commit limit shows as allocation failures and applications dying. We had already been there.
+
+Where the physical memory sat:
+
+| Owner | Working set |
+|---|---|
+| Process working sets | 46.0 GB |
+| Kernel paged pool | 4.7 GB |
+| Kernel nonpaged pool | 2.2 GB |
+| Drivers / locked / other | 0.35 GB |
+
+Note that ~7 GB lives in the kernel pools and belongs to no process at all. Any report built
+purely by summing process memory silently loses that and looks wrong.
+
+By category, at the busiest sample:
+
+| Category | Procs | Working set | Commit |
+|---|---|---|---|
+| build (MSBuild, test hosts, Roslyn) | 62 | 12.03 GB | 8.30 GB |
+| windows | 167 | 6.44 GB | 4.55 GB |
+| director | 4 | 6.05 GB | 10.33 GB |
+| agent (claude) | 12 | 4.78 GB | 10.88 GB |
+| desktop apps | 182 | 4.47 GB | 6.79 GB |
+| webview2 | 44 | 2.68 GB | 3.84 GB |
+| browser | 39 | 2.24 GB | 2.61 GB |
+| vm / wsl / docker | 17 | 1.03 GB | 3.27 GB |
+| database | 7 | 0.76 GB | 3.23 GB |
+| mcp node servers | 55 | 0.70 GB | 3.34 GB |
+
+## 2. Were sessions left open?
+
+No. Checked directly:
+
+- 14 Director sessions registered, 12-13 live `claude.exe` processes.
+- **Zero** orphaned `conhost.exe` (145 present, every one with a live parent).
+- **Zero** orphaned WebView2 trees.
+
+Cost of one agent session, measured as the agent process plus every descendant:
+
+| | Working set | Commit | Child processes |
+|---|---|---|---|
+| Typical session | 0.5 - 0.8 GB | 1.1 - 1.4 GB | 8 - 14 |
+| Heaviest observed | 1.55 GB | 1.66 GB | 29 |
+| All 12 together | 8.2 GB | - | - |
+
+Sessions are honest consumers. Closing them would have cost working state and freed little.
+Soren had already closed 10-15 sessions before this investigation, so peak session load was
+higher earlier - that was real memory, but it is not what was left behind.
+
+## 3. Root cause: a leaked dictation recorder (7.5 GB)
+
+The main `cc-director.exe` (up 23.6 h, 9 sessions) held 5-6 GB working set and 9.4 GB commit.
+The control arm made it obvious: `cc-director1.exe`, up 4.1 h with 3 sessions, held 0.46 GB.
+
+Runtime counters (`dotnet-counters`, no pause, no dump) split managed from native immediately:
+
+| Counter | main Director | slot 1 Director |
+|---|---|---|
+| Large Object Heap | **7.53 GB** | 0.08 GB |
+| Gen 2 | 1.17 GB | 0.09 GB |
+| GC committed | 8.73 GB | 0.19 GB |
+
+Ninety times the large-object retention for three times the sessions. Only 525 MB of the
+7.5 GB was fragmentation, so the rest was **live, retained** objects - not collection lag.
+
+A heap walk (ClrMD attached to the live process) found the whole heap is five byte arrays:
+
+```
+Heap total : 9.74 GB across 2,618,804 objects
+
+   8,128 MB     14,308  System.Byte[]              <- five arrays are 7,644 MB of this
+     971 MB    433,849  TerminalCell[]
+     621 MB     24,094  Free
+
+=== OBJECTS >= 100 MB : 5 ===
+  2,048.0 MB  System.Byte[]   gen=3 (Large Object Heap)
+  2,048.0 MB  System.Byte[]   gen=3
+  2,048.0 MB  System.Byte[]   gen=3
+  1,200.0 MB  System.Byte[]   gen=3
+    300.0 MB  System.Byte[]   gen=3
+```
+
+All five have the identical retention path back to a GC root:
+
+```
+[root: Stack] NAudio.Wave.WaveInEvent
+  -> EventHandler<NAudio.Wave.WaveInEventArgs>
+    -> CcDirector.Avalonia.Voice.MicAudioCapture
+      -> Action<System.Byte[]>
+        -> CcDirector.Avalonia.Voice.BatchDictationRecorder
+          -> System.IO.MemoryStream
+            -> System.Byte[]          <- 2,048 MB
+```
+
+### What this means
+
+`BatchDictationRecorder` accumulates captured microphone audio into an unbounded
+`MemoryStream`, with no cap of any kind:
+
+```csharp
+// src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+private readonly MemoryStream _audio = new();
+
+private void AppendChunk(byte[] chunk)
+{
+    if (chunk.Length == 0) return;
+    lock (_audioLock)
+    {
+        _audio.Write(chunk, 0, chunk.Length);   // no size limit, no duration limit
+    }
+    ...
+}
+```
+
+Capture format is 24,000 Hz, 16-bit, mono = **48 KB per second** (`MicAudioCapture.SampleRate`).
+That converts the array sizes directly into recording time:
+
+| Array | Audio captured |
+|---|---|
+| 2,048 MB | 12.4 hours |
+| 2,048 MB | 12.4 hours |
+| 2,048 MB | 12.4 hours |
+| 1,200 MB | 7.3 hours |
+| 300 MB | 1.8 hours |
+
+The three at exactly 2,048 MB have hit the .NET single-array ceiling (2 GB) and can grow no
+further. The Director had been up 23.6 hours.
+
+The live-versus-garbage census confirms these are leaks, not collection lag:
+
+| Type | Total in heap | **Reachable (live)** | Garbage |
+|---|---|---|---|
+| `BatchDictationRecorder` | 76 | **6** | 70 |
+| `MicAudioCapture` | 75 | **5** | 70 |
+
+Seventy of each are dead and awaiting collection - that part is normal. But **six recorders
+and five microphone captures are still rooted and still running**, each with a live NAudio
+capture thread appending 48 KB every second, forever.
+
+### Two distinct defects
+
+1. **No bound on dictation length.** No human dictation is 12 hours. The buffer should have
+   a hard cap (a few minutes of audio) after which capture stops and either transcribes or
+   fails loudly. Today the only thing that stops growth is the 2 GB array limit.
+2. **Recorders are leaked.** Five to six simultaneous live recorders is wrong on its own -
+   started and never disposed. `DisposeAsync` exists and unsubscribes correctly, so some
+   path is not calling it. Because the root is a *thread stack* (NAudio's capture thread),
+   the garbage collector can never reclaim these no matter how much pressure builds.
+
+### This is not only a memory bug
+
+Five leaked recorders means **five microphone captures held open at once**. That is very
+likely the same defect behind the Car Mode microphone-contention symptoms - a recorder that
+never released the device. Fixing the leak should fix both.
+
+**Cost of the leak: 48 KB/s per leaked recorder = 172 MB/hour each; with five live, about
+0.86 GB/hour.** That matches a Director growing to 9 GB over a day.
+
+## 4. Second finding: closed sessions are retained (~1.2 GB)
+
+Also from the census - these are all **reachable**, so something still holds them:
+
+| Type | Live instances |
+|---|---|
+| `CircularTerminalBuffer` | 138 |
+| `Session` | 138 |
+| `SessionViewModel` | 151 |
+| `TerminalCell[]` (scrollback lines) | 433,849 (971 MB) |
+
+The Director was running **9** sessions. It holds **138**.
+
+Per-session cost inside the Director is modest and correctly bounded:
+
+- 2 MB raw circular terminal buffer (`AgentOptions.DefaultBufferSizeBytes`, default 2 MB,
+  not overridden in the live config)
+- terminal scrollback capped at 5,000 lines per parser, two parsers per session
+  (`Session.HtmlMaxScrollback` / `StreamMaxScrollback`) - roughly 7 MB
+- **~9-10 MB per session in total**
+
+So history is kept in memory, but it is capped per session and does **not** grow without
+bound as a session gets longer. The growth is in the **number of retained sessions**: about
+129 closed sessions never released, at ~9-10 MB each, is roughly **1.2 GB**.
+
+This needs a follow-up: confirm whether retention is deliberate (a history feature) or an
+event-handler subscription that outlives the session. Not yet proven either way.
+
+## 5. Third finding: orphaned build servers (5-16 GB, fluctuating)
+
+MSBuild worker nodes with `/nodeReuse:true` outlive the build that started them. Observed
+between 46 and 81 of them holding 8-16 GB.
+
+**A trap worth recording.** The obvious test - "parent process is dead, so it is garbage" -
+is WRONG here, and would have broken live builds. Node reuse means a parked node gets
+adopted by a *later* build, so a node with a dead parent may be hard at work for someone
+else. Measured directly:
+
+- 81 nodes had a dead parent. All 81 looked reclaimable by that test.
+- A 45-second CPU watch showed **52 of them were actively working** for the two running
+  continuous-integration builds.
+- Of the 29 that looked idle, **9 more woke up** during the next 45 seconds.
+
+Short idle windows are not proof either. The safe mechanism is the supported one:
+
+```
+dotnet build-server shutdown
+```
+
+A node already connected to a build will not accept a new connection, so this command
+self-selects only genuinely free nodes. It is safe to run at any time, including during
+active builds.
+
+**Result when run:** 23 nodes shut down gracefully, **4.94 GB of node memory freed**,
+physical down 3.88 GB, commit down 4.16 GB. The 46 nodes serving live builds were untouched
+and no build was disturbed.
+
+## 6. What to do
+
+### Product fixes (the real work)
+
+1. **Cap the dictation buffer.** Hard limit on captured audio - a few minutes. On reaching
+   it, stop capture and surface the reason. Never let a buffer run to the 2 GB array ceiling.
+2. **Guarantee recorder disposal.** Find the path that leaks `BatchDictationRecorder`, and
+   add a watchdog that disposes any recorder capturing beyond the cap. Consider enforcing a
+   single live recorder, since more than one is always wrong.
+3. **Investigate session retention** - 138 retained for 9 running.
+4. **Validate configuration.** `DefaultBufferSizeBytes` is read with a bare `GetInt32()` and
+   no clamp; a bad value would allocate that much per session with no guard.
+
+### Operational
+
+5. **Run `dotnet build-server shutdown` routinely** - after continuous-integration jobs, or
+   on a schedule. Consider `MSBUILDDISABLENODEREUSE=1` for the build agents, which trades a
+   little build speed for never accumulating parked nodes.
+6. **Restart the main Director periodically** until fix 1 and 2 ship. It reclaims ~9 GB.
+7. **Restart the two build agents when idle** (`D:\Agents\N_Net8_1`, `N_Net8_2`) - they had
+   been up since 2026-07-29 06:19.
+
+### For the planned Director memory panel
+
+The panel should show, and offer to reclaim:
+
+- physical / commit / **commit peak against the limit** (commit is the number that kills)
+- memory by owner: this Director, each session tree, builds, everything else
+- its own managed heap by generation, with the **Large Object Heap called out** - that single
+  number is what turned this investigation from "the Director is big" into a named cause
+- reclaimable now: free build servers, with a one-click `dotnet build-server shutdown`
+- a warning when its own Large Object Heap crosses a threshold, since that is the signature
+  of exactly this class of bug
+
+## 7. Method, so this is repeatable
+
+Cheapest first; each step narrows the next.
+
+1. **True totals** - `GetPerformanceInfo` via P/Invoke, not the sum of process working sets
+   (that misses ~7 GB of kernel pools).
+2. **Group by process tree** - separates the Director itself from what it spawned. This is
+   what showed the Director's own process was the largest single consumer.
+3. **`dotnet-counters collect --process-id <pid> --counters System.Runtime`** - no pause, no
+   dump. Splits managed from native and gives per-generation heap sizes. One command turned
+   "big" into "the Large Object Heap is big".
+4. **Compare against a control** - the short-lived slot-1 Director. Without it, 7.5 GB is
+   just a number; with it, it is an anomaly.
+5. **Heap walk with ClrMD** - attach to the live process, find objects over a size threshold,
+   then walk breadth-first from every GC root to get the retention path. The path is what
+   names the cause; a type histogram alone would only have said "byte arrays".
+6. **Live-versus-garbage census** - an object present in the heap is not necessarily still
+   needed. Only reachability from a root separates a leak from collection lag. This is what
+   proved 6 live recorders (leak) versus 70 dead ones (normal).
+
+`dotnet-dump collect --type Heap` failed on this process with "Value does not fall within
+the expected range" - a known limitation on very large heaps. `dotnet-gcdump` (53 MB, 3.6
+seconds) and live ClrMD attach both worked fine and are the better tools here anyway.
+
+## 8. Artifacts
+
+Both tools are committed alongside this document so the analysis can be repeated. They are
+read-only: they inspect processes and heaps and change nothing.
+
+| Path | What |
+|---|---|
+| `scripts/memory-analysis/memory_map.py` | Standalone machine memory map; console report plus a self-contained HTML treemap. Needs `psutil`. |
+| `scripts/memory-analysis/heapscan/` | Heap scanner built on ClrMD: big-object finder, root-path walker, live-versus-garbage census. |
+
+Raw output from this investigation was left on the machine at `D:\memory-analysis\`
+(`heapscan-live.txt` has the five retention paths, `heapscan-census.txt` the census,
+`gcdump-report.txt` the type histogram, and the `.gcdump` snapshot opens in Visual Studio or
+PerfView). Those are machine-local and not committed - the findings above are the record.
+
+Rerun the machine map any time:
+
+```
+python scripts/memory-analysis/memory_map.py --html memory-map.html
+```
+
+Rerun the heap analysis against a live Director:
+
+```
+cd scripts/memory-analysis/heapscan
+dotnet build -c Release
+bin/Release/net10.0/heapscan.exe <director-pid> --suspend \
+    --census=CircularTerminalBuffer --census=BatchDictationRecorder
+```
+
+`--suspend` briefly pauses the target for a consistent heap. Omit it to attach without
+pausing, at the cost of occasional invalid reads on a busy heap.
+
+## 9. Caveats
+
+- All figures are a snapshot. Build activity moved the total by 8-10 GB during the session;
+  physical in use ranged 43.9 - 54.2 GB while nothing structural changed.
+- The session-retention finding (138 held for 9 running) is measured but its **cause is not
+  yet established**. Do not treat "closed sessions leak" as proven - only "138 session
+  objects are reachable" is proven.
+- The microphone-contention link is a strong inference from five live captures, not a
+  reproduced failure.
+- The build agents were mid-build throughout and were **not** restarted.

--- a/scripts/memory-analysis/heapscan/Program.cs
+++ b/scripts/memory-analysis/heapscan/Program.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.Runtime;
+
+// Attaches to a running .NET process (or opens a dump), finds the objects that
+// actually hold the heap, and walks back from each one to the GC root that keeps
+// it alive. A type histogram says WHAT is big; only the root path says WHY it is
+// still there, which is the difference between a guess and a cause.
+
+internal static class Program
+{
+    private const long BigObjectThreshold = 100L * 1024 * 1024;
+
+    private static int Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.WriteLine("usage: heapscan <pid|dumpfile> [--suspend]");
+            return 2;
+        }
+
+        bool suspend = args.Contains("--suspend");
+        DataTarget target;
+        if (int.TryParse(args[0], out var pid))
+        {
+            Console.WriteLine($"Attaching to pid {pid} (suspend={suspend})...");
+            target = DataTarget.AttachToProcess(pid, suspend);
+        }
+        else
+        {
+            Console.WriteLine($"Opening dump {args[0]}...");
+            target = DataTarget.LoadDump(args[0]);
+        }
+
+        using (target)
+        {
+            var clrInfo = target.ClrVersions.FirstOrDefault();
+            if (clrInfo is null)
+            {
+                Console.WriteLine("No CLR found in target.");
+                return 3;
+            }
+
+            var runtime = clrInfo.CreateRuntime();
+            var heap = runtime.Heap;
+            if (!heap.CanWalkHeap)
+            {
+                Console.WriteLine("Heap is not walkable (target may be mid-GC). Retry.");
+                return 4;
+            }
+
+            Console.WriteLine("Walking the heap...");
+            var byType = new Dictionary<string, (long Size, long Count)>();
+            var big = new List<(ulong Addr, string Type, ulong Size, ClrSegment Seg)>();
+            long total = 0, objects = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid || obj.Type is null) continue;
+                var size = obj.Size;
+                total += (long)size;
+                objects++;
+
+                var name = obj.Type.Name ?? "<unknown>";
+                byType.TryGetValue(name, out var acc);
+                byType[name] = (acc.Size + (long)size, acc.Count + 1);
+
+                if ((long)size >= BigObjectThreshold)
+                {
+                    var seg = heap.GetSegmentByAddress(obj.Address);
+                    big.Add((obj.Address, name, size, seg));
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Heap total : {total / 1024.0 / 1024 / 1024:F2} GB across {objects:N0} objects");
+            Console.WriteLine();
+
+            Console.WriteLine("=== TOP TYPES BY TOTAL SIZE ===");
+            foreach (var kv in byType.OrderByDescending(k => k.Value.Size).Take(20))
+                Console.WriteLine($"  {kv.Value.Size / 1024.0 / 1024,12:N1} MB  {kv.Value.Count,10:N0}  {Short(kv.Key)}");
+            Console.WriteLine();
+
+            Console.WriteLine($"=== OBJECTS >= {BigObjectThreshold / 1024 / 1024} MB : {big.Count} ===");
+            foreach (var b in big.OrderByDescending(b => b.Size))
+                Console.WriteLine($"  0x{b.Addr:x}  {b.Size / 1024.0 / 1024,10:N1} MB  {Short(b.Type)}  gen={GenOf(b.Seg, b.Addr)}");
+            Console.WriteLine();
+
+            // Live-versus-garbage census for named types. An object still present in
+            // the heap is not necessarily still needed - dead objects linger until the
+            // next gen2 collection, and gen2 is rare. Only reachability from a root
+            // separates a real leak from ordinary collection lag.
+            var censusTypes = args.Where(a => a.StartsWith("--census=", StringComparison.Ordinal))
+                                  .Select(a => a.Substring("--census=".Length))
+                                  .ToArray();
+            var census = new Dictionary<string, List<(ulong Addr, ulong Size)>>();
+            if (censusTypes.Length > 0)
+            {
+                foreach (var t in censusTypes) census[t] = new List<(ulong, ulong)>();
+                foreach (var obj in heap.EnumerateObjects())
+                {
+                    var tn = obj.IsValid ? obj.Type?.Name : null;
+                    if (tn is null) continue;
+                    foreach (var t in censusTypes)
+                        if (tn.Contains(t, StringComparison.OrdinalIgnoreCase))
+                            census[t].Add((obj.Address, obj.Size));
+                }
+            }
+
+            // Reverse-reference walk. Breadth-first from every GC root, remembering
+            // how we arrived at each object, so the first time we touch a target we
+            // already hold the shortest path that keeps it alive.
+            Console.WriteLine("Building reference graph from GC roots...");
+            var targets = new HashSet<ulong>(big.Select(b => b.Addr));
+            var parent = new Dictionary<ulong, ulong>();
+            var rootOf = new Dictionary<ulong, string>();
+            var seen = new HashSet<ulong>();
+            var queue = new Queue<ulong>();
+
+            foreach (var root in heap.EnumerateRoots())
+            {
+                var ro = root.Object;
+                if (ro.Address == 0 || !seen.Add(ro.Address)) continue;
+                rootOf[ro.Address] = $"{root.RootKind} {Short(ro.Type?.Name ?? "?")}";
+                queue.Enqueue(ro.Address);
+            }
+            Console.WriteLine($"  {queue.Count:N0} root objects");
+
+            // Run the walk to exhaustion, not just until the targets are found: the
+            // completed `seen` set IS the reachable set, which the census needs.
+            var found = new Dictionary<ulong, List<ulong>>();
+            while (queue.Count > 0)
+            {
+                var addr = queue.Dequeue();
+                var obj = heap.GetObject(addr);
+                if (!obj.IsValid || obj.Type is null) continue;
+
+                foreach (var child in obj.EnumerateReferences(carefully: true, considerDependantHandles: true))
+                {
+                    if (child.Address == 0 || !seen.Add(child.Address)) continue;
+                    parent[child.Address] = addr;
+                    if (targets.Contains(child.Address) && !found.ContainsKey(child.Address))
+                        found[child.Address] = PathTo(child.Address, parent);
+                    queue.Enqueue(child.Address);
+                }
+            }
+
+            if (census.Count > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("=== LIVE VERSUS GARBAGE CENSUS ===");
+                Console.WriteLine($"  {"type",-52} {"total",7} {"live",7} {"garbage",8} {"live MB",9}");
+                foreach (var kv in census)
+                {
+                    var live = kv.Value.Where(o => seen.Contains(o.Addr)).ToList();
+                    var liveMb = live.Sum(o => (double)o.Size) / 1024 / 1024;
+                    Console.WriteLine($"  {Short(kv.Key),-52} {kv.Value.Count,7:N0} {live.Count,7:N0} " +
+                                      $"{kv.Value.Count - live.Count,8:N0} {liveMb,9:N1}");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("=== WHAT KEEPS EACH BIG OBJECT ALIVE ===");
+            foreach (var b in big.OrderByDescending(b => b.Size))
+            {
+                Console.WriteLine();
+                Console.WriteLine($"0x{b.Addr:x}  {b.Size / 1024.0 / 1024:N1} MB  {Short(b.Type)}");
+                if (!found.TryGetValue(b.Addr, out var path))
+                {
+                    Console.WriteLine("  (no path found from a GC root - object may be unrooted and awaiting collection)");
+                    continue;
+                }
+                path.Reverse();
+                for (int i = 0; i < path.Count; i++)
+                {
+                    var o = heap.GetObject(path[i]);
+                    var tn = Short(o.Type?.Name ?? "?");
+                    var prefix = i == 0 && rootOf.TryGetValue(path[i], out var rk) ? $"[root:{rk}] " : "";
+                    Console.WriteLine($"  {new string(' ', i * 2)}-> {prefix}{tn}  (0x{path[i]:x})");
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private static List<ulong> PathTo(ulong addr, Dictionary<ulong, ulong> parent)
+    {
+        var path = new List<ulong>();
+        var cur = addr;
+        var guard = 0;
+        while (guard++ < 200)
+        {
+            path.Add(cur);
+            if (!parent.TryGetValue(cur, out var p)) break;
+            cur = p;
+        }
+        return path;
+    }
+
+    private static int GenOf(ClrSegment seg, ulong addr)
+    {
+        if (seg is null) return -1;
+        try { return (int)seg.GetGeneration(addr); }
+        catch { return -1; }
+    }
+
+    private static string Short(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return name;
+        return name.Length <= 110 ? name : name.Substring(0, 107) + "...";
+    }
+}

--- a/scripts/memory-analysis/heapscan/heapscan.csproj
+++ b/scripts/memory-analysis/heapscan/heapscan.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <AssemblyName>heapscan</AssemblyName>
+    <RootNamespace>heapscan</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
+  </ItemGroup>
+</Project>

--- a/scripts/memory-analysis/memory_map.py
+++ b/scripts/memory-analysis/memory_map.py
@@ -1,0 +1,602 @@
+"""
+Machine memory map.
+
+Answers three questions without guessing:
+  1. Where has the physical memory actually gone?
+  2. How much of it is the Director, and how much is the sessions it runs?
+  3. What is reclaimable right now, and what would reclaiming it cost?
+
+Standalone: reads only, changes nothing, touches no Director code.
+
+Usage:
+    python memory_map.py                 console report
+    python memory_map.py --html out.html console report + HTML map
+"""
+
+import argparse
+import ctypes
+import ctypes.wintypes as wt
+import html
+import os
+import sys
+import time
+from collections import defaultdict
+
+try:
+    import psutil
+except ImportError:
+    sys.exit("psutil is required: python -m pip install psutil")
+
+GB = 1024.0 ** 3
+MB = 1024.0 ** 2
+
+# How long to watch a process before calling it idle. A process that burns no
+# CPU across this window is not doing work right now; combined with a dead
+# parent that makes a build node a leftover rather than a participant.
+IDLE_SAMPLE_SECONDS = 3.0
+IDLE_CPU_THRESHOLD = 0.05
+
+
+# --------------------------------------------------------------------------
+# System-wide totals. Process working sets never add up to "memory in use" -
+# the kernel pools and the driver-locked pages are not owned by any process,
+# so a report built only from processes always under-counts and looks wrong.
+# --------------------------------------------------------------------------
+
+class PERFORMANCE_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("cb", wt.DWORD),
+        ("CommitTotal", ctypes.c_size_t),
+        ("CommitLimit", ctypes.c_size_t),
+        ("CommitPeak", ctypes.c_size_t),
+        ("PhysicalTotal", ctypes.c_size_t),
+        ("PhysicalAvailable", ctypes.c_size_t),
+        ("SystemCache", ctypes.c_size_t),
+        ("KernelTotal", ctypes.c_size_t),
+        ("KernelPaged", ctypes.c_size_t),
+        ("KernelNonpaged", ctypes.c_size_t),
+        ("PageSize", ctypes.c_size_t),
+        ("HandleCount", wt.DWORD),
+        ("ProcessCount", wt.DWORD),
+        ("ThreadCount", wt.DWORD),
+    ]
+
+
+def system_totals():
+    pi = PERFORMANCE_INFORMATION()
+    pi.cb = ctypes.sizeof(pi)
+    if not ctypes.windll.psapi.GetPerformanceInfo(ctypes.byref(pi), pi.cb):
+        raise ctypes.WinError()
+    page = pi.PageSize
+    vm = psutil.virtual_memory()
+    return {
+        "physical_total": pi.PhysicalTotal * page,
+        "physical_available": pi.PhysicalAvailable * page,
+        "physical_used": (pi.PhysicalTotal - pi.PhysicalAvailable) * page,
+        "commit_total": pi.CommitTotal * page,
+        "commit_limit": pi.CommitLimit * page,
+        "commit_peak": pi.CommitPeak * page,
+        "kernel_paged": pi.KernelPaged * page,
+        "kernel_nonpaged": pi.KernelNonpaged * page,
+        "system_cache": pi.SystemCache * page,
+        "process_count": pi.ProcessCount,
+        "thread_count": pi.ThreadCount,
+        "handle_count": pi.HandleCount,
+        "vm_percent": vm.percent,
+    }
+
+
+# --------------------------------------------------------------------------
+# Process snapshot
+# --------------------------------------------------------------------------
+
+FIELDS = ["pid", "ppid", "name", "create_time", "memory_info", "cmdline", "exe"]
+
+
+def snapshot():
+    procs = {}
+    for p in psutil.process_iter(FIELDS, ad_value=None):
+        try:
+            info = p.info
+            mi = info.get("memory_info")
+            if mi is None:
+                continue
+            procs[info["pid"]] = {
+                "pid": info["pid"],
+                "ppid": info.get("ppid") or 0,
+                "name": info.get("name") or "?",
+                "exe": info.get("exe") or "",
+                "cmdline": " ".join(info.get("cmdline") or []),
+                "create_time": info.get("create_time") or 0.0,
+                "rss": getattr(mi, "rss", 0),
+                "private": getattr(mi, "private", 0),
+                "proc": p,
+            }
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return procs
+
+
+def measure_idle(procs, names):
+    """Mark processes of the given names idle or busy over a sampling window."""
+    targets = [d for d in procs.values() if d["name"].lower() in names]
+    first = {}
+    for d in targets:
+        try:
+            t = d["proc"].cpu_times()
+            first[d["pid"]] = t.user + t.system
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    time.sleep(IDLE_SAMPLE_SECONDS)
+    for d in targets:
+        if d["pid"] not in first:
+            continue
+        try:
+            t = d["proc"].cpu_times()
+            delta = (t.user + t.system) - first[d["pid"]]
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        d["cpu_delta"] = delta
+        d["idle"] = delta < IDLE_CPU_THRESHOLD
+
+
+# --------------------------------------------------------------------------
+# Trees
+# --------------------------------------------------------------------------
+
+def children_map(procs):
+    kids = defaultdict(list)
+    for d in procs.values():
+        kids[d["ppid"]].append(d["pid"])
+    return kids
+
+
+def descendants(pid, kids):
+    out, stack = [], [pid]
+    while stack:
+        for c in kids.get(stack.pop(), ()):
+            out.append(c)
+            stack.append(c)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Classification. One process belongs to exactly one bucket, so the buckets
+# sum to the process total instead of double-counting shared trees.
+# --------------------------------------------------------------------------
+
+BUILD_NAMES = {"msbuild.exe", "vbcscompiler.exe", "testhost.exe", "vstest.console.exe"}
+BROWSER_NAMES = {"chrome.exe", "msedge.exe", "firefox.exe", "brave.exe"}
+SHELL_NAMES = {"conhost.exe", "powershell.exe", "pwsh.exe", "cmd.exe", "bash.exe",
+               "git.exe", "openconsole.exe", "windowsterminal.exe"}
+# Windows itself. Split out so it is obvious how much is the operating system
+# and therefore not ours to reclaim.
+WINDOWS_NAMES = {
+    "svchost.exe", "memory compression", "memcompression", "explorer.exe", "dwm.exe",
+    "runtimebroker.exe", "dllhost.exe", "wmiprvse.exe", "searchhost.exe", "secure system",
+    "registry", "system", "csrss.exe", "lsass.exe", "services.exe", "wininit.exe",
+    "winlogon.exe", "smss.exe", "fontdrvhost.exe", "taskhostw.exe", "sihost.exe",
+    "ctfmon.exe", "textinputhost.exe", "startmenuexperiencehost.exe", "shellexperiencehost.exe",
+    "applicationframehost.exe", "systemsettings.exe", "audiodg.exe", "spoolsv.exe",
+    "msmpeng.exe", "nissrv.exe", "securityhealthservice.exe", "mpdefendercoreservice.exe",
+    "taskmgr.exe", "smartscreen.exe", "backgroundtaskhost.exe", "widgets.exe",
+}
+DB_NAMES = {"sqlservr.exe", "postgres.exe", "mysqld.exe", "redis-server.exe",
+            "sqlwriter.exe", "sqlceip.exe", "reportingservicesservice.exe"}
+VM_NAMES = {"vmmem", "vmmemwsl", "vmwp.exe", "vmcompute.exe", "docker desktop.exe",
+            "com.docker.backend.exe", "com.docker.build.exe", "wslservice.exe"}
+
+
+def classify(d):
+    n = d["name"].lower()
+    cmd = d["cmdline"].lower()
+    if n.startswith("cc-director") or n in ("devthrottle-gateway.exe", "cc-launcher.exe"):
+        return "director"
+    if n == "claude.exe":
+        return "agent"
+    if n in BUILD_NAMES:
+        return "build"
+    if n == "dotnet.exe":
+        if "msbuild.dll" in cmd or "vstest" in cmd or " test " in cmd or cmd.endswith(" test"):
+            return "build"
+        return "dotnet-app"
+    if n == "node.exe":
+        return "mcp-node" if "mcp" in cmd else "node"
+    if n in ("python.exe", "py.exe"):
+        return "python"
+    if n == "msedgewebview2.exe":
+        return "webview"
+    if n in BROWSER_NAMES:
+        return "browser"
+    if n in SHELL_NAMES:
+        return "shell"
+    if n in WINDOWS_NAMES:
+        return "windows"
+    if n in DB_NAMES:
+        return "database"
+    if n in VM_NAMES:
+        return "vm-wsl-docker"
+    return "desktop-apps"
+
+
+# --------------------------------------------------------------------------
+# Reclaim analysis
+# --------------------------------------------------------------------------
+
+def find_reclaimable(procs, kids):
+    """Return a list of reclaim candidates, each with an explicit reason.
+
+    Only two things qualify. Both are caches that exist to make the NEXT build
+    faster and hold no state that matters:
+      - an MSBuild worker node whose driving build process is already gone
+      - a compiler server sitting idle
+    Anything still burning CPU, and anything with a live parent, is left alone:
+    a build that looks idle for three seconds may simply be waiting on a peer.
+    """
+    live = set(procs)
+    out = []
+    for d in procs.values():
+        n = d["name"].lower()
+        cmd = d["cmdline"].lower()
+        idle = d.get("idle", False)
+        age_min = (time.time() - d["create_time"]) / 60.0
+
+        if n == "dotnet.exe" and "msbuild.dll" in cmd and "/nodemode:" in cmd:
+            parent_dead = d["ppid"] not in live
+            if parent_dead and idle:
+                out.append((d, "orphaned MSBuild worker node - driving build has exited"))
+            elif idle and age_min > 15:
+                out.append((d, "idle MSBuild worker node - no CPU, older than 15 min"))
+        elif n == "vbcscompiler.exe" and idle:
+            out.append((d, "idle Roslyn compiler server - restarts on next build"))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+def fmt(b):
+    return "%.2f GB" % (b / GB) if b >= GB else "%.0f MB" % (b / MB)
+
+
+def bar(value, total, width=34):
+    if total <= 0:
+        return " " * width
+    filled = int(round(width * value / total))
+    return "#" * min(filled, width) + "." * max(0, width - filled)
+
+
+def build_report(html_path=None):
+    sys_t = system_totals()
+    procs = snapshot()
+    measure_idle(procs, {"dotnet.exe", "vbcscompiler.exe", "msbuild.exe", "testhost.exe"})
+    kids = children_map(procs)
+
+    proc_rss = sum(d["rss"] for d in procs.values())
+    proc_priv = sum(d["private"] for d in procs.values())
+    kernel = sys_t["kernel_paged"] + sys_t["kernel_nonpaged"]
+    unattributed = sys_t["physical_used"] - proc_rss - kernel
+
+    print("=" * 78)
+    print("MEMORY MAP  -  %s  -  %s" % (os.environ.get("COMPUTERNAME", "?"),
+                                        time.strftime("%Y-%m-%d %H:%M:%S")))
+    print("=" * 78)
+    print()
+    print("PHYSICAL")
+    print("  Installed            %s" % fmt(sys_t["physical_total"]))
+    print("  In use               %s   (%.0f%%)" % (fmt(sys_t["physical_used"]), sys_t["vm_percent"]))
+    print("  Available            %s" % fmt(sys_t["physical_available"]))
+    print()
+    print("COMMIT (physical + page file - the real ceiling)")
+    print("  Committed            %s" % fmt(sys_t["commit_total"]))
+    print("  Commit limit         %s" % fmt(sys_t["commit_limit"]))
+    print("  Headroom             %s" % fmt(sys_t["commit_limit"] - sys_t["commit_total"]))
+    print("  Peak this boot       %s" % fmt(sys_t["commit_peak"]))
+    print()
+    print("WHERE THE PHYSICAL MEMORY IS")
+    rows = [
+        ("Process working sets", proc_rss),
+        ("Kernel paged pool", sys_t["kernel_paged"]),
+        ("Kernel nonpaged pool", sys_t["kernel_nonpaged"]),
+        ("Drivers / locked / other", unattributed),
+    ]
+    for label, val in rows:
+        print("  %-26s %-11s %s" % (label, fmt(val), bar(val, sys_t["physical_used"])))
+    print()
+    print("  %d processes, %d threads, %d handles" %
+          (sys_t["process_count"], sys_t["thread_count"], sys_t["handle_count"]))
+    print()
+
+    # ---- by category -----------------------------------------------------
+    cat_rss, cat_priv, cat_n = defaultdict(int), defaultdict(int), defaultdict(int)
+    for d in procs.values():
+        c = classify(d)
+        d["cat"] = c
+        cat_rss[c] += d["rss"]
+        cat_priv[c] += d["private"]
+        cat_n[c] += 1
+
+    print("BY CATEGORY (working set, then commit)")
+    print("  %-14s %5s %-11s %-11s %s" % ("category", "procs", "working", "commit", ""))
+    for c in sorted(cat_rss, key=lambda k: -cat_rss[k]):
+        print("  %-14s %5d %-11s %-11s %s" %
+              (c, cat_n[c], fmt(cat_rss[c]), fmt(cat_priv[c]), bar(cat_rss[c], proc_rss, 26)))
+    print()
+
+    # ---- Directors -------------------------------------------------------
+    directors = [d for d in procs.values() if d["name"].lower().startswith("cc-director")]
+    print("DIRECTORS")
+    for d in sorted(directors, key=lambda x: -x["rss"]):
+        desc = descendants(d["pid"], kids)
+        t_rss = d["rss"] + sum(procs[c]["rss"] for c in desc)
+        t_priv = d["private"] + sum(procs[c]["private"] for c in desc)
+        agents = [c for c in desc if procs[c]["name"].lower() == "claude.exe"]
+        age_h = (time.time() - d["create_time"]) / 3600.0
+        print("  %s (pid %d), up %.1f h" % (d["name"], d["pid"], age_h))
+        print("    own process        %-11s working   %-11s commit" % (fmt(d["rss"]), fmt(d["private"])))
+        print("    whole tree         %-11s working   %-11s commit" % (fmt(t_rss), fmt(t_priv)))
+        print("    %d agent sessions, %d processes below it" % (len(agents), len(desc)))
+        if agents:
+            print("    per session avg    %-11s working" %
+                  fmt((t_rss - d["rss"]) / len(agents)))
+        print()
+
+    # ---- sessions --------------------------------------------------------
+    agents = [d for d in procs.values() if d["name"].lower() == "claude.exe"]
+    if agents:
+        print("AGENT SESSIONS (each agent plus everything it spawned)")
+        print("  %-8s %-8s %-6s %-11s %-11s %s" %
+              ("pid", "director", "age_h", "tree work", "tree commit", "children"))
+        rowsum = 0
+        for d in sorted(agents, key=lambda x: -(x["rss"])):
+            desc = descendants(d["pid"], kids)
+            t_rss = d["rss"] + sum(procs[c]["rss"] for c in desc)
+            t_priv = d["private"] + sum(procs[c]["private"] for c in desc)
+            rowsum += t_rss
+            age_h = (time.time() - d["create_time"]) / 3600.0
+            print("  %-8d %-8d %-6.1f %-11s %-11s %d" %
+                  (d["pid"], d["ppid"], age_h, fmt(t_rss), fmt(t_priv), len(desc)))
+        print("  %-8s %-8s %-6s %-11s" % ("TOTAL", "", "", fmt(rowsum)))
+        print()
+
+    # ---- top single processes -------------------------------------------
+    print("TOP 15 SINGLE PROCESSES BY WORKING SET")
+    for d in sorted(procs.values(), key=lambda x: -x["rss"])[:15]:
+        print("  %-24s pid %-7d %-11s %s" % (d["name"][:24], d["pid"], fmt(d["rss"]),
+                                             bar(d["rss"], proc_rss, 22)))
+    print()
+
+    # ---- reclaimable -----------------------------------------------------
+    rec = find_reclaimable(procs, kids)
+    rec_total = sum(d["rss"] for d, _ in rec)
+    rec_priv = sum(d["private"] for d, _ in rec)
+    print("RECLAIMABLE RIGHT NOW")
+    if not rec:
+        print("  Nothing. No orphaned or idle build processes found.")
+    else:
+        by_reason = defaultdict(lambda: [0, 0, 0])
+        for d, reason in rec:
+            e = by_reason[reason]
+            e[0] += 1
+            e[1] += d["rss"]
+            e[2] += d["private"]
+        for reason, (n, r, p) in sorted(by_reason.items(), key=lambda kv: -kv[1][1]):
+            print("  %-11s %-11s  %2d procs  %s" % (fmt(r), "(%s commit)" % fmt(p), n, reason))
+        print("  ---")
+        print("  %-11s %-11s  %2d procs  TOTAL" % (fmt(rec_total), "(%s commit)" % fmt(rec_priv), len(rec)))
+        print()
+        print("  Safe way to reclaim all of it (no data loss, no running app touched):")
+        print("    dotnet build-server shutdown")
+        print("  That asks the build servers to exit. It does NOT touch the Director,")
+        print("  the agent sessions, or any editor.")
+    print()
+
+    if html_path:
+        write_html(html_path, sys_t, procs, kids, cat_rss, cat_priv, cat_n,
+                   proc_rss, kernel, unattributed, rec, directors, agents)
+        print("HTML map written: %s" % html_path)
+
+    return sys_t, procs, rec
+
+
+# --------------------------------------------------------------------------
+# HTML map - squarified treemap, self contained, no external assets
+# --------------------------------------------------------------------------
+
+PALETTE = {
+    "director": "#4c78a8", "agent": "#f58518", "build": "#e45756",
+    "webview": "#72b7b2", "browser": "#54a24b", "mcp-node": "#eeca3b",
+    "node": "#b279a2", "python": "#ff9da6", "dotnet-app": "#9d755d",
+    "shell": "#bab0ac", "windows": "#7f8c9b", "database": "#6a5acd",
+    "vm-wsl-docker": "#2f8f9d", "desktop-apps": "#a67f5d", "other": "#8c8c8c",
+    "kernel": "#5c6b73", "unattributed": "#3d4a51",
+}
+
+
+def squarify(items, x, y, w, h):
+    """Classic squarified treemap. items = [(label, value, meta), ...] desc."""
+    out = []
+    items = [i for i in items if i[1] > 0]
+    if not items:
+        return out
+    total = sum(i[1] for i in items)
+    if total <= 0 or w <= 0 or h <= 0:
+        return out
+    scale = (w * h) / total
+    vals = [(i, i[1] * scale) for i in items]
+
+    def worst(row, length):
+        if not row or length <= 0:
+            return float("inf")
+        s = sum(r[1] for r in row)
+        mx, mn = max(r[1] for r in row), min(r[1] for r in row)
+        if s <= 0:
+            return float("inf")
+        return max((length * length * mx) / (s * s), (s * s) / (length * length * mn))
+
+    def layout(row, x, y, w, h, horizontal):
+        s = sum(r[1] for r in row)
+        if s <= 0:
+            return x, y, w, h
+        if horizontal:
+            rh = s / w if w else 0
+            cx = x
+            for it, v in row:
+                rw = v / rh if rh else 0
+                out.append((it, cx, y, rw, rh))
+                cx += rw
+            return x, y + rh, w, h - rh
+        rw = s / h if h else 0
+        cy = y
+        for it, v in row:
+            rh = v / rw if rw else 0
+            out.append((it, x, cy, rw, rh))
+            cy += rh
+        return x + rw, y, w - rw, h
+
+    row = []
+    while vals:
+        horizontal = w <= h
+        length = w if horizontal else h
+        head = vals[0]
+        if not row or worst(row + [head], length) <= worst(row, length):
+            row.append(head)
+            vals.pop(0)
+        else:
+            x, y, w, h = layout(row, x, y, w, h, horizontal)
+            row = []
+    if row:
+        layout(row, x, y, w, h, w <= h)
+    return out
+
+
+def write_html(path, sys_t, procs, kids, cat_rss, cat_priv, cat_n,
+               proc_rss, kernel, unattributed, rec, directors, agents):
+    W, H = 1160, 620
+    used = sys_t["physical_used"]
+
+    # Top level: every process grouped by category, plus the two non-process blocks.
+    top = [("%s" % c, cat_rss[c], {"cat": c, "n": cat_n[c], "commit": cat_priv[c]})
+           for c in cat_rss]
+    top.append(("kernel pools", kernel, {"cat": "kernel", "n": 0, "commit": kernel}))
+    top.append(("drivers / locked", max(unattributed, 0),
+                {"cat": "unattributed", "n": 0, "commit": 0}))
+    top.sort(key=lambda i: -i[1])
+    tiles = squarify(top, 0, 0, W, H)
+
+    rec_ids = {d["pid"] for d, _ in rec}
+    rec_total = sum(d["rss"] for d, _ in rec)
+
+    def esc(s):
+        return html.escape(str(s))
+
+    parts = []
+    parts.append("<title>Memory map - %s</title>" % esc(os.environ.get("COMPUTERNAME", "")))
+    parts.append("""<style>
+:root{--bg:#ffffff;--fg:#16191d;--muted:#5b6570;--line:#e3e6ea;--card:#f7f8fa;}
+@media (prefers-color-scheme:dark){:root{--bg:#14171a;--fg:#e8eaed;--muted:#9aa4ae;--line:#2a2f36;--card:#1c2025;}}
+:root[data-theme="dark"]{--bg:#14171a;--fg:#e8eaed;--muted:#9aa4ae;--line:#2a2f36;--card:#1c2025;}
+:root[data-theme="light"]{--bg:#ffffff;--fg:#16191d;--muted:#5b6570;--line:#e3e6ea;--card:#f7f8fa;}
+body{background:var(--bg);color:var(--fg);font:15px/1.55 -apple-system,Segoe UI,Roboto,sans-serif;margin:0;padding:28px;}
+h1{font-size:22px;margin:0 0 4px;} h2{font-size:16px;margin:30px 0 10px;letter-spacing:.02em;text-transform:uppercase;color:var(--muted);}
+.sub{color:var(--muted);font-size:13px;margin-bottom:22px;}
+.kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:26px;}
+.kpi{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 14px;}
+.kpi .v{font-size:21px;font-weight:600;} .kpi .l{color:var(--muted);font-size:12px;}
+.mapwrap{overflow-x:auto;} .map{position:relative;width:%dpx;height:%dpx;border:1px solid var(--line);border-radius:8px;overflow:hidden;}
+.tile{position:absolute;overflow:hidden;box-sizing:border-box;border:1px solid rgba(255,255,255,.35);color:#fff;padding:6px 8px;}
+.tile b{display:block;font-size:13px;} .tile span{font-size:11px;opacity:.9;}
+table{border-collapse:collapse;width:100%%;font-size:14px;} th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);}
+th{color:var(--muted);font-weight:600;font-size:12px;text-transform:uppercase;} td.n{text-align:right;font-variant-numeric:tabular-nums;}
+.flag{color:#e45756;font-weight:600;} .ok{color:#54a24b;}
+.note{background:var(--card);border-left:3px solid #4c78a8;padding:12px 14px;border-radius:6px;margin:14px 0;font-size:14px;}
+code{background:var(--card);padding:2px 6px;border-radius:4px;font-size:13px;}
+</style>""" % (W, H))
+
+    parts.append("<h1>Memory map</h1>")
+    parts.append('<div class="sub">%s &middot; %s &middot; %d processes, %d threads</div>' %
+                 (esc(os.environ.get("COMPUTERNAME", "")), time.strftime("%Y-%m-%d %H:%M:%S"),
+                  sys_t["process_count"], sys_t["thread_count"]))
+
+    kpis = [
+        ("Installed", fmt(sys_t["physical_total"])),
+        ("Physical in use", fmt(used)),
+        ("Available", fmt(sys_t["physical_available"])),
+        ("Committed", fmt(sys_t["commit_total"])),
+        ("Commit limit", fmt(sys_t["commit_limit"])),
+        ("Reclaimable now", fmt(rec_total)),
+    ]
+    parts.append('<div class="kpis">')
+    for l, v in kpis:
+        parts.append('<div class="kpi"><div class="v">%s</div><div class="l">%s</div></div>' % (esc(v), esc(l)))
+    parts.append("</div>")
+
+    parts.append("<h2>Physical memory, by owner</h2>")
+    parts.append('<div class="mapwrap"><div class="map">')
+    for (label, val, meta), x, y, w, h in tiles:
+        if w < 1 or h < 1:
+            continue
+        color = PALETTE.get(meta["cat"], "#8c8c8c")
+        show = w > 62 and h > 26
+        inner = ""
+        if show:
+            inner = "<b>%s</b><span>%s%s</span>" % (
+                esc(label), esc(fmt(val)),
+                (" &middot; %d procs" % meta["n"]) if meta["n"] else "")
+        parts.append('<div class="tile" style="left:%.1fpx;top:%.1fpx;width:%.1fpx;height:%.1fpx;background:%s" title="%s - %s">%s</div>'
+                     % (x, y, w, h, color, esc(label), esc(fmt(val)), inner))
+    parts.append("</div></div>")
+
+    parts.append("<h2>Directors</h2><table><tr><th>process</th><th>up</th><th class='n'>own working set</th><th class='n'>own commit</th><th class='n'>whole tree</th><th class='n'>sessions</th><th class='n'>procs below</th></tr>")
+    for d in sorted(directors, key=lambda x: -x["rss"]):
+        desc = descendants(d["pid"], kids)
+        t_rss = d["rss"] + sum(procs[c]["rss"] for c in desc)
+        n_ag = len([c for c in desc if procs[c]["name"].lower() == "claude.exe"])
+        age_h = (time.time() - d["create_time"]) / 3600.0
+        flag = ' class="flag"' if d["rss"] > 2 * GB else ""
+        parts.append("<tr><td>%s <span style='color:var(--muted)'>pid %d</span></td><td>%.1f h</td><td class='n'%s>%s</td><td class='n'>%s</td><td class='n'>%s</td><td class='n'>%d</td><td class='n'>%d</td></tr>"
+                     % (esc(d["name"]), d["pid"], age_h, flag, esc(fmt(d["rss"])),
+                        esc(fmt(d["private"])), esc(fmt(t_rss)), n_ag, len(desc)))
+    parts.append("</table>")
+
+    parts.append("<h2>Agent sessions</h2><table><tr><th>agent pid</th><th>director</th><th>age</th><th class='n'>tree working set</th><th class='n'>tree commit</th><th class='n'>child procs</th></tr>")
+    for d in sorted(agents, key=lambda x: -x["rss"]):
+        desc = descendants(d["pid"], kids)
+        t_rss = d["rss"] + sum(procs[c]["rss"] for c in desc)
+        t_priv = d["private"] + sum(procs[c]["private"] for c in desc)
+        age_h = (time.time() - d["create_time"]) / 3600.0
+        parts.append("<tr><td>%d</td><td>%d</td><td>%.1f h</td><td class='n'>%s</td><td class='n'>%s</td><td class='n'>%d</td></tr>"
+                     % (d["pid"], d["ppid"], age_h, esc(fmt(t_rss)), esc(fmt(t_priv)), len(desc)))
+    parts.append("</table>")
+
+    parts.append("<h2>Reclaimable right now</h2>")
+    if not rec:
+        parts.append('<div class="note ok">Nothing reclaimable - no orphaned or idle build processes.</div>')
+    else:
+        by_reason = defaultdict(lambda: [0, 0])
+        for d, reason in rec:
+            by_reason[reason][0] += 1
+            by_reason[reason][1] += d["rss"]
+        parts.append("<table><tr><th>reason</th><th class='n'>processes</th><th class='n'>working set</th></tr>")
+        for reason, (n, r) in sorted(by_reason.items(), key=lambda kv: -kv[1][1]):
+            parts.append("<tr><td>%s</td><td class='n'>%d</td><td class='n'>%s</td></tr>" % (esc(reason), n, esc(fmt(r))))
+        parts.append("<tr><td><b>Total</b></td><td class='n'><b>%d</b></td><td class='n'><b>%s</b></td></tr></table>" % (len(rec), esc(fmt(rec_total))))
+        parts.append('<div class="note">Reclaim all of it without touching the Director, the agent sessions, or any editor: <code>dotnet build-server shutdown</code></div>')
+
+    parts.append("<h2>Top processes</h2><table><tr><th>process</th><th>pid</th><th>category</th><th class='n'>working set</th><th class='n'>commit</th></tr>")
+    for d in sorted(procs.values(), key=lambda x: -x["rss"])[:25]:
+        mark = ' <span class="flag">reclaimable</span>' if d["pid"] in rec_ids else ""
+        parts.append("<tr><td>%s%s</td><td>%d</td><td>%s</td><td class='n'>%s</td><td class='n'>%s</td></tr>"
+                     % (esc(d["name"]), mark, d["pid"], esc(d.get("cat", "")), esc(fmt(d["rss"])), esc(fmt(d["private"]))))
+    parts.append("</table>")
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(parts))
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--html", help="also write an HTML memory map to this path")
+    a = ap.parse_args()
+    build_report(a.html)


### PR DESCRIPTION
Documents where a day-old Director's 9.4 gigabytes went, and commits the two read-only tools used to find it so the analysis can be repeated on any machine.

## What it found

The Director's entire managed heap was five byte arrays of captured microphone audio - 2048, 2048, 2048, 1200 and 300 megabytes - every one rooted through `BatchDictationRecorder`. The audio buffer has no cap, and recorders are leaked rather than disposed: six were still live, pinning five microphones open at once. At 48 kilobytes per second that is 12.4 hours of continuous recording in each of the three that reached the 2 gigabyte array ceiling.

Filed as issue thefrederiksen/devthrottle_internal#1286 and marked release-blocking. That issue carries the fix; this pull request only records the investigation.

Sessions were not the cause. No orphaned console hosts, no orphaned web views, and a session costs about 9-10 megabytes inside the Director with its terminal scrollback already capped at 5,000 lines per parser - so a long session costs no more than a short one.

## Also recorded

The trap this investigation walked into, because the next person will hit it too: a dead parent does **not** make an MSBuild worker node reclaimable. Node reuse means a later build adopts a parked node, so 52 of 81 apparent orphans turned out to be actively serving live continuous-integration builds. Killing them by process inspection would have broken those builds. `dotnet build-server shutdown` is the safe verb, because a node already connected to a build will not accept a new connection.

## What is deliberately not claimed

Two things are written down as measured but explicitly **not** proven, so they are not mistaken for conclusions later:

- 138 `Session` and `CircularTerminalBuffer` objects were reachable while only 9 sessions were running, roughly 1.2 gigabytes. Measured; cause not established. Deserves its own issue.
- The link between the five live microphone captures and the Car Mode contention symptoms is a strong inference, not a reproduced failure.

## Contents

- `docs/incidents/2026-07-30-director-memory-investigation.md` - the write-up, including the diagnostic method in cheapest-first order and notes for the planned Director memory panel.
- `scripts/memory-analysis/memory_map.py` - machine memory map; console report plus a self-contained HTML treemap. Reads true system totals rather than summing process working sets, which would silently lose about 7 gigabytes of kernel pools.
- `scripts/memory-analysis/heapscan/` - heap scanner on ClrMD: finds oversized objects, walks back to the garbage collector root that keeps each alive, and runs a live-versus-garbage census that separates a real leak from objects merely awaiting collection.

Documentation and standalone scripts only. No product code changes, nothing in the build.
