### PR TITLE
A renamed Director is named everywhere: the display name travels to the Gateway, and the Fleet Map gains a By director view

### DIFF
--- a/apps/cockpit/src/fleet/DirectorDetailView.tsx
+++ b/apps/cockpit/src/fleet/DirectorDetailView.tsx
@@ -15,6 +15,7 @@ import { useNow } from "@devthrottle/client-core/polling/useNow";
 import { isSettingsDirty, prettyPrintSettings } from "@devthrottle/client-core/fleet/settingsEditor";
 import { ConfirmDialog } from "../components";
 import { clockLabel, portLabel, relativeTime, repoBasename, uptime } from "./format";
+import { directorPrimaryLabel } from "./directorsFormat";
 
 // The standalone Director page (issue #975) - the React port of the Blazor DirectorDetail.razor:
 // registration facts, health, the Director's live sessions, and the repositories it offers for new
@@ -168,7 +169,14 @@ export function DirectorDetailView() {
       {lastError !== null && <div className="dpage-error">{lastError}</div>}
 
       <header className="dpage-head ddet-head">
-        <h1 className="dpage-h1">{d.machineName}</h1>
+        {/* devthrottle_internal#1176: the display name is the headline when the Director reports one;
+            the machine name then moves beside it as secondary detail. Unnamed Directors are unchanged,
+            and a name that IS the machine name (the seeded default) is not repeated beside itself. */}
+        <h1 className="dpage-h1">{directorPrimaryLabel(d)}</h1>
+        {(d.machineName ?? "").trim().length > 0 &&
+          (d.machineName ?? "").trim().toLowerCase() !== directorPrimaryLabel(d).toLowerCase() && (
+          <span className="dpage-sub">{d.machineName}</span>
+        )}
         <span className="dmono dpage-sub" title={d.directorId}>{portLabel(d.controlEndpoint, d.tailnetEndpoint, d.directorId)}</span>
         <span className="dpage-sub">v{d.version}</span>
         {unreachable ? (
@@ -276,6 +284,11 @@ export function DirectorDetailView() {
             <div className="ddet-sec-head"><h2>Registration</h2></div>
             <dl className="ddet-kv">
               <dt>Director id</dt><dd className="dmono">{d.directorId}</dd>
+              {(d.displayName ?? "").trim().length > 0 && (
+                <>
+                  <dt>Name</dt><dd>{d.displayName}</dd>
+                </>
+              )}
               <dt>Machine</dt><dd>{d.machineName}</dd>
               <dt>User</dt><dd>{d.user}</dd>
               <dt>Process id</dt><dd className="dmono">{d.pid}</dd>

--- a/apps/cockpit/src/fleet/DirectorsView.tsx
+++ b/apps/cockpit/src/fleet/DirectorsView.tsx
@@ -11,7 +11,7 @@ import { useVisiblePolling } from "@devthrottle/client-core/polling/useVisiblePo
 import { useNow } from "@devthrottle/client-core/polling/useNow";
 import { DataTable, PageHeader, type DataTableColumn } from "../components";
 import { clockLabel, relativeTime } from "./format";
-import { directorStatus, epochOf, repoNamesOf } from "./directorsFormat";
+import { directorPrimaryLabel, directorStatus, epochOf, repoNamesOf } from "./directorsFormat";
 
 // The Director registry table (issue #975; rebuilt on the shared DataTable in #1246) - the React view
 // over GET /directors, enriched with live session counts and unreachable flags from the roster
@@ -87,12 +87,13 @@ export function DirectorsView() {
     [errorByDirector],
   );
 
-  // The searchable text of a Director row: machine name, the user, the version, and the repositories it
-  // hosts - so the search box finds a Director by its machine or by a repository running on it.
+  // The searchable text of a Director row: display name, machine name, the user, the version, and the
+  // repositories it hosts - so the search box finds a renamed Director by its name (the point of
+  // devthrottle_internal#1176) as well as by machine or repository.
   const searchableText = useCallback(
     (d: FleetDirector): string => {
       const repos = repoNamesOf(sessionsByDirector.get(d.directorId.toLowerCase()) ?? []);
-      return [d.machineName ?? "", d.directorId, d.user ?? "", d.version ?? "", ...repos].join(" ");
+      return [d.displayName ?? "", d.machineName ?? "", d.directorId, d.user ?? "", d.version ?? "", ...repos].join(" ");
     },
     [sessionsByDirector],
   );
@@ -103,17 +104,28 @@ export function DirectorsView() {
     () => [
       {
         key: "machine",
-        header: "Machine",
+        header: "Director",
         sortable: true,
-        sortValue: (d) => (d.machineName ?? d.directorId).toLowerCase(),
-        render: (d) => (
-          <span className="dcell-machine">
-            <span className="dcell-name">
-              {(d.machineName ?? "").trim().length > 0 ? d.machineName : d.directorId}
+        sortValue: (d) => directorPrimaryLabel(d).toLowerCase(),
+        render: (d) => {
+          // devthrottle_internal#1176: the user-editable display name is the primary label when the
+          // Director reports one; machine + user become the dim secondary detail. Unnamed Directors
+          // render exactly as before (machine name bold, user dim; raw id as the last resort). A
+          // default instance's name is seeded to the hostname, so a machine name identical to the
+          // display name is not repeated beside it.
+          const primary = directorPrimaryLabel(d);
+          const machine = (d.machineName ?? "").trim();
+          const secondary = [machine.toLowerCase() === primary.toLowerCase() ? "" : machine, d.user ?? ""]
+            .map((part) => part.trim())
+            .filter((part) => part.length > 0)
+            .join(" ");
+          return (
+            <span className="dcell-machine">
+              <span className="dcell-name">{primary}</span>
+              {secondary.length > 0 && <span className="ddim"> {secondary}</span>}
             </span>
-            {(d.user ?? "").trim().length > 0 && <span className="ddim"> {d.user}</span>}
-          </span>
-        ),
+          );
+        },
       },
       {
         key: "status",
@@ -180,7 +192,7 @@ export function DirectorsView() {
           rows={directors}
           rowKey={(d) => d.directorId}
           searchableText={searchableText}
-          searchPlaceholder="Search by machine or repository"
+          searchPlaceholder="Search by name, machine or repository"
           defaultSort={{ columnKey: "machine", direction: "asc" }}
           emptyMessage={
             <>

--- a/apps/cockpit/src/fleet/FleetMapView.test.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.test.tsx
@@ -161,6 +161,50 @@ describe("FleetMapView - By machine free slots", () => {
   });
 });
 
+describe("FleetMapView - By director pivot (devthrottle_internal#1177)", () => {
+  it("gives every Director its own lane by NAME, keeps idle ones as free slots and offline ones dimmed", () => {
+    // Selecting the pivot through storage also proves initialPivot() accepts "director" - without that
+    // allow-list entry the saved choice would silently reset to "machine" and this whole test would fail.
+    window.localStorage.setItem("cockpit.fleetMapPivot", "director");
+    rosterValue.current = {
+      sessions: [session({ directorId: "north-alpha", machineName: "SOREN_NORTH" })],
+      machineErrors: [],
+      directors: [
+        // A renamed Director: the lane must read as its display name, not as 8 hex chars.
+        director({ directorId: "north-alpha", machineName: "SOREN_NORTH", state: "online", displayName: "SOREN_NORTH_SLOT_2" }),
+        // An idle, unnamed Director on the SAME machine: its own lane (the whole point of the pivot),
+        // labelled with the historical short-id fallback, rendered as a free slot.
+        director({ directorId: "north-idle", machineName: "SOREN_NORTH", state: "online" }),
+        // An offline Director: shown dated with no action, never dropped (same rule as the machine pivot).
+        director({ directorId: "dead-beta", machineName: "DEAD_MACHINE", state: "offline", lastSeenAgeSeconds: 420 }),
+      ],
+      error: null,
+      refreshNow: () => {},
+    };
+
+    render(<FleetMapView />);
+
+    // Three lanes: the named one, the idle one (short-id fallback), the offline one.
+    expect(screen.getByText("SOREN_NORTH_SLOT_2")).toBeTruthy();
+    expect(screen.getByText("Director idle")).toBeTruthy();
+    expect(screen.getByText("Director beta")).toBeTruthy();
+
+    // The busy lane shows its session; the machine rides in the subtitle.
+    expect(screen.getByText("release")).toBeTruthy();
+    expect(screen.getByText("SOREN_NORTH / 1 session")).toBeTruthy();
+
+    // The idle Director is a free slot; the offline one is unreachable and dated.
+    expect(screen.getAllByText(/free slot/i)).toHaveLength(1);
+    expect(screen.getByText(/machine unreachable/i)).toBeTruthy();
+    expect(screen.getByText(/Offline - last seen 7m ago/)).toBeTruthy();
+
+    // "+ New session" is offered on the reachable lanes and withheld on the offline one.
+    expect(screen.getByRole("button", { name: /Start a new session on SOREN_NORTH_SLOT_2/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Start a new session on Director idle/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Start a new session on Director beta/ })).toBeNull();
+  });
+});
+
 describe("FleetMapView - Director sub-header new-session button", () => {
   it("opens the shared dialog pre-targeted to the clicked Director, not the newest one", async () => {
     // The dialog would otherwise default to the NEWEST-started Director. Make "soren-bbb" newest, so if
@@ -169,6 +213,7 @@ describe("FleetMapView - Director sub-header new-session button", () => {
       {
         directorId: "north-aaa",
         machineName: "SOREN_NORTH",
+        displayName: "",
         version: "1",
         startedAt: "2026-07-20T00:00:00Z",
         lastSeen: "",
@@ -177,6 +222,7 @@ describe("FleetMapView - Director sub-header new-session button", () => {
       {
         directorId: "soren-bbb",
         machineName: "SOREN_SOUTH",
+        displayName: "",
         version: "1",
         startedAt: "2026-07-24T00:00:00Z", // newest -> the dialog's default pick
         lastSeen: "",

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -14,6 +14,7 @@ import { repoBasename, repoIdentity, relativeTime } from "./format";
 import {
   agentBadgeText,
   buildControllerTree,
+  directorLabelOf,
   directorsByMachine,
   groupByDirector,
   machineKeyOf,
@@ -50,10 +51,16 @@ const ReachabilityContext = createContext<DirectorReachability[]>([]);
 // fleet page reads that one store, this map and the Sessions roster always agree on the fleet at the
 // same moment, and a hidden tab makes no roster requests at all.
 
-type Pivot = "machine" | "repo" | "worktree" | "agent" | "list" | "mission";
+type Pivot = "machine" | "director" | "repo" | "worktree" | "agent" | "list" | "mission";
 
 const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = [
   { key: "machine", label: "By machine", kindLabel: "Machine" },
+  // "By director" (devthrottle_internal#1177): one lane per Director across the fleet, headed by the
+  // Director's display name (machine as the subtitle) - the level below machine in the machine pivot's
+  // machine -> Director -> session hierarchy, promoted to lanes so several Directors on one machine sit
+  // side by side. Idle reachable Directors keep a lane (a free slot), exactly like the machine pivot's
+  // sub-groups.
+  { key: "director", label: "By director", kindLabel: "Director" },
   // "By repository" groups by the GitHub "owner/repo" (SessionDto.repoName), so every worktree and clone
   // of one repository rolls up together. "By working tree" groups by the on-disk checkout folder, so each
   // worktree stands on its own - the two sit side by side because they answer two different questions.
@@ -71,7 +78,7 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
 
 // The pivots that lay the fleet out on the node canvas (root -> lanes). "list" is a flat grid and
 // "mission" is its own board; neither uses the canvas or the title search.
-const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "repo", "worktree", "agent"]);
+const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "director", "repo", "worktree", "agent"]);
 
 // The grouping is sticky per browser: the map opens on whatever the user last chose (rather than a
 // "smart" default that guesses from the fleet shape), so returning to the map lands them exactly where
@@ -83,6 +90,7 @@ function initialPivot(): Pivot {
     const saved = window.localStorage.getItem(PIVOT_STORAGE_KEY);
     if (
       saved === "machine" ||
+      saved === "director" ||
       saved === "repo" ||
       saved === "worktree" ||
       saved === "agent" ||
@@ -474,12 +482,38 @@ function LanePanel({ lane, pivot, onOpen, onNewSession, headRef }: LanePanelProp
   // still tags its machine/Director).
   const directorGroups = pivot === "machine" ? groupByDirector(lane.sessions, sessionSort, lane.directors) : null;
 
+  // Director pivot (devthrottle_internal#1177): the lane IS one Director, carrying its own reachability
+  // entry, so the head takes over what the machine pivot's Director sub-header does - state the tunnel
+  // condition, offer "+ New session" only while it could be honoured (withheld offline, kept wobbly,
+  // hidden for the unaddressable "(unknown)" lane), and render an idle lane as a free slot.
+  const directorLane = pivot === "director";
+  const laneReach = directorLane ? lane.directors[0] : undefined;
+  const laneOffline = directorLane && laneReach?.state === REACHABILITY_OFFLINE;
+  const laneWobbly = directorLane && laneReach?.state === REACHABILITY_WOBBLY;
+  const laneLastSeen = laneOffline || laneWobbly ? reachabilityLastSeen(laneReach?.lastSeenAgeSeconds) : "";
+
   return (
     <section className="fmap-lane">
       <div className="fmap-lane-head" ref={headRef}>
         <span className="fmap-lane-k">{lane.kindLabel}</span>
         <span className="fmap-lane-t">{lane.title}</span>
         {lane.subtitle.length > 0 && <span className="fmap-lane-sub">{lane.subtitle}</span>}
+        {(laneOffline || laneWobbly) && (
+          <span className="fmap-subhead-state">
+            {laneLastSeen.length > 0 ? `${laneOffline ? "Offline" : "Wobbly"} - ${laneLastSeen}` : laneOffline ? "Offline" : "Wobbly"}
+          </span>
+        )}
+        {directorLane && lane.key !== "(unknown)" && !laneOffline && (
+          <button
+            type="button"
+            className="fmap-subhead-new"
+            title="Start a new session on this Director"
+            aria-label={`Start a new session on ${lane.title}`}
+            onClick={() => onNewSession(lane.key)}
+          >
+            + New session
+          </button>
+        )}
         <span className="fmap-lane-agg">
           {agg.map((c) => (
             <span key={c} className="fmap-lane-aggdot" style={{ backgroundColor: dotColor(c) }} />
@@ -490,6 +524,12 @@ function LanePanel({ lane, pivot, onOpen, onNewSession, headRef }: LanePanelProp
       <div className="fmap-lane-body">
         {directorGroups !== null
           ? directorGroups.map((dg) => <DirectorSubGroup key={dg.key} group={dg} pivot={pivot} onOpen={onOpen} onNewSession={onNewSession} />)
+          : directorLane && lane.sessions.length === 0
+          ? (
+            <div className="fmap-freeslot">
+              {laneOffline ? "No sessions - machine unreachable" : "No sessions - free slot"}
+            </div>
+          )
           : <LaneCards sessions={lane.sessions} pivot={pivot} onOpen={onOpen} />}
       </div>
     </section>
@@ -700,6 +740,14 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot, directors: DirectorRea
       // onto the same key (see fleetMapFormat).
       return machineKeyOf(s.machineName);
     }
+    if (pivot === "director") {
+      // Key by the RAW director id - it is also the "+ New session" target, so it must stay addressable
+      // (the machine pivot's groupByDirector keys the same way). The title here is the id fallback; the
+      // fold below re-titles every lane through directorLabelOf once reachability (and with it the
+      // display name) is in hand.
+      const dir = (s.directorId ?? "").trim();
+      return { key: dir.length === 0 ? "(unknown)" : dir, title: directorLabelOf(dir, undefined) };
+    }
     if (pivot === "repo") {
       // GitHub "owner/repo" identity - worktrees and clones of one repository fold into one lane.
       const title = repoIdentity(s.repoName, s.repoPath);
@@ -741,6 +789,27 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot, directors: DirectorRea
     }
   }
 
+  // Director pivot (devthrottle_internal#1177): fold in EVERY Director the envelope reports - idle ones
+  // included, offline ones included (same delete-instead-of-dim rule as the machine pivot) - so a
+  // Director with no sessions still gets a lane (a free slot). Each lane carries its own reachability
+  // entry, and every lane is then re-titled through directorLabelOf so a lane whose Director reports a
+  // display name reads as that name rather than as 8 hex chars.
+  if (pivot === "director") {
+    for (const d of directors) {
+      const id = (d.directorId ?? "").trim();
+      if (id.length === 0) continue; // an unidentified Director is not an addressable slot
+      let g = byKey.get(id);
+      if (g === undefined) {
+        g = { title: "", list: [], directors: [] };
+        byKey.set(id, g);
+      }
+      g.directors = [d];
+    }
+    for (const [key, g] of byKey.entries()) {
+      g.title = key === "(unknown)" ? "Director (unknown)" : directorLabelOf(key, g.directors[0]);
+    }
+  }
+
   const kindLabel = PIVOTS.find((p) => p.key === pivot)?.kindLabel ?? "";
 
   return [...byKey.entries()]
@@ -760,6 +829,15 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot, directors: DirectorRea
 function laneSubtitle(sessions: SessionDto[], pivot: Pivot, machineDirectors: DirectorReachability[] = []): string {
   const n = sessions.length;
   const sessionWord = `${n} session${n === 1 ? "" : "s"}`;
+  if (pivot === "director") {
+    // Lane = one Director; the missing coordinate is WHICH MACHINE it runs on. From the reachability
+    // entry when the envelope has one, else from any of the lane's sessions.
+    const machine =
+      (machineDirectors[0]?.machineName ?? "").trim() ||
+      sessions.map((s) => (s.machineName ?? "").trim()).find((m) => m.length > 0) ||
+      "";
+    return machine.length > 0 ? `${machine} / ${sessionWord}` : sessionWord;
+  }
   if (pivot === "machine") {
     // Count the machine's Directors from BOTH the sessions and the folded-in idle Directors, so an
     // otherwise-empty machine still reads "1 director / 0 sessions" (an available slot) rather than
@@ -822,6 +900,11 @@ function cardTags(s: SessionDto, pivot: Pivot): Array<{ k: string; v: string }> 
   const machine = (s.machineName ?? "").trim();
   if (pivot === "machine") {
     // Lane = machine, sub-grouped by Director; the missing coordinate is the repository.
+    return [{ k: "repo", v: repoIdentity(s.repoName, s.repoPath) }];
+  }
+  if (pivot === "director") {
+    // Lane = one Director (machine already in the lane subtitle); the missing coordinate is the
+    // repository.
     return [{ k: "repo", v: repoIdentity(s.repoName, s.repoPath) }];
   }
   if (pivot === "repo") {

--- a/apps/cockpit/src/fleet/directorsFormat.test.ts
+++ b/apps/cockpit/src/fleet/directorsFormat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { ENDPOINT_STATE_UNREACHABLE_BY_NAME, type FleetDirector, type MachineError } from "@devthrottle/client-core/fleet/fleetClient";
-import { directorStatus, epochOf, repoNamesOf } from "./directorsFormat";
+import { directorPrimaryLabel, directorStatus, epochOf, repoNamesOf } from "./directorsFormat";
 
 function director(overrides: Partial<FleetDirector> = {}): FleetDirector {
   return {
@@ -77,6 +77,23 @@ describe("epochOf", () => {
     expect(epochOf(null)).toBe(0);
     expect(epochOf("")).toBe(0);
     expect(epochOf("nonsense")).toBe(0);
+  });
+});
+
+describe("directorPrimaryLabel", () => {
+  it("prefers the user-editable display name (devthrottle_internal#1176)", () => {
+    expect(directorPrimaryLabel(director({ displayName: "SOREN_NORTH_SLOT_2" }))).toBe("SOREN_NORTH_SLOT_2");
+  });
+
+  it("falls back to the machine name when unnamed - the pre-#1176 rendering, unchanged", () => {
+    expect(directorPrimaryLabel(director())).toBe("SOREN_NORTH");
+    expect(directorPrimaryLabel(director({ displayName: "" }))).toBe("SOREN_NORTH");
+    expect(directorPrimaryLabel(director({ displayName: "   " }))).toBe("SOREN_NORTH");
+  });
+
+  it("falls back to the raw id only when even the machine name is blank", () => {
+    expect(directorPrimaryLabel(director({ displayName: "", machineName: "" }))).toBe("dir-1");
+    expect(directorPrimaryLabel(director({ displayName: undefined, machineName: undefined }))).toBe("dir-1");
   });
 });
 

--- a/apps/cockpit/src/fleet/directorsFormat.ts
+++ b/apps/cockpit/src/fleet/directorsFormat.ts
@@ -52,6 +52,21 @@ export function endpointTooltip(d: FleetDirector): string {
   }`;
 }
 
+// The primary label of a Director row (devthrottle_internal#1176): the user-editable display name when
+// the Director reports one, else the machine name, else - only when even that is blank - the raw id.
+// This is THE precedence every director surface renders, so it lives in one tested place.
+export function directorPrimaryLabel(d: {
+  displayName?: string;
+  machineName?: string;
+  directorId: string;
+}): string {
+  const name = (d.displayName ?? "").trim();
+  if (name.length > 0) return name;
+  const machine = (d.machineName ?? "").trim();
+  if (machine.length > 0) return machine;
+  return d.directorId;
+}
+
 // A sortable epoch for the "last seen" column: the parsed milliseconds, or 0 when absent so a Director
 // the Gateway has never heard from sorts to the bottom of a newest-first sort.
 export function epochOf(iso: string | null | undefined): number {

--- a/apps/cockpit/src/fleet/fleetMapFormat.test.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   agentBadgeText,
   buildControllerTree,
+  directorLabelOf,
   directorsByMachine,
   groupByDirector,
   machineKeyOf,
@@ -212,6 +213,37 @@ describe("groupByDirector", () => {
     const out = groupByDirector(sessions, byId);
     expect(out.map((g) => g.key)).toEqual(["a", "b"]);
     expect(out[0].sessions).toHaveLength(2);
+  });
+
+  it("labels a group with the Director's display name when the envelope reports one (devthrottle_internal#1176)", () => {
+    const sessions = [session({ sessionId: "s1", directorId: "d1" })];
+    const out = groupByDirector(sessions, byId, [
+      director({ directorId: "d1", displayName: "SOREN_NORTH_SLOT_2" }),
+    ]);
+    expect(out[0].label).toBe("SOREN_NORTH_SLOT_2");
+  });
+});
+
+describe("directorLabelOf", () => {
+  it("prefers the user-editable display name", () => {
+    expect(directorLabelOf("abcd1234-guid", director({ displayName: "SOREN_NORTH_SLOT_2" }))).toBe(
+      "SOREN_NORTH_SLOT_2",
+    );
+  });
+
+  it("falls back to the historical short-id label when unnamed or when reachability is missing", () => {
+    // An unnamed Director (or one behind an older Gateway that strips the field) must render exactly
+    // as it always did - the display name is additive, never a regression.
+    expect(directorLabelOf("32c4851e", director({ displayName: "" }))).toBe("Director 32c4851e");
+    expect(directorLabelOf("32c4851e", undefined)).toBe("Director 32c4851e");
+  });
+
+  it("ignores a whitespace-only display name", () => {
+    expect(directorLabelOf("32c4851e", director({ displayName: "   " }))).toBe("Director 32c4851e");
+  });
+
+  it("labels an empty id as unknown", () => {
+    expect(directorLabelOf("", undefined)).toBe("Director (unknown)");
   });
 });
 

--- a/apps/cockpit/src/fleet/fleetMapFormat.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.ts
@@ -132,6 +132,21 @@ export function shortDir(directorId: string): string {
   return tail.length > 8 ? tail.slice(0, 8) : tail;
 }
 
+/**
+ * The human label of a Director group or lane (devthrottle_internal#1176): the user-editable display
+ * name when the envelope reports one, else the historical "Director <short-id>". The short id stays the
+ * fallback - never the primary - so a renamed Director finally reads as its name and an unnamed or
+ * older-Gateway Director renders exactly as before.
+ */
+export function directorLabelOf(
+  directorId: string,
+  reachability: DirectorReachability | undefined,
+): string {
+  const name = (reachability?.displayName ?? "").trim();
+  if (name.length > 0) return name;
+  return `Director ${directorId.length === 0 ? "(unknown)" : shortDir(directorId)}`;
+}
+
 /** One machine's reachable Directors, keyed exactly as the machine pivot's lanes are (machineKeyOf). */
 export interface MachineDirectors {
   key: string;
@@ -212,7 +227,7 @@ export function groupByDirector(
   return [...byDir.entries()]
     .map(([key, arr]) => ({
       key: key.length === 0 ? "(unknown)" : key,
-      label: `Director ${key.length === 0 ? "(unknown)" : shortDir(key)}`,
+      label: directorLabelOf(key, reachByDir.get(key)),
       sessions: [...arr].sort(sort),
       reachability: reachByDir.get(key),
     }))

--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -80,6 +80,9 @@ function saveStored(storageKey: string, value: string): void {
 }
 
 function directorLabel(d: DirectorInfo): string {
+  // devthrottle_internal#1176: the user-editable display name wins when the Director reports one - it
+  // is the label that tells several Directors on one machine apart by something a human chose.
+  if (d.displayName.trim()) return d.displayName.trim();
   if (d.machineName.trim()) return d.machineName.trim();
   return d.directorId || "director";
 }

--- a/apps/mobile/src/pages/NewSession.tsx
+++ b/apps/mobile/src/pages/NewSession.tsx
@@ -70,6 +70,9 @@ function directorSubtitle(d: DirectorInfo, now: number): string {
 }
 
 function directorLabel(d: DirectorInfo): string {
+  // devthrottle_internal#1176: the user-editable display name wins when the Director reports one - it
+  // is the label that tells several Directors on one machine apart by something a human chose.
+  if (d.displayName.trim()) return d.displayName.trim();
   if (d.machineName.trim()) return d.machineName.trim();
   return d.directorId || "director";
 }

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -53,6 +53,9 @@ type NewSessionRequest = components["schemas"]["NewSessionRequest"];
 export interface DirectorInfo {
   directorId: string;
   machineName: string;
+  /** The instance's user-editable display name (devthrottle_internal#1176). Empty when unnamed or from
+   *  an older Director - pickers fall back to machineName. */
+  displayName: string;
   /** Best-effort version label for the picker subtitle. */
   version: string;
   /** When the Director process started (ISO 8601 UTC), or empty. Drives the picker "up <uptime> /
@@ -1467,6 +1470,7 @@ export async function getDirectors(signal?: AbortSignal): Promise<DirectorInfo[]
     .map((d) => ({
       directorId: String(d.directorId ?? ""),
       machineName: String(d.machineName ?? ""),
+      displayName: String(d.displayName ?? ""),
       version: String(d.version ?? ""),
       startedAt: String(d.startedAt ?? ""),
       lastSeen: String(d.lastSeen ?? ""),

--- a/packages/client-core/src/fleet/fleetClient.ts
+++ b/packages/client-core/src/fleet/fleetClient.ts
@@ -23,6 +23,9 @@ export interface FleetDirector {
   controlEndpoint?: string;
   machineName?: string;
   user?: string;
+  /** The instance's user-editable display name (devthrottle_internal#1176), e.g. "SOREN_NORTH_SLOT_2".
+   * Empty/absent when unnamed or from an older Director - fall back to machineName. */
+  displayName?: string;
   version?: string;
   schemaVersion?: number;
   /** When the Gateway last heard from this Director (ISO 8601), or null. */
@@ -103,6 +106,9 @@ export type ReachabilityState =
 export interface DirectorReachability {
   directorId: string;
   machineName?: string;
+  /** The Director's user-editable display name (devthrottle_internal#1176). Empty/absent when unnamed
+   * or from an older Gateway - fall back to machineName. */
+  displayName?: string;
   /** "online" | "wobbly" | "offline". */
   state: ReachabilityState;
   /** When the Gateway last HEARD this machine - the arrival stamp of its newest push (ISO 8601 UTC), or

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Fleet;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Wingman;
 using CcDirector.Core.Utilities;
@@ -698,7 +699,10 @@ public sealed class ControlApiHost : IAsyncDisposable
         // synchronously. Kept in step with the config in ReapplyGatewayAsync.
         _sessionManager.FleetNumberingActive = gatewayConfig.IsEnabled;
 
-        _registration = new InstanceRegistration(DirectorId, Port, _version, _instancesDirectory);
+        _registration = new InstanceRegistration(DirectorId, Port, _version, _instancesDirectory,
+            // devthrottle_internal#1176: stamp the instance's display name into the same-machine discovery
+            // file too, so a file-discovered Director carries the same name a tunnel Hello would.
+            displayName: InstanceContext.DisplayName);
         _registration.Register();
 
         // Gateway Cleanup mission (tunnel-only): the Director NO LONGER opens an inbound Tailscale Serve
@@ -906,7 +910,11 @@ public sealed class ControlApiHost : IAsyncDisposable
             monitor: GatewayMonitor,
             // Repositories mission (#510 phase C): the repository/worktree snapshot rides the same
             // tunnel; null when this host was built without a monitor (tests, older callers).
-            repoSnapshot: _repositoryMonitor is null ? null : SnapshotRepositories);
+            repoSnapshot: _repositoryMonitor is null ? null : SnapshotRepositories,
+            // devthrottle_internal#1176: read the display name from the named-instance registry on EVERY
+            // reseed (not InstanceContext.DisplayName, a start-once static) so a rename lands fleet-wide
+            // on the next ~10s Hello without a Director restart.
+            displayName: () => NamedInstanceRegistry.Get(InstanceContext.Slug)?.DisplayName);
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -59,6 +59,14 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     // registers it from the stream (HTTP register is gone). Captured once at construction.
     private readonly DateTime _startedAt = System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime();
 
+    /// <summary>
+    /// devthrottle_internal#1176: provider of this instance's user-editable display name, consulted on
+    /// EVERY reseed (not captured once) so a rename lands fleet-wide on the next ~10s Hello without a
+    /// Director restart. Null in tests/older callers - the Hello then carries an empty name, which the
+    /// Gateway's merge guard treats as "no statement" rather than an erase.
+    /// </summary>
+    private readonly Func<string?>? _displayName;
+
     private HubConnection? _connection;
     private long _sequence;
     private int _started;
@@ -90,8 +98,10 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         TimeSpan? rePushInterval = null,
         SessionManager? sessionManager = null,
         GatewayConnectionMonitor? monitor = null,
-        Func<List<RepoStatusDto>>? repoSnapshot = null)
+        Func<List<RepoStatusDto>>? repoSnapshot = null,
+        Func<string?>? displayName = null)
     {
+        _displayName = displayName;
         _repoSnapshot = repoSnapshot;
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _directorId = string.IsNullOrWhiteSpace(directorId) ? throw new ArgumentException("directorId is required", nameof(directorId)) : directorId;
@@ -425,6 +435,25 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             new(TimeSpan.Zero, TimeSpan.Zero, Completed: false, Failure: "the tunnel was not connected");
     }
 
+    /// <summary>
+    /// devthrottle_internal#1176: the display name for this reseed's Hello. A cosmetic label must never
+    /// take the registration down, so a throwing provider (corrupt named-instances.json) is logged and
+    /// reported as "no statement" (empty) - the Gateway's merge guard keeps whatever it already holds.
+    /// </summary>
+    private string ReadDisplayName()
+    {
+        if (_displayName is null) return "";
+        try
+        {
+            return _displayName()?.Trim() ?? "";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayStreamClient] display-name provider FAILED (Hello proceeds unnamed): {ex.Message}");
+            return "";
+        }
+    }
+
     private async Task<ReseedReport> ReseedAsync()
     {
         var conn = _connection;
@@ -447,6 +476,7 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 User = Environment.UserName,
                 Pid = Environment.ProcessId,
                 StartedAt = _startedAt,
+                DisplayName = ReadDisplayName(),
             });
             awaitGateway += DateTime.UtcNow - helloStarted;
 

--- a/src/CcDirector.ControlApi/InstanceRegistration.cs
+++ b/src/CcDirector.ControlApi/InstanceRegistration.cs
@@ -35,7 +35,8 @@ public sealed class InstanceRegistration : IDisposable
     /// Override the shared instances directory. Tests pass an isolated temp directory so test
     /// Directors never appear in a real Gateway's discovery (and vice versa). Production omits it.
     /// </param>
-    public InstanceRegistration(string directorId, int port, string version, string? instancesDirectory = null)
+    public InstanceRegistration(string directorId, int port, string version, string? instancesDirectory = null,
+        string? displayName = null)
     {
         DirectorId = directorId;
         Port = port;
@@ -50,6 +51,9 @@ public sealed class InstanceRegistration : IDisposable
             ControlEndpoint = $"http://127.0.0.1:{port}",
             MachineName = Environment.MachineName,
             User = Environment.UserName,
+            // devthrottle_internal#1176: the instance's editable display name, so file-discovered
+            // Directors carry the same label a tunnel Hello reports. Empty = unnamed.
+            DisplayName = displayName?.Trim() ?? "",
             Version = version,
             SchemaVersion = 1,
         };

--- a/src/CcDirector.Gateway.Contracts/DirectorDto.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorDto.cs
@@ -25,6 +25,13 @@ public sealed class DirectorDto
     /// <summary>OS user name the Director is running as.</summary>
     public string User { get; set; } = "";
 
+    /// <summary>
+    /// devthrottle_internal#1176: the instance's user-editable display name (e.g. "SOREN_NORTH_SLOT_2"),
+    /// reported by the Director from its named-instance registry. Empty when the instance has no name
+    /// (older builds, unnamed default) - clients fall back to <see cref="MachineName"/>. Cosmetic only.
+    /// </summary>
+    public string DisplayName { get; set; } = "";
+
     /// <summary>Director version string (informational).</summary>
     public string Version { get; set; } = "";
 

--- a/src/CcDirector.Gateway.Contracts/DirectorReachabilityDto.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorReachabilityDto.cs
@@ -27,6 +27,14 @@ public sealed class DirectorReachabilityDto
     public string MachineName { get; set; } = "";
 
     /// <summary>
+    /// devthrottle_internal#1176: the Director's user-editable display name (copy of the registered
+    /// <c>DirectorDto.DisplayName</c>), carried here because the Fleet Map reads ONLY this envelope -
+    /// no second fetch - and its director labels need a real name. Empty when unnamed; clients fall
+    /// back to <see cref="MachineName"/>.
+    /// </summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>
     /// The presentation state, one of <see cref="StateOnline"/>, <see cref="StateWobbly"/>, or
     /// <see cref="StateOffline"/>. Never null.
     /// </summary>

--- a/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
@@ -30,4 +30,12 @@ public sealed class DirectorStreamHello
 
     /// <summary>Gateway Cleanup mission (tunnel-only): when the Director process started (UTC).</summary>
     public DateTime StartedAt { get; set; }
+
+    /// <summary>
+    /// devthrottle_internal#1176: the instance's user-editable display name (from the named-instance
+    /// registry, e.g. "SOREN_NORTH_SLOT_2"), so several Directors on one machine are tellable apart
+    /// in the fleet UI. Empty when the instance has no name (older builds, unnamed default). Cosmetic
+    /// only: the Gateway sanitizes it and never keys on it.
+    /// </summary>
+    public string DisplayName { get; set; } = "";
 }

--- a/src/CcDirector.Gateway.Tests/DirectorDisplayNameTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorDisplayNameTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// devthrottle_internal#1176: the Director's user-editable display name travels in the stream Hello and is
+/// stored on the registry entry, so the cockpit can finally tell three Directors on one machine apart.
+/// These tests pin the three registry-side rules the feature depends on:
+///
+///  1. A reported name is STORED and SERVED (ListDirectors carries it to GET /directors).
+///  2. The empty-field merge guard applies to it: a Hello with a blank name - an older Director build, or
+///     an instance that was never named - is "no statement", never an instruction to erase a stored name.
+///     Without this, one re-connect from a pre-name build would blank every name in the fleet.
+///  3. The name is CLIENT-WRITTEN and therefore sanitized at the single point every stream registration
+///     passes through: control characters stripped (a name must never carry escape sequences into a log
+///     line or the cockpit), length clamped rather than rejected.
+///
+/// Driven at the registry directly, like <see cref="DirectorRegistryTenantKeyTests"/> - no HTTP, no tunnel -
+/// so the result depends on nothing but the registration calls made here.
+/// </summary>
+public sealed class DirectorDisplayNameTests : IDisposable
+{
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-ddn-" + Guid.NewGuid().ToString("N"));
+    private readonly DirectorRegistry _registry;
+
+    public DirectorDisplayNameTests()
+    {
+        Directory.CreateDirectory(_instancesDir);
+        // Constructed but never Start()ed: no file watcher, no sweeper - only these registrations exist.
+        _registry = new DirectorRegistry(_instancesDir);
+    }
+
+    public void Dispose()
+    {
+        _registry.Dispose();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    private DirectorDtoLike Register(string displayName)
+    {
+        var dto = _registry.RegisterFromStream(
+            "dir-1", "SOREN_NORTH", "soren", "1.9.1", pid: 1234, startedAt: DateTime.UtcNow,
+            TenantId.Local, displayName);
+        return new DirectorDtoLike(dto.DirectorId, dto.DisplayName);
+    }
+
+    private string ServedDisplayName()
+    {
+        var served = _registry.ListDirectors(TenantId.Local).Single(d => d.DirectorId == "dir-1");
+        return served.DisplayName;
+    }
+
+    private readonly record struct DirectorDtoLike(string DirectorId, string DisplayName);
+
+    [Fact]
+    public void A_reported_name_is_stored_and_served()
+    {
+        Register("SOREN_NORTH_SLOT_2");
+        Assert.Equal("SOREN_NORTH_SLOT_2", ServedDisplayName());
+    }
+
+    [Fact]
+    public void A_blank_name_does_not_erase_a_stored_one()
+    {
+        // Positive control first: the name is really there before the old build says Hello. Without it,
+        // "still named" would also hold if the name had never been stored at all.
+        Register("SOREN_NORTH_SLOT_2");
+        Assert.Equal("SOREN_NORTH_SLOT_2", ServedDisplayName());
+
+        // An older Director build re-registers with no name field (deserializes to ""). No statement.
+        Register("");
+        Assert.Equal("SOREN_NORTH_SLOT_2", ServedDisplayName());
+    }
+
+    [Fact]
+    public void A_rename_replaces_the_stored_name_on_the_next_hello()
+    {
+        Register("OLD_NAME");
+        Register("NEW_NAME");
+        Assert.Equal("NEW_NAME", ServedDisplayName());
+    }
+
+    [Fact]
+    public void A_never_named_director_serves_an_empty_name()
+    {
+        Register("");
+        Assert.Equal("", ServedDisplayName());
+    }
+
+    [Fact]
+    public void Control_characters_are_stripped_from_a_client_written_name()
+    {
+        // A hostile or corrupted client must not be able to push escape sequences or newlines through the
+        // registry into the cockpit or a log line.
+        Register("evil\x1b[31mname\r\nline");
+        Assert.Equal("evil[31mnameline", ServedDisplayName());
+    }
+
+    [Fact]
+    public void An_overlong_name_is_clamped_not_rejected()
+    {
+        var longName = new string('x', DirectorRegistry.MaxDisplayNameLength + 25);
+        Register(longName);
+        Assert.Equal(new string('x', DirectorRegistry.MaxDisplayNameLength), ServedDisplayName());
+    }
+
+    [Fact]
+    public void Whitespace_is_trimmed_and_a_whitespace_only_name_is_no_statement()
+    {
+        Register("  padded name  ");
+        Assert.Equal("padded name", ServedDisplayName());
+
+        // Whitespace-only is the same "no statement" as blank: the trimmed-away padding must not erase.
+        Register("   ");
+        Assert.Equal("padded name", ServedDisplayName());
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1022,6 +1022,7 @@ internal static class GatewayEndpoints
                 {
                     DirectorId = d.DirectorId,
                     MachineName = d.MachineName ?? "",
+                    DisplayName = d.DisplayName ?? "",
                     State = linkState,
                     // WHEN THE GATEWAY LAST HEARD THIS MACHINE, taken from the store's own arrival stamp rather
                     // than from the clock at serve time. The old online branch wrote DateTime.UtcNow with an age

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -307,12 +307,18 @@ public sealed class DirectorRegistry : IDisposable
     /// its director id. It is never read from the Hello payload, and there is no default: an unresolved tenant
     /// is a rejected Hello at the hub, not a registration under a guessed owner.
     /// </summary>
-    public DirectorDto RegisterFromStream(string directorId, string machineName, string user, string version, int pid, DateTime startedAt, TenantId tenant)
+    public DirectorDto RegisterFromStream(string directorId, string machineName, string user, string version, int pid, DateTime startedAt, TenantId tenant,
+        string displayName = "")
     {
         if (string.IsNullOrEmpty(directorId))
             throw new ArgumentException("directorId is required", nameof(directorId));
         if (!tenant.IsValid)
             throw new ArgumentException("a valid tenant is required to register a Director", nameof(tenant));
+
+        // devthrottle_internal#1176: the display name is CLIENT-WRITTEN and cosmetic, so it is sanitized
+        // here - the single place every stream registration passes through - before it can reach the
+        // cockpit: control characters stripped, length clamped. Never keyed on, never trusted for tenancy.
+        var cleanDisplayName = SanitizeDisplayName(displayName);
 
         var now = DateTime.UtcNow;
         var key = new DirectorKey(tenant, directorId);
@@ -338,6 +344,9 @@ public sealed class DirectorRegistry : IDisposable
                 TailnetEndpoint = null,
                 MachineName = !string.IsNullOrEmpty(machineName) ? machineName : (existing?.MachineName ?? ""),
                 User = !string.IsNullOrEmpty(user) ? user : (existing?.User ?? ""),
+                // devthrottle_internal#1176: same merge guard as the fields above - an empty name from an
+                // older build's Hello is "no statement", not an instruction to erase the stored name.
+                DisplayName = !string.IsNullOrEmpty(cleanDisplayName) ? cleanDisplayName : (existing?.DisplayName ?? ""),
                 Version = !string.IsNullOrEmpty(version) ? version : (existing?.Version ?? ""),
                 SchemaVersion = 1,
                 LastSeen = now,
@@ -353,6 +362,22 @@ public sealed class DirectorRegistry : IDisposable
             OnDirectorAdded?.Invoke(new DirectorArrival(key.Tenant, dto));
         }
         return dto;
+    }
+
+    /// <summary>Longest display name the registry will store; anything longer is truncated, not rejected.</summary>
+    public const int MaxDisplayNameLength = 80;
+
+    /// <summary>
+    /// devthrottle_internal#1176: normalize a client-written display name before it is stored and served
+    /// to the cockpit. Trims, strips control characters (a name must never carry escape sequences into a
+    /// terminal or log line), and clamps to <see cref="MaxDisplayNameLength"/>. Empty in, empty out.
+    /// </summary>
+    internal static string SanitizeDisplayName(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName)) return "";
+        var chars = displayName.Trim().Where(c => !char.IsControl(c)).ToArray();
+        var clean = new string(chars);
+        return clean.Length <= MaxDisplayNameLength ? clean : clean[..MaxDisplayNameLength];
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -175,7 +175,8 @@ public sealed class DirectorHub : Hub
         // structurally impossible, however the client chose hello.DirectorId. It also makes the entry visible
         // to this account's /directors list and to no other. The tenant is the one resolved above from the
         // authenticated device key - never the Hello payload, which the client writes.
-        _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant);
+        _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant,
+            hello.DisplayName);
         FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version}, machine={hello.MachineName})");
     }
 


### PR DESCRIPTION
## What this changes

Renaming a Director used to change only its own title bar. The name lived in named-instances.json on the machine and never left it: the tunnel Hello carried only machine name, operating system user, version, process id and start time, so the cockpit showed three identical SOREN_NORTH rows for three Directors on one machine, and searching for the new name found nothing.

**Director side.** The stream client re-reads the display name from the named instance registry on every reseed, so a rename lands fleet-wide on the next heartbeat (about ten seconds) with no restart. The same-machine discovery file carries it too. A failing read logs loudly and sends no name, which the Gateway treats as no statement.

**Gateway side.** The display name rides the stream Hello into the director registry and out through GET /directors and the roster envelope's per-director reachability record (the Fleet Map deliberately reads only that envelope, so the name had to be there). The name is client-written, so the registry sanitizes it - control characters stripped, length clamped to eighty - and an empty name from an older build never erases a stored one (the same merge guard the other identity fields use).

**Cockpit and phone.** The Directors table shows the name as the primary label (machine and user become the dim detail, and a seeded name equal to the hostname is not repeated beside itself), the search box matches it, the director detail page headlines it, the New Session pickers on both surfaces prefer it, and the Fleet Map's director labels use it instead of eight hex characters of the identifier.

**The Fleet Map gains a By director view**, right of By machine: one lane per Director across the fleet, headed by its name with the machine in the subtitle. An idle reachable Director keeps a lane as a free slot with the new session action; an offline one is shown dated with the action withheld - never dropped. The choice is sticky across reloads like every other view.

## Compatibility

Additive on every wire. An older Director sends no name and renders exactly as today; an older Gateway strips the field and the clients fall back to the machine name; a stored name survives an old build's blank Hello.

## Tests

- New DirectorDisplayNameTests on the Gateway registry: store-and-serve, blank-is-no-statement merge guard, rename replaces, control characters stripped, length clamped, whitespace trimmed.
- New cases in directorsFormat, fleetMapFormat and FleetMapView tests: label precedence, group labels, and a rendered proof of the By director view's lanes, free slots and withheld offline action. The whole cockpit suite passes (255 tests).
- The solution builds clean. The owner waived the full .NET suite run for this change; the machine-wide test lock was held by other sessions.

Research, code review and implementation plan: thefrederiksen/devthrottle_internal#1176 and thefrederiksen/devthrottle_internal#1177.