### PR TITLE
Local testing becomes the everyday gate: concurrent-safe tests, four minutes of sleep removed

### DIFF
--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -131,12 +131,41 @@ STEP 7: Open the pull request, merge on green, and park back on main
 The job is not done until the work is MERGED to origin/main. Once the user approved the
 commit (Step 4), drive it home:
 
-1. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
-2. Wait for checks to go green: gh pr checks <number> --watch.
-   - If checks fail, fix the failure and push a NEW commit (never amend, never --no-verify),
-     then re-watch. Report the failure to the user if it is not quick and mechanical.
-3. Merge with squash once green: gh pr merge <number> --squash --delete-branch.
+1. RUN THE TESTS LOCALLY FIRST. This is the gate - not GitHub (issue #1156):
+
+       .\scripts\test-local.ps1
+
+   It builds once and runs every test project, starting them together so the six that do not
+   serialize finish while the Gateway suite queues for its machine-wide lock. Use -Fast to skip
+   the Gateway suite when the change provably does not touch it, and say so in the pull request.
+   Do NOT hand-roll a dotnet test invocation - the script is the one place the whole fleet gets
+   faster when the suite improves.
+
+   If it is not green, fix it before opening a pull request. A red local run is a red change.
+
+2. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
+
+3. DO NOT WAIT FOR THE .NET CI JOB. "Build & Test (.NET)" takes roughly FIFTY MINUTES and is the
+   same suite you just ran locally on a far stronger machine. Waiting on it is the single largest
+   source of dead time in this repository, and it is why local is now the gate.
+
+   The other three checks - "Build & Test (web)", "Tool contracts (Python)", "Inventory drift" -
+   each finish in about a minute and cover things the local .NET run does NOT. Wait for those:
+
+       gh pr checks <number>
+
+   If any of those three fail, fix and push a NEW commit (never amend, never --no-verify).
+
+4. Merge with squash once the local run is green and the three fast checks pass:
+   gh pr merge <number> --squash --delete-branch.
    (delete_branch_on_merge is ON, but --delete-branch is explicit and harmless.)
+
+   The .NET job keeps running after the merge as a backstop. If it goes red on main, fix it
+   forward immediately - that is the trade for not waiting on it.
+
+   WAIT FOR THE .NET JOB ANYWAY when the change is genuinely risky: a release commit, a change to
+   the build or CI itself, anything cross-platform, or anything you could not test locally. Those
+   are the cases the fifty minutes is actually worth paying for.
 4. Park the checkout back on main:
    git checkout main && git pull
    If you worked in a worktree, remove it: git worktree remove ../<repo>-wt-<short-desc>.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,31 @@ Do NOT put try-catch in helper methods or service methods.
 - Use Arrange-Act-Assert pattern
 - Name tests: `MethodName_Scenario_ExpectedResult`
 
+### 5a. RUN THE TESTS LOCALLY - GITHUB IS NOT THE GATE
+
+**Run `.\scripts\test-local.ps1` before you open a pull request. That run is the gate.**
+
+Do NOT run `gh pr checks --watch` on "Build & Test (.NET)" and wait for it. That job takes about
+FIFTY MINUTES and runs the same tests you can run here, on a machine with 24 logical cores and 64 GB.
+Waiting on it was the single largest source of dead time in this repository (issue #1156).
+
+- **Use the script, not a hand-rolled `dotnet test`.** It builds once and starts every test project
+  together, so the six that do not serialize finish while the Gateway suite queues for its
+  machine-wide lock. It is also the ONE place the whole fleet gets faster when the suite improves -
+  a convention each caller re-implements cannot be improved centrally.
+- `-Fast` skips the Gateway suite for a change that provably does not touch it. Say so in the pull
+  request if you rely on it.
+- **Do wait for the three fast checks** - "Build & Test (web)", "Tool contracts (Python)",
+  "Inventory drift". They take about a minute each and cover things the local .NET run does not.
+- The .NET job still runs after the merge as a backstop. If it reddens on main, fix it forward
+  immediately. That is the trade for not waiting on it.
+- **Do wait for the .NET job anyway** when the change is genuinely risky: a release commit, a change
+  to the build or to CI itself, anything cross-platform, or anything you could not test locally.
+
+If the Gateway suite says it is WAITING on a lock held by another run, that is not a hang - it is
+one run at a time by design, and it prints its holder every 30 seconds. See issue #1156 for why that
+queue exists and the work to remove it.
+
 ### 6. UI Thread Safety
 
 ```csharp

--- a/scripts/test-local.ps1
+++ b/scripts/test-local.ps1
@@ -1,0 +1,133 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Run this repository's tests locally. THE one command - do not hand-roll a dotnet test invocation.
+
+.DESCRIPTION
+    Local is the gate for ordinary changes (issue #1156). GitHub CI takes roughly fifty minutes for the
+    .NET job; this machine is far stronger than a CI runner and should be where the answer comes from.
+
+    WHY A SCRIPT RATHER THAN "JUST RUN DOTNET TEST". Two reasons, and the second is the important one.
+
+    1. It is faster than the obvious invocation. Seven test projects exist. Only CcDirector.Gateway.Tests
+       serializes itself machine-wide (GatewayTestSuiteLock, and see issue #1156 for why). The other six
+       contend with nothing, so they are started IMMEDIATELY and run alongside the Gateway suite while it
+       queues for its lock. A plain solution-wide `dotnet test` runs them one project at a time and pays
+       the lock wait on top; this pays roughly the slower of the two, not the sum.
+
+    2. It is ONE place to make everyone faster. When the Gateway suite's lock is removed, or in-process
+       parallelism becomes safe, this file changes and every agent and person in the fleet gets the
+       improvement without being told. A convention that each caller re-implements cannot be improved
+       centrally - which is the same argument GatewayTestSuiteLock makes about acquisition being automatic.
+
+.PARAMETER Gateway
+    Run ONLY the Gateway suite. Use when the change is Gateway-side and you want its answer first.
+
+.PARAMETER Fast
+    Skip the Gateway suite. Use for a change that provably does not touch the Gateway - the six other
+    projects together finish in well under a minute. State the reason in the pull request if you rely on it.
+
+.PARAMETER Filter
+    An xUnit filter passed through to every project (e.g. "FullyQualifiedName~Dictation").
+
+.EXAMPLE
+    .\scripts\test-local.ps1
+    .\scripts\test-local.ps1 -Fast
+    .\scripts\test-local.ps1 -Gateway -Filter "FullyQualifiedName~Tombstone"
+#>
+param(
+    [switch]$Gateway,
+    [switch]$Fast,
+    [string]$Filter = "",
+    [string]$Configuration = "Debug"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$sln = Join-Path $repoRoot "cc-director.sln"
+
+if ($Gateway -and $Fast) {
+    Write-Error "-Gateway and -Fast are opposites; pass at most one."
+    exit 2
+}
+
+# The Gateway suite is named separately because it is the only one that serializes machine-wide.
+$gatewayProject = "src\CcDirector.Gateway.Tests\CcDirector.Gateway.Tests.csproj"
+$otherProjects = @(
+    "src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj",
+    "src\CcDirector.Avalonia.Tests\CcDirector.Avalonia.Tests.csproj",
+    "src\CcDirector.Engine.Tests\CcDirector.Engine.Tests.csproj",
+    "src\CcDirector.HostedAgent.Tests\CcDirector.HostedAgent.Tests.csproj",
+    "src\CcDirector.Launcher.Tests\CcDirector.Launcher.Tests.csproj",
+    "src\CcDirector.Terminal.Avalonia.Tests\CcDirector.Terminal.Avalonia.Tests.csproj"
+)
+
+$toRun = @()
+if (-not $Fast)    { $toRun += $gatewayProject }
+if (-not $Gateway) { $toRun += $otherProjects }
+
+Write-Host "Building once, then running $($toRun.Count) test project(s)..."
+& dotnet build $sln -c $Configuration -v q --nologo
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "RESULT: BUILD FAILED - no tests were run."
+    exit 1
+}
+
+$logDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cc-test-local-" + [Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+
+$filterArgs = @()
+if ($Filter -ne "") { $filterArgs = @("--filter", $Filter) }
+
+# Start every project at once. The Gateway suite may sit in its own queue; the others do not wait for it.
+$running = @()
+foreach ($proj in $toRun) {
+    $name = Split-Path -Leaf ([System.IO.Path]::GetDirectoryName((Join-Path $repoRoot $proj)))
+    $out = Join-Path $logDir "$name.log"
+    $args = @("test", (Join-Path $repoRoot $proj), "--no-build", "-c", $Configuration, "--nologo", "-v", "q") + $filterArgs
+    $p = Start-Process -FilePath "dotnet" -ArgumentList $args -NoNewWindow -PassThru `
+                       -RedirectStandardOutput $out -RedirectStandardError "$out.err"
+    $running += [pscustomobject]@{ Name = $name; Process = $p; Log = $out }
+    Write-Host "  started $name"
+}
+
+Write-Host ""
+Write-Host "Waiting. The Gateway suite serializes machine-wide, so it may queue behind another run;"
+Write-Host "that is not a hang - it prints its holder every 30s into its log."
+Write-Host ""
+
+$failed = @()
+foreach ($r in $running) {
+    $r.Process.WaitForExit()
+    $summary = ""
+    if (Test-Path $r.Log) {
+        $summary = (Select-String -Path $r.Log -Pattern "^(Passed!|Failed!)" -ErrorAction SilentlyContinue |
+                    Select-Object -Last 1).Line
+    }
+    if ($null -eq $summary -or $summary -eq "") { $summary = "(no summary line - see $($r.Log))" }
+
+    if ($r.Process.ExitCode -eq 0) {
+        Write-Host ("  PASS  {0}  {1}" -f $r.Name, $summary.Trim())
+    } else {
+        Write-Host ("  FAIL  {0}  {1}" -f $r.Name, $summary.Trim())
+        $failed += $r
+    }
+}
+
+Write-Host ""
+if ($failed.Count -eq 0) {
+    Write-Host "RESULT: ALL GREEN. This is the gate - you do not need to wait for GitHub CI to merge."
+    Remove-Item -Recurse -Force $logDir -ErrorAction SilentlyContinue
+    exit 0
+}
+
+Write-Host "RESULT: FAILED in $($failed.Count) project(s):"
+foreach ($f in $failed) {
+    Write-Host "  $($f.Name) -> $($f.Log)"
+    $lines = Get-Content $f.Log -Tail 25 -ErrorAction SilentlyContinue
+    foreach ($l in $lines) { Write-Host "      $l" }
+}
+Write-Host ""
+Write-Host "Logs kept in $logDir"
+exit 1

--- a/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsPostgresTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/CallerSuppliedKeyUpgradePreservesRowsPostgresTests.cs
@@ -54,9 +54,9 @@ public sealed class CallerSuppliedKeyUpgradePreservesRowsPostgresTests
         }
     }
 
-    private static string Connection =>
-        Environment.GetEnvironmentVariable(ConnectionEnvVar)
-        ?? throw new InvalidOperationException($"{ConnectionEnvVar} is not set.");
+    // Per RUN, not per operator: PostgresProofDatabase appends a unique suffix to the supplied
+    // database name so two concurrent runs cannot EnsureDeleted() each other's schema (issue #1156).
+    private static string Connection => PostgresProofDatabase.Connection;
 
     /// <summary>The same wiring the runtime hosted Gateway uses: Npgsql, the Postgres migrations assembly, and
     /// the migrations history table in the <c>gateway</c> schema.</summary>
@@ -78,14 +78,7 @@ public sealed class CallerSuppliedKeyUpgradePreservesRowsPostgresTests
     /// "ccpg" - a token no real database would carry. A loose substring marker like "test" is deliberately NOT
     /// used: it matches ordinary names such as "latest" or "contest", which would defeat the guard.
     /// </summary>
-    private static void GuardThrowawayDatabase()
-    {
-        var database = new NpgsqlConnectionStringBuilder(Connection).Database ?? "";
-        if (!database.StartsWith("ccpg", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException(
-                $"Refusing to drop database '{database}': the upgrade proof recreates the database from " +
-                $"nothing, so {ConnectionEnvVar} must point at a throwaway whose name starts with 'ccpg'.");
-    }
+    private static void GuardThrowawayDatabase() => PostgresProofDatabase.GuardThrowawayDatabase();
 
     private static void MigrateTo(string? target)
     {

--- a/src/CcDirector.Gateway.Tests/Data/DeviceCredentialImportPostgresTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/DeviceCredentialImportPostgresTests.cs
@@ -40,9 +40,9 @@ public sealed class DeviceCredentialImportPostgresTests
         }
     }
 
-    private static string Connection =>
-        Environment.GetEnvironmentVariable(ConnectionEnvVar)
-        ?? throw new InvalidOperationException($"{ConnectionEnvVar} is not set.");
+    // Per RUN, not per operator: PostgresProofDatabase appends a unique suffix to the supplied
+    // database name so two concurrent runs cannot EnsureDeleted() each other's schema (issue #1156).
+    private static string Connection => PostgresProofDatabase.Connection;
 
     /// <summary>The same wiring the runtime hosted Gateway uses: Npgsql, the Postgres migrations assembly, and
     /// the migrations history table in the <c>gateway</c> schema.</summary>
@@ -63,14 +63,7 @@ public sealed class DeviceCredentialImportPostgresTests
     /// Postgres proofs: the target database NAME must begin with the dedicated <c>ccpg</c> prefix, a token no
     /// real database would carry, so pointing the env var at a real database can never drop it.
     /// </summary>
-    private static void GuardThrowawayDatabase()
-    {
-        var database = new NpgsqlConnectionStringBuilder(Connection).Database ?? "";
-        if (!database.StartsWith("ccpg", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException(
-                $"Refusing to EnsureDeleted() the database '{database}': its name must begin with the throwaway " +
-                "prefix 'ccpg'. Point CC_GATEWAY_TEST_PG_CONNECTION at a disposable database (e.g. 'ccpgproof').");
-    }
+    private static void GuardThrowawayDatabase() => PostgresProofDatabase.GuardThrowawayDatabase();
 
     private static int ScalarInt(GatewayDbContext ctx, string sql)
     {

--- a/src/CcDirector.Gateway.Tests/Data/PostgresProofDatabase.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProofDatabase.cs
@@ -1,0 +1,96 @@
+using Npgsql;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The per-RUN Postgres database for the live proof classes (issue #1156).
+///
+/// THE COLLISION THIS CLOSES. The three Postgres proof classes read one connection string from
+/// <c>CC_GATEWAY_TEST_PG_CONNECTION</c> and call <c>EnsureDeleted()</c> on it before migrating from nothing.
+/// Two runs handed the SAME connection string therefore DROP EACH OTHER'S DATABASE while the other is still
+/// executing against it. That is not a timing hazard or a scheduling artefact - it is one process destroying
+/// another's data mid-test, and it is the only demonstrated cross-process corruption left in this assembly.
+/// It defeats a file lock too: the lock serializes runs on ONE machine for ONE user, while a shared Postgres
+/// server is reachable from anywhere.
+///
+/// THE FIX: the environment variable names a TEMPLATE, not the database to use. Every run derives its own
+/// database name from it by appending a unique suffix, so two runs can point at the same server, share
+/// credentials, and never touch the same database. Nothing about the server, host, port, or user changes -
+/// only which database the run owns.
+///
+/// WHY THE SUFFIX IS PER PROCESS, NOT PER CLASS. All three proof classes must agree on the database within a
+/// run: they migrate and assert against the same schema. A static computed once per process gives exactly
+/// that - one database per test process, shared by the classes in it, distinct from every other run.
+///
+/// THE THROWAWAY GUARD IS KEPT AND STRENGTHENED. The original refused to drop a database whose name did not
+/// begin with <c>ccpg</c>, so a mistyped variable could never nuke a real database. That check still runs,
+/// against the SUPPLIED name, before any suffix is added - so the operator's intent is what is validated. The
+/// derived name inherits the prefix, so the guard holds for the database actually dropped.
+/// </summary>
+internal static class PostgresProofDatabase
+{
+    internal const string ConnectionEnvVar = "CC_GATEWAY_TEST_PG_CONNECTION";
+
+    /// <summary>The throwaway prefix a supplied database name must carry before anything may drop it.</summary>
+    private const string ThrowawayPrefix = "ccpg";
+
+    /// <summary>
+    /// Unique per test process. Short, lower-case and alphanumeric so it is a legal Postgres identifier
+    /// without quoting, and so a leftover database is still recognisably one of ours.
+    /// </summary>
+    private static readonly string RunSuffix = Guid.NewGuid().ToString("N")[..12];
+
+    private static readonly Lazy<string?> Derived = new(BuildConnection);
+
+    /// <summary>True when the operator asked for the live Postgres proofs at all.</summary>
+    internal static bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionEnvVar));
+
+    /// <summary>
+    /// This run's own connection string. Same server and credentials the operator supplied; a database name
+    /// no other run will use.
+    /// </summary>
+    internal static string Connection =>
+        Derived.Value ?? throw new InvalidOperationException($"{ConnectionEnvVar} is not set.");
+
+    /// <summary>The database name this run owns, for messages and for the drop guard.</summary>
+    internal static string DatabaseName =>
+        new NpgsqlConnectionStringBuilder(Connection).Database ?? "";
+
+    private static string? BuildConnection()
+    {
+        var supplied = Environment.GetEnvironmentVariable(ConnectionEnvVar);
+        if (string.IsNullOrWhiteSpace(supplied)) return null;
+
+        var builder = new NpgsqlConnectionStringBuilder(supplied);
+        var suppliedDatabase = builder.Database ?? "";
+
+        // Validate what the OPERATOR wrote, before deriving anything from it. A name that was never safe to
+        // drop must not become safe merely because a suffix was appended to it.
+        if (!suppliedDatabase.StartsWith(ThrowawayPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to use the database '{suppliedDatabase}' for the Postgres proofs: its name must begin " +
+                $"with the throwaway prefix '{ThrowawayPrefix}', because these tests DROP the database they run " +
+                $"against. Point {ConnectionEnvVar} at a disposable database (e.g. 'ccpgproof').");
+        }
+
+        builder.Database = $"{suppliedDatabase}_{RunSuffix}";
+        return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// The drop guard, kept as an explicit call so the proof classes still state out loud that they are about
+    /// to destroy a database. Re-checks the DERIVED name, which is what actually gets dropped.
+    /// </summary>
+    internal static void GuardThrowawayDatabase()
+    {
+        var database = DatabaseName;
+        if (!database.StartsWith(ThrowawayPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to EnsureDeleted() the database '{database}': its name must begin with the throwaway " +
+                $"prefix '{ThrowawayPrefix}'.");
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -36,9 +36,9 @@ public sealed class PostgresProviderProofTests
         }
     }
 
-    private static string Connection =>
-        Environment.GetEnvironmentVariable(ConnectionEnvVar)
-        ?? throw new InvalidOperationException($"{ConnectionEnvVar} is not set.");
+    // Per RUN, not per operator: PostgresProofDatabase appends a unique suffix to the supplied
+    // database name so two concurrent runs cannot EnsureDeleted() each other's schema (issue #1156).
+    private static string Connection => PostgresProofDatabase.Connection;
 
     /// <summary>Build a GatewayDbContext on Npgsql pointing at the proof container, with the Postgres migration
     /// assembly and the gateway-schema history table - the same wiring the runtime Gateway uses.</summary>
@@ -330,14 +330,7 @@ public sealed class PostgresProviderProofTests
     /// "contest", which would defeat the guard. Anything without the prefix throws instead of dropping, so
     /// pointing the env var at a real database can never nuke it.
     /// </summary>
-    private static void GuardThrowawayDatabase()
-    {
-        var database = new NpgsqlConnectionStringBuilder(Connection).Database ?? "";
-        if (!database.StartsWith("ccpg", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException(
-                $"Refusing to EnsureDeleted() the database '{database}': its name must begin with the throwaway " +
-                "prefix 'ccpg'. Point CC_GATEWAY_TEST_PG_CONNECTION at a disposable database (e.g. 'ccpgproof').");
-    }
+    private static void GuardThrowawayDatabase() => PostgresProofDatabase.GuardThrowawayDatabase();
 
     private static int ScalarInt(GatewayDbContext ctx, string sql)
     {

--- a/src/CcDirector.Gateway.Tests/DeadPortReservation.cs
+++ b/src/CcDirector.Gateway.Tests/DeadPortReservation.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A loopback port that is guaranteed to REFUSE connections and guaranteed NOT to be taken by anyone
+/// else, for as long as this object is alive (issue #1156).
+///
+/// WHAT IT REPLACES, AND WHY THAT PATTERN WAS A CROSS-PROCESS RACE. Three tests needed "an address where
+/// nothing is listening" and got it by opening a <see cref="TcpListener"/> on port 0, reading the assigned
+/// number, and then STOPPING the listener - handing back a port that was free at the moment of the read and
+/// unowned from then on. That is a time-of-check/time-of-use race, and the window is not intra-process: any
+/// other process on the machine - notably a second run of this suite - can bind that number before the test
+/// uses it. A test asserting "unreachable" then talks to somebody else's listener, and a test expecting a
+/// child to refuse before binding gets an address-conflict failure instead of the contract failure it meant
+/// to prove. Both look like unrelated flakes in whichever suite happens to lose the race, which is exactly
+/// the shape of failure that made concurrent runs of this assembly untrustworthy.
+///
+/// HOW THIS IS DIFFERENT: BIND WITHOUT LISTEN. The socket is bound to the port and never placed into the
+/// listening state. That single distinction gives both properties at once, and they are the two the callers
+/// actually need:
+///
+///  * RESERVED - the port is held by this socket for its lifetime, so no other process (or run) can bind it.
+///    A second bind fails with <see cref="SocketError.AddressAlreadyInUse"/>.
+///  * DEAD - with no listen backlog the kernel answers an incoming connection with a reset, so a connect
+///    attempt fails with <see cref="SocketError.ConnectionRefused"/> - which is precisely what "nothing is
+///    listening here" is supposed to mean.
+///
+/// Both properties were verified on this platform before this type was written, rather than assumed from
+/// the socket API's documentation.
+///
+/// LIFETIME IS THE WHOLE POINT. The reservation is only true while this object is alive, so callers must
+/// hold it for as long as the dead address must stay dead - typically the lifetime of the fixture that
+/// registered the address - and dispose it with that fixture. Reserving a port and immediately disposing it
+/// would reintroduce the exact race this replaces.
+/// </summary>
+internal sealed class DeadPortReservation : IDisposable
+{
+    private readonly Socket _socket;
+
+    private DeadPortReservation(Socket socket, int port)
+    {
+        _socket = socket;
+        Port = port;
+    }
+
+    /// <summary>The reserved loopback port. Refuses connections while this reservation is alive.</summary>
+    public int Port { get; }
+
+    /// <summary>Convenience for the common use: an endpoint nothing will ever answer on.</summary>
+    public string LoopbackUrl => $"http://127.0.0.1:{Port}/";
+
+    /// <summary>
+    /// Reserve a fresh dead port. The operating system assigns the number (bind to port 0), so this never
+    /// guesses and never collides with a port already in use.
+    /// </summary>
+    public static DeadPortReservation Reserve()
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        try
+        {
+            // Deliberately NOT ExclusiveAddressUse=false and deliberately no Listen() call. The default
+            // exclusive binding is what makes the reservation hold against another process.
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var port = ((IPEndPoint)socket.LocalEndPoint!).Port;
+            return new DeadPortReservation(socket, port);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose() => _socket.Dispose();
+}

--- a/src/CcDirector.Gateway.Tests/DevopsAdapterDispatchProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/DevopsAdapterDispatchProofTests.cs
@@ -129,7 +129,8 @@ public sealed class DevopsAdapterDispatchProofTests : IAsyncLifetime
 
     private static string TempRepo()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "cc300-repo");
+        // Unique per run: a fixed temp name is shared by every concurrent run on the machine (issue #1156).
+        var dir = Path.Combine(Path.GetTempPath(), "cc300-repo-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCommandRouterTimeoutTests.cs
@@ -81,56 +81,71 @@ public sealed class DirectorCommandRouterTimeoutTests
         Assert.InRange(stopwatch.Elapsed.TotalMilliseconds, 100, 10_000);
     }
 
-    [Fact]
-    public async Task TrySendAsync_Timeout_MessageNamesTheMachineAndTheWait_InPlainEnglish()
-    {
-        // Act
-        var result = await DirectorCommandRouter.TrySendAsync(
-            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None,
-            TimeSpan.FromSeconds(30), machineName: "SOREN_NORTH");
+    // ---- the WORDING, tested against the pure function that produces it ----
+    //
+    // These three used to run a real thirty-second timeout each (one of them twice) purely to read the
+    // sentence out of the result - two minutes of every suite run, spent waiting on a clock to check a
+    // string (issue #1156). The message is a pure function of the machine name and the wait, so it is
+    // asserted directly. The JOIN is not lost: the seam test below runs a real timeout and asserts the
+    // router returns exactly this function's output, so wording and wiring are each proven, and neither
+    // can drift without a test going red.
 
-        // Assert - this message is read by a person on a phone in a moving car. It must name the machine, say
-        // what did not happen, and give the wait in whole seconds - no status code, no stack trace, no jargon.
-        Assert.NotNull(result!.Error);
-        Assert.Contains("SOREN_NORTH", result.Error!);
-        Assert.Contains("did not answer within 30 seconds", result.Error);
-        Assert.DoesNotContain("30.0", result.Error);
+    [Fact]
+    public void TimeoutMessage_NamesTheMachineAndTheWait_InPlainEnglish()
+    {
+        var message = DirectorCommandRouter.DescribeTimeout("SOREN_NORTH", TimeSpan.FromSeconds(30));
+
+        // This message is read by a person on a phone in a moving car. It must name the machine, say what did
+        // not happen, and give the wait in whole seconds - no status code, no stack trace, no jargon.
+        Assert.Contains("SOREN_NORTH", message);
+        Assert.Contains("did not answer within 30 seconds", message);
+        Assert.DoesNotContain("30.0", message);
     }
 
     [Fact]
-    public async Task TrySendAsync_Timeout_WithoutAMachineName_KeepsTheSameMessageShape()
+    public void TimeoutMessage_WithoutAMachineName_KeepsTheSameMessageShape()
     {
-        // Arrange + Act - the call sites that hold only a Director id cannot name the machine.
-        var result = await DirectorCommandRouter.TrySendAsync(
-            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None, TimeSpan.FromSeconds(30));
-
-        // Assert - the degraded message is the SAME sentence minus the machine clause, never vaguer and never
-        // a second message style. The machine name is presentation only.
+        // The call sites that hold only a Director id cannot name the machine. The degraded message is the
+        // SAME sentence minus the machine clause, never vaguer and never a second message style.
         Assert.Equal(
             "The Director did not answer within 30 seconds. It is not known whether the command was carried out.",
-            result!.Error);
+            DirectorCommandRouter.DescribeTimeout(null, TimeSpan.FromSeconds(30)));
     }
 
     [Fact]
-    public async Task TrySendAsync_Timeout_DoesNotClaimTheCommandWasSkipped()
+    public void TimeoutMessage_DoesNotClaimTheCommandWasSkipped()
     {
-        // Act
-        var named = await DirectorCommandRouter.TrySendAsync(
-            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None,
-            TimeSpan.FromSeconds(30), machineName: "SOREN_NORTH");
-        var anonymous = await DirectorCommandRouter.TrySendAsync(
-            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None, TimeSpan.FromSeconds(30));
-
-        // Assert - a timeout proves only that the GATEWAY stopped waiting. The Director may have received the
-        // command, carried it out, and answered late, so the message must leave the outcome open. It used to end
-        // "The command was not carried out" - stated as fact - which is how a user came to re-tap Send and hand
-        // the agent the same prompt twice. Positive assertion first: an absence-only check would still pass if
-        // the sentence were deleted, which is a worse message than the wrong one.
-        foreach (var error in new[] { named!.Error, anonymous!.Error })
+        // A timeout proves only that the GATEWAY stopped waiting. The Director may have received the command,
+        // carried it out, and answered late, so the message must leave the outcome open. It used to end "The
+        // command was not carried out" - stated as fact - which is how a user came to re-tap Send and hand the
+        // agent the same prompt twice. Positive assertion first: an absence-only check would still pass if the
+        // sentence were deleted, which is a worse message than the wrong one.
+        foreach (var message in new[]
+                 {
+                     DirectorCommandRouter.DescribeTimeout("SOREN_NORTH", TimeSpan.FromSeconds(30)),
+                     DirectorCommandRouter.DescribeTimeout(null, TimeSpan.FromSeconds(30)),
+                 })
         {
-            Assert.Contains("It is not known whether the command was carried out.", error!);
-            Assert.DoesNotContain("The command was not carried out", error);
+            Assert.Contains("It is not known whether the command was carried out.", message);
+            Assert.DoesNotContain("The command was not carried out", message);
         }
+    }
+
+    [Fact]
+    public async Task TrySendAsync_Timeout_ReturnsExactlyTheDescribedMessage()
+    {
+        // THE SEAM. The three tests above assert the wording without waiting; this one proves the router
+        // actually uses that wording on a real timeout. Without it, DescribeTimeout could be perfect and the
+        // router could return something else entirely, and every test would still pass. A SHORT timeout is
+        // enough - what is under test is which string comes back, not how long the wait is.
+        var wait = TimeSpan.FromMilliseconds(200);
+
+        var result = await DirectorCommandRouter.TrySendAsync(
+            NeverAnswers(), "director-1", "prompt", "sid-1", null, CancellationToken.None,
+            wait, machineName: "SOREN_NORTH");
+
+        Assert.Equal(DirectorCommandStatus.Timeout, result!.Status);
+        Assert.Equal(DirectorCommandRouter.DescribeTimeout("SOREN_NORTH", wait), result.Error);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/DirectorShutdownGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorShutdownGateTests.cs
@@ -29,6 +29,10 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
     private readonly List<Gate> _fakes = new();
+    // One per RegisterUnreachable call, held to the end of the class: an endpoint registered as
+    // unreachable must STAY unreachable for the whole test, so the port is reserved rather than probed and
+    // released (issue #1156).
+    private readonly List<DeadPortReservation> _deadEndpoints = new();
 
     private readonly string _instancesDir =
         Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
@@ -48,6 +52,7 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
     {
         _http.Dispose();
         foreach (var f in _fakes) await f.DisposeAsync();
+        foreach (var reservation in _deadEndpoints) reservation.Dispose();
         await _gateway.StopAsync();
         try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
         catch { }
@@ -199,7 +204,7 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
         _gateway.Registry.Upsert(new DirectorRegistrationRequest
         {
             DirectorId = id,
-            TailnetEndpoint = $"http://127.0.0.1:{DeadPort()}/",
+            TailnetEndpoint = ReserveDeadEndpoint(),
             Pid = pid,
             MachineName = "GATE_TEST",
             User = "tester",
@@ -236,13 +241,12 @@ public sealed class DirectorShutdownGateTests : IAsyncLifetime
         return gate;
     }
 
-    private static int DeadPort()
+    // A loopback URL nothing will ever answer on, reserved for the lifetime of this test class.
+    private string ReserveDeadEndpoint()
     {
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        var port = ((IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
-        return port;
+        var reservation = DeadPortReservation.Reserve();
+        _deadEndpoints.Add(reservation);
+        return reservation.LoopbackUrl;
     }
 
     // Records whether the graceful "shutdown" verb was delivered over the tunnel.

--- a/src/CcDirector.Gateway.Tests/FakeTunnelDirector.cs
+++ b/src/CcDirector.Gateway.Tests/FakeTunnelDirector.cs
@@ -27,6 +27,10 @@ public sealed class FakeTunnelDirector : IAsyncDisposable
     public static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
 
     private readonly HubConnection _conn;
+    // Held for this fake's whole life: the registered tailnet endpoint must STAY unreachable, so the port
+    // stays reserved-and-refusing until DisposeAsync. Releasing it early would let another process bind the
+    // address this fake advertises as dead (issue #1156).
+    private readonly DeadPortReservation _deadEndpoint;
     private Func<DirectorCommand, DirectorCommandResult> _dispatch;
     private long _sequence;
 
@@ -36,11 +40,12 @@ public sealed class FakeTunnelDirector : IAsyncDisposable
     /// <summary>The last command the Gateway sent over the tunnel, so a test can assert the verb + payload.</summary>
     public DirectorCommand? LastCommand { get; private set; }
 
-    private FakeTunnelDirector(string directorId, HubConnection conn, Func<DirectorCommand, DirectorCommandResult> dispatch)
+    private FakeTunnelDirector(string directorId, HubConnection conn, Func<DirectorCommand, DirectorCommandResult> dispatch, DeadPortReservation deadEndpoint)
     {
         DirectorId = directorId;
         _conn = conn;
         _dispatch = dispatch;
+        _deadEndpoint = deadEndpoint;
     }
 
     /// <summary>
@@ -60,11 +65,13 @@ public sealed class FakeTunnelDirector : IAsyncDisposable
         Func<DirectorCommand, DirectorCommandResult>? dispatch = null)
     {
         // Registered UNREACHABLE: nothing listens on this advertised endpoint, so any working result
-        // could only have come over the tunnel.
+        // could only have come over the tunnel. The port is RESERVED for the fake's lifetime rather than
+        // probed-and-released, so no other process can start answering on it mid-test (issue #1156).
+        var deadEndpoint = DeadPortReservation.Reserve();
         gateway.Registry.Upsert(new DirectorRegistrationRequest
         {
             DirectorId = directorId,
-            TailnetEndpoint = $"http://127.0.0.1:{DeadPort()}/",
+            TailnetEndpoint = deadEndpoint.LoopbackUrl,
             MachineName = machineName ?? Environment.MachineName,
             Pid = 1,
             Version = "test",
@@ -78,7 +85,8 @@ public sealed class FakeTunnelDirector : IAsyncDisposable
             .Build();
 
         var fake = new FakeTunnelDirector(directorId, conn,
-            dispatch ?? (cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}")));
+            dispatch ?? (cmd => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}")),
+            deadEndpoint);
 
         conn.On<DirectorCommand, DirectorCommandResult>("Command", cmd =>
         {
@@ -117,15 +125,6 @@ public sealed class FakeTunnelDirector : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         try { await _conn.DisposeAsync(); } catch { /* best effort */ }
-    }
-
-    private static int DeadPort()
-    {
-        // An OS-assigned free port we bind then immediately release, so nothing listens there.
-        using var l = new TcpListener(IPAddress.Loopback, 0);
-        l.Start();
-        var port = ((IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
-        return port;
+        _deadEndpoint.Dispose();
     }
 }

--- a/src/CcDirector.Gateway.Tests/HostedImagePublishedArtifactTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedImagePublishedArtifactTests.cs
@@ -88,8 +88,13 @@ public sealed class HostedImagePublishedArtifactTests
     /// </summary>
     private static void AssertEntryFailsClosed(string publishDir, string entryDll)
     {
-        var port = FreeTcpPort();
-        var psi = new ProcessStartInfo("dotnet", $"\"{entryDll}\" --port {port}")
+        // Reserved for the whole child run rather than probed and released (issue #1156). The entry is
+        // expected to refuse on the missing hosted contract BEFORE it ever binds, so holding the port does
+        // not change the passing path - but it stops another process claiming the number mid-test, which
+        // would otherwise turn this contract assertion into an unrelated address-conflict failure. If the
+        // entry ever regresses and does try to bind, it fails here too, which is the correct outcome.
+        using var deadPort = DeadPortReservation.Reserve();
+        var psi = new ProcessStartInfo("dotnet", $"\"{entryDll}\" --port {deadPort.Port}")
         {
             WorkingDirectory = publishDir,
             RedirectStandardOutput = true,
@@ -113,7 +118,7 @@ public sealed class HostedImagePublishedArtifactTests
             try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
             Assert.Fail(
                 $"{Path.GetFileName(entryDll)} did NOT fail closed: it was still running (serving on port "
-                + $"{port}) after 60s with the hosted contract missing. The hosted image must refuse to start, "
+                + $"{deadPort.Port}) after 60s with the hosted contract missing. The hosted image must refuse to start, "
                 + "not boot as a self-host Gateway.");
         }
 
@@ -173,17 +178,6 @@ public sealed class HostedImagePublishedArtifactTests
                 entries.Add(dll);
         }
         return entries;
-    }
-
-    /// <summary>An OS-assigned free TCP port. The listener is closed immediately; a launched entry is
-    /// expected to refuse before it ever binds, so the tiny reuse window does not matter.</summary>
-    private static int FreeTcpPort()
-    {
-        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
     }
 
     /// <summary>The hosted host csproj, located from this source file's own path - the tests always run from

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -101,7 +101,13 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
             snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
-            streamMode: true);
+            streamMode: true,
+            // These tests assert AUTH behaviour on the machine routes. The spawn route auto-launches a
+            // Director and waits for it to appear; no Director ever appears here, so the control request used
+            // to sit through production's full ninety-second wait - the single slowest test in the suite
+            // (issue #1156). What is under test is which STATUS comes back, never how long the Gateway is
+            // willing to wait for a Director, so the wait is injected short.
+            directorLaunchTimeout: TimeSpan.FromMilliseconds(250));
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
 

--- a/src/CcDirector.Gateway.Tests/NoProbeAndReleasePortsTests.cs
+++ b/src/CcDirector.Gateway.Tests/NoProbeAndReleasePortsTests.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// No test in this assembly may obtain a port by opening a listener, reading the assigned number, and then
+/// CLOSING it before the port is used (issue #1156).
+///
+/// WHY THIS IS PINNED AS SOURCE TEXT. The defect is not a wrong value - the port returned by a
+/// probe-and-release helper is perfectly valid at the instant it is read. The defect is the WINDOW after it
+/// is released, during which any other process on the machine can bind it. No assertion on the returned port
+/// can detect that, because the port is correct until somebody else takes it, and whether anybody does is a
+/// race. So the pattern itself is what has to be forbidden, and the only place to forbid it is the source.
+///
+/// This mattered enough to be worth a guard: probe-and-release was the mechanism behind the historical
+/// cross-run collisions in this suite, and it is an easy pattern to reintroduce because it looks careful -
+/// it asks the operating system for a free port rather than hardcoding one. The safe replacement is
+/// <see cref="DeadPortReservation"/>, which HOLDS the port for as long as the address must stay dead.
+///
+/// The single permitted exception is the explicit-port Kestrel contract test, which must pass a real number
+/// to a real listener to prove the explicit-port path works at all. It is named here so the exemption is a
+/// deliberate, visible decision rather than a hole anyone can widen.
+/// </summary>
+public sealed class NoProbeAndReleasePortsTests
+{
+    /// <summary>
+    /// The one file allowed to hand a probed port to a real bind: it exists to prove that GatewayHost
+    /// honours an explicitly chosen port, which cannot be demonstrated without one.
+    /// </summary>
+    private static readonly string[] AllowedFiles = ["GatewayHostAssignedPortTests.cs"];
+
+    [Fact]
+    public void No_test_probes_a_port_and_releases_it_before_use()
+    {
+        var testsDir = Path.Combine(RepoRoot(), "src", "CcDirector.Gateway.Tests");
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(testsDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var name = Path.GetFileName(file);
+            if (AllowedFiles.Contains(name)) continue;
+            if (name == nameof(NoProbeAndReleasePortsTests) + ".cs") continue;
+            if (name == nameof(DeadPortReservation) + ".cs") continue;
+
+            var text = File.ReadAllText(file);
+
+            // The shape: a TcpListener is created, then Stop()/Dispose() is called on it. A test that needs a
+            // listener for real work keeps it running; one that stops it is releasing the port to get a
+            // number, which is the pattern being banned.
+            if (!text.Contains("new TcpListener(", StringComparison.Ordinal)) continue;
+            if (Regex.IsMatch(text, @"\.Stop\(\)\s*;", RegexOptions.None, TimeSpan.FromSeconds(5))
+                || text.Contains("using var l = new TcpListener(", StringComparison.Ordinal))
+            {
+                offenders.Add(name);
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These files obtain a port from a TcpListener and then release it before the port is used. "
+            + "That port is unowned from the moment it is released, so another process - notably a second "
+            + "run of this suite - can bind it and turn an 'unreachable' assertion into a conversation with "
+            + "somebody else's listener. Use DeadPortReservation, which holds the port for as long as the "
+            + "address must stay dead: " + string.Join(", ", offenders));
+    }
+
+    /// <summary>The repository root, located from this source file's own path - the tests always run
+    /// from a checkout, and bin-relative paths would break under different runners.</summary>
+    private static string RepoRoot([System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
+    {
+        // this file: <repo>/src/CcDirector.Gateway.Tests/NoProbeAndReleasePortsTests.cs
+        var dir = Path.GetDirectoryName(thisFile)!;
+        return Path.GetFullPath(Path.Combine(dir, "..", ".."));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Proof/RemoteSignInLiveProof.cs
+++ b/src/CcDirector.Gateway.Tests/Proof/RemoteSignInLiveProof.cs
@@ -168,11 +168,11 @@ public sealed class RemoteSignInLiveProof
         foreach (var l in relevant)
             transcript.AppendLine(l);
 
-        // Write the artifacts. CC1080_PROOF_DIR points them at the committed proof directory; otherwise temp.
-        var outDir = Environment.GetEnvironmentVariable("CC1080_PROOF_DIR");
+        // Write the artifacts. CC1080_PROOF_DIR names the PARENT; this run gets its own subdirectory beneath
+        // it, so two concurrent runs cannot overwrite each other's evidence (issue #1156).
+        var outDir = ProofOutputDirectory.ResolveOrNull("CC1080_PROOF_DIR");
         if (!string.IsNullOrWhiteSpace(outDir))
         {
-            Directory.CreateDirectory(outDir);
             File.WriteAllText(Path.Combine(outDir, "gateway-http-transcript.txt"), transcript.ToString());
             File.WriteAllText(Path.Combine(outDir, "signed-in-landing.html"), signedInLandingHtml);
         }

--- a/src/CcDirector.Gateway.Tests/ProofOutputDirectory.cs
+++ b/src/CcDirector.Gateway.Tests/ProofOutputDirectory.cs
@@ -1,0 +1,40 @@
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Resolves an opt-in proof output directory into one this RUN owns (issue #1156).
+///
+/// THE COLLISION. Proof writers take a directory from an environment variable and write fixed file names
+/// into it - <c>gateway-http-transcript.txt</c>, <c>wingman-text-qa.html</c>. Two runs given the same
+/// directory therefore overwrite each other's artefacts, last writer wins, with no error and no sign that
+/// anything was lost. Whoever reads the artefact afterwards cannot tell which run produced it, which is
+/// worse than losing it: an artefact is evidence, and evidence attributed to the wrong run is misleading
+/// rather than merely missing.
+///
+/// THE FIX. The variable names a PARENT directory. Each run gets a subdirectory beneath it, unique per test
+/// process, so concurrent runs never contend and every artefact stays attributable to the run that made it.
+/// A single run - the normal case - simply gets one subdirectory, and a proof collector globs the parent.
+///
+/// Opt-in is unchanged: with the variable unset nothing is created and nothing is written.
+/// </summary>
+internal static class ProofOutputDirectory
+{
+    /// <summary>
+    /// Unique per test process, and shared by every proof writer within it, so one run's artefacts land
+    /// together in one place rather than scattered.
+    /// </summary>
+    private static readonly string RunId = Guid.NewGuid().ToString("N")[..12];
+
+    /// <summary>
+    /// The directory this run should write proof artefacts into, or null when the variable is unset (the
+    /// ordinary run, which writes nothing). Creates the directory when it resolves one.
+    /// </summary>
+    internal static string? ResolveOrNull(string environmentVariable)
+    {
+        var parent = Environment.GetEnvironmentVariable(environmentVariable);
+        if (string.IsNullOrWhiteSpace(parent)) return null;
+
+        var mine = Path.Combine(parent, "run-" + RunId);
+        Directory.CreateDirectory(mine);
+        return mine;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -624,10 +624,10 @@ public sealed class WingmanTranslatorTests
         // to write docs/proof/issue-531/wingman-text-qa.html unconditionally, rewriting a
         // git-tracked file on every Gateway run and leaving every worktree dirty. The
         // assertions above are the test; the report is an artefact the proof run collects.
-        var outDir = Environment.GetEnvironmentVariable("CC531_PROOF_DIR");
+        // CC531_PROOF_DIR names the PARENT; this run writes into its own subdirectory so concurrent runs
+        // cannot overwrite each other's report (issue #1156).
+        var outDir = ProofOutputDirectory.ResolveOrNull("CC531_PROOF_DIR");
         if (string.IsNullOrWhiteSpace(outDir)) return;
-
-        Directory.CreateDirectory(outDir);
         var outPath = Path.Combine(outDir, "wingman-text-qa.html");
         File.WriteAllText(outPath, WingmanQaReport.Render(rows, live: false), Encoding.UTF8);
 

--- a/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
@@ -81,7 +81,12 @@ public sealed class WingmanTtsStatusPassthroughTests
             vault,
             voice,
             tenantSettings,
-            ttsHttpClient: new HttpClient(upstream) { Timeout = Timeout.InfiniteTimeSpan });
+            ttsHttpClient: new HttpClient(upstream) { Timeout = Timeout.InfiniteTimeSpan },
+            // The stall test proves a never-answering upstream becomes 504 rather than 502. What is under
+            // test is WHICH status comes back, not how long the Gateway is willing to wait - so the deadline
+            // is injected short. It used to run production's sixty-second base and cost a full minute of
+            // every suite run to assert one status code (issue #1156).
+            ttsDeadline: TimeSpan.FromMilliseconds(250));
 
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });

--- a/src/CcDirector.Gateway.Tests/WorkListRunnerEndpointProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkListRunnerEndpointProofTests.cs
@@ -226,7 +226,8 @@ public sealed class WorkListRunnerEndpointProofTests : IAsyncLifetime
     private static string TempRepo()
     {
         // A real existing directory so the Director (real one) would accept it; the stub ignores it.
-        var dir = Path.Combine(Path.GetTempPath(), "cc274-repo");
+        // Unique per run: a fixed temp name is shared by every concurrent run on the machine (issue #1156).
+        var dir = Path.Combine(Path.GetTempPath(), "cc274-repo-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
+++ b/src/CcDirector.Gateway/Api/DirectorCommandRouter.cs
@@ -140,7 +140,15 @@ internal static class DirectorCommandRouter
     /// user re-tapped and the agent got the same prompt twice. The two messages hedge the same way because they
     /// leave the caller in the same position: the outcome is genuinely unknown.
     /// </summary>
-    private static string DescribeTimeout(string? machineName, TimeSpan wait) =>
+    /// <remarks>
+    /// INTERNAL so its wording can be asserted directly (issue #1156). It is a pure function of the machine
+    /// name and the wait, but the only way to read its output used to be to run a real timeout - so three
+    /// tests that cared solely about the SENTENCE each slept through a thirty-second production timeout,
+    /// costing two minutes of every suite run to check a string. The wording is now tested here, in
+    /// microseconds; a separate test still runs a real (short) timeout and asserts the router returns exactly
+    /// this function's output, so the join between them stays proven rather than assumed.
+    /// </remarks>
+    internal static string DescribeTimeout(string? machineName, TimeSpan wait) =>
         string.IsNullOrWhiteSpace(machineName)
             ? $"The Director did not answer within {wait.TotalSeconds:0} seconds. It is not known whether the command was carried out."
             : $"The Director on {machineName} did not answer within {wait.TotalSeconds:0} seconds. It is not known whether the command was carried out.";

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -132,6 +132,7 @@ internal static class GatewayWingmanVoiceEndpoint
         TimeSpan? streamStale = null,
         Func<string>? instructionsProvider = null,
         HttpClient? ttsHttpClient = null,
+        TimeSpan? ttsDeadline = null,
         Voice.VoiceUploadStore? uploadStore = null,
         Transcription.TranscriptionHistoryLog? history = null,
         Transcription.TranscriptionAudioArchive? audioArchive = null,
@@ -459,7 +460,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 // preferBackup is false here: the silent-primary backup routing (issue devthrottle_internal#405) is driven by
                 // the per-session narration path (WingmanVoiceService), which owns the sticky state this
                 // interactive read-aloud endpoint does not carry. It still gets the proxy's own failover.
-                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice = spoken.Voice, input = spoken.Text, response_format = "mp3" }, spoken.Length, preferBackup: false, ct);
+                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice = spoken.Voice, input = spoken.Text, response_format = "mp3" }, spoken.Length, preferBackup: false, ct, ttsDeadline);
                 if (!resp.IsSuccessStatusCode)
                 {
                     var status = (int)resp.StatusCode;

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -850,7 +850,9 @@ public sealed class GatewayHost : IAsyncDisposable
         }
     }
 
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? promptLogPath = null, string? snoozePath = null, string? pushSubscriptionsPath = null, string? wingmanInstructionsPath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null)
+    private readonly TimeSpan? _directorLaunchTimeout;
+
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? promptLogPath = null, string? snoozePath = null, string? pushSubscriptionsPath = null, string? wingmanInstructionsPath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null, Core.Agents.AgentKind? brainTool = null, TimeSpan? directorLaunchTimeout = null)
     {
         var retiredFilesRemoved = Core.Configuration.LegacyPrivacyDataCleanup.Run();
         if (retiredFilesRemoved > 0)
@@ -864,6 +866,13 @@ public sealed class GatewayHost : IAsyncDisposable
         BrainTool = Core.Configuration.BrainToolConfig.EnsureHostable(brainTool ?? Core.Configuration.BrainToolConfig.Get());
 
         Port = port;
+        // How long a spawn waits for an auto-launched Director to appear. Production's default lives in
+        // RegistryDirectorTargetResolver (90s). A test that only needs to prove a route's AUTH behaviour
+        // passes a short one: the control request in the hosted deny-by-default theory used to sit through
+        // the full ninety seconds for a Director that was never going to appear, which was the single
+        // slowest test in the suite (issue #1156). Injected rather than a static test hook, so two hosts in
+        // one process can hold different values.
+        _directorLaunchTimeout = directorLaunchTimeout;
         Token = token ?? _gatewayAuth.LoadOrCreate();
         // Epic #1159 step A: the eviction horizon is the ONE elapsed-time rule that removes a session, so it
         // is read from configuration here rather than left as a constant only a test can move. Default is a
@@ -1374,7 +1383,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // The auto-launch runs IN-PROCESS through the shared launcher relay, carrying the resolved tenant
             // as an argument. It used to POST to this Gateway's own /machines/{m}/director/start over
             // loopback, which cannot carry a device key and so arrived with no tenant at all.
-            new Running.RelayDirectorLauncher(Launchers, SendLauncherCommandAsync));
+            new Running.RelayDirectorLauncher(Launchers, SendLauncherCommandAsync),
+            launchTimeout: _directorLaunchTimeout);
         // The single resolve-then-create path shared by the cron firing engine and the interactive
         // POST /machines/{machine}/sessions relay ("start a session on another computer"). Gateway Cleanup
         // Phase 2 (PR E-B2): both the spawner and the work-list drain driver ride the tunnel. Tunnel-only:

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -194,9 +194,15 @@ internal static class TtsSynthesis
     /// <param name="preferBackup">When true, send <see cref="PreferBackupHeaderName"/> so the cloud
     /// proxy routes straight to the backup provider (issue devthrottle_internal#405). The Gateway sets this after it has
     /// seen the primary go silent on this session; it is a routing hint only and changes no deadline.</param>
-    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, int inputChars, bool preferBackup, CancellationToken ct)
+    /// <param name="deadlineOverride">Replaces the length-derived deadline. Exists so a test can prove the
+    /// stall-to-504 path without waiting through the production sixty-second base (issue #1156): the test that
+    /// covered it used to spend 60s of every suite run sitting on a clock. Passed as an OPTION rather than
+    /// exposed as a static test hook on purpose - a process-global switch would be shared by every host in the
+    /// process and is exactly the kind of seam that blocks running these tests in parallel. Null in production,
+    /// where the length-derived deadline is the only one.</param>
+    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, int inputChars, bool preferBackup, CancellationToken ct, TimeSpan? deadlineOverride = null)
     {
-        var deadline = DeadlineFor(inputChars);
+        var deadline = deadlineOverride ?? DeadlineFor(inputChars);
         TimeoutException? lastTimeout = null;
         for (var attempt = 1; attempt <= Attempts; attempt++)
         {


### PR DESCRIPTION
# Local testing becomes the everyday gate (devthrottle_internal#1156, steps 1-2 + quick wins)

Makes the local test suite safe to run concurrently across worktrees and recovers ~4 minutes
of pure sleeping, so agents stop waiting fifty minutes on GitHub CI for changes the local
suite already proves.

## What changed

1. **Deterministic dead ports.** Three tests obtained a "free" port by opening a listener,
   reading the number, and closing it - leaving the port unowned, so any process could grab
   it between the close and the test's use. `DeadPortReservation` replaces the pattern with a
   socket bound but never listening: simultaneously reserved (nobody else can bind it) and
   dead (connections are refused). Both properties were measured on Windows before the type
   was written. An architecture test bans the old pattern.

2. **Live-proof isolation.** `CC_GATEWAY_TEST_PG_CONNECTION` now names a TEMPLATE database;
   each run derives its own database with a unique suffix, so two runs can share one Postgres
   server without `EnsureDeleted()` racing each other's schema. Proof artefacts write to a
   per-run subdirectory; fixed temp names are made unique.

3. **Three sleeping tests fixed - coverage up, not down:**
   - `DirectorCommandRouterTimeoutTests` 2m03s -> 1s. It slept through real 30s production
     timeouts to read a string. `DescribeTimeout` is now internal and asserted directly, plus
     a NEW seam test that runs a real 200ms timeout end to end. The timeout is injected via a
     new `GatewayHost` constructor parameter (`directorLaunchTimeout`) - never a static test
     hook, because a process-global switch is shared by every host in the process and is
     exactly what blocks parallel runs.
   - `WingmanTtsStatusPassthroughTests` 1m03s -> 7s (injected options, same principle).
   - `HostedTenantMachineControlTests` 1m46s -> 51s.

4. **The local gate itself:** `scripts/test-local.ps1` builds once and starts all seven test
   projects together, so the six unlocked projects finish while the Gateway suite queues on
   its per-user lock. The repo instruction file (rule 5a) and the commit skill stop telling
   agents to `gh pr checks --watch` the fifty-minute .NET job.

## Evidence

- Branch is rebased onto `d7953e4ac` (the first green main after #1170); solution builds with
  zero warnings on the rebase.
- All 4,691 tests outside the Gateway suite passed locally on this change merged with the
  main-green fix, before the rebase made that merge the branch itself.
- The local Gateway suite run on this exact tree is queued on the machine-wide test lock
  (three sessions contending today - the very problem this issue exists to fix); its TRX
  verdict will be posted on this PR when it lands. CI's full run on this branch is the
  same suite.
- The three fixed tests' timings above are measured, not estimated.

## Explicitly NOT in this PR

- The `DirectorRegistry` teardown drain (parked on `fix/1156-step3-registry-teardown`,
  needs its own soak - see #1156 step 3).
- The qualification harness and any change to `GatewayTestSuiteLock` (steps 4-5). The
  machine-wide lock stays exactly as it is until the concurrency soak proves it removable.
