### PR TITLE
ci(release): mirror only the current build, under names that never change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -900,9 +900,10 @@ jobs:
             echo "\`$GITHUB_REF_NAME\` left draft with every asset attached, so there is no window in which it is latest but incomplete."
           } >> "$GITHUB_STEP_SUMMARY"
       # Mirror the files a PERSON downloads to a stable public address
-      # (devthrottle_internal #1186). GitHub stays the archive - this is not a
-      # second copy of history, only ever the latest build plus a short tail of
-      # versions.
+      # (devthrottle_internal #1186). GitHub stays the archive: this holds ONLY
+      # the current build, under names that never change. Per-version copies were
+      # removed deliberately - GitHub already serves an immutable URL per version
+      # for free, so a second copy bought nothing and doubled the storage.
       #
       # Why this exists: the GitHub download link is not a stable address. It
       # redirects twice, and the URL the browser actually fetches from carries a
@@ -921,7 +922,6 @@ jobs:
           AZ_ACCOUNT: stdevthrottledl
           AZ_CONTAINER: download
           AZ_KEY: ${{ secrets.AZURE_DOWNLOADS_KEY }}
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -965,11 +965,11 @@ jobs:
               *.json) ctype="application/json" ;;
               *)      ctype="application/octet-stream" ;;
             esac
-            # latest/ is overwritten every release, so it must not be cached for
-            # long or people keep getting yesterday's build. The versioned copy
-            # never changes, so it is immutable.
-            upload "$src" "latest/$name"        "public, max-age=300"                 "$ctype"
-            upload "$src" "v$VERSION/$name"     "public, max-age=31536000, immutable" "$ctype"
+            # One copy, one name, overwritten every release - so the download
+            # address never changes. Short cache or people keep getting
+            # yesterday's build. release-manifest.json alongside it says which
+            # version is currently there, for anything that needs to know.
+            upload "$src" "latest/$name" "public, max-age=300" "$ctype"
           done
 
           echo "Mirrored to https://$AZ_ACCOUNT.blob.core.windows.net/$AZ_CONTAINER/latest/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -919,7 +919,7 @@ jobs:
       - name: Mirror downloads to Azure Blob
         if: ${{ !contains(github.ref_name, '-') }}
         env:
-          AZ_ACCOUNT: stdevthrottledl
+          AZ_ACCOUNT: devthrottle
           AZ_CONTAINER: download
           AZ_KEY: ${{ secrets.AZURE_DOWNLOADS_KEY }}
         run: |
@@ -969,10 +969,10 @@ jobs:
             # address never changes. Short cache or people keep getting
             # yesterday's build. release-manifest.json alongside it says which
             # version is currently there, for anything that needs to know.
-            upload "$src" "latest/$name" "public, max-age=300" "$ctype"
+            upload "$src" "$name" "public, max-age=300" "$ctype"
           done
 
-          echo "Mirrored to https://$AZ_ACCOUNT.blob.core.windows.net/$AZ_CONTAINER/latest/"
+          echo "Mirrored to https://$AZ_ACCOUNT.blob.core.windows.net/$AZ_CONTAINER/"
 
       # Prove the mirror rather than trust the exit code: fetch the installer
       # back anonymously and check its SHA-256 against the manifest we just built.
@@ -980,7 +980,7 @@ jobs:
         if: ${{ !contains(github.ref_name, '-') }}
         env:
           AZ_KEY: ${{ secrets.AZURE_DOWNLOADS_KEY }}
-          BASE: https://stdevthrottledl.blob.core.windows.net/download/latest
+          BASE: https://devthrottle.blob.core.windows.net/download
         run: |
           set -euo pipefail
           if [ -z "${AZ_KEY:-}" ]; then


### PR DESCRIPTION
Removes the per-version copies from the download mirror added in #2348.

## Why they were wrong

The mirror wrote every asset twice - `latest/` and `v<version>/`. I justified the second copy on the grounds that winget manifests and Store submissions pin a URL **and** a hash per version, so a moving URL would break every published manifest on the next release.

That part is true. The conclusion was not: **GitHub already serves an immutable URL per version, permanently, for free.** Anything needing a pinned address uses that. The blob copy duplicated it at ~400 MB per release and dragged in a retention question nobody had answered.

## What it does now

One copy of each file, one name, overwritten every release. That is the whole point of the mirror - an address that never moves - and per-version folders worked against it.

`release-manifest.json` sits beside the installers and carries the current version, size and SHA-256 of every asset, so anything that needs to know what is downloadable reads that rather than inferring it from a folder name. Same pattern mindzie uses.

## Effect

- Storage halves, and stops growing without bound.
- No retention policy to decide.
- Nothing lost: every previous version remains on GitHub Releases, which is and stays the archive.

The `v1.9.2/` folder already uploaded is being removed by hand.