### PR TITLE
Repair the two Postgres proofs that went stale while gated off every gate

### DIFF
--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -98,15 +98,20 @@ public sealed class PostgresProviderProofTests
     }
 
     /// <summary>
-    /// Proves the migration applied an EXPLICIT byte-ordinal collation "C" to exactly the four natural-key
-    /// primary-key columns and to no others. This reads pg_attribute.attcollation (the column's DEFINED
-    /// collation), which is the type-default pseudo-collation ("default") for a plain text column and the
-    /// "C" collation only where the migration set COLLATE "C" explicitly - so it distinguishes our explicit
-    /// collation from the database's default collation even if that default happens to be C. Without this,
-    /// the behavioral ordering test alone could pass on a container whose default collation is already C.
+    /// Proves the migrations applied an EXPLICIT byte-ordinal collation "C" to exactly the natural-key
+    /// columns the model declares with UseCollation("C") - and to no others. This reads
+    /// pg_attribute.attcollation (the column's DEFINED collation), which is the type-default
+    /// pseudo-collation ("default") for a plain text column and the "C" collation only where the migration
+    /// set COLLATE "C" explicitly - so it distinguishes our explicit collation from the database's default
+    /// collation even if that default happens to be C. Without this, the behavioral ordering test alone
+    /// could pass on a container whose default collation is already C.
+    ///
+    /// The list below is kept as an EXPLICIT enumeration on purpose: adding a C collation to the model must
+    /// be acknowledged here, so an accidental one is loud. It went stale once (issue #1191) because this
+    /// suite is environment-gated and ran nowhere; it is now part of the routine local gate.
     /// </summary>
     [RequiresPostgresFact]
-    public void Collation_ExplicitC_OnExactlyTheFourNaturalKeys_OnRealPostgres()
+    public void Collation_ExplicitC_OnExactlyTheDeclaredNaturalKeys_OnRealPostgres()
     {
         EnsureMigrated();
         using var ctx = NewContext();
@@ -123,23 +128,28 @@ public sealed class PostgresProviderProofTests
             "AND col.collname = 'C' " +
             "ORDER BY c.relname, a.attname");
 
+        // One entry per UseCollation("C") declaration in GatewayDbContext, read back from the live catalog.
+        // 18 declarations, 18 columns - verified one-to-one against the model on 2026-07-31 (#1191).
         var expected = new[]
         {
-            // The device-credential natural keys (MTR-14): the DeviceId primary key and the DeviceKeyHash lookup
-            // index, plus the device-import marker's SourcePath key - all byte-ordinal to match SQLite BINARY.
+            ("account_trials", "subject"),
             ("device_credentials", "DeviceId"),
             ("device_credentials", "DeviceKeyHash"),
             ("device_import_markers", "SourcePath"),
+            ("dictation_suggestion_dismissals", "Term"),
+            ("dictation_suggestion_verdicts", "Term"),
             ("mission_notes", "Key"),
             ("push_subscriptions", "Endpoint"),
+            ("session_history", "SessionId"),
+            ("session_history_rollups", "RepoKey"),
             ("session_spend", "SessionId"),
+            ("skill_tenant_overrides", "SkillId"),
+            ("skills", "Id"),
             ("snoozes", "SessionId"),
-            // The per-account settings key (AddTenantSettings): tenant_settings.Key is byte-ordinal
-            // (GatewayDbContext UseCollation("C")) so a settings key compares exactly. This entry was
-            // missing here because the PG-gated suite never runs in CI; real-Postgres proof surfaced the gap.
             ("tenant_settings", "Key"),
             ("tenants", "AccountSubject"),
             ("tenants", "Id"),
+            ("workflow_tenant_overrides", "WorkflowId"),
         };
         Assert.Equal(expected, withExplicitC.ToArray());
 

--- a/src/CcDirector.Gateway.Tests/Stats/GatewayStatsWritePathPostgresTests.cs
+++ b/src/CcDirector.Gateway.Tests/Stats/GatewayStatsWritePathPostgresTests.cs
@@ -980,6 +980,11 @@ public sealed class GatewayStatsWritePathPostgresTests
     /// satisfied honestly by a block on an unrelated identity row; requiring the blocked backend to hold a
     /// write lock on the contested relation AND no other write lock in this schema is what ties the wait to
     /// the row under test, which the fixture has already established is the only row in that table.
+    ///
+    /// The no-other-write-lock clause counts TABLES only (relkind 'r'). A write also takes RowExclusiveLock
+    /// on the target's indexes, which are relations in the same schema - so without the relkind filter the
+    /// contested table's own primary-key index disqualified a correctly-blocked writer, and this witness
+    /// could never fire on any non-HOT update (issue #1190, observed live in pg_locks).
     /// </summary>
     private static bool IsBlockedOnRelation(int blockedPid, int blockerPid, string table)
     {
@@ -1000,6 +1005,7 @@ public sealed class GatewayStatsWritePathPostgresTests
                                   WHERE other.pid = {0} AND other.granted
                                     AND other.locktype = 'relation'
                                     AND other.mode = 'RowExclusiveLock'
+                                    AND c.relkind = 'r'
                                     AND n.nspname = {3}
                                     AND other.relation <> CAST({2} AS regclass))",
             blockedPid, blockerPid, table, GatewayStatsDbContext.PostgresSchema).Single() > 0;


### PR DESCRIPTION
Fixes devthrottle_internal#1190 and devthrottle_internal#1191 - the two test-side defects found on the first routine local run of the environment-gated Postgres proof family (which until today ran nowhere: no CI job and no machine set its connection variables).

## The blocking witness (#1190)

The three InterleavedWriters tests failed with 'never blocked' on every real Postgres - fresh container and the port author's original rig alike. Live pg_locks capture during the failing window shows the second writer correctly blocked (locktype=transactionid, granted=false, waiting on the first writer) while holding the contested row's table lock. The witness could not see it: its no-other-write-lock clause counted every relation in the schema, and an INSERT/UPDATE also takes RowExclusiveLock on the table's indexes - so the contested table's own primary-key index disqualified the very block under test. The clause now counts tables only (relkind 'r'). The product was never at fault; no assertion is weakened, and the existing negative control (TheRelationCheck_RefusesToCertify_AnUnrelatedLock) still refuses an unrelated block.

## The collation list (#1191)

Collation_ExplicitC pinned the four C-collated natural keys of its day; GatewayDbContext deliberately declares eighteen. The expected list now carries all eighteen, verified one-to-one against both the model's UseCollation declarations and the live catalog of a freshly migrated database. Exact-set equality stays, so the next drift fails loudly on the first local run instead of silently for months.

## Evidence

- Both full classes green on postgres:16: 20/20 in 10s (the write-path class was 3m10s before the fix - three witnesses each burning a 60s timeout).
- Revert-proof in both directions is the history itself: the unfixed tests fail on every real Postgres, and the negative-control witness test still passes with the fix.
- The family now runs routinely on the standing local rig (cc-pg-test container, user-wide test connection variables on SOREN_NORTH).