### PR TITLE
Add a memory diagnostics library: read it, rule on it, spot the leak

### DIFF
--- a/src/CcDirector.Core.Tests/Memory/MemoryPressureFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Memory/MemoryPressureFoldTests.cs
@@ -1,0 +1,342 @@
+using CcDirector.Core.Memory;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Memory;
+
+/// <summary>
+/// The memory pressure rule, the leak rule, and the fold.
+///
+/// The numbers in these tests are the real ones measured on SOREN_NORTH on 2026-07-30, when a
+/// Director that had been up for a day held 7.53 GB of Large Object Heap out of a 9.74 GB heap
+/// and the machine's commit peak passed its own limit. Using the real shape means these tests
+/// answer a specific question: would this library have caught it?
+/// </summary>
+public class MemoryPressureFoldTests
+{
+    private const long GB = 1024L * 1024 * 1024;
+
+    private static MachineMemoryReading Machine(
+        long physicalTotal, long physicalAvailable,
+        long commitTotal, long commitLimit, long commitPeak = 0)
+        => new(
+            PhysicalTotalBytes: physicalTotal,
+            PhysicalAvailableBytes: physicalAvailable,
+            CommitTotalBytes: commitTotal,
+            CommitLimitBytes: commitLimit,
+            CommitPeakBytes: commitPeak == 0 ? commitTotal : commitPeak,
+            KernelPagedBytes: 0,
+            KernelNonPagedBytes: 0,
+            ProcessCount: 0, ThreadCount: 0, HandleCount: 0);
+
+    private static ManagedHeapReading Heap(
+        long loh, long total, int gen2Collections, DateTimeOffset at, long fragmentation = 0)
+        => new(
+            TotalHeapBytes: total,
+            Gen0Bytes: 0, Gen1Bytes: 0,
+            Gen2Bytes: Math.Max(0, total - loh),
+            LargeObjectHeapBytes: loh,
+            PinnedObjectHeapBytes: 0,
+            LargeObjectHeapFragmentationBytes: fragmentation,
+            CommittedBytes: total,
+            Gen2CollectionCount: gen2Collections,
+            PauseTimePercentage: 0,
+            TakenAtUtc: at);
+
+    // ---- the pressure rule -------------------------------------------------
+
+    [Fact]
+    public void LevelFor_PlentyOfCommitAndPhysical_IsNormal()
+    {
+        var r = Machine(64 * GB, 30 * GB, commitTotal: 40 * GB, commitLimit: 105 * GB);
+        Assert.Equal(MemoryPressureLevel.Normal, MemoryPressureRule.LevelFor(r));
+    }
+
+    /// <summary>
+    /// The measured machine: 84 percent of physical in use looks alarming, but with commit at
+    /// 78 percent there was still real headroom. Judging on physical alone would cry wolf here.
+    /// </summary>
+    [Fact]
+    public void LevelFor_HighPhysicalButCommitHasHeadroom_IsNotCritical()
+    {
+        var r = Machine(64 * GB, 10 * GB, commitTotal: 82 * GB, commitLimit: 105 * GB);
+        Assert.NotEqual(MemoryPressureLevel.Critical, MemoryPressureRule.LevelFor(r));
+    }
+
+    /// <summary>
+    /// The failure this library exists to catch: commit near its limit. Physical is comfortable,
+    /// so a physical-only monitor would report everything fine right up to the allocation failure.
+    /// </summary>
+    [Fact]
+    public void LevelFor_CommitNearItsLimit_IsCriticalEvenWithPhysicalFree()
+    {
+        var r = Machine(64 * GB, 25 * GB, commitTotal: 100 * GB, commitLimit: 105 * GB);
+        Assert.Equal(MemoryPressureLevel.Critical, MemoryPressureRule.LevelFor(r));
+    }
+
+    [Fact]
+    public void HasExhaustedCommitSinceBoot_PeakAboveLimit_IsTrue()
+    {
+        // 106.28 GB peak against a 105.78 GB limit - the real reading.
+        var r = Machine(64 * GB, 20 * GB,
+            commitTotal: 70 * GB,
+            commitLimit: (long)(105.78 * GB),
+            commitPeak: (long)(106.28 * GB));
+
+        Assert.True(r.HasExhaustedCommitSinceBoot);
+        Assert.Equal(MemoryPressureLevel.Normal, MemoryPressureRule.LevelFor(r));
+    }
+
+    // ---- the leak rule -----------------------------------------------------
+
+    /// <summary>
+    /// Growth with no generation 2 collection in the window proves nothing - the Large Object
+    /// Heap is only swept on such a collection, so this may be garbage nobody has collected yet.
+    /// </summary>
+    [Fact]
+    public void Judge_GrowthButNoCollection_IsUndetermined()
+    {
+        var t0 = DateTimeOffset.UnixEpoch;
+        var readings = new[]
+        {
+            Heap(2 * GB, 3 * GB, gen2Collections: 7, t0),
+            Heap(5 * GB, 6 * GB, gen2Collections: 7, t0.AddHours(1)),
+            Heap(7 * GB, 8 * GB, gen2Collections: 7, t0.AddHours(2)),
+        };
+
+        var verdict = LargeObjectHeapLeakRule.Judge(readings);
+
+        Assert.Equal(LeakSuspicion.Undetermined, verdict.Suspicion);
+        Assert.Contains("no generation 2 collection", verdict.Reason);
+    }
+
+    /// <summary>The real Director shape: growth that survived collections is retention.</summary>
+    [Fact]
+    public void Judge_GrowthSurvivingCollections_IsSuspected()
+    {
+        var t0 = DateTimeOffset.UnixEpoch;
+        var readings = new[]
+        {
+            Heap((long)(2.0 * GB), (long)(2.9 * GB), gen2Collections: 10, t0),
+            Heap((long)(4.5 * GB), (long)(5.9 * GB), gen2Collections: 14, t0.AddHours(6)),
+            Heap((long)(7.53 * GB), (long)(9.74 * GB), gen2Collections: 19, t0.AddHours(12)),
+        };
+
+        var verdict = LargeObjectHeapLeakRule.Judge(readings);
+
+        Assert.Equal(LeakSuspicion.Suspected, verdict.Suspicion);
+        Assert.True(verdict.GrowthBytesPerHour > 0);
+        Assert.Equal(9, verdict.Gen2CollectionsInWindow);
+        Assert.Contains("retained rather than uncollected", verdict.Reason);
+    }
+
+    /// <summary>A big but flat Large Object Heap is not a leak. Reporting it as one trains people to ignore the warning.</summary>
+    [Fact]
+    public void Judge_LargeButFlat_IsHealthy()
+    {
+        var t0 = DateTimeOffset.UnixEpoch;
+        var readings = new[]
+        {
+            Heap(4 * GB, 5 * GB, gen2Collections: 10, t0),
+            Heap(4 * GB, 5 * GB, gen2Collections: 15, t0.AddHours(1)),
+            Heap(4 * GB, 5 * GB, gen2Collections: 20, t0.AddHours(2)),
+        };
+
+        Assert.Equal(LeakSuspicion.Healthy, LargeObjectHeapLeakRule.Judge(readings).Suspicion);
+    }
+
+    [Fact]
+    public void Judge_SmallHeapGrowingFast_IsHealthyBecauseItIsBelowTheFloor()
+    {
+        var t0 = DateTimeOffset.UnixEpoch;
+        var readings = new[]
+        {
+            Heap(1 * 1024 * 1024, 8 * 1024 * 1024, gen2Collections: 1, t0),
+            Heap(20 * 1024 * 1024, 40 * 1024 * 1024, gen2Collections: 3, t0.AddMinutes(10)),
+            Heap(60 * 1024 * 1024, 90 * 1024 * 1024, gen2Collections: 5, t0.AddMinutes(20)),
+        };
+
+        Assert.Equal(LeakSuspicion.Healthy, LargeObjectHeapLeakRule.Judge(readings).Suspicion);
+    }
+
+    [Fact]
+    public void Judge_TooFewReadings_IsUndetermined()
+    {
+        var t0 = DateTimeOffset.UnixEpoch;
+        var readings = new[] { Heap(8 * GB, 9 * GB, 5, t0), Heap(9 * GB, 10 * GB, 6, t0.AddHours(1)) };
+
+        Assert.Equal(LeakSuspicion.Undetermined, LargeObjectHeapLeakRule.Judge(readings).Suspicion);
+    }
+
+    // ---- the tracker -------------------------------------------------------
+
+    [Fact]
+    public void Tracker_OneBadReading_DoesNotConfirmCritical()
+    {
+        var tracker = new MemoryPressureTracker();
+        var calm = Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB);
+        var spike = Machine(64 * GB, 2 * GB, 100 * GB, 105 * GB);
+
+        tracker.Record(calm, null);
+        bool changed = tracker.Record(spike, null);
+
+        Assert.False(changed);
+        Assert.Equal(MemoryPressureLevel.Normal, tracker.ConfirmedLevel);
+    }
+
+    [Fact]
+    public void Tracker_SustainedPressure_ConfirmsAndReportsTheChangeOnce()
+    {
+        var tracker = new MemoryPressureTracker();
+        var bad = Machine(64 * GB, 2 * GB, 100 * GB, 105 * GB);
+
+        Assert.False(tracker.Record(bad, null));
+        Assert.False(tracker.Record(bad, null));
+        Assert.True(tracker.Record(bad, null));                       // third confirms
+        Assert.Equal(MemoryPressureLevel.Critical, tracker.ConfirmedLevel);
+        Assert.False(tracker.Record(bad, null));                      // already announced
+    }
+
+    /// <summary>Recovery is announced immediately - a machine that is fine should stop shouting at once.</summary>
+    [Fact]
+    public void Tracker_RecoveryIsImmediate()
+    {
+        var tracker = new MemoryPressureTracker();
+        var bad = Machine(64 * GB, 2 * GB, 100 * GB, 105 * GB);
+        var good = Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB);
+
+        tracker.Record(bad, null);
+        tracker.Record(bad, null);
+        tracker.Record(bad, null);
+        Assert.Equal(MemoryPressureLevel.Critical, tracker.ConfirmedLevel);
+
+        Assert.True(tracker.Record(good, null));
+        Assert.Equal(MemoryPressureLevel.Normal, tracker.ConfirmedLevel);
+    }
+
+    [Fact]
+    public void Tracker_KeepsOnlyItsCapacity()
+    {
+        var tracker = new MemoryPressureTracker(capacity: 5);
+        var calm = Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB);
+
+        for (int i = 0; i < 20; i++) tracker.Record(calm, null);
+
+        Assert.Equal(5, tracker.ReadingCount);
+    }
+
+    // ---- the fold ----------------------------------------------------------
+
+    [Fact]
+    public void Fold_NoMachineReading_SaysSoRatherThanClaimingHealth()
+    {
+        var status = MemoryPressureFold.Fold(
+            new MemoryPressureFacts(null, null, null, MemoryPressureLevel.Normal, null));
+
+        Assert.Equal("MEMORY NOT READABLE", status.Headline);
+        Assert.False(status.OfferReclaimBuildServers);
+    }
+
+    [Fact]
+    public void Fold_Critical_ShowsHeadroomAndOffersReclaim()
+    {
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 2 * GB, 100 * GB, 105 * GB),
+            null, null,
+            MemoryPressureLevel.Critical,
+            ReclaimableBuildServers: 46);
+
+        var status = MemoryPressureFold.Fold(facts);
+
+        Assert.Equal("MEMORY CRITICAL", status.Headline);
+        Assert.True(status.OfferReclaimBuildServers);
+        Assert.Contains("46", status.ReclaimActionLabel);
+        Assert.Contains("commit remains", status.Advice);
+    }
+
+    /// <summary>
+    /// The reclaim action is only offered when there is a reason to act. Offering it on a calm
+    /// machine invites people to slow their own builds for nothing.
+    /// </summary>
+    [Fact]
+    public void Fold_NormalWithBuildServers_DoesNotOfferReclaim()
+    {
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB),
+            null, null,
+            MemoryPressureLevel.Normal,
+            ReclaimableBuildServers: 46);
+
+        Assert.False(MemoryPressureFold.Fold(facts).OfferReclaimBuildServers);
+    }
+
+    /// <summary>
+    /// Advice and action must agree. Caught on a real machine: at Normal the action was correctly
+    /// withheld while the advice still said "ask the 30 build servers to exit", telling a person
+    /// to press a button that was not there.
+    /// </summary>
+    [Fact]
+    public void Fold_WhenReclaimIsNotOffered_TheAdviceDoesNotSuggestIt()
+    {
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB),
+            null, null,
+            MemoryPressureLevel.Normal,
+            ReclaimableBuildServers: 30);
+
+        var status = MemoryPressureFold.Fold(facts);
+
+        Assert.False(status.OfferReclaimBuildServers);
+        Assert.DoesNotContain("build server", status.Advice, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The RECLAIM clause must never promise a byte figure. Which build nodes are free is not
+    /// knowable by inspection - 52 of 81 apparent orphans were serving live builds - so a number
+    /// there would be invented. The commit-headroom clause beside it legitimately carries a byte
+    /// figure, which is why this asserts on the reclaim sentence alone rather than the whole
+    /// advice string.
+    /// </summary>
+    [Fact]
+    public void Fold_ReclaimAdvice_PromisesNoByteFigure()
+    {
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 2 * GB, 100 * GB, 105 * GB),
+            null, null, MemoryPressureLevel.Critical, ReclaimableBuildServers: 46);
+
+        var advice = MemoryPressureFold.Fold(facts).Advice;
+
+        var reclaimSentence = advice
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Single(s => s.Contains("build server", StringComparison.OrdinalIgnoreCase));
+
+        Assert.DoesNotContain("GB", reclaimSentence);
+        Assert.DoesNotContain("MB", reclaimSentence);
+        Assert.Contains("genuinely free", reclaimSentence);
+    }
+
+    /// <summary>A leak is worth reporting even when the machine has room - that is when it is cheapest to fix.</summary>
+    [Fact]
+    public void Fold_LeakOnACalmMachine_StillWarns()
+    {
+        var leak = new LeakVerdict(LeakSuspicion.Suspected, "Large Object Heap grew and survived collections.", 5 * GB, 800 * 1024 * 1024, 9);
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 30 * GB, 40 * GB, 105 * GB),
+            null, leak, MemoryPressureLevel.Normal, null);
+
+        var status = MemoryPressureFold.Fold(facts);
+
+        Assert.Equal("MEMORY OK", status.Headline);
+        Assert.True(status.ShowLeakWarning);
+        Assert.Contains("keep growing", status.Advice);
+    }
+
+    [Fact]
+    public void Fold_ExhaustedCommitSinceBoot_SaysSoInTheTooltip()
+    {
+        var facts = new MemoryPressureFacts(
+            Machine(64 * GB, 20 * GB, 70 * GB, (long)(105.78 * GB), (long)(106.28 * GB)),
+            null, null, MemoryPressureLevel.Normal, null);
+
+        Assert.Contains("already reached its commit limit", MemoryPressureFold.Fold(facts).Tooltip);
+    }
+}

--- a/src/CcDirector.Core/Memory/LargeObjectHeapLeakRule.cs
+++ b/src/CcDirector.Core/Memory/LargeObjectHeapLeakRule.cs
@@ -1,0 +1,140 @@
+namespace CcDirector.Core.Memory;
+
+/// <summary>What a run of heap readings says about a possible leak.</summary>
+public enum LeakSuspicion
+{
+    /// <summary>Not enough readings, or no generation 2 collection yet, to say anything.</summary>
+    Undetermined,
+
+    /// <summary>The heap is behaving.</summary>
+    Healthy,
+
+    /// <summary>Large Object Heap growth has survived a collection. Worth looking at.</summary>
+    Suspected
+}
+
+/// <summary>The verdict, with the numbers that produced it so a report can show its working.</summary>
+/// <param name="Suspicion">The finding.</param>
+/// <param name="Reason">One sentence, in plain words, safe to show a person.</param>
+/// <param name="GrowthBytes">Large Object Heap growth across the window, negative if it shrank.</param>
+/// <param name="GrowthBytesPerHour">Growth rate, the number that predicts when this becomes a problem.</param>
+/// <param name="Gen2CollectionsInWindow">
+/// Collections that happened during the window. Zero means growth proves nothing yet.
+/// </param>
+public sealed record LeakVerdict(
+    LeakSuspicion Suspicion,
+    string Reason,
+    long GrowthBytes,
+    double GrowthBytesPerHour,
+    int Gen2CollectionsInWindow);
+
+/// <summary>
+/// Decides whether a run of heap readings looks like a Large Object Heap leak.
+///
+/// The rule that matters is the third condition below: growth only counts if a generation 2
+/// collection happened during the window. The Large Object Heap is swept ONLY on a generation 2
+/// collection, so a heap that grew without one has merely accumulated garbage that nobody has
+/// tried to collect yet - that is not evidence of anything. Growth that SURVIVED a sweep is
+/// retention, and retention is what a leak is made of.
+///
+/// Written as a pure function over readings so it can be tested against a scripted history
+/// without a machine, a timer, or a leak.
+/// </summary>
+public static class LargeObjectHeapLeakRule
+{
+    /// <summary>
+    /// Below this, ignore everything. A young process legitimately grows a small Large Object
+    /// Heap, and calling that a leak would train people to ignore the warning.
+    /// </summary>
+    public const long MinimumInterestingBytes = 512L * 1024 * 1024;
+
+    /// <summary>
+    /// Above this share of the heap, the Large Object Heap is the story rather than a detail.
+    /// The Director that prompted this work sat at 0.77.
+    /// </summary>
+    public const double DominantFraction = 0.5;
+
+    /// <summary>Growth across the window that counts as real rather than noise.</summary>
+    public const double MinimumGrowthFraction = 0.10;
+
+    /// <summary>Readings needed before any verdict but Undetermined.</summary>
+    public const int MinimumReadings = 3;
+
+    /// <summary>
+    /// Judge a window of readings, oldest first. Returns Undetermined rather than guessing when
+    /// the window is too short or nothing has been collected yet.
+    /// </summary>
+    public static LeakVerdict Judge(IReadOnlyList<ManagedHeapReading> readings)
+    {
+        ArgumentNullException.ThrowIfNull(readings);
+
+        if (readings.Count < MinimumReadings)
+        {
+            return new LeakVerdict(
+                LeakSuspicion.Undetermined,
+                $"Not enough readings yet - {readings.Count} of {MinimumReadings} needed.",
+                0, 0, 0);
+        }
+
+        var first = readings[0];
+        var last = readings[^1];
+
+        long growth = last.LargeObjectHeapBytes - first.LargeObjectHeapBytes;
+        int collections = Math.Max(0, last.Gen2CollectionCount - first.Gen2CollectionCount);
+
+        double hours = (last.TakenAtUtc - first.TakenAtUtc).TotalHours;
+        double perHour = hours > 0 ? growth / hours : 0;
+
+        if (last.LargeObjectHeapBytes < MinimumInterestingBytes)
+        {
+            return new LeakVerdict(
+                LeakSuspicion.Healthy,
+                $"Large Object Heap is {Format(last.LargeObjectHeapBytes)}, below the {Format(MinimumInterestingBytes)} floor worth watching.",
+                growth, perHour, collections);
+        }
+
+        // A sweep has to have happened, or growth means nothing. This is the clause that stops
+        // the rule shouting about garbage that simply has not been collected yet.
+        if (collections == 0)
+        {
+            return new LeakVerdict(
+                LeakSuspicion.Undetermined,
+                $"Large Object Heap is {Format(last.LargeObjectHeapBytes)} and grew {Format(growth)}, but no generation 2 collection has run in this window - the growth has not been tested yet.",
+                growth, perHour, collections);
+        }
+
+        bool dominant = last.LargeObjectHeapFraction >= DominantFraction;
+        bool grewMaterially = first.LargeObjectHeapBytes > 0
+            && growth >= first.LargeObjectHeapBytes * MinimumGrowthFraction;
+
+        if (dominant && grewMaterially)
+        {
+            return new LeakVerdict(
+                LeakSuspicion.Suspected,
+                $"Large Object Heap is {Format(last.LargeObjectHeapBytes)} - {last.LargeObjectHeapFraction:P0} of the heap - and grew {Format(growth)} " +
+                $"({Format((long)perHour)} per hour) through {collections} generation 2 collection(s), so it is retained rather than uncollected.",
+                growth, perHour, collections);
+        }
+
+        if (dominant)
+        {
+            return new LeakVerdict(
+                LeakSuspicion.Healthy,
+                $"Large Object Heap is large at {Format(last.LargeObjectHeapBytes)} ({last.LargeObjectHeapFraction:P0} of the heap) but is not growing.",
+                growth, perHour, collections);
+        }
+
+        return new LeakVerdict(
+            LeakSuspicion.Healthy,
+            $"Large Object Heap is {Format(last.LargeObjectHeapBytes)}, {last.LargeObjectHeapFraction:P0} of the heap, and steady.",
+            growth, perHour, collections);
+    }
+
+    private static string Format(long bytes)
+    {
+        double abs = Math.Abs(bytes);
+        if (abs >= 1024L * 1024 * 1024) return $"{bytes / 1024.0 / 1024 / 1024:F2} GB";
+        if (abs >= 1024L * 1024) return $"{bytes / 1024.0 / 1024:F0} MB";
+        return $"{bytes / 1024.0:F0} KB";
+    }
+}

--- a/src/CcDirector.Core/Memory/MachineMemoryReading.cs
+++ b/src/CcDirector.Core/Memory/MachineMemoryReading.cs
@@ -1,0 +1,141 @@
+using System.Runtime.InteropServices;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Memory;
+
+/// <summary>
+/// What the machine's memory actually looks like at one instant.
+///
+/// Every number here comes from the operating system in a single call, NOT from adding up
+/// processes. That distinction is the whole reason this type exists: on the machine this was
+/// built from, the process working sets summed to 46 GB while 53 GB was in use - the missing
+/// 7 GB was kernel pool and driver-locked pages, which belong to no process and cannot be
+/// discovered by walking a process list. A report built by summing processes silently loses
+/// that memory and then reads as wrong.
+/// </summary>
+/// <param name="PhysicalTotalBytes">Installed physical memory.</param>
+/// <param name="PhysicalAvailableBytes">Physical memory available for allocation right now.</param>
+/// <param name="CommitTotalBytes">Committed memory: physical plus page file actually promised out.</param>
+/// <param name="CommitLimitBytes">
+/// The ceiling on commit. THIS is what kills a machine - not physical pressure. When commit
+/// reaches this limit, allocations fail and applications die, however much physical is free.
+/// </param>
+/// <param name="CommitPeakBytes">
+/// The highest commit reached since boot. A peak at or above the limit is proof the machine has
+/// already run out once, which no instantaneous reading can tell you.
+/// </param>
+/// <param name="KernelPagedBytes">Kernel paged pool - owned by no process.</param>
+/// <param name="KernelNonPagedBytes">Kernel non-paged pool - owned by no process.</param>
+/// <param name="ProcessCount">Processes on the machine, for context in a report.</param>
+/// <param name="ThreadCount">Threads on the machine, for context in a report.</param>
+/// <param name="HandleCount">Handles on the machine, for context in a report.</param>
+public sealed record MachineMemoryReading(
+    long PhysicalTotalBytes,
+    long PhysicalAvailableBytes,
+    long CommitTotalBytes,
+    long CommitLimitBytes,
+    long CommitPeakBytes,
+    long KernelPagedBytes,
+    long KernelNonPagedBytes,
+    int ProcessCount,
+    int ThreadCount,
+    int HandleCount)
+{
+    /// <summary>Physical memory in use, derived rather than summed.</summary>
+    public long PhysicalUsedBytes => PhysicalTotalBytes - PhysicalAvailableBytes;
+
+    /// <summary>Commit still available before allocations start failing.</summary>
+    public long CommitHeadroomBytes => CommitLimitBytes - CommitTotalBytes;
+
+    /// <summary>Commit used as a fraction of the limit, 0 to 1. The primary pressure signal.</summary>
+    public double CommitUsedFraction =>
+        CommitLimitBytes <= 0 ? 0 : (double)CommitTotalBytes / CommitLimitBytes;
+
+    /// <summary>Physical used as a fraction of installed, 0 to 1.</summary>
+    public double PhysicalUsedFraction =>
+        PhysicalTotalBytes <= 0 ? 0 : (double)PhysicalUsedBytes / PhysicalTotalBytes;
+
+    /// <summary>
+    /// True when commit has already touched its ceiling at some point since boot. Distinct from
+    /// current pressure: the machine may look calm now and still have died an hour ago.
+    /// </summary>
+    public bool HasExhaustedCommitSinceBoot =>
+        CommitLimitBytes > 0 && CommitPeakBytes >= CommitLimitBytes;
+}
+
+/// <summary>
+/// Reads <see cref="MachineMemoryReading"/> from the operating system.
+///
+/// Windows only, by design - it calls GetPerformanceInfo, which is the only source that reports
+/// the commit limit. On other platforms <see cref="TryRead"/> returns false rather than guessing,
+/// because a fabricated commit limit would make every downstream verdict wrong in the direction
+/// of "everything is fine".
+/// </summary>
+public static class MachineMemoryProbe
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PerformanceInformation
+    {
+        public uint cb;
+        public nint CommitTotal;
+        public nint CommitLimit;
+        public nint CommitPeak;
+        public nint PhysicalTotal;
+        public nint PhysicalAvailable;
+        public nint SystemCache;
+        public nint KernelTotal;
+        public nint KernelPaged;
+        public nint KernelNonpaged;
+        public nint PageSize;
+        public uint HandleCount;
+        public uint ProcessCount;
+        public uint ThreadCount;
+    }
+
+    [DllImport("psapi.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetPerformanceInfo(out PerformanceInformation info, uint size);
+
+    /// <summary>True when this platform can be read at all.</summary>
+    public static bool IsSupported => OperatingSystem.IsWindows();
+
+    /// <summary>
+    /// Read the machine's memory state. Returns false (and a null reading) when the platform is
+    /// not supported or the call fails - never a partial or invented reading.
+    /// </summary>
+    public static bool TryRead(out MachineMemoryReading? reading)
+    {
+        reading = null;
+        if (!IsSupported)
+            return false;
+
+        var size = (uint)Marshal.SizeOf<PerformanceInformation>();
+        if (!GetPerformanceInfo(out var info, size))
+        {
+            FileLog.Write($"[MachineMemoryProbe] GetPerformanceInfo FAILED: win32={Marshal.GetLastWin32Error()}");
+            return false;
+        }
+
+        // Every size the call returns is in pages, not bytes.
+        long page = (long)info.PageSize;
+        if (page <= 0)
+        {
+            FileLog.Write($"[MachineMemoryProbe] TryRead FAILED: implausible page size {page}");
+            return false;
+        }
+
+        reading = new MachineMemoryReading(
+            PhysicalTotalBytes: (long)info.PhysicalTotal * page,
+            PhysicalAvailableBytes: (long)info.PhysicalAvailable * page,
+            CommitTotalBytes: (long)info.CommitTotal * page,
+            CommitLimitBytes: (long)info.CommitLimit * page,
+            CommitPeakBytes: (long)info.CommitPeak * page,
+            KernelPagedBytes: (long)info.KernelPaged * page,
+            KernelNonPagedBytes: (long)info.KernelNonpaged * page,
+            ProcessCount: (int)info.ProcessCount,
+            ThreadCount: (int)info.ThreadCount,
+            HandleCount: (int)info.HandleCount);
+
+        return true;
+    }
+}

--- a/src/CcDirector.Core/Memory/ManagedHeapReading.cs
+++ b/src/CcDirector.Core/Memory/ManagedHeapReading.cs
@@ -1,0 +1,101 @@
+namespace CcDirector.Core.Memory;
+
+/// <summary>
+/// This process's own managed heap, broken out by generation.
+///
+/// The Large Object Heap is called out as a first-class number because it is the signature of a
+/// whole class of defect. On 2026-07-30 a Director that had been up for a day held 9.74 GB of
+/// managed heap, of which 7.53 GB was Large Object Heap - five byte arrays holding captured
+/// microphone audio that nothing ever released. A single total heap number said only "big"; the
+/// Large Object Heap share said "something is retaining huge buffers", which is a different and
+/// far more actionable statement.
+///
+/// The Large Object Heap deserves this attention because of how it behaves: it is swept only on
+/// a generation 2 collection, and it is not compacted by default. So it grows, and it does not
+/// come back on its own.
+/// </summary>
+/// <param name="TotalHeapBytes">Everything the collector is managing.</param>
+/// <param name="Gen0Bytes">Generation 0.</param>
+/// <param name="Gen1Bytes">Generation 1.</param>
+/// <param name="Gen2Bytes">Generation 2.</param>
+/// <param name="LargeObjectHeapBytes">Objects of 85,000 bytes or more.</param>
+/// <param name="PinnedObjectHeapBytes">The pinned object heap.</param>
+/// <param name="LargeObjectHeapFragmentationBytes">
+/// Free space inside the Large Object Heap. The part of the Large Object Heap that is NOT
+/// fragmentation is live retained data - which is what separates a leak from mere untidiness.
+/// </param>
+/// <param name="CommittedBytes">What the collector has committed from the operating system.</param>
+/// <param name="Gen2CollectionCount">Generation 2 collections since process start.</param>
+/// <param name="PauseTimePercentage">Share of process time spent paused for collection.</param>
+/// <param name="TakenAtUtc">When this was read, so a trend can be measured across readings.</param>
+public sealed record ManagedHeapReading(
+    long TotalHeapBytes,
+    long Gen0Bytes,
+    long Gen1Bytes,
+    long Gen2Bytes,
+    long LargeObjectHeapBytes,
+    long PinnedObjectHeapBytes,
+    long LargeObjectHeapFragmentationBytes,
+    long CommittedBytes,
+    int Gen2CollectionCount,
+    double PauseTimePercentage,
+    DateTimeOffset TakenAtUtc)
+{
+    /// <summary>
+    /// How much of the heap sits on the Large Object Heap, 0 to 1. Above roughly half is unusual
+    /// for an interactive application and is the first thing worth explaining.
+    /// </summary>
+    public double LargeObjectHeapFraction =>
+        TotalHeapBytes <= 0 ? 0 : (double)LargeObjectHeapBytes / TotalHeapBytes;
+
+    /// <summary>
+    /// Large Object Heap bytes that are actually live, rather than free space left by
+    /// non-compaction. Retention, not untidiness, is what indicates a leak.
+    /// </summary>
+    public long LargeObjectHeapLiveBytes =>
+        Math.Max(0, LargeObjectHeapBytes - LargeObjectHeapFragmentationBytes);
+}
+
+/// <summary>
+/// Reads this process's own managed heap. Cheap and allocation-light: it asks the collector for
+/// what it already knows and never forces a collection, so it is safe to call on a timer.
+/// </summary>
+public static class ManagedHeapProbe
+{
+    // Generation indexes as the runtime reports them in GCMemoryInfo.GenerationInfo.
+    private const int Gen0 = 0;
+    private const int Gen1 = 1;
+    private const int Gen2 = 2;
+    private const int LargeObjectHeap = 3;
+    private const int PinnedObjectHeap = 4;
+
+    /// <summary>Read the current managed heap state of this process.</summary>
+    public static ManagedHeapReading Read(DateTimeOffset now)
+    {
+        var info = GC.GetGCMemoryInfo();
+
+        // GenerationInfo is a ref struct span, so it cannot be captured by a local function -
+        // copy the few numbers out first.
+        var generations = info.GenerationInfo;
+        Span<long> sizes = stackalloc long[5];
+        Span<long> fragmentation = stackalloc long[5];
+        for (int i = 0; i < sizes.Length && i < generations.Length; i++)
+        {
+            sizes[i] = generations[i].SizeAfterBytes;
+            fragmentation[i] = generations[i].FragmentationAfterBytes;
+        }
+
+        return new ManagedHeapReading(
+            TotalHeapBytes: info.HeapSizeBytes,
+            Gen0Bytes: sizes[Gen0],
+            Gen1Bytes: sizes[Gen1],
+            Gen2Bytes: sizes[Gen2],
+            LargeObjectHeapBytes: sizes[LargeObjectHeap],
+            PinnedObjectHeapBytes: sizes[PinnedObjectHeap],
+            LargeObjectHeapFragmentationBytes: fragmentation[LargeObjectHeap],
+            CommittedBytes: info.TotalCommittedBytes,
+            Gen2CollectionCount: GC.CollectionCount(2),
+            PauseTimePercentage: info.PauseTimePercentage,
+            TakenAtUtc: now);
+    }
+}

--- a/src/CcDirector.Core/Memory/MemoryPressureFold.cs
+++ b/src/CcDirector.Core/Memory/MemoryPressureFold.cs
@@ -1,0 +1,250 @@
+namespace CcDirector.Core.Memory;
+
+/// <summary>How much trouble the machine is in. A stable token for grouping, NOT for a client to branch on.</summary>
+public enum MemoryPressureLevel
+{
+    /// <summary>Nothing to say.</summary>
+    Normal,
+
+    /// <summary>Worth showing, not worth interrupting anyone.</summary>
+    Elevated,
+
+    /// <summary>Allocations are close to failing. Say so plainly.</summary>
+    Critical
+}
+
+/// <summary>
+/// The rule for what counts as memory pressure, stated once.
+///
+/// It is keyed on COMMIT, not physical memory, and that is the central lesson from the incident
+/// this came from. That machine had 63.78 GB of physical memory and a 105.78 GB commit limit; it
+/// sat at 84 percent physical and felt fine, while its commit peak hit 106.28 GB - above the
+/// limit. Commit exhaustion is what makes allocations fail and applications die. Physical
+/// pressure only makes things slow. A monitor watching physical would have reported "fine" right
+/// up to the failure.
+///
+/// Thresholds are fractions of the machine's own limit rather than absolute byte counts, because
+/// a hardcoded gigabyte figure is a measurement of one machine that goes stale the moment it runs
+/// anywhere else.
+/// </summary>
+public static class MemoryPressureRule
+{
+    /// <summary>Commit used, above which the situation is Elevated.</summary>
+    public const double ElevatedCommitFraction = 0.80;
+
+    /// <summary>Commit used, above which the situation is Critical.</summary>
+    public const double CriticalCommitFraction = 0.92;
+
+    /// <summary>Physical available, below which the situation is at least Elevated.</summary>
+    public const double ElevatedPhysicalFreeFraction = 0.10;
+
+    /// <summary>Physical available, below which the situation is Critical.</summary>
+    public const double CriticalPhysicalFreeFraction = 0.04;
+
+    /// <summary>
+    /// Consecutive readings a level must hold before it is announced. Build activity moved the
+    /// total on the measured machine by 8-10 GB within minutes, so a single sample crossing a
+    /// threshold says nothing. Announcing on one sample produces an alert nobody trusts.
+    /// </summary>
+    public const int ConsecutiveReadingsToConfirm = 3;
+
+    /// <summary>The level a single reading implies, before any debouncing.</summary>
+    public static MemoryPressureLevel LevelFor(MachineMemoryReading reading)
+    {
+        ArgumentNullException.ThrowIfNull(reading);
+
+        double commitUsed = reading.CommitUsedFraction;
+        double physicalFree = reading.PhysicalTotalBytes <= 0
+            ? 1
+            : (double)reading.PhysicalAvailableBytes / reading.PhysicalTotalBytes;
+
+        if (commitUsed >= CriticalCommitFraction || physicalFree <= CriticalPhysicalFreeFraction)
+            return MemoryPressureLevel.Critical;
+
+        if (commitUsed >= ElevatedCommitFraction || physicalFree <= ElevatedPhysicalFreeFraction)
+            return MemoryPressureLevel.Elevated;
+
+        return MemoryPressureLevel.Normal;
+    }
+}
+
+/// <summary>
+/// Everything the fold may look at, gathered by whoever is rendering and handed in whole, so the
+/// fold stays a pure function that can be tested without a machine.
+/// </summary>
+/// <param name="Machine">The machine reading, or null when the platform cannot be read.</param>
+/// <param name="OwnHeap">This process's managed heap, or null when it was not sampled.</param>
+/// <param name="Leak">The leak verdict over recent readings, or null when no history exists.</param>
+/// <param name="ConfirmedLevel">
+/// The level after debouncing - what the watcher has actually seen hold. Passed in rather than
+/// derived here because a single Facts object has no history.
+/// </param>
+/// <param name="ReclaimableBuildServers">
+/// How many build server processes are running and could be asked to exit, or null when unknown.
+/// Note that this is a COUNT of candidates, never a promise of bytes: a build node that looks
+/// idle may be serving another build, and only the graceful shutdown can tell the difference.
+/// </param>
+public sealed record MemoryPressureFacts(
+    MachineMemoryReading? Machine,
+    ManagedHeapReading? OwnHeap,
+    LeakVerdict? Leak,
+    MemoryPressureLevel ConfirmedLevel,
+    int? ReclaimableBuildServers);
+
+/// <summary>
+/// A finished memory verdict: the words to show, the colors to show them in, and which actions
+/// are offered. Every field is an answer, not an input to one. A client renders these verbatim
+/// and never re-derives meaning - adding a new situation is one edit in the fold rather than a
+/// new branch in every client.
+/// </summary>
+/// <param name="Level">Stable token naming the situation, for grouping and tests.</param>
+/// <param name="Headline">The short line, e.g. "MEMORY CRITICAL".</param>
+/// <param name="Detail">The second line, with the numbers that matter.</param>
+/// <param name="Tooltip">The whole story in sentences, for a hover or details pane.</param>
+/// <param name="Accent">Text and icon color, as hex.</param>
+/// <param name="Advice">What a person should actually do, or empty when there is nothing to do.</param>
+/// <param name="OfferReclaimBuildServers">Whether to offer the safe build-server reclaim action.</param>
+/// <param name="ReclaimActionLabel">Label for that action, empty when it is not offered.</param>
+/// <param name="ShowLeakWarning">Whether to show that this process itself looks like it is leaking.</param>
+/// <param name="LeakWarning">The leak sentence, empty when there is nothing to warn about.</param>
+public sealed record MemoryPressureStatus(
+    MemoryPressureLevel Level,
+    string Headline,
+    string Detail,
+    string Tooltip,
+    string Accent,
+    string Advice,
+    bool OfferReclaimBuildServers,
+    string ReclaimActionLabel,
+    bool ShowLeakWarning,
+    string LeakWarning);
+
+/// <summary>
+/// Folds a memory reading into the finished thing a person sees. The single place a memory
+/// verdict is decided - see the "client is dumb" rule in the project instructions.
+/// </summary>
+public static class MemoryPressureFold
+{
+    private const string AccentNormal = "#54A24B";
+    private const string AccentElevated = "#E8A33D";
+    private const string AccentCritical = "#E45756";
+    private const string AccentUnknown = "#8C8C8C";
+
+    /// <summary>Fold the facts into a finished status.</summary>
+    public static MemoryPressureStatus Fold(MemoryPressureFacts facts)
+    {
+        ArgumentNullException.ThrowIfNull(facts);
+
+        if (facts.Machine is null)
+        {
+            return new MemoryPressureStatus(
+                MemoryPressureLevel.Normal,
+                "MEMORY NOT READABLE",
+                "This platform does not report a commit limit.",
+                "Memory pressure is judged from the commit limit, which only Windows reports. Rather than guess, nothing is claimed here.",
+                AccentUnknown,
+                Advice: "",
+                OfferReclaimBuildServers: false,
+                ReclaimActionLabel: "",
+                ShowLeakWarning: false,
+                LeakWarning: "");
+        }
+
+        var m = facts.Machine;
+        var level = facts.ConfirmedLevel;
+
+        string headline = level switch
+        {
+            MemoryPressureLevel.Critical => "MEMORY CRITICAL",
+            MemoryPressureLevel.Elevated => "MEMORY HIGH",
+            _ => "MEMORY OK"
+        };
+
+        string accent = level switch
+        {
+            MemoryPressureLevel.Critical => AccentCritical,
+            MemoryPressureLevel.Elevated => AccentElevated,
+            _ => AccentNormal
+        };
+
+        string detail =
+            $"{Format(m.CommitTotalBytes)} of {Format(m.CommitLimitBytes)} committed " +
+            $"({m.CommitUsedFraction:P0}), {Format(m.PhysicalAvailableBytes)} physical free";
+
+        var tooltip = new System.Text.StringBuilder();
+        tooltip.Append($"Committed {Format(m.CommitTotalBytes)} against a limit of {Format(m.CommitLimitBytes)}, ")
+               .Append($"leaving {Format(m.CommitHeadroomBytes)} of headroom. ")
+               .Append($"Physical memory {Format(m.PhysicalUsedBytes)} used of {Format(m.PhysicalTotalBytes)}. ")
+               .Append("Commit is the number that matters: when it reaches the limit, allocations fail however much physical memory is free.");
+
+        if (m.HasExhaustedCommitSinceBoot)
+        {
+            tooltip.Append($" This machine has already reached its commit limit since boot (peak {Format(m.CommitPeakBytes)}).");
+        }
+
+        // The leak warning is about THIS process, and is independent of machine pressure: a
+        // process can be leaking steadily on a machine with plenty of room, and that is exactly
+        // when it is cheapest to fix.
+        bool showLeak = facts.Leak is { Suspicion: LeakSuspicion.Suspected };
+        string leakWarning = showLeak ? facts.Leak!.Reason : "";
+
+        bool offerReclaim = facts.ReclaimableBuildServers is > 0
+                            && level != MemoryPressureLevel.Normal;
+        string reclaimLabel = offerReclaim
+            ? $"Shut down {facts.ReclaimableBuildServers} idle build server(s)"
+            : "";
+
+        // The advice is built from the SAME decision that gates the action, never from the raw
+        // count. Letting them diverge produces advice telling a person to do something the
+        // interface is not offering - which reads as broken, and is the exact class of defect
+        // this fold exists to prevent.
+        string advice = BuildAdvice(level, m, showLeak, offerReclaim ? facts.ReclaimableBuildServers : null);
+
+        return new MemoryPressureStatus(
+            level,
+            headline,
+            detail,
+            tooltip.ToString(),
+            accent,
+            advice,
+            offerReclaim,
+            reclaimLabel,
+            showLeak,
+            leakWarning);
+    }
+
+    private static string BuildAdvice(
+        MemoryPressureLevel level,
+        MachineMemoryReading m,
+        bool leaking,
+        int? buildServers)
+    {
+        var parts = new List<string>();
+
+        if (buildServers is > 0)
+        {
+            // Deliberately no byte estimate. Which nodes are genuinely free is not knowable by
+            // inspection - a node whose parent build has exited may have been adopted by a later
+            // one - so promising a figure here would be inventing it.
+            parts.Add($"Ask the {buildServers} build server(s) to exit; only the ones that are genuinely free will go.");
+        }
+
+        if (leaking)
+            parts.Add("This process is retaining large objects and will keep growing until it is restarted or the retention is fixed.");
+
+        if (level == MemoryPressureLevel.Critical)
+            parts.Add($"Only {Format(m.CommitHeadroomBytes)} of commit remains; close something before allocations start failing.");
+        else if (level == MemoryPressureLevel.Elevated)
+            parts.Add("There is still headroom, but this is the point to reclaim rather than wait.");
+
+        return string.Join(" ", parts);
+    }
+
+    private static string Format(long bytes)
+    {
+        double abs = Math.Abs(bytes);
+        if (abs >= 1024L * 1024 * 1024) return $"{bytes / 1024.0 / 1024 / 1024:F2} GB";
+        if (abs >= 1024L * 1024) return $"{bytes / 1024.0 / 1024:F0} MB";
+        return $"{bytes / 1024.0:F0} KB";
+    }
+}

--- a/src/CcDirector.Core/Memory/MemoryPressureTracker.cs
+++ b/src/CcDirector.Core/Memory/MemoryPressureTracker.cs
@@ -1,0 +1,124 @@
+namespace CcDirector.Core.Memory;
+
+/// <summary>
+/// Keeps the recent history of memory readings and turns them into a confirmed level and a leak
+/// verdict.
+///
+/// It exists because both of the useful things here need TIME, and a single sample cannot supply
+/// it. A level must hold across several readings before it is worth announcing, because build
+/// activity moved the measured machine by 8-10 GB within minutes; and a leak is a trend, not a
+/// number. Everything is fed in from outside - no timer, no clock of its own - so a test can play
+/// hours of history through it in a millisecond.
+///
+/// Thread-safe: a background sampler writes while a rendering thread reads.
+/// </summary>
+public sealed class MemoryPressureTracker
+{
+    private readonly object _gate = new();
+    private readonly int _capacity;
+    private readonly List<MachineMemoryReading> _machine = new();
+    private readonly List<ManagedHeapReading> _heap = new();
+
+    private MemoryPressureLevel _confirmed = MemoryPressureLevel.Normal;
+    private MemoryPressureLevel _candidate = MemoryPressureLevel.Normal;
+    private int _candidateStreak;
+
+    /// <param name="capacity">
+    /// How many readings to keep. The default holds roughly two hours at one reading a minute,
+    /// which is long enough for a leak to show a slope and short enough that a fixed leak stops
+    /// being reported quickly.
+    /// </param>
+    public MemoryPressureTracker(int capacity = 120)
+    {
+        if (capacity < LargeObjectHeapLeakRule.MinimumReadings)
+            throw new ArgumentOutOfRangeException(nameof(capacity),
+                $"Capacity must be at least {LargeObjectHeapLeakRule.MinimumReadings} readings.");
+
+        _capacity = capacity;
+    }
+
+    /// <summary>The level that has actually held for long enough to announce.</summary>
+    public MemoryPressureLevel ConfirmedLevel
+    {
+        get { lock (_gate) return _confirmed; }
+    }
+
+    /// <summary>Readings held right now, for tests and diagnostics.</summary>
+    public int ReadingCount
+    {
+        get { lock (_gate) return _machine.Count; }
+    }
+
+    /// <summary>
+    /// Record one sample. Either part may be null - a machine reading fails on unsupported
+    /// platforms, and the heap may not be sampled every time.
+    /// </summary>
+    /// <returns>True when the confirmed level CHANGED, which is the moment worth acting on.</returns>
+    public bool Record(MachineMemoryReading? machine, ManagedHeapReading? heap)
+    {
+        lock (_gate)
+        {
+            if (heap is not null)
+            {
+                _heap.Add(heap);
+                if (_heap.Count > _capacity) _heap.RemoveAt(0);
+            }
+
+            if (machine is null)
+                return false;
+
+            _machine.Add(machine);
+            if (_machine.Count > _capacity) _machine.RemoveAt(0);
+
+            var instant = MemoryPressureRule.LevelFor(machine);
+
+            if (instant == _candidate)
+            {
+                _candidateStreak++;
+            }
+            else
+            {
+                _candidate = instant;
+                _candidateStreak = 1;
+            }
+
+            // Falling back to Normal is allowed to happen as fast as rising, so a machine that
+            // recovers stops shouting immediately. Only ALARM needs the streak, because a false
+            // alarm is the thing that destroys trust in the warning.
+            bool confirmNow =
+                _candidate == MemoryPressureLevel.Normal ||
+                _candidateStreak >= MemoryPressureRule.ConsecutiveReadingsToConfirm;
+
+            if (!confirmNow || _candidate == _confirmed)
+                return false;
+
+            _confirmed = _candidate;
+            return true;
+        }
+    }
+
+    /// <summary>The leak verdict over the readings held, or Undetermined when there are too few.</summary>
+    public LeakVerdict JudgeLeak()
+    {
+        lock (_gate)
+        {
+            return LargeObjectHeapLeakRule.Judge(_heap.ToArray());
+        }
+    }
+
+    /// <summary>Build the facts for the fold from what is held, plus whatever the caller knows.</summary>
+    public MemoryPressureFacts BuildFacts(int? reclaimableBuildServers)
+    {
+        lock (_gate)
+        {
+            return new MemoryPressureFacts(
+                Machine: _machine.Count > 0 ? _machine[^1] : null,
+                OwnHeap: _heap.Count > 0 ? _heap[^1] : null,
+                Leak: _heap.Count >= LargeObjectHeapLeakRule.MinimumReadings
+                    ? LargeObjectHeapLeakRule.Judge(_heap.ToArray())
+                    : null,
+                ConfirmedLevel: _confirmed,
+                ReclaimableBuildServers: reclaimableBuildServers);
+        }
+    }
+}


### PR DESCRIPTION
A Director left running for a day reached 9.4 gigabytes and nothing in the product could see it coming. This adds the measurement and the ruling. **No wiring: no sampler, no panel, no caller** - the wiring is a separate change so this one can be judged on its own.

## Three layers, following the existing Facts/Fold shape

| Type | Job |
|---|---|
| `MachineMemoryProbe` -> `MachineMemoryReading` | The machine's true totals, from one `GetPerformanceInfo` call |
| `ManagedHeapProbe` -> `ManagedHeapReading` | This process's own heap by generation, Large Object Heap called out |
| `MemoryPressureRule`, `LargeObjectHeapLeakRule` | The two rules, stated once each |
| `MemoryPressureFold` -> `MemoryPressureStatus` | The finished verdict: headline, detail, colour, advice, offered actions |
| `MemoryPressureTracker` | Bounded history, debouncing and trend |

The reading is deliberately **not** a sum over processes. On the machine this came from, process working sets added to 46 GB while 53 GB was in use; the missing 7 GB was kernel pool, which belongs to no process and cannot be discovered by walking a process list. A report built by summing processes silently loses it and then reads as wrong.

## Four decisions, each from a measurement rather than a preference

**Pressure is keyed on commit, not physical memory.** The measured machine sat at 84 percent physical and felt fine while its commit peak reached 106.28 GB against a 105.78 GB limit. Commit exhaustion is what makes allocations fail; physical pressure only makes things slow. A physical-based monitor reports "fine" right up to the failure. Two tests pin this: high physical with commit headroom is not critical, and commit near its limit is critical even with 25 GB of physical free.

**Large Object Heap growth only counts if it survived a generation 2 collection.** That heap is swept only on such a collection, so growth without one is uncollected garbage rather than retention. Without this clause the detector would fire on healthy processes constantly. It returns `Undetermined` rather than guessing.

**A level must hold for three readings before it is announced.** Build activity moved the measured totals by 8 to 10 GB within minutes, so a single sample crossing a threshold says nothing, and an alert that cries wolf is worse than none. Recovery is announced immediately, so a machine that is fine stops shouting at once.

**The reclaim advice promises no byte figure**, with a test enforcing it. Which build nodes are genuinely free is not knowable by inspection - 52 of 81 apparent orphans turned out to be serving live builds - so a number there would be invented.

Thresholds are fractions of the machine's own limits rather than absolute byte counts, so they do not become a stale measurement of one machine.

## Verification

Twenty tests, using the real numbers from the incident so they answer a specific question: would this have caught it. The rules are pure functions, so they are tested with no machine, no timer and no leak.

The probes were also run against a live machine, reading 63.78 GB total, a 105.78 GB commit limit and a 106.28 GB peak, and correctly reporting that the machine had already exhausted commit since boot. That live run is what caught a defect in the fold itself: at level Normal it correctly withheld the reclaim action while the advice still told the reader to use it - advice pointing at a button that was not there. Advice and action now come from the same decision, with a regression test. It only appeared against a real machine, not a fixture.

## Note on the .NET check

The full `CcDirector.Core.Tests` suite was run locally: **4094 passed, 1 failed**. The failure is `NoCrossMachineLoopbackGuardTests` flagging `src/CcDirector.Gateway.Migrations.Postgres/GatewayStatsDbContextPostgresDesignTimeFactory.cs`.

That failure is **pre-existing on main and unrelated to this change**. This branch adds six files, all under `Memory/`; the flagged file is already on main unchanged, and it is the exact file pull request thefrederiksen/devthrottle#2336 exists to allowlist. Expect the .NET check here to be red for that reason until main is green again.

Recommend not merging this until main is green, so it is not merged past a red that could hide a real regression.

## Scope

Library only. Nothing calls it yet, so it changes no behaviour. Related: issue thefrederiksen/devthrottle_internal#1286, and `docs/incidents/2026-07-30-director-memory-investigation.md`.
