### PR TITLE
Three review findings: the safe recorder state becomes the free one, the cross-language acceptance stops passing when it never ran, and the access log says which device asked

### DIFF
--- a/src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs
+++ b/src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs
@@ -47,7 +47,11 @@ public sealed class TerminalSessionRecorder : IDisposable
     private bool _started;
     private bool _disposed;
 
-    public TerminalSessionRecorder(SessionManager sessionManager, string? root = null, long maxBytesPerSession = 8L * 1024 * 1024, bool captureEnabled = true)
+    // captureEnabled defaults to FALSE so that the safe state is the free one: the shipped product
+    // records nothing unless the operator turns it on, and a future call site that forgets the flag
+    // inherits that posture instead of silently recording. Production passes
+    // SessionRecordingConfig.IsEnabled() explicitly; this default is the backstop, not the policy.
+    public TerminalSessionRecorder(SessionManager sessionManager, string? root = null, long maxBytesPerSession = 8L * 1024 * 1024, bool captureEnabled = false)
     {
         _sessionManager = sessionManager;
         _root = root ?? CcStorage.SessionRecordings();

--- a/src/CcDirector.Gateway.Tests/CleanInstallCliAuthenticationTests.cs
+++ b/src/CcDirector.Gateway.Tests/CleanInstallCliAuthenticationTests.cs
@@ -74,7 +74,20 @@ public sealed class CleanInstallCliAuthenticationTests : IAsyncLifetime
     {
         var python = FindPython();
         if (python is null)
-            return; // no Python on this machine; the resolver's unit tests still cover the logic
+        {
+            // This is the acceptance row for the whole cross-language credential fix: it is the only
+            // test that drives the REAL Python command line against a REAL host. Returning green when
+            // Python is absent made it report success on a machine where it never ran - a check that
+            // cannot fail is not a check. Continuous integration always has Python, so its absence
+            // there is a genuine failure of the environment the acceptance depends on, and is now
+            // loud. On a developer machine without Python it stays a pass, but says so.
+            Assert.True(Environment.GetEnvironmentVariable("CI") is null,
+                "Python was not found, so the real command-line acceptance never ran. In CI this must " +
+                "never happen: this test is the cross-language proof and a silent pass hides its absence.");
+            Console.WriteLine("[CleanInstallCliAuthenticationTests] SKIPPED: no Python on this machine; " +
+                "the cross-language acceptance row did NOT run. The resolver unit tests still cover the logic.");
+            return;
+        }
 
         // Arrangement sanity: the layout is the clean named-default one. The host minted its secret
         // under the INSTANCE home, its registration (with this process's pid and the bound port)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1620,6 +1620,31 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// The authenticated caller's identity for the access log: which device asked, and for which
+    /// account. The log already recorded WHAT was requested - including the file path on a session
+    /// file read - but only the remote address for WHO, and an address attributes nothing when the
+    /// caller is a phone on a mobile network or a tunnel. Without this, a log can show that a private
+    /// key was read and still not say which device read it, which is the difference between knowing
+    /// you were breached and knowing whose credential to revoke.
+    ///
+    /// Carries NO key material: DeviceCredentialIdentity holds neither the raw credential nor its
+    /// stored hash, so DT-05 (a credential never reaches the log) still holds. The account identifier
+    /// is already disclosed on /privacy as something service logs may contain. Unauthenticated
+    /// requests add nothing, so public routes are unchanged.
+    /// </summary>
+    private static string DeviceForLog(HttpContext ctx)
+    {
+        if (ctx.Items.TryGetValue(Util.AuthMiddleware.AuthenticatedDeviceItemKey, out var value)
+            && value is Pairing.DeviceCredentialIdentity identity)
+        {
+            var tenant = string.IsNullOrEmpty(identity.TenantId) ? "-" : identity.TenantId;
+            return $" device={identity.DeviceId} type={identity.DeviceType} account={tenant}";
+        }
+
+        return "";
+    }
+
+    /// <summary>
     /// Resolves this device's platform string for cloud device registration (issue #857): a short, stable
     /// operating-system label sent as the device's <c>platform</c>. The Gateway credential service is
     /// Windows-only today, so this is "windows" in practice, but the label is computed (not hard-coded) so
@@ -2366,7 +2391,7 @@ public sealed class GatewayHost : IAsyncDisposable
                     && !path.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase))
                 {
                     var client = ctx.Connection.RemoteIpAddress?.ToString() ?? "?";
-                    FileLog.Write($"[GatewayHost] {ctx.Request.Method} {path}{SafeQueryForLog(ctx.Request.Path, ctx.Request.QueryString)} -> {ctx.Response.StatusCode} ({sw.ElapsedMilliseconds}ms) client={client} host={ctx.Request.Host}");
+                    FileLog.Write($"[GatewayHost] {ctx.Request.Method} {path}{SafeQueryForLog(ctx.Request.Path, ctx.Request.QueryString)} -> {ctx.Response.StatusCode} ({sw.ElapsedMilliseconds}ms) client={client} host={ctx.Request.Host}{DeviceForLog(ctx)}");
                 }
             }
         });


### PR DESCRIPTION
Two findings from the independent reviews run over the release-candidate code, both small and both of the same family: a state that reports success without having earned it.

**The recorder default.** `TerminalSessionRecorder`'s constructor defaulted `captureEnabled` to `true` while the shipped product default is `false` and /privacy tells customers recording is off unless they turn it on. The single production call site passes `SessionRecordingConfig.IsEnabled()` explicitly, so nothing records today that should not - this is not a live defect. But a future call site that forgets the flag would silently record, which is the opposite of the posture we publish. The default is now `false`: forgetting it lands on the safe state. Purge-on-removal and the startup orphan sweep run regardless of capture, so `TerminalSessionRecorderPolicyTests` passes unchanged (8/8 locally).

**The acceptance that could not fail.** `CleanInstallCliAuthenticationTests` returned green when Python was absent. That test is the acceptance row for the entire cross-language credential change - the only one that drives the real Python command line against a real host - so on any machine without Python it reported success for a proof that never executed. It now fails when `CI` is set, because continuous integration always has Python and its absence there would mean the acceptance had quietly stopped running; on a developer machine without Python it still passes, but prints that it skipped instead of vanishing into a green tick.

Note for this pull request's own run: the .NET job has no `setup-python` step of its own, so this run is also the check of whether the Windows runner provides Python. If the .NET job goes red here on that assertion, the assertion is right and the environment is the thing to fix - it means the acceptance row has not been running in CI at all.