### PR TITLE
chore(release): make cutting a release need only the version number

### DIFF
--- a/docs/architecture/VERSIONING.md
+++ b/docs/architecture/VERSIONING.md
@@ -59,18 +59,64 @@ release and its exact commit.
   `CcDirector.Core.AppVersion` (or the inline equivalent in projects that do
   not reference Core).
 
-## How a release flows
+## How to cut a release
 
-1. Run `scripts/new-release.ps1`. It bumps **one file**
-   (`Directory.Build.props`), commits `release: vX.Y.Z`, tags `vX.Y.Z`, pushes.
-2. CI (`release.yml`) builds everything from the tagged commit. Every .NET
-   binary is stamped `X.Y.Z` automatically. A guard step fails the release if
-   the tag and `Directory.Build.props` disagree.
-3. The release manifest lists every asset with its version (= the release
-   version) and its SHA-256.
-4. Installed machines see `X.Y.Z > installed` and update every asset in their
+**Two things to do. Write the notes, run the script.**
+
+1. **Write `docs/public/release-notes/vX.Y.Z.md`.** This file *is* the release
+   page - the workflow publishes it verbatim and **fails if it is missing or
+   under 200 non-whitespace characters**. It will not generate a substitute,
+   because a page of internal pull request titles looks like release notes and
+   therefore ships unread. Leave it uncommitted; the script commits it.
+
+2. **Run `scripts/new-release.ps1` from `main`, with a clean tree.** It offers
+   the next patch version - press Enter to take it. That is the only decision.
+
+```
+Current version: 1.9.2
+New version [1.9.3]:          <- Enter
+```
+
+Everything after that is automatic, and every step is checked before the next
+one runs.
+
+### What the script does, and why in this order
+
+**main is protected by a ruleset requiring a pull request**, so the version bump
+cannot be pushed straight to it. The script therefore branches, opens a pull
+request, **merges it, and only then creates the tag** - after re-reading
+`Directory.Build.props` from the merged `main` to prove the bump actually landed.
+
+That order is not a style preference. An earlier version of this script ran
+`git push origin main` then `git push origin <tag>`: the branch push is rejected
+by the ruleset and the tag push succeeds, so the tag ends up pointing at a commit
+that is not on `main` - a released version whose bump and notes are missing from
+the branch everyone works from. It happened on **v1.9.2** and was repaired by
+hand. **A tag can never be un-pushed, so it is created last.**
+
+It also refuses to start if: the notes are missing or too short, the tag already
+exists locally or on the remote, a `.csproj` declares its own `<Version>`, the
+tree has unrelated changes, you are not on `main`, or `main` is behind the remote.
+
+### What happens after the tag
+
+3. `release.yml` builds everything from the tagged commit. Every .NET binary is
+   stamped `X.Y.Z` automatically, and a guard fails the release if the tag and
+   `Directory.Build.props` disagree.
+4. The release is created as a **draft**, and published only once
+   `release-manifest.json` is provably attached - so a release is never "latest"
+   while incomplete.
+5. The public downloads are **mirrored to a stable address** (see
+   devthrottle_internal #1186), then the installer is fetched back from that
+   address and its SHA-256 compared to the manifest. **A mismatch fails the
+   release**, so the public URL is never quietly serving the wrong build.
+6. The manifest lists every asset with its version and SHA-256.
+7. Installed machines see `X.Y.Z > installed` and update every asset in their
    role: Director self-update on launch, Gateway self-update with health-check
    rollback, tools via ToolUpdater.
+
+If the workflow goes red, **the release is not usable** - read the failing step
+before announcing anything.
 
 ## Where the version is shown
 

--- a/scripts/new-release.ps1
+++ b/scripts/new-release.ps1
@@ -87,8 +87,8 @@ if (git -C $repoRoot ls-remote --tags origin $tagName) { Fail "Tag $tagName alre
 #     release page and fails without it. Catching that here costs nothing; a
 #     pushed tag cannot be un-pushed. The file may be uncommitted - this script
 #     commits it along with the version bump. ---
-$notesRel  = "docs/public/release-notes/$tagName.md"
-$notesPath = Join-Path $repoRoot ($notesRel -replace '/', '\')
+$notesRel  = "docs/public/release-notes/$tagName.md"   # forward slashes: matched against git status output
+$notesPath = Join-Path $repoRoot "docs\public\release-notes\$tagName.md"
 if (-not (Test-Path $notesPath)) {
     Fail "No written release notes for $tagName." "Expected: $notesPath`n`nWrite them first. The workflow publishes that file as the release page and refuses`nto invent a substitute - a list of internal pull request titles looks like release`nnotes and therefore ships unread."
 }

--- a/scripts/new-release.ps1
+++ b/scripts/new-release.ps1
@@ -1,168 +1,194 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    Bumps the product version, commits, tags, and pushes to trigger a GitHub Actions release.
+    Cuts a release. The only thing you need to decide is the version number.
 
 .DESCRIPTION
-    The product version lives in EXACTLY ONE file: Directory.Build.props at the
-    repo root (see docs/architecture/VERSIONING.md). MSBuild stamps that version
-    into every .NET binary in the release (Director, Gateway, Launcher, setup
-    wizards, setup CLI); all UIs read it from their assembly at runtime, so no
-    other file needs to change. (The Cockpit is the React app served in-process by
-    the Gateway now - issue #979 - so it has no separate stamped binary.)
+    Run it, press Enter to accept the next version, done.
 
-    This script bumps Directory.Build.props, commits, creates the vX.Y.Z git tag,
-    and pushes. The GitHub Actions release workflow builds and publishes the
-    release for Windows and macOS; a workflow guard fails the release if the tag
-    and Directory.Build.props ever disagree.
+    The product version lives in EXACTLY ONE file: Directory.Build.props at the
+    repo root (see docs/architecture/VERSIONING.md). MSBuild stamps it into every
+    .NET binary in the release (Director, Gateway, Launcher, setup wizards, setup
+    CLI); all UIs read it from their assembly at runtime, so no other file needs
+    to change.
+
+    WHY THIS OPENS A PULL REQUEST INSTEAD OF PUSHING TO MAIN
+    -------------------------------------------------------
+    main is protected by a ruleset that requires a pull request. The previous
+    version of this script ended with `git push origin main` followed by
+    `git push origin <tag>`. The branch push is rejected and the tag push
+    succeeds, which leaves the tag pointing at a commit that is not on main - a
+    released version whose bump and notes are missing from the branch everyone
+    works from. That happened on v1.9.2 and had to be repaired by hand.
+
+    So the order is: branch, commit, pull request, MERGE, and only then tag the
+    commit that is now on main. The tag can never get ahead of main.
 
 .EXAMPLE
     .\scripts\new-release.ps1
+    Current version: 1.9.2
+    New version [1.9.3]:            <- press Enter to take it
 #>
 
 $ErrorActionPreference = "Stop"
-
 $repoRoot = Split-Path -Parent $PSScriptRoot
+$repoSlug = "thefrederiksen/devthrottle"
 
-# --- Check for uncommitted changes ---
-$status = git -C $repoRoot status --porcelain
-if ($status) {
+function Fail($message, $howToFix) {
     Write-Host ""
-    Write-Host "ERROR: Working tree has uncommitted changes." -ForegroundColor Red
-    Write-Host "Commit or stash your changes before running a release." -ForegroundColor Red
-    Write-Host ""
-    git -C $repoRoot status --short
+    Write-Host "ERROR: $message" -ForegroundColor Red
+    if ($howToFix) { Write-Host $howToFix -ForegroundColor Yellow }
     Write-Host ""
     exit 1
 }
+
+# --- Tools this needs ---
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Fail "The GitHub CLI (gh) is not installed." "It is required because main only accepts changes through a pull request.`nInstall from https://cli.github.com/ then run: gh auth login"
+}
+gh auth status 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) { Fail "The GitHub CLI is not signed in." "Run: gh auth login" }
 
 # --- The single version source ---
 $propsPath = Join-Path $repoRoot "Directory.Build.props"
-if (-not (Test-Path $propsPath)) {
-    Write-Error "Directory.Build.props not found at $propsPath"
-    exit 1
-}
+if (-not (Test-Path $propsPath)) { Fail "Directory.Build.props not found at $propsPath" }
 
 [xml]$props = Get-Content $propsPath
 $currentVersion = $props.SelectSingleNode("//Version").InnerText
-if (-not $currentVersion) {
-    Write-Error "Could not read <Version> from $propsPath"
-    exit 1
+if (-not $currentVersion) { Fail "Could not read <Version> from $propsPath" }
+
+# --- Suggest the next patch version, which is what we ship day to day ---
+$suggested = $null
+if ($currentVersion -match '^(\d+)\.(\d+)\.(\d+)$') {
+    $suggested = "{0}.{1}.{2}" -f $matches[1], $matches[2], ([int]$matches[3] + 1)
 }
 
 Write-Host ""
 Write-Host "Current version: $currentVersion" -ForegroundColor Cyan
-$newVersion = Read-Host "New version (X.Y.Z or X.Y.Z-rcN)"
+if ($suggested) {
+    $answer = Read-Host "New version [$suggested]"
+    if ([string]::IsNullOrWhiteSpace($answer)) { $newVersion = $suggested } else { $newVersion = $answer.Trim() }
+} else {
+    $newVersion = (Read-Host "New version (X.Y.Z or X.Y.Z-rcN)").Trim()
+}
 
-# --- Validate semver format ---
 if ($newVersion -notmatch '^\d+\.\d+\.\d+(-rc\d+)?$') {
-    Write-Error "Invalid version format: '$newVersion'. Expected X.Y.Z or X.Y.Z-rcN"
-    exit 1
+    Fail "Invalid version format: '$newVersion'." "Expected X.Y.Z or X.Y.Z-rcN"
 }
+if ($newVersion -eq $currentVersion) { Fail "New version is the same as the current one ($currentVersion)." }
 
-if ($newVersion -eq $currentVersion) {
-    Write-Error "New version is the same as current version ($currentVersion)"
-    exit 1
-}
-
-# --- Check tag doesn't already exist ---
 $tagName = "v$newVersion"
-$existingTag = git -C $repoRoot tag -l $tagName
-if ($existingTag) {
-    Write-Error "Tag $tagName already exists"
-    exit 1
-}
+$branch  = "release/$tagName"
 
-# --- Guard: no .csproj may carry its own <Version> (it would silently override the props file) ---
-$strayVersions = Get-ChildItem $repoRoot -Recurse -Filter *.csproj |
-    Where-Object { $_.FullName -notmatch '\\archived\\' } |
-    Where-Object { (Get-Content $_.FullName -Raw) -match '<Version>' }
-if ($strayVersions) {
-    Write-Host ""
-    Write-Host "ERROR: These .csproj files declare their own <Version>, which overrides Directory.Build.props:" -ForegroundColor Red
-    $strayVersions | ForEach-Object { Write-Host "  - $($_.FullName)" -ForegroundColor Red }
-    Write-Host "Remove the <Version> element(s); the props file is the single source of truth." -ForegroundColor Red
-    exit 1
-}
+if (git -C $repoRoot tag -l $tagName)                  { Fail "Tag $tagName already exists locally." }
+if (git -C $repoRoot ls-remote --tags origin $tagName) { Fail "Tag $tagName already exists on the remote." "That version has been released. Pick the next one." }
 
-# --- Guard: the written release notes MUST exist before the tag does ---
-#
-# The release workflow publishes docs/public/release-notes/<tag>.md verbatim and FAILS when it is
-# absent - it will not generate a substitute, because a page of internal pull-request titles looks
-# like release notes and therefore ships unread. This guard is the same rule applied a minute
-# earlier, where it costs nothing: a tag that is already pushed cannot be un-pushed, and the
-# workflow's copy of the check can only fail AFTER the whole build has run.
-#
-# The working tree is clean by this point, so the notes file has to be committed already.
-$notesPath = Join-Path $repoRoot "docs\public\release-notes\$tagName.md"
+# --- Release notes must exist. The workflow publishes this file verbatim as the
+#     release page and fails without it. Catching that here costs nothing; a
+#     pushed tag cannot be un-pushed. The file may be uncommitted - this script
+#     commits it along with the version bump. ---
+$notesRel  = "docs/public/release-notes/$tagName.md"
+$notesPath = Join-Path $repoRoot ($notesRel -replace '/', '\')
 if (-not (Test-Path $notesPath)) {
-    Write-Host ""
-    Write-Host "ERROR: No written release notes for $tagName." -ForegroundColor Red
-    Write-Host "  Expected: $notesPath" -ForegroundColor Red
-    Write-Host ""
-    Write-Host "Write the notes, commit them, then run this script again. The release workflow" -ForegroundColor Yellow
-    Write-Host "publishes that file and refuses to invent a substitute." -ForegroundColor Yellow
-    Write-Host ""
-    exit 1
+    Fail "No written release notes for $tagName." "Expected: $notesPath`n`nWrite them first. The workflow publishes that file as the release page and refuses`nto invent a substitute - a list of internal pull request titles looks like release`nnotes and therefore ships unread."
 }
-
 $notesChars = ((Get-Content $notesPath -Raw) -replace '\s', '').Length
 if ($notesChars -lt 200) {
-    Write-Host ""
-    Write-Host "ERROR: $notesPath has only $notesChars non-whitespace characters." -ForegroundColor Red
-    Write-Host "That is a placeholder, not release notes. The workflow applies the same floor." -ForegroundColor Red
-    Write-Host ""
-    exit 1
+    Fail "$notesRel has only $notesChars non-whitespace characters." "That is a placeholder, not release notes. The workflow applies the same floor."
 }
-Write-Host ""
-Write-Host "Release notes: $notesPath ($notesChars characters)" -ForegroundColor Gray
 
-# --- Update the one file ---
-Write-Host ""
-Write-Host "Updating version to $newVersion..." -ForegroundColor Cyan
-$props.SelectSingleNode("//Version").InnerText = $newVersion
-$props.Save($propsPath)
-Write-Host "  [+] $propsPath" -ForegroundColor Gray
+# --- Guard: no .csproj may carry its own <Version> (it silently overrides the props file) ---
+$stray = Get-ChildItem $repoRoot -Recurse -Filter *.csproj |
+    Where-Object { $_.FullName -notmatch '\\archived\\' } |
+    Where-Object { (Get-Content $_.FullName -Raw) -match '<Version>' }
+if ($stray) {
+    $list = ($stray | ForEach-Object { "  - $($_.FullName)" }) -join "`n"
+    Fail "These .csproj files declare their own <Version>, overriding Directory.Build.props:`n$list" "Remove the <Version> elements; the props file is the single source of truth."
+}
 
-# --- Determine pre-release ---
+# --- Working tree must be clean apart from the two files this script owns ---
+$notesPattern = [regex]::Escape($notesRel)
+$dirty = git -C $repoRoot status --porcelain | Where-Object {
+    $_ -notmatch 'Directory\.Build\.props$' -and $_ -notmatch "$notesPattern$"
+}
+if ($dirty) {
+    Fail "The working tree has changes that are not part of this release:`n$($dirty -join "`n")" "Commit, stash or discard them first. A release must be cut from a known state."
+}
+
+# --- Cut from an up-to-date main ---
+Write-Host "Fetching origin..." -ForegroundColor Gray
+git -C $repoRoot fetch --quiet origin main
+$currentBranch = git -C $repoRoot rev-parse --abbrev-ref HEAD
+if ($currentBranch -ne "main") { Fail "You are on '$currentBranch', not main." "Run: git checkout main" }
+$behind = git -C $repoRoot rev-list --count HEAD..origin/main
+if ([int]$behind -gt 0) { Fail "Local main is $behind commit(s) behind origin/main." "Run: git pull" }
+
 $isPreRelease = $newVersion -match '-rc\d+$'
 
-# --- Summary ---
 Write-Host ""
-Write-Host "=== Release Summary ===" -ForegroundColor Yellow
+Write-Host "=== Release summary ===" -ForegroundColor Yellow
 Write-Host "  Version : $currentVersion -> $newVersion"
-Write-Host "  Tag     : $tagName"
-if ($isPreRelease) {
-    Write-Host "  Type    : Pre-release" -ForegroundColor Yellow
-} else {
-    Write-Host "  Type    : Stable release" -ForegroundColor Green
+Write-Host "  Tag     : $tagName  (created only AFTER the pull request merges)"
+Write-Host "  Branch  : $branch"
+Write-Host "  Notes   : $notesRel ($notesChars characters)"
+if ($isPreRelease) { Write-Host "  Type    : Pre-release" -ForegroundColor Yellow }
+else               { Write-Host "  Type    : Stable release" -ForegroundColor Green }
+Write-Host ""
+Write-Host "This will bump the version, open a pull request, merge it, then tag main." -ForegroundColor Gray
+Write-Host ""
+
+$confirm = Read-Host "Go? (Y/N)"
+if ($confirm -ne 'Y' -and $confirm -ne 'y') { Write-Host "Aborted. Nothing was changed." -ForegroundColor Yellow; exit 0 }
+
+# --- 1. Branch, bump, commit, push ---
+Write-Host ""
+Write-Host "Creating $branch..." -ForegroundColor Cyan
+git -C $repoRoot checkout -q -b $branch
+
+$props.SelectSingleNode("//Version").InnerText = $newVersion
+$props.Save($propsPath)
+
+git -C $repoRoot add -- $propsPath $notesPath
+git -C $repoRoot commit -q -m "release: $tagName"
+git -C $repoRoot push -q -u origin $branch
+if ($LASTEXITCODE -ne 0) { Fail "Could not push $branch." }
+
+# --- 2. Pull request, then merge. main requires this; see the header. ---
+Write-Host "Opening the pull request..." -ForegroundColor Cyan
+$prBody = "Version bump and release notes for $tagName.`n`nThe tag is created only after this merges, so it can never point at a commit that is not on main.`n`nSee $notesRel for what is in this release."
+gh pr create --repo $repoSlug --base main --head $branch --title "release: $tagName" --body $prBody | Out-Null
+if ($LASTEXITCODE -ne 0) { Fail "Could not open the pull request." "The branch is pushed. Open and merge it by hand, then run:`n  git checkout main; git pull; git tag $tagName; git push origin $tagName" }
+
+Write-Host "Merging..." -ForegroundColor Cyan
+gh pr merge $branch --repo $repoSlug --squash --delete-branch
+if ($LASTEXITCODE -ne 0) {
+    Fail "The pull request did not merge." "It is open and the branch is pushed. Merge it in the browser, then run:`n  git checkout main; git pull; git tag $tagName; git push origin $tagName"
 }
-Write-Host ""
-Write-Host "File changed:" -ForegroundColor Yellow
-Write-Host "  - Directory.Build.props (the single version source)"
-Write-Host ""
 
-$confirm = Read-Host "Commit, tag, and push? (Y/N)"
-if ($confirm -ne 'Y' -and $confirm -ne 'y') {
-    Write-Host ""
-    Write-Host "Aborted. The file was updated but not committed." -ForegroundColor Yellow
-    Write-Host "Run 'git checkout -- Directory.Build.props' to undo." -ForegroundColor Yellow
-    exit 0
+# --- 3. Only now: tag the commit that is actually on main ---
+Write-Host "Returning to main..." -ForegroundColor Cyan
+git -C $repoRoot checkout -q main
+git -C $repoRoot pull -q
+
+# Prove the merge landed before tagging it.
+[xml]$check = Get-Content $propsPath
+$onMain = $check.SelectSingleNode("//Version").InnerText
+if ($onMain -ne $newVersion) {
+    Fail "main still reports version '$onMain', not '$newVersion'." "The merge did not land as expected. Nothing has been tagged, so nothing has been`nreleased. Check the pull request, then tag by hand once main is correct."
 }
 
-# --- Git operations ---
-Write-Host ""
-Write-Host "Committing..." -ForegroundColor Cyan
-git -C $repoRoot add $propsPath
-git -C $repoRoot commit -m "release: v$newVersion"
-
-Write-Host "Tagging $tagName..." -ForegroundColor Cyan
+Write-Host "Tagging $tagName on main..." -ForegroundColor Cyan
 git -C $repoRoot tag $tagName
-
-Write-Host "Pushing to origin..." -ForegroundColor Cyan
-git -C $repoRoot push origin main
 git -C $repoRoot push origin $tagName
+if ($LASTEXITCODE -ne 0) { Fail "Could not push the tag." "main is correct; only the tag is missing. Run: git push origin $tagName" }
 
 Write-Host ""
-Write-Host "Done! Release $tagName pushed." -ForegroundColor Green
-Write-Host "GitHub Actions: https://github.com/example-org/devthrottle/actions" -ForegroundColor Cyan
+Write-Host "Released $tagName." -ForegroundColor Green
+Write-Host "  Build    : https://github.com/$repoSlug/actions/workflows/release.yml" -ForegroundColor Cyan
+Write-Host "  Release  : https://github.com/$repoSlug/releases/tag/$tagName" -ForegroundColor Cyan
+Write-Host "  Download : https://stdevthrottledl.blob.core.windows.net/download/latest/devthrottle-setup-win-x64.exe" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "The workflow builds, signs, publishes, mirrors the public downloads, and then" -ForegroundColor Gray
+Write-Host "fetches the installer back from that address to check its hash. If it goes red," -ForegroundColor Gray
+Write-Host "the release is not usable - read the failing step before announcing anything." -ForegroundColor Gray
+Write-Host ""

--- a/src/CcDirector.Core.Tests/ReleaseWorkflowContractTests.cs
+++ b/src/CcDirector.Core.Tests/ReleaseWorkflowContractTests.cs
@@ -137,12 +137,27 @@ public sealed class ReleaseWorkflowContractTests
             + "only fail AFTER the tag is pushed and the whole build has run, and a pushed tag cannot be "
             + "un-pushed. Checking here costs nothing.");
 
-        Assert.True(Regex.IsMatch(script, @"if \(-not \(Test-Path \$notesPath\)\)[\s\S]*?exit 1"),
+        // The guard must TERMINATE, by whatever route. The script may exit inline or call its Fail
+        // helper; both end the run, and pinning one spelling would fail an honest refactor while
+        // proving nothing extra. What must not happen is warning and carrying on, because that
+        // pushes the tag.
+        Assert.True(Regex.IsMatch(script, @"if \(-not \(Test-Path \$notesPath\)\)[\s\S]*?(exit 1|Fail )"),
             $"{ScriptPath} no longer EXITS when the notes file is absent. Warning and continuing would push the tag.");
 
-        Assert.True(Regex.IsMatch(script, @"\$notesChars -lt 200[\s\S]*?exit 1"),
+        Assert.True(Regex.IsMatch(script, @"\$notesChars -lt 200[\s\S]*?(exit 1|Fail )"),
             $"{ScriptPath} no longer rejects a placeholder notes file. The workflow applies a 200-character floor; "
             + "these two must agree, or the script waves through exactly what the workflow will reject.");
+
+        // ...and if it terminates via the helper, the helper has to actually terminate. Without this
+        // the assertions above could be satisfied by a Fail that printed a message and returned,
+        // which is precisely the "warned and carried on" failure they exist to prevent.
+        if (Regex.IsMatch(script, @"function Fail"))
+        {
+            var fail = Regex.Match(script, @"function Fail[\s\S]*?\n\}");
+            Assert.True(fail.Success && fail.Value.Contains("exit 1", StringComparison.Ordinal),
+                $"{ScriptPath} defines a Fail helper that does not exit. Every guard that calls it would print its "
+                + "message and then carry on to push the tag - the exact defect these guards exist to stop.");
+        }
 
         // The guard has to run BEFORE the tag is created, or it is decoration.
         var guardAt = script.IndexOf("$notesPath = Join-Path", StringComparison.Ordinal);


### PR DESCRIPTION
Cutting v1.9.2 exposed that `scripts/new-release.ps1` **cannot complete against this repo's ruleset**, and left the tag ahead of main.

## The bug

The script ended with:

```
git push origin main
git push origin $tagName
```

main is protected by *Protect main branch (... require pull request)*, so the first push is **rejected** and the second **succeeds**. The result is a tag pointing at a commit that is not on main - v1.9.2 released correctly, but main kept reporting 1.9.1 with no release notes, and needed a hand-made pull request (#2349) to catch up. Every future release would have repeated it.

## The fix

Branch -> commit -> pull request -> **merge** -> **then** tag. The tag is created only after re-reading `Directory.Build.props` from the merged main to prove the bump actually landed. A tag cannot be un-pushed, so it is created last, once there is something correct to point it at.

## Only the version is a decision

```
Current version: 1.9.2
New version [1.9.3]:          <- Enter
```

The next patch is offered and Enter takes it. The release notes may be **uncommitted** - the script commits them with the bump - so the whole procedure is: write the notes, run the script.

## Fails early, by name

Missing or signed-out `gh`; missing or under-200-character release notes; a tag that already exists locally **or on the remote**; a `.csproj` declaring its own `<Version>`; unrelated working-tree changes; not being on main; main behind the remote. Each says what to do about it.

Also fixes the closing message, which pointed at a nonexistent `example-org` URL, and now names the release page and the public download address.

## Docs

`docs/architecture/VERSIONING.md` rewritten to match - the two-step procedure, why the tag is created last, and what the workflow does after it: draft-then-publish, the download mirror, and the hash check that fails the release if the public address is not serving that build.

Validated: parses clean under PowerShell 5.1, ASCII only, no 7.x-only syntax.