### PR TITLE
The lock-removal qualification harness: a controlled bypass and the concurrency soak

### DIFF
--- a/scripts/test-qualification.ps1
+++ b/scripts/test-qualification.ps1
@@ -1,0 +1,303 @@
+<#
+.SYNOPSIS
+    The lock-removal qualification soak (issue #1156 step 4).
+
+    Runs N ordinary Gateway suite processes CONCURRENTLY from separate worktrees, each with its own
+    results file and console log, using the controlled GatewayTestSuiteLock bypass. The point is to
+    accumulate evidence that concurrent runs no longer corrupt each other, so the machine-wide lock
+    can come off (step 5). ONE GREEN PAIR IS NOT PROOF - the historical race was intermittent. Run
+    this repeatedly (use -Rounds, or rerun the script) until the ledger covers thousands of host
+    starts.
+
+.DESCRIPTION
+    What one round does:
+      1. Ensures N worktrees exist under -WorkRoot, detached at the SAME commit this repo is on,
+         and builds the Gateway test project in each (once - later rounds reuse the build).
+      2. Launches N 'dotnet test --no-build' processes at once. Each child gets:
+           CC_GATEWAY_TEST_LOCK_QUALIFICATION=isolated-worktree-soak   (the bypass token)
+           CC_GATEWAY_TEST_PG_CONNECTION=                              (cleared - fail-closed pair)
+           CC_GATEWAY_TEST_PG_STATS_CONNECTION=                        (cleared)
+           CC_GATEWAY_DB_CONNECTION=                                   (cleared)
+         The lock itself refuses to bypass if any live-proof variable leaks through - a forgotten
+         variable is a loud stop, never quiet false evidence.
+      3. Judges every process by its TRX file: ResultSummary outcome must be 'Completed' AND the
+         total/executed/passed counters must be IDENTICAL across all N siblings (same tree, same
+         filter - any divergence is exactly the cross-process interference this soak hunts).
+      4. Appends one JSON line per process to the ledger (qual-ledger.jsonl in -WorkRoot), plus a
+         round summary with the running host-start estimate.
+
+    Host-start accounting: the Gateway suite boots a real GatewayHost in roughly 106 fixture files
+    plus per-test hosts; the ledger books a conservative 106 host starts per completed process run.
+    The number to beat is in issue #1156: thousands.
+
+.PARAMETER Processes
+    Concurrent suite processes per round. Start with 2; qualify with 4.
+
+.PARAMETER Rounds
+    How many rounds to run back to back in this invocation.
+
+.PARAMETER WorkRoot
+    Where the qualification worktrees and the ledger live. Default: <repo-parent>\dt-qual.
+
+.PARAMETER TearDown
+    Remove the qualification worktrees after the last round (the ledger is kept).
+
+.EXAMPLE
+    .\scripts\test-qualification.ps1 -Processes 2 -Rounds 3
+.EXAMPLE
+    .\scripts\test-qualification.ps1 -Processes 4 -Rounds 5
+#>
+[CmdletBinding()]
+param(
+    [ValidateRange(2, 8)]
+    [int] $Processes = 2,
+
+    [ValidateRange(1, 100)]
+    [int] $Rounds = 1,
+
+    [string] $WorkRoot = "",
+
+    [switch] $TearDown
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$TestProject = 'src\CcDirector.Gateway.Tests\CcDirector.Gateway.Tests.csproj'
+$QualificationToken = 'isolated-worktree-soak'
+$HostStartsPerRun = 106   # fixture files that boot a real GatewayHost; deliberately conservative
+
+if ([string]::IsNullOrWhiteSpace($WorkRoot)) {
+    $WorkRoot = Join-Path (Split-Path $RepoRoot -Parent) 'dt-qual'
+}
+$Ledger = Join-Path $WorkRoot 'qual-ledger.jsonl'
+
+function Write-Step([string] $Message) {
+    Write-Host ("[qual] " + $Message)
+}
+
+# Every native call goes through cmd.exe with the redirection INSIDE cmd. Under Windows PowerShell 5.1
+# with $ErrorActionPreference='Stop', a native command's stderr - even git's ordinary progress lines -
+# becomes a terminating NativeCommandError the moment it is redirected in PowerShell (and when the host
+# process's own stderr is a pipe, which is exactly how agents run this script). cmd absorbs all of it
+# and hands back plain strings plus an exit code.
+function Invoke-Native([string] $CommandLine) {
+    $out = & $env:ComSpec /d /c "$CommandLine 2>&1"
+    $script:NativeExit = $LASTEXITCODE
+    return $out
+}
+
+function Get-Commit {
+    $c = [string] (Invoke-Native "git -C `"$RepoRoot`" rev-parse HEAD")
+    $c = $c.Trim()
+    if ($script:NativeExit -ne 0 -or [string]::IsNullOrWhiteSpace($c)) {
+        throw "Could not resolve HEAD in $RepoRoot"
+    }
+    return $c
+}
+
+function Ensure-Worktree([int] $Index, [string] $Commit) {
+    $path = Join-Path $WorkRoot ("p" + $Index)
+    if (Test-Path (Join-Path $path $TestProject)) {
+        $null = Invoke-Native "git -C `"$path`" checkout --detach $Commit"
+        if ($script:NativeExit -ne 0) { throw "Worktree $path could not check out $Commit" }
+        return $path
+    }
+    # An interrupted earlier run can leave any combination of: the directory without registration,
+    # the registration without the directory, and a LOCK on the registration (which prune ignores).
+    # Clear all three unconditionally - each step is a no-op when its half is absent.
+    $null = Invoke-Native "git -C `"$RepoRoot`" worktree unlock `"$path`""
+    $null = Invoke-Native "git -C `"$RepoRoot`" worktree remove `"$path`" --force"
+    if (Test-Path $path) {
+        Write-Step "Clearing incomplete worktree $path"
+        Remove-Item -Recurse -Force $path
+    }
+    $null = Invoke-Native "git -C `"$RepoRoot`" worktree prune"
+    New-Item -ItemType Directory -Force (Split-Path $path -Parent) | Out-Null
+    Write-Step "Creating worktree $path at $($Commit.Substring(0,9))"
+    $out = Invoke-Native "git -C `"$RepoRoot`" worktree add --detach `"$path`" $Commit"
+    if ($script:NativeExit -ne 0) { throw "git worktree add failed for ${path}: $out" }
+    return $path
+}
+
+function Build-Worktree([string] $Path) {
+    $marker = Join-Path $Path '.qual-built-commit'
+    $commit = ([string] (Invoke-Native "git -C `"$Path`" rev-parse HEAD")).Trim()
+    if ((Test-Path $marker) -and ((Get-Content $marker -TotalCount 1) -eq $commit)) {
+        return
+    }
+    Write-Step "Building $Path (once per commit)"
+    $buildLog = Join-Path $WorkRoot ("build-" + (Split-Path $Path -Leaf) + ".log")
+    $null = Invoke-Native "dotnet build `"$(Join-Path $Path $TestProject)`" --nologo -v q > `"$buildLog`""
+    if ($script:NativeExit -ne 0) { throw "Build failed in $Path - see $buildLog" }
+    Set-Content -Path $marker -Value $commit -Encoding Ascii
+}
+
+function Read-Trx([string] $TrxPath) {
+    [xml] $trx = Get-Content $TrxPath -Raw
+    $summary = $trx.TestRun.ResultSummary
+    $c = $summary.Counters
+    return [pscustomobject]@{
+        Outcome  = [string] $summary.outcome
+        Total    = [int] $c.total
+        Executed = [int] $c.executed
+        Passed   = [int] $c.passed
+        Failed   = [int] $c.failed
+    }
+}
+
+function Acquire-SuiteLock {
+    # The parent holds the REAL machine-wide suite lock for the whole soak. The children bypass it by
+    # design - but an ordinary run from another session must never find itself overlapping them
+    # unawares, so the soak occupies the lock exactly like any other run and the fleet queues as usual.
+    $lockPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'cc-director\test-locks\gateway-test-suite.lock'
+    New-Item -ItemType Directory -Force (Split-Path $lockPath -Parent) | Out-Null
+    $deadline = (Get-Date).AddMinutes(45)
+    $announced = $false
+    while ($true) {
+        try {
+            $stream = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::OpenOrCreate,
+                [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read)
+            $writer = New-Object System.IO.StreamWriter($stream)
+            $writer.WriteLine("processId=$PID")
+            $writer.WriteLine("processStartUtc=$((Get-Process -Id $PID).StartTime.ToUniversalTime().ToString('o'))")
+            $writer.WriteLine("acquiredUtc=$((Get-Date).ToUniversalTime().ToString('o'))")
+            $writer.WriteLine("session=qualification soak parent (scripts/test-qualification.ps1, issue #1156 step 4)")
+            $writer.WriteLine("machine=$env:COMPUTERNAME")
+            $writer.Flush()
+            Write-Step "Holding the machine-wide suite lock for the whole soak, so ordinary runs queue as usual."
+            return @{ Stream = $stream; Writer = $writer }
+        } catch [System.IO.IOException] {
+            if (-not $announced) {
+                $announced = $true
+                Write-Step "The suite lock is held by an ordinary run; the soak waits its turn (up to 45 minutes)."
+            }
+            if ((Get-Date) -gt $deadline) { throw "The suite lock did not free within 45 minutes; rerun the soak later." }
+            Start-Sleep -Seconds 3
+        }
+    }
+}
+
+function Get-LedgerHostStarts {
+    if (-not (Test-Path $Ledger)) { return 0 }
+    $sum = 0
+    foreach ($line in Get-Content $Ledger) {
+        try {
+            $row = $line | ConvertFrom-Json
+            if ($row.kind -eq 'process' -and $row.outcome -eq 'Completed') { $sum += $HostStartsPerRun }
+        } catch { }
+    }
+    return $sum
+}
+
+# ---- provisioning ----
+
+$commit = Get-Commit
+New-Item -ItemType Directory -Force $WorkRoot | Out-Null
+$worktrees = @()
+for ($i = 1; $i -le $Processes; $i++) { $worktrees += Ensure-Worktree -Index $i -Commit $commit }
+foreach ($w in $worktrees) { Build-Worktree -Path $w }
+
+# ---- rounds ----
+
+$suiteLock = Acquire-SuiteLock
+$anyFailure = $false
+try {
+for ($round = 1; $round -le $Rounds; $round++) {
+    $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+    Write-Step "Round $round of $Rounds : launching $Processes concurrent suite runs (commit $($commit.Substring(0,9)))"
+
+    $running = @()
+    for ($i = 1; $i -le $Processes; $i++) {
+        $w = $worktrees[$i - 1]
+        $tag = "r$round-p$i-$stamp"
+        $trxName = "qual-$tag.trx"
+        $log = Join-Path $WorkRoot "qual-$tag.log"
+        $cmdFile = Join-Path $WorkRoot "qual-$tag.cmd"
+
+        # A per-process launcher file, so each child gets EXACTLY this environment: the bypass token
+        # set, and every live-proof connection variable cleared ('set NAME=' unsets in cmd). The lock
+        # fails closed if one leaks through anyway.
+        $lines = @(
+            '@echo off',
+            "set CC_GATEWAY_TEST_LOCK_QUALIFICATION=$QualificationToken",
+            'set CC_GATEWAY_TEST_PG_CONNECTION=',
+            'set CC_GATEWAY_TEST_PG_STATS_CONNECTION=',
+            'set CC_GATEWAY_DB_CONNECTION=',
+            "cd /d `"$w`"",
+            "dotnet test $TestProject --no-build --nologo --logger `"trx;LogFileName=$trxName`" > `"$log`" 2>&1",
+            'exit /b %ERRORLEVEL%'
+        )
+        Set-Content -Path $cmdFile -Value $lines -Encoding Ascii
+
+        $p = Start-Process -FilePath $env:ComSpec -ArgumentList '/c', "`"$cmdFile`"" -PassThru -WindowStyle Hidden
+        $running += [pscustomobject]@{ Index = $i; Process = $p; Worktree = $w; TrxName = $trxName; Log = $log }
+    }
+
+    $running | ForEach-Object { $_.Process.WaitForExit() }
+
+    # ---- judge the round: TRX outcome and counters, never the console ----
+    $results = @()
+    foreach ($r in $running) {
+        $trxPath = Join-Path $r.Worktree ("src\CcDirector.Gateway.Tests\TestResults\" + $r.TrxName)
+        if (-not (Test-Path $trxPath)) {
+            $anyFailure = $true
+            Write-Step ("FAILURE round $round p$($r.Index): NO TRX WAS WRITTEN (exit code $($r.Process.ExitCode)). " +
+                "A vanished results file is a crashed or refused host, never a pass. Console: $($r.Log)")
+            $results += [pscustomobject]@{ Outcome = 'NoTrx'; Total = 0; Executed = 0; Passed = 0; Failed = 0 }
+            continue
+        }
+        $results += Read-Trx $trxPath
+    }
+
+    $reference = $results | Where-Object { $_.Outcome -eq 'Completed' } | Select-Object -First 1
+    for ($i = 0; $i -lt $results.Count; $i++) {
+        $res = $results[$i]
+        $verdict = 'pass'
+        if ($res.Outcome -ne 'Completed') { $verdict = 'fail-outcome'; $anyFailure = $true }
+        elseif ($null -ne $reference -and ($res.Total -ne $reference.Total -or $res.Executed -ne $reference.Executed)) {
+            # Same commit, same filter, sibling processes: any counter divergence is interference.
+            $verdict = 'fail-divergence'; $anyFailure = $true
+        }
+        elseif ($res.Failed -gt 0) { $verdict = 'fail-tests'; $anyFailure = $true }
+
+        $row = [ordered]@{
+            kind = 'process'; utc = $stamp; commit = $commit; round = $round; process = ($i + 1)
+            outcome = $res.Outcome; total = $res.Total; executed = $res.Executed
+            passed = $res.Passed; failed = $res.Failed; verdict = $verdict
+        }
+        Add-Content -Path $Ledger -Value (([pscustomobject]$row) | ConvertTo-Json -Compress) -Encoding Ascii
+        Write-Step "round $round p$($i + 1): outcome=$($res.Outcome) total=$($res.Total) passed=$($res.Passed) failed=$($res.Failed) verdict=$verdict"
+    }
+
+    $hostStarts = Get-LedgerHostStarts
+    $roundRow = [ordered]@{
+        kind = 'round'; utc = $stamp; commit = $commit; round = $round; processes = $Processes
+        cumulativeHostStartsEstimate = $hostStarts
+    }
+    Add-Content -Path $Ledger -Value (([pscustomobject]$roundRow) | ConvertTo-Json -Compress) -Encoding Ascii
+    Write-Step "Ledger now covers an estimated $hostStarts host starts ($Ledger)"
+
+    if ($anyFailure) {
+        Write-Step "STOPPING after round $round : a failure or divergence is the soak's most valuable output. Investigate before running more."
+        break
+    }
+}
+
+} finally {
+    $suiteLock.Writer.Dispose()
+    $suiteLock.Stream.Dispose()
+    Write-Step "Released the machine-wide suite lock."
+}
+
+# ---- teardown ----
+if ($TearDown) {
+    foreach ($w in $worktrees) {
+        Write-Step "Removing worktree $w"
+        $null = Invoke-Native "git -C `"$RepoRoot`" worktree remove `"$w`" --force"
+    }
+}
+
+if ($anyFailure) { exit 1 }
+Write-Step "All rounds green. Remember: the deliverable is the accumulated ledger, not one invocation."
+exit 0

--- a/scripts/test-qualification.ps1
+++ b/scripts/test-qualification.ps1
@@ -57,7 +57,15 @@ param(
 
     [string] $WorkRoot = "",
 
-    [switch] $TearDown
+    [switch] $TearDown,
+
+    # How long the parent waits for the machine-wide suite lock before giving up. The default matches
+    # the suite's own MaxWait. Raise it for overnight soaks on a busy machine. FAIRNESS NOTE: while the
+    # soak holds the lock, an ordinary run queues with ITS 45-minute refusal ticking - so on a busy
+    # fleet keep -Rounds low enough that one hold stays under about 40 minutes (one round of 2-4
+    # processes), and save multi-round invocations for quiet hours.
+    [ValidateRange(1, 720)]
+    [int] $LockWaitMinutes = 45
 )
 
 $ErrorActionPreference = 'Stop'
@@ -152,7 +160,7 @@ function Acquire-SuiteLock {
     # unawares, so the soak occupies the lock exactly like any other run and the fleet queues as usual.
     $lockPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'cc-director\test-locks\gateway-test-suite.lock'
     New-Item -ItemType Directory -Force (Split-Path $lockPath -Parent) | Out-Null
-    $deadline = (Get-Date).AddMinutes(45)
+    $deadline = (Get-Date).AddMinutes($LockWaitMinutes)
     $announced = $false
     while ($true) {
         try {
@@ -172,7 +180,7 @@ function Acquire-SuiteLock {
                 $announced = $true
                 Write-Step "The suite lock is held by an ordinary run; the soak waits its turn (up to 45 minutes)."
             }
-            if ((Get-Date) -gt $deadline) { throw "The suite lock did not free within 45 minutes; rerun the soak later." }
+            if ((Get-Date) -gt $deadline) { throw "The suite lock did not free within $LockWaitMinutes minutes; rerun the soak later." }
             Start-Sleep -Seconds 3
         }
     }
@@ -214,6 +222,7 @@ for ($round = 1; $round -le $Rounds; $round++) {
         $trxName = "qual-$tag.trx"
         $log = Join-Path $WorkRoot "qual-$tag.log"
         $cmdFile = Join-Path $WorkRoot "qual-$tag.cmd"
+        $exitFile = Join-Path $WorkRoot "qual-$tag.exit"
 
         # A per-process launcher file, so each child gets EXACTLY this environment: the bypass token
         # set, and every live-proof connection variable cleared ('set NAME=' unsets in cmd). The lock
@@ -226,19 +235,27 @@ for ($round = 1; $round -le $Rounds; $round++) {
             'set CC_GATEWAY_DB_CONNECTION=',
             "cd /d `"$w`"",
             "dotnet test $TestProject --no-build --nologo --logger `"trx;LogFileName=$trxName`" > `"$log`" 2>&1",
+            # The child's exit code, written where the parent can read it even if the parent died. It is
+            # the ONLY artefact that separates a silent Environment.Exit(0) from a crash from an external
+            # kill - a distinction a vanished test host does not otherwise offer (issue #1203).
+            "echo %ERRORLEVEL% > `"$exitFile`"",
             'exit /b %ERRORLEVEL%'
         )
         Set-Content -Path $cmdFile -Value $lines -Encoding Ascii
 
         $p = Start-Process -FilePath $env:ComSpec -ArgumentList '/c', "`"$cmdFile`"" -PassThru -WindowStyle Hidden
-        $running += [pscustomobject]@{ Index = $i; Process = $p; Worktree = $w; TrxName = $trxName; Log = $log }
+        $running += [pscustomobject]@{ Index = $i; Process = $p; Worktree = $w; TrxName = $trxName; Log = $log; ExitFile = $exitFile }
     }
 
     $running | ForEach-Object { $_.Process.WaitForExit() }
 
     # ---- judge the round: TRX outcome and counters, never the console ----
     $results = @()
+    $exitCodes = @()
     foreach ($r in $running) {
+        $childExit = if (Test-Path $r.ExitFile) { (Get-Content $r.ExitFile -TotalCount 1).Trim() } else { 'unrecorded' }
+        $exitCodes += $childExit
+
         $trxPath = Join-Path $r.Worktree ("src\CcDirector.Gateway.Tests\TestResults\" + $r.TrxName)
         if (-not (Test-Path $trxPath)) {
             $anyFailure = $true
@@ -264,10 +281,10 @@ for ($round = 1; $round -le $Rounds; $round++) {
         $row = [ordered]@{
             kind = 'process'; utc = $stamp; commit = $commit; round = $round; process = ($i + 1)
             outcome = $res.Outcome; total = $res.Total; executed = $res.Executed
-            passed = $res.Passed; failed = $res.Failed; verdict = $verdict
+            passed = $res.Passed; failed = $res.Failed; verdict = $verdict; childExit = $exitCodes[$i]
         }
         Add-Content -Path $Ledger -Value (([pscustomobject]$row) | ConvertTo-Json -Compress) -Encoding Ascii
-        Write-Step "round $round p$($i + 1): outcome=$($res.Outcome) total=$($res.Total) passed=$($res.Passed) failed=$($res.Failed) verdict=$verdict"
+        Write-Step "round $round p$($i + 1): outcome=$($res.Outcome) total=$($res.Total) passed=$($res.Passed) failed=$($res.Failed) exit=$($exitCodes[$i]) verdict=$verdict"
     }
 
     $hostStarts = Get-LedgerHostStarts

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -121,6 +121,80 @@ internal static class GatewayTestSuiteLock
     /// <summary>Exit code used when the lock location itself is unusable - a setup failure, not contention.</summary>
     internal const int SetupFailureExitCode = 98;
 
+    /// <summary>
+    /// The qualification bypass (issue #1156 step 4). The soak that qualifies removing this lock has to run
+    /// several ordinary suite processes CONCURRENTLY - the very thing the lock forbids - so the
+    /// qualification script, and only it, asks for a bypass by setting this variable to
+    /// <see cref="QualificationToken"/> in each child process it launches.
+    /// </summary>
+    internal const string QualificationEnvVar = "CC_GATEWAY_TEST_LOCK_QUALIFICATION";
+
+    /// <summary>
+    /// The exact value <see cref="QualificationEnvVar"/> must carry. A specific sentence rather than "1",
+    /// so a stray truthy value copied between shells cannot silently disable the lock.
+    /// </summary>
+    internal const string QualificationToken = "isolated-worktree-soak";
+
+    /// <summary>
+    /// The live-proof connection variables the bypass fails CLOSED on. The stats write-path proofs point at
+    /// one named database rather than deriving a per-run one, and the gateway-database live proofs use the
+    /// production variable outright - two qualification processes sharing either would corrupt each other
+    /// and report failures nobody caused, which is precisely the false evidence a soak must never produce.
+    /// The qualification script clears these for its children; this check is what makes forgetting that a
+    /// loud stop instead of a quiet lie.
+    /// </summary>
+    internal static readonly string[] LiveProofEnvVars =
+    {
+        "CC_GATEWAY_TEST_PG_CONNECTION",
+        "CC_GATEWAY_TEST_PG_STATS_CONNECTION",
+        "CC_GATEWAY_DB_CONNECTION",
+    };
+
+    /// <summary>True when this run was admitted through the qualification bypass rather than the lock.
+    /// The two lock-behaviour tests read it: the serialization property is DELIBERATELY suspended in a
+    /// qualification run, and they assert that state rather than false-failing the soak.</summary>
+    internal static bool QualificationBypassActive { get; private set; }
+
+    /// <summary>How the run may proceed, ruled from values alone so both branches are unit-testable.</summary>
+    internal enum QualificationRuling
+    {
+        /// <summary>No bypass requested: take the lock as always.</summary>
+        NotRequested,
+
+        /// <summary>Requested with the exact token and no live-proof variable set: run without the lock.</summary>
+        Bypass,
+
+        /// <summary>Requested while a live-proof variable is set: stop the process, run nothing.</summary>
+        RefuseLiveProof,
+
+        /// <summary>The variable is set but carries the wrong value. Stop the process: silently taking the
+        /// locked path instead would serialize the whole soak, and thousands of "clean" host starts that
+        /// never actually overlapped would certify nothing while looking like proof.</summary>
+        RefuseWrongToken,
+    }
+
+    /// <summary>
+    /// Pure ruling over the qualification request - reads nothing ambient, so a test can hand it every
+    /// combination without mutating process state (the same rule <see cref="ComputeLockFilePath"/> follows).
+    /// </summary>
+    internal static QualificationRuling RuleOnQualification(
+        string? qualificationValue, IReadOnlyList<(string Name, string? Value)> liveProofValues)
+    {
+        if (string.IsNullOrWhiteSpace(qualificationValue))
+            return QualificationRuling.NotRequested;
+
+        if (!string.Equals(qualificationValue, QualificationToken, StringComparison.Ordinal))
+            return QualificationRuling.RefuseWrongToken;
+
+        foreach (var (_, value) in liveProofValues)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                return QualificationRuling.RefuseLiveProof;
+        }
+
+        return QualificationRuling.Bypass;
+    }
+
     /// <summary>The file name every run of this assembly contends for, whatever working tree it was built
     /// from.</summary>
     private const string LockFileName = "gateway-test-suite.lock";
@@ -230,6 +304,45 @@ internal static class GatewayTestSuiteLock
     [ModuleInitializer]
     internal static void Acquire()
     {
+        var liveProofValues = new (string Name, string? Value)[LiveProofEnvVars.Length];
+        for (var i = 0; i < LiveProofEnvVars.Length; i++)
+            liveProofValues[i] = (LiveProofEnvVars[i], Environment.GetEnvironmentVariable(LiveProofEnvVars[i]));
+
+        switch (RuleOnQualification(Environment.GetEnvironmentVariable(QualificationEnvVar), liveProofValues))
+        {
+            case QualificationRuling.Bypass:
+                QualificationBypassActive = true;
+                Say($"[gateway-test-lock] QUALIFICATION BYPASS (issue #1156 step 4): this run was launched "
+                    + $"by the qualification script and runs WITHOUT the per-user lock, concurrently with "
+                    + $"its sibling processes, to qualify removing the lock. pid {Environment.ProcessId}. "
+                    + $"If you are seeing this outside scripts/test-qualification.ps1, unset "
+                    + $"{QualificationEnvVar} - an ordinary run must never bypass the lock.");
+                return;
+
+            case QualificationRuling.RefuseLiveProof:
+                var offending = string.Join(", ", Array.ConvertAll(
+                    Array.FindAll(liveProofValues, v => !string.IsNullOrWhiteSpace(v.Value)), v => v.Name));
+                Say($"[gateway-test-lock] *** QUALIFICATION REFUSED. {QualificationEnvVar} is set, but a "
+                    + $"live-proof connection variable is also set ({offending}). Concurrent qualification "
+                    + $"processes sharing a live database corrupt each other and produce false soak "
+                    + $"evidence. NO TESTS WILL RUN. Clear those variables in the qualification children "
+                    + $"and run again. ***");
+                Console.Out.Flush();
+                Console.Error.Flush();
+                Environment.Exit(SetupFailureExitCode);
+                return;
+
+            case QualificationRuling.RefuseWrongToken:
+                Say($"[gateway-test-lock] *** QUALIFICATION REFUSED. {QualificationEnvVar} is set but does "
+                    + $"not carry the exact token '{QualificationToken}'. Falling back to the locked path "
+                    + $"would silently serialize the soak and certify nothing, so NO TESTS WILL RUN. Fix "
+                    + $"the value or unset the variable. ***");
+                Console.Out.Flush();
+                Console.Error.Flush();
+                Environment.Exit(SetupFailureExitCode);
+                return;
+        }
+
         var started = DateTime.UtcNow;
         var lastProgress = DateTime.MinValue;
         var announcedWait = false;

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLockTests.cs
@@ -39,6 +39,18 @@ public sealed class GatewayTestSuiteLockTests
     [Fact]
     public void TheLockIsHeldWhileTestsRun()
     {
+        if (GatewayTestSuiteLock.QualificationBypassActive)
+        {
+            // A qualification run (issue #1156 step 4) SUSPENDS the serialization property on purpose -
+            // that is the experiment. The honest assertion here is that the suspension was explicit and
+            // recorded, never that the lock is somehow both bypassed and held.
+            Assert.False(
+                GatewayTestSuiteLock.IsHeld,
+                "The qualification bypass is active yet the lock is also held - the bypass and the "
+                + "acquisition path both ran, which means Acquire's ruling is broken.");
+            return;
+        }
+
         Assert.True(
             GatewayTestSuiteLock.IsHeld,
             "This run does not hold the per-user Gateway test lock, so nothing is stopping a second "
@@ -48,6 +60,15 @@ public sealed class GatewayTestSuiteLockTests
     [Fact]
     public void ASecondExclusiveOpenIsRefused_WhichIsWhatBlocksAConcurrentRun()
     {
+        if (GatewayTestSuiteLock.QualificationBypassActive)
+        {
+            // Under the qualification bypass this process holds no handle, so the exclusivity this test
+            // proves has no subject - and probing the real lock file here would race whatever ordinary
+            // run may legitimately hold it on this machine during a soak. Nothing to prove in this mode;
+            // the bypass itself is asserted by TheLockIsHeldWhileTestsRun.
+            return;
+        }
+
         // The exact open a second run would attempt. Share modes are per-handle, not per-process, so this
         // is refused inside the holding process too - which makes it a real proof of exclusivity rather
         // than a restatement of a flag we set ourselves.
@@ -97,6 +118,15 @@ public sealed class GatewayTestSuiteLockTests
 
         // Same file this run holds - that is the property being pinned.
         Assert.Equal(GatewayTestSuiteLock.LockFilePath, asAnotherRunWouldComputeIt);
+
+        if (GatewayTestSuiteLock.QualificationBypassActive)
+        {
+            // The path-identity half above still holds and was asserted. The refused-open half needs
+            // "this held lock" as its subject, and a qualification run (issue #1156 step 4) holds
+            // nothing - whether the open is refused depends on whichever ordinary run happens to hold
+            // the real file right now, which is not this test's property to pin.
+            return;
+        }
 
         // And therefore the open that run would attempt is refused by the operating system. Under the
         // defect the recomputed path was a DIFFERENT file, this open succeeded, and two suites ran side
@@ -169,6 +199,14 @@ public sealed class GatewayTestSuiteLockTests
     [Fact]
     public void TheLockFileNamesThisProcess_SoABlockedRunCanSayWhoIsBlockingIt()
     {
+        if (GatewayTestSuiteLock.QualificationBypassActive)
+        {
+            // A qualification run (issue #1156 step 4) never writes the lock file, so "names THIS
+            // process" has no subject: the file holds whichever ordinary run last held the real lock.
+            // The diagnostics-writing property is still proven by every ordinary run of this suite.
+            return;
+        }
+
         // Read exactly the way a blocked run reads it: read-only, sharing everything, while the holder
         // still has the file open for writing.
         using var stream = new FileStream(
@@ -183,5 +221,89 @@ public sealed class GatewayTestSuiteLockTests
             StringComparison.Ordinal);
         Assert.Contains("acquiredUtc=", text, StringComparison.Ordinal);
         Assert.Contains("session=", text, StringComparison.Ordinal);
+    }
+
+    // ---- The qualification ruling (issue #1156 step 4) ----
+    // Pure-value tests, the same way the lock path is tested: every branch of the ruling is provable
+    // without touching process environment, so nothing here can be perturbed by a real soak running
+    // on the machine at the same time.
+
+    private static (string Name, string? Value)[] NoLiveProof() => new (string, string?)[]
+    {
+        ("CC_GATEWAY_TEST_PG_CONNECTION", null),
+        ("CC_GATEWAY_TEST_PG_STATS_CONNECTION", null),
+        ("CC_GATEWAY_DB_CONNECTION", null),
+    };
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Qualification_AbsentOrBlank_TakesTheLockAsAlways(string? value)
+    {
+        Assert.Equal(
+            GatewayTestSuiteLock.QualificationRuling.NotRequested,
+            GatewayTestSuiteLock.RuleOnQualification(value, NoLiveProof()));
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("isolated-worktree-soak ")] // trailing space: close is not exact
+    [InlineData("ISOLATED-WORKTREE-SOAK")]
+    public void Qualification_WrongToken_RefusesRatherThanSilentlySerializing(string value)
+    {
+        // The dangerous fallback would be taking the locked path: a soak whose runs never actually
+        // overlapped produces thousands of clean host starts that certify nothing.
+        Assert.Equal(
+            GatewayTestSuiteLock.QualificationRuling.RefuseWrongToken,
+            GatewayTestSuiteLock.RuleOnQualification(value, NoLiveProof()));
+    }
+
+    [Fact]
+    public void Qualification_ExactTokenAndNoLiveProof_Bypasses()
+    {
+        Assert.Equal(
+            GatewayTestSuiteLock.QualificationRuling.Bypass,
+            GatewayTestSuiteLock.RuleOnQualification(GatewayTestSuiteLock.QualificationToken, NoLiveProof()));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Qualification_AnyLiveProofVariable_FailsClosed(int position)
+    {
+        var vars = NoLiveProof();
+        vars[position] = (vars[position].Name, "Host=localhost;Database=ccpgsomething");
+
+        Assert.Equal(
+            GatewayTestSuiteLock.QualificationRuling.RefuseLiveProof,
+            GatewayTestSuiteLock.RuleOnQualification(GatewayTestSuiteLock.QualificationToken, vars));
+    }
+
+    [Fact]
+    public void Qualification_WhitespaceLiveProofValue_CountsAsUnset()
+    {
+        // The skip logic throughout the proof classes treats whitespace as unset; the bypass ruling must
+        // agree, or a stray space would refuse a soak the proofs themselves would have skipped cleanly.
+        var vars = NoLiveProof();
+        vars[1] = (vars[1].Name, "   ");
+
+        Assert.Equal(
+            GatewayTestSuiteLock.QualificationRuling.Bypass,
+            GatewayTestSuiteLock.RuleOnQualification(GatewayTestSuiteLock.QualificationToken, vars));
+    }
+
+    [Fact]
+    public void Qualification_TheLiveProofList_NamesTheVariablesTheProofClassesActuallyRead()
+    {
+        // The fail-closed list is only as good as its names. Two of the three are declared by the classes
+        // that read them; pin all three so a rename there breaks here instead of silently un-guarding.
+        Assert.Contains("CC_GATEWAY_TEST_PG_CONNECTION", GatewayTestSuiteLock.LiveProofEnvVars);
+        Assert.Contains("CC_GATEWAY_TEST_PG_STATS_CONNECTION", GatewayTestSuiteLock.LiveProofEnvVars);
+        Assert.Contains(
+            CcDirector.Gateway.Data.GatewayDatabase.PostgresConnectionEnvVar,
+            GatewayTestSuiteLock.LiveProofEnvVars);
     }
 }


### PR DESCRIPTION
The qualification harness for removing the machine-wide Gateway test lock (devthrottle_internal#1156 step 4).

**This does not remove the lock and does not change how an ordinary run behaves.** It builds the instrument that has to prove removal is safe first.

## The bypass

The soak has to run several ordinary suite processes at once - the one thing the lock forbids - so `GatewayTestSuiteLock` gains a controlled bypass the qualification script alone uses. The ruling is a pure function with every branch unit-tested:

- An EXACT token. A stray truthy value (`1`, `true`, wrong case, trailing space) does not disable the lock.
- Fail-closed on all three live-proof connection variables. Concurrent processes sharing a live database corrupt each other, which is precisely the false evidence a soak must never produce.
- A wrong token REFUSES rather than silently taking the locked path. Falling back would serialize the whole soak, and thousands of "clean" host starts that never actually overlapped would certify nothing while looking like proof.

All four modes proven live: ordinary acquires (21/21), bypass runs lockless (21/21), and both refusal modes stop the host with the reason as the last line and zero tests run.

The four lock-behaviour tests now assert the qualification state explicitly when the bypass is active. The serialization property is deliberately suspended in that mode, and a test whose subject is "this held lock" says so rather than false-failing the soak.

## The soak script

`scripts/test-qualification.ps1`: N detached worktrees at the commit under test, one build per commit, N concurrent children carrying exactly the token and cleared live-proof variables, judgment by **TRX outcome plus counter identity across siblings** (divergence IS the interference being hunted), each child's **exit code** recorded, and a cumulative JSONL ledger tracking the host-start estimate.

Two deliberate fairness properties: the parent holds the REAL suite lock for the whole soak, so ordinary fleet runs queue exactly as they do today and can never overlap the bypassing children unawares; and one invocation runs one round, releasing the lock between rounds rather than holding it for hours.

## Evidence so far

| Round | Shape | Result |
|---|---|---|
| 1 | 2 concurrent | clean, identical counters |
| 2 | 4 concurrent | clean, identical counters |
| 3 | 4 concurrent | one process ended quietly at 22 min - filed as devthrottle_internal#1203 |
| 4 | 4 concurrent | clean, identical counters, every child exit code 0 |

About 1,378 estimated host starts banked. **No cross-process interference in any round** - the property the lock actually guards has been clean throughout. Round 3 has not reproduced; its round is also the one where the soak parent was itself killed, which is why exit-code recording was added.

The soak continues after this merges. Step 5 (actually removing the lock) is a separate change, gated on the ledger reaching thousands of host starts and on #1203 being settled.
