### PR TITLE
Teach the empty state, and call the thing a browser profile

### DIFF
--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml
@@ -10,18 +10,20 @@
 
     <Grid RowDefinitions="Auto,Auto,Auto,*" Margin="0,4,0,0">
 
-        <!-- Header: what this is, the honest one-sign-in rule, and the primary actions. -->
-        <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,14,8">
-            <TextBlock Classes="sectionTitle" Text="Browsers" />
+        <!-- Header: shown ONLY once profiles exist. On a clean install the empty state below is the
+             teaching surface and says all of this at length, so repeating it here would be noise.
+             Once it has done its job it shrinks to these two lines plus a way back to the detail. -->
+        <StackPanel Grid.Row="0" x:Name="HeaderPanel" Spacing="8" Margin="0,0,14,8">
+            <TextBlock Classes="sectionTitle" Text="Browser profiles" />
             <TextBlock Classes="hint"
-                       Text="Real, signed-in browsers your agents can drive through Browser Harness. Each one is a dedicated browser profile DevThrottle creates - never your everyday browser. You sign it in once, by hand, and the login lasts for months; after that any agent on this machine attaches with one command. The one sign-in cannot be automated away: modern browsers block driving your main profile and encrypt its logins, so a dedicated profile with a single hand sign-in is the honest design." />
+                       Text="Real, signed-in browser profiles your agents can drive. Each one has its own logins, kept apart from the profile you browse in yourself. Add one per role you want an agent to act as." />
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
-                <Button x:Name="NewBrowserButton" Classes="primaryButton" Content="+ New browser"
+                <Button x:Name="NewBrowserButton" Classes="primaryButton" Content="+ New browser profile"
                         MinWidth="130" Click="BtnNewBrowser_Click"
                         ToolTip.Tip="Create a new drivable browser profile" />
                 <Button x:Name="RefreshButton" Classes="dialogButton" Content="Refresh"
                         Click="BtnRefresh_Click"
-                        ToolTip.Tip="Re-check each browser's live status" />
+                        ToolTip.Tip="Re-check each profile's live status" />
                 <TextBlock x:Name="StatusText" Text="" Foreground="#888888" FontSize="11"
                            TextWrapping="Wrap" VerticalAlignment="Center" MaxWidth="480" />
             </StackPanel>
@@ -37,7 +39,7 @@
                     <TextBlock Text="Turn on browser control" Foreground="#CCCCCC"
                                FontSize="13" FontWeight="SemiBold" />
                     <TextBlock Classes="hint"
-                               Text="To let your agents drive these browsers, install Browser Harness - the tool DevThrottle uses to drive them, made by browser-use. DevThrottle installs it for you, into its own environment. Your browsers below stay listed and ready; they just cannot be driven until it is installed." />
+                               Text="To let your agents drive these profiles, install Browser Harness - the tool DevThrottle uses to drive them, made by browser-use. DevThrottle installs it for you, into its own environment. Your profiles below stay listed and ready; they just cannot be driven until it is installed." />
                     <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
                         <Button x:Name="HarnessInstallButton" Classes="dialogButton"
                                 Content="Install Browser Harness"
@@ -57,25 +59,108 @@
             </Grid>
         </Border>
 
-        <!-- Inline create panel, shown by + New browser. -->
+        <!-- Inline create panel, shown by + New browser profile.
+
+             Two columns on purpose. The left is the form; the right says what clicking Create will
+             DO, before it does it. The thing people get wrong here is assuming this adopts a profile
+             they already use - it does not, it makes an empty one - and the moment to correct that is
+             before they click, not after they open it and find themselves logged out of everything. -->
         <Border Grid.Row="2" x:Name="CreatePanel" Classes="card" IsVisible="False" Margin="0,0,14,10">
-            <StackPanel Spacing="8">
-                <TextBlock Classes="sectionTitle" Margin="0" Text="New browser" />
-                <TextBlock Classes="hint"
-                           Text="Name it after the identity it will hold (for example the account or client it signs in as). DevThrottle creates a fresh, dedicated profile - your everyday browser is never touched." />
-                <Grid ColumnDefinitions="*,140,Auto,Auto" Margin="0,4,0,0">
-                    <TextBox x:Name="CreateNameBox" Grid.Column="0" Classes="settingsInput"
-                             Watermark="e.g. Center Consulting" />
-                    <ComboBox x:Name="CreateKindCombo" Grid.Column="1" Margin="8,0,0,0"
-                              VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
-                    <Button Grid.Column="2" Classes="primaryButton" Content="Create"
-                            Margin="8,0,0,0" MinWidth="90" Click="BtnCreate_Click" />
-                    <Button Grid.Column="3" Classes="dialogButton" Content="Cancel"
-                            Margin="8,0,0,0" Click="BtnCreateCancel_Click" />
-                </Grid>
-                <TextBlock x:Name="CreateError" Text="" Foreground="#EF4444" FontSize="11"
-                           TextWrapping="Wrap" IsVisible="False" />
-            </StackPanel>
+            <Grid ColumnDefinitions="*,340">
+
+                <StackPanel Grid.Column="0" Spacing="8" Margin="0,0,18,0">
+                    <TextBlock Classes="sectionTitle" Margin="0" Text="New browser profile" />
+                    <TextBlock Classes="hint"
+                               Text="You are about to create a brand new, empty profile - not a copy of one you already use." />
+
+                    <TextBlock Text="What will this profile be signed in as?" Foreground="#CCCCCC"
+                               FontSize="12" FontWeight="SemiBold" Margin="0,8,0,0" />
+                    <TextBox x:Name="CreateNameBox" Classes="settingsInput" Watermark="Work" />
+                    <TextBlock Classes="hint"
+                               Text="Name it after the identity it will hold, not what you plan to do with it. &quot;Work&quot; and &quot;Acme Corp&quot; tell you what an agent can reach; &quot;testing&quot; and &quot;profile 2&quot; will not, six weeks from now." />
+                    <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,2,0,0">
+                        <Button Classes="dialogButton" Content="Work" MinWidth="0" Height="22"
+                                Padding="10,0" FontSize="11" Tag="Work" Click="BtnNameSuggestion_Click" />
+                        <Button Classes="dialogButton" Content="Personal" MinWidth="0" Height="22"
+                                Padding="10,0" FontSize="11" Tag="Personal" Click="BtnNameSuggestion_Click" />
+                        <Button Classes="dialogButton" Content="Research" MinWidth="0" Height="22"
+                                Padding="10,0" FontSize="11" Tag="Research" Click="BtnNameSuggestion_Click" />
+                    </StackPanel>
+
+                    <TextBlock Text="Which browser" Foreground="#CCCCCC" FontSize="12"
+                               FontWeight="SemiBold" Margin="0,10,0,0" />
+                    <ComboBox x:Name="CreateKindCombo" HorizontalAlignment="Left" MinWidth="180" />
+                    <TextBlock Classes="hint"
+                               Text="Only browsers installed on this machine are listed. Pick the one whose account you want to sign in to - otherwise the choice makes no difference to your agents." />
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,12,0,0">
+                        <Button Classes="primaryButton" Content="Create and sign in"
+                                MinWidth="150" Click="BtnCreate_Click"
+                                ToolTip.Tip="Create the profile, then open it so you can sign in by hand" />
+                        <Button Classes="dialogButton" Content="Cancel" Click="BtnCreateCancel_Click" />
+                    </StackPanel>
+                    <TextBlock x:Name="CreateError" Text="" Foreground="#EF4444" FontSize="11"
+                               TextWrapping="Wrap" IsVisible="False" />
+                </StackPanel>
+
+                <Border Grid.Column="1" Background="#212122" BorderBrush="#3C3C3C" BorderThickness="1,0,0,0"
+                        Padding="18,2,4,4">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="What happens when you click Create" Foreground="#CCCCCC"
+                                   FontSize="12" FontWeight="SemiBold" Margin="0,0,0,6" />
+
+                        <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,12">
+                            <Border Grid.Column="0" Width="19" Height="19" CornerRadius="10"
+                                    Background="#2D2D30" BorderBrush="#505052" BorderThickness="1"
+                                    VerticalAlignment="Top">
+                                <TextBlock Text="1" Foreground="#9A9A9A" FontSize="11"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="1">
+                                <TextBlock Text="A new browser window opens" Foreground="#CCCCCC"
+                                           FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="Empty, with its own profile folder. The Chrome or Edge you use yourself keeps running, untouched." />
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,12">
+                            <Border Grid.Column="0" Width="19" Height="19" CornerRadius="10"
+                                    Background="#2D2D30" BorderBrush="#505052" BorderThickness="1"
+                                    VerticalAlignment="Top">
+                                <TextBlock Text="2" Foreground="#9A9A9A" FontSize="11"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="1">
+                                <TextBlock Text="You sign in, by hand" Foreground="#CCCCCC"
+                                           FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="Whatever you want the agent to reach. DevThrottle never types your credentials and never sees them." />
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,10">
+                            <Border Grid.Column="0" Width="19" Height="19" CornerRadius="10"
+                                    Background="#2D2D30" BorderBrush="#505052" BorderThickness="1"
+                                    VerticalAlignment="Top">
+                                <TextBlock Text="3" Foreground="#9A9A9A" FontSize="11"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="1">
+                                <TextBlock Text="You tell us you are done" Foreground="#CCCCCC"
+                                           FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="It is then listed here as ready, and any agent on this machine can drive it." />
+                            </StackPanel>
+                        </Grid>
+
+                        <Border Background="#2A2A2B" CornerRadius="4" Padding="10,8" Margin="0,4,0,0">
+                            <TextBlock Classes="hint"
+                                       Text="Nothing here touches the browser you use yourself - not its tabs, not its bookmarks, not its logins. You can delete this browser at any time and it takes its own folder with it." />
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
         <!-- One card per browser. -->
@@ -108,7 +193,7 @@
                                                     Height="22" Padding="8,0" FontSize="10"
                                                     Tag="{Binding Id}" Click="BtnRenameStart_Click"
                                                     IsEnabled="{Binding NotBusy}"
-                                                    ToolTip.Tip="Rename this browser (DevThrottle's own name - the browser profile itself is untouched)" />
+                                                    ToolTip.Tip="Rename this profile (DevThrottle's own label - the profile's data is untouched)" />
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Spacing="6"
                                                     IsVisible="{Binding IsRenaming}">
@@ -136,11 +221,11 @@
                                         <Button Classes="primaryButton" Content="Sign in once" MinWidth="110"
                                                 IsVisible="{Binding ShowSignIn}" IsEnabled="{Binding NotBusy}"
                                                 Tag="{Binding Id}" Click="BtnSignIn_Click"
-                                                ToolTip.Tip="Open this browser on its sign-in page for the one-time hand sign-in" />
+                                                ToolTip.Tip="Open this profile on its sign-in page for the one-time hand sign-in" />
                                         <Button Classes="dialogButton" Content="Start" MinWidth="70"
                                                 IsVisible="{Binding ShowStart}" IsEnabled="{Binding NotBusy}"
                                                 Tag="{Binding Id}" Click="BtnStart_Click"
-                                                ToolTip.Tip="Launch this browser so an agent can attach to it" />
+                                                ToolTip.Tip="Launch this profile so an agent can attach to it" />
                                         <Button Classes="dialogButton" Content="Copy attach command" MinWidth="150"
                                                 IsVisible="{Binding ShowAttach}" IsEnabled="{Binding NotBusy}"
                                                 Tag="{Binding Id}" Click="BtnAttach_Click"
@@ -148,11 +233,11 @@
                                         <Button Classes="dialogButton" Content="Stop" MinWidth="60"
                                                 IsVisible="{Binding ShowStop}" IsEnabled="{Binding NotBusy}"
                                                 Tag="{Binding Id}" Click="BtnStop_Click"
-                                                ToolTip.Tip="Close this browser cleanly (its login is kept)" />
+                                                ToolTip.Tip="Close this profile cleanly (its login is kept)" />
                                         <Button Classes="iconButton"
                                                 Tag="{Binding Id}" Click="BtnRemove_Click"
                                                 IsEnabled="{Binding NotBusy}"
-                                                ToolTip.Tip="Remove this browser and permanently delete its profile folder">
+                                                ToolTip.Tip="Remove this profile and permanently delete its folder">
                                             <Canvas Width="12" Height="14" HorizontalAlignment="Center" VerticalAlignment="Center">
                                                 <Rectangle Canvas.Left="0" Canvas.Top="2" Width="12" Height="1.6" Fill="#E06C6C" />
                                                 <Rectangle Canvas.Left="4" Canvas.Top="0" Width="4" Height="2" Fill="#E06C6C" />
@@ -168,10 +253,151 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <TextBlock x:Name="EmptyText" IsVisible="False"
-                           Text="No browsers yet. Click + New browser to create one - DevThrottle opens it, you sign in once, and from then on your agents drive it."
-                           Foreground="#888888" FontSize="12" FontStyle="Italic" Margin="4,4,0,0"
-                           TextWrapping="Wrap" />
+                <!-- The empty state is the ONE moment we have the whole window and the user's full
+                     attention, so it is the teaching surface rather than an apology for having no
+                     rows. It answers, in order, the four things people get wrong: what a browser here
+                     IS, why it is not the browser they already use, how many to make, and the fact
+                     that it starts signed in to nothing. -->
+                <StackPanel x:Name="EmptyStatePanel" IsVisible="False" Spacing="0" MaxWidth="900"
+                            HorizontalAlignment="Left" Margin="0,2,0,0">
+
+                    <TextBlock Text="Give your agents a browser profile of their own"
+                               Foreground="#E6E6E6" FontSize="20" FontWeight="SemiBold"
+                               TextWrapping="Wrap" Margin="0,0,0,10" />
+                    <TextBlock Classes="hint" MaxWidth="760" HorizontalAlignment="Left"
+                               Text="A profile here is a real, signed-in Chrome or Edge profile your agents can drive - click things, read pages, fill forms - through Browser Harness. It is not a scraper and not a headless shell. It is a real browser, running on this machine, that an agent controls the way a person would." />
+                    <TextBlock Classes="hint" MaxWidth="760" HorizontalAlignment="Left" Margin="0,8,0,0"
+                               Text="It is not the profile you browse in yourself, and that is deliberate. Chrome and Edge now refuse to be remote-controlled on your everyday profile, and they encrypt its saved logins so they cannot be copied out. So DevThrottle creates a separate, dedicated one instead - which is also the arrangement you want: your agent gets exactly the accounts you give it, and nothing else." />
+
+                    <!-- The lifecycle, in the order it happens. -->
+                    <Grid ColumnDefinitions="*,12,*,12,*" Margin="0,18,0,0">
+                        <Border Grid.Column="0" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1"
+                                CornerRadius="6" Padding="14,13">
+                            <StackPanel Spacing="5">
+                                <Border Width="22" Height="22" CornerRadius="11" Background="#0F6CBD"
+                                        HorizontalAlignment="Left">
+                                    <TextBlock Text="1" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                </Border>
+                                <TextBlock Text="You create it" Foreground="#CCCCCC" FontSize="13"
+                                           FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="DevThrottle makes a fresh, dedicated browser profile in its own folder. Your everyday Chrome and Edge are never touched." />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="2" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1"
+                                CornerRadius="6" Padding="14,13">
+                            <StackPanel Spacing="5">
+                                <Border Width="22" Height="22" CornerRadius="11" Background="#0F6CBD"
+                                        HorizontalAlignment="Left">
+                                    <TextBlock Text="2" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                </Border>
+                                <TextBlock Text="You sign it in, once" Foreground="#CCCCCC" FontSize="13"
+                                           FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="It opens and you log in by hand - DevThrottle never types your credentials. The login then lasts for months." />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="4" Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1"
+                                CornerRadius="6" Padding="14,13">
+                            <StackPanel Spacing="5">
+                                <Border Width="22" Height="22" CornerRadius="11" Background="#0F6CBD"
+                                        HorizontalAlignment="Left">
+                                    <TextBlock Text="3" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                </Border>
+                                <TextBlock Text="Any agent attaches" Foreground="#CCCCCC" FontSize="13"
+                                           FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock Classes="hint"
+                                           Text="From then on any agent on this machine drives it with one command. No sign-in, no re-auth, no captcha loop." />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
+                    <!-- One per role: the mental model that makes the whole feature click. -->
+                    <Border Background="#252526" BorderBrush="#3C3C3C" BorderThickness="1"
+                            CornerRadius="6" Padding="16" Margin="0,16,0,0">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Make one for each role you want an agent to act as"
+                                       Foreground="#CCCCCC" FontSize="13" FontWeight="SemiBold"
+                                       TextWrapping="Wrap" />
+                            <TextBlock Classes="hint"
+                                       Text="The useful way to think about it is to mirror the separation you already keep in your own head - work, personal, a particular client. Name each one after the identity it holds, and you always know what an agent can reach when you point it at that profile." />
+                            <Grid ColumnDefinitions="*,10,*,10,*" Margin="0,10,0,0">
+                                <Border Grid.Column="0" Background="#2D2D30" BorderBrush="#3C3C3C"
+                                        BorderThickness="1" CornerRadius="5" Padding="11,10">
+                                    <Grid ColumnDefinitions="Auto,*">
+                                        <Border Grid.Column="0" Width="26" Height="26" CornerRadius="5"
+                                                Background="#0F6CBD" VerticalAlignment="Top">
+                                            <TextBlock Text="W" Foreground="White" FontSize="13" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="2">
+                                            <TextBlock Text="Work" Foreground="#CCCCCC" FontSize="12"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Classes="hint"
+                                                       Text="Company account, internal tools, the ticket tracker" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                                <Border Grid.Column="2" Background="#2D2D30" BorderBrush="#3C3C3C"
+                                        BorderThickness="1" CornerRadius="5" Padding="11,10">
+                                    <Grid ColumnDefinitions="Auto,*">
+                                        <Border Grid.Column="0" Width="26" Height="26" CornerRadius="5"
+                                                Background="#1AA1B8" VerticalAlignment="Top">
+                                            <TextBlock Text="A" Foreground="White" FontSize="13" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="2">
+                                            <TextBlock Text="Acme Corp" Foreground="#CCCCCC" FontSize="12"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Classes="hint"
+                                                       Text="One client only - their portal and dashboards, nothing else" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                                <Border Grid.Column="4" Background="#2D2D30" BorderBrush="#3C3C3C"
+                                        BorderThickness="1" CornerRadius="5" Padding="11,10">
+                                    <Grid ColumnDefinitions="Auto,*">
+                                        <Border Grid.Column="0" Width="26" Height="26" CornerRadius="5"
+                                                Background="#8A63D2" VerticalAlignment="Top">
+                                            <TextBlock Text="P" Foreground="White" FontSize="13" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <StackPanel Grid.Column="1" Margin="10,0,0,0" Spacing="2">
+                                            <TextBlock Text="Personal" Foreground="#CCCCCC" FontSize="12"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Classes="hint"
+                                                       Text="Your own accounts, kept well away from anything work" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- The one fact whose absence makes the feature look broken. -->
+                    <Border Background="#231F16" BorderBrush="#5C4A22" BorderThickness="1"
+                            CornerRadius="6" Padding="14,12" Margin="0,16,0,0">
+                        <Grid ColumnDefinitions="Auto,*">
+                            <TextBlock Grid.Column="0" Text="!" Foreground="#F0B848" FontSize="14"
+                                       FontWeight="Bold" VerticalAlignment="Top" Margin="2,0,0,0" />
+                            <TextBlock Grid.Column="1" Margin="12,0,0,0" Foreground="#D8D2C6" FontSize="12"
+                                       TextWrapping="Wrap" LineHeight="18"
+                                       Text="It starts completely empty. A new profile here is signed in to nothing at all - it does not inherit your existing tabs, bookmarks or logins. You choose what goes in it: sign in to a Google or Microsoft account to bring a whole profile across, or just sign in to the individual websites you want the agent to reach. Whatever you sign in is exactly what your agents can drive - nothing else." />
+                        </Grid>
+                    </Border>
+
+                    <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,20,0,0"
+                                VerticalAlignment="Center">
+                        <Button Classes="primaryButton" Content="+ Create browser profile"
+                                MinWidth="210" Height="34" FontSize="13" Click="BtnNewBrowser_Click"
+                                ToolTip.Tip="Create a new drivable browser profile" />
+                        <TextBlock Text="Takes about a minute, most of it you signing in."
+                                   Foreground="#777777" FontSize="12" VerticalAlignment="Center" />
+                    </StackPanel>
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSettingsView.axaml.cs
@@ -43,6 +43,10 @@ public partial class BrowserSettingsView : UserControl
     public void OpenCreatePanel()
     {
         CreatePanel.IsVisible = true;
+        // The empty state and the form both want the window. While the form is open the form wins -
+        // the teaching has already been read by anyone who got this far, and leaving it underneath
+        // pushes the fields the user is filling in off the top of a small window.
+        EmptyStatePanel.IsVisible = false;
         CreateNameBox.Focus();
     }
 
@@ -78,7 +82,15 @@ public partial class BrowserSettingsView : UserControl
 
             _views = views;
             HarnessBanner.IsVisible = !harnessInstalled;
-            EmptyText.IsVisible = views.Count == 0;
+
+            // With no browsers, the empty state IS the tab: it has the whole window to explain what a
+            // browser here is, why it is not the one you already use, and that it starts signed in to
+            // nothing. The header repeats the first line of that, so it stays out of the way until
+            // there is a list to head. The create panel replaces the empty state while it is open,
+            // rather than pushing a wall of teaching below the form the user is already filling in.
+            var isEmpty = views.Count == 0;
+            EmptyStatePanel.IsVisible = isEmpty && !CreatePanel.IsVisible;
+            HeaderPanel.IsVisible = !isEmpty;
             StatusText.Text = "";
 
             // The create panel offers only the browsers actually installed on this machine.
@@ -277,11 +289,36 @@ public partial class BrowserSettingsView : UserControl
                 throw new ArgumentException("Pick which browser to use.");
 
             CreateError.IsVisible = false;
-            await Task.Run(() => AutomationBrowserService.Create(name, kind));
+            var created = await Task.Run(() => AutomationBrowserService.Create(name, kind));
 
             CreateNameBox.Text = "";
             CreatePanel.IsVisible = false;
-            StatusText.Text = $"Created \"{name}\". Next: Sign in once, so it holds a login your agents can use.";
+            await RefreshAndNotifyAsync();
+
+            // Go straight into the sign-in, which is what the button says it will do. A profile
+            // created and left unsigned is worth nothing to an agent, and the old flow - create, then
+            // find and click "Sign in once" on the new card - made the one step that MATTERS the one
+            // step the user had to know to take. Backing out is still allowed: the profile exists and
+            // its card offers the sign-in whenever they come back to it.
+            //
+            // Reported through StatusText and NOT through CreateError, in its own try: by this point
+            // the profile has been created and the create panel is closed, so a failure written to
+            // CreateError would land in a hidden control and the user would see nothing at all. What
+            // can fail here is the launch - the browser not coming up on its debug port - and that
+            // must be visible, with the profile still listed so they can retry from its card.
+            try
+            {
+                if (await BrowserSignInFlow.RunAsync(OwnerWindow(), AutomationBrowserViewFold.FoldPending(created)))
+                    StatusText.Text = $"\"{name}\" is signed in and ready to drive.";
+                else
+                    StatusText.Text = $"Created \"{name}\". It holds no login yet - use Sign in once when you are ready.";
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[BrowserSettingsView] BtnCreate_Click: sign-in after create FAILED: {ex.Message}");
+                StatusText.Text = $"Created \"{name}\", but it could not be opened for sign-in: {ex.Message}";
+            }
+
             await RefreshAndNotifyAsync();
         }
         catch (Exception ex)
@@ -296,6 +333,22 @@ public partial class BrowserSettingsView : UserControl
     {
         CreatePanel.IsVisible = false;
         CreateError.IsVisible = false;
+        // Backing out of the form on a machine with no browsers must land back on the explanation,
+        // not on a blank tab.
+        EmptyStatePanel.IsVisible = _views.Count == 0;
+    }
+
+    /// <summary>
+    /// Fill the name box from one of the offered role names. These are a starting point for the
+    /// hardest part of the form - people stall on naming, then type "test" and regret it - so the
+    /// text stays editable rather than being a fixed choice.
+    /// </summary>
+    private void BtnNameSuggestion_Click(object? sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is not string suggestion) return;
+        CreateNameBox.Text = suggestion;
+        CreateNameBox.Focus();
+        CreateNameBox.CaretIndex = suggestion.Length;
     }
 
     // ---- per-card actions ----

--- a/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowserSignInFlow.cs
@@ -38,7 +38,7 @@ internal static class BrowserSignInFlow
             ? $"Sign in to whatever you want this browser to reach: {accountKind} to bring your profile "
               + "across, or just the individual websites you want an agent to use."
             : "Sign in to the individual websites you want an agent to use - this browser has no single "
-              + "account that carries a profile across.";
+              + "account that carries a whole profile across.";
 
         var dialog = new ConfirmDialog(
             "Sign in once",
@@ -48,8 +48,8 @@ internal static class BrowserSignInFlow
             + "DevThrottle never types your credentials.\n\n"
             + $"{whatToSignInTo} Whatever is signed in "
             + "here is what your agents can drive - nothing else.\n\n"
-            + "The logins are kept in this browser's own profile, apart from your everyday browser, and "
-            + "last until the account signs them out.\n\n"
+            + "The logins are kept in this profile's own folder, apart from the profile you browse in "
+            + "yourself, and last until the account signs them out.\n\n"
             + "When you are signed in, click Done.",
             confirmLabel: "Done - I am signed in",
             cancelLabel: "Not yet");

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
@@ -60,14 +60,14 @@
                     <Button x:Name="AddButton" Classes="rowAction" Content="+"
                             Foreground="#CCCCCC" FontSize="13" Padding="5,0"
                             Click="AddButton_Click"
-                            ToolTip.Tip="Add a browser" />
+                            ToolTip.Tip="Add a browser profile" />
                     <Path x:Name="Chevron" Fill="#888888" VerticalAlignment="Center"
                           Data="M 0,0 L 4,4 L 8,0" Stretch="None" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                     <TextBlock Text="[B]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
                                FontSize="12" VerticalAlignment="Center" />
-                    <TextBlock Text="Browsers" Foreground="#CCCCCC" FontSize="12"
+                    <TextBlock Text="Browser profiles" Foreground="#CCCCCC" FontSize="12"
                                FontWeight="SemiBold" VerticalAlignment="Center" />
                 </StackPanel>
             </DockPanel>

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
@@ -158,9 +158,9 @@ public partial class BrowsersRailGroup : UserControl
             ActionForeground = v.Status == AutomationBrowserStatus.NeedsSignIn ? AmberBrush : AccentBrush,
             ActionToolTip = v.Status switch
             {
-                AutomationBrowserStatus.Stopped => "Start this browser",
+                AutomationBrowserStatus.Stopped => "Start this profile",
                 AutomationBrowserStatus.NeedsSignIn => "Open the sign-in page for the one-time hand sign-in",
-                _ => "Copy the command that points an agent's Browser Harness at this browser",
+                _ => "Copy the command that points an agent's Browser Harness at this profile",
             },
             RowToolTip = $"{v.Subtitle} ({v.StatusLabel}). Click to manage in Settings.",
         }).ToList();

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -272,7 +272,7 @@ public partial class FirstRunWizardDialog : Window
         WizardStep.Tools => "Tools",
         WizardStep.Code => "Your code",
         WizardStep.Screenshots => "Screenshots",
-        WizardStep.Browsers => "Browsers",
+        WizardStep.Browsers => "Browser profiles",
         WizardStep.Done => "Done",
         _ => step.ToString(),
     };
@@ -2007,7 +2007,7 @@ public partial class FirstRunWizardDialog : Window
         throw new InvalidOperationException(
             $"None of the browsers DevThrottle can drive ({string.Join(", ", Enum.GetNames<BrowserKind>())}) "
             + "is installed on this machine, so there is no browser to set up. "
-            + "Install one, then set browsers up from the Browsers group in the left rail.");
+            + "Install one, then set profiles up from the Browser profiles group in the left rail.");
     }
 
     /// <summary>The honest way out: move on, having done nothing and written nothing. The panel names
@@ -2536,16 +2536,16 @@ public partial class FirstRunWizardDialog : Window
         else if (_browsersView is not null)
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 $"Browser created - {_browsersView.Name}",
-                "Nobody has signed in to it yet - finish that in the Browsers group in the left rail",
+                "Nobody has signed in to it yet - finish that in the Browser profiles group in the left rail",
                 RowState.NotSetUp));
         else if (_browsersHarnessInstalled)
             DoneReceiptPanel.Children.Add(ReceiptRow(
                 "Browser Harness installed",
-                "No browser set up yet - add one from the Browsers group in the left rail", RowState.NotSetUp));
+                "No profile set up yet - add one from the Browser profiles group in the left rail", RowState.NotSetUp));
         else
             DoneReceiptPanel.Children.Add(ReceiptRow(
-                "Browsers",
-                "Give agents a signed-in browser any time - the Browsers group in the left rail", done: false));
+                "Browser profiles",
+                "Give agents a signed-in browser profile any time - the Browser profiles group in the left rail", done: false));
 
         // Morning report row. There is no longer a frequency question in the wizard - the report is
         // one person, one email, and asking about it once per machine could never reconcile (issue

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4036,9 +4036,9 @@ public partial class MainWindow : Window
         // Top-level on purpose (Browsers feature, slice 2): the drivable-browser capability is a
         // headline feature and the menu entry is how it advertises itself. Both items land on
         // Settings > Browsers - the rail group is the everyday launch surface.
-        var browsers = new NativeMenuItem("Browsers") { Menu = new NativeMenu() };
-        browsers.Menu.Items.Add(Item("New Browser...", () => _ = OpenSettingsAsync(onBrowsersTab: true, openBrowserCreate: true)));
-        browsers.Menu.Items.Add(Item("Manage Browsers...", () => _ = OpenSettingsAsync(onBrowsersTab: true)));
+        var browsers = new NativeMenuItem("Browser profiles") { Menu = new NativeMenu() };
+        browsers.Menu.Items.Add(Item("New Browser Profile...", () => _ = OpenSettingsAsync(onBrowsersTab: true, openBrowserCreate: true)));
+        browsers.Menu.Items.Add(Item("Manage Browser Profiles...", () => _ = OpenSettingsAsync(onBrowsersTab: true)));
         menu.Items.Add(browsers);
 
         // ===== Tools (alpha only - none of these are verified working yet) =====

--- a/src/CcDirector.Avalonia/SettingsDialog.axaml
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml
@@ -264,7 +264,7 @@
                 </Grid>
             </TabItem>
 
-            <TabItem Header="Browsers">
+            <TabItem Header="Browser profiles">
                 <!-- Browsers feature (slice 2): the workshop for drivable automation browsers -
                      create, sign in once, rename, remove. The rail's pinned Browsers group is the
                      launch surface; this tab is where they are set up. All logic lives in the view. -->

--- a/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
@@ -105,13 +105,22 @@ public static class AutomationBrowserViewFold
             .ToDictionary(v => v.Id, v => v.Status, StringComparer.OrdinalIgnoreCase);
 
         return AutomationBrowserRegistry.Load()
-            .Select(b => Fold(
-                b,
-                lastKnown is not null && lastKnown.TryGetValue(b.Id, out var status)
-                    ? status
-                    : AutomationBrowserStatus.Checking,
-                ReadAccountOrNull(b)))
+            .Select(b => lastKnown is not null && lastKnown.TryGetValue(b.Id, out var status)
+                ? Fold(b, status, ReadAccountOrNull(b))
+                : FoldPending(b))
             .ToList();
+    }
+
+    /// <summary>
+    /// Fold ONE browser without probing it: the full view, status
+    /// <see cref="AutomationBrowserStatus.Checking"/>. Used for a browser that has just been created
+    /// and so cannot have a probed status yet, and by <see cref="ListPending"/> for rows being shown
+    /// for the first time.
+    /// </summary>
+    public static AutomationBrowserView FoldPending(AutomationBrowser browser)
+    {
+        if (browser is null) throw new ArgumentNullException(nameof(browser));
+        return Fold(browser, AutomationBrowserStatus.Checking, ReadAccountOrNull(browser));
     }
 
     /// <summary>Fold one browser: probe its live status, read its signed-in account, then map.</summary>

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -89,7 +89,10 @@ autostart_app = typer.Typer(
     no_args_is_help=True,
 )
 browser_app = typer.Typer(
-    help="Manage DevThrottle's drivable automation browsers (signed in once, driven by an agent; machine-local).",
+    # The verb stays "browser": it is the resource name agents already hold, in the actions registry
+    # and in the attach command baked into the fold. The HELP says "profile", which is what the thing
+    # actually is - a dedicated signed-in profile inside Chrome or Edge, not a browser we installed.
+    help="Manage DevThrottle's drivable browser profiles (signed in once, driven by an agent; machine-local).",
     add_completion=False,
     no_args_is_help=True,
 )
@@ -636,14 +639,14 @@ _ACTIONS = [
     },
     {
         "id": "browser-list",
-        "description": "List this machine's drivable automation browsers (name, browser, status, account).",
+        "description": "List this machine's drivable browser profiles (name, browser, status, account).",
         "command": "cc-devthrottle browser list --json",
         "mutatesState": False,
         "args": [],
     },
     {
         "id": "browser-create",
-        "description": "Register a new drivable browser (does not launch it).",
+        "description": "Register a new drivable browser profile (does not launch it).",
         "command": 'cc-devthrottle browser create --name "Center Consulting" --browser chrome',
         "mutatesState": True,
         "args": [],
@@ -657,21 +660,21 @@ _ACTIONS = [
     },
     {
         "id": "browser-start",
-        "description": "Launch a browser if it is down, then print how to attach the harness.",
+        "description": "Launch a profile if it is down, then print how to attach the harness.",
         "command": 'cc-devthrottle browser start "Center Consulting"',
         "mutatesState": True,
         "args": [],
     },
     {
         "id": "browser-attach",
-        "description": "Print the BU_NAME/BU_CDP_URL export lines to attach browser-harness to a browser.",
+        "description": "Print the BU_NAME/BU_CDP_URL export lines to attach browser-harness to a profile.",
         "command": 'eval "$(cc-devthrottle browser attach \'Center Consulting\')"',
         "mutatesState": False,
         "args": [],
     },
     {
         "id": "browser-stop",
-        "description": "Close a running automation browser cleanly (its login is kept).",
+        "description": "Close a running browser profile cleanly (its login is kept).",
         "command": 'cc-devthrottle browser stop "Center Consulting"',
         "mutatesState": True,
         "args": [],
@@ -689,7 +692,7 @@ def _version_callback(value: bool) -> None:
 def browser_list(
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
 ) -> None:
-    """List the drivable automation browsers on this machine."""
+    """List the drivable browser profiles on this machine."""
     browser_ops.list_browsers(json_output)
 
 
@@ -701,7 +704,7 @@ def browser_create(
     ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
 ) -> None:
-    """Register a new drivable browser (does not launch it)."""
+    """Register a new drivable browser profile (does not launch it)."""
     browser_ops.create_browser(name, browser, json_output)
 
 


### PR DESCRIPTION
Follow-on to #2359, on the same tab.

## The empty state is now the teaching surface

The tab explained itself in one dense paragraph that read like a design justification, and on a clean install that paragraph plus a button *was* the screen. Four things people get wrong went unanswered:

- what a browser here **is** (a real Chrome/Edge profile an agent drives, not a scraper or a headless shell)
- why it is **not** the browser they already use (Chrome and Edge refuse to be remote-controlled on your everyday profile and encrypt its logins - and you want the agent to have exactly the accounts you give it)
- **how many** to make (one per role, mirroring the separation you already keep: work, personal, a client)
- that it **starts signed in to nothing** - the one whose absence makes the feature look broken when you open a new profile and find yourself logged out of everything

The empty state now answers those in that order, using the whole window. Once profiles exist it shrinks to two lines, so the tab stops lecturing after the lesson has landed.

## The create panel says what Create will do

Second column with the three steps, before the click rather than after. The name field asks *what will this profile be signed in as?* rather than just "name", with role suggestions - people stall on naming, then type "test" and regret it six weeks later.

**Create now runs the sign-in flow**, which is what the button always implied. It previously only registered the profile and left the user to find "Sign in once" on the new card - making the step that MATTERS the step you had to know to take. A launch failure there reports through the status line, not the create panel: by then the panel is closed, so an error written to it would land in a hidden control and the user would see nothing.

## It is a profile, not a browser

We do not create a browser - Chrome already exists. We create a dedicated signed-in profile inside it. Every string a human reads now says so, and "browser" is used only for the application (Chrome, Edge, Brave, Opera):

| Surface | Now |
|---|---|
| Settings tab | Browser profiles |
| Left rail group | Browser profiles |
| App menu | Browser profiles -> New Browser Profile... / Manage Browser Profiles... |
| First-run wizard step + done-receipt | Browser profiles |
| Per-row tooltips, sign-in dialog | ...this profile |

The wizard had three separate strings pointing people at "the Browsers group in the left rail", which would have sent them looking for a group that no longer answers to that name.

## The CLI verb deliberately stays `browser`

`cc-devthrottle browser ...` is unchanged, and so is every `command` string and action `id` in the actions registry. That registry is the agent-discoverable contract, and the attach one-liner is baked into the Core fold, asserted by a test, rendered in the UI and copied to the clipboard. Renaming it would break sessions in flight to fix a misreading a command line does not produce - `browser` reads there as a resource collection, the way `git remote` does.

Only the prose agents read changed: the five action descriptions and the group help now say profile. A comment at the group definition records why the verb and the help deliberately disagree, so nobody "fixes" it later.

## Proof

- Full solution builds clean, 0 warnings.
- Avalonia 348/348, Core browsers 96/96, cc-devthrottle actions + browser tests 8/8.
- Run on a real Director in an isolated instance (slot 5), both empty and populated.

## Not covered

"Browser profiles" is roughly twice the width of "Browsers" in a seven-tab strip. It builds and renders, but tab crowding is a judgement call best made by looking at it.