### PR TITLE
release: v1.9.2 (version bump + written release notes)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.1</Version>
+    <Version>1.9.2</Version>
   </PropertyGroup>
 
   <!--

--- a/docs/public/release-notes/v1.9.2.md
+++ b/docs/public/release-notes/v1.9.2.md
@@ -1,0 +1,102 @@
+## v1.9.2 - July 31, 2026
+
+The main window now fits the screen it opens on, a first install stops reporting its own success as
+a failure, and your sessions stay on the board when the connection to a machine wobbles instead of
+disappearing. Renaming a Director finally means something everywhere.
+
+### The window fits the screen it opens on
+
+The Director's main window could open larger than the display it was on, which put the Settings
+button off the right edge where it could not be clicked.
+
+This was not cosmetic. The setup wizard points at Settings five times as its answer for everything
+you defer - including the way back after choosing "Not now" at the gateway step. On a display where
+Settings is off the edge, every "you can change this later in Settings" the wizard says is untrue,
+and so is the promise that you can decline an account now and connect one later.
+
+The window is now measured against the screen's usable area and centred there before it is shown.
+The minimum supported display is 1280x720, which is about 1280x672 of working space once the taskbar
+is taken off. The old window was 1044x788 tall, which missed that by 68 pixels.
+
+### A first install stops calling a healthy launcher dead
+
+On a clean Windows 11 machine, a first install could finish on a red ERROR saying the launcher
+"started but did not answer on 7900" - while that same launcher was answering perfectly well on 7900.
+Pressing Retry then completed the install with no error at all.
+
+Nothing had failed. The launcher is a large single-file program that unpacks itself the first time it
+runs, so it is slow exactly once: on the machine where somebody is installing for the first time and
+watching. The installer allowed a fixed twenty seconds, a figure tuned on a warm developer machine,
+and treated the end of that clock as a verdict rather than as a reason to keep waiting.
+
+It now waits for the launcher to actually be ready.
+
+### Your sessions stop vanishing when a machine goes quiet
+
+The board used to drop every session on a machine once its last update was more than twenty seconds
+old, against an update sent every ten. Two missed ticks and the whole machine's work disappeared -
+not dimmed, not marked old, gone. With connections dropping through the day, the board could empty
+several times an hour while the Gateway sat holding the very information it had just refused to show.
+
+- **A machine that goes quiet keeps its sessions on the board**, dimmed, and labelled with how old
+  the information is.
+- **Whether a machine is connected is now judged by whether the connection is actually up**, not by
+  a stopwatch since its last message - which only ever measured how chatty it was being.
+- **Sessions leave for two reasons only**: the Director said one ended, or the machine never came
+  back within a set period, which defaults to twenty-four hours.
+- **A machine nobody can reach no longer nags.** It is not counted in the needs-you badge and does
+  not enter the voice queue.
+- **The command line tools stop contradicting themselves.** They used to hand you a machine's
+  sessions and simultaneously tell you those sessions were missing.
+
+### Connections to your machines hold together
+
+Both ends of the tunnel ran on defaults that allowed exactly two late messages before hanging up. On
+30 July one Director disconnected 35 times in a single day reporting a timeout, while the Gateway was
+alive and answering the whole time. Messages now go six times more often, so six missed ones are
+absorbed where two used to be fatal. The tolerance itself is deliberately unchanged - lengthening it
+would only delay noticing a machine that has genuinely gone.
+
+A related piece of noise is gone too: when a connection dropped mid-send, the time spent waiting was
+logged as though the send itself had been slow. It was true about the wait and said nothing about the
+send, and it sent a day of investigation after the wrong thing.
+
+### Updates stop downloading themselves over and over
+
+The hourly update check asked whether a newer release existed but never whether it had already been
+downloaded. A Director left running for days re-downloaded the same hundred-megabyte build every
+hour, announcing "downloaded" each time, until a restart finally applied it.
+
+The check now recognises a build that is already downloaded and waiting, and does nothing. If that
+staged file has since been deleted, it downloads again - which is the repair. A genuinely newer
+release still downloads as normal.
+
+### A renamed Director is named everywhere
+
+Renaming a Director used to change only its own title bar. The name never left the machine, so three
+Directors on one machine showed as three identical rows, and searching for the name you had just set
+found nothing.
+
+The name now travels with the machine's regular heartbeat, so a rename appears across the fleet
+within about ten seconds and needs no restart. It is used as the main label in the Directors table,
+matched by the search box, headlined on the director page, and offered by the New Session pickers on
+both desktop and phone.
+
+**The Fleet Map gains a By director view**, alongside By machine: one lane per Director, headed by
+its name. A Director that is idle but reachable keeps its lane as a free slot you can start work in;
+one that is offline is shown dated rather than dropped. Your choice of view is remembered.
+
+### On the hosted service
+
+The hosted Gateway kept its statistics in a file-based database on shared storage. On 30 July that
+file corrupted, and because reading the session list wrote to it on every request, the board answered
+an error to every client for 32 minutes. Later the same day the same file blocked a deployment
+outright - the Gateway refused to start when it could not open it.
+
+Statistics have moved to the main database, and the hosted Gateway no longer opens that file store at
+all. More importantly, **the Gateway now starts even when the statistics store does not**: a
+statistics failure now degrades the statistics screens with a stated reason instead of stopping the
+whole service from booting.
+
+Self-hosted installs carrying the older store are adopted automatically. Anything unexpected is
+refused with a named reason rather than guessed at.


### PR DESCRIPTION
Catches main up with the v1.9.2 tag, which is already pushed and building.

## What happened

`scripts/new-release.ps1` ends with `git push origin main` followed by `git push origin <tag>`. **Main is protected by a ruleset requiring a pull request**, so the branch push is rejected while the tag push succeeds - leaving the tag ahead of main. I hit exactly that: `v1.9.2` is on the remote and the Release workflow is running from it, but main did not move.

The release itself is sound. The tagged commit is main at `53b712be3` plus these two commits, which touch only the release notes and the version string - no product code differs.

## This PR

| Commit | Change |
|---|---|
| `10fa2a444` | `docs/public/release-notes/v1.9.2.md` - written notes covering the window fit, the installer launcher wait, the session roster, tunnel liveness, the staged-update fix, Director renaming, and the hosted statistics move |
| `9d642a342` | `Directory.Build.props` 1.9.1 -> 1.9.2, the single version source |

Verified before tagging: notes are 5111 non-whitespace characters (the workflow floor is 200), ASCII only, and no .csproj declares its own `<Version>` that would override the props file.

## Follow-up worth filing separately

`scripts/new-release.ps1` cannot complete against the current ruleset. It should either open a pull request for the version bump and tag only after it merges, or the ruleset needs a bypass for whoever cuts releases. As it stands every release will leave main behind by two commits and require this cleanup by hand.