### PR TITLE
release: v1.9.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.2</Version>
+    <Version>1.9.3</Version>
   </PropertyGroup>
 
   <!--

--- a/docs/public/release-notes/v1.9.3.md
+++ b/docs/public/release-notes/v1.9.3.md
@@ -1,0 +1,41 @@
+## v1.9.3 - July 31, 2026
+
+**Nothing in the app has changed since v1.9.2.** If you are running v1.9.2 there is no reason to
+update, and nothing here will look different.
+
+This release exists to prove a change to how DevThrottle is delivered to you, and it is published
+rather than kept private because the only honest way to test a release pipeline is to run one.
+
+### Where the download comes from
+
+Until now the download link on devthrottle.com pointed into GitHub's release storage. That link
+looked permanent but was not: it redirected twice, and the address your browser finally fetched from
+carried a one-time signature and a fresh identifier for every single release - and, in fact, for
+every request. No two people downloading the same installer were ever getting it from the same
+address.
+
+The installers now come from one fixed address that never changes:
+
+```
+https://devthrottle.blob.core.windows.net/download/
+```
+
+Alongside them sits `release-manifest.json`, which always describes what is currently there - the
+version, the size, and the SHA-256 of every file. Anything that needs to know what the current
+download is can read that one file rather than guessing from a URL.
+
+**Why bother.** Windows decides how much to trust a download partly by how many people have
+fetched that file before. A link that changes every time gives it nothing to accumulate against.
+This does not make the first-download warning disappear - nothing we can buy does that, and we
+looked - but it is the one thing under our control that makes accumulating possible at all. It is
+also a prerequisite for ever offering DevThrottle through package managers, which need a stable,
+direct address.
+
+Everything published before this release remains on GitHub exactly where it was. That is still the
+archive; nothing has been moved or removed.
+
+### Verified rather than assumed
+
+The release pipeline now fetches the installer back from that public address after publishing and
+checks its SHA-256 against the manifest. If the address is not serving the build that was just
+released, the release fails loudly instead of quietly appearing to succeed.


### PR DESCRIPTION
Version bump and release notes for v1.9.3.

No product changes since v1.9.2 - everything merged since is release tooling. **This release exists to prove the download pipeline end to end.**

The mirror step was rewritten to publish to `devthrottle.blob.core.windows.net/download/` with no prefix, but no release has run since that change: the files currently at that address were copied there by hand during the rename. This release is the first to exercise the workflow as configured, and its own verification step (fetch the installer back from the public address, compare SHA-256 to the manifest) either confirms it or fails the release.

The tag is created only after this merges, so it cannot point at a commit that is not on main.