### PR TITLE
Stop re-downloading an update that is already staged

### DIFF
--- a/src/CcDirector.Core.Tests/Update/UpdateCheckOutcomeTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateCheckOutcomeTests.cs
@@ -100,6 +100,40 @@ public class UpdateCheckOutcomeTests
         Assert.Contains("9.9.9", view.Detail);
     }
 
+    [Fact]
+    public async Task AnAlreadyStagedRelease_IsNotDownloadedAgain()
+    {
+        if (!Supported) return;
+
+        // The defect: a Director that runs for days re-checks every hour, and the check only asked
+        // "is the release newer than the running build?" - never "do I already have it?". So the same
+        // release was downloaded again every hour until a restart applied it. Here the staged build is
+        // already on disk and the handler REFUSES any download, so the check can only pass by
+        // recognising the work is done.
+        var stagedFile = Path.Combine(Path.GetTempPath(), $"cc-update-staged-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(stagedFile, "the already-downloaded build");
+        try
+        {
+            var seed = new UpdaterState
+            {
+                StagedVersion = "9.9.9",
+                StagedExecutable = stagedFile,
+            };
+
+            var (outcome, state) = await CheckAgainstReleaseAsync(tag: "v9.9.9", withAssets: true,
+                seed: seed, handler: new DownloadRefusingHandler(tag: "v9.9.9"));
+
+            Assert.Equal(UpdatePhase.Staged, outcome);
+            Assert.Equal("Staged", state.LastCheckOutcome);
+            Assert.Equal("9.9.9", state.StagedVersion);
+            Assert.Equal(stagedFile, state.StagedExecutable);
+        }
+        finally
+        {
+            File.Delete(stagedFile);
+        }
+    }
+
     // ---- Harness ----------------------------------------------------------
 
     /// <summary>
@@ -158,6 +192,31 @@ public class UpdateCheckOutcomeTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
             => throw new HttpRequestException("the network is unreachable");
+    }
+
+    /// <summary>
+    /// Answers the releases/latest call with a complete release, and fails the test outright if
+    /// anything tries to download one of its files. This is how the already-staged test can prove a
+    /// negative: the only way through it is to not download.
+    /// </summary>
+    private sealed class DownloadRefusingHandler(string tag) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.RequestUri is { } uri && uri.Host == "example.invalid")
+                throw new InvalidOperationException($"the check tried to download {uri} for a release that is already staged");
+
+            var body = $$"""
+                {"tag_name":"{{tag}}","assets":[
+                  {"name":"cc-director-win-x64.exe","browser_download_url":"https://example.invalid/a"},
+                  {"name":"release-manifest.json","browser_download_url":"https://example.invalid/m"}
+                ]}
+                """;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Update/UpdateServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateServiceTests.cs
@@ -101,6 +101,51 @@ public class UpdateServiceTests
         Assert.True(UpdateService.ShouldStage(new Version(0, 3, 1), new Version(0, 3, 3), state));
     }
 
+    // ---- AlreadyStaged ----------------------------------------------------
+
+    [Fact]
+    public void AlreadyStaged_SameVersionAndFilePresent_True()
+    {
+        var (path, _) = WriteTempWithHash("staged build");
+        try
+        {
+            var state = new UpdaterState { StagedVersion = "0.3.3", StagedExecutable = path };
+            Assert.True(UpdateService.AlreadyStaged("0.3.3", state));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void AlreadyStaged_DifferentVersionStaged_False()
+    {
+        // A newer release than the one staged must still be downloaded.
+        var (path, _) = WriteTempWithHash("staged build");
+        try
+        {
+            var state = new UpdaterState { StagedVersion = "0.3.3", StagedExecutable = path };
+            Assert.False(UpdateService.AlreadyStaged("0.3.4", state));
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void AlreadyStaged_StagedFileDeleted_False()
+    {
+        // The record says staged but the build is gone from disk: download again.
+        var state = new UpdaterState
+        {
+            StagedVersion = "0.3.3",
+            StagedExecutable = Path.Combine(Path.GetTempPath(), $"cc-update-gone-{Guid.NewGuid():N}.exe"),
+        };
+        Assert.False(UpdateService.AlreadyStaged("0.3.3", state));
+    }
+
+    [Fact]
+    public void AlreadyStaged_NothingStaged_False()
+    {
+        Assert.False(UpdateService.AlreadyStaged("0.3.3", new UpdaterState()));
+    }
+
     // ---- Sha256Matches ----------------------------------------------------
 
     [Fact]

--- a/src/CcDirector.Core/Update/UpdateService.cs
+++ b/src/CcDirector.Core/Update/UpdateService.cs
@@ -186,6 +186,19 @@ public sealed class UpdateService
                 return Conclude(state, UpdatePhase.UpToDate, versionText);
             }
 
+            if (AlreadyStaged(versionText, state))
+            {
+                // This exact release was already downloaded, verified, and staged by an earlier check,
+                // and its build is still on disk waiting for a restart. A Director that runs for days
+                // re-checked every hour, and because this test was missing it re-downloaded the same
+                // hundred-megabyte build every one of those hours and announced "downloaded" each time.
+                // There is nothing to fetch until either a newer release appears or a restart applies
+                // this one; if the staged file has meanwhile been deleted, the test below fails and the
+                // download runs again, which is the repair.
+                FileLog.Write($"[UpdateService] Release {tag} is already staged at {state.StagedExecutable}; not downloading it again.");
+                return Conclude(state, UpdatePhase.Staged, versionText);
+            }
+
             var assetUrl = FindAssetUrl(release.RootElement, assetName);
             var manifestUrl = FindAssetUrl(release.RootElement, ManifestAssetName);
 
@@ -377,6 +390,18 @@ public sealed class UpdateService
             return false;
         return true;
     }
+
+    /// <summary>
+    /// True when <paramref name="version"/> was already downloaded, verified, and staged by an earlier
+    /// check and its staged executable is still on disk. <see cref="UpdaterState.StagedVersion"/> is
+    /// only ever written after the SHA-256 verification passes, so a matching record plus a present
+    /// file means the work is done; checking the version alone would trust a record whose file has
+    /// since been deleted, and checking the file alone would trust a leftover from a different version.
+    /// </summary>
+    public static bool AlreadyStaged(string version, UpdaterState state)
+        => state.StagedVersion == version
+           && !string.IsNullOrEmpty(state.StagedExecutable)
+           && File.Exists(state.StagedExecutable);
 
     /// <summary>Compute a file's SHA-256 and compare (case-insensitive hex) to the expected value.</summary>
     public static bool Sha256Matches(string filePath, string expectedHex)


### PR DESCRIPTION
The hourly update check only asked whether the latest release is newer than the running build, never whether that release had already been downloaded and staged. A Director that runs for days between restarts therefore re-downloaded the same hundred-megabyte build every hour and announced 'downloaded' in a toast every time, until a restart finally applied it.

The check now recognises a release that is already staged: when the staged version in the updater state matches the latest release and the staged executable is still on disk, the check concludes Staged without downloading anything. The staged version is only ever recorded after the SHA-256 verification passes, so a matching record plus a present file means the work is done. If the staged file has meanwhile been deleted, the download runs again, which is the repair. A newer release than the staged one still downloads normally.

Verified: the new regression test uses a handler that fails the test outright if anything tries to download a file of an already-staged release, and it was confirmed to fail against the code without the guard. All 154 Update tests pass and the full solution builds with zero warnings.