### PR TITLE
Drive Brave and Opera, and show the browser list instantly

### DIFF
--- a/docs/mockups/browsers-tab-guidance.html
+++ b/docs/mockups/browsers-tab-guidance.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Browsers tab - guidance redesign mockup</title>
+<style>
+  :root{
+    --bg:#1e1e1e;
+    --panel:#252526;
+    --panel2:#2d2d30;
+    --input:#1b1b1c;
+    --border:#3c3c3c;
+    --border-strong:#505052;
+    --text:#e6e6e6;
+    --muted:#9a9a9a;
+    --faint:#777;
+    --blue:#0f6cbd;
+    --blue-hi:#4a9eff;
+    --amber:#f0b848;
+    --edge:#1aa1b8;
+    --danger:#e06c6c;
+  }
+  *{box-sizing:border-box;}
+  body{
+    margin:0;background:#121212;color:var(--text);
+    font-family:"Segoe UI",system-ui,sans-serif;font-size:13px;
+    display:flex;flex-direction:column;align-items:center;gap:18px;
+    padding:28px 16px 60px;
+  }
+  h1.page{font-size:18px;margin:0;font-weight:600;}
+  .caption{color:var(--muted);max-width:900px;text-align:center;line-height:1.55;}
+  .caption b{color:var(--text);}
+  .toolbar{display:flex;gap:8px;align-items:center;flex-wrap:wrap;justify-content:center;}
+  .toolbar button{
+    background:var(--panel2);color:var(--text);border:1px solid var(--border-strong);
+    padding:7px 14px;border-radius:5px;cursor:pointer;font-size:12px;
+  }
+  .toolbar button.active{background:var(--blue);border-color:var(--blue-hi);}
+
+  /* ---- the settings window ---- */
+  .window{
+    width:1040px;background:var(--bg);border:1px solid #000;border-radius:6px;
+    box-shadow:0 18px 50px rgba(0,0,0,.6);overflow:hidden;
+  }
+  .titlebar{padding:12px 18px 0;font-weight:600;font-size:14px;}
+  .tabs{display:flex;gap:26px;padding:14px 18px 0;font-size:16px;color:var(--faint);}
+  .tabs .on{color:var(--text);border-bottom:2px solid var(--blue-hi);padding-bottom:5px;}
+  .body{padding:16px 18px 22px;min-height:620px;}
+  .footer{
+    display:flex;justify-content:space-between;align-items:center;
+    padding:12px 18px 16px;border-top:1px solid #2a2a2a;
+  }
+  .footer a{color:var(--blue-hi);text-decoration:none;font-size:12px;}
+
+  /* ---- shared bits ---- */
+  .btn{
+    background:var(--panel2);color:var(--text);border:1px solid var(--border-strong);
+    padding:7px 14px;border-radius:4px;font-size:12px;cursor:pointer;
+  }
+  .btn.primary{background:var(--blue);border-color:var(--blue);}
+  .btn.big{padding:10px 20px;font-size:13px;font-weight:600;}
+  .sectionhead{font-weight:600;font-size:13px;margin:0 0 6px;}
+  .sub{color:var(--muted);font-size:12px;line-height:1.6;}
+
+  /* ---- EMPTY STATE ---- */
+  .hero{max-width:760px;}
+  .hero h2{font-size:22px;margin:2px 0 8px;font-weight:600;}
+  .hero p{color:var(--muted);font-size:13px;line-height:1.65;margin:0 0 14px;}
+  .hero p b{color:var(--text);font-weight:600;}
+
+  .cards3{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:20px 0 8px;}
+  .card{
+    background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:14px 16px;
+  }
+  .card .num{
+    width:22px;height:22px;border-radius:50%;background:var(--blue);color:#fff;
+    display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;margin-bottom:9px;
+  }
+  .card h4{margin:0 0 5px;font-size:13px;font-weight:600;}
+  .card p{margin:0;color:var(--muted);font-size:12px;line-height:1.55;}
+
+  .rolestrip{
+    background:var(--panel);border:1px solid var(--border);border-radius:6px;
+    padding:16px;margin-top:18px;
+  }
+  .roles{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px;}
+  .role{
+    background:var(--panel2);border:1px solid var(--border);border-radius:5px;padding:11px 12px;
+    display:flex;gap:10px;align-items:flex-start;
+  }
+  .avatar{
+    width:26px;height:26px;border-radius:5px;flex:0 0 26px;
+    display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px;color:#fff;
+  }
+  .role .nm{font-weight:600;font-size:12px;}
+  .role .dt{color:var(--faint);font-size:11px;line-height:1.5;margin-top:2px;}
+
+  .callout{
+    display:flex;gap:11px;background:rgba(240,184,72,.07);
+    border:1px solid rgba(240,184,72,.35);border-radius:6px;padding:12px 14px;margin-top:18px;
+  }
+  .callout .ic{color:var(--amber);font-weight:700;font-size:13px;line-height:1.5;}
+  .callout p{margin:0;font-size:12px;line-height:1.6;color:#d8d2c6;}
+  .callout p b{color:var(--amber);font-weight:600;}
+
+  .cta{display:flex;align-items:center;gap:14px;margin-top:22px;}
+  .cta .hint{color:var(--faint);font-size:12px;}
+
+  /* ---- NEW BROWSER PANEL ---- */
+  .createpanel{
+    background:var(--panel);border:1px solid var(--border);border-radius:6px;
+    display:grid;grid-template-columns:1fr 340px;
+  }
+  .createleft{padding:18px 20px;}
+  .createright{
+    padding:18px 20px;border-left:1px solid var(--border);background:#212122;
+    border-radius:0 6px 6px 0;
+  }
+  label.fld{display:block;font-size:12px;font-weight:600;margin:0 0 5px;}
+  .field{
+    width:100%;background:var(--input);border:1px solid var(--border-strong);color:var(--text);
+    padding:9px 11px;border-radius:4px;font-size:13px;font-family:inherit;
+  }
+  .field::placeholder{color:#5f5f5f;}
+  .helptext{color:var(--faint);font-size:11px;margin:6px 0 0;line-height:1.5;}
+  .chips{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap;}
+  .chip{
+    background:var(--panel2);border:1px solid var(--border-strong);border-radius:11px;
+    padding:3px 10px;font-size:11px;color:var(--muted);cursor:pointer;
+  }
+  .row2{display:grid;grid-template-columns:1fr 200px;gap:14px;margin-top:16px;}
+  select.field{appearance:none;background-image:linear-gradient(45deg,transparent 50%,#999 50%),linear-gradient(135deg,#999 50%,transparent 50%);background-position:calc(100% - 16px) 52%,calc(100% - 11px) 52%;background-size:5px 5px;background-repeat:no-repeat;}
+  .steps{list-style:none;margin:10px 0 0;padding:0;}
+  .steps li{display:flex;gap:10px;padding:0 0 14px;}
+  .steps .n{
+    width:19px;height:19px;flex:0 0 19px;border-radius:50%;background:var(--panel2);
+    border:1px solid var(--border-strong);color:var(--muted);
+    display:flex;align-items:center;justify-content:center;font-size:11px;
+  }
+  .steps .tx{font-size:12px;line-height:1.55;color:var(--muted);}
+  .steps .tx b{color:var(--text);font-weight:600;display:block;margin-bottom:1px;}
+  .reassure{
+    margin-top:4px;padding-top:12px;border-top:1px solid var(--border);
+    font-size:11px;color:var(--faint);line-height:1.6;
+  }
+  .actions{display:flex;gap:9px;margin-top:20px;}
+
+  /* ---- SIGN IN ---- */
+  .modalwrap{padding:40px 0;display:flex;justify-content:center;}
+  .modal{
+    width:620px;background:var(--panel);border:1px solid var(--border-strong);border-radius:7px;
+    box-shadow:0 20px 60px rgba(0,0,0,.7);overflow:hidden;
+  }
+  .modal h3{margin:0;padding:15px 20px;font-size:14px;border-bottom:1px solid var(--border);}
+  .modalbody{padding:18px 20px;}
+  .modalbody p{margin:0 0 13px;font-size:12.5px;line-height:1.65;color:var(--muted);}
+  .modalbody p b{color:var(--text);font-weight:600;}
+  .choice{
+    display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:15px 0;
+  }
+  .opt{background:var(--panel2);border:1px solid var(--border-strong);border-radius:6px;padding:12px 13px;}
+  .opt h5{margin:0 0 5px;font-size:12px;font-weight:600;}
+  .opt p{margin:0;font-size:11.5px;color:var(--faint);line-height:1.55;}
+  .modalfoot{display:flex;justify-content:flex-end;gap:9px;padding:13px 20px;border-top:1px solid var(--border);}
+
+  /* ---- POPULATED ---- */
+  .slimbar{
+    display:flex;gap:12px;align-items:flex-start;background:var(--panel);
+    border:1px solid var(--border);border-radius:6px;padding:12px 15px;margin-bottom:14px;
+  }
+  .slimbar .tx{font-size:12px;color:var(--muted);line-height:1.6;flex:1;}
+  .slimbar .tx b{color:var(--text);}
+  .slimbar a{color:var(--blue-hi);text-decoration:none;white-space:nowrap;font-size:12px;}
+  .toprow{display:flex;gap:9px;margin-bottom:14px;}
+  .browserrow{
+    display:flex;align-items:center;gap:12px;background:var(--panel);
+    border:1px solid var(--border);border-radius:6px;padding:12px 14px;margin-bottom:9px;
+  }
+  .browserrow .meta{flex:1;}
+  .browserrow .nm{font-weight:600;font-size:13px;display:flex;align-items:center;gap:8px;}
+  .tag{background:var(--panel2);border:1px solid var(--border-strong);border-radius:3px;font-size:10px;padding:1px 6px;color:var(--muted);}
+  .browserrow .dt{color:var(--muted);font-size:11.5px;margin-top:3px;}
+  .pill{background:var(--border);color:#ccc;border-radius:10px;font-size:11px;padding:3px 11px;}
+  .pill.green{background:#2ea043;color:#08130a;}
+  .trash{color:var(--danger);cursor:pointer;font-size:14px;}
+
+  .screen{display:none;}
+  .screen.on{display:block;}
+</style>
+</head>
+<body>
+
+<h1 class="page">Browsers tab &mdash; guidance redesign</h1>
+<div class="caption">
+  Four screens. The <b>empty state</b> is where the teaching goes, because it is the only moment we
+  have the user's full attention and the whole window free. <b>New browser</b> says what is about to
+  happen before it happens. <b>Sign in</b> is where the one real catch lands. <b>With browsers</b>
+  shows the explanation shrinking to a single line once it has done its job.
+</div>
+
+<div class="toolbar">
+  <button class="active" onclick="show(0,this)">1 &middot; Empty (first run)</button>
+  <button onclick="show(1,this)">2 &middot; New browser</button>
+  <button onclick="show(2,this)">3 &middot; Sign in once</button>
+  <button onclick="show(3,this)">4 &middot; With browsers</button>
+</div>
+
+<!-- ================= SCREEN 1 : EMPTY ================= -->
+<div class="window screen on">
+  <div class="titlebar">Director Settings</div>
+  <div class="tabs"><span>Account</span><span>Gateway</span><span>Agents</span><span class="on">Browsers</span><span>Directories</span><span>Advanced</span><span>Tools</span></div>
+  <div class="body">
+
+    <div class="hero">
+      <h2>Give your agents a browser of their own</h2>
+      <p>
+        A browser here is a <b>real, signed-in browser your agents can drive</b> &mdash; click things,
+        read pages, fill forms &mdash; through Browser Harness. It is not a scraper and not a
+        headless shell. It is Chrome or Edge, running on this machine, that an agent controls
+        like a person would.
+      </p>
+      <p>
+        It is <b>not your everyday browser</b>, and that is deliberate. Chrome and Edge now refuse to
+        be remote-controlled on your main profile, and they encrypt its saved logins so they cannot be
+        copied out. So DevThrottle creates a separate, dedicated profile instead &mdash; which is also
+        the arrangement you want: your agent gets exactly the accounts you give it, and nothing else.
+      </p>
+    </div>
+
+    <div class="cards3">
+      <div class="card">
+        <div class="num">1</div>
+        <h4>You create it</h4>
+        <p>DevThrottle makes a fresh, dedicated browser profile in its own folder. Your everyday
+           Chrome and Edge are never touched.</p>
+      </div>
+      <div class="card">
+        <div class="num">2</div>
+        <h4>You sign it in, once</h4>
+        <p>It opens and you log in by hand &mdash; DevThrottle never types your credentials. The
+           login then lasts for months.</p>
+      </div>
+      <div class="card">
+        <div class="num">3</div>
+        <h4>Any agent attaches</h4>
+        <p>From then on any agent on this machine drives it with one command. No sign-in, no
+           re-auth, no captcha loop.</p>
+      </div>
+    </div>
+
+    <div class="rolestrip">
+      <p class="sectionhead">Make one for each role you want an agent to act as</p>
+      <div class="sub">
+        The useful way to think about it is to mirror the separation you already keep in your own
+        head &mdash; work, personal, a particular client. Name each one after the identity it holds,
+        and you always know what an agent can reach when you point it at that browser.
+      </div>
+      <div class="roles">
+        <div class="role">
+          <div class="avatar" style="background:var(--blue)">W</div>
+          <div><div class="nm">Work</div><div class="dt">Company Google account, internal tools, the ticket tracker</div></div>
+        </div>
+        <div class="role">
+          <div class="avatar" style="background:var(--edge)">C</div>
+          <div><div class="nm">Acme Corp</div><div class="dt">One client only &mdash; their portal and dashboards, nothing else</div></div>
+        </div>
+        <div class="role">
+          <div class="avatar" style="background:#8a63d2">P</div>
+          <div><div class="nm">Personal</div><div class="dt">Your own accounts, kept well away from anything work</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <div class="ic">!</div>
+      <p>
+        <b>It starts completely empty.</b> A new browser here is signed in to nothing at all &mdash;
+        it does not inherit your existing tabs, bookmarks or logins. You choose what goes in it:
+        sign in to a Google or Microsoft account to bring a whole profile across, or just sign in to
+        the individual websites you want the agent to reach. Whatever you sign in is exactly what
+        your agents can drive &mdash; nothing else.
+      </p>
+    </div>
+
+    <div class="cta">
+      <button class="btn primary big">+ Create your first browser</button>
+      <span class="hint">Takes about a minute, most of it you signing in.</span>
+    </div>
+
+  </div>
+  <div class="footer"><a>Open config.json</a><div><button class="btn primary">Save and Close</button> <button class="btn">Cancel</button></div></div>
+</div>
+
+<!-- ================= SCREEN 2 : NEW BROWSER ================= -->
+<div class="window screen">
+  <div class="titlebar">Director Settings</div>
+  <div class="tabs"><span>Account</span><span>Gateway</span><span>Agents</span><span class="on">Browsers</span><span>Directories</span><span>Advanced</span><span>Tools</span></div>
+  <div class="body">
+
+    <p class="sectionhead" style="font-size:15px;margin-bottom:3px;">New browser</p>
+    <div class="sub" style="margin-bottom:16px;">
+      You are about to create a brand new, empty browser profile &mdash; not a copy of one you
+      already use.
+    </div>
+
+    <div class="createpanel">
+      <div class="createleft">
+        <label class="fld">What will this browser be signed in as?</label>
+        <input class="field" placeholder="Work">
+        <p class="helptext">
+          Name it after the identity it will hold, not what you plan to do with it. &ldquo;Work&rdquo;
+          and &ldquo;Acme Corp&rdquo; tell you what an agent can reach; &ldquo;testing&rdquo; and
+          &ldquo;browser 2&rdquo; will not, six weeks from now.
+        </p>
+        <div class="chips">
+          <span class="chip">Work</span><span class="chip">Personal</span>
+          <span class="chip">Acme Corp</span><span class="chip">Research</span>
+        </div>
+
+        <div class="row2">
+          <div>
+            <label class="fld">Which browser</label>
+            <select class="field">
+              <option>Chrome</option><option>Edge</option><option>Brave</option><option>Opera</option>
+            </select>
+            <p class="helptext">Only browsers found on this machine are listed. Pick the one whose
+              account you want to sign in to &mdash; otherwise it makes no difference.</p>
+          </div>
+          <div></div>
+        </div>
+
+        <div class="actions">
+          <button class="btn primary">Create and sign in</button>
+          <button class="btn">Cancel</button>
+        </div>
+      </div>
+
+      <div class="createright">
+        <p class="sectionhead">What happens when you click Create</p>
+        <ul class="steps">
+          <li><span class="n">1</span><span class="tx"><b>A new browser window opens</b>
+            Empty, with its own profile folder. Your everyday browser keeps running, untouched.</span></li>
+          <li><span class="n">2</span><span class="tx"><b>You sign in, by hand</b>
+            Whatever you want the agent to reach. DevThrottle never types your credentials and
+            never sees them.</span></li>
+          <li><span class="n">3</span><span class="tx"><b>You tell us you are done</b>
+            The browser is then listed here as ready, and any agent on this machine can drive it.</span></li>
+        </ul>
+        <div class="reassure">
+          Nothing here touches the Chrome or Edge you use yourself &mdash; not its tabs, not its
+          bookmarks, not its logins. You can delete this browser at any time and it takes its own
+          folder with it.
+        </div>
+      </div>
+    </div>
+
+  </div>
+  <div class="footer"><a>Open config.json</a><div><button class="btn primary">Save and Close</button> <button class="btn">Cancel</button></div></div>
+</div>
+
+<!-- ================= SCREEN 3 : SIGN IN ================= -->
+<div class="window screen">
+  <div class="titlebar">Director Settings</div>
+  <div class="tabs"><span>Account</span><span>Gateway</span><span>Agents</span><span class="on">Browsers</span><span>Directories</span><span>Advanced</span><span>Tools</span></div>
+  <div class="body" style="opacity:.35;">
+    <div class="toprow"><button class="btn primary">+ New browser</button><button class="btn">Refresh</button></div>
+    <div class="browserrow"><div class="avatar" style="background:var(--blue)">C</div>
+      <div class="meta"><div class="nm">Work</div><div class="dt">Chrome &mdash; not signed in yet &nbsp;(port 9310)</div></div>
+      <span class="pill">Needs sign-in</span></div>
+  </div>
+
+  <div class="modalwrap" style="margin-top:-330px;">
+    <div class="modal">
+      <h3>Sign in once &mdash; &ldquo;Work&rdquo;</h3>
+      <div class="modalbody">
+        <p>
+          A <b>&ldquo;Work&rdquo;</b> window has just opened. Sign in <b>by hand</b> in that window.
+          DevThrottle never types your credentials.
+        </p>
+        <p>This browser is empty right now. What you sign in is exactly what your agents will be able
+           to reach &mdash; so sign in to whichever of these fits:</p>
+
+        <div class="choice">
+          <div class="opt">
+            <h5>A Google account</h5>
+            <p>Brings a whole profile across at once &mdash; mail, calendar, drive, and anything
+               that account already signs you in to.</p>
+          </div>
+          <div class="opt">
+            <h5>Just the individual sites</h5>
+            <p>Keeps this browser to exactly the handful of websites you want an agent to touch,
+               and nothing more.</p>
+          </div>
+        </div>
+
+        <p style="font-size:11.5px;color:var(--faint);margin-bottom:0;">
+          The logins are kept in this browser's own folder, apart from your everyday browser, and
+          last until the account signs them out. You can come back and sign in to more later.
+        </p>
+      </div>
+      <div class="modalfoot">
+        <button class="btn">Not yet</button>
+        <button class="btn primary">Done &mdash; I am signed in</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer"><a>Open config.json</a><div><button class="btn primary">Save and Close</button> <button class="btn">Cancel</button></div></div>
+</div>
+
+<!-- ================= SCREEN 4 : POPULATED ================= -->
+<div class="window screen">
+  <div class="titlebar">Director Settings</div>
+  <div class="tabs"><span>Account</span><span>Gateway</span><span>Agents</span><span class="on">Browsers</span><span>Directories</span><span>Advanced</span><span>Tools</span></div>
+  <div class="body">
+
+    <div class="slimbar">
+      <div class="tx">
+        <b>Real, signed-in browsers your agents can drive.</b> Each one is a dedicated profile with
+        its own logins &mdash; your everyday browser is never touched. Add one per role you want an
+        agent to act as.
+      </div>
+      <a>How this works &rsaquo;</a>
+    </div>
+
+    <div class="toprow">
+      <button class="btn primary">+ New browser</button>
+      <button class="btn">Refresh</button>
+    </div>
+
+    <div class="browserrow">
+      <div class="avatar" style="background:var(--blue)">C</div>
+      <div class="meta"><div class="nm">Center Consulting <span class="tag">Rename</span></div>
+        <div class="dt">Chrome &mdash; soren@centerconsulting.com &nbsp;(port 9310)</div></div>
+      <span class="pill green">Ready</span><button class="btn">Attach</button>
+      <button class="btn">Stop</button><span class="trash">&#128465;</span>
+    </div>
+    <div class="browserrow">
+      <div class="avatar" style="background:var(--blue)">C</div>
+      <div class="meta"><div class="nm">Private <span class="tag">Rename</span></div>
+        <div class="dt">Chrome &mdash; soren@duksrevo.com &nbsp;(port 9311)</div></div>
+      <span class="pill">Stopped</span><button class="btn">Start</button><span class="trash">&#128465;</span>
+    </div>
+    <div class="browserrow">
+      <div class="avatar" style="background:var(--edge)">E</div>
+      <div class="meta"><div class="nm">mindzie <span class="tag">Rename</span></div>
+        <div class="dt">Edge &mdash; soren.frederiksen@mindzie.com &nbsp;(port 9312)</div></div>
+      <span class="pill">Stopped</span><button class="btn">Start</button><span class="trash">&#128465;</span>
+    </div>
+    <div class="browserrow">
+      <div class="avatar" style="background:var(--blue)">C</div>
+      <div class="meta"><div class="nm">Agent browser <span class="tag">Rename</span></div>
+        <div class="dt">Chrome &mdash; checking&hellip; &nbsp;(port 9313)</div></div>
+      <span class="pill">Checking&hellip;</span>
+    </div>
+
+    <div class="sub" style="margin-top:16px;">
+      A browser you no longer recognise is a browser you should delete &mdash; it still holds whatever
+      it was signed in to.
+    </div>
+
+  </div>
+  <div class="footer"><a>Open config.json</a><div><button class="btn primary">Save and Close</button> <button class="btn">Cancel</button></div></div>
+</div>
+
+<script>
+  function show(i, btn){
+    document.querySelectorAll('.screen').forEach((s,n)=>s.classList.toggle('on', n===i));
+    document.querySelectorAll('.toolbar button').forEach(b=>b.classList.remove('active'));
+    btn.classList.add('active');
+    window.scrollTo({top:0,behavior:'smooth'});
+  }
+</script>
+</body>
+</html>

--- a/src/CcDirector.Avalonia.Tests/Controls/BrowserSignInFlowTests.cs
+++ b/src/CcDirector.Avalonia.Tests/Controls/BrowserSignInFlowTests.cs
@@ -1,0 +1,38 @@
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests.Controls;
+
+/// <summary>
+/// Proves the one-time sign-in dialog names an account route only for browsers that HAVE one. The
+/// dialog is the single instruction a person gets about what to sign in to, and naming the wrong
+/// provider sends them hunting for a profile sync their browser does not offer.
+/// </summary>
+public sealed class BrowserSignInFlowTests
+{
+    [Fact]
+    public void ChromeAndEdge_AreNamedByTheirOwnAccountProvider()
+    {
+        Assert.Equal("a Google account", BrowserSignInFlow.AccountRoute(nameof(BrowserKind.Chrome)));
+        Assert.Equal("a Microsoft account", BrowserSignInFlow.AccountRoute(nameof(BrowserKind.Edge)));
+    }
+
+    [Fact]
+    public void BraveAndOpera_AreNotOfferedAnAccountRouteAtAll()
+    {
+        // Neither has an account that carries a signed-in profile across, so the dialog must fall to
+        // the per-site instruction rather than naming Google's or Microsoft's.
+        Assert.Null(BrowserSignInFlow.AccountRoute(nameof(BrowserKind.Brave)));
+        Assert.Null(BrowserSignInFlow.AccountRoute(nameof(BrowserKind.Opera)));
+    }
+
+    [Fact]
+    public void TheBrowserNameIsMatchedCaseInsensitively()
+    {
+        // The view carries whatever text the fold produced; a case difference must not silently drop
+        // Chrome into the accountless branch.
+        Assert.Equal("a Google account", BrowserSignInFlow.AccountRoute("chrome"));
+        Assert.Equal("a Microsoft account", BrowserSignInFlow.AccountRoute("EDGE"));
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,8 +25,13 @@ public partial class BrowserSettingsView : UserControl
     public event EventHandler? Changed;
 
     private IReadOnlyList<AutomationBrowserView> _views = Array.Empty<AutomationBrowserView>();
+    private ObservableCollection<BrowserCardViewModel> _cards = new();
     private readonly HashSet<string> _renamingIds = new(StringComparer.OrdinalIgnoreCase);
     private bool _refreshing;
+
+    /// <summary>Bumped by every refresh. A status probe carries the generation it started under and
+    /// drops its result if a newer refresh has replaced the list underneath it.</summary>
+    private int _refreshGeneration;
 
     public BrowserSettingsView()
     {
@@ -40,23 +46,34 @@ public partial class BrowserSettingsView : UserControl
         CreateNameBox.Focus();
     }
 
-    /// <summary>Re-read the registry, probe live status, and repaint the whole tab.</summary>
+    /// <summary>
+    /// Re-read the registry and repaint the tab, in TWO passes.
+    ///
+    /// The list itself is local file data and costs microseconds, so it paints immediately with every
+    /// browser's real name, browser, port and account. Whether each one is RUNNING is the only slow
+    /// fact - it needs a probe of that browser's debug port, and on a machine whose network stack does
+    /// not refuse a dead port promptly that probe takes seconds. So each browser shows "Checking..."
+    /// and its own row is swapped in the moment its own probe answers. Nothing waits for anything else.
+    ///
+    /// This replaces a single pass that probed every browser before painting anything, which left the
+    /// whole tab blank behind "Checking browsers..." for as long as the slowest probe took.
+    /// </summary>
     public async Task RefreshAsync()
     {
         if (_refreshing) return;
         _refreshing = true;
+        var generation = ++_refreshGeneration;
         try
         {
-            StatusText.Text = "Checking browsers...";
-
+            var previous = _views;
             var harnessInstalled = false;
             IReadOnlyList<AutomationBrowserView> views = Array.Empty<AutomationBrowserView>();
             IReadOnlyList<BrowserInfo> installed = Array.Empty<BrowserInfo>();
-            await Task.Run(async () =>
+            await Task.Run(() =>
             {
                 harnessInstalled = AutomationBrowserViewFold.IsHarnessInstalled();
                 installed = BrowserLauncher.DetectBrowsers();
-                views = await AutomationBrowserViewFold.ListAsync().ConfigureAwait(false);
+                views = AutomationBrowserViewFold.ListPending(previous);
             });
 
             _views = views;
@@ -71,22 +88,90 @@ public partial class BrowserSettingsView : UserControl
             CreateKindCombo.SelectedItem = kinds.Contains(selected ?? "") ? selected : kinds.FirstOrDefault();
             NewBrowserButton.IsEnabled = kinds.Count > 0;
             if (kinds.Count == 0)
-                StatusText.Text = "No Chrome or Edge installation was found on this machine, so no browser can be created.";
+                // Named from the enum rather than spelled out, so this sentence cannot go stale the
+                // next time a browser is added - a list that says "Chrome or Edge" on a build that also
+                // supports Brave tells someone to install a browser they may already have.
+                StatusText.Text =
+                    $"None of the browsers DevThrottle can drive ({string.Join(", ", Enum.GetNames<BrowserKind>())}) "
+                    + "was found on this machine, so no browser can be created.";
 
-            BrowserCards.ItemsSource = views.Select(v => new BrowserCardViewModel(v)
+            _cards = new ObservableCollection<BrowserCardViewModel>(views.Select(v => new BrowserCardViewModel(v)
             {
                 IsRenaming = _renamingIds.Contains(v.Id),
-            }).ToList();
+            }));
+            BrowserCards.ItemsSource = _cards;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[BrowserSettingsView] RefreshAsync FAILED: {ex.Message}");
             StatusText.Text = $"Could not read the browsers list: {ex.Message}";
+            return;
         }
         finally
         {
             _refreshing = false;
         }
+
+        // The list is on screen; now find out which of them are running. Deliberately NOT awaited into
+        // the paint above - that is the whole point.
+        await ProbeStatusesAsync(generation);
+    }
+
+    /// <summary>
+    /// Probe every listed browser CONCURRENTLY and swap each row in as its own answer arrives. A
+    /// browser that answers in milliseconds is not made to wait behind one that takes seconds.
+    ///
+    /// <paramref name="generation"/> is the refresh this probe run belongs to. A result is dropped when
+    /// a newer refresh has started, because by then the rows it would update belong to a list that no
+    /// longer exists - writing into it would resurrect a browser the user just removed, or paint a
+    /// status onto the wrong row.
+    /// </summary>
+    private async Task ProbeStatusesAsync(int generation)
+    {
+        var browsers = _views;
+        if (browsers.Count == 0) return;
+
+        await Task.WhenAll(browsers.Select(async pending =>
+        {
+            AutomationBrowserView probed;
+            try
+            {
+                probed = await Task.Run(() => AutomationBrowserViewFold.FoldAsync(AutomationBrowserRegistry.Get(pending.Id)));
+            }
+            catch (Exception ex)
+            {
+                // One browser that cannot be probed (removed mid-refresh, unreadable entry) leaves its
+                // own row saying "Checking..." and takes nothing else down with it.
+                FileLog.Write($"[BrowserSettingsView] ProbeStatusesAsync: id={pending.Id} failed (non-fatal): {ex.Message}");
+                return;
+            }
+
+            if (generation != _refreshGeneration) return;
+            ApplyProbedView(probed);
+        }));
+    }
+
+    /// <summary>Swap one browser's finished view into the list, keeping its position and any in-progress
+    /// rename. Called on the UI thread - Avalonia marshals the await continuation back to it.</summary>
+    private void ApplyProbedView(AutomationBrowserView probed)
+    {
+        _views = _views.Select(v => v.Id == probed.Id ? probed : v).ToList();
+
+        var index = IndexOfCard(probed.Id);
+        if (index < 0) return;
+
+        _cards[index] = new BrowserCardViewModel(probed)
+        {
+            IsRenaming = _renamingIds.Contains(probed.Id),
+        };
+    }
+
+    private int IndexOfCard(string id)
+    {
+        for (var i = 0; i < _cards.Count; i++)
+            if (_cards[i].Id == id)
+                return i;
+        return -1;
     }
 
     private async Task RefreshAndNotifyAsync()
@@ -102,7 +187,7 @@ public partial class BrowserSettingsView : UserControl
     private BrowserCardViewModel? CardFor(object? sender)
     {
         var id = (sender as Button)?.Tag as string;
-        return (BrowserCards.ItemsSource as IEnumerable<BrowserCardViewModel>)?.FirstOrDefault(c => c.Id == id);
+        return _cards.FirstOrDefault(c => c.Id == id);
     }
 
     // ---- header actions ----
@@ -407,14 +492,16 @@ public partial class BrowserSettingsView : UserControl
 
             ShowStart = view.Status == AutomationBrowserStatus.Stopped;
             ShowSignIn = view.Status == AutomationBrowserStatus.NeedsSignIn;
+            // Stop is offered for the two states we KNOW are running - never merely for "not stopped",
+            // which would put a Stop button on a browser whose status we have not established yet.
+            ShowStop = view.Status is AutomationBrowserStatus.Ready or AutomationBrowserStatus.NeedsSignIn;
             ShowAttach = view.Status == AutomationBrowserStatus.Ready;
-            ShowStop = view.Status != AutomationBrowserStatus.Stopped;
 
-            // The pill's color IS the fold's dot color; only the text contrast is chosen here.
-            PillBackground = view.Status == AutomationBrowserStatus.Stopped
-                ? PillGreyBg
-                : StatusPalette.BrushFor(view.DotColor);
-            PillForeground = view.Status == AutomationBrowserStatus.Stopped ? PillLightText : PillDarkText;
+            // The pill's color IS the fold's dot color; only the text contrast is chosen here. Checking
+            // wears the same quiet grey as stopped: it is the absence of an answer, not a fourth state.
+            var quiet = view.Status is AutomationBrowserStatus.Stopped or AutomationBrowserStatus.Checking;
+            PillBackground = quiet ? PillGreyBg : StatusPalette.BrushFor(view.DotColor);
+            PillForeground = quiet ? PillLightText : PillDarkText;
         }
 
         public string Id { get; }

--- a/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
@@ -30,16 +30,23 @@ internal static class BrowserSignInFlow
         // user who signs in to nothing gets a browser their agents cannot do anything useful with.
         // Both routes are named because both are legitimate - a browser account carries everything at
         // once, and per-site logins keep the profile to just the accounts it is meant to reach.
-        var accountKind = view.Browser.Equals("Edge", StringComparison.OrdinalIgnoreCase)
-            ? "a Microsoft account"
-            : "a Google account";
+        //
+        // Only Chrome and Edge HAVE that carry-everything account. Naming one for Brave or Opera would
+        // send someone looking for a thing their browser does not have, so those are told the one route
+        // that is real for them.
+        var whatToSignInTo = AccountRoute(view.Browser) is { } accountKind
+            ? $"Sign in to whatever you want this browser to reach: {accountKind} to bring your profile "
+              + "across, or just the individual websites you want an agent to use."
+            : "Sign in to the individual websites you want an agent to use - this browser has no single "
+              + "account that carries a profile across.";
 
         var dialog = new ConfirmDialog(
             "Sign in once",
-            $"A \"{view.Name}\" window just opened on its sign-in page. Sign in by hand in that window - "
+            // Not "on its sign-in page": Brave and Opera open on their start page, because they have no
+            // account page to open. Saying so would send someone looking for a form that is not there.
+            $"A \"{view.Name}\" window just opened. Sign in by hand in that window - "
             + "DevThrottle never types your credentials.\n\n"
-            + $"Sign in to whatever you want this browser to reach: {accountKind} to bring your profile "
-            + "across, or just the individual websites you want an agent to use. Whatever is signed in "
+            + $"{whatToSignInTo} Whatever is signed in "
             + "here is what your agents can drive - nothing else.\n\n"
             + "The logins are kept in this browser's own profile, apart from your everyday browser, and "
             + "last until the account signs them out.\n\n"
@@ -56,4 +63,17 @@ internal static class BrowserSignInFlow
 
         return confirmed;
     }
+
+    /// <summary>
+    /// The name of the browser account that carries a whole signed-in profile across in one go, or
+    /// null for a browser that has no such thing. Matched on the same text the view carries
+    /// (<see cref="BrowserKind"/>'s name), so a new browser lands in the null branch and gets the
+    /// per-site instruction rather than being told to sign in to someone else's account.
+    /// </summary>
+    internal static string? AccountRoute(string browser) => browser switch
+    {
+        _ when browser.Equals(nameof(BrowserKind.Chrome), StringComparison.OrdinalIgnoreCase) => "a Google account",
+        _ when browser.Equals(nameof(BrowserKind.Edge), StringComparison.OrdinalIgnoreCase) => "a Microsoft account",
+        _ => null,
+    };
 }

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
@@ -37,6 +37,10 @@ public partial class BrowsersRailGroup : UserControl
     private bool _expanded = true;
     private bool _refreshing;
 
+    /// <summary>Bumped by every refresh. A status probe carries the generation it started under and
+    /// drops its result if a newer refresh has replaced the list underneath it.</summary>
+    private int _refreshGeneration;
+
     public BrowsersRailGroup()
     {
         InitializeComponent();
@@ -55,21 +59,29 @@ public partial class BrowsersRailGroup : UserControl
     }
 
     /// <summary>
-    /// Re-read the registry, probe each browser's live status, and repaint the group. Safe to call
-    /// from anywhere; overlapping calls collapse into one.
+    /// Re-read the registry and repaint the group, then find out which browsers are running.
+    ///
+    /// The rows come from local files and paint immediately; each browser's running/stopped answer
+    /// costs a probe of its debug port and arrives after, on its own. Rows already on screen keep their
+    /// last known status while the fresh probe runs - this method is also driven by a timer, and
+    /// blinking every row to "Checking..." on each tick would read as instability.
+    ///
+    /// Safe to call from anywhere; overlapping calls collapse into one.
     /// </summary>
     public async Task RefreshAsync()
     {
         if (_refreshing) return;
         _refreshing = true;
+        var generation = ++_refreshGeneration;
         try
         {
+            var previous = _views;
             var harnessInstalled = false;
             IReadOnlyList<AutomationBrowserView> views = Array.Empty<AutomationBrowserView>();
-            await Task.Run(async () =>
+            await Task.Run(() =>
             {
                 harnessInstalled = AutomationBrowserViewFold.IsHarnessInstalled();
-                views = await AutomationBrowserViewFold.ListAsync().ConfigureAwait(false);
+                views = AutomationBrowserViewFold.ListPending(previous);
             });
 
             _views = views;
@@ -80,11 +92,45 @@ public partial class BrowsersRailGroup : UserControl
         {
             FileLog.Write($"[BrowsersRailGroup] RefreshAsync FAILED: {ex.Message}");
             Notified?.Invoke(this, $"Could not read the browsers list: {ex.Message}");
+            return;
         }
         finally
         {
             _refreshing = false;
         }
+
+        await ProbeStatusesAsync(generation);
+    }
+
+    /// <summary>
+    /// Probe every listed browser CONCURRENTLY and repaint as each answer arrives. Results from a
+    /// superseded refresh are dropped: by then the rows they would update belong to a list that no
+    /// longer exists.
+    /// </summary>
+    private async Task ProbeStatusesAsync(int generation)
+    {
+        var listed = _views;
+        if (listed.Count == 0) return;
+
+        await Task.WhenAll(listed.Select(async pending =>
+        {
+            AutomationBrowserView probed;
+            try
+            {
+                probed = await Task.Run(() => AutomationBrowserViewFold.FoldAsync(AutomationBrowserRegistry.Get(pending.Id)));
+            }
+            catch (Exception ex)
+            {
+                // One browser that cannot be probed leaves its own row on its last known status and
+                // takes nothing else down with it.
+                FileLog.Write($"[BrowsersRailGroup] ProbeStatusesAsync: id={pending.Id} failed (non-fatal): {ex.Message}");
+                return;
+            }
+
+            if (generation != _refreshGeneration) return;
+            _views = _views.Select(v => v.Id == probed.Id ? probed : v).ToList();
+            Render(_views, _harnessInstalled);
+        }));
     }
 
     private void Render(IReadOnlyList<AutomationBrowserView> views, bool harnessInstalled)
@@ -105,7 +151,9 @@ public partial class BrowsersRailGroup : UserControl
             DotBrush = StatusPalette.BrushFor(v.DotColor),
             // Dimmed advertising rows when the harness is missing: discoverable, not operable.
             RowOpacity = harnessInstalled ? 1.0 : 0.45,
-            ActionVisible = harnessInstalled,
+            // No action while the status is still unknown: every action here depends on whether the
+            // browser is running, and the fold gives an empty label for exactly that reason.
+            ActionVisible = harnessInstalled && v.Status != AutomationBrowserStatus.Checking,
             ActionLabel = v.ActionLabel,
             ActionForeground = v.Status == AutomationBrowserStatus.NeedsSignIn ? AmberBrush : AccentBrush,
             ActionToolTip = v.Status switch

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -1995,16 +1995,18 @@ public partial class FirstRunWizardDialog : Window
     }
 
     /// <summary>
-    /// Which browser to set up. Chrome first because it is what most people have signed in to, Edge
-    /// otherwise. THROWS when neither is installed, naming both - there is nothing to substitute.
+    /// Which browser to set up: the first one installed, in DetectBrowsers' own most-used-first order
+    /// (Chrome, then Edge, then the rest). Taking that order rather than naming browsers here means a
+    /// machine with only Brave or only Opera now gets set up instead of being told to install Chrome.
+    /// THROWS when none of them is installed, naming all of them - there is nothing to substitute.
     /// </summary>
     private static BrowserKind PickBrowserKind()
     {
         var installed = BrowserLauncher.DetectBrowsers();
-        if (installed.Any(b => b.Kind == BrowserKind.Chrome)) return BrowserKind.Chrome;
-        if (installed.Any(b => b.Kind == BrowserKind.Edge)) return BrowserKind.Edge;
+        if (installed.Count > 0) return installed[0].Kind;
         throw new InvalidOperationException(
-            "Neither Chrome nor Edge is installed on this machine, so there is no browser to set up. "
+            $"None of the browsers DevThrottle can drive ({string.Join(", ", Enum.GetNames<BrowserKind>())}) "
+            + "is installed on this machine, so there is no browser to set up. "
             + "Install one, then set browsers up from the Browsers group in the left rail.");
     }
 

--- a/src/CcDirector.ControlApi/BrowserEndpoints.cs
+++ b/src/CcDirector.ControlApi/BrowserEndpoints.cs
@@ -40,7 +40,13 @@ internal static class BrowserEndpoints
             if (req is null || string.IsNullOrWhiteSpace(req.Name))
                 return Results.BadRequest(new { error = "name is required" });
             if (!TryParseKind(req.Browser, out var kind))
-                return Results.BadRequest(new { error = $"unknown browser \"{req.Browser}\" - use chrome or edge" });
+                return Results.BadRequest(new
+                {
+                    // Listed from the enum so the error names every browser this build accepts, rather
+                    // than an older pair someone has to discover is out of date.
+                    error = $"unknown browser \"{req.Browser}\" - use one of: "
+                        + string.Join(", ", Enum.GetNames<BrowserKind>().Select(n => n.ToLowerInvariant())),
+                });
 
             try
             {

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserListPendingTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserListPendingTests.cs
@@ -1,0 +1,108 @@
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Tests for the instant, unprobed list - the pass a surface paints BEFORE it knows which browsers are
+/// running. Runs against an isolated CC_DIRECTOR_ROOT so it reads a throwaway registry.json, and opens
+/// no sockets: the whole point of this path is that it touches nothing but local files.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class AutomationBrowserListPendingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private static readonly Func<int, bool> AllFree = _ => true;
+
+    public AutomationBrowserListPendingTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-pendinglist-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void FirstPaint_ListsEveryBrowserAsChecking()
+    {
+        AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+        AutomationBrowserRegistry.Create("mindzie", BrowserKind.Edge, AllFree);
+
+        var views = AutomationBrowserViewFold.ListPending();
+
+        Assert.Equal(2, views.Count);
+        Assert.All(views, v => Assert.Equal(AutomationBrowserStatus.Checking, v.Status));
+
+        // Nothing about the row is deferred except whether it is running: the names, browsers and
+        // ports are all present, which is what makes painting this first worth doing.
+        Assert.Equal(new[] { "Center Consulting", "mindzie" }, views.Select(v => v.Name).ToArray());
+        Assert.Equal(new[] { "Chrome", "Edge" }, views.Select(v => v.Browser).ToArray());
+        Assert.All(views, v => Assert.True(v.Port > 0));
+    }
+
+    [Fact]
+    public void ARefresh_KeepsTheLastKnownStatusInsteadOfBlinkingBackToChecking()
+    {
+        var created = AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+        var previous = new[] { AutomationBrowserViewFold.Fold(created, AutomationBrowserStatus.Ready, "a@b.com") };
+
+        var views = AutomationBrowserViewFold.ListPending(previous);
+
+        // The rail re-reads on a timer. Resetting an already-answered row to "Checking..." every tick
+        // reads as instability, so a row we have an answer for keeps it while the fresh probe runs.
+        var view = Assert.Single(views);
+        Assert.Equal(AutomationBrowserStatus.Ready, view.Status);
+    }
+
+    [Fact]
+    public void ARefresh_StillShowsARenameImmediately()
+    {
+        var created = AutomationBrowserRegistry.Create("Old Name", BrowserKind.Chrome, AllFree);
+        var previous = new[] { AutomationBrowserViewFold.Fold(created, AutomationBrowserStatus.Ready, account: null) };
+        AutomationBrowserRegistry.Rename(created.Id, "New Name");
+
+        var view = Assert.Single(AutomationBrowserViewFold.ListPending(previous));
+
+        // ONLY the status is carried over. Everything else is re-read, or a rename would appear to do
+        // nothing until the probe came back.
+        Assert.Equal("New Name", view.Name);
+        Assert.Equal(AutomationBrowserStatus.Ready, view.Status);
+    }
+
+    [Fact]
+    public void ABrowserAddedSinceTheLastPaint_IsCheckingNotStale()
+    {
+        var first = AutomationBrowserRegistry.Create("First", BrowserKind.Chrome, AllFree);
+        var previous = new[] { AutomationBrowserViewFold.Fold(first, AutomationBrowserStatus.Ready, account: null) };
+        AutomationBrowserRegistry.Create("Second", BrowserKind.Edge, AllFree);
+
+        var views = AutomationBrowserViewFold.ListPending(previous);
+
+        Assert.Equal(AutomationBrowserStatus.Ready, Assert.Single(views, v => v.Name == "First").Status);
+        Assert.Equal(AutomationBrowserStatus.Checking, Assert.Single(views, v => v.Name == "Second").Status);
+    }
+
+    [Fact]
+    public void APreviousListThatWasItselfStillChecking_DoesNotCarryCheckingForward()
+    {
+        // Carrying "Checking" forward would be carrying a non-answer, which is the same as having none.
+        var created = AutomationBrowserRegistry.Create("Center Consulting", BrowserKind.Chrome, AllFree);
+        var previous = new[] { AutomationBrowserViewFold.Fold(created, AutomationBrowserStatus.Checking, account: null) };
+
+        var view = Assert.Single(AutomationBrowserViewFold.ListPending(previous));
+
+        Assert.Equal(AutomationBrowserStatus.Checking, view.Status);
+    }
+
+    [Fact]
+    public void AnEmptyRegistry_ListsNothingRatherThanThrowing()
+    {
+        Assert.Empty(AutomationBrowserViewFold.ListPending());
+    }
+}

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserServiceAccountUrlTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserServiceAccountUrlTests.cs
@@ -1,0 +1,44 @@
+using CcDirector.Core.Browsers;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Proves the sign-in landing page is decided for EVERY browser we can drive. The sign-in flow opens
+/// this URL in the browser the human is about to sign in to by hand, so an unmapped browser is not a
+/// cosmetic gap - it is the one screen the whole feature depends on, opened on the wrong page or not
+/// at all.
+/// </summary>
+public sealed class AutomationBrowserServiceAccountUrlTests
+{
+    [Fact]
+    public void EveryBrowserKind_HasASignInLandingPage()
+    {
+        foreach (var kind in Enum.GetValues<BrowserKind>())
+        {
+            var url = AutomationBrowserService.AccountUrl(kind);
+            Assert.StartsWith("https://", url);
+        }
+    }
+
+    [Fact]
+    public void ChromeAndEdge_LandOnTheirOwnAccountProvider()
+    {
+        // These two DO have a browser account that carries a profile across, and landing on the right
+        // provider is the shortcut the flow is offering. Sending an Edge user to Google's page is a
+        // dead end they cannot sign in from.
+        Assert.Equal("https://accounts.google.com/", AutomationBrowserService.AccountUrl(BrowserKind.Chrome));
+        Assert.Equal("https://login.live.com/", AutomationBrowserService.AccountUrl(BrowserKind.Edge));
+    }
+
+    [Fact]
+    public void BraveAndOpera_DoNotLandOnAnotherBrowsersAccountPage()
+    {
+        // Neither has a carry-everything account, so neither may be pointed at Google's or Microsoft's
+        // sign-in - that would send someone hunting for a profile sync their browser does not have.
+        var accountPages = new[] { "https://accounts.google.com/", "https://login.live.com/" };
+
+        Assert.DoesNotContain(AutomationBrowserService.AccountUrl(BrowserKind.Brave), accountPages);
+        Assert.DoesNotContain(AutomationBrowserService.AccountUrl(BrowserKind.Opera), accountPages);
+    }
+}

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
@@ -45,6 +45,52 @@ public sealed class AutomationBrowserViewFoldTests
     }
 
     [Fact]
+    public void Fold_Checking_IsGreyAndOffersNoAction()
+    {
+        var view = AutomationBrowserViewFold.Fold(Browser(), AutomationBrowserStatus.Checking, account: null);
+
+        Assert.Equal("Checking...", view.StatusLabel);
+        Assert.Equal("grey", view.DotColor);
+        Assert.Equal("Chrome - checking...", view.Subtitle);
+
+        // The empty action is the point, not an oversight: every action a surface could offer depends
+        // on whether the browser is running, and "Start" on a browser that turns out to be running is
+        // the wrong button. A surface reads empty as "offer nothing yet".
+        Assert.Equal("", view.ActionLabel);
+    }
+
+    [Fact]
+    public void Fold_Checking_StillCarriesEverythingThatCostsNoProbe()
+    {
+        // The whole reason this status exists: a surface can paint the row in full - name, browser,
+        // port, account, attach command - and wait only for the one fact that is slow.
+        var view = AutomationBrowserViewFold.Fold(Browser(), AutomationBrowserStatus.Checking, "soren@centerconsulting.com");
+
+        Assert.Equal("center-consulting", view.Id);
+        Assert.Equal("Center Consulting", view.Name);
+        Assert.Equal("Chrome", view.Browser);
+        Assert.Equal(9310, view.Port);
+        Assert.Equal("soren@centerconsulting.com", view.Account);
+        Assert.Equal("Chrome - soren@centerconsulting.com", view.Subtitle);
+        Assert.Contains("center-consulting", view.AttachCommand);
+    }
+
+    [Fact]
+    public void EveryStatus_FoldsWithoutThrowing()
+    {
+        // The three display switches throw on an unhandled status, so a status added without a display
+        // decision takes the whole list down at render time rather than at build time. This is the
+        // build-time catch.
+        foreach (var status in Enum.GetValues<AutomationBrowserStatus>())
+        {
+            var view = AutomationBrowserViewFold.Fold(Browser(), status, account: null);
+            Assert.False(string.IsNullOrWhiteSpace(view.StatusLabel));
+            Assert.False(string.IsNullOrWhiteSpace(view.DotColor));
+            Assert.False(string.IsNullOrWhiteSpace(view.Subtitle));
+        }
+    }
+
+    [Fact]
     public void Fold_Stopped_IsGreyStart()
     {
         var view = AutomationBrowserViewFold.Fold(Browser(BrowserKind.Edge), AutomationBrowserStatus.Stopped, account: null);

--- a/src/CcDirector.Core.Tests/Browsers/BrowserLauncherTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/BrowserLauncherTests.cs
@@ -147,8 +147,72 @@ public class BrowserLauncherTests
     {
         var windows = BrowserLauncher.WindowsCandidates();
 
-        Assert.All(windows, c => Assert.EndsWith("User Data", c.UserDataDir));
+        // The Chromium-standard shape, which is every browser here EXCEPT Opera - Opera keeps its
+        // profile in Roaming with no "User Data" level, asserted on its own below. Blanket-asserting
+        // "User Data" across the whole table would have made the Opera row unaddable rather than
+        // catching a real defect.
+        Assert.All(windows.Where(c => c.Kind != BrowserKind.Opera),
+            c => Assert.EndsWith("User Data", c.UserDataDir));
         Assert.All(windows, c => Assert.All(c.ExeCandidates, p => Assert.EndsWith(".exe", p)));
+    }
+
+    [Fact]
+    public void WindowsCandidates_OperaUsesRoamingAppDataWithNoUserDataLevel()
+    {
+        var opera = Assert.Single(BrowserLauncher.WindowsCandidates(), c => c.Kind == BrowserKind.Opera);
+
+        // Opera's profile is NOT where the Chromium pattern says: it is under Roaming, and the folder
+        // is "Opera Stable" rather than a "User Data" level. Reading Local State from a Chrome-shaped
+        // guess finds nothing and the browser silently reports no signed-in account.
+        Assert.EndsWith(Path.Combine("Opera Software", "Opera Stable"), opera.UserDataDir);
+        Assert.DoesNotContain("User Data", opera.UserDataDir);
+        Assert.StartsWith(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), opera.UserDataDir);
+
+        // The installer defaults to a per-user install, so that path must be tried before the
+        // all-users one or the default install is the case we miss.
+        Assert.StartsWith(
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "Opera"),
+            opera.ExeCandidates[0]);
+    }
+
+    [Fact]
+    public void WindowsCandidates_BraveUsesItsOwnVendorFolder()
+    {
+        var brave = Assert.Single(BrowserLauncher.WindowsCandidates(), c => c.Kind == BrowserKind.Brave);
+
+        Assert.All(brave.ExeCandidates, p => Assert.EndsWith(Path.Combine("Brave-Browser", "Application", "brave.exe"), p));
+        Assert.EndsWith(Path.Combine("BraveSoftware", "Brave-Browser", "User Data"), brave.UserDataDir);
+    }
+
+    [Fact]
+    public void MacCandidates_BraveAndOperaReachTheBinaryAndTheirOwnSupportFolders()
+    {
+        var mac = BrowserLauncher.MacCandidates();
+        var brave = Assert.Single(mac, c => c.Kind == BrowserKind.Brave);
+        var opera = Assert.Single(mac, c => c.Kind == BrowserKind.Opera);
+
+        Assert.All(brave.ExeCandidates, p => Assert.EndsWith(".app/Contents/MacOS/Brave Browser", Slashes(p)));
+        Assert.All(opera.ExeCandidates, p => Assert.EndsWith(".app/Contents/MacOS/Opera", Slashes(p)));
+
+        // Neither follows the product name: Brave nests under a vendor folder, and Opera's support
+        // folder is named by BUNDLE ID. Both are the kind of thing a pattern-match gets wrong.
+        Assert.EndsWith("Library/Application Support/BraveSoftware/Brave-Browser", Slashes(brave.UserDataDir));
+        Assert.EndsWith("Library/Application Support/com.operasoftware.Opera", Slashes(opera.UserDataDir));
+        Assert.DoesNotContain("User Data", Slashes(brave.UserDataDir));
+        Assert.DoesNotContain("User Data", Slashes(opera.UserDataDir));
+    }
+
+    [Fact]
+    public void EveryBrowserKind_HasAWindowsAndAMacCandidateRow()
+    {
+        // The bug this catches is an enum member added without its install locations: the browser
+        // appears in the API's accepted list and in error messages, then reports "not installed" on
+        // every machine because nothing ever looks for it.
+        foreach (var kind in Enum.GetValues<BrowserKind>())
+        {
+            Assert.Single(BrowserLauncher.WindowsCandidates(), c => c.Kind == kind);
+            Assert.Single(BrowserLauncher.MacCandidates(), c => c.Kind == kind);
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Core/Browsers/AutomationBrowser.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowser.cs
@@ -17,7 +17,7 @@ namespace CcDirector.Core.Browsers;
 /// the <c>BU_NAME</c> the harness attaches with and as the on-disk sub-directory name. Never changes,
 /// even when <paramref name="Name"/> is edited.</param>
 /// <param name="Name">Human-facing, user-editable label (e.g. "Center Consulting").</param>
-/// <param name="Kind">Which Chromium browser this drives (Chrome or Edge).</param>
+/// <param name="Kind">Which Chromium browser this drives (see <see cref="BrowserKind"/>).</param>
 /// <param name="UserDataDir">This browser's dedicated <c>--user-data-dir</c> (absolute path). Never a
 /// real personal profile - always a folder DevThrottle created under <see cref="Storage.CcStorage.Browsers"/>.</param>
 /// <param name="Port">The fixed <c>--remote-debugging-port</c> this browser always launches on, so the
@@ -51,6 +51,19 @@ public enum AutomationBrowserStatus
 
     /// <summary>The browser is running AND has been signed in - fully drivable by an agent.</summary>
     Ready,
+
+    /// <summary>
+    /// Not asked yet. Everything a browser IS - its name, browser, port, folder, attach command,
+    /// signed-in account - is read from local files in microseconds, but whether it is RUNNING costs a
+    /// probe of its debug port, and that probe is the slow part on some machines. This status lets a
+    /// surface show the browsers it has immediately and fill the running/stopped answer in when it
+    /// arrives, instead of holding the whole list hostage to the probe.
+    ///
+    /// It is a DISPLAY state, never a stored one: nothing writes it to the registry and no decision is
+    /// made from it. A surface showing Checking must offer no action, because "Start" on a browser that
+    /// turns out to be running is the wrong button.
+    /// </summary>
+    Checking,
 }
 
 /// <summary>

--- a/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserService.cs
@@ -383,11 +383,27 @@ public static class AutomationBrowserService
 
     private static string VersionUrl(int port) => $"http://127.0.0.1:{port}/json/version";
 
-    /// <summary>The sign-in landing page appropriate to the browser's identity provider.</summary>
-    private static string AccountUrl(BrowserKind kind) => kind switch
+    /// <summary>
+    /// The sign-in landing page appropriate to the browser's identity provider.
+    ///
+    /// Chrome and Edge each have a browser account that carries a whole profile across in one sign-in,
+    /// so landing on it is a real shortcut. Brave and Opera have no such account - Brave Sync is a
+    /// pairing code and an Opera account syncs bookmarks, neither of which signs the profile in to
+    /// anything an agent will drive. For those two the honest landing is the browser's own start page:
+    /// the window comes up focused and the human signs in to the sites this profile is FOR, which is
+    /// what the sign-in dialog's copy tells them to do.
+    ///
+    /// Exhaustive on purpose: a fifth browser added to <see cref="BrowserKind"/> without a decision
+    /// made here should fail loudly at this seam rather than quietly land someone on a page chosen for
+    /// a different browser.
+    /// </summary>
+    internal static string AccountUrl(BrowserKind kind) => kind switch
     {
         BrowserKind.Chrome => "https://accounts.google.com/",
         BrowserKind.Edge => "https://login.live.com/",
-        _ => "https://www.google.com/",
+        BrowserKind.Brave => "https://search.brave.com/",
+        BrowserKind.Opera => "https://www.opera.com/",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind,
+            $"No sign-in landing page has been chosen for {kind}. Add one to AccountUrl."),
     };
 }

--- a/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
@@ -11,7 +11,7 @@ namespace CcDirector.Core.Browsers;
 /// </summary>
 /// <param name="Id">Stable slug id (also the <c>BU_NAME</c>).</param>
 /// <param name="Name">Human-facing, user-editable label.</param>
-/// <param name="Browser">"Chrome" or "Edge".</param>
+/// <param name="Browser">The browser's name, e.g. "Chrome" (see <see cref="BrowserKind"/>).</param>
 /// <param name="Port">The fixed remote-debugging port.</param>
 /// <param name="Status">The folded lifecycle state (see <see cref="AutomationBrowserStatus"/>).</param>
 /// <param name="StatusLabel">The human status text: "Ready" / "Needs sign-in" / "Stopped".</param>
@@ -61,14 +61,57 @@ public static class AutomationBrowserViewFold
     /// <summary>True when browser-harness is installed (resolvable on PATH) on this machine.</summary>
     public static bool IsHarnessInstalled() => ExecutableResolver.Resolve(HarnessExecutable) is not null;
 
-    /// <summary>Fold every registered browser on this machine into its render-ready view.</summary>
+    /// <summary>
+    /// Fold every registered browser on this machine into its render-ready view, all at once.
+    ///
+    /// CONCURRENT ON PURPOSE, and the reason is measured rather than assumed. Each fold's cost is one
+    /// probe of a loopback debug port, and a probe of a port nothing is listening on does NOT fail
+    /// instantly on every machine: on a box where something in the network stack swallows the RST, the
+    /// refusal takes a full two seconds. Folded one after another, that is two seconds PER STOPPED
+    /// BROWSER before the list can paint - four browsers spent eight seconds on "Checking browsers...",
+    /// and it grew with every browser added. Concurrently it is the cost of the slowest single probe,
+    /// whatever the machine's refusal behaviour is, and it stops growing.
+    ///
+    /// Order is preserved: the results come back in registry order, not completion order, so the list
+    /// does not reshuffle itself between refreshes.
+    /// </summary>
     public static async Task<IReadOnlyList<AutomationBrowserView>> ListAsync(CancellationToken ct = default)
     {
         var browsers = AutomationBrowserRegistry.Load();
-        var views = new List<AutomationBrowserView>(browsers.Count);
-        foreach (var browser in browsers)
-            views.Add(await FoldAsync(browser, ct).ConfigureAwait(false));
-        return views;
+        return await Task.WhenAll(browsers.Select(b => FoldAsync(b, ct))).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Fold every registered browser WITHOUT asking whether any of them is running. Reads only local
+    /// files, so it returns in microseconds however many browsers there are and whatever the machine's
+    /// network stack does.
+    ///
+    /// This is what a surface paints FIRST. Each browser carries its real name, browser, port, account
+    /// and attach command - everything except the one fact that costs a probe. The surface then calls
+    /// <see cref="FoldAsync"/> per browser and swaps each row in as its answer lands.
+    ///
+    /// <paramref name="previous"/> is the list this surface is currently showing, when it has one. A
+    /// browser already on screen KEEPS its last known status while the fresh probe runs, and only a
+    /// browser being shown for the first time reads <see cref="AutomationBrowserStatus.Checking"/>.
+    /// Without that, a surface that re-reads on a timer would blink every row back to "Checking..."
+    /// every few seconds, which reads as instability rather than as a refresh. Everything else in the
+    /// view is still re-read from the registry, so a rename shows immediately - it is ONLY the status
+    /// that is carried over, because it is the only field we have not re-established yet.
+    /// </summary>
+    public static IReadOnlyList<AutomationBrowserView> ListPending(IReadOnlyList<AutomationBrowserView>? previous = null)
+    {
+        var lastKnown = previous?
+            .Where(v => v.Status != AutomationBrowserStatus.Checking)
+            .ToDictionary(v => v.Id, v => v.Status, StringComparer.OrdinalIgnoreCase);
+
+        return AutomationBrowserRegistry.Load()
+            .Select(b => Fold(
+                b,
+                lastKnown is not null && lastKnown.TryGetValue(b.Id, out var status)
+                    ? status
+                    : AutomationBrowserStatus.Checking,
+                ReadAccountOrNull(b)))
+            .ToList();
     }
 
     /// <summary>Fold one browser: probe its live status, read its signed-in account, then map.</summary>
@@ -77,21 +120,26 @@ public static class AutomationBrowserViewFold
         if (browser is null) throw new ArgumentNullException(nameof(browser));
 
         var status = await AutomationBrowserService.StatusAsync(browser, ct).ConfigureAwait(false);
+        return Fold(browser, status, ReadAccountOrNull(browser));
+    }
 
-        // The account is decoration on the subtitle, never load-bearing: an unreadable profile (first
-        // run, mid-write Local State) must not take the whole list down, so this read alone is allowed
-        // to degrade to "no account shown" - and it logs when it does.
-        string? account = null;
+    /// <summary>
+    /// The signed-in account, or null when it cannot be read. The account is decoration on the
+    /// subtitle, never load-bearing: an unreadable profile (first run, mid-write Local State) must not
+    /// take the whole list down, so this read alone is allowed to degrade to "no account shown" - and
+    /// it logs when it does.
+    /// </summary>
+    private static string? ReadAccountOrNull(AutomationBrowser browser)
+    {
         try
         {
-            account = AutomationBrowserService.ReadAccount(browser);
+            return AutomationBrowserService.ReadAccount(browser);
         }
         catch (Exception ex)
         {
             FileLog.Write($"[AutomationBrowserViewFold] ReadAccount id={browser.Id} failed (non-fatal): {ex.Message}");
+            return null;
         }
-
-        return Fold(browser, status, account);
     }
 
     /// <summary>
@@ -128,6 +176,7 @@ public static class AutomationBrowserViewFold
         AutomationBrowserStatus.Stopped => "Stopped",
         AutomationBrowserStatus.NeedsSignIn => "Needs sign-in",
         AutomationBrowserStatus.Ready => "Ready",
+        AutomationBrowserStatus.Checking => "Checking...",
         _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
     };
 
@@ -138,15 +187,24 @@ public static class AutomationBrowserViewFold
         AutomationBrowserStatus.Stopped => "grey",
         AutomationBrowserStatus.NeedsSignIn => "yellow",
         AutomationBrowserStatus.Ready => "green",
+        // Grey, the same as stopped: an unknown state must not claim attention, and a colour of its
+        // own would read as a fourth thing a browser can be rather than "we have not asked yet".
+        AutomationBrowserStatus.Checking => "grey",
         _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
     };
 
-    /// <summary>The single next action a surface offers for this browser.</summary>
+    /// <summary>
+    /// The single next action a surface offers for this browser, or empty while the answer is still
+    /// unknown. Empty is the honest answer for <see cref="AutomationBrowserStatus.Checking"/>: the
+    /// right action depends entirely on whether the browser is running, and offering "Start" for a
+    /// browser that turns out to be running is worse than offering nothing for a moment.
+    /// </summary>
     public static string ActionLabel(AutomationBrowserStatus status) => status switch
     {
         AutomationBrowserStatus.Stopped => "Start",
         AutomationBrowserStatus.NeedsSignIn => "Sign in",
         AutomationBrowserStatus.Ready => "Attach",
+        AutomationBrowserStatus.Checking => "",
         _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
     };
 
@@ -162,6 +220,7 @@ public static class AutomationBrowserViewFold
             AutomationBrowserStatus.Stopped => $"{kind} - stopped",
             AutomationBrowserStatus.NeedsSignIn => $"{kind} - not signed in yet",
             AutomationBrowserStatus.Ready => $"{kind} - signed in",
+            AutomationBrowserStatus.Checking => $"{kind} - checking...",
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
         };
     }

--- a/src/CcDirector.Core/Browsers/BrowserLauncher.cs
+++ b/src/CcDirector.Core/Browsers/BrowserLauncher.cs
@@ -5,11 +5,21 @@ using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Browsers;
 
-/// <summary>The Chromium browsers we can launch a specific profile in.</summary>
+/// <summary>
+/// The Chromium browsers we can launch a specific profile in.
+///
+/// Chromium is the whole list, and that is a capability boundary rather than a preference: a browser
+/// is drivable here only because it speaks the Chrome DevTools Protocol on a
+/// <c>--remote-debugging-port</c>, which is how browser-harness attaches. Firefox (WebDriver BiDi) and
+/// Safari (WebKit remote inspector) speak neither, so they cannot be added by listing them here - they
+/// would need a second protocol backend.
+/// </summary>
 public enum BrowserKind
 {
     Chrome,
-    Edge
+    Edge,
+    Brave,
+    Opera
 }
 
 /// <summary>
@@ -70,6 +80,7 @@ public static class BrowserLauncher
     internal static IReadOnlyList<(BrowserKind Kind, string DisplayName, string[] ExeCandidates, string UserDataDir)> WindowsCandidates()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var roamingAppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
@@ -90,6 +101,27 @@ public static class BrowserLauncher
                     Path.Combine(programFiles, "Microsoft", "Edge", "Application", "msedge.exe"),
                 },
                 Path.Combine(localAppData, "Microsoft", "Edge", "User Data")),
+            (BrowserKind.Brave, "Brave",
+                new[]
+                {
+                    Path.Combine(programFiles, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+                    Path.Combine(programFilesX86, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+                    Path.Combine(localAppData, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+                },
+                Path.Combine(localAppData, "BraveSoftware", "Brave-Browser", "User Data")),
+            // Opera breaks the pattern twice, so neither line is a copy of the ones above. Its
+            // installer defaults to a PER-USER install under Local\Programs (the all-users location is
+            // the option, not the default), which is why that candidate is first. And its profile lives
+            // in ROAMING AppData with no "User Data" level - a Chrome-shaped guess here would look
+            // right and find nothing.
+            (BrowserKind.Opera, "Opera",
+                new[]
+                {
+                    Path.Combine(localAppData, "Programs", "Opera", "opera.exe"),
+                    Path.Combine(programFiles, "Opera", "opera.exe"),
+                    Path.Combine(programFilesX86, "Opera", "opera.exe"),
+                },
+                Path.Combine(roamingAppData, "Opera Software", "Opera Stable")),
         };
     }
 
@@ -126,12 +158,21 @@ public static class BrowserLauncher
             (BrowserKind.Edge, "Microsoft Edge",
                 BundlePaths(home, "Microsoft Edge.app", "Microsoft Edge"),
                 Path.Combine(appSupport, "Microsoft Edge")),
+            (BrowserKind.Brave, "Brave",
+                BundlePaths(home, "Brave Browser.app", "Brave Browser"),
+                Path.Combine(appSupport, "BraveSoftware", "Brave-Browser")),
+            // Opera names its support folder by bundle id, not by product name, so this one is not
+            // guessable from the pattern the other three follow.
+            (BrowserKind.Opera, "Opera",
+                BundlePaths(home, "Opera.app", "Opera"),
+                Path.Combine(appSupport, "com.operasoftware.Opera")),
         };
     }
 
     /// <summary>
     /// Returns the Chromium browsers found at their standard install locations, in a stable order
-    /// (Chrome, then Edge). A browser is "installed" when one of its candidate exe paths exists.
+    /// (Chrome, Edge, Brave, Opera - most-used first, which is also the order the pickers show and the
+    /// first-run wizard prefers). A browser is "installed" when one of its candidate exe paths exists.
     /// </summary>
     public static IReadOnlyList<BrowserInfo> DetectBrowsers()
     {

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -696,7 +696,9 @@ def browser_list(
 @browser_app.command("create")
 def browser_create(
     name: str = typer.Option(..., "--name", help='Human-facing name, e.g. "Center Consulting".'),
-    browser: str = typer.Option("chrome", "--browser", help="Which browser: chrome or edge."),
+    browser: str = typer.Option(
+        "chrome", "--browser", help="Which browser: chrome, edge, brave, or opera."
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
 ) -> None:
     """Register a new drivable browser (does not launch it)."""


### PR DESCRIPTION
Two changes to the drivable-browsers feature, both visible in the Browsers tab and the rail group.

## Brave and Opera join Chrome and Edge

The list is Chromium-only, and that is a capability boundary rather than a preference: everything after launch speaks the Chrome DevTools Protocol on a `--remote-debugging-port`, which is how Browser Harness attaches. Firefox (WebDriver BiDi) and Safari (WebKit remote inspector) speak neither, so they cannot be added by listing them - they would need a second protocol backend, in a third-party project. That decision is written into the enum's doc comment so it does not get re-litigated.

Two of the four new install paths do not follow the Chrome pattern and would have been wrong if copied. Both are pinned by tests:

- Opera's installer defaults to a **per-user** install under `Local\Programs\Opera`, and its profile lives in **Roaming** as `Opera Software\Opera Stable` - no `User Data` level.
- On macOS, Opera's support folder is named by **bundle id** (`com.operasoftware.Opera`), and Brave nests under a vendor folder.

The user-facing strings that spelled out "Chrome or Edge" now list from the enum, so they cannot go stale the next time a browser is added. The first-run wizard no longer names browsers either - it takes the first installed one in detection order, so a machine with only Brave gets set up instead of being told to install Chrome.

## The list no longer waits on port probes

Everything a browser *is* - name, browser, port, folder, signed-in account - is local file data costing microseconds. Whether it is **running** needs a probe of its debug port, and on a machine whose network stack does not promptly refuse a connection to a dead port, that probe takes a full two seconds. Those probes ran sequentially before anything painted, so four stopped browsers sat behind "Checking browsers..." for eight seconds, growing by two seconds per browser added.

The list now paints from local files, and each row's status is swapped in as its own probe answers. Measured against a real four-browser registry, same process and machine:

```
ORIGINAL - blank until every probe answered, one at a time : 8044 ms
PARALLEL - blank until every probe answered, all at once   : 2012 ms
NOW      - list on screen                                  :    6 ms
```

A new `Checking` display status carries this. It is a display state only - nothing writes it to the registry and no decision is made from it. Rows already on screen keep their last known status while re-probing, so the timer-driven rail does not blink every row back to "Checking..." every few seconds; only the status is carried over, so a rename still shows immediately.

## Latent bug fixed

Stop was offered for any browser that was not `Stopped`, which with the new state would have put a Stop button on a browser whose status had not been established yet. It now shows only for the two states known to be running.

## Proof

- Full solution build clean, 0 warnings.
- The new Opera path guard is negative-control proven: rewriting that path to the Chrome shape turns `WindowsCandidates_OperaUsesRoamingAppDataWithNoUserDataLevel` red.
- New tests fail the build if a future browser is added without install paths, without a sign-in landing page, or without a display decision for a new status.
- Ran on a real Director in an isolated instance (slot 5) against a four-browser registry.

## Not covered

Detection and launch are unproven against a real Brave or Opera install - neither is on this machine. Opera has a history of restricting remote debugging; if it does, `LaunchAsync` fails loudly with its "debug port did not come up" message rather than half-working.

Also includes an HTML mockup (`docs/mockups/browsers-tab-guidance.html`) for a guidance redesign of the tab's empty and create states. Mockup only - nothing there is implemented.