### PR TITLE
Gateway load-test harness: Stage 0 instrumentation, the rig, and the Stage 1/2 drivers (#1173)

### DIFF
--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -527,6 +527,13 @@ internal static class GatewayEndpoints
         // time, not server work - keeping the reported latency honest.
         app.MapGet("/diag/ping", () => Results.Json(new { t = DateTime.UtcNow }));
 
+        // GET /diag/loadmetrics: the Stage 0 load-test instrumentation window (issue #1173) - lock wait,
+        // fold duration, sweep overlap, hub connection and push-ingress pressure, roster latency, and the
+        // standard process numbers. Behind the same auth gate as every other route. `?reset=true` starts a
+        // fresh window after the read, so each load step scrapes its own numbers.
+        app.MapGet("/diag/loadmetrics", (bool? reset) =>
+            Results.Json(Diagnostics.LoadTestMetrics.Snapshot(reset == true)));
+
         // Result logging: the phone/Cockpit POSTs its completed speed-test result here; the Gateway stamps
         // what IT saw about the connection, writes one greppable log line, and keeps it in a small ring so
         // an agent can read the recent history at GET /diag/results with no phone. This is the "log all of
@@ -3495,6 +3502,11 @@ internal static class GatewayEndpoints
         if (roleUniverse is null) throw new ArgumentNullException(nameof(roleUniverse));
         if (toStamp is null) throw new ArgumentNullException(nameof(toStamp));
 
+        // Load-test Stage 0 (issue #1173): time the whole fold pass. This method is the shared hot path -
+        // the roster, the display sweep, and every accepted hub push all run it - so its duration under
+        // load is one of the numbers the load-test baseline exists to capture.
+        var foldStart = Stopwatch.GetTimestamp();
+
         var all = toStamp;
 
         // Snooze Length mission: an EXPIRED snooze must read as "needs you" again. The registry is the
@@ -3602,6 +3614,8 @@ internal static class GatewayEndpoints
             // pushes this down to the desktop, and the single-session read all emit the same deadline.
             s.SnoozeUntil = snoozeRegistry?.SnoozeUntilFor(s.SessionId);
         }
+
+        Diagnostics.LoadTestMetrics.FoldDurationMs.RecordSince(foldStart);
     }
 
     // Gateway Cleanup CUT RESTORATION (SB-4a): map a tunnel command's null-or-failed result to the faithful

--- a/src/CcDirector.Gateway/Diagnostics/LoadTestMetrics.cs
+++ b/src/CcDirector.Gateway/Diagnostics/LoadTestMetrics.cs
@@ -1,0 +1,259 @@
+using System.Diagnostics;
+
+namespace CcDirector.Gateway.Diagnostics;
+
+/// <summary>
+/// Stage 0 of the Gateway load-test plan (devthrottle_internal issue #1173, mission 05): the numbers that
+/// did not exist and without which a load test is blind on exactly the thing it expects to break. The
+/// read-model review says the hot cost is database work and N+1 reads held under process-wide locks, the
+/// five-second display sweep has no overlap guard, and cross-tenant harm comes from shared locks. This
+/// class measures those claims so the load-test harness can confirm or refute them with numbers:
+///
+///   * how long callers WAIT to enter the snooze registry's process-wide gate (the shared-lock claim);
+///   * how many database reads the snooze registry performs (the N+1 claim - divide by roster requests);
+///   * how long one <c>StampFleetRolesAndFold</c> pass takes (the fold cost);
+///   * whether two display sweeps were ever in flight at once (the missing-overlap-guard claim);
+///   * how many Director stream connections are held and how many pushes are in flight (the socket and
+///     ingress-pressure numbers);
+///   * server-side <c>GET /sessions</c> latency, beside what the load driver measures from outside.
+///
+/// MEASUREMENT ONLY. Nothing here changes behavior, adds a guard, caches a read, or fixes anything the
+/// numbers reveal - the fixes belong to the read-model epic (#1159). Everything is a lock-free counter or
+/// a fixed-bucket histogram (a handful of interlocked adds per observation), cheap enough to stay on
+/// permanently. Deliberately NO FileLog entry/exit logging in this class: these methods run millions of
+/// times per minute under load, and a log line per observation would make the instrument the bottleneck
+/// it exists to find.
+///
+/// Read it at <c>GET /diag/loadmetrics</c>; pass <c>?reset=true</c> to also start a fresh window, so each
+/// load step reads its own numbers rather than a mix with the previous step's.
+/// </summary>
+public static class LoadTestMetrics
+{
+    /// <summary>Time callers spent waiting to ENTER the snooze registry's process-wide gate on the hot
+    /// read path (HoldStateFor / IsExpired / SnoozeUntilFor). Near zero uncontended; the read-model
+    /// review predicts this is what grows first under multi-tenant load.</summary>
+    public static readonly DurationHistogram SnoozeLockWaitMs = new();
+
+    /// <summary>Duration of one whole <c>StampFleetRolesAndFold</c> pass (roles + hold + color/label/triage
+    /// over the stamped set, including its per-session snooze reads).</summary>
+    public static readonly DurationHistogram FoldDurationMs = new();
+
+    /// <summary>Server-side duration of <c>GET /sessions</c>, recorded by the access-log middleware. The
+    /// outside-the-process twin of the load driver's own latency measurement.</summary>
+    public static readonly DurationHistogram RosterDurationMs = new();
+
+    /// <summary>Duration of one display-state sweep tick (all tenants), measured around the whole
+    /// <c>ForEachTenant(Sweep)</c> pass in the five-second timer.</summary>
+    public static readonly DurationHistogram SweepDurationMs = new();
+
+    /// <summary>Duration of one DirectorHub push handler (PushSnapshot or PushDelta), which runs the
+    /// store apply AND the synchronous fold observers inline on the hub invocation.</summary>
+    public static readonly DurationHistogram HubPushDurationMs = new();
+
+    private static long _snoozeDbReads;
+    private static long _deviceCredentialLookups;
+    private static long _rosterRequests;
+    private static long _rosterNonSuccess;
+    private static long _sweepTicks;
+    private static long _sweepOverlaps;
+    private static int _sweepInFlight;
+    private static int _hubConnections;
+    private static long _hubConnectionsTotal;
+    private static long _hubPushEvents;
+    private static int _hubPushInFlight;
+
+    /// <summary>One database read performed by the snooze registry (each is one context + one query under
+    /// the gate). Divided by <see cref="RosterRequestObserved"/>'s count, this is the N+1 measurement.</summary>
+    public static void SnoozeDbReadObserved() => Interlocked.Increment(ref _snoozeDbReads);
+
+    /// <summary>One per-request device-credential lookup by key hash (the uncached auth read).</summary>
+    public static void DeviceCredentialLookupObserved() => Interlocked.Increment(ref _deviceCredentialLookups);
+
+    /// <summary>One finished <c>GET /sessions</c> request, with its server-side elapsed time and status.</summary>
+    public static void RosterRequestObserved(TimeSpan elapsed, int statusCode)
+    {
+        Interlocked.Increment(ref _rosterRequests);
+        if (statusCode >= 400)
+            Interlocked.Increment(ref _rosterNonSuccess);
+        RosterDurationMs.Record(elapsed);
+    }
+
+    /// <summary>A display sweep tick is starting. Returns the timestamp to hand to
+    /// <see cref="SweepFinished"/>. If another tick is still in flight, the overlap the read-model review
+    /// predicted has actually happened, and it is counted - never prevented (measurement only).</summary>
+    public static long SweepStarting()
+    {
+        if (Interlocked.Increment(ref _sweepInFlight) > 1)
+            Interlocked.Increment(ref _sweepOverlaps);
+        Interlocked.Increment(ref _sweepTicks);
+        return Stopwatch.GetTimestamp();
+    }
+
+    /// <summary>The matching end of <see cref="SweepStarting"/>. Call from a finally block.</summary>
+    public static void SweepFinished(long startTimestamp)
+    {
+        SweepDurationMs.Record(Stopwatch.GetElapsedTime(startTimestamp));
+        Interlocked.Decrement(ref _sweepInFlight);
+    }
+
+    /// <summary>A DirectorHub connection opened.</summary>
+    public static void HubConnectionOpened()
+    {
+        Interlocked.Increment(ref _hubConnections);
+        Interlocked.Increment(ref _hubConnectionsTotal);
+    }
+
+    /// <summary>A DirectorHub connection closed.</summary>
+    public static void HubConnectionClosed() => Interlocked.Decrement(ref _hubConnections);
+
+    /// <summary>A hub push handler (PushSnapshot/PushDelta) is starting. Returns the timestamp to hand to
+    /// <see cref="HubPushFinished"/>. The in-flight count is the ingress-pressure gauge: SignalR queues
+    /// per-connection, so a growing in-flight count means handlers are not keeping up with arrivals.</summary>
+    public static long HubPushStarting()
+    {
+        Interlocked.Increment(ref _hubPushEvents);
+        Interlocked.Increment(ref _hubPushInFlight);
+        return Stopwatch.GetTimestamp();
+    }
+
+    /// <summary>The matching end of <see cref="HubPushStarting"/>. Call from a finally block.</summary>
+    public static void HubPushFinished(long startTimestamp)
+    {
+        HubPushDurationMs.Record(Stopwatch.GetElapsedTime(startTimestamp));
+        Interlocked.Decrement(ref _hubPushInFlight);
+    }
+
+    /// <summary>
+    /// The full snapshot the <c>/diag/loadmetrics</c> endpoint serves: every counter and histogram above,
+    /// plus standard process numbers (CPU, working set, GC, thread pool) read live. With
+    /// <paramref name="reset"/> the histograms and counters start a fresh window AFTER being read, so a
+    /// load step can scrape its own numbers; the gauges (in-flight, connections) and process numbers are
+    /// instantaneous and never reset.
+    /// </summary>
+    public static object Snapshot(bool reset)
+    {
+        var process = Process.GetCurrentProcess();
+        var snapshot = new
+        {
+            capturedAtUtc = DateTime.UtcNow,
+            snoozeLockWaitMs = SnoozeLockWaitMs.Snapshot(reset),
+            foldDurationMs = FoldDurationMs.Snapshot(reset),
+            rosterDurationMs = RosterDurationMs.Snapshot(reset),
+            sweepDurationMs = SweepDurationMs.Snapshot(reset),
+            hubPushDurationMs = HubPushDurationMs.Snapshot(reset),
+            counters = new
+            {
+                snoozeDbReads = reset ? Interlocked.Exchange(ref _snoozeDbReads, 0) : Interlocked.Read(ref _snoozeDbReads),
+                deviceCredentialLookups = reset ? Interlocked.Exchange(ref _deviceCredentialLookups, 0) : Interlocked.Read(ref _deviceCredentialLookups),
+                rosterRequests = reset ? Interlocked.Exchange(ref _rosterRequests, 0) : Interlocked.Read(ref _rosterRequests),
+                rosterNonSuccess = reset ? Interlocked.Exchange(ref _rosterNonSuccess, 0) : Interlocked.Read(ref _rosterNonSuccess),
+                sweepTicks = reset ? Interlocked.Exchange(ref _sweepTicks, 0) : Interlocked.Read(ref _sweepTicks),
+                sweepOverlaps = reset ? Interlocked.Exchange(ref _sweepOverlaps, 0) : Interlocked.Read(ref _sweepOverlaps),
+                hubPushEvents = reset ? Interlocked.Exchange(ref _hubPushEvents, 0) : Interlocked.Read(ref _hubPushEvents),
+                hubConnectionsTotal = reset ? Interlocked.Exchange(ref _hubConnectionsTotal, 0) : Interlocked.Read(ref _hubConnectionsTotal),
+            },
+            gauges = new
+            {
+                hubConnections = Volatile.Read(ref _hubConnections),
+                hubPushInFlight = Volatile.Read(ref _hubPushInFlight),
+                sweepInFlight = Volatile.Read(ref _sweepInFlight),
+            },
+            process = new
+            {
+                cpuTotalSeconds = process.TotalProcessorTime.TotalSeconds,
+                workingSetBytes = process.WorkingSet64,
+                gcHeapBytes = GC.GetTotalMemory(forceFullCollection: false),
+                gcGen0 = GC.CollectionCount(0),
+                gcGen1 = GC.CollectionCount(1),
+                gcGen2 = GC.CollectionCount(2),
+                gcTotalPauseMs = GC.GetTotalPauseDuration().TotalMilliseconds,
+                threadPoolThreads = ThreadPool.ThreadCount,
+                threadPoolPendingWorkItems = ThreadPool.PendingWorkItemCount,
+                processorCount = Environment.ProcessorCount,
+            },
+        };
+        return snapshot;
+    }
+}
+
+/// <summary>
+/// A fixed-bucket duration histogram: lock-free to record (three interlocked adds), approximate to read.
+/// Percentiles are reported as the upper bound of the bucket the quantile falls in, which is accurate to
+/// the bucket granularity below - ample for finding a ceiling, where the question is "did p95 cross 300
+/// milliseconds", not "was it 301 or 304". Reset swaps the whole window atomically by reference, so a
+/// racing record can at worst land in the window that was just read - one sample, not a corruption.
+/// </summary>
+public sealed class DurationHistogram
+{
+    /// <summary>Bucket upper bounds in milliseconds. The last bucket is unbounded.</summary>
+    private static readonly double[] BoundsMs =
+    {
+        0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 300, 500, 800, 1000, 2500, 5000, 10000, 30000,
+    };
+
+    private sealed class Window
+    {
+        public readonly long[] Buckets = new long[BoundsMs.Length + 1];
+        public long Count;
+        /// <summary>Sum in microseconds, so an interlocked long carries fractional milliseconds.</summary>
+        public long SumMicroseconds;
+        public long MaxMicroseconds;
+    }
+
+    private Window _window = new();
+
+    /// <summary>Record one duration.</summary>
+    public void Record(TimeSpan elapsed)
+    {
+        var window = Volatile.Read(ref _window);
+        var ms = elapsed.TotalMilliseconds;
+        var micro = (long)(ms * 1000.0);
+        var bucket = 0;
+        while (bucket < BoundsMs.Length && ms > BoundsMs[bucket])
+            bucket++;
+        Interlocked.Increment(ref window.Buckets[bucket]);
+        Interlocked.Increment(ref window.Count);
+        Interlocked.Add(ref window.SumMicroseconds, micro);
+        // Lock-free max: retry until our value is no longer larger than the stored one.
+        long seen;
+        while (micro > (seen = Interlocked.Read(ref window.MaxMicroseconds)))
+            if (Interlocked.CompareExchange(ref window.MaxMicroseconds, micro, seen) == seen)
+                break;
+    }
+
+    /// <summary>Record the time elapsed since a <see cref="Stopwatch.GetTimestamp"/> value.</summary>
+    public void RecordSince(long startTimestamp) => Record(Stopwatch.GetElapsedTime(startTimestamp));
+
+    /// <summary>Read the window: count, mean, max, and approximate p50/p95/p99. With
+    /// <paramref name="reset"/> a fresh window starts after the read.</summary>
+    public object Snapshot(bool reset)
+    {
+        var window = reset ? Interlocked.Exchange(ref _window, new Window()) : Volatile.Read(ref _window);
+        var count = Interlocked.Read(ref window.Count);
+        var sumMicro = Interlocked.Read(ref window.SumMicroseconds);
+        var maxMicro = Interlocked.Read(ref window.MaxMicroseconds);
+        return new
+        {
+            count,
+            meanMs = count == 0 ? 0 : sumMicro / 1000.0 / count,
+            maxMs = maxMicro / 1000.0,
+            p50Ms = Quantile(window, count, 0.50),
+            p95Ms = Quantile(window, count, 0.95),
+            p99Ms = Quantile(window, count, 0.99),
+        };
+    }
+
+    private static double Quantile(Window window, long count, double quantile)
+    {
+        if (count == 0) return 0;
+        var rank = (long)Math.Ceiling(quantile * count);
+        long cumulative = 0;
+        for (var i = 0; i < window.Buckets.Length; i++)
+        {
+            cumulative += Interlocked.Read(ref window.Buckets[i]);
+            if (cumulative >= rank)
+                return i < BoundsMs.Length ? BoundsMs[i] : BoundsMs[^1];
+        }
+        return BoundsMs[^1];
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2333,6 +2333,11 @@ public sealed class GatewayHost : IAsyncDisposable
             {
                 sw.Stop();
                 var path = ctx.Request.Path.Value ?? "";
+                // Load-test Stage 0 (issue #1173): the server-side roster latency, recorded beside the
+                // access log so the load driver's outside view has an inside twin.
+                if (path.Equals("/sessions", StringComparison.OrdinalIgnoreCase)
+                    && HttpMethods.IsGet(ctx.Request.Method))
+                    Diagnostics.LoadTestMetrics.RosterRequestObserved(sw.Elapsed, ctx.Response.StatusCode);
                 if (!path.Equals("/healthz", StringComparison.OrdinalIgnoreCase)
                     && !path.Equals("/favicon.ico", StringComparison.OrdinalIgnoreCase)
                     // The keep-warm heartbeat (P2) hits /diag/ping every ~25s per client - warming traffic,
@@ -3255,7 +3260,16 @@ public sealed class GatewayHost : IAsyncDisposable
             // ambient snapshot and per-tenant gate resolve to each tenant in turn. The try/catch is OUTSIDE the
             // per-tenant loop only as a backstop - ForEachTenant itself does not isolate a throwing tenant here,
             // but Sweep is fire-and-forget internally and does not throw on a single bad send.
-            _ => { try { _tenantPass.ForEachTenant(() => FleetDisplayState.Sweep()); } catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); } },
+            // Load-test Stage 0 (issue #1173): measure each tick's duration and COUNT overlapping ticks -
+            // the read-model review names the missing overlap guard as a suspect, and this proves or
+            // refutes it with a number. Measurement only: no guard is added here (that fix is #1159's).
+            _ =>
+            {
+                var sweepStart = Diagnostics.LoadTestMetrics.SweepStarting();
+                try { _tenantPass.ForEachTenant(() => FleetDisplayState.Sweep()); }
+                catch (Exception ex) { FileLog.Write($"[GatewayHost] display-state sweep error: {ex.Message}"); }
+                finally { Diagnostics.LoadTestMetrics.SweepFinished(sweepStart); }
+            },
             null, DisplayStateSweepInterval, DisplayStateSweepInterval);
         FileLog.Write($"[GatewayHost] display-state sweep started: every {DisplayStateSweepInterval.TotalSeconds:0}s");
 
@@ -3674,14 +3688,40 @@ public sealed class GatewayHost : IAsyncDisposable
         var periodEnd = currentPeriodEnd ?? DateTime.UtcNow.AddYears(1);
         var tierValue = tier ?? Tenancy.EntitlementRegistry.TierHosted;
         using var ctx = _gatewayDb.CreateUnscopedContext();
-        ctx.Database.ExecuteSqlRaw(
-            "CREATE TABLE IF NOT EXISTS entitlements (" +
-            "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
-            "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
-            "livemode INTEGER NULL, tier TEXT NULL)");
-        ctx.Database.ExecuteSqlRaw(
-            "INSERT OR REPLACE INTO entitlements (subject, status, current_period_end, livemode, tier) VALUES ({0}, {1}, {2}, {3}, {4})",
-            subject, status, periodEnd, livemode, tierValue);
+        // Provider CONDITIONAL, same signal the model shape uses (issue #1173 made this seam run on
+        // Postgres for the first time - the load-test rig seeds synthetic tenants through it against a
+        // throwaway Postgres, and the SQLite-only SQL below was a hard syntax error there). On Postgres
+        // the table is the website-owned shape the model maps: gateway.entitlements with a uuid subject,
+        // upserted with the Postgres conflict clause. SQLite keeps its original SQL, byte-identical.
+        if (ctx.Database.IsNpgsql())
+        {
+            ctx.Database.ExecuteSqlRaw("CREATE SCHEMA IF NOT EXISTS gateway");
+            ctx.Database.ExecuteSqlRaw(
+                "CREATE TABLE IF NOT EXISTS gateway.entitlements (" +
+                "subject uuid NOT NULL PRIMARY KEY, status text NOT NULL, " +
+                "current_period_end timestamptz NULL, stripe_subscription_id text NULL, updated_at timestamptz NULL, " +
+                "livemode boolean NULL, tier text NULL)");
+            // Guid.Parse is the same demand the model's subject-to-uuid value converter makes of every
+            // read: on Postgres a subject that is not a uuid could never be entitled anyway, so a bad
+            // test subject fails HERE, loudly, not later as a mysterious 402.
+            ctx.Database.ExecuteSqlRaw(
+                "INSERT INTO gateway.entitlements (subject, status, current_period_end, livemode, tier) " +
+                "VALUES ({0}, {1}, {2}, {3}, {4}) " +
+                "ON CONFLICT (subject) DO UPDATE SET status = EXCLUDED.status, " +
+                "current_period_end = EXCLUDED.current_period_end, livemode = EXCLUDED.livemode, tier = EXCLUDED.tier",
+                Guid.Parse(subject), status, periodEnd, livemode, tierValue);
+        }
+        else
+        {
+            ctx.Database.ExecuteSqlRaw(
+                "CREATE TABLE IF NOT EXISTS entitlements (" +
+                "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
+                "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
+                "livemode INTEGER NULL, tier TEXT NULL)");
+            ctx.Database.ExecuteSqlRaw(
+                "INSERT OR REPLACE INTO entitlements (subject, status, current_period_end, livemode, tier) VALUES ({0}, {1}, {2}, {3}, {4})",
+                subject, status, periodEnd, livemode, tierValue);
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -155,6 +155,9 @@ public sealed class DeviceRegistry : IDisposable
         {
             var suppliedBytes = HashKeyBytes(key);
             var suppliedHash = HashBytesToHex(suppliedBytes);
+            // Load-test Stage 0 (issue #1173): every authenticated request pays this uncached database
+            // lookup; counting it puts a number on that cost beside the roster's own reads.
+            Diagnostics.LoadTestMetrics.DeviceCredentialLookupObserved();
             using var ctx = _db.CreateUnscopedContext();
             var matches = ctx.DeviceCredentials
                 .AsNoTracking()

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -397,8 +397,13 @@ public sealed class SnoozeRegistry
     public bool IsExpired(string sessionId, DateTime nowUtc)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
+        // Load-test Stage 0 (issue #1173): measure the WAIT to enter the process-wide gate, and count the
+        // read - this method is one leg of the fold's per-session N+1 the read-model review names.
+        var gateWaitStart = System.Diagnostics.Stopwatch.GetTimestamp();
         lock (_gate)
         {
+            Diagnostics.LoadTestMetrics.SnoozeLockWaitMs.RecordSince(gateWaitStart);
+            Diagnostics.LoadTestMetrics.SnoozeDbReadObserved();
             using var ctx = _db.CreateContext();
             var e = Find(ctx, sessionId, tracking: false);
             return e is not null
@@ -426,8 +431,12 @@ public sealed class SnoozeRegistry
     public string HoldStateFor(string sessionId, DateTime nowUtc)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return HoldStates.None;
+        // Load-test Stage 0 (issue #1173): same wait-and-count measurement as IsExpired above.
+        var gateWaitStart = System.Diagnostics.Stopwatch.GetTimestamp();
         lock (_gate)
         {
+            Diagnostics.LoadTestMetrics.SnoozeLockWaitMs.RecordSince(gateWaitStart);
+            Diagnostics.LoadTestMetrics.SnoozeDbReadObserved();
             using var ctx = _db.CreateContext();
             var e = Find(ctx, sessionId, tracking: false);
             if (e is null)
@@ -449,8 +458,12 @@ public sealed class SnoozeRegistry
     public DateTime? SnoozeUntilFor(string sessionId)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return null;
+        // Load-test Stage 0 (issue #1173): same wait-and-count measurement as IsExpired above.
+        var gateWaitStart = System.Diagnostics.Stopwatch.GetTimestamp();
         lock (_gate)
         {
+            Diagnostics.LoadTestMetrics.SnoozeLockWaitMs.RecordSince(gateWaitStart);
+            Diagnostics.LoadTestMetrics.SnoozeDbReadObserved();
             using var ctx = _db.CreateContext();
             return Find(ctx, sessionId, tracking: false)?.SnoozeUntilUtc;
         }

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -183,6 +183,22 @@ public sealed class DirectorHub : Hub
     /// <summary>A full snapshot: replaces the bound Director's session set (pruning anything absent).</summary>
     public void PushSnapshot(long sequence, SessionDto[] sessions)
     {
+        // Load-test Stage 0 (issue #1173): count and time every push handler - the store apply AND the
+        // synchronous fold observers below run inline on this hub invocation, so this duration is the
+        // real ingress cost. The in-flight gauge is the push-pressure number the plan requires.
+        var pushStart = Diagnostics.LoadTestMetrics.HubPushStarting();
+        try
+        {
+            PushSnapshotCore(sequence, sessions);
+        }
+        finally
+        {
+            Diagnostics.LoadTestMetrics.HubPushFinished(pushStart);
+        }
+    }
+
+    private void PushSnapshotCore(long sequence, SessionDto[] sessions)
+    {
         var directorId = RequireBoundDirector();
         // Hosted Multi-Tenancy increment 1: run the whole handler in the bound tenant's scope, so the
         // EF-writing observers below (snooze landings, spend) stamp and filter by this connection's tenant.
@@ -221,6 +237,20 @@ public sealed class DirectorHub : Hub
 
     /// <summary>A single-session delta: upserts one session for the bound Director.</summary>
     public void PushDelta(long sequence, SessionDto session)
+    {
+        // Load-test Stage 0 (issue #1173): same count-and-time as PushSnapshot above.
+        var pushStart = Diagnostics.LoadTestMetrics.HubPushStarting();
+        try
+        {
+            PushDeltaCore(sequence, session);
+        }
+        finally
+        {
+            Diagnostics.LoadTestMetrics.HubPushFinished(pushStart);
+        }
+    }
+
+    private void PushDeltaCore(long sequence, SessionDto session)
     {
         var directorId = RequireBoundDirector();
         if (session is null || string.IsNullOrEmpty(session.SessionId))
@@ -307,12 +337,15 @@ public sealed class DirectorHub : Hub
 
     public override Task OnConnectedAsync()
     {
+        // Load-test Stage 0 (issue #1173): the held-socket count, one of the numbers the plan requires.
+        Diagnostics.LoadTestMetrics.HubConnectionOpened();
         FileLog.Write($"[DirectorHub] connected: conn={Short(Context.ConnectionId)}");
         return base.OnConnectedAsync();
     }
 
     public override Task OnDisconnectedAsync(Exception? exception)
     {
+        Diagnostics.LoadTestMetrics.HubConnectionClosed();
         var directorId = BoundDirectorId();
         var tenant = BoundTenant();
         if (directorId is not null && tenant is { } t)

--- a/tools/loadtest/DirectorSim/DirectorSim.csproj
+++ b/tools/loadtest/DirectorSim/DirectorSim.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Stage 2 of the Gateway load-test plan (devthrottle_internal issue #1173): the Director push
+       simulator. Opens N SignalR HubConnections to the Gateway's /director-stream, sends the real
+       Hello(DirectorStreamHello) + PushSnapshot(sequence, SessionDto[]) contract, then streams
+       PushDelta at a target total rate with a strictly increasing per-connection sequence (the
+       PushedSessionStore drops anything else, and a simulator that violated that would be load-testing
+       the reject path, not the fold). Deliberately NOT in cc-director.sln (tools/harnesses precedent). -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>DirectorSim</AssemblyName>
+    <SelfContained>false</SelfContained>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootNamespace>CcDirector.LoadTest.DirectorSim</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Version-matched to the ASP.NET Core 10 server the Gateway runs on. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The REAL wire contracts (DirectorStreamHello, SessionDto), so the simulator's messages are the
+         messages a real Director sends - not a lookalike shape the hub would bind differently. -->
+    <ProjectReference Include="..\..\..\src\CcDirector.Gateway.Contracts\CcDirector.Gateway.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\LoadTargetGuard.cs" Link="LoadTargetGuard.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -152,6 +152,7 @@ var reporter = Task.Run(async () =>
 });
 
 var deltaWindowStart = DateTime.UtcNow;
+var windowEndUtc = deltaWindowStart;
 if (eventsPerSecond > 0)
 {
     // The delta stream: a token-bucket paced loop distributing PushDelta round-robin across all
@@ -186,16 +187,21 @@ if (eventsPerSecond > 0)
             try { await inFlight.WaitAsync(windowCts.Token); } catch (OperationCanceledException) { break; }
             _ = sim.SendOneDeltaAsync(windowCts.Token).ContinueWith(t =>
             {
-                inFlight.Release();
+                // Counters BEFORE the release: the drain below treats a full semaphore as "every
+                // outcome recorded", so releasing first would let it read totals with this
+                // callback's count still pending (review finding).
                 if (t.IsCompletedSuccessfully && t.Result) Interlocked.Increment(ref deltasOk);
                 else Interlocked.Increment(ref deltasFailed);
+                inFlight.Release();
             }, TaskScheduler.Default);
         }
     }
     // Window over: cancel whatever is still queued or in flight, then DRAIN before the counters are
     // read - a total printed while completion callbacks are still landing is not a total (review
     // finding). Cancellation makes in-flight invocations fail fast, so the drain is bounded anyway;
-    // the 15 s cap is a backstop against a fully wedged server.
+    // the 15 s cap is a backstop against a fully wedged server. The window END is stamped HERE,
+    // before the drain, so the reported window length is the measurement, not measurement + drain.
+    windowEndUtc = DateTime.UtcNow;
     windowCts.Cancel();
     var drainDeadline = DateTime.UtcNow.AddSeconds(15);
     while (inFlight.CurrentCount < maxInFlight && DateTime.UtcNow < drainDeadline)
@@ -208,13 +214,14 @@ else
     // Hold mode: keep connections and their pushed rosters open (the Stage 1 background fleet).
     try { await Task.Delay(durationSeconds > 0 ? TimeSpan.FromSeconds(durationSeconds) : Timeout.InfiniteTimeSpan, stopRequested.Token); }
     catch (OperationCanceledException) { }
+    windowEndUtc = DateTime.UtcNow;
 }
 
 // The measurement WINDOW ends here. Cancelling also cancels every queued and in-flight send, so
 // completions that would otherwise trickle in during teardown cannot inflate the run's numbers -
 // the first baseline's totals included exactly that drain, and read as double the true rate
 // (review finding). The window numbers are printed before teardown so they are unambiguous.
-var windowSeconds = (DateTime.UtcNow - deltaWindowStart).TotalSeconds;
+var windowSeconds = (windowEndUtc - deltaWindowStart).TotalSeconds;
 Console.WriteLine($"[DirectorSim] WINDOW END: deltasOk={Interlocked.Read(ref deltasOk)} deltasFailed={Interlocked.Read(ref deltasFailed)} over {windowSeconds:F0}s (configured duration {durationSeconds}s)");
 stopRequested.Cancel();
 await reporter;

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -217,6 +217,11 @@ internal sealed class SimDirector : IAsyncDisposable
     private readonly HubConnection _connection;
     private readonly SessionDto[] _sessions;
     private readonly DirectorKey _key;
+    // ONE send at a time per connection. Sequence assignment and the send must be one atomic step:
+    // two concurrent sends on the same connection could otherwise reach the wire in the opposite
+    // order to their sequences, and PushedSessionStore would drop the lower one as stale - the
+    // simulator would be load-testing the reject path and counting it as success (review finding).
+    private readonly SemaphoreSlim _sendGate = new(1, 1);
     private long _sequence;
     private int _deltaIndex;
 
@@ -232,8 +237,16 @@ internal sealed class SimDirector : IAsyncDisposable
         // and treats the cache as stale until this sim pushes again: re-Hello + full snapshot, next sequence.
         _connection.Reconnected += async _ =>
         {
-            await _connection.InvokeAsync("Hello", BuildHello());
-            await _connection.InvokeAsync("PushSnapshot", Interlocked.Increment(ref _sequence), _sessions);
+            await _sendGate.WaitAsync();
+            try
+            {
+                await _connection.InvokeAsync("Hello", BuildHello());
+                await _connection.InvokeAsync("PushSnapshot", Interlocked.Increment(ref _sequence), _sessions);
+            }
+            finally
+            {
+                _sendGate.Release();
+            }
         };
     }
 
@@ -246,24 +259,30 @@ internal sealed class SimDirector : IAsyncDisposable
         await _connection.InvokeAsync("PushSnapshot", Interlocked.Increment(ref _sequence), _sessions, cancellation);
     }
 
-    /// <summary>Mutate one session (round-robin) and push it as a delta. Returns false on failure.</summary>
+    /// <summary>Mutate one session (round-robin) and push it as a delta, serialized with every other
+    /// send on this connection so sequences reach the wire in order. Returns false on failure.</summary>
     public async Task<bool> SendOneDeltaAsync()
     {
         if (_connection.State != HubConnectionState.Connected)
             return false;
-        var session = _sessions[_deltaIndex = (_deltaIndex + 1) % _sessions.Length];
-        var now = DateTime.UtcNow;
-        session.LastActivityAt = now;
-        session.ActivityState = session.ActivityState == "working" ? "waiting" : "working";
-        session.StatusColor = session.ActivityState == "working" ? "blue" : "green";
+        await _sendGate.WaitAsync();
         try
         {
+            var session = _sessions[_deltaIndex = (_deltaIndex + 1) % _sessions.Length];
+            var now = DateTime.UtcNow;
+            session.LastActivityAt = now;
+            session.ActivityState = session.ActivityState == "working" ? "waiting" : "working";
+            session.StatusColor = session.ActivityState == "working" ? "blue" : "green";
             await _connection.InvokeAsync("PushDelta", Interlocked.Increment(ref _sequence), session);
             return true;
         }
         catch
         {
             return false;
+        }
+        finally
+        {
+            _sendGate.Release();
         }
     }
 

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -1,0 +1,297 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using CcDirector.LoadTest.Shared;
+using Microsoft.AspNetCore.SignalR.Client;
+
+// Stage 2 of the Gateway load-test plan (devthrottle_internal issue #1173): the Director push simulator.
+//
+// Opens N HubConnections to /director-stream (one per synthetic Director key from the LoadRig's
+// directors.json), sends the real Hello + PushSnapshot, then streams PushDelta at a target TOTAL rate
+// across all connections, keeping every per-connection sequence strictly increasing (the
+// PushedSessionStore's acceptance rule). With EVENTS_PER_SEC=0 it holds the connections and their pushed
+// rosters open silently - that is the background fleet Stage 1's roster polling reads.
+//
+// Environment:
+//   GATEWAY_URL            REQUIRED. Refused unless local or explicitly named (never production).
+//   KEYS_FILE              REQUIRED. The LoadRig's directors.json.
+//   DIRECTORS              How many Directors to simulate (default: all keys in the file).
+//   SESSIONS_PER_DIRECTOR  Sessions in each Director's snapshot (default 8, the plan's assumption).
+//   EVENTS_PER_SEC         Target TOTAL PushDelta rate across all connections (default 0 = hold only).
+//   DURATION_SECONDS       Stop after this long (default 0 = run until Ctrl+C).
+//   CONNECT_PER_SEC        Connection open rate (default 50/s, so negotiate is a ramp, not a stampede).
+//   METRICS_FILE           Optional JSONL output; one line per report interval.
+//   METRICS_KEY            Optional viewer device key; when set, /diag/loadmetrics is scraped into the report.
+//   REPORT_SECONDS         Report interval (default 5).
+
+var gatewayUrl = Environment.GetEnvironmentVariable("GATEWAY_URL")
+    ?? throw new InvalidOperationException("GATEWAY_URL is required (e.g. http://127.0.0.1:7891).");
+LoadTargetGuard.AssertUrlAllowed(gatewayUrl);
+gatewayUrl = gatewayUrl.TrimEnd('/');
+
+var keysFile = Environment.GetEnvironmentVariable("KEYS_FILE")
+    ?? throw new InvalidOperationException("KEYS_FILE is required (the LoadRig's directors.json).");
+var allKeys = JsonSerializer.Deserialize<List<DirectorKey>>(File.ReadAllText(keysFile),
+        new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+    ?? throw new InvalidOperationException($"KEYS_FILE {keysFile} parsed to null.");
+if (allKeys.Count == 0)
+    throw new InvalidOperationException($"KEYS_FILE {keysFile} holds no director keys.");
+
+var directorCount = ReadInt("DIRECTORS", allKeys.Count);
+if (directorCount > allKeys.Count)
+    throw new InvalidOperationException($"DIRECTORS={directorCount} but KEYS_FILE holds only {allKeys.Count} keys. Seed a bigger rig (LOADTEST_TENANTS / LOADTEST_DIRECTORS_PER_TENANT).");
+var sessionsPerDirector = ReadInt("SESSIONS_PER_DIRECTOR", 8);
+var eventsPerSecond = ReadInt("EVENTS_PER_SEC", 0);
+var durationSeconds = ReadInt("DURATION_SECONDS", 0);
+var connectPerSecond = ReadInt("CONNECT_PER_SEC", 50);
+var reportSeconds = ReadInt("REPORT_SECONDS", 5);
+var metricsFile = Environment.GetEnvironmentVariable("METRICS_FILE");
+var metricsKey = Environment.GetEnvironmentVariable("METRICS_KEY");
+
+Console.WriteLine($"[DirectorSim] target={gatewayUrl} directors={directorCount} sessionsPerDirector={sessionsPerDirector} eventsPerSec={eventsPerSecond} duration={(durationSeconds == 0 ? "until Ctrl+C" : durationSeconds + "s")}");
+
+var stopRequested = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; stopRequested.Cancel(); };
+
+// ---- Open the connections at the configured ramp rate. -------------------------------------------
+var sims = new List<SimDirector>(directorCount);
+long connectFailures = 0;
+var connectStart = DateTime.UtcNow;
+for (var i = 0; i < directorCount && !stopRequested.IsCancellationRequested; i++)
+{
+    var sim = new SimDirector(gatewayUrl, allKeys[i], sessionsPerDirector);
+    try
+    {
+        await sim.ConnectAndPushSnapshotAsync(stopRequested.Token);
+        sims.Add(sim);
+    }
+    catch (OperationCanceledException) { break; }
+    catch (Exception ex)
+    {
+        Interlocked.Increment(ref connectFailures);
+        Console.Error.WriteLine($"[DirectorSim] connect FAILED for {allKeys[i].DirectorId}: {ex.Message}");
+    }
+
+    // Ramp: no more than CONNECT_PER_SEC opens per second.
+    var expectedElapsed = TimeSpan.FromSeconds((double)(i + 1) / connectPerSecond);
+    var actualElapsed = DateTime.UtcNow - connectStart;
+    if (expectedElapsed > actualElapsed)
+        try { await Task.Delay(expectedElapsed - actualElapsed, stopRequested.Token); }
+        catch (OperationCanceledException) { break; }
+
+    if ((i + 1) % 250 == 0)
+        Console.WriteLine($"[DirectorSim] {i + 1}/{directorCount} connected ({connectFailures} failures) in {(DateTime.UtcNow - connectStart).TotalSeconds:F0}s");
+}
+Console.WriteLine($"[DirectorSim] CONNECTED {sims.Count}/{directorCount} directors ({connectFailures} failures) in {(DateTime.UtcNow - connectStart).TotalSeconds:F0}s; " +
+                  $"{sims.Count * sessionsPerDirector} sessions pushed");
+
+if (sims.Count == 0)
+{
+    Console.Error.WriteLine("[DirectorSim] no connection succeeded; nothing to do.");
+    return 1;
+}
+
+// ---- Report loop + delta stream. ------------------------------------------------------------------
+long deltasOk = 0, deltasFailed = 0;
+var runUntil = durationSeconds > 0 ? DateTime.UtcNow.AddSeconds(durationSeconds) : DateTime.MaxValue;
+using var httpForMetrics = new HttpClient { BaseAddress = new Uri(gatewayUrl + "/") };
+if (!string.IsNullOrEmpty(metricsKey))
+    httpForMetrics.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", metricsKey);
+
+var reporter = Task.Run(async () =>
+{
+    long lastOk = 0, lastFailed = 0;
+    while (!stopRequested.IsCancellationRequested && DateTime.UtcNow < runUntil)
+    {
+        try { await Task.Delay(TimeSpan.FromSeconds(reportSeconds), stopRequested.Token); }
+        catch (OperationCanceledException) { break; }
+        var ok = Interlocked.Read(ref deltasOk);
+        var failed = Interlocked.Read(ref deltasFailed);
+        var okRate = (ok - lastOk) / (double)reportSeconds;
+        var connected = sims.Count(s => s.IsConnected);
+        Console.WriteLine($"[DirectorSim] connected={connected}/{sims.Count} deltasOk={ok} (+{okRate:F0}/s) deltasFailed={failed} (+{failed - lastFailed})");
+
+        if (!string.IsNullOrEmpty(metricsFile))
+        {
+            object? gatewayMetrics = null;
+            if (!string.IsNullOrEmpty(metricsKey))
+                try
+                {
+                    var raw = await httpForMetrics.GetStringAsync("diag/loadmetrics", stopRequested.Token);
+                    gatewayMetrics = JsonSerializer.Deserialize<JsonElement>(raw);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    gatewayMetrics = new { scrapeError = ex.Message };
+                }
+            var line = JsonSerializer.Serialize(new
+            {
+                atUtc = DateTime.UtcNow,
+                connected,
+                total = sims.Count,
+                deltasOk = ok,
+                deltasFailed = failed,
+                achievedPerSecond = okRate,
+                gateway = gatewayMetrics,
+            });
+            File.AppendAllText(metricsFile, line + Environment.NewLine);
+        }
+        lastOk = ok; lastFailed = failed;
+    }
+});
+
+if (eventsPerSecond > 0)
+{
+    // The delta stream: a token-bucket paced loop distributing PushDelta round-robin across all
+    // connections. InvokeAsync (not fire-and-forget Send) so a server that stops keeping up shows as
+    // rising in-flight here, bounded by the semaphore, instead of unbounded queueing hiding the ceiling.
+    var inFlight = new SemaphoreSlim(2000);
+    var scheduleStart = DateTime.UtcNow;
+    long scheduled = 0;
+    var simIndex = 0;
+    while (!stopRequested.IsCancellationRequested && DateTime.UtcNow < runUntil)
+    {
+        var due = (long)((DateTime.UtcNow - scheduleStart).TotalSeconds * eventsPerSecond);
+        if (scheduled >= due)
+        {
+            try { await Task.Delay(10, stopRequested.Token); } catch (OperationCanceledException) { break; }
+            continue;
+        }
+        while (scheduled < due && !stopRequested.IsCancellationRequested)
+        {
+            var sim = sims[simIndex];
+            simIndex = (simIndex + 1) % sims.Count;
+            scheduled++;
+            try { await inFlight.WaitAsync(stopRequested.Token); } catch (OperationCanceledException) { break; }
+            _ = sim.SendOneDeltaAsync().ContinueWith(t =>
+            {
+                inFlight.Release();
+                if (t.IsCompletedSuccessfully && t.Result) Interlocked.Increment(ref deltasOk);
+                else Interlocked.Increment(ref deltasFailed);
+            }, TaskScheduler.Default);
+        }
+    }
+}
+else
+{
+    // Hold mode: keep connections and their pushed rosters open (the Stage 1 background fleet).
+    try { await Task.Delay(durationSeconds > 0 ? TimeSpan.FromSeconds(durationSeconds) : Timeout.InfiniteTimeSpan, stopRequested.Token); }
+    catch (OperationCanceledException) { }
+}
+
+stopRequested.Cancel();
+await reporter;
+
+Console.WriteLine("[DirectorSim] closing connections...");
+await Parallel.ForEachAsync(sims, new ParallelOptions { MaxDegreeOfParallelism = 64 },
+    async (sim, _) => await sim.DisposeAsync());
+Console.WriteLine($"SIM DONE connected={sims.Count} deltasOk={Interlocked.Read(ref deltasOk)} deltasFailed={Interlocked.Read(ref deltasFailed)} connectFailures={connectFailures}");
+return 0;
+
+static int ReadInt(string variable, int fallback)
+{
+    var raw = Environment.GetEnvironmentVariable(variable);
+    if (string.IsNullOrWhiteSpace(raw)) return fallback;
+    if (!int.TryParse(raw, out var value) || value < 0)
+        throw new InvalidOperationException($"{variable} must be a non-negative integer, got '{raw}'.");
+    return value;
+}
+
+internal sealed record DirectorKey(string Tenant, string DirectorId, string MachineName, string DeviceKey);
+
+/// <summary>
+/// One simulated Director: one HubConnection, one session set, one strictly increasing sequence. The
+/// sequence discipline is the whole trick: PushedSessionStore drops any push whose sequence is not
+/// greater than the last accepted one for the active connection, and resets its baseline when a NEW
+/// connection re-Hellos - so on reconnect this sim re-Hellos and re-pushes a full snapshot with its
+/// next sequence, exactly as a real Director does.
+/// </summary>
+internal sealed class SimDirector : IAsyncDisposable
+{
+    private readonly HubConnection _connection;
+    private readonly SessionDto[] _sessions;
+    private readonly DirectorKey _key;
+    private long _sequence;
+    private int _deltaIndex;
+
+    public SimDirector(string gatewayUrl, DirectorKey key, int sessionsPerDirector)
+    {
+        _key = key;
+        _connection = new HubConnectionBuilder()
+            .WithUrl($"{gatewayUrl}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(key.DeviceKey))
+            .WithAutomaticReconnect()
+            .Build();
+        _sessions = Enumerable.Range(1, sessionsPerDirector).Select(n => BuildSession(key, n)).ToArray();
+        // On automatic reconnect the server sees a NEW connection id, so the store expects a fresh Hello
+        // and treats the cache as stale until this sim pushes again: re-Hello + full snapshot, next sequence.
+        _connection.Reconnected += async _ =>
+        {
+            await _connection.InvokeAsync("Hello", BuildHello());
+            await _connection.InvokeAsync("PushSnapshot", Interlocked.Increment(ref _sequence), _sessions);
+        };
+    }
+
+    public bool IsConnected => _connection.State == HubConnectionState.Connected;
+
+    public async Task ConnectAndPushSnapshotAsync(CancellationToken cancellation)
+    {
+        await _connection.StartAsync(cancellation);
+        await _connection.InvokeAsync("Hello", BuildHello(), cancellation);
+        await _connection.InvokeAsync("PushSnapshot", Interlocked.Increment(ref _sequence), _sessions, cancellation);
+    }
+
+    /// <summary>Mutate one session (round-robin) and push it as a delta. Returns false on failure.</summary>
+    public async Task<bool> SendOneDeltaAsync()
+    {
+        if (_connection.State != HubConnectionState.Connected)
+            return false;
+        var session = _sessions[_deltaIndex = (_deltaIndex + 1) % _sessions.Length];
+        var now = DateTime.UtcNow;
+        session.LastActivityAt = now;
+        session.ActivityState = session.ActivityState == "working" ? "waiting" : "working";
+        session.StatusColor = session.ActivityState == "working" ? "blue" : "green";
+        try
+        {
+            await _connection.InvokeAsync("PushDelta", Interlocked.Increment(ref _sequence), session);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private DirectorStreamHello BuildHello() => new()
+    {
+        DirectorId = _key.DirectorId,
+        Version = "loadtest-sim",
+        MachineName = _key.MachineName,
+        User = "loadtest",
+        Pid = Environment.ProcessId,
+        StartedAt = DateTime.UtcNow,
+    };
+
+    private static SessionDto BuildSession(DirectorKey key, int number) => new()
+    {
+        SessionId = $"{key.DirectorId}-sess-{number:D2}",
+        DirectorId = key.DirectorId,
+        Agent = "claude",
+        RepoPath = $"D:\\repos\\loadtest\\synthetic-{number:D2}",
+        RepoName = $"synthetic-{number:D2}",
+        Status = "running",
+        ActivityState = "working",
+        CreatedAt = DateTime.UtcNow,
+        Name = $"loadtest session {number:D2} of {key.DirectorId}",
+        MachineName = key.MachineName,
+        User = "loadtest",
+        StatusColor = "green",
+        LastActivityAt = DateTime.UtcNow,
+        BackendType = "conpty",
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await _connection.StopAsync(); } catch { /* closing anyway */ }
+        await _connection.DisposeAsync();
+    }
+}

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -157,25 +157,34 @@ if (eventsPerSecond > 0)
     // The delta stream: a token-bucket paced loop distributing PushDelta round-robin across all
     // connections. InvokeAsync (not fire-and-forget Send) so a server that stops keeping up shows as
     // rising in-flight here, bounded by the semaphore, instead of unbounded queueing hiding the ceiling.
-    var inFlight = new SemaphoreSlim(2000);
+    const int maxInFlight = 2000;
+    var inFlight = new SemaphoreSlim(maxInFlight);
+    // The window deadline is enforced by CANCELLATION, not only by loop conditions: with the backlog
+    // full the scheduler is parked inside WaitAsync, and a loop condition alone would never be
+    // evaluated again, so the run could outlive its configured duration indefinitely (review
+    // finding). This token fires at the deadline or on Ctrl+C, whichever comes first, and every wait
+    // and send in the window observes it.
+    using var windowCts = CancellationTokenSource.CreateLinkedTokenSource(stopRequested.Token);
+    if (durationSeconds > 0)
+        windowCts.CancelAfter(runUntil - DateTime.UtcNow);
     var scheduleStart = deltaWindowStart;
     long scheduled = 0;
     var simIndex = 0;
-    while (!stopRequested.IsCancellationRequested && DateTime.UtcNow < runUntil)
+    while (!windowCts.IsCancellationRequested && DateTime.UtcNow < runUntil)
     {
         var due = (long)((DateTime.UtcNow - scheduleStart).TotalSeconds * eventsPerSecond);
         if (scheduled >= due)
         {
-            try { await Task.Delay(10, stopRequested.Token); } catch (OperationCanceledException) { break; }
+            try { await Task.Delay(10, windowCts.Token); } catch (OperationCanceledException) { break; }
             continue;
         }
-        while (scheduled < due && !stopRequested.IsCancellationRequested)
+        while (scheduled < due && !windowCts.IsCancellationRequested)
         {
             var sim = sims[simIndex];
             simIndex = (simIndex + 1) % sims.Count;
             scheduled++;
-            try { await inFlight.WaitAsync(stopRequested.Token); } catch (OperationCanceledException) { break; }
-            _ = sim.SendOneDeltaAsync(stopRequested.Token).ContinueWith(t =>
+            try { await inFlight.WaitAsync(windowCts.Token); } catch (OperationCanceledException) { break; }
+            _ = sim.SendOneDeltaAsync(windowCts.Token).ContinueWith(t =>
             {
                 inFlight.Release();
                 if (t.IsCompletedSuccessfully && t.Result) Interlocked.Increment(ref deltasOk);
@@ -183,6 +192,16 @@ if (eventsPerSecond > 0)
             }, TaskScheduler.Default);
         }
     }
+    // Window over: cancel whatever is still queued or in flight, then DRAIN before the counters are
+    // read - a total printed while completion callbacks are still landing is not a total (review
+    // finding). Cancellation makes in-flight invocations fail fast, so the drain is bounded anyway;
+    // the 15 s cap is a backstop against a fully wedged server.
+    windowCts.Cancel();
+    var drainDeadline = DateTime.UtcNow.AddSeconds(15);
+    while (inFlight.CurrentCount < maxInFlight && DateTime.UtcNow < drainDeadline)
+        await Task.Delay(100);
+    if (inFlight.CurrentCount < maxInFlight)
+        Console.WriteLine($"[DirectorSim] WARNING: {maxInFlight - inFlight.CurrentCount} sends still unresolved after the 15 s drain; the WINDOW END totals undercount by at most that many.");
 }
 else
 {

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -120,7 +120,13 @@ var reporter = Task.Run(async () =>
                     var raw = await httpForMetrics.GetStringAsync("diag/loadmetrics", stopRequested.Token);
                     gatewayMetrics = JsonSerializer.Deserialize<JsonElement>(raw);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (OperationCanceledException)
+                {
+                    // Shutdown cancelled an in-flight scrape - end the reporter, do not crash the run
+                    // (a TaskCanceledException here took the whole first Stage 2 run's summary with it).
+                    break;
+                }
+                catch (Exception ex)
                 {
                     gatewayMetrics = new { scrapeError = ex.Message };
                 }

--- a/tools/loadtest/DirectorSim/Program.cs
+++ b/tools/loadtest/DirectorSim/Program.cs
@@ -101,13 +101,18 @@ if (!string.IsNullOrEmpty(metricsKey))
 var reporter = Task.Run(async () =>
 {
     long lastOk = 0, lastFailed = 0;
+    var lastReportAt = DateTime.UtcNow;
     while (!stopRequested.IsCancellationRequested && DateTime.UtcNow < runUntil)
     {
         try { await Task.Delay(TimeSpan.FromSeconds(reportSeconds), stopRequested.Token); }
         catch (OperationCanceledException) { break; }
         var ok = Interlocked.Read(ref deltasOk);
         var failed = Interlocked.Read(ref deltasFailed);
-        var okRate = (ok - lastOk) / (double)reportSeconds;
+        // Rate over the MEASURED interval, not the nominal one - under load the delay drifts, and a
+        // rate divided by the nominal interval understates or overstates accordingly (review finding).
+        var reportElapsed = (DateTime.UtcNow - lastReportAt).TotalSeconds;
+        lastReportAt = DateTime.UtcNow;
+        var okRate = (ok - lastOk) / Math.Max(1.0, reportElapsed);
         var connected = sims.Count(s => s.IsConnected);
         Console.WriteLine($"[DirectorSim] connected={connected}/{sims.Count} deltasOk={ok} (+{okRate:F0}/s) deltasFailed={failed} (+{failed - lastFailed})");
 
@@ -146,13 +151,14 @@ var reporter = Task.Run(async () =>
     }
 });
 
+var deltaWindowStart = DateTime.UtcNow;
 if (eventsPerSecond > 0)
 {
     // The delta stream: a token-bucket paced loop distributing PushDelta round-robin across all
     // connections. InvokeAsync (not fire-and-forget Send) so a server that stops keeping up shows as
     // rising in-flight here, bounded by the semaphore, instead of unbounded queueing hiding the ceiling.
     var inFlight = new SemaphoreSlim(2000);
-    var scheduleStart = DateTime.UtcNow;
+    var scheduleStart = deltaWindowStart;
     long scheduled = 0;
     var simIndex = 0;
     while (!stopRequested.IsCancellationRequested && DateTime.UtcNow < runUntil)
@@ -169,7 +175,7 @@ if (eventsPerSecond > 0)
             simIndex = (simIndex + 1) % sims.Count;
             scheduled++;
             try { await inFlight.WaitAsync(stopRequested.Token); } catch (OperationCanceledException) { break; }
-            _ = sim.SendOneDeltaAsync().ContinueWith(t =>
+            _ = sim.SendOneDeltaAsync(stopRequested.Token).ContinueWith(t =>
             {
                 inFlight.Release();
                 if (t.IsCompletedSuccessfully && t.Result) Interlocked.Increment(ref deltasOk);
@@ -185,13 +191,19 @@ else
     catch (OperationCanceledException) { }
 }
 
+// The measurement WINDOW ends here. Cancelling also cancels every queued and in-flight send, so
+// completions that would otherwise trickle in during teardown cannot inflate the run's numbers -
+// the first baseline's totals included exactly that drain, and read as double the true rate
+// (review finding). The window numbers are printed before teardown so they are unambiguous.
+var windowSeconds = (DateTime.UtcNow - deltaWindowStart).TotalSeconds;
+Console.WriteLine($"[DirectorSim] WINDOW END: deltasOk={Interlocked.Read(ref deltasOk)} deltasFailed={Interlocked.Read(ref deltasFailed)} over {windowSeconds:F0}s (configured duration {durationSeconds}s)");
 stopRequested.Cancel();
 await reporter;
 
 Console.WriteLine("[DirectorSim] closing connections...");
 await Parallel.ForEachAsync(sims, new ParallelOptions { MaxDegreeOfParallelism = 64 },
     async (sim, _) => await sim.DisposeAsync());
-Console.WriteLine($"SIM DONE connected={sims.Count} deltasOk={Interlocked.Read(ref deltasOk)} deltasFailed={Interlocked.Read(ref deltasFailed)} connectFailures={connectFailures}");
+Console.WriteLine($"SIM DONE connected={sims.Count} deltasOk={Interlocked.Read(ref deltasOk)} deltasFailed={Interlocked.Read(ref deltasFailed)} connectFailures={connectFailures} windowSeconds={windowSeconds:F0}");
 return 0;
 
 static int ReadInt(string variable, int fallback)
@@ -260,12 +272,13 @@ internal sealed class SimDirector : IAsyncDisposable
     }
 
     /// <summary>Mutate one session (round-robin) and push it as a delta, serialized with every other
-    /// send on this connection so sequences reach the wire in order. Returns false on failure.</summary>
-    public async Task<bool> SendOneDeltaAsync()
+    /// send on this connection so sequences reach the wire in order. Cancelled sends (the window
+    /// ended) count as failures, never as completions. Returns false on failure.</summary>
+    public async Task<bool> SendOneDeltaAsync(CancellationToken cancellation)
     {
         if (_connection.State != HubConnectionState.Connected)
             return false;
-        await _sendGate.WaitAsync();
+        await _sendGate.WaitAsync(cancellation);
         try
         {
             var session = _sessions[_deltaIndex = (_deltaIndex + 1) % _sessions.Length];
@@ -273,7 +286,7 @@ internal sealed class SimDirector : IAsyncDisposable
             session.LastActivityAt = now;
             session.ActivityState = session.ActivityState == "working" ? "waiting" : "working";
             session.StatusColor = session.ActivityState == "working" ? "blue" : "green";
-            await _connection.InvokeAsync("PushDelta", Interlocked.Increment(ref _sequence), session);
+            await _connection.InvokeAsync("PushDelta", Interlocked.Increment(ref _sequence), session, cancellation);
             return true;
         }
         catch

--- a/tools/loadtest/LoadRig/LoadRig.csproj
+++ b/tools/loadtest/LoadRig/LoadRig.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Gateway load-test rig (devthrottle_internal issue #1173, mission 05): boots the REAL GatewayHost
+       in hosted mode (CC_GATEWAY_HOSTED=1, Postgres) inside this process, seeds SYNTHETIC tenants and
+       device keys through the real TenantRegistry/DeviceRegistry, writes the key files the load drivers
+       read, and then runs as the load-test target until stopped.
+
+       Deliberately NOT in cc-director.sln (the tools/harnesses precedent) and deliberately WITHOUT the
+       hosted-gateway.image marker: hosted-by-environment but not hosted-image is the exact seam the
+       Gateway's own hosted tests use, where DeviceRegistry.OnAccountBoundForTest auto-seeds an
+       entitlement for each synthetic tenant so the request path's 402 gate does not fire. -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>LoadRig</AssemblyName>
+    <SelfContained>false</SelfContained>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootNamespace>CcDirector.LoadTest.LoadRig</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\CcDirector.Gateway\CcDirector.Gateway.csproj" />
+    <!-- The Postgres migration set, referenced exactly as CcDirector.Gateway.Host references it: so the
+         DLL ships in this host's output and Database.Migrate() resolves it by name when the rig runs on
+         the throwaway Postgres. -->
+    <ProjectReference Include="..\..\..\src\CcDirector.Gateway.Migrations.Postgres\CcDirector.Gateway.Migrations.Postgres.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\LoadTargetGuard.cs" Link="LoadTargetGuard.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tools/loadtest/LoadRig/Program.cs
+++ b/tools/loadtest/LoadRig/Program.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+using CcDirector.Gateway;
+using CcDirector.LoadTest.Shared;
+
+// The Gateway load-test rig (devthrottle_internal issue #1173, mission 05).
+//
+// Boots the REAL GatewayHost in hosted mode against a THROWAWAY Postgres, seeds synthetic tenants and
+// device keys, writes the key files the load drivers (k6, DirectorSim) read, then serves as the target
+// until stopped. Teardown of the synthetic tenants is the teardown of the throwaway database container
+// (tools/loadtest/scripts/stop-postgres.ps1 removes the container AND its volume) - no synthetic tenant
+// can survive into a real database because this rig refuses to start against anything but a local (or
+// explicitly named non-production) database host.
+//
+// Environment:
+//   CC_GATEWAY_DB_CONNECTION   REQUIRED. The throwaway Postgres connection string. The host inside it
+//                              must be local (or named via LOADTEST_ALLOW_HOST); production is refused.
+//   LOADTEST_PORT              Port to listen on. Default 7891 (deliberately NOT 7878, the real default,
+//                              so a live local Gateway is never mistaken for the rig).
+//   LOADTEST_TENANTS           Synthetic tenants to seed. Default 20.
+//   LOADTEST_DIRECTORS_PER_TENANT  Synthetic Director identities (and keys) per tenant. Default 5.
+//   LOADTEST_OUT_DIR           Where the key files are written. Default ./loadtest-out.
+//   CC_DIRECTOR_ROOT           Set by this program to an isolated scratch directory if not already set,
+//                              so the rig never touches the machine's real cc-director storage.
+
+var port = ReadInt("LOADTEST_PORT", 7891);
+var tenantCount = ReadInt("LOADTEST_TENANTS", 20);
+var directorsPerTenant = ReadInt("LOADTEST_DIRECTORS_PER_TENANT", 5);
+var outDir = Environment.GetEnvironmentVariable("LOADTEST_OUT_DIR") ?? Path.Combine(Environment.CurrentDirectory, "loadtest-out");
+
+var dbConnection = Environment.GetEnvironmentVariable(CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar);
+if (string.IsNullOrWhiteSpace(dbConnection))
+{
+    Console.Error.WriteLine(
+        "ERROR: CC_GATEWAY_DB_CONNECTION is not set. The rig runs the hosted path, which is Postgres. " +
+        "Start the throwaway database first: powershell -File tools/loadtest/scripts/start-postgres.ps1 " +
+        "- it prints the connection string to export.");
+    return 2;
+}
+
+// The one hard rule: never production. The database host must be local or an explicitly named rig.
+LoadTargetGuard.AssertHostAllowed(ReadHostFromConnectionString(dbConnection), "CC_GATEWAY_DB_CONNECTION");
+
+// Isolate ALL file-based Gateway storage from the machine's real cc-director root.
+if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT")))
+{
+    var scratchRoot = Path.Combine(Path.GetTempPath(), "dt-loadtest-root-" + Guid.NewGuid().ToString("N")[..8]);
+    Directory.CreateDirectory(scratchRoot);
+    Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", scratchRoot);
+    Console.WriteLine($"[LoadRig] CC_DIRECTOR_ROOT isolated to {scratchRoot}");
+}
+
+// Hosted-by-environment, NOT hosted-image: exactly the seam the Gateway's own hosted tests use. With no
+// image marker, DeviceRegistry.OnAccountBoundForTest auto-seeds an entitlement per synthetic tenant, so
+// the request path's hosted 402 gate does not fire for them.
+Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+if (GatewayHostedMode.IsHostedImage)
+{
+    Console.Error.WriteLine("ERROR: this build carries the hosted-image marker; the rig must never run as the hosted image.");
+    return 2;
+}
+
+// The PRODUCTION hosted image mirrors every FileLog line synchronously to the console
+// (GatewayEntryPoint does this when IsHostedImage). The rig is not the hosted image, so that cost is
+// absent by default; set LOADTEST_MIRROR_CONSOLE=1 to reproduce it when measuring how much it matters.
+// Either way, record which mode a run used in its baseline notes - it is a real difference.
+if (Environment.GetEnvironmentVariable("LOADTEST_MIRROR_CONSOLE") == "1")
+{
+    CcDirector.Core.Utilities.FileLog.MirrorToConsole = true;
+    Console.WriteLine("[LoadRig] FileLog console mirror ON (matching the production hosted image)");
+}
+
+const string rigToken = "loadtest-rig-token";
+Console.WriteLine($"[LoadRig] starting GatewayHost: port={port} hosted=env postgres={ReadHostFromConnectionString(dbConnection)}");
+var gateway = new GatewayHost(port: port, token: rigToken, authEnabled: true, streamMode: true);
+await gateway.StartAsync();
+Console.WriteLine($"[LoadRig] Gateway up at http://127.0.0.1:{gateway.Port}");
+
+// ---- Seed synthetic tenants and device keys through the real registries. --------------------------
+var runId = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+var viewers = new List<object>();
+var directors = new List<object>();
+var seedStart = DateTime.UtcNow;
+
+for (var t = 1; t <= tenantCount; t++)
+{
+    // A GUID subject, because that is the production shape: account subjects are Supabase uuids, and
+    // on Postgres the website-owned gateway.entitlements.subject column IS uuid - a non-uuid synthetic
+    // subject could never be entitled there.
+    var subject = Guid.NewGuid().ToString();
+    var tenant = gateway.TenantRegistry.MintOrLookupBySubject(subject, $"loadtest-{t:D4}@loadtest.invalid");
+
+    var viewerDeviceId = $"loadtest-viewer-{runId}-{t:D4}";
+    var viewerKey = gateway.Devices.Register(viewerDeviceId, $"LOADTEST-VIEWER-{t:D4}").DeviceKey;
+    gateway.Devices.SetAccountBinding(viewerDeviceId, subject, tenant.Value);
+    viewers.Add(new { tenant = tenant.Value, deviceKey = viewerKey });
+
+    for (var d = 1; d <= directorsPerTenant; d++)
+    {
+        var directorDeviceId = $"loadtest-dir-{runId}-{t:D4}-{d:D4}";
+        var directorKey = gateway.Devices.Register(directorDeviceId, $"LOADTEST-DIR-{t:D4}-{d:D4}").DeviceKey;
+        gateway.Devices.SetAccountBinding(directorDeviceId, subject, tenant.Value);
+        directors.Add(new
+        {
+            tenant = tenant.Value,
+            directorId = $"loadtest-director-{t:D4}-{d:D4}",
+            machineName = $"LOADTEST-DIR-{t:D4}-{d:D4}",
+            deviceKey = directorKey,
+        });
+    }
+
+    if (t % 25 == 0 || t == tenantCount)
+        Console.WriteLine($"[LoadRig] seeded {t}/{tenantCount} tenants ({directors.Count} director keys) in {(DateTime.UtcNow - seedStart).TotalSeconds:F0}s");
+}
+
+Directory.CreateDirectory(outDir);
+var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
+var viewersFile = Path.Combine(outDir, "viewers.json");
+var directorsFile = Path.Combine(outDir, "directors.json");
+var rigFile = Path.Combine(outDir, "rig.json");
+File.WriteAllText(viewersFile, JsonSerializer.Serialize(viewers, jsonOptions));
+File.WriteAllText(directorsFile, JsonSerializer.Serialize(directors, jsonOptions));
+File.WriteAllText(rigFile, JsonSerializer.Serialize(new
+{
+    runId,
+    gatewayUrl = $"http://127.0.0.1:{gateway.Port}",
+    port = gateway.Port,
+    tenants = tenantCount,
+    directorsPerTenant,
+    seededAtUtc = DateTime.UtcNow,
+}, new JsonSerializerOptions { WriteIndented = true }));
+
+Console.WriteLine($"[LoadRig] keys written: {viewersFile} ({viewers.Count} viewers), {directorsFile} ({directors.Count} directors)");
+Console.WriteLine($"RIG READY url=http://127.0.0.1:{gateway.Port} tenants={tenantCount} directors={directors.Count} out={outDir}");
+Console.WriteLine("[LoadRig] press Ctrl+C to stop. Teardown: stop the rig, then remove the throwaway " +
+                  "database (tools/loadtest/scripts/stop-postgres.ps1) so no synthetic tenant survives.");
+
+// Run until Ctrl+C, then stop the Gateway cleanly.
+var stop = new TaskCompletionSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; stop.TrySetResult(); };
+AppDomain.CurrentDomain.ProcessExit += (_, _) => stop.TrySetResult();
+await stop.Task;
+Console.WriteLine("[LoadRig] stopping...");
+await gateway.StopAsync();
+Console.WriteLine("[LoadRig] stopped. Remember: tools/loadtest/scripts/stop-postgres.ps1 removes the synthetic tenants with the database.");
+return 0;
+
+static int ReadInt(string variable, int fallback)
+{
+    var raw = Environment.GetEnvironmentVariable(variable);
+    if (string.IsNullOrWhiteSpace(raw)) return fallback;
+    if (!int.TryParse(raw, out var value) || value <= 0)
+        throw new InvalidOperationException($"{variable} must be a positive integer, got '{raw}'.");
+    return value;
+}
+
+static string ReadHostFromConnectionString(string connectionString)
+{
+    foreach (var part in connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+    {
+        var eq = part.IndexOf('=');
+        if (eq <= 0) continue;
+        var key = part[..eq].Trim();
+        if (key.Equals("Host", StringComparison.OrdinalIgnoreCase) || key.Equals("Server", StringComparison.OrdinalIgnoreCase))
+            return part[(eq + 1)..].Trim();
+    }
+    throw new InvalidOperationException("CC_GATEWAY_DB_CONNECTION has no Host= (or Server=) part; the rig cannot verify the database is local, so it refuses to start.");
+}

--- a/tools/loadtest/README.md
+++ b/tools/loadtest/README.md
@@ -1,0 +1,101 @@
+# Gateway load-test harness
+
+The instrument built by mission 05 (devthrottle_internal issue #1173, under the read-model epic #1159).
+It finds the hosted Gateway's ceiling on a test rig - the load at which it degrades, and which resource
+gives first - so the read-model epic knows where to aim. It measures; it does not fix.
+
+The plan it implements: `devthrottle_internal/docs/load-test/gateway-load-test-plan.md`.
+Baseline reports live in `devthrottle_internal/docs/load-test/runs/`.
+
+## The one hard rule
+
+**NEVER run any of this against production.** Every tool refuses production-looking hosts
+(azurewebsites.net, anything containing "devthrottle") with no override, allows loopback freely, and
+requires any other host to be named explicitly in `LOADTEST_ALLOW_HOST` (for a dedicated staging rig).
+The guard lives in `Shared/LoadTargetGuard.cs` and is mirrored inside `stage1-roster.js`. Only synthetic
+tenants, only a throwaway database, torn down after every run.
+
+## What is here
+
+| Piece | What it does |
+|---|---|
+| `LoadRig/` | Boots the REAL `GatewayHost` in hosted mode (Postgres) in-process, seeds synthetic tenants + device keys through the real registries, writes the key files, then serves as the target. |
+| `DirectorSim/` | Stage 2 driver: N SignalR connections to `/director-stream`, real `Hello` + `PushSnapshot` + `PushDelta` contract, strictly increasing per-connection sequences. `EVENTS_PER_SEC=0` holds a silent background fleet for Stage 1. |
+| `stage1-roster.js` | Stage 1 driver: k6 ramping viewers polling `GET /sessions` every 2 s (the real client cadence), climbing 100 -> 10,000 viewers. |
+| `scripts/start-postgres.ps1` / `stop-postgres.ps1` | The throwaway Postgres container (`dt-loadtest-pg`, port 55442). Stopping REMOVES it and its data - that is the tenant teardown. |
+| `scripts/run-stage1.ps1` | Wraps k6: resets the metrics window, runs the climb, scrapes `/diag/loadmetrics` every 10 s into a JSONL beside the k6 summary. |
+| `Shared/LoadTargetGuard.cs` | The never-production guard, compiled into both consoles. |
+
+The Gateway-side instrumentation (Stage 0 of the plan) lives in the product at
+`src/CcDirector.Gateway/Diagnostics/LoadTestMetrics.cs`, served at `GET /diag/loadmetrics`
+(auth-gated; `?reset=true` starts a fresh window). It measures: snooze-gate lock wait, snooze database
+reads (the N+1 counter), fold duration, roster latency, sweep duration + overlap count, DirectorHub
+connection count, push in-flight and duration, device-credential lookups, and process numbers
+(CPU, working set, GC, thread pool).
+
+## How to run (local rig, one machine)
+
+Prerequisites: .NET 10 SDK, Docker Desktop, and k6 (one static binary - `winget install k6.k6`, or
+unzip a release from github.com/grafana/k6/releases onto PATH).
+
+```powershell
+# 1. Throwaway database (container dt-loadtest-pg on 127.0.0.1:55442).
+powershell -NoProfile -File tools/loadtest/scripts/start-postgres.ps1
+
+# 2. Build and start the rig (seeds tenants, writes key files, serves as the target).
+dotnet build tools/loadtest/LoadRig/LoadRig.csproj -c Release
+$env:CC_GATEWAY_DB_CONNECTION = "Host=127.0.0.1;Port=55442;Database=gateway_loadtest;Username=loadtest;Password=loadtest"
+$env:LOADTEST_TENANTS = "20"; $env:LOADTEST_DIRECTORS_PER_TENANT = "5"
+$env:LOADTEST_OUT_DIR = "$env:TEMP\loadtest-out"
+tools\loadtest\LoadRig\bin\Release\net10.0\LoadRig.exe
+# wait for: RIG READY url=http://127.0.0.1:7891 ...
+
+# 3. (second terminal) Background fleet for Stage 1: hold 100 Directors x 8 sessions open.
+dotnet build tools/loadtest/DirectorSim/DirectorSim.csproj -c Release
+$env:GATEWAY_URL = "http://127.0.0.1:7891"
+$env:KEYS_FILE = "$env:TEMP\loadtest-out\directors.json"
+$env:DIRECTORS = "100"; $env:SESSIONS_PER_DIRECTOR = "8"; $env:EVENTS_PER_SEC = "0"
+tools\loadtest\DirectorSim\bin\Release\net10.0\DirectorSim.exe
+
+# 4. (third terminal) Stage 1: the roster-polling climb.
+powershell -NoProfile -File tools/loadtest/scripts/run-stage1.ps1 `
+    -GatewayUrl http://127.0.0.1:7891 -OutDir "$env:TEMP\loadtest-out" -MaxVus 5000
+
+# 5. Stage 2: the Director push climb (stop the hold-mode sim first; seed a bigger rig for more
+#    directors, e.g. LOADTEST_TENANTS=50 LOADTEST_DIRECTORS_PER_TENANT=10 for 500).
+$env:EVENTS_PER_SEC = "1000"; $env:DIRECTORS = "500"; $env:DURATION_SECONDS = "300"
+$env:METRICS_FILE = "$env:TEMP\loadtest-out\stage2-metrics.jsonl"
+$env:METRICS_KEY = (Get-Content "$env:TEMP\loadtest-out\viewers.json" | ConvertFrom-Json)[0].deviceKey
+tools\loadtest\DirectorSim\bin\Release\net10.0\DirectorSim.exe
+
+# 6. Stage 3 (combined) = run steps 4 and 5 at the same time.
+
+# 7. TEARDOWN - removes the database and every synthetic tenant. Always do this.
+powershell -NoProfile -File tools/loadtest/scripts/stop-postgres.ps1
+```
+
+Every knob each tool takes is documented at the top of its `Program.cs` (or the k6 script header).
+
+## Reading a run
+
+- The k6 summary (`stage1-<stamp>-summary.json`) has client-side p50/p95/p99 and error rate per the
+  plan's thresholds: p95 < 300 ms, p99 < 800 ms, errors < 0.1 percent.
+- The scrape file (`stage1-<stamp>-loadmetrics.jsonl`) has the inside view over time: watch
+  `snoozeLockWaitMs.p95Ms` (the shared-gate wait), `counters.snoozeDbReads / counters.rosterRequests`
+  (the N+1 ratio - 3 x sessions-per-tenant when confirmed), `foldDurationMs`, `sweepOverlaps`, and
+  `process.cpuTotalSeconds` deltas.
+- The CEILING is the load step where a threshold crosses; WHICH resource gave first is read from the
+  scrape (lock wait vs CPU vs GC vs thread-pool starvation vs sockets).
+- Write the result to `devthrottle_internal/docs/load-test/runs/<date>-<stage>.md` (rig identified as
+  "local" or by staging digest), per section 8 of the plan.
+
+## Honesty notes (rig vs production)
+
+- The rig boots `GatewayHost` directly (hosted-by-environment, NOT the hosted image). That is exactly
+  the seam the Gateway's own hosted tests use; it auto-seeds an entitlement per synthetic tenant so the
+  hosted 402 gate stays out of the measurement.
+- The production image mirrors every log line synchronously to the console; the rig does not, unless
+  you set `LOADTEST_MIRROR_CONSOLE=1`. State which mode a run used in its report.
+- A single-machine run has the drivers, the Gateway, and Postgres sharing one CPU. Note the machine in
+  the report; treat absolute numbers as a floor and the SHAPE (which resource saturates first, where
+  the knee is) as the finding.

--- a/tools/loadtest/Shared/LoadTargetGuard.cs
+++ b/tools/loadtest/Shared/LoadTargetGuard.cs
@@ -1,0 +1,59 @@
+namespace CcDirector.LoadTest.Shared;
+
+/// <summary>
+/// The one hard safety rule of the load-test plan (devthrottle_internal issue #1173): NEVER point the
+/// harness at production. Every tool in tools/loadtest calls this before touching its target, and the k6
+/// script carries the same rule in JavaScript. The rule, in order:
+///
+///  1. A production-looking host is REFUSED with no override: anything under azurewebsites.net, and any
+///     host containing "devthrottle". There is deliberately no environment variable that unlocks these.
+///  2. Loopback targets (localhost, 127.0.0.1, [::1], host.docker.internal) are allowed - that is the
+///     local hosted-mode rig.
+///  3. Any other host (a staging rig) is allowed ONLY when LOADTEST_ALLOW_HOST is set to exactly that
+///     host, so pointing at a non-local machine is always a deliberate, named act.
+/// </summary>
+public static class LoadTargetGuard
+{
+    public const string AllowHostVariable = "LOADTEST_ALLOW_HOST";
+
+    /// <summary>Validate a Gateway base URL. Throws with the exact reason and fix on refusal.</summary>
+    public static void AssertUrlAllowed(string gatewayUrl)
+    {
+        if (string.IsNullOrWhiteSpace(gatewayUrl))
+            throw new InvalidOperationException("GATEWAY_URL is required (e.g. http://127.0.0.1:7891).");
+        if (!Uri.TryCreate(gatewayUrl, UriKind.Absolute, out var uri))
+            throw new InvalidOperationException($"GATEWAY_URL is not a valid absolute URL: {gatewayUrl}");
+        AssertHostAllowed(uri.Host, $"the Gateway URL {gatewayUrl}");
+    }
+
+    /// <summary>Validate a bare host name (used for the database host). Throws on refusal.</summary>
+    public static void AssertHostAllowed(string host, string what)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            throw new InvalidOperationException($"No host could be read from {what}.");
+
+        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
+
+        // Rule 1: production shapes are refused outright, before any allow rule is consulted.
+        if (normalized.EndsWith("azurewebsites.net", StringComparison.Ordinal)
+            || normalized.Contains("devthrottle", StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"REFUSED: {what} points at '{host}', which matches the production deny list " +
+                "(azurewebsites.net / devthrottle). The load-test harness NEVER runs against production, " +
+                "and there is no override for this rule. Use the local rig (tools/loadtest/README.md) or a " +
+                "dedicated staging host.");
+
+        // Rule 2: the local rig.
+        if (normalized is "localhost" or "127.0.0.1" or "::1" or "[::1]" or "host.docker.internal")
+            return;
+
+        // Rule 3: a named, deliberate staging target.
+        var allowed = Environment.GetEnvironmentVariable(AllowHostVariable);
+        if (string.Equals(allowed?.Trim(), normalized, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        throw new InvalidOperationException(
+            $"REFUSED: {what} points at non-local host '{host}'. If this is a dedicated staging rig, set " +
+            $"{AllowHostVariable}={normalized} to name it deliberately. Production is refused regardless.");
+    }
+}

--- a/tools/loadtest/Shared/LoadTargetGuard.cs
+++ b/tools/loadtest/Shared/LoadTargetGuard.cs
@@ -32,7 +32,7 @@ public static class LoadTargetGuard
         if (string.IsNullOrWhiteSpace(host))
             throw new InvalidOperationException($"No host could be read from {what}.");
 
-        var normalized = host.Trim().TrimEnd('.').ToLowerInvariant();
+        var normalized = host.Trim().TrimEnd('.').Trim('[', ']').ToLowerInvariant();
 
         // Rule 1: production shapes are refused outright, before any allow rule is consulted.
         if (normalized.EndsWith("azurewebsites.net", StringComparison.Ordinal)
@@ -43,8 +43,12 @@ public static class LoadTargetGuard
                 "and there is no override for this rule. Use the local rig (tools/loadtest/README.md) or a " +
                 "dedicated staging host.");
 
-        // Rule 2: the local rig.
-        if (normalized is "localhost" or "127.0.0.1" or "::1" or "[::1]" or "host.docker.internal")
+        // Rule 2: the local rig. Loopback is ruled by PARSING (127.0.0.0/8 and ::1 in every
+        // spelling - some hosts expand ::1 to the full zero-padded form), never by string-matching
+        // one spelling of it.
+        if (normalized is "localhost" or "host.docker.internal")
+            return;
+        if (System.Net.IPAddress.TryParse(normalized, out var parsed) && System.Net.IPAddress.IsLoopback(parsed))
             return;
 
         // Rule 3: a named, deliberate staging target.

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -26,9 +26,11 @@ if (-not (Test-Path $viewersFile)) {
     throw "No viewers.json in $OutDir. Start the LoadRig first (tools/loadtest/README.md) - it writes the key files there."
 }
 
-# The same production guard the tools carry, applied before anything is sent.
+# The same production guard the tools carry, applied before anything is sent - including the
+# metrics reset below, which carries a bearer key. Trailing dots are trimmed first, exactly as in
+# LoadTargetGuard.cs: the absolute-DNS spelling of a production host must not slip past endsWith.
 $uri = [Uri]$GatewayUrl
-$hostName = $uri.Host.ToLowerInvariant()
+$hostName = $uri.Host.ToLowerInvariant().TrimEnd('.')
 if ($hostName.EndsWith("azurewebsites.net") -or $hostName.Contains("devthrottle")) {
     throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production."
 }

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -31,13 +31,16 @@ if (-not (Test-Path $viewersFile)) {
 # production deny list has no override; loopback is free; any other host must be named exactly in
 # LOADTEST_ALLOW_HOST. Trailing dots trimmed first so the absolute-DNS spelling cannot slip past.
 $uri = [Uri]$GatewayUrl
-# Uri.Host keeps IPv6 addresses in brackets ('[::1]'); strip them so the loopback list matches.
+# Uri.Host keeps IPv6 in brackets, and Windows PowerShell 5.1 EXPANDS [::1] to the full zero-padded
+# form - so loopback is ruled by PARSING the address (IPAddress.IsLoopback covers 127.0.0.0/8 and
+# ::1 in every spelling), never by string-matching one spelling of it.
 $hostName = $uri.Host.ToLowerInvariant().TrimEnd('.').Trim('[', ']')
 if ($hostName.EndsWith("azurewebsites.net") -or $hostName.Contains("devthrottle")) {
     throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production; there is no override."
 }
-$localHosts = @('localhost', '127.0.0.1', '::1', 'host.docker.internal')
-if (-not ($localHosts -contains $hostName)) {
+$parsedIp = $null
+$isLoopback = [System.Net.IPAddress]::TryParse($hostName, [ref]$parsedIp) -and [System.Net.IPAddress]::IsLoopback($parsedIp)
+if (-not ($isLoopback -or $hostName -eq 'localhost' -or $hostName -eq 'host.docker.internal')) {
     $allowedHost = $env:LOADTEST_ALLOW_HOST
     if ($null -ne $allowedHost) { $allowedHost = $allowedHost.Trim().ToLowerInvariant().TrimEnd('.') }
     if ($allowedHost -ne $hostName) {

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -31,7 +31,8 @@ if (-not (Test-Path $viewersFile)) {
 # production deny list has no override; loopback is free; any other host must be named exactly in
 # LOADTEST_ALLOW_HOST. Trailing dots trimmed first so the absolute-DNS spelling cannot slip past.
 $uri = [Uri]$GatewayUrl
-$hostName = $uri.Host.ToLowerInvariant().TrimEnd('.')
+# Uri.Host keeps IPv6 addresses in brackets ('[::1]'); strip them so the loopback list matches.
+$hostName = $uri.Host.ToLowerInvariant().TrimEnd('.').Trim('[', ']')
 if ($hostName.EndsWith("azurewebsites.net") -or $hostName.Contains("devthrottle")) {
     throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production; there is no override."
 }

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -26,13 +26,22 @@ if (-not (Test-Path $viewersFile)) {
     throw "No viewers.json in $OutDir. Start the LoadRig first (tools/loadtest/README.md) - it writes the key files there."
 }
 
-# The same production guard the tools carry, applied before anything is sent - including the
-# metrics reset below, which carries a bearer key. Trailing dots are trimmed first, exactly as in
-# LoadTargetGuard.cs: the absolute-DNS spelling of a production host must not slip past endsWith.
+# The FULL target guard the tools carry (LoadTargetGuard.cs), applied before anything is sent -
+# including the metrics reset below, which carries a bearer key. All three rules, in order: the
+# production deny list has no override; loopback is free; any other host must be named exactly in
+# LOADTEST_ALLOW_HOST. Trailing dots trimmed first so the absolute-DNS spelling cannot slip past.
 $uri = [Uri]$GatewayUrl
 $hostName = $uri.Host.ToLowerInvariant().TrimEnd('.')
 if ($hostName.EndsWith("azurewebsites.net") -or $hostName.Contains("devthrottle")) {
-    throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production."
+    throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production; there is no override."
+}
+$localHosts = @('localhost', '127.0.0.1', '::1', 'host.docker.internal')
+if (-not ($localHosts -contains $hostName)) {
+    $allowedHost = $env:LOADTEST_ALLOW_HOST
+    if ($null -ne $allowedHost) { $allowedHost = $allowedHost.Trim().ToLowerInvariant().TrimEnd('.') }
+    if ($allowedHost -ne $hostName) {
+        throw "REFUSED: non-local host '$hostName'. If this is a dedicated staging rig, set LOADTEST_ALLOW_HOST=$hostName. Production is refused regardless."
+    }
 }
 
 $stamp = Get-Date -Format "yyyyMMdd-HHmmss"

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -42,7 +42,7 @@ $viewerKey = (Get-Content $viewersFile -Raw | ConvertFrom-Json)[0].deviceKey
 $headers = @{ Authorization = "Bearer $viewerKey" }
 
 # Fresh metrics window for this run.
-Invoke-RestMethod -Uri "$GatewayUrl/diag/loadmetrics?reset=true" -Headers $headers | Out-Null
+Invoke-RestMethod -Uri "$GatewayUrl/diag/loadmetrics?reset=true" -Headers $headers -TimeoutSec 15 | Out-Null
 Write-Host "[run-stage1] metrics window reset; scraping every $ScrapeSeconds s into $scrapeFile"
 
 # Background scraper: one JSON line per interval for the whole run.
@@ -51,7 +51,9 @@ $scraper = Start-Job -ScriptBlock {
     $h = @{ Authorization = "Bearer $key" }
     while ($true) {
         try {
-            $m = Invoke-RestMethod -Uri "$url/diag/loadmetrics" -Headers $h
+            # A hard timeout, or a wedged Gateway hangs this scraper forever and the timeline just stops
+            # exactly when it gets interesting (learned on the first baseline run).
+            $m = Invoke-RestMethod -Uri "$url/diag/loadmetrics" -Headers $h -TimeoutSec 15
             ($m | ConvertTo-Json -Compress -Depth 10) | Add-Content -Path $file -Encoding utf8
         } catch {
             "{`"scrapeError`":`"$($_.Exception.Message -replace '\"','')`"}" | Add-Content -Path $file -Encoding utf8

--- a/tools/loadtest/scripts/run-stage1.ps1
+++ b/tools/loadtest/scripts/run-stage1.ps1
@@ -1,0 +1,78 @@
+# Run Stage 1 (roster polling load) against a running LoadRig (devthrottle_internal issue #1173).
+# Wraps k6 with the rig's key file, resets the Gateway's metrics window at the start, and scrapes
+# /diag/loadmetrics into a JSONL beside the k6 summary for the whole run.
+#
+# Usage:
+#   powershell -NoProfile -File tools/loadtest/scripts/run-stage1.ps1 `
+#       -GatewayUrl http://127.0.0.1:7891 -OutDir .\loadtest-out [-MaxVus 10000] [-ScrapeSeconds 10]
+#
+# Requires: k6 on PATH (winget install k6.k6), and the LoadRig running with its keys in -OutDir.
+param(
+    [Parameter(Mandatory = $true)][string]$GatewayUrl,
+    [Parameter(Mandatory = $true)][string]$OutDir,
+    [int]$MaxVus = 10000,
+    [int]$ScrapeSeconds = 10,
+    # Optional custom climb, e.g. "60s:10,60s:25,60s:50,120s:100" - zoom in on the knee, or repeat an
+    # identical shape after a fix for comparison.
+    [string]$Stages = ""
+)
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command k6 -ErrorAction SilentlyContinue)) {
+    throw "k6 is not on PATH. Install it with: winget install k6.k6 (then open a fresh shell)."
+}
+$viewersFile = Join-Path $OutDir "viewers.json"
+if (-not (Test-Path $viewersFile)) {
+    throw "No viewers.json in $OutDir. Start the LoadRig first (tools/loadtest/README.md) - it writes the key files there."
+}
+
+# The same production guard the tools carry, applied before anything is sent.
+$uri = [Uri]$GatewayUrl
+$hostName = $uri.Host.ToLowerInvariant()
+if ($hostName.EndsWith("azurewebsites.net") -or $hostName.Contains("devthrottle")) {
+    throw "REFUSED: $GatewayUrl matches the production deny list. The harness never runs against production."
+}
+
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$summaryFile = Join-Path $OutDir "stage1-$stamp-summary.json"
+$scrapeFile = Join-Path $OutDir "stage1-$stamp-loadmetrics.jsonl"
+
+# One viewer key authenticates the metrics scrapes.
+$viewerKey = (Get-Content $viewersFile -Raw | ConvertFrom-Json)[0].deviceKey
+$headers = @{ Authorization = "Bearer $viewerKey" }
+
+# Fresh metrics window for this run.
+Invoke-RestMethod -Uri "$GatewayUrl/diag/loadmetrics?reset=true" -Headers $headers | Out-Null
+Write-Host "[run-stage1] metrics window reset; scraping every $ScrapeSeconds s into $scrapeFile"
+
+# Background scraper: one JSON line per interval for the whole run.
+$scraper = Start-Job -ScriptBlock {
+    param($url, $key, $file, $interval)
+    $h = @{ Authorization = "Bearer $key" }
+    while ($true) {
+        try {
+            $m = Invoke-RestMethod -Uri "$url/diag/loadmetrics" -Headers $h
+            ($m | ConvertTo-Json -Compress -Depth 10) | Add-Content -Path $file -Encoding utf8
+        } catch {
+            "{`"scrapeError`":`"$($_.Exception.Message -replace '\"','')`"}" | Add-Content -Path $file -Encoding utf8
+        }
+        Start-Sleep -Seconds $interval
+    }
+} -ArgumentList $GatewayUrl, $viewerKey, $scrapeFile, $ScrapeSeconds
+
+try {
+    $env:GATEWAY_URL = $GatewayUrl
+    $env:KEYS_FILE = $viewersFile
+    $env:MAX_VUS = "$MaxVus"
+    if ($Stages) { $env:STAGES = $Stages } else { Remove-Item Env:STAGES -ErrorAction SilentlyContinue }
+    $env:SUMMARY_FILE = $summaryFile
+    $scriptPath = Join-Path $PSScriptRoot "..\stage1-roster.js"
+    k6 run $scriptPath
+    $k6Exit = $LASTEXITCODE
+} finally {
+    Stop-Job $scraper | Out-Null
+    Remove-Job $scraper -Force | Out-Null
+}
+
+Write-Host "[run-stage1] done (k6 exit $k6Exit). Summary: $summaryFile  Metrics: $scrapeFile"
+exit $k6Exit

--- a/tools/loadtest/scripts/start-postgres.ps1
+++ b/tools/loadtest/scripts/start-postgres.ps1
@@ -1,0 +1,41 @@
+# Start the THROWAWAY Postgres the load-test rig runs against (devthrottle_internal issue #1173).
+# One dedicated container, its own name and port, no volume mounts from the host - so teardown
+# (stop-postgres.ps1) removes the database and every synthetic tenant with it.
+#
+# Usage:  powershell -NoProfile -File tools/loadtest/scripts/start-postgres.ps1 [-Port 55442]
+param(
+    [int]$Port = 55442
+)
+$ErrorActionPreference = "Stop"
+$container = "dt-loadtest-pg"
+
+$existing = docker ps -a --filter "name=^/$container$" --format "{{.Names}}"
+if ($existing -eq $container) {
+    Write-Host "[start-postgres] container '$container' already exists; starting it (stop-postgres.ps1 removes it)."
+    docker start $container | Out-Null
+} else {
+    Write-Host "[start-postgres] creating container '$container' on port $Port"
+    docker run -d --name $container `
+        -e POSTGRES_USER=loadtest `
+        -e POSTGRES_PASSWORD=loadtest `
+        -e POSTGRES_DB=gateway_loadtest `
+        -p "127.0.0.1:${Port}:5432" `
+        postgres:16 | Out-Null
+}
+
+# Wait until it answers.
+$deadline = (Get-Date).AddSeconds(60)
+while ($true) {
+    $ready = docker exec $container pg_isready -U loadtest -d gateway_loadtest 2>&1
+    if ($LASTEXITCODE -eq 0) { break }
+    if ((Get-Date) -gt $deadline) { throw "Postgres in '$container' did not become ready within 60 seconds. Last output: $ready" }
+    Start-Sleep -Milliseconds 500
+}
+
+$conn = "Host=127.0.0.1;Port=$Port;Database=gateway_loadtest;Username=loadtest;Password=loadtest"
+Write-Host "[start-postgres] READY."
+Write-Host "[start-postgres] connection string (set this before starting the LoadRig):"
+Write-Host ""
+Write-Host "  `$env:CC_GATEWAY_DB_CONNECTION = `"$conn`""
+Write-Host ""
+Write-Host "[start-postgres] teardown after the run: powershell -NoProfile -File tools/loadtest/scripts/stop-postgres.ps1"

--- a/tools/loadtest/scripts/stop-postgres.ps1
+++ b/tools/loadtest/scripts/stop-postgres.ps1
@@ -1,0 +1,16 @@
+# Tear down the throwaway load-test Postgres COMPLETELY (devthrottle_internal issue #1173).
+# Removing the container removes the database and with it every synthetic tenant and device key -
+# the plan's "no load-test tenant survives into a real database" rule, enforced by destruction.
+#
+# Usage:  powershell -NoProfile -File tools/loadtest/scripts/stop-postgres.ps1
+$ErrorActionPreference = "Stop"
+$container = "dt-loadtest-pg"
+
+$existing = docker ps -a --filter "name=^/$container$" --format "{{.Names}}"
+if ($existing -ne $container) {
+    Write-Host "[stop-postgres] container '$container' does not exist; nothing to tear down."
+    exit 0
+}
+
+docker rm -f -v $container | Out-Null
+Write-Host "[stop-postgres] container '$container' removed with its data. All synthetic tenants are gone."

--- a/tools/loadtest/stage1-roster.js
+++ b/tools/loadtest/stage1-roster.js
@@ -56,6 +56,7 @@ const rosterLatency = new Trend('roster_latency', true);
 const rosterErrors = new Rate('roster_errors');
 
 export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
   // The plan's climb: 100 -> 500 -> 1000 -> 2500 -> 5000 -> 10000 viewers at a 2 s cadence
   // (~9,000 requests/second at the top). Each step ramps then holds, so every plateau gives a clean
   // window to read (scrape /diag/loadmetrics?reset=true at each plateau start).

--- a/tools/loadtest/stage1-roster.js
+++ b/tools/loadtest/stage1-roster.js
@@ -24,7 +24,8 @@ if (!BASE) throw new Error('GATEWAY_URL is required (e.g. http://127.0.0.1:7891)
 
 // The one hard safety rule, in JavaScript: never production, loopback is free, anything else must be
 // named in LOADTEST_ALLOW_HOST. Mirrors tools/loadtest/Shared/LoadTargetGuard.cs.
-const hostMatch = BASE.match(/^https?:\/\/\[?([^\/\]:]+)\]?(?::\d+)?$/);
+const v6Match = BASE.match(/^https?:\/\/\[([0-9a-fA-F:]+)\](?::\d+)?$/);
+const hostMatch = v6Match || BASE.match(/^https?:\/\/([^/\]:]+)(?::\d+)?$/);
 if (!hostMatch) throw new Error(`GATEWAY_URL is not a plain base URL: ${BASE}`);
 // Strip trailing dots before ruling: 'gw.azurewebsites.net.' is the same DNS name as without the
 // dot, and an endsWith check that misses it would let the absolute-form spelling of a production
@@ -32,7 +33,10 @@ if (!hostMatch) throw new Error(`GATEWAY_URL is not a plain base URL: ${BASE}`);
 const host = hostMatch[1].toLowerCase().replace(/\.+$/, '');
 if (host.endsWith('azurewebsites.net') || host.includes('devthrottle'))
   throw new Error(`REFUSED: ${BASE} matches the production deny list. The harness NEVER runs against production; there is no override.`);
-const LOCAL_HOSTS = ['localhost', '127.0.0.1', '::1', 'host.docker.internal'];
+// IPv6 loopback in its compressed, expanded, and zero-padded spellings - k6 has no address parser,
+// so the known spellings are listed; anything else IPv6 falls through to the allow-host rule.
+const LOCAL_HOSTS = ['localhost', '127.0.0.1', 'host.docker.internal',
+  '::1', '0:0:0:0:0:0:0:1', '0000:0000:0000:0000:0000:0000:0000:0001'];
 if (!LOCAL_HOSTS.includes(host) && (__ENV.LOADTEST_ALLOW_HOST || '').toLowerCase() !== host)
   throw new Error(`REFUSED: non-local host '${host}'. If this is a dedicated staging rig, set LOADTEST_ALLOW_HOST=${host}.`);
 

--- a/tools/loadtest/stage1-roster.js
+++ b/tools/loadtest/stage1-roster.js
@@ -1,0 +1,122 @@
+// Stage 1 of the Gateway load-test plan (devthrottle_internal issue #1173): read/polling load.
+//
+// N virtual viewers poll GET /sessions every 2 seconds (the real client roster cadence,
+// ROSTER_POLL_MS = 2000), each authenticated as a synthetic tenant's viewer device key from the
+// LoadRig's viewers.json. The ramp climbs toward the plan's ~9,000 requests/second target; the ceiling
+// is the step where p95 crosses the threshold or errors appear.
+//
+// Run (see tools/loadtest/README.md):
+//   GATEWAY_URL=http://127.0.0.1:7891 KEYS_FILE=./loadtest-out/viewers.json k6 run tools/loadtest/stage1-roster.js
+//
+// Environment:
+//   GATEWAY_URL   REQUIRED. Local hosts only, unless LOADTEST_ALLOW_HOST names a staging host.
+//                 Production (azurewebsites.net / devthrottle hosts) is REFUSED with no override.
+//   KEYS_FILE     REQUIRED. The LoadRig's viewers.json: [{"tenant": "...", "deviceKey": "..."}].
+//   MAX_VUS       Cap the profile (default 10000). Steps above the cap are clamped, so a smaller
+//                 machine can run the same shape lower.
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+const BASE = (__ENV.GATEWAY_URL || '').replace(/\/+$/, '');
+if (!BASE) throw new Error('GATEWAY_URL is required (e.g. http://127.0.0.1:7891).');
+
+// The one hard safety rule, in JavaScript: never production, loopback is free, anything else must be
+// named in LOADTEST_ALLOW_HOST. Mirrors tools/loadtest/Shared/LoadTargetGuard.cs.
+const hostMatch = BASE.match(/^https?:\/\/\[?([^\/\]:]+)\]?(?::\d+)?$/);
+if (!hostMatch) throw new Error(`GATEWAY_URL is not a plain base URL: ${BASE}`);
+const host = hostMatch[1].toLowerCase();
+if (host.endsWith('azurewebsites.net') || host.includes('devthrottle'))
+  throw new Error(`REFUSED: ${BASE} matches the production deny list. The harness NEVER runs against production; there is no override.`);
+const LOCAL_HOSTS = ['localhost', '127.0.0.1', '::1', 'host.docker.internal'];
+if (!LOCAL_HOSTS.includes(host) && (__ENV.LOADTEST_ALLOW_HOST || '').toLowerCase() !== host)
+  throw new Error(`REFUSED: non-local host '${host}'. If this is a dedicated staging rig, set LOADTEST_ALLOW_HOST=${host}.`);
+
+if (!__ENV.KEYS_FILE) throw new Error('KEYS_FILE is required (the LoadRig viewers.json).');
+const KEYS = JSON.parse(open(__ENV.KEYS_FILE));
+if (!Array.isArray(KEYS) || KEYS.length === 0) throw new Error(`KEYS_FILE ${__ENV.KEYS_FILE} holds no viewer keys.`);
+
+const MAX_VUS = parseInt(__ENV.MAX_VUS || '10000', 10);
+const clamp = (n) => Math.min(n, MAX_VUS);
+
+// STAGES: override the default climb, e.g. STAGES=60s:10,60s:25,60s:50,120s:100 - used to zoom in on
+// the knee once a standard run shows the first plateau already degraded, and to re-run the exact same
+// shape after a fix for comparison.
+function stagesFromEnv() {
+  if (!__ENV.STAGES) return null;
+  return __ENV.STAGES.split(',').map((s) => {
+    const [duration, target] = s.split(':');
+    if (!duration || !target) throw new Error(`STAGES entry '${s}' is not duration:target`);
+    return { duration, target: clamp(parseInt(target, 10)) };
+  });
+}
+
+const rosterLatency = new Trend('roster_latency', true);
+const rosterErrors = new Rate('roster_errors');
+
+export const options = {
+  // The plan's climb: 100 -> 500 -> 1000 -> 2500 -> 5000 -> 10000 viewers at a 2 s cadence
+  // (~9,000 requests/second at the top). Each step ramps then holds, so every plateau gives a clean
+  // window to read (scrape /diag/loadmetrics?reset=true at each plateau start).
+  scenarios: {
+    viewers: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: stagesFromEnv() || [
+        { duration: '30s', target: clamp(100) },
+        { duration: '90s', target: clamp(100) },
+        { duration: '30s', target: clamp(500) },
+        { duration: '90s', target: clamp(500) },
+        { duration: '30s', target: clamp(1000) },
+        { duration: '90s', target: clamp(1000) },
+        { duration: '45s', target: clamp(2500) },
+        { duration: '90s', target: clamp(2500) },
+        { duration: '60s', target: clamp(5000) },
+        { duration: '90s', target: clamp(5000) },
+        { duration: '90s', target: clamp(10000) },
+        { duration: '120s', target: clamp(10000) },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  // The plan's first-cut thresholds (section 6). Crossing them does not abort the run - the point is
+  // to find WHERE they cross, which is the ceiling the baseline records.
+  thresholds: {
+    roster_latency: ['p(95)<300', 'p(99)<800'],
+    roster_errors: ['rate<0.001'],
+  },
+};
+
+export default function () {
+  const k = KEYS[__VU % KEYS.length];
+  const res = http.get(`${BASE}/sessions`, {
+    headers: { Authorization: `Bearer ${k.deviceKey}` },
+    tags: { tenant: k.tenant },
+  });
+  rosterLatency.add(res.timings.duration);
+  rosterErrors.add(res.status !== 200);
+  check(res, { 'status 200': (r) => r.status === 200 });
+  sleep(2); // the real client roster cadence (ROSTER_POLL_MS = 2000)
+}
+
+export function handleSummary(data) {
+  const out = __ENV.SUMMARY_FILE || 'stage1-summary.json';
+  return { [out]: JSON.stringify(data, null, 2), stdout: textSummary(data) };
+}
+
+function textSummary(data) {
+  const m = data.metrics;
+  const t = (name) => (m[name] && m[name].values) || {};
+  const lat = t('roster_latency');
+  const err = t('roster_errors');
+  const reqs = t('http_reqs');
+  return [
+    '',
+    '=== Stage 1 roster summary ===',
+    `requests: ${reqs.count || 0} (${(reqs.rate || 0).toFixed(1)}/s average)`,
+    `latency ms: p50=${(lat['p(50)'] || lat.med || 0).toFixed(1)} p95=${(lat['p(95)'] || 0).toFixed(1)} p99=${(lat['p(99)'] || 0).toFixed(1)} max=${(lat.max || 0).toFixed(1)}`,
+    `error rate: ${((err.rate || 0) * 100).toFixed(3)}%`,
+    '',
+  ].join('\n');
+}

--- a/tools/loadtest/stage1-roster.js
+++ b/tools/loadtest/stage1-roster.js
@@ -26,7 +26,10 @@ if (!BASE) throw new Error('GATEWAY_URL is required (e.g. http://127.0.0.1:7891)
 // named in LOADTEST_ALLOW_HOST. Mirrors tools/loadtest/Shared/LoadTargetGuard.cs.
 const hostMatch = BASE.match(/^https?:\/\/\[?([^\/\]:]+)\]?(?::\d+)?$/);
 if (!hostMatch) throw new Error(`GATEWAY_URL is not a plain base URL: ${BASE}`);
-const host = hostMatch[1].toLowerCase();
+// Strip trailing dots before ruling: 'gw.azurewebsites.net.' is the same DNS name as without the
+// dot, and an endsWith check that misses it would let the absolute-form spelling of a production
+// host through (the C# guard trims the same way).
+const host = hostMatch[1].toLowerCase().replace(/\.+$/, '');
 if (host.endsWith('azurewebsites.net') || host.includes('devthrottle'))
   throw new Error(`REFUSED: ${BASE} matches the production deny list. The harness NEVER runs against production; there is no override.`);
 const LOCAL_HOSTS = ['localhost', '127.0.0.1', '::1', 'host.docker.internal'];


### PR DESCRIPTION
Mission 05 of the 31 July release (devthrottle_internal issue #1173, read-model epic #1159): the hosted Gateway had never been load-tested. This adds the instrument and the harness, measurement only - the fixes belong to the read-model epic. The first baseline produced with it is devthrottle_internal pull request #1184.

## Product changes (measurement only, no behavior change)

- **New: src/CcDirector.Gateway/Diagnostics/LoadTestMetrics.cs** - lock-free counters and fixed-bucket histograms served at GET /diag/loadmetrics (auth-gated; ?reset=true starts a fresh window). Measured: snooze-gate lock wait, snooze database read count (the N+1 counter), fold duration, roster latency, sweep duration and OVERLAP count, DirectorHub connection count and push in-flight/duration, device-credential lookups, and live process numbers. Deliberately no logging in the hot recording paths - these run millions of times per minute under load.
- **Instrumentation touch points**: the three SnoozeRegistry hot reads (wait to enter the gate, read count), StampFleetRolesAndFold (duration), the display-sweep timer (duration + overlap count - counted, never prevented), the access-log middleware (roster latency), DirectorHub (connection and push counters; the two push handler bodies moved to Core methods so a try/finally can time them), DeviceRegistry.ResolveCredential (lookup counter).
- **One real fix: SeedEntitlementForTest now works on Postgres.** The test seam had SQLite-only SQL (INSERT OR REPLACE into an unqualified table) and the load rig is its first Postgres caller - it was a hard syntax error there. Provider conditional on the same IsNpgsql() signal the model shape uses; the Postgres arm creates and upserts the website-owned gateway.entitlements shape (uuid subject); the SQLite arm is byte-identical to before.

## The harness (tools/loadtest, outside the solution, per the tools/harnesses precedent)

- **LoadRig**: boots the REAL GatewayHost hosted-by-environment against a throwaway Postgres, seeds synthetic tenants and device keys through the real registries (GUID subjects - the production shape), writes key files, serves as the target. Storage isolated via CC_DIRECTOR_ROOT.
- **DirectorSim**: N SignalR connections to /director-stream sending the real Hello / PushSnapshot / PushDelta contract with strictly increasing per-connection sequences (the PushedSessionStore acceptance rule); hold mode doubles as the Stage 1 background fleet; scrapes /diag/loadmetrics into a JSONL.
- **stage1-roster.js**: k6 ramping viewers polling GET /sessions at the real 2-second cadence, with a STAGES override for knee-finding and repeat-for-comparison runs.
- **scripts/**: throwaway Postgres up/down (teardown REMOVES the container, and with it every synthetic tenant), and a Stage 1 runner that resets the metrics window and scrapes it through the run.
- **tools/loadtest/README.md**: the one-page how-to-run, including the honesty notes (rig versus production differences).

## The one hard safety rule, enforced in code

Production-looking hosts (azurewebsites.net, anything containing devthrottle) are REFUSED with no override; loopback is free; any other host must be named explicitly in LOADTEST_ALLOW_HOST. The guard is compiled into both consoles (Shared/LoadTargetGuard.cs) and mirrored in the k6 script. The first baseline ran entirely against a local rig with synthetic tenants, torn down after.

## Proof

- Stage 0 sanity on the rig: roster serves the pushed sessions with the Gateway fold stamped; the metrics endpoint returned exactly 3 database reads per session per fold (96 reads = 4 folds x 8 sessions x 3) - the N+1, confirmed by the new counter.
- The full baseline (knee run, standard profile, wedge thread-stack capture, Stage 2) is in devthrottle_internal pull request #1184.
- CcDirector.Gateway builds with zero warnings under TreatWarningsAsErrors; the Gateway test suite run is reported on this pull request before merge.