### PR TITLE
fix(gateway-tests): stop pinning the stats schema version to a literal in five files

### DIFF
--- a/src/CcDirector.Gateway.Tests/ConcurrencyTablesAreAdditiveTests.cs
+++ b/src/CcDirector.Gateway.Tests/ConcurrencyTablesAreAdditiveTests.cs
@@ -67,7 +67,12 @@ public sealed class ConcurrencyTablesAreAdditiveTests : IDisposable
         // already has on disk.
         using (var real = new GatewayStatsDatabase(_path))
         {
-            Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
+            // The fixture is the FILE this block just created by running the real shipped code; what it
+            // must look like is pinned by the assertions that follow. There used to be an
+            // Assert.Equal(5, GatewayStatsDatabase.SchemaVersion) here - a literal copy of a constant,
+            // which can only ever fail when somebody legitimately moves the constant. Raising the
+            // schema version to 7 did exactly that and reddened five files at once for no defect
+            // (issue #1156). A pin that fires on correct changes is noise, not a guard.
         }
 
         var tables = TableNamesInTheRealFile();

--- a/src/CcDirector.Gateway.Tests/Data/GatewayStatsSqliteAdoptionTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayStatsSqliteAdoptionTests.cs
@@ -46,20 +46,34 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     }
 
     /// <summary>
-    /// Build a REAL version 5 statistics store at <see cref="_path"/> by running the shipped hand-rolled
-    /// creation and migration code, then close it so the file is free. This is the state every self-host user
-    /// who has ever opened the statistics page is in: sixteen tables, PRAGMA user_version 5, and no
-    /// __EFMigrationsHistory table.
+    /// Build a REAL hand-rolled statistics store at <see cref="_path"/> by running the shipped
+    /// <see cref="GatewayStatsDatabase"/> creation and migration code, then close it so the file is free.
+    /// This is the state every self-host user who has ever opened the statistics page is in: the full table
+    /// set, PRAGMA user_version stamped by the hand-rolled migrator, and no __EFMigrationsHistory table.
+    ///
+    /// WHY THIS IS NOT PINNED TO A VERSION NUMBER ANY MORE. It used to assert the literal 5 in two places,
+    /// which is how it broke: raising <see cref="GatewayStatsDatabase.SchemaVersion"/> to 7 left the
+    /// assertion behind and the whole class failed on arrival. A literal copy of a constant, kept in a second
+    /// place, rots the first time the constant moves - and the version number was never the premise anyway.
+    ///
+    /// The premise that actually matters is UNCHANGED and still pinned below: the file is produced by running
+    /// the REAL shipped code (never hand-written, never synthesised from the new model's idea of the old
+    /// schema), and it carries NO EF migrations-history table, so adoption has something genuine to adopt.
+    /// The version is asserted against the shipped constant rather than a literal, so the fixture keeps
+    /// telling the truth as the schema moves, and still fails loudly if the file and the build ever disagree.
+    ///
+    /// This is also the right shape for the field. A user upgrading arrives with an older file, the
+    /// hand-rolled migrator brings it up to the current version on open, and adoption runs on THAT - so a
+    /// store at the current version is exactly the state adoption meets in practice.
     /// </summary>
-    private void BuildRealVersion5Store()
+    private void BuildRealHandRolledStore()
     {
         using (var db = new GatewayStatsDatabase(_path))
         {
             // Pin the fixture's own premises. If the shipped code ever stops producing this shape, these
             // tests must say so here rather than silently going on to prove something about a file that no
             // longer exists in the field.
-            Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
-            Assert.Equal(5, ScalarInt(db.Connection, "PRAGMA user_version"));
+            Assert.Equal(GatewayStatsDatabase.SchemaVersion, ScalarInt(db.Connection, "PRAGMA user_version"));
             Assert.Equal(0, ScalarInt(db.Connection,
                 "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'"));
         }
@@ -132,7 +146,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Migrate_Version5Store_WithoutAdoption_FailsOnTablesThatAlreadyExist()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using var context = OpenContext();
 
@@ -153,7 +167,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_RealVersion5Store_StampsBaselineAndLetsTheChainRun()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         using var context = OpenContext();
@@ -178,7 +192,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_RealVersion5Store_KeepsEveryRowItAlreadyHeld()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         using var context = OpenContext();
@@ -227,7 +241,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_AlreadyAdoptedStore_IsTrackedAndDoesNothingTwice()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var first = OpenContext())
         {
@@ -310,7 +324,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [InlineData(6)]  // written by a newer build that knows something this one does not
     public void Adopt_StatisticsStoreAtAnotherVersion_IsRefusedWithANamedReasonAndLeftUntouched(int version)
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         // Move the REAL store's version stamp. The file keeps its genuine version 5 table shape, so this
@@ -388,7 +402,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_NeverThrowsOnAnyStateAUsersFileCanBeIn()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         using (var connection = new SqliteConnection(
@@ -429,7 +443,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_HistoryTableWithoutTheBaseline_IsRefusedRatherThanCertifiedAsTracked()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         // The state an interrupted first migration leaves: the history table exists and records nothing,
         // while the sixteen tables are already there. Created with Entity Framework's OWN create script, so
@@ -469,7 +483,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_TrackedStoreWithATableDropped_IsRefusedAndLeavesTheFileByteIdentical()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var context = OpenContext())
         {
@@ -505,7 +519,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_StoreWhoseTableHasTheRightNamesAndNothingElse_IsRefusedAndLeavesTheFileByteIdentical()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         // The exact column names, and no primary key, no NOT NULL, no default and no indexes. A names-only
         // check adopted this and stamped it.
@@ -621,7 +635,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_StoreCarryingAnAbandonedMigrationLock_RefusesImmediatelyRatherThanWaitingForever()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var connection = new SqliteConnection(
                    new SqliteConnectionStringBuilder { DataSource = _path }.ToString()))
@@ -674,7 +688,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_TrackedStoreWrittenByANewerBuild_IsRefusedAndLeavesTheFileByteIdentical()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var context = OpenContext())
         {
@@ -747,7 +761,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
             "lock reaches the operator through the wrong bucket - which is the misdirection this work exists " +
             "to remove.");
 
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         // A second connection holds a real write transaction, so adoption must genuinely contend for it.
         using var holder = new SqliteConnection(
@@ -806,7 +820,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_AHealthyVersion5StoreWithRows_IsNeverRefused()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         using var context = OpenContext();
@@ -826,7 +840,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_AHealthyVersion5StoreWithEveryTablePopulated_IsNeverRefused()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var db = new GatewayStatsDatabase(_path))
         {
@@ -936,7 +950,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_AVersion5StoreWithAnExtraColumn_IsStillAdopted()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedDistinguishableStatDeltaRows();
 
         using (var connection = new SqliteConnection(
@@ -971,7 +985,7 @@ public sealed class GatewayStatsSqliteAdoptionTests : IDisposable
     [Fact]
     public void Adopt_AVersion5StoreMissingAColumn_IsRefused()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
 
         using (var connection = new SqliteConnection(
                    new SqliteConnectionStringBuilder { DataSource = _path }.ToString()))

--- a/src/CcDirector.Gateway.Tests/Data/GatewayStatsSqliteBaselineEquivalenceTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayStatsSqliteBaselineEquivalenceTests.cs
@@ -90,7 +90,12 @@ public sealed class GatewayStatsSqliteBaselineEquivalenceTests : IDisposable
     {
         using (var db = new GatewayStatsDatabase(_handRolledPath))
         {
-            Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
+            // The fixture is the FILE this block just created by running the real shipped code; what it
+            // must look like is pinned by the assertions that follow. There used to be an
+            // Assert.Equal(5, GatewayStatsDatabase.SchemaVersion) here - a literal copy of a constant,
+            // which can only ever fail when somebody legitimately moves the constant. Raising the
+            // schema version to 7 did exactly that and reddened five files at once for no defect
+            // (issue #1156). A pin that fires on correct changes is noise, not a guard.
         }
         SqliteConnection.ClearAllPools();
     }

--- a/src/CcDirector.Gateway.Tests/GatewayStatsStoreMidChainContainmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsStoreMidChainContainmentTests.cs
@@ -89,7 +89,12 @@ public sealed class GatewayStatsStoreMidChainContainmentTests : IDisposable
     {
         using (var db = new GatewayStatsDatabase(SqlitePath))
         {
-            Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
+            // The fixture is the FILE this block just created by running the real shipped code; what it
+            // must look like is pinned by the assertions that follow. There used to be an
+            // Assert.Equal(5, GatewayStatsDatabase.SchemaVersion) here - a literal copy of a constant,
+            // which can only ever fail when somebody legitimately moves the constant. Raising the
+            // schema version to 7 did exactly that and reddened five files at once for no defect
+            // (issue #1156). A pin that fires on correct changes is noise, not a guard.
         }
 
         SqliteConnection.ClearAllPools();

--- a/src/CcDirector.Gateway.Tests/GatewayStatsStoreRefusalLeavesTheStoreUntouchedTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsStoreRefusalLeavesTheStoreUntouchedTests.cs
@@ -116,7 +116,7 @@ public sealed class GatewayStatsStoreRefusalLeavesTheStoreUntouchedTests : IDisp
     [Fact]
     public void StoreAtAnUnadoptableVersion_IsRefused_AndKeepsEveryTableAndRow()
     {
-        BuildRealVersion5Store();
+        BuildRealHandRolledStore();
         SeedOneStatDeltaRow();
         SetUserVersion(99);
 
@@ -174,11 +174,16 @@ public sealed class GatewayStatsStoreRefusalLeavesTheStoreUntouchedTests : IDisp
 
     /// <summary>A REAL version 5 store, built by running the shipped hand-rolled creation code rather than
     /// by describing what such a file is believed to contain.</summary>
-    private void BuildRealVersion5Store()
+    private void BuildRealHandRolledStore()
     {
         using (var db = new GatewayStatsDatabase(SqlitePath))
         {
-            Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
+            // The fixture is the FILE this block just created by running the real shipped code; what it
+            // must look like is pinned by the assertions that follow. There used to be an
+            // Assert.Equal(5, GatewayStatsDatabase.SchemaVersion) here - a literal copy of a constant,
+            // which can only ever fail when somebody legitimately moves the constant. Raising the
+            // schema version to 7 did exactly that and reddened five files at once for no defect
+            // (issue #1156). A pin that fires on correct changes is noise, not a guard.
         }
 
         SqliteConnection.ClearAllPools();


### PR DESCRIPTION
Partial fix for a red main. See devthrottle_internal#1170 for the full diagnosis.

## What broke

`fb658e3d5` (#2335) raised `GatewayStatsDatabase.SchemaVersion` from **5 to 7**. Five test files
carried a hardcoded copy of that constant:

```csharp
Assert.Equal(5, GatewayStatsDatabase.SchemaVersion);
```

That compares a constant against a literal copy of itself kept somewhere else. It cannot catch a
defect - it can only fire when somebody legitimately moves the constant, which is exactly what
happened, reddening five files at once for no defect. A pin that goes off on correct changes is
noise, not a guard.

## What this does

The four incidental copies are removed - what those fixtures must look like is already pinned by the
assertions that follow them. The adoption fixture keeps a pin, but one that cannot rot: the FILE the
shipped code just produced must carry the SHIPPED version. That stays true as the schema moves and
still fails loudly if the file and the build ever disagree.

`BuildRealVersion5Store` is renamed `BuildRealHandRolledStore` because the old name became untrue.
`GatewayStatsDatabase` migrates any file it opens up to `SchemaVersion`, so running the shipped code
can no longer produce a version 5 file at all. Changing the literal to 7 would have papered over
that. The renamed scenario is also the right one for the field: a user upgrading arrives with an
older file, the hand-rolled migrator brings it to the current version on open, and adoption runs on
THAT.

## What is STILL RED, and is not this

On pristine main the adoption class fails **20 of 24** in isolation. With this change it fails
**15 of 24**. The remainder are broader than any version premise - they include cases with no
pre-existing file at all:

- `Adopt_NoFile_IsAFreshStoreAndTheChainCreatesTheSchema`
- `Adopt_EmptyFile_IsAFreshStoreRatherThanAnIncompatibleVersion`
- `TheWriteLockWait_IsStrictlyInsideTheCallersContainmentDeadline`

That points at the adoption path itself rather than at stale test premises, and wants the author of
#2335. It is filed as devthrottle_internal#1170 rather than guessed at here.

## On CI

CI cannot be green on this branch, because main itself is red - that is the thing being partially
fixed. The evidence for this change is the isolated before/after on the affected classes (20 -> 15
failures), not a green tick it cannot earn yet.

Deliberately not bundled with the local-testing work on #1156: this is an unrelated regression on
main and should be reviewable and revertable on its own.