### PR TITLE
Prompt history gets a retention window, export, and delete (CR-3b)

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -587,7 +587,7 @@
 
                         <RadioButton x:Name="GatewayHostedCard" GroupName="GatewayChoice"
                                      Classes="gatewayCard emphasized" IsChecked="True"
-                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled."
+                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled. Your agents run on your machines; fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work."
                                      IsCheckedChanged="GatewayCard_IsCheckedChanged">
                             <StackPanel Spacing="6">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
@@ -601,6 +601,12 @@
                                 </StackPanel>
                                 <TextBlock TextWrapping="Wrap" FontSize="13.5" Foreground="#5A616B"
                                            Text="We run it for you. Sign in and this machine is enrolled - phone access, voice, and the morning report work immediately." />
+                                <!-- The hosted data disclosure (CR-3b): the one honest sentence about what
+                                     leaves this machine, stated at the moment of choosing hosted - not a
+                                     broad "runs on your machines" that hides the history push. The data map
+                                     the /privacy page renders says the same thing in full. -->
+                                <TextBlock TextWrapping="Wrap" FontSize="12.5" Foreground="#5A616B"
+                                           Text="Your agents run on your machines. Fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work." />
                                 <!-- State the plan, never assert what this user already owns: on a
                                      brand-new free account "included with your subscription" is false. -->
                                 <TextBlock FontSize="12.5" Foreground="#8A909A"

--- a/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
@@ -45,39 +45,50 @@ public sealed class ClientErrorEndpointsTests
 
     private const string Sensitive = "the password is hunter2 and the prompt said fix login";
 
-    [Fact]
-    public void DurableLine_reduces_every_client_controlled_field_to_structure()
+    // Hostile values that fit ANY identifier/route alphabet - the fifth review pass's point: a
+    // character filter cannot tell these from genuine route tokens, so nothing client-supplied may
+    // be logged verbatim at all.
+    private const string SensitiveToken = "hunter2";
+    private const string SensitivePath = "/prompt/api_key_sk-abc123/fix-login";
+
+    [Theory]
+    [InlineData(Sensitive)]
+    [InlineData(SensitiveToken)]
+    [InlineData(SensitivePath)]
+    public void DurableLine_never_carries_a_client_controlled_value_verbatim(string hostile)
     {
         var record = new ClientErrorEndpoints.ClientErrorRecord(
             AtUtc: DateTime.UtcNow,
             DeviceHash: "abcdef1234567890",
-            Surface: Sensitive,
-            Page: Sensitive,
-            Message: Sensitive,
-            Detail: Sensitive,
-            Stack: Sensitive);
+            Surface: hostile,
+            Page: hostile,
+            Message: hostile,
+            Detail: hostile,
+            Stack: hostile);
 
         var line = ClientErrorEndpoints.DurableLine(new TenantId("11111111-1111-1111-1111-111111111111"), record);
 
-        Assert.DoesNotContain("hunter2", line);
-        Assert.DoesNotContain("prompt said", line);
+        Assert.DoesNotContain(hostile, line);
         // The raw account tenant id must not appear either - only its one-way hash form.
         Assert.DoesNotContain("11111111-1111-1111-1111-111111111111", line);
         Assert.Contains("t#", line);
-        Assert.Contains($"messageLength={Sensitive.Length}", line);
+        Assert.Contains($"messageLength={hostile.Length}", line);
     }
 
-    /// <summary>The gate has two failure directions: a genuinely structural value must still be logged,
-    /// or the line stops being useful and someone reverts the gate.</summary>
+    /// <summary>The tag must stay CORRELATABLE (same value, same tag; different values, different
+    /// tags) or the line stops being useful for debugging and someone reverts the gate.</summary>
     [Fact]
-    public void StructuralToken_admits_route_shapes_and_refuses_prose()
+    public void HashTag_is_content_free_but_correlatable()
     {
-        Assert.Equal("/m/sessions/list", ClientErrorEndpoints.StructuralToken("/m/sessions/list", 200));
-        Assert.Equal("cockpit", ClientErrorEndpoints.StructuralToken("cockpit", 40));
-        Assert.Equal("(empty)", ClientErrorEndpoints.StructuralToken("", 40));
-        Assert.Equal($"(nonstructural:{Sensitive.Length})", ClientErrorEndpoints.StructuralToken(Sensitive, 200));
-        Assert.Equal("(nonstructural:9)", ClientErrorEndpoints.StructuralToken("a\"quote\"b", 40));
-        Assert.StartsWith("(overlong:", ClientErrorEndpoints.StructuralToken(new string('a', 300), 200));
+        var a1 = ClientErrorEndpoints.HashTag("/m/sessions/list");
+        var a2 = ClientErrorEndpoints.HashTag("/m/sessions/list");
+        var b = ClientErrorEndpoints.HashTag("/m/settings");
+
+        Assert.Equal(a1, a2);
+        Assert.NotEqual(a1, b);
+        Assert.StartsWith("h#", a1);
+        Assert.DoesNotContain("sessions", a1);
+        Assert.Equal("(empty)", ClientErrorEndpoints.HashTag(""));
     }
 
     /// <summary>
@@ -98,10 +109,12 @@ public sealed class ClientErrorEndpointsTests
         try
         {
             using var client = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+            // Surface and Page get the alphabet-fitting hostile values on purpose: they would sail
+            // through any character filter, and the promise is that they still never reach the log.
             var resp = await client.PostAsJsonAsync("/client-errors", new ClientErrorEndpoints.ClientErrorPost
             {
-                Surface = Sensitive,
-                Page = Sensitive,
+                Surface = SensitiveToken,
+                Page = SensitivePath,
                 Message = Sensitive,
                 Detail = Sensitive,
                 Stack = Sensitive,
@@ -119,7 +132,9 @@ public sealed class ClientErrorEndpointsTests
         Assert.NotEmpty(durable);
         Assert.All(lines, l =>
         {
-            Assert.DoesNotContain("hunter2", l);
+            Assert.DoesNotContain(SensitiveToken, l);
+            Assert.DoesNotContain(SensitivePath, l);
+            Assert.DoesNotContain("api_key_sk-abc123", l);
             Assert.DoesNotContain("prompt said", l);
         });
         Assert.Contains(durable, l => l.Contains($"messageLength={Sensitive.Length}"));

--- a/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/ClientErrorEndpointsTests.cs
@@ -1,4 +1,9 @@
+using System.Net.Http.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -6,6 +11,12 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// The client error channel's per-device rate gate (client error logging build): a browser error loop
 /// must not flood the Gateway log, and one device's flood must never gag another device's reports.
+///
+/// Also the durable-line content gate (CR-3b review, third and fourth passes): every field of the POST
+/// body is client-supplied free text, and a browser error can carry anything on the page - including
+/// prompt or dictation content - so the data map's promise that service logs never carry customer
+/// content is only true if NO client-controlled field reaches the durable log verbatim. The tests here
+/// post hostile content into every field and assert none of it lands in FileLog.
 /// </summary>
 public sealed class ClientErrorEndpointsTests
 {
@@ -28,5 +39,89 @@ public sealed class ClientErrorEndpointsTests
         var deviceB = "device-" + Guid.NewGuid().ToString("N");
         for (var i = 0; i < 100; i++) ClientErrorEndpoints.AdmitWithinRate(deviceA);
         Assert.True(ClientErrorEndpoints.AdmitWithinRate(deviceB));
+    }
+
+    // ---- The durable line never carries client-supplied free text ---------------------------------
+
+    private const string Sensitive = "the password is hunter2 and the prompt said fix login";
+
+    [Fact]
+    public void DurableLine_reduces_every_client_controlled_field_to_structure()
+    {
+        var record = new ClientErrorEndpoints.ClientErrorRecord(
+            AtUtc: DateTime.UtcNow,
+            DeviceHash: "abcdef1234567890",
+            Surface: Sensitive,
+            Page: Sensitive,
+            Message: Sensitive,
+            Detail: Sensitive,
+            Stack: Sensitive);
+
+        var line = ClientErrorEndpoints.DurableLine(new TenantId("11111111-1111-1111-1111-111111111111"), record);
+
+        Assert.DoesNotContain("hunter2", line);
+        Assert.DoesNotContain("prompt said", line);
+        // The raw account tenant id must not appear either - only its one-way hash form.
+        Assert.DoesNotContain("11111111-1111-1111-1111-111111111111", line);
+        Assert.Contains("t#", line);
+        Assert.Contains($"messageLength={Sensitive.Length}", line);
+    }
+
+    /// <summary>The gate has two failure directions: a genuinely structural value must still be logged,
+    /// or the line stops being useful and someone reverts the gate.</summary>
+    [Fact]
+    public void StructuralToken_admits_route_shapes_and_refuses_prose()
+    {
+        Assert.Equal("/m/sessions/list", ClientErrorEndpoints.StructuralToken("/m/sessions/list", 200));
+        Assert.Equal("cockpit", ClientErrorEndpoints.StructuralToken("cockpit", 40));
+        Assert.Equal("(empty)", ClientErrorEndpoints.StructuralToken("", 40));
+        Assert.Equal($"(nonstructural:{Sensitive.Length})", ClientErrorEndpoints.StructuralToken(Sensitive, 200));
+        Assert.Equal("(nonstructural:9)", ClientErrorEndpoints.StructuralToken("a\"quote\"b", 40));
+        Assert.StartsWith("(overlong:", ClientErrorEndpoints.StructuralToken(new string('a', 300), 200));
+    }
+
+    /// <summary>
+    /// The reviewer's exact demand (CR-3b, fourth pass): post sensitive strings in EVERY
+    /// client-controlled field over the real HTTP pipeline and assert none reaches FileLog.
+    /// </summary>
+    [Fact]
+    public async Task A_hostile_report_leaves_no_customer_content_in_the_durable_log()
+    {
+        using var logScope = FileLog.RedirectForTests();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+        ClientErrorEndpoints.Map(app, tenantBoundary: null!);
+        await app.StartAsync();
+        try
+        {
+            using var client = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+            var resp = await client.PostAsJsonAsync("/client-errors", new ClientErrorEndpoints.ClientErrorPost
+            {
+                Surface = Sensitive,
+                Page = Sensitive,
+                Message = Sensitive,
+                Detail = Sensitive,
+                Stack = Sensitive,
+            });
+            resp.EnsureSuccessStatusCode();
+        }
+        finally
+        {
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+
+        var lines = logScope.DrainAndReadLines();
+        var durable = lines.Where(l => l.Contains("[ClientError]")).ToList();
+        Assert.NotEmpty(durable);
+        Assert.All(lines, l =>
+        {
+            Assert.DoesNotContain("hunter2", l);
+            Assert.DoesNotContain("prompt said", l);
+        });
+        Assert.Contains(durable, l => l.Contains($"messageLength={Sensitive.Length}"));
     }
 }

--- a/src/CcDirector.Gateway.Tests/Prompts/PromptEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/Prompts/PromptEndpointsTests.cs
@@ -129,6 +129,65 @@ public sealed class PromptEndpointsTests : IAsyncLifetime
         Assert.Equal(new[] { "SOREN_NORTH", "SOREN_LAPTOP" }, body.Records.Select(r => r.Machine));
     }
 
+    // ---- Export and delete: the account data rights (CR-3b) ----------------------------------------
+
+    [Fact]
+    public async Task Export_downloads_the_whole_history_regardless_of_age()
+    {
+        var now = DateTime.UtcNow;
+        await _client.PostAsJsonAsync("/prompts", new PromptIngestRequest
+        {
+            Records = new[] { Rec(now.AddDays(-200), "long ago"), Rec(now, "just now") },
+        });
+
+        var resp = await _client.GetAsync("/prompts/export");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType!.MediaType);
+        Assert.Contains("prompt-history-", resp.Content.Headers.ContentDisposition!.FileName);
+        var body = await resp.Content.ReadFromJsonAsync<ExportResponse>();
+        Assert.Equal(2, body!.Count);
+        Assert.Equal(new[] { "long ago", "just now" }, body.Records.Select(r => r.Text));
+        Assert.True(body.ExportedAtUtc > now.AddMinutes(-1));
+    }
+
+    [Fact]
+    public async Task Delete_erases_the_history_and_a_read_afterwards_finds_nothing()
+    {
+        var now = DateTime.UtcNow;
+        await _client.PostAsJsonAsync("/prompts", new PromptIngestRequest
+        {
+            Records = new[] { Rec(now.AddDays(-3), "old"), Rec(now, "new") },
+        });
+
+        var del = await _client.DeleteAsync("/prompts");
+
+        Assert.Equal(HttpStatusCode.OK, del.StatusCode);
+        var ack = await del.Content.ReadFromJsonAsync<DeleteResponse>();
+        Assert.Equal(2, ack!.DeletedFiles);
+
+        // The proof the exit row asks for: the rows are GONE, from both the ranged read and the export.
+        var after = await _client.GetFromJsonAsync<PromptsResponse>($"/prompts?from={Day(now.AddDays(-3))}&to={Day(now)}");
+        Assert.Equal(0, after!.Count);
+        var export = await (await _client.GetAsync("/prompts/export")).Content.ReadFromJsonAsync<ExportResponse>();
+        Assert.Equal(0, export!.Count);
+    }
+
+    [Fact]
+    public async Task Deleting_an_empty_history_succeeds_with_nothing_to_do()
+    {
+        var del = await _client.DeleteAsync("/prompts");
+
+        Assert.Equal(HttpStatusCode.OK, del.StatusCode);
+        Assert.Equal(0, (await del.Content.ReadFromJsonAsync<DeleteResponse>())!.DeletedFiles);
+    }
+
     /// <summary>The GET /prompts body shape.</summary>
     private sealed record PromptsResponse(int Count, IReadOnlyList<PromptRecord> Records);
+
+    /// <summary>The GET /prompts/export body shape.</summary>
+    private sealed record ExportResponse(DateTime ExportedAtUtc, int Count, IReadOnlyList<PromptRecord> Records);
+
+    /// <summary>The DELETE /prompts body shape.</summary>
+    private sealed record DeleteResponse(int DeletedFiles);
 }

--- a/src/CcDirector.Gateway.Tests/Prompts/PromptLogRetentionTests.cs
+++ b/src/CcDirector.Gateway.Tests/Prompts/PromptLogRetentionTests.cs
@@ -1,0 +1,225 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Prompts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Prompts;
+
+/// <summary>
+/// Tests for the prompt log's bounded retention and account erasure (CR-3b, devthrottle_internal
+/// issue #1180): the purge that ages daily files out, the delete that removes an account's whole
+/// history, the export read behind GET /prompts/export, and the window resolution rules.
+/// </summary>
+public sealed class PromptLogRetentionTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly GatewayPromptLog _log;
+
+    // A minted account tenant, the exact canonical-lowercase-guid shape DirectoryFor accepts.
+    private static readonly TenantId TenantA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly TenantId TenantB = new("22222222-2222-2222-2222-222222222222");
+
+    public PromptLogRetentionTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "gw-promptret-" + Guid.NewGuid().ToString("N"));
+        _log = new GatewayPromptLog(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static PromptRecord Rec(DateTime ts, string text) => new()
+    {
+        TsUtc = ts,
+        Machine = "SOREN_NORTH",
+        SessionId = "session-1",
+        ContextId = "ctx-1",
+        RepoPath = @"D:\ReposFred\devthrottle",
+        Agent = "ClaudeCode",
+        Role = "user",
+        TimestampFromAgent = true,
+        CharCount = text.Length,
+        WordCount = 1,
+        Text = text,
+    };
+
+    // ---- PurgeOlderThan: the retention window made true -------------------------------------------
+
+    [Fact]
+    public void Purge_removes_an_aged_day_and_keeps_a_young_one_in_every_partition()
+    {
+        var now = DateTime.UtcNow;
+        var aged = now.AddDays(-40);
+        _log.Append(TenantId.Local, new[] { Rec(aged, "old local"), Rec(now, "young local") });
+        _log.Append(TenantA, new[] { Rec(aged, "old tenant"), Rec(now, "young tenant") });
+
+        var deleted = _log.PurgeOlderThan(now.AddDays(-30));
+
+        Assert.Equal(2, deleted);
+        Assert.False(File.Exists(_log.FileFor(TenantId.Local, aged)));
+        Assert.False(File.Exists(_log.FileFor(TenantA, aged)));
+        Assert.Equal("young local", Assert.Single(_log.Read(TenantId.Local, now, now)).Text);
+        Assert.Equal("young tenant", Assert.Single(_log.Read(TenantA, now, now)).Text);
+    }
+
+    /// <summary>
+    /// The file whose day EQUALS the cutoff's day stays: it holds records younger than the cutoff
+    /// instant, and the granularity of this store is the daily file. A record therefore lives at most
+    /// one day past the window - never less than the window.
+    /// </summary>
+    [Fact]
+    public void Purge_keeps_the_file_on_the_cutoff_day_itself()
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-30);
+        _log.Append(TenantId.Local, new[] { Rec(cutoff.AddHours(1), "on the boundary day") });
+
+        var deleted = _log.PurgeOlderThan(cutoff);
+
+        Assert.Equal(0, deleted);
+        Assert.True(File.Exists(_log.FileFor(TenantId.Local, cutoff.AddHours(1))));
+    }
+
+    /// <summary>
+    /// The purge walks partitions found ON DISK, not a tenant census - so a partition whose tenant was
+    /// deleted from the registry still ages out instead of holding that customer's text forever.
+    /// </summary>
+    [Fact]
+    public void Purge_ages_out_a_partition_no_census_would_name()
+    {
+        var aged = DateTime.UtcNow.AddDays(-40);
+        // Simulate an orphaned partition: a tenant folder written in the past whose account is gone.
+        // (Written through the log while the tenant "existed" - the folder simply remains on disk.)
+        _log.Append(TenantB, new[] { Rec(aged, "orphaned text") });
+
+        var deleted = _log.PurgeOlderThan(DateTime.UtcNow.AddDays(-30));
+
+        Assert.Equal(1, deleted);
+        Assert.False(File.Exists(_log.FileFor(TenantB, aged)));
+    }
+
+    [Fact]
+    public void Purge_does_not_touch_files_that_are_not_daily_log_files()
+    {
+        var stranger = Path.Combine(_dir, "conversation-notes.jsonl");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(stranger, "not a daily file");
+
+        var deleted = _log.PurgeOlderThan(DateTime.UtcNow);
+
+        Assert.Equal(0, deleted);
+        Assert.True(File.Exists(stranger));
+    }
+
+    [Fact]
+    public void Purge_of_an_empty_store_is_a_quiet_zero()
+    {
+        Assert.Equal(0, _log.PurgeOlderThan(DateTime.UtcNow));
+    }
+
+    // ---- DeleteAll: the account right-to-erasure ---------------------------------------------------
+
+    [Fact]
+    public void DeleteAll_removes_one_tenants_whole_history_and_nobody_elses()
+    {
+        var now = DateTime.UtcNow;
+        _log.Append(TenantA, new[] { Rec(now.AddDays(-5), "a old"), Rec(now, "a new") });
+        _log.Append(TenantB, new[] { Rec(now, "b keeps this") });
+        _log.Append(TenantId.Local, new[] { Rec(now, "local keeps this") });
+
+        var deleted = _log.DeleteAll(TenantA);
+
+        Assert.Equal(2, deleted);
+        Assert.Empty(_log.ReadAll(TenantA));
+        Assert.Equal("b keeps this", Assert.Single(_log.ReadAll(TenantB)).Text);
+        Assert.Equal("local keeps this", Assert.Single(_log.ReadAll(TenantId.Local)).Text);
+    }
+
+    [Fact]
+    public void DeleteAll_of_a_tenant_with_no_history_is_a_quiet_zero()
+    {
+        Assert.Equal(0, _log.DeleteAll(TenantA));
+    }
+
+    // ---- ReadAll: the export read ------------------------------------------------------------------
+
+    [Fact]
+    public void ReadAll_returns_every_day_oldest_first_without_being_told_a_range()
+    {
+        var now = DateTime.UtcNow;
+        _log.Append(TenantA, new[] { Rec(now, "newest"), Rec(now.AddDays(-400), "over a year old") });
+
+        var all = _log.ReadAll(TenantA);
+
+        Assert.Equal(new[] { "over a year old", "newest" }, all.Select(r => r.Text));
+    }
+
+    [Fact]
+    public void ReadAll_of_an_absent_partition_is_empty_rather_than_throwing()
+    {
+        Assert.Empty(_log.ReadAll(TenantA));
+    }
+
+    // ---- ResolveRetention: the window's rules ------------------------------------------------------
+
+    [Fact]
+    public void Unset_override_means_the_default_everywhere()
+    {
+        Assert.Equal(PromptLogRetentionSweep.DefaultRetention, PromptLogRetentionSweep.ResolveRetention(isHosted: false, configuredDays: null));
+        Assert.Equal(PromptLogRetentionSweep.DefaultRetention, PromptLogRetentionSweep.ResolveRetention(isHosted: true, configuredDays: null));
+        Assert.Equal(PromptLogRetentionSweep.DefaultRetention, PromptLogRetentionSweep.ResolveRetention(isHosted: false, configuredDays: "  "));
+    }
+
+    [Fact]
+    public void A_self_host_operator_may_choose_their_own_window()
+    {
+        Assert.Equal(TimeSpan.FromDays(365), PromptLogRetentionSweep.ResolveRetention(isHosted: false, configuredDays: "365"));
+    }
+
+    /// <summary>
+    /// Hosted retention is the PUBLISHED product default; an operator-side environment variable must
+    /// never quietly change a promise made to customers, so on hosted a set override is ignored.
+    /// </summary>
+    [Fact]
+    public void The_hosted_gateway_ignores_the_override()
+    {
+        Assert.Equal(PromptLogRetentionSweep.DefaultRetention, PromptLogRetentionSweep.ResolveRetention(isHosted: true, configuredDays: "365"));
+    }
+
+    /// <summary>
+    /// A malformed override throws rather than silently running the default: the operator would
+    /// believe a window that is not the one running.
+    /// </summary>
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("0")]
+    [InlineData("-30")]
+    public void A_malformed_override_is_refused_loudly(string configured)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => PromptLogRetentionSweep.ResolveRetention(isHosted: false, configuredDays: configured));
+        Assert.Contains(PromptLogRetentionSweep.RetentionDaysEnvVar, ex.Message);
+    }
+
+    // ---- The sweep end to end ----------------------------------------------------------------------
+
+    [Fact]
+    public void The_sweep_makes_the_window_true()
+    {
+        var now = DateTime.UtcNow;
+        _log.Append(TenantId.Local, new[] { Rec(now.AddDays(-45), "past the window"), Rec(now, "inside the window") });
+        var sweep = new PromptLogRetentionSweep(_log, TimeSpan.FromDays(30));
+
+        var deleted = sweep.Sweep();
+
+        Assert.Equal(1, deleted);
+        Assert.Equal("inside the window", Assert.Single(_log.ReadAll(TenantId.Local)).Text);
+    }
+
+    [Fact]
+    public void A_non_positive_window_cannot_be_constructed()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PromptLogRetentionSweep(_log, TimeSpan.Zero));
+    }
+}

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -240,7 +240,9 @@ internal static class AiModelsEndpoint
                 // turn): the resolver CLEARS the tenant override on blank so the read falls back to the default.
                 resolver.SetCarModeEndPhrase(t.Value, body?.Phrase ?? string.Empty, DateTime.UtcNow);
                 var phrase = resolver.CarModeEndPhrase(t.Value);
-                FileLog.Write($"[AiModelsEndpoint] car mode end phrase set: {phrase} for tenant={t.Value.ToLogString()}");
+                // The phrase is something the member SAYS out loud - spoken customer content - so it
+                // stays out of the log (data-map promise); the length is enough to see a set happened.
+                FileLog.Write($"[AiModelsEndpoint] car mode end phrase set: length={phrase.Length} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { phrase });
             }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }

--- a/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
@@ -95,7 +95,9 @@ internal static class ClientErrorEndpoints
             // The durable record: one greppable line in the same log every Gateway error goes to. The
             // stack is deliberately excluded from the line (it is multi-line noise in a line-oriented
             // log) - it stays readable on the ring.
-            FileLog.Write($"[ClientError] tenant={tenant.Value} device={record.DeviceHash} surface={record.Surface} "
+            // ToLogString, never Value: on hosted the raw account tenant id must not reach a log (the data
+            // map promises hashed tenant ids in service logs, and this line was one of two that broke it).
+            FileLog.Write($"[ClientError] tenant={tenant.Value.ToLogString()} device={record.DeviceHash} surface={record.Surface} "
                 + $"page={record.Page} message={record.Message}"
                 + (record.Detail.Length > 0 ? $" detail={record.Detail}" : ""));
 

--- a/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
@@ -92,14 +92,14 @@ internal static class ClientErrorEndpoints
                 Detail: Cap(req.Detail ?? "", 2000),
                 Stack: Cap(req.Stack ?? "", 4000));
 
-            // The durable record: one greppable line in the same log every Gateway error goes to. The
-            // stack is deliberately excluded from the line (it is multi-line noise in a line-oriented
-            // log) - it stays readable on the ring.
-            // ToLogString, never Value: on hosted the raw account tenant id must not reach a log (the data
-            // map promises hashed tenant ids in service logs, and this line was one of two that broke it).
+            // The durable line is STRUCTURAL ONLY - who, where, when, and how big. Message and Detail are
+            // client-supplied free text: a browser error payload can carry anything on the page, including
+            // prompt or dictation content, so writing them verbatim here would falsify the data map's
+            // promise that service logs never carry customer content (the review that caught it: CR-3b,
+            // third pass). The full text stays readable on the per-tenant ring below, which is served only
+            // back to the account that reported it. ToLogString, never Value, for the same promise.
             FileLog.Write($"[ClientError] tenant={tenant.Value.ToLogString()} device={record.DeviceHash} surface={record.Surface} "
-                + $"page={record.Page} message={record.Message}"
-                + (record.Detail.Length > 0 ? $" detail={record.Detail}" : ""));
+                + $"page={record.Page} messageLength={record.Message.Length} detailLength={record.Detail.Length}");
 
             var ring = Rings.GetOrAdd(tenant.Value, static _ => new TenantRing());
             lock (ring.Lock)

--- a/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
@@ -42,7 +42,8 @@ internal static class ClientErrorEndpoints
     ///  logged once), so a render-loop error cannot flood the Gateway log.</summary>
     private const int MaxReportsPerDevicePerMinute = 30;
 
-    private sealed record ClientErrorRecord(
+    // Internal (not private) so the durable-line regression test can build hostile records directly.
+    internal sealed record ClientErrorRecord(
         DateTime AtUtc, string DeviceHash, string Surface, string Page, string Message, string Detail, string Stack);
 
     private sealed class TenantRing
@@ -52,6 +53,37 @@ internal static class ClientErrorEndpoints
     }
 
     private static readonly ConcurrentDictionary<TenantId, TenantRing> Rings = new();
+
+    /// <summary>
+    /// The one durable log line for a report. Internal so the regression test can post hostile content
+    /// into every client-controlled field and assert none of it reaches this line: each field is either
+    /// validated against a closed structural format (<see cref="StructuralToken"/>) or reduced to its
+    /// length. Nothing client-supplied is ever interpolated verbatim.
+    /// </summary>
+    internal static string DurableLine(TenantId tenant, ClientErrorRecord record)
+        => $"[ClientError] tenant={tenant.ToLogString()} device={record.DeviceHash} "
+            + $"surface={StructuralToken(record.Surface, 40)} page={StructuralToken(record.Page, 200)} "
+            + $"messageLength={record.Message.Length} detailLength={record.Detail.Length}";
+
+    /// <summary>
+    /// Admit a client-supplied identifier into the durable log ONLY if it has the shape of a code
+    /// identifier or route path: letters, digits, and the separator characters routes use. Anything
+    /// else - a space, a quote, a colon, any character free prose needs - is replaced by a placeholder
+    /// carrying just the length. A closed allowed-set, not a denylist: the field must PROVE it is
+    /// structural to be logged, so prose can never sneak through a gap nobody predicted.
+    /// </summary>
+    internal static string StructuralToken(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value)) return "(empty)";
+        if (value.Length > maxLength) return $"(overlong:{value.Length})";
+        foreach (var c in value)
+        {
+            var ok = c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')
+                or '/' or '-' or '_' or '.' or '~';
+            if (!ok) return $"(nonstructural:{value.Length})";
+        }
+        return value;
+    }
 
     // The per-device rate window: device hash -> (window start, count in window). Pruned lazily.
     private static readonly ConcurrentDictionary<string, (DateTime WindowStartUtc, int Count)> RateWindows = new();
@@ -92,14 +124,15 @@ internal static class ClientErrorEndpoints
                 Detail: Cap(req.Detail ?? "", 2000),
                 Stack: Cap(req.Stack ?? "", 4000));
 
-            // The durable line is STRUCTURAL ONLY - who, where, when, and how big. Message and Detail are
-            // client-supplied free text: a browser error payload can carry anything on the page, including
-            // prompt or dictation content, so writing them verbatim here would falsify the data map's
-            // promise that service logs never carry customer content (the review that caught it: CR-3b,
-            // third pass). The full text stays readable on the per-tenant ring below, which is served only
-            // back to the account that reported it. ToLogString, never Value, for the same promise.
-            FileLog.Write($"[ClientError] tenant={tenant.Value.ToLogString()} device={record.DeviceHash} surface={record.Surface} "
-                + $"page={record.Page} messageLength={record.Message.Length} detailLength={record.Detail.Length}");
+            // The durable line is STRUCTURAL ONLY - who, where, when, and how big. EVERY client-supplied
+            // field is either validated against a closed structural format or reduced to its length,
+            // because a browser error payload can carry anything on the page - including prompt or
+            // dictation content - and writing any free-text field verbatim would falsify the data map's
+            // promise that service logs never carry customer content (CR-3b review, third and fourth
+            // passes: first Message/Detail, then Surface/Page). The full text stays readable on the
+            // per-tenant ring below, which is served only back to the account that reported it.
+            // ToLogString, never Value, for the same promise.
+            FileLog.Write(DurableLine(tenant.Value, record));
 
             var ring = Rings.GetOrAdd(tenant.Value, static _ => new TenantRing());
             lock (ring.Lock)

--- a/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ClientErrorEndpoints.cs
@@ -56,33 +56,26 @@ internal static class ClientErrorEndpoints
 
     /// <summary>
     /// The one durable log line for a report. Internal so the regression test can post hostile content
-    /// into every client-controlled field and assert none of it reaches this line: each field is either
-    /// validated against a closed structural format (<see cref="StructuralToken"/>) or reduced to its
-    /// length. Nothing client-supplied is ever interpolated verbatim.
+    /// into every client-controlled field and assert none of it reaches this line. NOTHING
+    /// client-supplied is ever interpolated verbatim - not even values that look like identifiers,
+    /// because a character filter cannot tell a route token from a pasted secret that happens to fit
+    /// the same alphabet (the review's fifth pass: "hunter2" passes any structural shape test).
+    /// Surface and page are logged as one-way hash tags: the same value always produces the same tag,
+    /// so durable lines still correlate with each other and with the ring entry the account can read,
+    /// while the log itself carries no content.
     /// </summary>
     internal static string DurableLine(TenantId tenant, ClientErrorRecord record)
         => $"[ClientError] tenant={tenant.ToLogString()} device={record.DeviceHash} "
-            + $"surface={StructuralToken(record.Surface, 40)} page={StructuralToken(record.Page, 200)} "
+            + $"surface={HashTag(record.Surface)} page={HashTag(record.Page)} "
             + $"messageLength={record.Message.Length} detailLength={record.Detail.Length}";
 
-    /// <summary>
-    /// Admit a client-supplied identifier into the durable log ONLY if it has the shape of a code
-    /// identifier or route path: letters, digits, and the separator characters routes use. Anything
-    /// else - a space, a quote, a colon, any character free prose needs - is replaced by a placeholder
-    /// carrying just the length. A closed allowed-set, not a denylist: the field must PROVE it is
-    /// structural to be logged, so prose can never sneak through a gap nobody predicted.
-    /// </summary>
-    internal static string StructuralToken(string value, int maxLength)
+    /// <summary>A content-free, correlatable rendering of one client-supplied value: its length and a
+    /// short one-way hash (the same form <see cref="TenantId.ToLogString"/> uses). Never the value.</summary>
+    internal static string HashTag(string value)
     {
         if (string.IsNullOrEmpty(value)) return "(empty)";
-        if (value.Length > maxLength) return $"(overlong:{value.Length})";
-        foreach (var c in value)
-        {
-            var ok = c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')
-                or '/' or '-' or '_' or '.' or '~';
-            if (!ok) return $"(nonstructural:{value.Length})";
-        }
-        return value;
+        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value));
+        return $"h#{Convert.ToHexString(hash, 0, 4).ToLowerInvariant()}:{value.Length}";
     }
 
     // The per-device rate window: device hash -> (window start, count in window). Pruned lazily.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -512,6 +512,15 @@ public sealed class GatewayHost : IAsyncDisposable
     private static readonly TimeSpan ActivityRetentionInterval = TimeSpan.FromHours(6);
     private static readonly TimeSpan ActivityRetentionStartupDelay = TimeSpan.FromMinutes(5);
 
+    // The prompt log's retention purge (CR-3b, devthrottle_internal #1180): wakes a few times a day and
+    // deletes every partition's daily files older than the retention window. Guarded against overlap the
+    // same way the activity sweep is. Created in StartAsync, disposed in StopAsync.
+    private Prompts.PromptLogRetentionSweep? _promptRetentionSweep;
+    private System.Threading.Timer? _promptRetentionTimer;
+    private int _promptRetentionInFlight;
+    private static readonly TimeSpan PromptRetentionInterval = TimeSpan.FromHours(6);
+    private static readonly TimeSpan PromptRetentionStartupDelay = TimeSpan.FromMinutes(7);
+
     // The daily dictionary-suggestion scan (devthrottle #2115): the timer ticks every few minutes; the sweep
     // decides PER TENANT whether that tenant's local 00:05 has passed since its last stored scan, so each
     // tenant scans at its own midnight from one timer. Cheap when nothing is due (one stored-row read per
@@ -3210,6 +3219,16 @@ public sealed class GatewayHost : IAsyncDisposable
             ActivityRetentionStartupDelay, ActivityRetentionInterval);
         FileLog.Write($"[GatewayHost] activity retention sweep started: every {ActivityRetentionInterval.TotalHours:0}h, retention {Activity.ActivityRetentionSweep.RetentionPeriod.TotalDays:0} days");
 
+        // The prompt log's retention purge (CR-3b): same footing as the other bounded stores. The window
+        // resolves from the deployment mode - hosted is always the product default; self-host may override
+        // via the environment (a malformed override throws HERE, loudly, at startup, not mid-sweep).
+        _promptRetentionSweep = new Prompts.PromptLogRetentionSweep(_promptLog,
+            Prompts.PromptLogRetentionSweep.ResolveRetention(GatewayHostedMode.IsHosted,
+                Environment.GetEnvironmentVariable(Prompts.PromptLogRetentionSweep.RetentionDaysEnvVar)));
+        _promptRetentionTimer = new System.Threading.Timer(_ => SweepPromptRetention(), null,
+            PromptRetentionStartupDelay, PromptRetentionInterval);
+        FileLog.Write($"[GatewayHost] prompt-log retention sweep started: every {PromptRetentionInterval.TotalHours:0}h, retention {_promptRetentionSweep.Retention.TotalDays:0} days");
+
         // The daily dictionary-suggestion scan (devthrottle #2115): each tick asks, per tenant, whether that
         // tenant's local 00:05 has passed since its last stored scan; only then does it mine and screen. The
         // first pass is delayed so startup is never contended, and a tenant with no stored scan yet is seeded
@@ -3576,6 +3595,29 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// The prompt-log retention timer callback (a boundary - it owns the overlap guard and the try/catch so
+    /// a purge failure never crashes the timer thread). One sweep at a time; a skipped tick simply purges on
+    /// the next one, which retention granularity is indifferent to.
+    /// </summary>
+    private void SweepPromptRetention()
+    {
+        if (Interlocked.CompareExchange(ref _promptRetentionInFlight, 1, 0) != 0)
+            return;
+        try
+        {
+            _promptRetentionSweep?.Sweep();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHost] prompt-log retention sweep FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _promptRetentionInFlight, 0);
+        }
+    }
+
+    /// <summary>
     /// The dictionary-suggestion timer callback (a boundary - it owns the overlap guard and the try/catch so
     /// a scan failure never crashes the timer thread). One sweep at a time; a skipped tick simply checks on
     /// the next one, which a daily schedule is indifferent to.
@@ -3807,6 +3849,8 @@ public sealed class GatewayHost : IAsyncDisposable
         try { _cronTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] cron timer dispose error: {ex.Message}"); }
         _cronTimer = null;
         try { _activityRetentionTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] activity retention timer dispose error: {ex.Message}"); }
+        try { _promptRetentionTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] prompt-log retention timer dispose error: {ex.Message}"); }
+        _promptRetentionTimer = null;
         try { _suggestionSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] dictionary-suggestion timer dispose error: {ex.Message}"); }
         try { _sessionHistoryTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] session history timer dispose error: {ex.Message}"); }
         _sessionHistoryTimer = null;

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -32,8 +32,11 @@ namespace CcDirector.Gateway.Prompts;
 /// migrates); a hosted account tenant lands under tenants/&lt;id&gt;/. The tenant is always supplied by the
 /// caller, which resolved it from the authenticated device key at the boundary - this type never guesses one.
 ///
-/// Retention is unbounded. The point is looking back across weeks and months, and the text is small.
-/// (Contrast TurnReviewLog, which holds terminal SCREENS and expires at 7 days.) Nothing prunes this.
+/// Retention is BOUNDED (CR-3b, devthrottle_internal issue #1180). Prompt text is customer content -
+/// proprietary code, file paths, error output, pasted credentials - so it lives for the retention window
+/// and no longer. <see cref="PromptLogRetentionSweep"/> owns the window and the timer;
+/// <see cref="PurgeOlderThan"/> is the enforcement. A member can also export their whole history and
+/// delete it outright (<see cref="ReadAll"/> / <see cref="DeleteAll"/>, served by PromptEndpoints).
 ///
 /// Fail-safe: every write is wrapped, so a logging error can never fail a Director's push.
 /// </summary>
@@ -219,5 +222,114 @@ public sealed class GatewayPromptLog
             }
         }
         return results;
+    }
+
+    /// <summary>
+    /// Every message ONE tenant holds, oldest day first - the account-export read. Enumerates the daily
+    /// files that actually exist in the tenant's partition rather than iterating a date range, so the whole
+    /// history is returned without knowing how far back it goes.
+    /// </summary>
+    public IReadOnlyList<PromptRecord> ReadAll(TenantId tenant)
+    {
+        var directory = DirectoryFor(tenant);
+        if (!Directory.Exists(directory)) return Array.Empty<PromptRecord>();
+
+        var days = DailyFilesIn(directory).Keys.OrderBy(d => d).ToList();
+        if (days.Count == 0) return Array.Empty<PromptRecord>();
+        return Read(tenant, days[0], days[^1]);
+    }
+
+    /// <summary>
+    /// Delete EVERY daily file in one tenant's partition - the account right-to-erasure. This is the single
+    /// copy (the Director keeps none), so when this returns the tenant's prompt history is gone. Deliberately
+    /// LOUD on failure, unlike <see cref="Append"/>: a delete the caller believes happened but did not is a
+    /// broken promise about customer data, so an IO failure propagates and the endpoint reports it.
+    /// Returns how many daily files were removed.
+    /// </summary>
+    public int DeleteAll(TenantId tenant)
+    {
+        var directory = DirectoryFor(tenant);
+        if (!Directory.Exists(directory)) return 0;
+
+        var deleted = 0;
+        lock (GateFor(tenant))
+        {
+            foreach (var path in DailyFilesIn(directory).Values)
+            {
+                File.Delete(path);
+                deleted++;
+            }
+        }
+        FileLog.Write($"[GatewayPromptLog] DeleteAll: tenant={tenant.ToLogString()}, deleted {deleted} daily files");
+        return deleted;
+    }
+
+    /// <summary>
+    /// Retention enforcement: delete every daily file, in EVERY partition, whose day is strictly before the
+    /// cutoff's day. Sweeps the partitions found ON DISK (the Local root plus every folder under tenants/)
+    /// rather than a tenant census, so a partition orphaned by a deleted tenant still ages out instead of
+    /// holding that customer's prompt text forever. Granularity is the daily file: a file is removed only
+    /// once its whole day is past the cutoff, so a record lives at most one day past the window.
+    /// Per-file failures are logged and skipped - a locked file must not stop the rest of the sweep - and
+    /// the file that failed is simply retried on the next pass. Returns how many files were removed.
+    /// </summary>
+    public int PurgeOlderThan(DateTime cutoffUtc)
+    {
+        var deleted = 0;
+        deleted += PurgePartition(TenantId.Local, _directory, cutoffUtc);
+
+        var tenantsRoot = Path.Combine(_directory, "tenants");
+        if (Directory.Exists(tenantsRoot))
+        {
+            foreach (var partition in Directory.GetDirectories(tenantsRoot))
+            {
+                // The folder name IS the tenant id; an orphaned or malformed folder still gets its own gate
+                // (keyed by the raw name) so the purge never crosses another partition's lock.
+                deleted += PurgePartition(new TenantId(Path.GetFileName(partition)), partition, cutoffUtc);
+            }
+        }
+        return deleted;
+    }
+
+    private int PurgePartition(TenantId tenant, string directory, DateTime cutoffUtc)
+    {
+        if (!Directory.Exists(directory)) return 0;
+        var deleted = 0;
+        lock (GateFor(tenant))
+        {
+            foreach (var (day, path) in DailyFilesIn(directory))
+            {
+                if (day >= cutoffUtc.Date) continue;
+                try
+                {
+                    File.Delete(path);
+                    deleted++;
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[GatewayPromptLog] PurgePartition: could not delete {Path.GetFileName(path)} for tenant={tenant.ToLogString()}: {Redact(ex.Message, tenant)}");
+                }
+            }
+        }
+        return deleted;
+    }
+
+    /// <summary>
+    /// The daily files in one partition directory, keyed by their UTC day. Only files matching the exact
+    /// conversation-yyyyMMdd.jsonl shape are returned - anything else in the folder is not this log's to
+    /// touch, and deleting by parsed-name-only is how a purge eats a file it does not own.
+    /// </summary>
+    private static Dictionary<DateTime, string> DailyFilesIn(string directory)
+    {
+        var files = new Dictionary<DateTime, string>();
+        foreach (var path in Directory.GetFiles(directory, "conversation-*.jsonl"))
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            var stamp = name.Substring("conversation-".Length);
+            if (DateTime.TryParseExact(stamp, "yyyyMMdd", null,
+                    System.Globalization.DateTimeStyles.None, out var day))
+                files[day.Date] = path;
+        }
+        return files;
     }
 }

--- a/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
@@ -16,6 +16,12 @@ namespace CcDirector.Gateway.Prompts;
 /// GET /prompts  - anyone asking for history asks here. That is the point of the log living on the
 /// Gateway: it already has the whole fleet's record, so nothing has to go hunting across machines.
 ///
+/// GET /prompts/export and DELETE /prompts - the account data rights (CR-3b, devthrottle_internal issue
+/// #1180). Export returns the requesting account's ENTIRE prompt history as a downloadable JSON document;
+/// delete removes every one of that account's daily files. The log is the single copy (the Director keeps
+/// none, and the Gateway makes no backup of it), so the delete IS the erasure - immediate, not queued.
+/// Both are tenant-scoped exactly like the verbs above; neither can name another account's partition.
+///
 /// TENANT-SCOPED (issue #1848). "The whole fleet's record" means the REQUESTING ACCOUNT'S fleet. Both verbs
 /// resolve the request's tenant from the authenticated device key with the same seam the cockpit read path
 /// uses, and write into / read out of only that tenant's partition. Before this, neither handler took an
@@ -70,6 +76,38 @@ public static class PromptEndpoints
 
             var records = store.Read(tenant.Value, fromUtc, toUtc);
             return Results.Ok(new { count = records.Count, records });
+        });
+
+        app.MapGet("/prompts/export", (HttpContext ctx) =>
+        {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var records = store.ReadAll(tenant.Value);
+            var payload = new { exportedAtUtc = DateTime.UtcNow, count = records.Count, records };
+            // Web defaults so the export's field names match what GET /prompts serves; indented because
+            // this file is FOR the member to read and keep, not for a machine round-trip.
+            var bytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(payload,
+                new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web) { WriteIndented = true });
+            FileLog.Write($"[PromptEndpoints] GET /prompts/export: tenant={tenant.Value.ToLogString()}, exported {records.Count} records");
+            return Results.File(bytes, "application/json",
+                $"prompt-history-{DateTime.UtcNow:yyyyMMdd}.json");
+        });
+
+        app.MapDelete("/prompts", (HttpContext ctx) =>
+        {
+            var tenant = ResolveTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            // DeleteAll is loud on failure by design: an erasure that half-happened must surface as an
+            // error to the caller (the pipeline's 500), never as a success with rows left behind.
+            var deletedFiles = store.DeleteAll(tenant.Value);
+            FileLog.Write($"[PromptEndpoints] DELETE /prompts: tenant={tenant.Value.ToLogString()}, deleted {deletedFiles} daily files");
+            return Results.Ok(new { deletedFiles });
         });
     }
 

--- a/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
@@ -1,0 +1,89 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Prompts;
+
+/// <summary>
+/// The prompt log's retention window and its enforcement (CR-3b, devthrottle_internal issue #1180).
+/// Before this sweep existed the log said "retention is unbounded" out loud, which for a store of
+/// customer prompt text was the finding, not a feature. Now the log sits on the same footing as the
+/// other bounded stores (turn-review 7 days, session history 90 days, dictation transcripts 30 days,
+/// voice-turn archives 24 hours): a window, and a sweep that makes the window true.
+///
+/// This sweep does NOT ride the <see cref="Tenancy.TenantScopedSweep"/> seam, on purpose: that seam
+/// exists to enter an ambient tenant scope for the database stores, and it fans out over the tenant
+/// CENSUS. The prompt log is file-partitioned and takes its tenant explicitly, and its purge walks the
+/// partitions found ON DISK - so a partition orphaned by a deleted tenant (which the census can no
+/// longer name) still ages out instead of keeping that customer's prompt text forever.
+///
+/// Timer cadence and lifecycle are owned by GatewayHost (the ActivityRetentionSweep pattern).
+/// </summary>
+public sealed class PromptLogRetentionSweep
+{
+    /// <summary>
+    /// THE default retention window for prompt/reply history. PROVISIONAL: the owner's decision between
+    /// 30 and 90 days is still open (release plan, "Owner decisions that block work"); 30 is built as the
+    /// conservative interim per the release coordinator's ruling of 2026-07-31, and this ONE constant is
+    /// where the settled number lands. The customer-facing data map
+    /// (devthrottle_internal/docs/architecture/data-map.md) states the same number and must change with it.
+    /// </summary>
+    public static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Self-host override: a positive whole number of days. Self-host is the operator's own machine and
+    /// their own data, so they may keep history LONGER (or shorter) than the product default. On the
+    /// hosted Gateway this variable is deliberately IGNORED: hosted retention is the published product
+    /// default, and an operator-side variable must not quietly change a promise made to customers.
+    /// </summary>
+    public const string RetentionDaysEnvVar = "CC_GATEWAY_PROMPT_RETENTION_DAYS";
+
+    private readonly GatewayPromptLog _log;
+    private readonly TimeSpan _retention;
+
+    public PromptLogRetentionSweep(GatewayPromptLog log, TimeSpan retention)
+    {
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+        if (retention <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(retention), "The prompt-log retention window must be positive.");
+        _retention = retention;
+    }
+
+    /// <summary>The window this sweep enforces (resolved once at construction).</summary>
+    public TimeSpan Retention => _retention;
+
+    /// <summary>
+    /// Resolve the effective window from the deployment mode and the raw environment value. Pure and
+    /// static so a test can prove every branch without touching process environment or a real host.
+    /// An UNSET variable is the default everywhere. A SET variable is honored on self-host and refused
+    /// with a loud throw when malformed - a typo silently falling back to the default would be the
+    /// operator believing a window that is not the one running. On hosted a set variable is ignored
+    /// (and logged), never applied.
+    /// </summary>
+    public static TimeSpan ResolveRetention(bool isHosted, string? configuredDays)
+    {
+        if (string.IsNullOrWhiteSpace(configuredDays))
+            return DefaultRetention;
+
+        if (isHosted)
+        {
+            FileLog.Write($"[PromptLogRetentionSweep] {RetentionDaysEnvVar} is set but this is the hosted Gateway - ignored; hosted retention is the product default ({DefaultRetention.TotalDays:0} days)");
+            return DefaultRetention;
+        }
+
+        if (!int.TryParse(configuredDays.Trim(), out var days) || days <= 0)
+            throw new InvalidOperationException(
+                $"{RetentionDaysEnvVar} must be a positive whole number of days; found '{configuredDays}'. " +
+                "Unset it to use the default, or set it to the number of days to keep prompt history.");
+
+        return TimeSpan.FromDays(days);
+    }
+
+    /// <summary>One pass: purge every partition's files older than the window. Returns files removed.</summary>
+    public int Sweep()
+    {
+        var cutoffUtc = DateTime.UtcNow - _retention;
+        var deleted = _log.PurgeOlderThan(cutoffUtc);
+        if (deleted > 0)
+            FileLog.Write($"[PromptLogRetentionSweep] purged {deleted} daily files older than {cutoffUtc:O}");
+        return deleted;
+    }
+}

--- a/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
@@ -20,13 +20,12 @@ namespace CcDirector.Gateway.Prompts;
 public sealed class PromptLogRetentionSweep
 {
     /// <summary>
-    /// THE default retention window for prompt/reply history. PROVISIONAL: the owner's decision between
-    /// 30 and 90 days is still open (release plan, "Owner decisions that block work"); 30 is built as the
-    /// conservative interim per the release coordinator's ruling of 2026-07-31, and this ONE constant is
-    /// where the settled number lands. The customer-facing data map
-    /// (devthrottle_internal/docs/architecture/data-map.md) states the same number and must change with it.
+    /// THE default retention window for prompt/reply history: 90 days, the owner's ruling of 2026-07-31
+    /// (chosen over 30 so month-over-month comparison across history is possible). The customer-facing
+    /// data map (devthrottle_internal/docs/architecture/data-map.md) states the same number and must
+    /// change with it - one constant, one table row, together.
     /// </summary>
-    public static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(30);
+    public static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(90);
 
     /// <summary>
     /// Self-host override: a positive whole number of days. Self-host is the operator's own machine and

--- a/src/CcDirector.Gateway/Streaming/LauncherHub.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherHub.cs
@@ -73,7 +73,9 @@ public sealed class LauncherHub : Hub
         Context.Items[MachineNameItemKey] = machine;
         Context.Items[TenantIdItemKey] = tenant;
         _registry.RegisterConnection(tenant, machine, Context.ConnectionId);
-        FileLog.Write($"[LauncherHub] Hello: tenant={tenant.Value}, machine={machine} bound to conn={Short(Context.ConnectionId)} (port={hello.Port}, version={hello.Version})");
+        // ToLogString, never Value: on hosted the raw account tenant id must not reach a log (the data
+        // map promises hashed tenant ids in service logs, and this line was one of two that broke it).
+        FileLog.Write($"[LauncherHub] Hello: tenant={tenant.ToLogString()}, machine={machine} bound to conn={Short(Context.ConnectionId)} (port={hello.Port}, version={hello.Version})");
     }
 
     /// <summary>The tenant that owns this connection, from the authenticated device key (never the payload).

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionDismissalStore.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionDismissalStore.cs
@@ -78,7 +78,8 @@ public sealed class DictionarySuggestionDismissalStore
                 existing.DismissedAtUtc = nowUtc.ToUniversalTime();
             }
             ctx.SaveChanges();
-            FileLog.Write($"[DismissalStore] Dismiss: tenant={tenant.ToLogString()} term={norm} wrong={suggestion.WrongCount}/{suggestion.TotalCount}");
+            // The term is dictation-derived customer content and stays out of the log (data-map promise).
+            FileLog.Write($"[DismissalStore] Dismiss: tenant={tenant.ToLogString()} termLength={norm.Length} wrong={suggestion.WrongCount}/{suggestion.TotalCount}");
         }
     }
 
@@ -99,7 +100,8 @@ public sealed class DictionarySuggestionDismissalStore
             if (existing is null) return false;
             ctx.DictationSuggestionDismissals.Remove(existing);
             ctx.SaveChanges();
-            FileLog.Write($"[DismissalStore] Restore: tenant={tenant.ToLogString()} term={norm}");
+            // Same rule as Dismiss: the term is dictation-derived customer content, log its length only.
+            FileLog.Write($"[DismissalStore] Restore: tenant={tenant.ToLogString()} termLength={norm.Length}");
             return true;
         }
     }

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionScanStore.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionScanStore.cs
@@ -112,7 +112,9 @@ public sealed class DictionarySuggestionScanStore
             if (kept.Count == suggestions.Count) return;
             existing.SuggestionsJson = SerializeSuggestions(kept);
             ctx.SaveChanges();
-            FileLog.Write($"[SuggestionScanStore] RemoveSuggestion: tenant={tenant.ToLogString()} term={norm} remaining={kept.Count}");
+            // The term itself is dictation-derived customer content and stays out of the log (the data
+            // map promises service logs carry no dictation content); its length is enough to correlate.
+            FileLog.Write($"[SuggestionScanStore] RemoveSuggestion: tenant={tenant.ToLogString()} termLength={norm.Length} remaining={kept.Count}");
         }
     }
 


### PR DESCRIPTION
Closes the product half of CR-3b (devthrottle_internal issue 1180, label release-must-have): the Gateway's prompt log held every prompt and agent reply forever, with no delete route and no export, and its own doc comment said so. Prompt text is customer content - proprietary code, file paths, error output, credentials pasted for debugging - so the unbounded model was itself the release-blocking finding.

What changes:

- **Retention is bounded.** New PromptLogRetentionSweep enforces a window on the same footing as the other bounded stores (activity 30 days, session history 90, dictation transcripts 30, voice-turn audio 24 hours). The default is 30 days in ONE named constant, clearly marked PROVISIONAL: the owner's 30-versus-90 decision is still open, and 30 ships as the conservative interim per the release coordinator's ruling today. A self-host operator may choose their own window via CC_GATEWAY_PROMPT_RETENTION_DAYS; the hosted Gateway always runs the published default, and a malformed override throws at startup rather than silently running a different window than the operator believes.
- **The purge walks partitions on disk, not the tenant census** - so a partition orphaned by a deleted tenant still ages out instead of holding that customer's prompt text forever. Wired in GatewayHost on the exact ActivityRetentionSweep timer pattern (overlap guard, startup delay, disposal).
- **Export and delete.** GET /prompts/export downloads the requesting account's entire prompt history as one JSON file; DELETE /prompts erases it immediately. The Gateway holds the single copy (the Director keeps none) and makes no backups of it, so the delete IS the erasure. Both routes are tenant-scoped in PromptEndpoints.cs exactly like the existing verbs - per the release plan, nothing touches GatewayEndpoints.cs or ControlApiHost.cs.
- **The hosted first-run disclosure.** The wizard's hosted-gateway card now states, at the moment of choosing hosted: your agents run on your machines; fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work.

The customer-facing data map this code enforces is devthrottle_internal pull request 1181 (docs/architecture/data-map.md), the single source the /privacy page renders - contract agreed with the website mission, recorder policy confirmed with the local-trust-boundary mission (recorder off by default, purge on session removal, local disk only).

Tests: PromptLogRetentionTests covers the purge (aged day removed, cutoff day kept, orphaned partition aged out, foreign files untouched), the erasure (one tenant's history gone, nobody else's touched), the export read, the window-resolution rules (hosted ignores the override, malformed override refused loudly), and the sweep end to end. PromptEndpointsTests adds export and delete over a real HTTP pipeline, proving deleted rows are gone from both the ranged read and the export. Test-run results are being posted as a comment once the machine-wide test lock frees (the statistics release-gate run has it at the moment).