### PR TITLE
fix(gateway): menu verdicts are model-judged; waiting-screen regex demoted to tripwire

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanMenuMisfireTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanMenuMisfireTests.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using CcDirector.Gateway.Speech;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The session-115 menu misfire (issue devthrottle_internal#1195): the pure classifier declared a finished
+/// summary - a numbered list of completed work above an empty composer - to be "waiting on a menu", because
+/// (a) any two lines shaped like "1. ..." counted as menu options wherever they sat on the grid, and (b) a
+/// stale composer glyph supplied the "drawn selection marker". These tests pin the two mechanical fixes
+/// (the contiguous option block; the real U+276F composer prompt) with a sanitized twin of the real grid,
+/// and the SCREEN-verdict contract that makes the model - not the regex - the authority on "menu".
+/// The REAL captured grid lives in the private repo's goldens corpus, reachable via WINGMAN_GOLDENS_DIR.
+/// </summary>
+public sealed class WingmanMenuMisfireTests
+{
+    // A sanitized twin of session 115's live grid at misfire time: the agent's finishing summary is a
+    // numbered list whose items are separated by wrapped prose (rows apart, as on the real screen), a STALE
+    // '❯' glyph from an earlier frame sits at the start of the "1." row, and below it all is the agent's
+    // real, empty '❯' composer with the mode-status footer. Nothing here is interactive.
+    private static readonly string[] SummaryWithStaleMarker =
+    {
+        "● All three jobs are done:",
+        "❯ 1. Updated the release notes - two commits today: the rebuilt draft plus the",
+        "  final proofread pass over every section. Nothing is only on this machine",
+        "  anymore, and the branch is deleted.",
+        "  more prose recounting what happened, wrapped across several rows,",
+        "  as a real reply wraps in a narrow terminal window.",
+        "  3. Cleaned up the temp folders - nothing left to review there.",
+        "",
+        "──────────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────────",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    };
+
+    [Fact]
+    public void SummaryWithStaleMarker_IsNotAMenuSelection()
+        // The fix under test: "1." and "3." with paragraphs between them are prose, not an option block,
+        // no matter what stale glyph sits next to the "1.".
+        => Assert.False(WingmanMenuLogic.LiveScreenHasMenuSelection(SummaryWithStaleMarker));
+
+    [Fact]
+    public void SummaryWithStaleMarker_NeverClassifiesAsMenu()
+        // The cursor sits in the real (empty) composer on row 9, visible, at the insertion point. Menu-ish
+        // structure elsewhere on the grid keeps this Blocked rather than PlainText - but it must NEVER be
+        // Menu, because Menu is what refuses voice replies and announces "waiting on a menu".
+        => Assert.NotEqual(WaitingScreenKind.Menu, WaitingScreenClassifier.Classify(
+            SummaryWithStaleMarker, cursorRow: 9, cursorCol: 2, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+
+    [Fact]
+    public void RealClaudeComposer_Glyph_IsRecognized()
+    {
+        // Claude Code draws its composer prompt as '❯' (U+276F), not '>'. Before the fix this composer was
+        // invisible to the classifier, so the ambiguity rule (menu + composer -> Blocked) could never fire.
+        var rows = new[]
+        {
+            "I finished the change. What next?",
+            "──────────────────────────────────",
+            "❯ ",
+            "──────────────────────────────────",
+            "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+        };
+        Assert.Equal(WaitingScreenKind.PlainText, WaitingScreenClassifier.Classify(
+            rows, cursorRow: 2, cursorCol: 2, cursorVisible: true, isAlternateScreen: false, hasGrid: true));
+    }
+
+    [Fact]
+    public void CompactSummaryWithStaleMarker_StillTripsTheTripwire()
+    {
+        // DOCUMENTED LIMIT, not a defect: a compact one-line-per-item summary with a stray marker is
+        // indistinguishable from a picker by shape alone. The tripwire fires - and that is acceptable
+        // BECAUSE the surfaces that block all confirm with the model first (ConfirmedMenuAsync). If this
+        // assertion ever flips, re-check that the model confirmation still guards every blocking surface.
+        var rows = new[] { "❯ 1. Committed the fix", "  2. Updated the tests", "  3. Cleaned up" };
+        Assert.True(WingmanMenuLogic.LiveScreenHasMenuSelection(rows));
+    }
+
+    [Fact]
+    public void RealPermissionMenu_StillRecognized()
+    {
+        var rows = new[]
+        {
+            "╭──────────────────────────────────────────────╮",
+            "│ Do you want to proceed?                      │",
+            "│ ❯ 1. Yes                                     │",
+            "│   2. Yes, and don't ask again this session   │",
+            "│   3. No, and tell Claude what to do          │",
+            "╰──────────────────────────────────────────────╯",
+        };
+        Assert.True(WingmanMenuLogic.LiveScreenHasMenuSelection(rows));
+    }
+
+    [Fact]
+    public void MenuWithOneWrappedOptionLabel_StillRecognized()
+    {
+        // One non-option row inside the block is tolerated: a long option label wraps in a narrow terminal.
+        var rows = new[]
+        {
+            "Do you want to proceed?",
+            "❯ 1. Yes, apply the change to every file in the",
+            "     selected folder and keep going",
+            "  2. No",
+        };
+        Assert.True(WingmanMenuLogic.LiveScreenHasMenuSelection(rows));
+    }
+
+    [Fact]
+    public void OptionsSeparatedByParagraphs_NotRecognized()
+        // Two "options" in different blocks never merge across the prose between them.
+        => Assert.False(WingmanMenuLogic.LiveScreenHasMenuSelection(new[]
+        {
+            "❯ 1. First thing I did",
+            "  a paragraph about it",
+            "  and another line of prose",
+            "  2. Second thing I did",
+        }));
+
+    // ===== The SCREEN verdict: the model's JSON judgment riding the narration call =====
+
+    [Fact]
+    public void ParseScreenVerdict_Menu_WithQuestionAndOptions()
+    {
+        var v = WingmanTranslator.ParseScreenVerdict(
+            "===DEVTHROTTLE-ANSWER-BEGIN===\nIt wants permission to run a command.\n===DEVTHROTTLE-ANSWER-END===\n"
+            + "SCREEN: {\"needs\":\"menu\",\"question\":\"Run the build command?\",\"options\":[\"1. Yes\",\"2. No\"]}");
+        Assert.NotNull(v);
+        Assert.Equal("menu", v!.Needs);
+        Assert.Equal("Run the build command?", v.Question);
+        Assert.Equal(2, v.Options.Count);
+    }
+
+    [Theory]
+    [InlineData("SCREEN: {\"needs\":\"answer\"}", "answer")]
+    [InlineData("SCREEN: {\"needs\":\"nothing\"}", "nothing")]
+    [InlineData("the spoken part\nSCREEN:{\"needs\":\"MENU\"}", "menu")]   // case-insensitive value
+    public void ParseScreenVerdict_KnownValues_Parse(string reply, string expected)
+        => Assert.Equal(expected, WingmanTranslator.ParseScreenVerdict(reply)?.Needs);
+
+    [Theory]
+    [InlineData("no verdict line at all")]
+    [InlineData("SCREEN: {\"needs\":\"maybe\"}")]              // unknown value is UNKNOWN, never a guess
+    [InlineData("SCREEN: {\"needs\":")]                        // unbalanced braces
+    [InlineData("SCREEN: not json")]
+    [InlineData("")]
+    public void ParseScreenVerdict_GarbageDegradesToNull(string reply)
+        => Assert.Null(WingmanTranslator.ParseScreenVerdict(reply));
+
+    [Fact]
+    public void ParseScreenVerdict_LastLabelWins()
+        // A model that echoes the contract's example line must not have the echo win over its verdict.
+        => Assert.Equal("nothing", WingmanTranslator.ParseScreenVerdict(
+            "SCREEN: {\"needs\":\"menu\",\"question\":\"...\",\"options\":[\"1. Yes\",\"2. No\"]}\n"
+            + "the real one:\nSCREEN: {\"needs\":\"nothing\"}")?.Needs);
+
+    [Fact]
+    public void BuildPrompt_WithLiveScreen_CarriesScreenAndVerdictContract()
+    {
+        var p = WingmanTranslator.BuildPrompt(SpokenLanguages.English, "instructions", "ctx", "reply", "title",
+            liveScreen: "❯ 1. the grid rows");
+        Assert.Contains("❯ 1. the grid rows", p);
+        Assert.Contains("SCREEN:", p);
+        Assert.Contains("\"needs\":\"menu\"", p);
+        // The negative rule the misfire earned: a numbered list in prose is not a menu.
+        Assert.Contains("NOT a menu", p);
+    }
+
+    [Fact]
+    public void BuildPrompt_WithoutLiveScreen_AsksForNoVerdict()
+    {
+        var p = WingmanTranslator.BuildPrompt(SpokenLanguages.English, "instructions", "ctx", "reply", "title");
+        Assert.DoesNotContain("SCREEN:", p);
+    }
+
+    // ===== The per-screen verdict cache =====
+
+    [Fact]
+    public void VerdictCache_ServesOnlyTheJudgedScreen()
+    {
+        WingmanScreenVerdictCache.Clear();
+        var rowsA = new[] { "row one", "row two" };
+        var rowsB = new[] { "row one", "row two changed" };
+        var key = "Local/cache-test-sid";
+        WingmanScreenVerdictCache.Store(key, WingmanScreenVerdictCache.HashRows(rowsA), "menu");
+        Assert.True(WingmanScreenVerdictCache.TryGet(key, WingmanScreenVerdictCache.HashRows(rowsA), out var needs));
+        Assert.Equal("menu", needs);
+        // The screen moved: the stale verdict must NOT be served.
+        Assert.False(WingmanScreenVerdictCache.TryGet(key, WingmanScreenVerdictCache.HashRows(rowsB), out _));
+    }
+
+    // ===== The private goldens hook (real captured screens live in the internal repo only) =====
+
+    [Fact]
+    public void PrivateGoldens_WhenConfigured_ClassifyCorrectly()
+    {
+        // Point WINGMAN_GOLDENS_DIR at the private goldens corpus (devthrottle_internal
+        // docs/wingman/goldens) to also validate the classifier against REAL captured screens. Unset (CI,
+        // other machines) this test asserts nothing - the public repo never carries a real session's screen.
+        var dir = Environment.GetEnvironmentVariable("WINGMAN_GOLDENS_DIR");
+        if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir)) return;
+        foreach (var file in Directory.EnumerateFiles(dir, "*.json"))
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(file));
+            if (!doc.RootElement.TryGetProperty("rows", out var rowsEl) || rowsEl.ValueKind != JsonValueKind.Array)
+                continue;   // evidence-only capture (no full-fidelity rows) - nothing to classify
+            var rows = rowsEl.EnumerateArray().Select(r => r.GetString() ?? "").ToArray();
+            var expected = doc.RootElement.GetProperty("expectedVerdict").GetString();
+            var isMenu = WingmanMenuLogic.LiveScreenHasMenuSelection(rows);
+            if (expected == "menu") Assert.True(isMenu, $"{Path.GetFileName(file)}: expected a menu");
+            else Assert.False(isMenu, $"{Path.GetFileName(file)}: expected not-a-menu");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -158,7 +158,12 @@ internal static class GatewayEndpoints
         Transcription.DictionarySuggestionDismissalStore? dictionaryDismissals = null,
         // Composes the daily email's suggestions block for the caller's tenant. Null (older callers,
         // recording-only test harnesses) simply does not expose the email-block route.
-        Transcription.SuggestionEmailComposer? suggestionEmailComposer = null)
+        Transcription.SuggestionEmailComposer? suggestionEmailComposer = null,
+        // Issue devthrottle_internal#1195: the wingman brain, the JUDGE the menu guard consults before it
+        // refuses a prompt - the pure classifier only trips the question, it never convicts on its own.
+        // Null (older callers, tests without a brain) makes a tripwire-positive screen refuse outright:
+        // fail closed, because the guard exists to keep an Enter out of a real picker.
+        Wingman.WingmanTranslator? wingmanTranslator = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -1997,23 +2002,28 @@ internal static class GatewayEndpoints
             // the send. On a menu we type nothing and press nothing: the trailing Enter this prompt carries
             // would otherwise confirm whatever option the picker had highlighted.
             //
-            // Only a CONFIDENTLY-recognized menu refuses. A screen the classifier cannot read is forwarded
-            // exactly as it was before this guard existed - blocking on uncertainty would silently break
-            // ordinary voice replies, which is worse than the gap it would close.
+            // Only a MODEL-CONFIRMED menu refuses (issue devthrottle_internal#1195): the pure classifier is
+            // the tripwire, and when it fires the verdict comes from the wingman brain - served from the
+            // per-screen verdict cache when the screen has not changed since the turn was narrated, one
+            // small model call when it has. The regex alone convicted a finished summary of being a menu
+            // (session 115) and locked its owner out of voice; it never convicts on its own again. A screen
+            // the classifier cannot read is forwarded exactly as before the guard existed - blocking on
+            // uncertainty would silently break ordinary voice replies.
             if (req.MenuGuard)
             {
+                // The tenant is resolved BEFORE the check: the model confirmation and the spoken refusal
+                // both need it, and a menu-guard request that cannot resolve one has no honest answer.
+                var guardTenant = ResolveReadTenant(httpCtx, tenantBoundary);
+                if (guardTenant is null)
+                    return Results.Json(new { error = "a tenant could not be resolved for this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
                 var guardRoute = new SessionVerbClient(director, sendCommand);
-                if (await Wingman.WaitingScreenReader.IsMenuAsync(guardRoute, sid, CancellationToken.None))
+                if (await Wingman.WaitingScreenReader.ConfirmedMenuAsync(guardRoute, sid, guardTenant.Value, wingmanTranslator, CancellationToken.None))
                 {
                     // The refusal is SPOKEN - a voice reply asked for this guard - so it is said in the
-                    // account's language (issue #1009). The tenant is resolved and the resolver required
-                    // rather than defaulted: a caller that reaches this branch without either would speak
-                    // English at somebody who chose French, which is the failure this mission exists to
-                    // remove. The on-screen Error line stays English like every other label.
-                    var guardTenant = ResolveReadTenant(httpCtx, tenantBoundary);
-                    if (guardTenant is null)
-                        return Results.Json(new { error = "a tenant could not be resolved for this request" },
-                            statusCode: StatusCodes.Status403Forbidden);
+                    // account's language (issue #1009). The resolver is required rather than defaulted: a
+                    // caller that reaches this branch without one would speak English at somebody who chose
+                    // French. The on-screen Error line stays English like every other label.
                     if (tenantSettings is null)
                         throw new InvalidOperationException(
                             "The menu guard speaks a refusal, so GatewayEndpoints.Map must be given a "

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -558,7 +558,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // Every menu, and every uncertain / unreadable / alternate-screen / hidden-cursor screen, types
             // NOTHING and presses NOTHING. (Fully hands-free voice-ANSWERING - the wingman pressing menu keys -
             // is its own later issue with per-agent picker profiles and a screen-version lock; it is not here.)
-            var (kind, blockedSpoken) = await ClassifyLiveScreenAtAsync(route, sid, tenantSettings.SpokenLanguage(reqTenant.Value), ct);
+            var (kind, blockedSpoken) = await ClassifyLiveScreenAtAsync(route, sid, reqTenant.Value, translator, tenantSettings.SpokenLanguage(reqTenant.Value), ct);
             if (kind != WaitingScreenKind.PlainText)
             {
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: FAIL CLOSED - not typing (screen is {kind})");
@@ -569,7 +569,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // immediately before the send and re-confirm it is STILL a confident plain-text composer. If it
             // changed in the meantime (now a menu / alternate screen / cursor hidden / gone), fail closed - the
             // spoken words must never land on anything but the composer they were classified against.
-            var (kindNow, blockedNow) = await ClassifyLiveScreenAtAsync(route, sid, tenantSettings.SpokenLanguage(reqTenant.Value), ct);
+            var (kindNow, blockedNow) = await ClassifyLiveScreenAtAsync(route, sid, reqTenant.Value, translator, tenantSettings.SpokenLanguage(reqTenant.Value), ct);
             if (kindNow != WaitingScreenKind.PlainText)
             {
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: screen changed before send (now {kindNow}) - fail closed, not typing");
@@ -611,7 +611,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 var recentContext = string.IsNullOrWhiteSpace(priorContext)
                     ? "You: " + req.Text.Trim()
                     : priorContext + "\n\nYou: " + req.Text.Trim();
-                var t = await translator.TranslateAsync(reqTenant.Value, recentContext, reply, SessionTitle(reqTenant.Value, sid), CancellationToken.None);
+                var t = await translator.TranslateAsync(reqTenant.Value, recentContext, reply, SessionTitle(reqTenant.Value, sid), ct: CancellationToken.None);
                 await voice.StoreSpokenAsync(reqTenant.Value, sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: replyLen={reply.Length}, spokenLen={t.Spoken.Length}");
                 return Results.Json(new { reply, spoken = t.Spoken, replySeconds = t.ReplySeconds });
@@ -727,7 +727,7 @@ internal static class GatewayWingmanVoiceEndpoint
             voice.BeginGenerating(reqTenant.Value, sid);
             try
             {
-                var t = await translator.TranslateAsync(reqTenant.Value, recentContext, lastReply, SessionTitle(reqTenant.Value, sid), CancellationToken.None);
+                var t = await translator.TranslateAsync(reqTenant.Value, recentContext, lastReply, SessionTitle(reqTenant.Value, sid), ct: CancellationToken.None);
                 await voice.StoreSpokenAsync(reqTenant.Value, sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: replyLen={lastReply.Length}, spokenLen={t.Spoken.Length}");
                 return Results.Json(new { reply = lastReply, spoken = t.Spoken, replySeconds = t.ReplySeconds });
@@ -839,6 +839,13 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
             var kind = await WaitingScreenReader.ClassifyAsync(route, sid, ct);
+            // The pure classifier only TRIPS the menu question (issue devthrottle_internal#1195) - the
+            // verdict that reaches a client comes from the model, served from the per-screen verdict cache
+            // when the screen has not changed since the turn was narrated. A model "not a menu" downgrades
+            // to Blocked, which keeps canType=true: typing stays allowed, no menu is announced.
+            if (kind == WaitingScreenKind.Menu
+                && !await WaitingScreenReader.ConfirmedMenuAsync(route, sid, reqTenant.Value, translator, ct))
+                kind = WaitingScreenKind.Blocked;
             FileLog.Write($"[GatewayWingmanVoice] waiting-screen(pure) sid={sid}: {kind}");
             return Results.Json(new
             {
@@ -986,13 +993,20 @@ internal static class GatewayWingmanVoiceEndpoint
     /// and never presses - so no menu extraction (brain) happens on the send path.
     /// </summary>
     private static async Task<(WaitingScreenKind Kind, string BlockedSpoken)> ClassifyLiveScreenAtAsync(
-        SessionVerbClient route, string sid, SpokenLanguage language, CancellationToken ct)
+        SessionVerbClient route, string sid, TenantId tenant, WingmanTranslator translator, SpokenLanguage language, CancellationToken ct)
     {
         // The read-and-classify step itself lives in ONE place (issue #2193) so this endpoint, the prompt
         // front door's menu guard, and the narration generator can never drift on what counts as a menu.
         // The WORDING stays here, because this path fails closed on an unreadable screen too and therefore
         // has a second thing to say; the guard refuses only on a menu and has one.
         var kind = await WaitingScreenReader.ClassifyAsync(route, sid, ct);
+        // A MENU claim is the model's to make (issue devthrottle_internal#1195): the classifier trips the
+        // question, the confirmed verdict decides what is SPOKEN. An unconfirmed "menu" downgrades to
+        // Blocked - still not typed (this path types only on PlainText), but the person is told the honest
+        // "I can't read this screen" line instead of being sent to look for a menu that is not there.
+        if (kind == WaitingScreenKind.Menu
+            && !await WaitingScreenReader.ConfirmedMenuAsync(route, sid, tenant, translator, ct))
+            kind = WaitingScreenKind.Blocked;
         // A menu says "look at the terminal"; everything else uncertain says the generic unreadable line.
         var spoken = kind == WaitingScreenKind.Menu
             ? SpokenPhrases.VoiceTurnBlockedMenu.In(language)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2510,6 +2510,10 @@ public sealed class GatewayHost : IAsyncDisposable
             dictionaryDismissals: _dictionaryDismissals,
             // The daily-email block route for the caller's tenant.
             suggestionEmailComposer: _suggestionEmailComposer,
+            // Issue devthrottle_internal#1195: the wingman brain judges the menu guard's refusals - the
+            // same translator (and verdict cache) the narration path uses, so an unchanged screen is
+            // answered from the cached per-turn verdict without a second model call.
+            wingmanTranslator: _voiceService?.Translator,
             requestShutdown: () =>
             {
                 var handler = OnShutdownRequested;

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenClassifier.cs
@@ -139,11 +139,14 @@ public static class WaitingScreenClassifier
         var line = rows[cursorRow];
         if (string.IsNullOrWhiteSpace(line)) return false;
 
-        // The first non-border, non-space column is the prompt marker.
+        // The first non-border, non-space column is the prompt marker. Claude Code draws its composer prompt
+        // as '❯' (U+276F), not the ASCII '>'; accepting only '>' meant a REAL Claude Code composer was never
+        // positively recognized, so the classifier's own ambiguity rule (menu-ish structure + live composer ->
+        // Blocked, never Menu) could not fire - one of the two defects behind the session-115 menu misfire.
         var first = 0;
         while (first < line.Length && System.Array.IndexOf(BorderOrSpace, line[first]) >= 0) first++;
-        if (first >= line.Length || line[first] != '>') return false;
-        if (first + 1 < line.Length && line[first + 1] == '>') return false; // ">>" is the mode-cycle arrow
+        if (first >= line.Length || (line[first] != '>' && line[first] != '❯')) return false;
+        if (first + 1 < line.Length && (line[first + 1] == '>' || line[first + 1] == '❯')) return false; // ">>" is the mode-cycle arrow
 
         // THE COMPOSER INVARIANT (issue #1777, final tighten): a real text composer has the visible cursor at
         // the INSERTION POINT - it TRAILS the input, right after the last non-space character the user typed, or

--- a/src/CcDirector.Gateway/Wingman/WaitingScreenReader.cs
+++ b/src/CcDirector.Gateway/Wingman/WaitingScreenReader.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
@@ -64,6 +65,65 @@ internal static class WaitingScreenReader
     /// </summary>
     public static async Task<bool> IsMenuAsync(SessionVerbClient route, string sid, CancellationToken ct = default)
         => await ClassifyAsync(route, sid, ct) == WaitingScreenKind.Menu;
+
+    /// <summary>
+    /// The MODEL-CONFIRMED menu verdict (issue devthrottle_internal#1195) - the one every surface that BLOCKS
+    /// on a menu must use. The session-115 misfire proved the pure classifier can be satisfied by ordinary
+    /// prose (a numbered summary of finished work) plus a stale marker glyph, so the regex is demoted to a
+    /// tripwire: it decides when the model must be asked, and it alone never convicts.
+    ///
+    /// The flow: read the grid once; anything unreadable is not a menu (phase-1 behavior unchanged). If the
+    /// pure classifier sees no confident menu, that is final - no model call, which keeps ordinary sends at
+    /// regex cost. If it does, the verdict cache is consulted by grid fingerprint - the narration call judges
+    /// every turn's screen, so an unchanged screen is answered instantly with the model's verdict. Only a
+    /// changed, menu-shaped screen pays for one <see cref="WingmanTranslator.DetectMenuAsync"/> call. The two
+    /// failure directions are deliberate: no translator, or a model that cannot be reached while menu
+    /// structure is on screen, BLOCKS (typing into a real picker presses Enter on an option the person never
+    /// chose - the original #2193 disaster); an unreadable screen or a quiet classifier never blocks.
+    /// </summary>
+    public static async Task<bool> ConfirmedMenuAsync(
+        SessionVerbClient route, string sid, TenantId tenant, WingmanTranslator? translator, CancellationToken ct = default)
+    {
+        ScreenGridResponse? grid;
+        try { grid = await route.GetScreenGridAsync(sid, ct); }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: screen-grid read threw ({ex.Message}) - not a menu");
+            return false;
+        }
+        if (grid is null || grid.Rows is null || grid.Rows.Count == 0) return false;
+
+        var kind = WaitingScreenClassifier.Classify(
+            grid.Rows, grid.CursorRow, grid.CursorCol, grid.CursorVisible, grid.IsAlternateScreen, grid.HasGrid);
+        if (kind != WaitingScreenKind.Menu) return false;
+
+        var key = $"{tenant}/{sid}";
+        var hash = WingmanScreenVerdictCache.HashRows(grid.Rows);
+        if (WingmanScreenVerdictCache.TryGet(key, hash, out var cached))
+        {
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: menu-shaped screen, cached model verdict '{cached}'");
+            return cached == "menu";
+        }
+
+        if (translator is null)
+        {
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: menu-shaped screen and no judge available - fail closed");
+            return true;
+        }
+
+        try
+        {
+            var menu = await translator.DetectMenuAsync(tenant, string.Join("\n", grid.Rows), ct);
+            WingmanScreenVerdictCache.Store(key, hash, menu.IsMenu ? "menu" : "not-menu");
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: menu-shaped screen, model says isMenu={menu.IsMenu}");
+            return menu.IsMenu;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WaitingScreenReader] sid={sid}: menu-shaped screen, model unreachable ({ex.Message}) - fail closed");
+            return true;
+        }
+    }
 
     /// <summary>The wire word for a classified screen: what the phone and the Cockpit read.</summary>
     public static string KindWord(WaitingScreenKind kind) => kind switch

--- a/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanMenu.cs
@@ -140,20 +140,42 @@ public static class WingmanMenuLogic
 
     /// <summary>
     /// True when the LIVE grid carries a menu OWNED BY ITS DRAWN SELECTION MARKER (issue #1777, round-4): a row
-    /// with the drawn <c>❯</c>/<c>&gt;</c> marker on a numbered/lettered option, plus two or more option lines.
+    /// with the drawn <c>❯</c>/<c>&gt;</c> marker on a numbered/lettered option, plus two or more option lines
+    /// forming ONE CONTIGUOUS BLOCK with the marker inside it. The block rule exists because an agent's prose
+    /// reply routinely ends in a numbered summary of finished work; counting "1." and "3." with paragraphs of
+    /// prose between them as menu options declared a finished session to be "waiting on a menu" (the session-115
+    /// misfire, where a stale composer glyph supplied the marker). A real Ink picker draws its options as
+    /// consecutive rows; a single non-option row inside the block is tolerated for a wrapped option label.
     /// This is cursor-INDEPENDENT on purpose - a full-screen Ink menu hides the hardware cursor - so
     /// menu-answering works with a hidden cursor. A menu with no recognizable textual marker (reverse-video
     /// only) is NOT recognized here and the caller fails closed (styled-picker parsing is deferred).
+    /// This shape check remains a TRIPWIRE, not a conviction: a compact one-line-per-item summary with a stray
+    /// marker still passes it, which is why every surface that BLOCKS on a menu confirms with the model first
+    /// (see WaitingScreenReader.ConfirmedMenuAsync).
     /// </summary>
     public static bool LiveScreenHasMenuSelection(IReadOnlyList<string>? rows)
     {
         if (rows is null || rows.Count == 0) return false;
         var options = 0;
         var hasMarker = false;
+        var gap = 0;
         foreach (var r in rows)
         {
-            if (IsOptionLine(r)) options++;
-            if (!hasMarker && IsSelectedOptionLine(r)) hasMarker = true;
+            if (IsOptionLine(r))
+            {
+                options++;
+                if (IsSelectedOptionLine(r)) hasMarker = true;
+                gap = 0;
+            }
+            else if (options > 0 && gap == 0 && !string.IsNullOrWhiteSpace(r))
+            {
+                gap = 1;   // one wrapped option-label row is allowed inside the block
+            }
+            else
+            {
+                if (hasMarker && options >= 2) return true;   // the block that just ended was a menu
+                options = 0; hasMarker = false; gap = 0;
+            }
         }
         return hasMarker && options >= 2;
     }

--- a/src/CcDirector.Gateway/Wingman/WingmanScreenVerdict.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanScreenVerdict.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// The model's judgment of what a session's live screen needs from its owner, produced alongside the
+/// per-turn spoken summary (the SCREEN line of the translation contract). Three answers, one story:
+/// <c>menu</c> - an interactive picker owns the screen and typed text cannot answer it; <c>answer</c> -
+/// the agent is waiting on words or a decision the owner types or speaks; <c>nothing</c> - the turn is
+/// informational, the agent reported and is not waiting on the owner. Null/absent means the model gave
+/// no verdict (no live screen was supplied, or the line did not parse) - callers treat that as unknown
+/// and fall back to their fail-safe default, never to a block.
+/// </summary>
+public sealed class WingmanScreenVerdict
+{
+    /// <summary>"menu" | "answer" | "nothing" - normalized lowercase; anything else never leaves the parser.</summary>
+    public string Needs { get; set; } = "";
+
+    /// <summary>For a menu: the choice being asked, in plain words. Empty otherwise.</summary>
+    public string Question { get; set; } = "";
+
+    /// <summary>For a menu: the visible option labels as shown on screen. Empty otherwise.</summary>
+    public List<string> Options { get; set; } = new();
+}
+
+/// <summary>
+/// Remembers the model's latest screen verdict per session, keyed by a FINGERPRINT of the grid rows it
+/// judged. The point: the menu question is asked at two different moments - once per turn (when the
+/// narration call sees the screen anyway) and again at send time (the prompt menu guard, a voice
+/// reply) - and the screen usually has not changed between them. A fingerprint match serves the model's
+/// verdict instantly, so the send path gets model-grade judgment at regex cost; a mismatch means the
+/// screen moved and the verdict is stale, so the caller re-judges. One entry per session (newest wins).
+/// </summary>
+public static class WingmanScreenVerdictCache
+{
+    private static readonly ConcurrentDictionary<string, (string Hash, string Needs)> Entries = new();
+
+    /// <summary>The fingerprint of a live grid: SHA-256 over the rows joined with newlines. Any repaint -
+    /// even a spinner glyph - changes it, which is the conservative direction: a changed screen is
+    /// re-judged rather than served a stale verdict.</summary>
+    public static string HashRows(IReadOnlyList<string> rows)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(string.Join("\n", rows)));
+        return Convert.ToHexString(bytes);
+    }
+
+    /// <summary>Record the model's verdict for the screen with this fingerprint.</summary>
+    public static void Store(string sessionKey, string hash, string needs)
+        => Entries[sessionKey] = (hash, needs);
+
+    /// <summary>The cached verdict, but ONLY when the fingerprint still matches the live screen.</summary>
+    public static bool TryGet(string sessionKey, string hash, out string needs)
+    {
+        needs = "";
+        if (!Entries.TryGetValue(sessionKey, out var e) || e.Hash != hash) return false;
+        needs = e.Needs;
+        return true;
+    }
+
+    /// <summary>TEST-ONLY: drop every cached verdict so one test's screens never leak into another's.</summary>
+    public static void Clear() => Entries.Clear();
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -288,24 +288,24 @@ public sealed class WingmanTranslator
     /// </summary>
     /// <returns>The faithful, speakable translation and how long the brain took.</returns>
     /// <exception cref="ArgumentException">The latest reply is empty - there is nothing to translate.</exception>
-    public Task<WingmanTranslation> TranslateAsync(TenantId tenant, string recentContext, string latestReply, string? sessionTitle, CancellationToken ct = default)
-        => TranslateWithAsync(tenant, _instructions(), recentContext, latestReply, sessionTitle, ct);
+    public Task<WingmanTranslation> TranslateAsync(TenantId tenant, string recentContext, string latestReply, string? sessionTitle, string? liveScreen = null, CancellationToken ct = default)
+        => TranslateWithAsync(tenant, _instructions(), recentContext, latestReply, sessionTitle, liveScreen, ct);
 
     /// <summary>
     /// Same as <see cref="TranslateAsync"/> but with caller-supplied instructions instead of the
     /// active ones (issue #537 A/B testing): re-run a DRAFT prompt over a captured reply to compare
     /// its spoken output against what the wingman said before, without changing the live instructions.
     /// </summary>
-    public async Task<WingmanTranslation> TranslateWithAsync(TenantId tenant, string instructions, string recentContext, string latestReply, string? sessionTitle, CancellationToken ct = default)
+    public async Task<WingmanTranslation> TranslateWithAsync(TenantId tenant, string instructions, string recentContext, string latestReply, string? sessionTitle, string? liveScreen = null, CancellationToken ct = default)
     {
         RequireTenant(tenant);
         if (string.IsNullOrWhiteSpace(latestReply))
             throw new ArgumentException("Latest reply is required - there is nothing to translate.", nameof(latestReply));
 
-        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}, title={(string.IsNullOrWhiteSpace(sessionTitle) ? "(none)" : sessionTitle)}, language={LanguageFor(tenant).Code}");
+        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}, screenLen={liveScreen?.Length ?? 0}, title={(string.IsNullOrWhiteSpace(sessionTitle) ? "(none)" : sessionTitle)}, language={LanguageFor(tenant).Code}");
 
         var language = LanguageFor(tenant);
-        var prompt = BuildPrompt(language, instructions ?? FidelityPrompt, recentContext ?? "", latestReply, sessionTitle);
+        var prompt = BuildPrompt(language, instructions ?? FidelityPrompt, recentContext ?? "", latestReply, sessionTitle, liveScreen);
 
         var brain = await _brainProvider(tenant, WingmanModelRole.Fast, ct);
         AskResult ask;
@@ -325,12 +325,51 @@ public sealed class WingmanTranslator
             throw new InvalidOperationException(
                 "[WingmanTranslator] The wingman returned an empty spoken translation for a non-empty reply.");
 
-        _log($"[WingmanTranslator] TranslateWithAsync OK: spokenLen={spoken.Length}, replySeconds={ask.ReplySeconds:F1}");
+        // The SCREEN verdict is asked for only when a live screen went in, and its absence or garbling is
+        // deliberately harmless: Screen stays null and every consumer falls back to its fail-safe default.
+        var screen = string.IsNullOrWhiteSpace(liveScreen) ? null : ParseScreenVerdict(ask.Text);
+        _log($"[WingmanTranslator] TranslateWithAsync OK: spokenLen={spoken.Length}, needs={screen?.Needs ?? "(none)"}, replySeconds={ask.ReplySeconds:F1}");
         return new WingmanTranslation
         {
             Spoken = spoken,
             ReplySeconds = ask.ReplySeconds,
+            Screen = screen,
         };
+    }
+
+    /// <summary>
+    /// Pull the one-line <c>SCREEN: {...}</c> verdict out of the brain's reply (issue devthrottle_internal#1195).
+    /// Tolerant on purpose: the LAST "SCREEN" label in the reply wins (the prompt's own example lines sit
+    /// earlier), the JSON object is taken by brace balance rather than to end-of-line, and anything that does
+    /// not parse to a known <c>needs</c> value returns null - unknown, never a guess. Internal so a test can
+    /// assert the happy path and that garbage degrades to null.
+    /// </summary>
+    internal static WingmanScreenVerdict? ParseScreenVerdict(string reply)
+    {
+        if (string.IsNullOrWhiteSpace(reply)) return null;
+        var label = Regex.Matches(reply, @"SCREEN\s*:\s*\{");
+        if (label.Count == 0) return null;
+        var m = label[^1];
+        var start = m.Index + m.Length - 1;   // the '{'
+        var depth = 0;
+        var end = -1;
+        for (var i = start; i < reply.Length; i++)
+        {
+            if (reply[i] == '{') depth++;
+            else if (reply[i] == '}' && --depth == 0) { end = i; break; }
+        }
+        if (end < 0) return null;
+        try
+        {
+            var v = JsonSerializer.Deserialize<WingmanScreenVerdict>(reply[start..(end + 1)],
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (v is null) return null;
+            v.Needs = (v.Needs ?? "").Trim().ToLowerInvariant();
+            v.Question ??= "";
+            v.Options ??= new();
+            return v.Needs is "menu" or "answer" or "nothing" ? v : null;
+        }
+        catch (JsonException) { return null; }
     }
 
     /// <summary>
@@ -520,6 +559,17 @@ public sealed class WingmanTranslator
         sb.AppendLine("a numbered/lettered list, a permission prompt (\"Do you want to proceed?\"), a picker, or a");
         sb.AppendLine("plan approval. A free-text \"type your message\" prompt or an idle screen is NOT a menu.");
         sb.AppendLine();
+        sb.AppendLine("A numbered list INSIDE the agent's own prose is NOT a menu. Agents routinely end a turn");
+        sb.AppendLine("with a numbered summary of finished work (\"1. Committed the fix... 2. Updated the tests...");
+        sb.AppendLine("3. Cleaned up...\") sitting above an empty input box - that is a report, not a choice, even");
+        sb.AppendLine("when a stray marker glyph appears next to a number. A menu is an interactive control that");
+        sb.AppendLine("owns the screen and is waiting for a selection, like:");
+        sb.AppendLine("  Do you want to proceed?");
+        sb.AppendLine("  > 1. Yes");
+        sb.AppendLine("    2. Yes, and don't ask again this session");
+        sb.AppendLine("    3. No, and tell the agent what to do differently");
+        sb.AppendLine("If the screen only shows a finished reply above an empty composer, answer isMenu=false.");
+        sb.AppendLine();
         sb.AppendLine("If it IS a menu, extract it (rules from the proven brief contract):");
         sb.AppendLine("- question: the choice being asked, in plain words to hear out loud. No code or paths.");
         sb.AppendLine("- options: each listed choice. key = its visible label (e.g. \"1. Yes\"). send = the EXACT");
@@ -673,7 +723,7 @@ public sealed class WingmanTranslator
     /// no session here" case (the draft-prompt A/B path) and omits the block entirely, which the
     /// rule's own escape clause covers - the model is never handed an empty title to voice.
     /// </summary>
-    public static string BuildPrompt(SpokenLanguage language, string instructions, string recentContext, string latestReply, string? sessionTitle)
+    public static string BuildPrompt(SpokenLanguage language, string instructions, string recentContext, string latestReply, string? sessionTitle, string? liveScreen = null)
     {
         ArgumentNullException.ThrowIfNull(language);
         var sb = new StringBuilder();
@@ -700,6 +750,15 @@ public sealed class WingmanTranslator
             sb.Append(recentContext.Trim());
             sb.Append("\n---\n\n");
         }
+        if (!string.IsNullOrWhiteSpace(liveScreen))
+        {
+            sb.Append("The terminal screen this session is showing RIGHT NOW, top to bottom (its live ");
+            sb.Append("grid; stale glyphs from earlier frames may linger on it). Use it ONLY for the ");
+            sb.Append("SCREEN verdict asked for after the markers - do not narrate it:\n");
+            sb.Append("---\n");
+            sb.Append(liveScreen.Trim());
+            sb.Append("\n---\n\n");
+        }
         sb.Append("The agent's LATEST reply - translate THIS for the ear (adding the minimum context ");
         sb.Append("from above only if the reply is too short to stand on its own):\n");
         sb.Append("---\n");
@@ -711,8 +770,35 @@ public sealed class WingmanTranslator
         sb.Append('\n');
         sb.Append("<spoken version>\n");
         sb.Append(SessionAskRunner.AnswerEndMarker);
+        if (!string.IsNullOrWhiteSpace(liveScreen))
+        {
+            sb.Append('\n');
+            sb.Append(ScreenVerdictContract);
+        }
         return sb.ToString();
     }
+
+    /// <summary>
+    /// The SCREEN verdict addendum (issue devthrottle_internal#1195): asked for ONLY when a live screen was
+    /// supplied, and asked for AFTER the spoken markers so the proven spoken contract stays byte-identical -
+    /// <see cref="ExtractSpoken"/> reads between the markers and never sees this line, which is what makes a
+    /// garbled verdict harmless to the narration. Public so a test can assert the contract.
+    /// </summary>
+    public const string ScreenVerdictContract =
+        "Then, AFTER the end marker, output EXACTLY ONE more line - your verdict on what the live screen\n"
+        + "needs from the person, as JSON on a single line:\n"
+        + "SCREEN: {\"needs\":\"menu\",\"question\":\"...\",\"options\":[\"1. Yes\",\"2. No\"]}\n"
+        + "or SCREEN: {\"needs\":\"answer\"}  or  SCREEN: {\"needs\":\"nothing\"}\n"
+        + "- \"menu\": the screen RIGHT NOW shows an interactive picker that must be answered by SELECTING a\n"
+        + "  listed option (a permission prompt, a plan approval, a chooser with a selection marker). Typed\n"
+        + "  free text will NOT work there. Include the question and the visible option labels.\n"
+        + "- \"answer\": the agent asked the person something they answer in typed or spoken WORDS, or is\n"
+        + "  waiting on a decision from them.\n"
+        + "- \"nothing\": informational - the agent reported progress or results and is not waiting on the\n"
+        + "  person for anything.\n"
+        + "A numbered list INSIDE the agent's prose (a summary of work done, steps, findings) is NOT a menu,\n"
+        + "even if a stray marker glyph sits next to a number - a menu is an interactive control waiting for\n"
+        + "a selection. A finished reply above an empty input box is \"answer\" or \"nothing\", never \"menu\".";
 
     /// <summary>
     /// Build the "recent conversation" context string from a session's transcript widgets: the last
@@ -754,4 +840,9 @@ public sealed class WingmanTranslation
 
     /// <summary>Seconds the warm brain took to produce the translation.</summary>
     public double ReplySeconds { get; init; }
+
+    /// <summary>The model's verdict on what the live screen needs from the person
+    /// (issue devthrottle_internal#1195), or null when no live screen was supplied or the verdict line did
+    /// not parse. Null means UNKNOWN: callers fall back to their fail-safe default, never to a block.</summary>
+    public WingmanScreenVerdict? Screen { get; init; }
 }

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -71,6 +71,11 @@ public sealed class WingmanVoiceService
     }
 
     private readonly WingmanTranslator _translator;
+
+    /// <summary>The wingman brain this service narrates with, exposed so the host can hand the SAME judge
+    /// to the prompt menu guard (issue devthrottle_internal#1195) - one translator, one verdict cache, no
+    /// second warm-brain wiring.</summary>
+    public WingmanTranslator Translator => _translator;
     private readonly KeyVault _vault;
     private readonly TenantSettingsResolver _tenantSettings;
     /// <summary>Tenant partition key (see <see cref="CanonicalTenantKey"/>) -> that tenant's whole voice
@@ -877,6 +882,15 @@ public sealed class WingmanVoiceService
         }
         // Recent conversation so the wingman can add context to a short/terse latest reply.
         var recentContext = WingmanTranslator.BuildRecentContext(widgets);
+        // The LIVE screen goes into the same call (issue devthrottle_internal#1195): the model that writes
+        // the summary also judges what the screen needs - menu, an answer, or nothing - because the pure
+        // regex classifier convicted a finished summary of being a menu (session 115). One tunnel read per
+        // narration, exactly the read the old post-translate menu check made anyway. A failed read just
+        // means no verdict this turn: the narration itself never depends on it.
+        ScreenGridResponse? screenGrid = null;
+        try { screenGrid = await route.GetScreenGridAsync(sid, ct); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] screen-grid read failed for sid={sid}: {ex.Message} - narrating without a screen verdict"); }
+        var liveScreen = screenGrid is { HasGrid: true, Rows.Count: > 0 } ? string.Join("\n", screenGrid.Rows) : null;
         // The wingman is now running for this session - show it yellow until the summary lands, but
         // only for a brand-new turn. A background refresh / catch-up stays quiet so a session a phone
         // may be listening to is never flipped yellow mid-play (issue #1322).
@@ -886,7 +900,7 @@ public sealed class WingmanVoiceService
             WingmanTranslation t;
             try
             {
-                t = await _translator.TranslateAsync(tenant, recentContext, lastReply, _sessionTitleResolver?.Invoke(tenant, sid), ct);
+                t = await _translator.TranslateAsync(tenant, recentContext, lastReply, _sessionTitleResolver?.Invoke(tenant, sid), liveScreen, ct);
             }
             catch (Exception ex) when (IsModelDidNotAnswer(ex, ct))
             {
@@ -905,15 +919,20 @@ public sealed class WingmanVoiceService
             }
             // Announce a waiting menu AS THE TURN IS READ (issue #2193). A turn that ends on a picker is the
             // one case where the narration alone is misleading: the agent's words are read out, the person
-            // answers by voice, and the answer goes nowhere - because voice cannot pick an option yet. So the
-            // live screen is read once here (pure classifier, NO model call) and the fact is spoken with the
-            // turn, before they try to reply. One extra tunnel read per NARRATION - deliberately not added to
-            // the session poll, so this costs nothing per-poll across a fleet.
+            // answers by voice, and the answer goes nowhere - because voice cannot pick an option yet.
+            // The verdict is the MODEL's, from the same call that wrote the summary (issue
+            // devthrottle_internal#1195) - the pure classifier declared a finished summary to be a menu
+            // (session 115), so it no longer announces on its own. The verdict is cached against the screen
+            // fingerprint it judged, which is what lets the send-time guards answer an unchanged screen
+            // without a second model call. No verdict (no readable screen, or a garbled SCREEN line) means
+            // no announcement - the fail-safe direction for a spoken claim.
             var spoken = t.Spoken;
-            if (await WaitingScreenReader.IsMenuAsync(route, sid, ct))
+            if (t.Screen is not null && screenGrid?.Rows is { Count: > 0 } judgedRows)
+                WingmanScreenVerdictCache.Store($"{tenant}/{sid}", WingmanScreenVerdictCache.HashRows(judgedRows), t.Screen.Needs);
+            if (t.Screen?.Needs == "menu")
             {
                 spoken += Speech.SpokenPhrases.WaitingScreenMenuNarrationSuffix.In(_tenantSettings.SpokenLanguage(tenant));
-                FileLog.Write($"[WingmanVoiceService] narration announces a waiting menu: sid={sid}");
+                FileLog.Write($"[WingmanVoiceService] narration announces a waiting menu (model verdict): sid={sid}");
             }
             await StoreSpokenAsync(tenant, sid, spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the


### PR DESCRIPTION
The waiting-screen classifier falsely reported a menu on summary screens - a numbered list in the agent's finishing reply plus a stale composer glyph satisfied the marker+options rules, which refused voice replies and announced a menu that was not there.

- The composer detector now recognizes the real U+276F prompt glyph (only '>' before), so the ambiguity rule can actually fire on real screens.
- A menu now requires a contiguous option block with the drawn marker inside it; prose-separated numbered lines never count as one menu.
- The per-turn wingman narration call receives the live screen grid and returns a one-line SCREEN JSON verdict (needs: menu | answer | nothing) after the spoken markers; the spoken contract is unchanged.
- Every surface that blocks on a menu (prompt menu guard, voice-turn, waiting-screen endpoint, narration suffix) acts on the model's verdict, served from a per-screen fingerprint cache; the regex only trips the question and fails closed when the model is unreachable.
- New tests cover the misfire shape, the composer glyph, block contiguity, verdict parsing and the cache; an optional WINGMAN_GOLDENS_DIR hook validates against a private goldens corpus.

Ref: devthrottle_internal#1195