### PR TITLE
Keep hosted tenants apart: contain the file read, gate the launch, partition the queue, and fail closed on a missing tenant

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -74,7 +74,7 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             "coaching-categories" => CoachingCategories(),
             "claude-sessions" => ClaudeSessions(command),
             "interrupted-list" => InterruptedList(),
-            "fs-list" => FsList(command),
+            "fs-list" => FsList(context.SessionManager, command),
             "facts" => Facts(context.DirectorId, context.Services?.DirectorVersion),
             "repos-list" => ReposList(context.Services?.Repositories),
             "agents-list" => AgentsList(context.SessionManager.Options),
@@ -419,20 +419,25 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
     }
 
     /// <summary>
-    /// The <c>fs-list</c> verb (the list-directory read): the remote folder browser. Mirrors the Director's
-    /// <c>GET /fs/list</c> lambda - lists the drive roots when the payload path is null/blank, otherwise the
-    /// named directory - and returns a serialized <see cref="DirectoryListingDto"/>. The source route wrapped
-    /// the listing in a try/catch that turned any fault (a missing directory, an access error) into a 400 with
-    /// the message, so that try/catch is preserved here and surfaced as a <see cref="DirectorCommandStatus.BadRequest"/>.
+    /// The <c>fs-list</c> verb (the list-directory read): the remote folder browser, CONTAINED to the
+    /// working directories of the sessions this Director hosts. A null/blank payload path lists those
+    /// allowed roots; a named path must resolve inside one of them or the listing is refused (the
+    /// pre-hardening version listed drive roots and any directory on the machine, which on a hosted
+    /// Gateway handed any active device key a full remote directory browse). Returns a serialized
+    /// <see cref="DirectoryListingDto"/>. The source route wrapped the listing in a try/catch that
+    /// turned any fault (a missing directory, an access error, and now an out-of-root refusal) into a
+    /// 400 with the message, so that try/catch is preserved here and surfaced as a
+    /// <see cref="DirectorCommandStatus.BadRequest"/>.
     /// </summary>
-    internal static DirectorCommandResult FsList(DirectorCommand command)
+    internal static DirectorCommandResult FsList(SessionManager sessionManager, DirectorCommand command)
     {
         var request = SessionCommandExecutor.Deserialize<FsListRequest>(command.PayloadJson);
         var path = request?.Path;
         FileLog.Write($"[CatalogReadExecutor] fs-list: path={path}");
         try
         {
-            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ControlEndpoints.ListDirectory(path)));
+            var allowedRoots = sessionManager.ListSessions().Select(s => s.WorkingDirectory);
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ControlEndpoints.ListDirectory(path, allowedRoots)));
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -719,7 +719,8 @@ internal static class ControlEndpoints
             try
             {
                 var (status, body) = await gw.LaunchOnMachineAsync(
-                    machine, req?.Path, req?.App, req?.Args, req?.Cwd, req?.Headless ?? false, ct);
+                    machine, req?.Path, req?.App, req?.Args, req?.Cwd, req?.Headless ?? false,
+                    req?.ConfirmProtected ?? false, ct);
                 return Results.Content(body, "application/json; charset=utf-8", statusCode: status);
             }
             catch (Exception ex)
@@ -2272,4 +2273,11 @@ internal sealed class MachineLaunchRequest
     public string? Args { get; init; }
     public string? Cwd { get; init; }
     public bool Headless { get; init; }
+
+    /// <summary>
+    /// Tenant-boundary hardening (CR-5): the explicit confirmation the Gateway's launch relay now requires
+    /// on every launch (the restart/stop slot-guard flag, applied to program starts). Forwarded through this
+    /// Director hop verbatim, so a caller that wants a program started must say so explicitly end to end.
+    /// </summary>
+    public bool ConfirmProtected { get; init; }
 }

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1701,33 +1701,59 @@ internal static class ControlEndpoints
     }
 
     /// <summary>
-    /// List sub-directories of <paramref name="path"/> for the remote folder browser. A null or
-    /// empty path returns the drive roots. Solo-tailnet: no path sandboxing (see remote-experience-plan.md).
+    /// List sub-directories of <paramref name="path"/> for the remote folder browser, contained to
+    /// <paramref name="allowedRoots"/> - the working directories of the sessions this Director hosts.
+    /// A null or empty path lists the allowed roots themselves; a named path must resolve INSIDE one
+    /// of them or the listing is refused. The pre-hardening version listed the drive roots and any
+    /// directory on the machine ("solo-tailnet: no path sandboxing"); that stood only while a single
+    /// owner held every key, and on a hosted Gateway it handed any active device key a full remote
+    /// directory browse. Same containment discipline as <see cref="ResolveSessionFile"/> and
+    /// <see cref="ResolveScreenshot"/>: resolve fully, then refuse anything outside an allowed root.
     /// </summary>
     // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's fs-list core (the
     // list-directory read, lifted from GET /fs/list) calls the SAME helper - no drift, no duplication.
-    internal static DirectoryListingDto ListDirectory(string? path)
+    internal static DirectoryListingDto ListDirectory(string? path, IEnumerable<string> allowedRoots)
     {
+        // Normalize the roots once: full paths, trailing separators trimmed, duplicates collapsed.
+        var roots = new List<string>();
+        foreach (var root in allowedRoots)
+        {
+            if (string.IsNullOrWhiteSpace(root)) continue;
+            string fullRoot;
+            try { fullRoot = Path.GetFullPath(root).TrimEnd('\\', '/'); }
+            catch (ArgumentException) { continue; } // a label, not a local directory (remote-thread sessions)
+            if (!roots.Contains(fullRoot, StringComparer.OrdinalIgnoreCase))
+                roots.Add(fullRoot);
+        }
+
         if (string.IsNullOrWhiteSpace(path))
         {
-            var drives = DriveInfo.GetDrives()
-                .Where(d => d.IsReady)
-                .Select(d => new DirEntryDto
+            var rootEntries = roots
+                .Select(r => new DirEntryDto
                 {
-                    Name = d.Name.TrimEnd('\\', '/'),
-                    Path = d.RootDirectory.FullName,
-                    IsDrive = true,
+                    Name = Path.GetFileName(r) is { Length: > 0 } name ? name : r,
+                    Path = r,
+                    IsDrive = false,
                 })
                 .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
-            return new DirectoryListingDto { CurrentPath = null, ParentPath = null, Entries = drives };
+            return new DirectoryListingDto { CurrentPath = null, ParentPath = null, Entries = rootEntries };
         }
 
-        var full = Path.GetFullPath(path);
+        var full = Path.GetFullPath(path).TrimEnd('\\', '/');
+        var containingRoot = roots.FirstOrDefault(r =>
+            string.Equals(full, r, StringComparison.OrdinalIgnoreCase)
+            || full.StartsWith(r + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase));
+        if (containingRoot is null)
+            throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
+
         if (!Directory.Exists(full))
             throw new DirectoryNotFoundException($"directory not found: {full}");
 
-        var parent = Directory.GetParent(full.TrimEnd('\\', '/'))?.FullName;
+        // Never offer navigation above the containing root: the root's own parent is not browsable.
+        var parent = string.Equals(full, containingRoot, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : Directory.GetParent(full)?.FullName;
 
         var entries = Directory.EnumerateDirectories(full)
             .Select(d =>
@@ -2164,6 +2190,42 @@ internal static class ControlEndpoints
         if (!full.StartsWith(dirFull + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
             return null;
         return File.Exists(full) ? full : null;
+    }
+
+    /// <summary>
+    /// Resolve a client-supplied path for the session file read (the Local Files viewer) to an absolute
+    /// path INSIDE the session's own working directory, or null when it escapes it - an absolute path
+    /// elsewhere on the machine, a traversal that resolves outside, or an invalid path. This is
+    /// <see cref="ResolveScreenshot"/>'s twin for the read-file stream verb: resolve fully first, then
+    /// refuse anything outside the allowed root. The allowed root is the session's working directory -
+    /// the one directory the session is about - so a session-scoped file read can never reach
+    /// credentials, tokens, or any other file elsewhere on the machine.
+    /// </summary>
+    internal static string? ResolveSessionFile(string? workingDirectory, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectory) || string.IsNullOrWhiteSpace(path))
+            return null;
+
+        string root;
+        string full;
+        try
+        {
+            root = Path.GetFullPath(workingDirectory);
+            // A relative path resolves against the session's working directory; an absolute path stays
+            // itself. Either way the containment check below runs on the fully resolved result.
+            full = Path.GetFullPath(path, root);
+        }
+        catch (ArgumentException)
+        {
+            // Invalid characters, an embedded NUL, or a relative working directory (a session with no
+            // real local checkout, e.g. a remote-thread session) - nothing here is safe to serve.
+            return null;
+        }
+
+        var rootTrimmed = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!full.StartsWith(rootTrimmed + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            return null;
+        return full;
     }
 
     internal static string ScreenshotContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1765,8 +1765,8 @@ internal static class ControlEndpoints
             .Select(ResolveRealPath)
             .Where(r => r is not null)
             .Select(r => NormalizeDirectoryPath(r!))
-            .Any(r => string.Equals(realFullTrimmed, r, PathContainmentComparison)
-                      || realFullTrimmed.StartsWith(ContainmentPrefix(r), PathContainmentComparison));
+            .Any(r => string.Equals(realFullTrimmed, r, PathIdentityComparison)
+                      || realFullTrimmed.StartsWith(ContainmentPrefix(r), PathIdentityComparison));
         if (!containedForReal)
             throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
 
@@ -2221,10 +2221,13 @@ internal static class ControlEndpoints
         if (realFull is null || realDir is null)
             return null;
         var realDirTrimmed = NormalizeDirectoryPath(realDir);
-        if (!realFull.StartsWith(ContainmentPrefix(realDirTrimmed), PathContainmentComparison))
+        if (!realFull.StartsWith(ContainmentPrefix(realDirTrimmed), PathIdentityComparison))
             return null;
 
-        return full;
+        // And the same last gate as the session-file read: an in-folder HARD LINK named
+        // "innocent.png" passes the bare-name test, the extension test and both prefix tests while
+        // naming a file that also lives outside the screenshots folder (M03-I2-01).
+        return RefuseUnlessSingleName(full);
     }
 
     /// <summary>
@@ -2272,9 +2275,43 @@ internal static class ControlEndpoints
         if (realRoot is null || realFull is null)
             return null; // identity not establishable (an unresolvable reparse point, a cycle) - refuse
         var realRootTrimmed = NormalizeDirectoryPath(realRoot);
-        if (!realFull.StartsWith(ContainmentPrefix(realRootTrimmed), PathContainmentComparison))
+        if (!realFull.StartsWith(ContainmentPrefix(realRootTrimmed), PathIdentityComparison))
             return null;
 
+        // Everything above decides where the NAME is. This decides whether the name is the only one
+        // (M03-I2-01). A hard link is a second directory entry for the same file object and carries
+        // no reparse-point attribute, so nothing above can see it: the in-root alias resolves to
+        // itself, passes containment, and the read serves a file that also lives outside the root.
+        // A file with more than one name cannot be proven to be inside anything, so it is refused,
+        // and so is a file whose name count cannot be established.
+        return RefuseUnlessSingleName(full);
+    }
+
+    /// <summary>
+    /// The last gate of the file-containment decision: return <paramref name="full"/> only when the
+    /// filesystem says this file has exactly ONE name. See <see cref="FilesystemIdentity"/> for why a
+    /// second name defeats every path-based containment test ever written.
+    /// </summary>
+    private static string? RefuseUnlessSingleName(string full)
+    {
+        // A path with no file behind it has no identity to alias and serves nothing; the caller's own
+        // existence check answers it as an ordinary not-found. Asking the filesystem how many names a
+        // missing file has would turn every not-found into a containment refusal, which is a worse
+        // answer to debug and would deny a session file the moment it is deleted.
+        if (!File.Exists(full))
+            return full;
+
+        var singleName = FilesystemIdentity.HasExactlyOneName(full);
+        if (singleName is null)
+        {
+            FileLog.Write($"[ControlEndpoints] REFUSED {full}: the number of names this file has could not be established");
+            return null;
+        }
+        if (singleName == false)
+        {
+            FileLog.Write($"[ControlEndpoints] REFUSED {full}: the file has more than one name, so it cannot be shown to live inside the allowed root");
+            return null;
+        }
         return full;
     }
 
@@ -2328,6 +2365,25 @@ internal static class ControlEndpoints
     internal static StringComparison PathContainmentComparisonFor(bool windowsFileSystem) =>
         windowsFileSystem ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
+    /// <summary>
+    /// Comparison for the containment decision made on RESOLVED paths - always ordinal, on every
+    /// platform, because both sides have already been folded to the spelling the filesystem itself
+    /// uses (<see cref="FilesystemIdentity.CanonicalPath"/>).
+    ///
+    /// This is the second half of inspection finding M03-I2-01. The platform-wide ignore-case rule
+    /// above is right about the DEFAULT Windows filesystem and wrong about a directory carrying the
+    /// NTFS per-directory case-sensitive flag, where "repo" and "REPO" are two different directories
+    /// and an ignore-case prefix test accepts the wrong one as inside. Comparing canonical spellings
+    /// ordinally decides correctly under either rule, and needs no guess about which rule applies:
+    /// on a case-insensitive parent every spelling folds onto the one real name, and on a
+    /// case-sensitive parent the two names fold to themselves and stay distinct.
+    ///
+    /// <see cref="PathContainmentComparison"/> is kept for the cheap LEXICAL pre-filter that runs
+    /// before anything touches the filesystem. That pre-filter is deliberately the more permissive
+    /// of the two on Windows: it only has to avoid resolving obvious nonsense, and the resolved
+    /// comparison below is what actually decides.
+    /// </summary>
+    internal static StringComparison PathIdentityComparison => StringComparison.Ordinal;
 
     /// <summary>
     /// Resolve <paramref name="path"/> to its REAL filesystem identity: every symbolic link,
@@ -2341,6 +2397,23 @@ internal static class ControlEndpoints
     /// so a non-existent suffix is kept lexically (the caller's own existence checks handle it).
     /// </summary>
     internal static string? ResolveRealPath(string path)
+    {
+        var resolved = ResolveLinkChain(path);
+        if (resolved is null)
+            return null;
+
+        // Fold the result to the spelling the filesystem itself uses. On Windows that is what makes
+        // the containment comparison ORDINAL and therefore correct on a per-directory case-sensitive
+        // parent, which the platform supports and the old ignore-case rule got wrong (M03-I2-01).
+        // Everywhere else this returns the path unchanged.
+        return FilesystemIdentity.CanonicalPath(resolved);
+    }
+
+    /// <summary>
+    /// The link-following half of <see cref="ResolveRealPath"/>: every existing component walked,
+    /// every resolvable reparse point followed. See there for the contract.
+    /// </summary>
+    private static string? ResolveLinkChain(string path)
     {
         // More link hops than this is a cycle (a link pointing back at its own ancestor) or an
         // absurd chain; either way the identity is not establishable - refuse.

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1723,7 +1723,7 @@ internal static class ControlEndpoints
             string fullRoot;
             try { fullRoot = Path.GetFullPath(root).TrimEnd('\\', '/'); }
             catch (ArgumentException) { continue; } // a label, not a local directory (remote-thread sessions)
-            if (!roots.Contains(fullRoot, StringComparer.OrdinalIgnoreCase))
+            if (!roots.Contains(fullRoot, StringComparer.FromComparison(PathContainmentComparison)))
                 roots.Add(fullRoot);
         }
 
@@ -1743,16 +1743,35 @@ internal static class ControlEndpoints
 
         var full = Path.GetFullPath(path).TrimEnd('\\', '/');
         var containingRoot = roots.FirstOrDefault(r =>
-            string.Equals(full, r, StringComparison.OrdinalIgnoreCase)
-            || full.StartsWith(r + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase));
+            string.Equals(full, r, PathContainmentComparison)
+            || full.StartsWith(r + Path.DirectorySeparatorChar, PathContainmentComparison));
         if (containingRoot is null)
             throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
 
         if (!Directory.Exists(full))
             throw new DirectoryNotFoundException($"directory not found: {full}");
 
+        // The containment test above is LEXICAL, and Path.GetFullPath never touches the filesystem, so a
+        // link or junction planted under an allowed root keeps a legal prefix while the enumeration
+        // below follows it anywhere on disk. Decide again on the REAL filesystem identity of both the
+        // requested directory and the allowed roots (a root may itself be reached through a link), and
+        // refuse an identity that cannot be established rather than following an unresolvable reparse
+        // point.
+        var realFull = ResolveRealPath(full);
+        if (realFull is null)
+            throw new UnauthorizedAccessException($"directory could not be resolved to a real path: {full}");
+        var realFullTrimmed = realFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var containedForReal = roots
+            .Select(ResolveRealPath)
+            .Where(r => r is not null)
+            .Select(r => r!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+            .Any(r => string.Equals(realFullTrimmed, r, PathContainmentComparison)
+                      || realFullTrimmed.StartsWith(r + Path.DirectorySeparatorChar, PathContainmentComparison));
+        if (!containedForReal)
+            throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
+
         // Never offer navigation above the containing root: the root's own parent is not browsable.
-        var parent = string.Equals(full, containingRoot, StringComparison.OrdinalIgnoreCase)
+        var parent = string.Equals(full, containingRoot, PathContainmentComparison)
             ? null
             : Directory.GetParent(full)?.FullName;
 
@@ -2188,9 +2207,23 @@ internal static class ControlEndpoints
         var full = Path.GetFullPath(Path.Combine(dir, name));
         // Confirm the resolved path is still under the screenshots folder.
         var dirFull = Path.GetFullPath(dir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!full.StartsWith(dirFull + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        if (!full.StartsWith(dirFull + Path.DirectorySeparatorChar, PathContainmentComparison))
             return null;
-        return File.Exists(full) ? full : null;
+        if (!File.Exists(full))
+            return null;
+
+        // The bare-name gate above stops a traversal SPELLING, but it cannot stop a symbolic link
+        // PLANTED inside the screenshots folder under an innocent image name - the name is bare, the
+        // extension is allowed, and the lexical prefix is legal, while the file itself is somewhere
+        // else entirely. Decide on the real identity, and refuse when it cannot be established.
+        var realFull = ResolveRealPath(full);
+        var realDir = ResolveRealPath(dirFull);
+        if (realFull is null || realDir is null)
+            return null;
+        var realDirTrimmed = realDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!realFull.StartsWith(realDirTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
+            return null;
+        return full;
     }
 
     /// <summary>
@@ -2224,9 +2257,134 @@ internal static class ControlEndpoints
         }
 
         var rootTrimmed = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!full.StartsWith(rootTrimmed + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        if (!full.StartsWith(rootTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
+            return null;
+
+        // The prefix test above is necessary but NOT sufficient. Path.GetFullPath is pure string
+        // normalization - it never touches the filesystem - so a symbolic link or directory junction
+        // planted UNDER the working directory keeps a perfectly legal lexical prefix while the read
+        // that follows walks out to anywhere on disk. Decide again on the REAL filesystem identity.
+        // BOTH sides are resolved: the working directory may itself be reached through a link, and
+        // resolving only the candidate would then make every legal file look out-of-root.
+        var realRoot = ResolveRealPath(rootTrimmed);
+        var realFull = ResolveRealPath(full);
+        if (realRoot is null || realFull is null)
+            return null; // identity not establishable (an unresolvable reparse point, a cycle) - refuse
+        var realRootTrimmed = realRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!realFull.StartsWith(realRootTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
             return null;
         return full;
+    }
+
+    /// <summary>
+    /// Comparison for path-containment decisions. Case-insensitive ONLY on Windows, where the
+    /// filesystem itself compares names case-insensitively; ordinal (case-sensitive) everywhere
+    /// else. On Linux paths are case-sensitive, so an ignore-case prefix test would accept
+    /// "/ROOT/x" as inside "/root" - two genuinely different directories. macOS is deliberately
+    /// treated as case-sensitive as well: its default volumes compare case-insensitively, but
+    /// case-sensitive APFS volumes are common on developer machines, and mis-classifying one
+    /// OPENS the boundary while the reverse only refuses a case-variant spelling of a legal
+    /// path - fail closed. Exposed through <see cref="PathContainmentComparisonFor"/> so both
+    /// branches of the decision are testable on any one build machine.
+    /// </summary>
+    internal static StringComparison PathContainmentComparison { get; } =
+        PathContainmentComparisonFor(OperatingSystem.IsWindows());
+
+    /// <summary>The pure decision behind <see cref="PathContainmentComparison"/>; see there.</summary>
+    internal static StringComparison PathContainmentComparisonFor(bool windowsFileSystem) =>
+        windowsFileSystem ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Resolve <paramref name="path"/> to its REAL filesystem identity: every symbolic link,
+    /// junction, or other resolvable reparse point in every EXISTING component - intermediate
+    /// directories included, which a single <see cref="File.ResolveLinkTarget(string, bool)"/>
+    /// call does not cover - is followed to its final target, and a resolved target is walked
+    /// again in full so a target that itself sits behind links is also resolved. Returns null
+    /// when the identity cannot be established: a reparse point .NET cannot interpret, a link
+    /// cycle, or a component whose attributes cannot be read. Callers must REFUSE on null -
+    /// never fall back to the lexical answer. Components that do not exist cannot hide a link,
+    /// so a non-existent suffix is kept lexically (the caller's own existence checks handle it).
+    /// </summary>
+    internal static string? ResolveRealPath(string path)
+    {
+        // More link hops than this is a cycle (a link pointing back at its own ancestor) or an
+        // absurd chain; either way the identity is not establishable - refuse.
+        const int maxLinkResolutions = 40;
+        var resolutions = 0;
+
+        string current;
+        try { current = Path.GetFullPath(path); }
+        catch (ArgumentException) { return null; }
+
+        var followedLink = true;
+        while (followedLink)
+        {
+            followedLink = false;
+            var pathRoot = Path.GetPathRoot(current);
+            if (string.IsNullOrEmpty(pathRoot))
+                return null; // not an absolute path - no real identity to establish
+            var components = current[pathRoot.Length..].Split(
+                new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                StringSplitOptions.RemoveEmptyEntries);
+
+            var prefix = pathRoot;
+            for (var i = 0; i < components.Length; i++)
+            {
+                var candidate = Path.Combine(prefix, components[i]);
+
+                FileAttributes attributes;
+                try
+                {
+                    attributes = File.GetAttributes(candidate);
+                }
+                catch (FileNotFoundException)
+                {
+                    // Nothing exists from this component down, so nothing below can be a link;
+                    // keep the remainder lexically.
+                    return Path.Combine(prefix, string.Join(Path.DirectorySeparatorChar, components[i..]));
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    return Path.Combine(prefix, string.Join(Path.DirectorySeparatorChar, components[i..]));
+                }
+                catch (IOException) { return null; }
+                catch (UnauthorizedAccessException) { return null; }
+
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    if (++resolutions > maxLinkResolutions)
+                        return null;
+
+                    FileSystemInfo linkInfo = (attributes & FileAttributes.Directory) != 0
+                        ? new DirectoryInfo(candidate)
+                        : new FileInfo(candidate);
+                    FileSystemInfo? target;
+                    try { target = linkInfo.ResolveLinkTarget(returnFinalTarget: true); }
+                    catch (IOException) { return null; }
+                    catch (UnauthorizedAccessException) { return null; }
+                    if (target is null)
+                        return null; // a reparse point whose target cannot be read - refuse, never follow
+
+                    var remainder = components[(i + 1)..];
+                    current = remainder.Length == 0
+                        ? target.FullName
+                        : Path.Combine(target.FullName, Path.Combine(remainder));
+                    try { current = Path.GetFullPath(current); }
+                    catch (ArgumentException) { return null; }
+
+                    // The target's own path may run through further links; walk it again in full.
+                    followedLink = true;
+                    break;
+                }
+
+                prefix = candidate;
+            }
+
+            if (!followedLink)
+                current = prefix;
+        }
+
+        return current;
     }
 
     internal static string ScreenshotContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1721,7 +1721,7 @@ internal static class ControlEndpoints
         {
             if (string.IsNullOrWhiteSpace(root)) continue;
             string fullRoot;
-            try { fullRoot = Path.GetFullPath(root).TrimEnd('\\', '/'); }
+            try { fullRoot = NormalizeDirectoryPath(Path.GetFullPath(root)); }
             catch (ArgumentException) { continue; } // a label, not a local directory (remote-thread sessions)
             if (!roots.Contains(fullRoot, StringComparer.FromComparison(PathContainmentComparison)))
                 roots.Add(fullRoot);
@@ -1741,10 +1741,10 @@ internal static class ControlEndpoints
             return new DirectoryListingDto { CurrentPath = null, ParentPath = null, Entries = rootEntries };
         }
 
-        var full = Path.GetFullPath(path).TrimEnd('\\', '/');
+        var full = NormalizeDirectoryPath(Path.GetFullPath(path));
         var containingRoot = roots.FirstOrDefault(r =>
             string.Equals(full, r, PathContainmentComparison)
-            || full.StartsWith(r + Path.DirectorySeparatorChar, PathContainmentComparison));
+            || full.StartsWith(ContainmentPrefix(r), PathContainmentComparison));
         if (containingRoot is null)
             throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
 
@@ -1760,13 +1760,13 @@ internal static class ControlEndpoints
         var realFull = ResolveRealPath(full);
         if (realFull is null)
             throw new UnauthorizedAccessException($"directory could not be resolved to a real path: {full}");
-        var realFullTrimmed = realFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var realFullTrimmed = NormalizeDirectoryPath(realFull);
         var containedForReal = roots
             .Select(ResolveRealPath)
             .Where(r => r is not null)
-            .Select(r => r!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+            .Select(r => NormalizeDirectoryPath(r!))
             .Any(r => string.Equals(realFullTrimmed, r, PathContainmentComparison)
-                      || realFullTrimmed.StartsWith(r + Path.DirectorySeparatorChar, PathContainmentComparison));
+                      || realFullTrimmed.StartsWith(ContainmentPrefix(r), PathContainmentComparison));
         if (!containedForReal)
             throw new UnauthorizedAccessException($"directory is outside this Director's session working directories: {full}");
 
@@ -2206,8 +2206,8 @@ internal static class ControlEndpoints
         var dir = CcStorage.Screenshots();
         var full = Path.GetFullPath(Path.Combine(dir, name));
         // Confirm the resolved path is still under the screenshots folder.
-        var dirFull = Path.GetFullPath(dir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!full.StartsWith(dirFull + Path.DirectorySeparatorChar, PathContainmentComparison))
+        var dirFull = NormalizeDirectoryPath(Path.GetFullPath(dir));
+        if (!full.StartsWith(ContainmentPrefix(dirFull), PathContainmentComparison))
             return null;
         if (!File.Exists(full))
             return null;
@@ -2220,9 +2220,10 @@ internal static class ControlEndpoints
         var realDir = ResolveRealPath(dirFull);
         if (realFull is null || realDir is null)
             return null;
-        var realDirTrimmed = realDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!realFull.StartsWith(realDirTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
+        var realDirTrimmed = NormalizeDirectoryPath(realDir);
+        if (!realFull.StartsWith(ContainmentPrefix(realDirTrimmed), PathContainmentComparison))
             return null;
+
         return full;
     }
 
@@ -2256,8 +2257,8 @@ internal static class ControlEndpoints
             return null;
         }
 
-        var rootTrimmed = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!full.StartsWith(rootTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
+        var rootTrimmed = NormalizeDirectoryPath(root);
+        if (!full.StartsWith(ContainmentPrefix(rootTrimmed), PathContainmentComparison))
             return null;
 
         // The prefix test above is necessary but NOT sufficient. Path.GetFullPath is pure string
@@ -2270,11 +2271,44 @@ internal static class ControlEndpoints
         var realFull = ResolveRealPath(full);
         if (realRoot is null || realFull is null)
             return null; // identity not establishable (an unresolvable reparse point, a cycle) - refuse
-        var realRootTrimmed = realRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (!realFull.StartsWith(realRootTrimmed + Path.DirectorySeparatorChar, PathContainmentComparison))
+        var realRootTrimmed = NormalizeDirectoryPath(realRoot);
+        if (!realFull.StartsWith(ContainmentPrefix(realRootTrimmed), PathContainmentComparison))
             return null;
+
         return full;
     }
+
+    /// <summary>
+    /// A directory path with its trailing separators removed - EXCEPT when the path IS a filesystem
+    /// root, where the separator is part of the name and removing it changes the meaning completely.
+    ///
+    /// This is not a tidiness helper, it is a correctness one. On Windows <c>D:\</c> trimmed becomes
+    /// <c>D:</c>, which is DRIVE-RELATIVE: it resolves to that drive's current directory, not to the
+    /// drive's root. On Unix <c>/</c> trimmed becomes the empty string, which resolves to the process
+    /// current directory. Either way a session whose working directory is a filesystem root would have
+    /// its containment decided against a completely different directory, and every file under it
+    /// refused - which is exactly the regression the second inspection found (M03-I2B-04).
+    /// </summary>
+    internal static string NormalizeDirectoryPath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return path;
+        var pathRoot = Path.GetPathRoot(path);
+        if (!string.IsNullOrEmpty(pathRoot) && string.Equals(path, pathRoot, StringComparison.Ordinal))
+            return path;
+        var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return trimmed.Length == 0 ? path : trimmed;
+    }
+
+    /// <summary>
+    /// The prefix every path INSIDE <paramref name="directory"/> begins with: the directory followed
+    /// by exactly one separator. A filesystem root already ends in its own separator, so appending a
+    /// second one would build a prefix that no real path can ever match.
+    /// </summary>
+    internal static string ContainmentPrefix(string directory) =>
+        directory.EndsWith(Path.DirectorySeparatorChar) || directory.EndsWith(Path.AltDirectorySeparatorChar)
+            ? directory
+            : directory + Path.DirectorySeparatorChar;
 
     /// <summary>
     /// Comparison for path-containment decisions. Case-insensitive ONLY on Windows, where the
@@ -2293,6 +2327,7 @@ internal static class ControlEndpoints
     /// <summary>The pure decision behind <see cref="PathContainmentComparison"/>; see there.</summary>
     internal static StringComparison PathContainmentComparisonFor(bool windowsFileSystem) =>
         windowsFileSystem ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
 
     /// <summary>
     /// Resolve <paramref name="path"/> to its REAL filesystem identity: every symbolic link,

--- a/src/CcDirector.ControlApi/DirectorUpStreamHandler.cs
+++ b/src/CcDirector.ControlApi/DirectorUpStreamHandler.cs
@@ -91,11 +91,25 @@ internal sealed class DirectorUpStreamHandler
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "streamId is required");
         if (string.IsNullOrEmpty(request.Path))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "path is required");
-        if (!File.Exists(request.Path))
+
+        // The file read is SESSION-SCOPED: resolve the session exactly as OpenTerminal does, and refuse any
+        // path outside its working directory through ResolveSessionFile (ResolveScreenshot's twin - resolve
+        // fully, then refuse anything outside the allowed root). The pre-hardening version served ANY path
+        // after only File.Exists, so on a hosted Gateway any active device key could read gateway-token.txt,
+        // .ssh keys, or .env files on any machine in the account.
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+        var session = _sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var path = ControlEndpoints.ResolveSessionFile(session.WorkingDirectory, request.Path);
+        if (path is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "path is outside the session's working directory");
+        if (!File.Exists(path))
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "file not found");
 
         var streamId = request.StreamId;
-        var path = request.Path;
         StartProducer(streamId, ct => DirectorStreamProducers.ProduceFileAsync(path, streamId, ct));
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(BuildReadResponse(path, ControlEndpoints.FileContentType(path))));
     }

--- a/src/CcDirector.ControlApi/FilesystemIdentity.cs
+++ b/src/CcDirector.ControlApi/FilesystemIdentity.cs
@@ -207,13 +207,27 @@ internal static class FilesystemIdentity
     private static extern bool GetFileInformationByHandle(
         SafeFileHandle hFile, out ByHandleFileInformation lpFileInformation);
 
+    /// <summary>
+    /// BY_HANDLE_FILE_INFORMATION, field for field.
+    ///
+    /// Every member is written out as a 32-bit value, including the three timestamps, because the
+    /// Win32 structure is a run of DWORDs and FILETIMEs and is therefore 4-byte aligned throughout.
+    /// Declaring the timestamps as <c>long</c> is the obvious-looking mistake and it is silent: the
+    /// runtime aligns a 64-bit field to 8 bytes, inserts padding after the leading attributes DWORD,
+    /// and every field after it reads from the wrong offset - so the link count comes back as an
+    /// arbitrary number rather than failing. It was caught here by a probe that printed the count for
+    /// an ordinary file and got 983040 instead of 1.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     private struct ByHandleFileInformation
     {
         public uint FileAttributes;
-        public long CreationTime;
-        public long LastAccessTime;
-        public long LastWriteTime;
+        public uint CreationTimeLow;
+        public uint CreationTimeHigh;
+        public uint LastAccessTimeLow;
+        public uint LastAccessTimeHigh;
+        public uint LastWriteTimeLow;
+        public uint LastWriteTimeHigh;
         public uint VolumeSerialNumber;
         public uint FileSizeHigh;
         public uint FileSizeLow;

--- a/src/CcDirector.ControlApi/FilesystemIdentity.cs
+++ b/src/CcDirector.ControlApi/FilesystemIdentity.cs
@@ -1,0 +1,418 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using CcDirector.Core.Utilities;
+using Microsoft.Win32.SafeHandles;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// The two filesystem facts a path-containment decision needs and that .NET does not expose:
+/// how many names a file has, and what a path's real on-disk spelling is.
+///
+/// Tenant-boundary hardening, Phase 5b, inspection finding M03-I2-01. The Phase 5a containment work
+/// resolved reparse points - symbolic links and directory junctions - and called that "the real
+/// filesystem identity". It was not. A HARD LINK is a second directory entry for the SAME file
+/// object and carries no reparse-point attribute at all, so an in-root name for an outside file
+/// passed every check and the file was served. The independent inspector executed exactly that and
+/// read a seeded secret through an in-root alias.
+///
+/// A file with more than one name cannot be proven to live inside a root: the name you were given is
+/// inside, and the other name - the one you cannot see from here - may be anywhere on the machine.
+/// So containment refuses any candidate whose link count is not exactly one. An ordinary file has
+/// exactly one name, so nothing legitimate is lost. When the count CANNOT be established the answer
+/// is null and the caller refuses; there is no lexical fallback, because falling back to the lexical
+/// answer is the defect itself.
+///
+/// The casing half of the same finding: the containment comparison assumed every Windows directory
+/// compares case-insensitively. It does not - NTFS carries a PER-DIRECTORY case-sensitive flag
+/// (fsutil file setCaseSensitiveInfo), so one parent can hold both "repo" and "REPO" as different
+/// directories while an ignore-case prefix test accepts the wrong one as inside. Rather than trying
+/// to read that flag per directory and decide what an unreadable flag means, the path is folded to
+/// its canonical on-disk spelling and the comparison becomes ORDINAL. That decides correctly under
+/// both rules: on a case-insensitive parent a differently-spelled request folds onto the one real
+/// name, and on a case-sensitive parent "repo" and "REPO" fold to themselves and stay distinct.
+/// </summary>
+internal static class FilesystemIdentity
+{
+    // ------------------------------------------------------------------ how many names ----
+
+    /// <summary>
+    /// How many directory entries name the file at <paramref name="filePath"/>: 1 for an ordinary
+    /// file, more when it is hard-linked. Returns null when the count cannot be established - an
+    /// unreadable file, a platform whose link count could not be located (see the Unix section),
+    /// any error at all. Callers MUST refuse on null.
+    /// </summary>
+    internal static int? NameCount(string filePath)
+    {
+        try
+        {
+            return OperatingSystem.IsWindows() ? WindowsNameCount(filePath) : UnixNameCount(filePath);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FilesystemIdentity] NameCount undeterminable for {filePath}: {ex.GetType().Name} {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// True when the file has exactly one name and so can be contained by the directory it sits in;
+    /// false when it has more; null when the question could not be answered. Null must be refused,
+    /// never treated as true.
+    /// </summary>
+    internal static bool? HasExactlyOneName(string filePath) => NameCount(filePath) switch
+    {
+        null => null,
+        1 => true,
+        _ => false,
+    };
+
+    private static int? WindowsNameCount(string filePath)
+    {
+        // FILE_READ_ATTRIBUTES only: this asks the filesystem about the entry, it does not read the
+        // contents, so it works on files the caller may stat but not read. Every share mode is
+        // allowed so an open handle elsewhere does not turn a containment decision into a refusal.
+        using var handle = CreateFileW(
+            filePath,
+            FileReadAttributes,
+            FileShareRead | FileShareWrite | FileShareDelete,
+            IntPtr.Zero,
+            OpenExisting,
+            FileFlagBackupSemantics,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+            return null;
+
+        if (!GetFileInformationByHandle(handle, out var info))
+            return null;
+
+        return info.NumberOfLinks > int.MaxValue ? int.MaxValue : (int)info.NumberOfLinks;
+    }
+
+    // ------------------------------------------------------------- canonical on-disk name ----
+
+    /// <summary>
+    /// The path as the filesystem itself spells it - true casing, links already followed, long
+    /// (non 8.3) form. On Windows this is <c>GetFinalPathNameByHandle</c>. Everywhere else paths are
+    /// already compared case-sensitively and the caller has resolved links itself, so the path is
+    /// returned unchanged.
+    ///
+    /// Components that do not exist cannot be canonicalized - and cannot hide a differently-cased
+    /// real entry either, because there is nothing there - so a non-existent suffix is carried
+    /// through unchanged on the canonical prefix. Returns null when an EXISTING component cannot be
+    /// opened, which the caller must refuse.
+    /// </summary>
+    internal static string? CanonicalPath(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            return path;
+
+        try
+        {
+            return WindowsCanonicalPath(path);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FilesystemIdentity] CanonicalPath undeterminable for {path}: {ex.GetType().Name} {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string? WindowsCanonicalPath(string path)
+    {
+        var remainder = new List<string>();
+        var current = path;
+
+        while (true)
+        {
+            using var handle = CreateFileW(
+                current,
+                FileReadAttributes,
+                FileShareRead | FileShareWrite | FileShareDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics,
+                IntPtr.Zero);
+
+            if (!handle.IsInvalid)
+            {
+                var canonical = FinalPathName(handle);
+                if (canonical is null)
+                    return null;
+                remainder.Reverse();
+                return remainder.Count == 0
+                    ? canonical
+                    : Path.Combine(canonical, Path.Combine([.. remainder]));
+            }
+
+            var error = Marshal.GetLastWin32Error();
+            if (error is not (ErrorFileNotFound or ErrorPathNotFound or ErrorInvalidName))
+                return null; // it exists and we cannot identify it - refuse, never guess
+
+            // Nothing is there. Peel the last component and ask about the parent: a name that does
+            // not exist has no on-disk spelling to fold onto, so it is kept exactly as written.
+            var parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent) || parent == current)
+                return path; // not one component of this path exists - nothing to canonicalize
+            remainder.Add(current[(parent.Length)..].TrimStart(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            current = parent;
+        }
+    }
+
+    private static string? FinalPathName(SafeFileHandle handle)
+    {
+        var needed = GetFinalPathNameByHandleW(handle, null, 0, VolumeNameDos);
+        if (needed == 0)
+            return null;
+        var buffer = new char[needed + 1];
+        var written = GetFinalPathNameByHandleW(handle, buffer, (uint)buffer.Length, VolumeNameDos);
+        if (written == 0 || written >= buffer.Length)
+            return null;
+
+        var result = new string(buffer, 0, (int)written);
+        // GetFinalPathNameByHandle answers in the extended-length namespace. Strip the prefix so the
+        // result is an ordinary path the rest of the code can compare and open.
+        if (result.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
+            return @"\\" + result[8..];
+        if (result.StartsWith(@"\\?\", StringComparison.Ordinal))
+            return result[4..];
+        return result;
+    }
+
+    // ------------------------------------------------------------------ Windows interop ----
+
+    private const uint FileReadAttributes = 0x0080;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint FileShareDelete = 0x00000004;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000; // required to open a DIRECTORY handle
+    private const uint VolumeNameDos = 0x0;
+    private const int ErrorFileNotFound = 2;
+    private const int ErrorPathNotFound = 3;
+    private const int ErrorInvalidName = 123;
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        string lpFileName, uint dwDesiredAccess, uint dwShareMode, IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition, uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle hFile, char[]? lpszFilePath, uint cchFilePath, uint dwFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle hFile, out ByHandleFileInformation lpFileInformation);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ByHandleFileInformation
+    {
+        public uint FileAttributes;
+        public long CreationTime;
+        public long LastAccessTime;
+        public long LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    // --------------------------------------------------------------------- Unix interop ----
+    //
+    // The link count lives in libc's "struct stat", whose layout differs by operating system, by
+    // architecture, and by which of several stat entry points the C library actually exports. A
+    // hard-coded offset table would be a security decision this build machine cannot verify, and a
+    // wrong offset would silently read some other field - the worst possible failure for a check
+    // whose whole job is to be trustworthy.
+    //
+    // So the field is LOCATED EMPIRICALLY, once per process: stat a temporary file (one name), add a
+    // hard link (two names), add a second (three), and keep every buffer position whose value tracked
+    // exactly 1, then 2, then 3. Positions that survive that are the link count; nothing else in the
+    // structure counts up by one as names are added. If no entry point works, or no position
+    // survives, the count is undeterminable and every caller refuses. The probe is self-proving: it
+    // cannot be wrong about the layout, only unable to determine it.
+
+    private const int StatBufferBytes = 512; // struct stat is at most ~150 bytes on any supported target
+
+    private static readonly Lazy<UnixLinkCount?> UnixReader =
+        new(CalibrateUnixLinkCount, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private sealed record UnixLinkCount(string EntryPoint, Func<byte[], byte[], int> Stat,
+        IReadOnlyList<(int Offset, int Width)> Fields);
+
+    private static int? UnixNameCount(string filePath)
+    {
+        var reader = UnixReader.Value;
+        if (reader is null)
+            return null;
+
+        var buffer = new byte[StatBufferBytes];
+        if (reader.Stat(NullTerminated(filePath), buffer) != 0)
+            return null;
+
+        ulong? agreed = null;
+        foreach (var (offset, width) in reader.Fields)
+        {
+            var value = ReadUnsigned(buffer, offset, width);
+            if (agreed is null) agreed = value;
+            else if (agreed.Value != value) return null; // the surviving positions disagree - do not guess
+        }
+        if (agreed is null || agreed.Value < 1 || agreed.Value > int.MaxValue)
+            return null;
+        return (int)agreed.Value;
+    }
+
+    private static UnixLinkCount? CalibrateUnixLinkCount()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ccd-linkcount-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var probe = Path.Combine(dir, "probe");
+            File.WriteAllBytes(probe, []);
+            var probeBytes = NullTerminated(probe);
+
+            foreach (var (name, stat) in UnixStatEntryPoints())
+            {
+                var first = new byte[StatBufferBytes];
+                if (SafeCall(() => stat(probeBytes, first)) != 0)
+                    continue;
+
+                if (Link(probeBytes, NullTerminated(Path.Combine(dir, "second-name"))) != 0)
+                {
+                    FileLog.Write("[FilesystemIdentity] Unix link-count calibration cannot create a hard link; " +
+                                  "the link count will be reported as undeterminable and containment will refuse.");
+                    return null;
+                }
+                var second = new byte[StatBufferBytes];
+                if (SafeCall(() => stat(probeBytes, second)) != 0)
+                    continue;
+
+                if (Link(probeBytes, NullTerminated(Path.Combine(dir, "third-name"))) != 0)
+                    return null;
+                var third = new byte[StatBufferBytes];
+                if (SafeCall(() => stat(probeBytes, third)) != 0)
+                    continue;
+
+                var fields = LocateCountingField(first, second, third);
+
+                if (fields.Count > 0)
+                {
+                    FileLog.Write($"[FilesystemIdentity] Unix link count located via '{name}' at " +
+                                  string.Join(", ", fields.Select(f => $"offset {f.Offset} width {f.Width}")));
+                    return new UnixLinkCount(name, stat, fields);
+                }
+
+                File.Delete(Path.Combine(dir, "second-name"));
+                File.Delete(Path.Combine(dir, "third-name"));
+            }
+
+            FileLog.Write("[FilesystemIdentity] Unix link count could NOT be located in any stat layout; " +
+                          "file containment will refuse every candidate rather than decide lexically.");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FilesystemIdentity] Unix link-count calibration failed: {ex.GetType().Name} {ex.Message}");
+            return null;
+        }
+        finally
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// The stat entry points worth trying, in order. Which one a C library exports depends on the
+    /// platform and its age: glibc before 2.33 exports only the versioned <c>__xstat</c>; macOS on
+    /// Intel exports the modern 64-bit-inode variant under a decorated name. Every candidate is
+    /// PROVEN by the calibration before it is used, so an entry point that is present but wrong is
+    /// discarded rather than trusted.
+    /// </summary>
+    private static IEnumerable<(string Name, Func<byte[], byte[], int> Stat)> UnixStatEntryPoints()
+    {
+        yield return ("stat", Stat);
+        yield return ("stat64", Stat64);
+        yield return ("stat$INODE64", StatInode64);
+        yield return ("__xstat", (p, b) => XStat(1, p, b));
+        yield return ("__xstat64", (p, b) => XStat64(1, p, b));
+    }
+
+    /// <summary>
+    /// Run one interop call, turning "this C library does not export that symbol" into an ordinary
+    /// non-zero result so the next candidate is tried. Nothing here decides anything - the
+    /// calibration still has to prove whichever entry point answers.
+    /// </summary>
+    private static int SafeCall(Func<int> call)
+    {
+        try { return call(); }
+        catch (EntryPointNotFoundException) { return -1; }
+        catch (DllNotFoundException) { return -1; }
+    }
+
+    private static byte[] NullTerminated(string path)
+    {
+        var bytes = Encoding.UTF8.GetBytes(path);
+        var terminated = new byte[bytes.Length + 1];
+        Array.Copy(bytes, terminated, bytes.Length);
+        return terminated;
+    }
+
+    private static ulong ReadUnsigned(byte[] buffer, int offset, int width) => width switch
+    {
+        2 => BitConverter.ToUInt16(buffer, offset),
+        4 => BitConverter.ToUInt32(buffer, offset),
+        8 => BitConverter.ToUInt64(buffer, offset),
+        _ => throw new ArgumentOutOfRangeException(nameof(width)),
+    };
+
+    [DllImport("libc", EntryPoint = "stat", SetLastError = true)]
+    private static extern int Stat(byte[] path, byte[] statBuffer);
+
+    [DllImport("libc", EntryPoint = "stat64", SetLastError = true)]
+    private static extern int Stat64(byte[] path, byte[] statBuffer);
+
+    [DllImport("libc", EntryPoint = "stat$INODE64", SetLastError = true)]
+    private static extern int StatInode64(byte[] path, byte[] statBuffer);
+
+    [DllImport("libc", EntryPoint = "__xstat", SetLastError = true)]
+    private static extern int XStat(int version, byte[] path, byte[] statBuffer);
+
+    [DllImport("libc", EntryPoint = "__xstat64", SetLastError = true)]
+    private static extern int XStat64(int version, byte[] path, byte[] statBuffer);
+
+    [DllImport("libc", EntryPoint = "link", SetLastError = true)]
+    private static extern int Link(byte[] existingPath, byte[] newPath);
+
+    // ------------------------------------------------------- the calibration, as pure code ----
+
+    /// <summary>
+    /// The position search the Unix calibration performs, exposed so it can be exercised on ANY build
+    /// machine against synthetic buffers. This is the part that decides where the link count lives,
+    /// and it is the part that must not be wrong; the interop around it only fetches bytes.
+    /// </summary>
+    internal static IReadOnlyList<(int Offset, int Width)> LocateCountingField(
+        byte[] first, byte[] second, byte[] third)
+    {
+        var fields = new List<(int Offset, int Width)>();
+        var length = Math.Min(first.Length, Math.Min(second.Length, third.Length));
+        foreach (var width in new[] { 2, 4, 8 })
+        {
+            for (var offset = 0; offset + width <= length; offset++)
+            {
+                if (ReadUnsigned(first, offset, width) == 1
+                    && ReadUnsigned(second, offset, width) == 2
+                    && ReadUnsigned(third, offset, width) == 3)
+                {
+                    fields.Add((offset, width));
+                }
+            }
+        }
+        return fields;
+    }
+}

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -454,16 +454,18 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     /// <summary>
     /// Start something on one machine through the Gateway's machine relay. Either <paramref name="path"/> or
     /// <paramref name="app"/> identifies it; the launcher resolves a name against its own catalogue.
+    /// <paramref name="confirmProtected"/> is the explicit confirmation the Gateway requires on every launch
+    /// (tenant-boundary hardening, CR-5) - forwarded verbatim, never invented on the caller's behalf.
     /// </summary>
     public async Task<(int Status, string Body)> LaunchOnMachineAsync(string machine, string? path, string? app,
-        string? args, string? cwd, bool headless, CancellationToken ct = default)
+        string? args, string? cwd, bool headless, bool confirmProtected = false, CancellationToken ct = default)
     {
         if (!_config.IsEnabled)
             throw new InvalidOperationException($"Gateway is not configured; cannot launch on machine '{machine}'.");
 
         FileLog.Write($"[GatewayClient] LaunchOnMachineAsync: {machine} path={path ?? "(none)"} app={app ?? "(none)"}");
         using var resp = await _http.PostAsJsonAsync($"machines/{Uri.EscapeDataString(machine)}/launch",
-            new { path, app, args, cwd, headless }, ct);
+            new { path, app, args, cwd, headless, confirmProtected }, ct);
         var body = await resp.Content.ReadAsStringAsync(ct);
         FileLog.Write($"[GatewayClient] LaunchOnMachineAsync: {machine} -> {(int)resp.StatusCode}");
         return ((int)resp.StatusCode, body);

--- a/src/CcDirector.Gateway.Tests/Account/AccountActingCredentialSelfHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountActingCredentialSelfHostTests.cs
@@ -137,8 +137,12 @@ public sealed class AccountActingCredentialSelfHostTests
         app.Urls.Add("http://127.0.0.1:0");
 
         var cloud = new CloudStub();
-        AccountStatusEndpoint.Map(app, account);
-        AccountEmailEndpoint.Map(app, account, new AccountNotifyClient(new HttpClient(cloud)));
+        // The boundary is required and non-nullable now (finding I1-01). This is a self-host harness, so it
+        // gets the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        var boundary = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry());
+        AccountStatusEndpoint.Map(app, account, boundary);
+        AccountEmailEndpoint.Map(app, account, new AccountNotifyClient(new HttpClient(cloud)), boundary);
         await app.StartAsync();
 
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, cloud);

--- a/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
@@ -139,8 +139,11 @@ public sealed class AccountDevicesEndpointTests
         }
 
         // Self-host path: GatewayHostedMode is not hosted here, so the local registry and tenant boundary are
-        // never consulted - a bare registry satisfies the required argument and no boundary is passed.
-        AccountDevicesEndpoint.Map(app, account, devices, ThisMachine, new DeviceRegistry());
+        // never consulted - a bare registry satisfies the required argument, and the boundary (required and
+        // non-nullable, finding I1-01) is the REAL self-host one over the SingleTenantContext.
+        AccountDevicesEndpoint.Map(app, account, devices, ThisMachine, new DeviceRegistry(),
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new DeviceRegistry()));
         await app.StartAsync();
 
         var baseUrl = app.Urls.First();

--- a/src/CcDirector.Gateway.Tests/Account/AccountLogoutEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountLogoutEndpointTests.cs
@@ -89,8 +89,12 @@ public sealed class AccountLogoutEndpointTests
             app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
         }
 
-        AccountStatusEndpoint.Map(app, account);
-        AccountLogoutEndpoint.Map(app, account);
+        // The boundary is required and non-nullable now (finding I1-01). This is a self-host harness, so it
+        // gets the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        var boundary = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.SingleTenantContext(), new DeviceRegistry());
+        AccountStatusEndpoint.Map(app, account, boundary);
+        AccountLogoutEndpoint.Map(app, account, boundary);
         await app.StartAsync();
 
         var baseUrl = app.Urls.First();

--- a/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
@@ -89,7 +89,12 @@ public sealed class AccountStatusEndpointTests
             app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
         }
 
-        AccountStatusEndpoint.Map(app, account, nickname);
+        // The boundary is required and non-nullable now (finding I1-01). This is a self-host harness, so it
+        // gets the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        AccountStatusEndpoint.Map(app, account,
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new DeviceRegistry()),
+            nickname);
         await app.StartAsync();
 
         var baseUrl = app.Urls.First();

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountStatusTests.cs
@@ -222,7 +222,10 @@ public sealed class HostedAccountStatusTests : IAsyncLifetime
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add("http://127.0.0.1:0");
-        AccountStatusEndpoint.Map(app, account: null);   // hosted mode is on; no boundary, no registry
+        // Hosted mode is on; no boundary, no registry. The boundary parameter is required and non-nullable
+        // now (finding I1-01), so the accidental version of this miswire no longer compiles - the forced
+        // null below is the deliberate simulation of it, and the runtime gate must still fail closed.
+        AccountStatusEndpoint.Map(app, account: null, tenantBoundary: null!);
         await app.StartAsync();
         try
         {

--- a/src/CcDirector.Gateway.Tests/Activity/ActivityEventEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/Activity/ActivityEventEndpointsTests.cs
@@ -30,7 +30,9 @@ public sealed class ActivityEventEndpointsTests : IAsyncLifetime
         _app = builder.Build();
         _app.Urls.Add("http://127.0.0.1:0");
 
-        ActivityEventEndpoints.Map(_app, new ActivityEventStore(_harness.Open()));
+        // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+        // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+        ActivityEventEndpoints.Map(_app, new ActivityEventStore(_harness.Open()), tenantBoundary: null);
         await _app.StartAsync();
 
         _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -157,9 +157,11 @@ public sealed class CatalogReadExecutorTests
     // ---------- fs-list ----------
 
     [Fact]
-    public async Task DispatchAsync_FsList_NullPath_ReturnsDriveRoots()
+    public async Task DispatchAsync_FsList_NullPath_ListsTheSessionRoots()
     {
-        // A null/absent path lists the drive roots: CurrentPath is null and every entry is a drive.
+        // Tenant-boundary hardening (CR-4): a null/absent path lists the ALLOWED ROOTS - the working
+        // directories of this Director's sessions - not the machine's drive roots. With no sessions there
+        // is nothing browsable, and the listing says so honestly.
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {
@@ -169,17 +171,16 @@ public sealed class CatalogReadExecutorTests
             var listing = JsonSerializer.Deserialize<DirectoryListingDto>(result.BodyJson ?? "", Json);
             Assert.NotNull(listing);
             Assert.Null(listing!.CurrentPath);
-            Assert.NotEmpty(listing.Entries);
-            Assert.All(listing.Entries, e => Assert.True(e.IsDrive));
+            Assert.Empty(listing.Entries);
         }
         finally { sm.Dispose(); }
     }
 
     [Fact]
-    public async Task DispatchAsync_FsList_MissingDirectory_ReturnsBadRequest()
+    public async Task DispatchAsync_FsList_DirectoryOutsideTheSessionRoots_ReturnsBadRequest()
     {
-        // The source route wrapped ListDirectory in a try/catch that turned a missing directory into a 400;
-        // that preserved try/catch surfaces here as a BadRequest with the message.
+        // The source route wrapped ListDirectory in a try/catch that turned any fault into a 400; the CR-4
+        // out-of-root refusal surfaces through that same preserved try/catch as a BadRequest with the message.
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -273,20 +273,28 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         await SeedPublishedSkill(_keyB, sid, body, "notes.md", "supporting");
 
         // CROSS: every write verb tenant A can name B's id with.
-        foreach (var (method, path) in new[]
+        //
+        // Inspection finding I1-04, and the probe was weaker than even the inspection realised. The
+        // enable and disable rows used to send an empty body and accept 400 as a refusal. Both routes
+        // require a 'by' field naming who is making the change, so both were answering
+        // 400 "Turning a skill on or off requires 'by'" - a VALIDATION error raised before any tenancy
+        // decision was reached. Those two rows were passing without the tenant boundary ever being
+        // consulted. Each row now sends a well formed body, so the only thing left that can refuse it is
+        // the tenant partition, and the accepted status is tightened to the ordinary not-found that a
+        // cross-tenant miss actually produces.
+        foreach (var (method, path, reqBody) in new[]
                  {
-                     ("POST", $"gateway/skills/{sid}/publish"),
-                     ("POST", $"gateway/skills/{sid}/enable"),
-                     ("POST", $"gateway/skills/{sid}/disable"),
-                     ("DELETE", $"gateway/skills/{sid}"),
+                     ("POST", $"gateway/skills/{sid}/publish", "{}"),
+                     ("POST", $"gateway/skills/{sid}/enable?by=census-probe", "{}"),
+                     ("POST", $"gateway/skills/{sid}/disable?by=census-probe", "{}"),
+                     ("DELETE", $"gateway/skills/{sid}", null),
                  })
         {
-            var resp = await Send(method, path, _keyA, method == "POST" ? "{}" : null);
+            var resp = await Send(method, path, _keyA, reqBody);
             var text = await resp.Content.ReadAsStringAsync();
             _out.WriteLine($"CROSS   {method} /{path} (tenant A) -> {(int)resp.StatusCode} {text}");
-            Assert.True(resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest
-                            or HttpStatusCode.Conflict,
-                $"{method} /{path}: tenant A must be refused, got {(int)resp.StatusCode}; body was: {text}");
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            Assert.DoesNotContain(body, text, StringComparison.Ordinal);
         }
 
         // A's clone attempt of B's id - the clone path is the one write that READS the named skill.
@@ -322,10 +330,11 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         // been removed would have satisfied the security assertion. The owner drives both here.
         foreach (var verb in new[] { "disable", "enable" })
         {
-            var ownerToggle = await Send("POST", $"gateway/skills/{sid}/{verb}", _keyB, "{}");
-            _out.WriteLine($"CONTROL POST /gateway/skills/{{id}}/{verb} (owner B) -> {(int)ownerToggle.StatusCode}");
+            var ownerToggle = await Send("POST", $"gateway/skills/{sid}/{verb}?by=census-probe", _keyB, "{}");
+            var toggleText = await ownerToggle.Content.ReadAsStringAsync();
+            _out.WriteLine($"CONTROL POST /gateway/skills/{{id}}/{verb} (owner B) -> {(int)ownerToggle.StatusCode} {toggleText}");
             Assert.True(ownerToggle.IsSuccessStatusCode,
-                $"the owner's own {verb} must succeed or A's refusal of it proves nothing, got {(int)ownerToggle.StatusCode}");
+                $"the owner's own {verb} must succeed or A's refusal of it proves nothing, got {(int)ownerToggle.StatusCode}; body was: {toggleText}");
         }
 
         // INDEPENDENT RE-READ: B's skill survived every attempt, still published, still readable.

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -217,9 +217,6 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
                      $"gateway/skills/{sid}/files/{fileName}",
                      $"gateway/skills/{sid}/versions",
                      $"gateway/skills/{sid}/versions/1",
-                     // The traversal-shaped file name, on the catch-all leg: the census verdict is that
-                     // this is a database key and never a path, so it must reach nothing either.
-                     $"gateway/skills/{sid}/files/../../{fileName}",
                  })
         {
             var resp = await Send("GET", path, _keyA, null);
@@ -230,6 +227,29 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
             Assert.DoesNotContain(body, text, StringComparison.Ordinal);
             Assert.DoesNotContain(fileContent, text, StringComparison.Ordinal);
         }
+
+        // THE TRAVERSAL-SHAPED FILE NAME, ON THE CATCH-ALL LEG (inspection finding I1-04).
+        //
+        // This used to ride in the loop above as "gateway/skills/{id}/files/../../{name}" and it proved
+        // NOTHING: HttpClient resolved the dot segments before sending, so the server saw
+        // /gateway/skills/{name}, a different route answered, and its 404 satisfied the assertion. The
+        // catch-all leg this row is named after never ran. It is now sent WITHOUT canonicalization, so
+        // the escape reaches the handler under test, and the test asserts that it did.
+        var traversal = $"gateway/skills/{sid}/files/../../{fileName}";
+        var travResp = await SendRaw("GET", traversal, _keyA);
+        var travText = await travResp.Content.ReadAsStringAsync();
+        _out.WriteLine($"CROSS   GET /{traversal} (tenant A, uncanonicalized) -> {(int)travResp.StatusCode} {travText}");
+
+        // The request went out with the dot segments intact - if this fails, the probe is back to
+        // testing the wrong route and its refusal below would be meaningless.
+        Assert.Contains("/files/../../", travResp.RequestMessage!.RequestUri!.OriginalString, StringComparison.Ordinal);
+
+        // The census verdict for this row is that the file name is a DATABASE KEY and never a path, so a
+        // traversal-shaped key is simply a key that matches nothing. Tightened from "404 or 400": the
+        // refusal must be the ordinary not-found, and it must not disclose either seeded secret.
+        Assert.Equal(HttpStatusCode.NotFound, travResp.StatusCode);
+        Assert.DoesNotContain(body, travText, StringComparison.Ordinal);
+        Assert.DoesNotContain(fileContent, travText, StringComparison.Ordinal);
 
         // INDEPENDENT RE-READ: B's skill is untouched by A's attempts.
         var stillThere = await Json(await Send("GET", $"gateway/skills/{sid}", _keyB, null),
@@ -269,13 +289,44 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
                 $"{method} /{path}: tenant A must be refused, got {(int)resp.StatusCode}; body was: {text}");
         }
 
-        // A's clone attempt of B's id: whatever it answers, it must not have produced a copy of B's
-        // content in A's partition - the clone path is the one write that READS the named skill.
+        // A's clone attempt of B's id - the clone path is the one write that READS the named skill.
+        //
+        // Inspection finding I1-04: the clone RESPONSE used to go unasserted entirely. Only the later
+        // "no stolen copy" read was checked, which a missing or completely inert clone handler passes
+        // just as happily as a working one that correctly refused. The response is now asserted.
         var clone = await Send("POST", $"gateway/skills/{sid}/clone?newId=stolen-copy", _keyA, "{}");
-        _out.WriteLine($"CROSS   POST clone (tenant A) -> {(int)clone.StatusCode} {await clone.Content.ReadAsStringAsync()}");
+        var cloneText = await clone.Content.ReadAsStringAsync();
+        _out.WriteLine($"CROSS   POST clone (tenant A) -> {(int)clone.StatusCode} {cloneText}");
+        Assert.False(clone.IsSuccessStatusCode,
+            $"clone of another tenant's skill must not succeed, got {(int)clone.StatusCode}; body was: {cloneText}");
+        Assert.DoesNotContain(body, cloneText, StringComparison.Ordinal);
+
         var stolen = await Send("GET", "gateway/skills/stolen-copy", _keyA, null);
         var stolenText = await stolen.Content.ReadAsStringAsync();
         Assert.DoesNotContain(body, stolenText, StringComparison.Ordinal);
+
+        // THE LIVE CONTROL FOR CLONE (inspection finding I1-04). A refusal only means something if the
+        // same operation demonstrably WORKS for the owner. B clones its own skill and the copy really
+        // carries the body - so the handler is present, reachable and functional, and A's refusal above
+        // is a refusal rather than an inert route answering everyone the same way.
+        var ownerClone = await Send("POST", $"gateway/skills/{sid}/clone?newId=bobs-own-copy", _keyB, "{}");
+        _out.WriteLine($"CONTROL POST clone (owner B) -> {(int)ownerClone.StatusCode} {await ownerClone.Content.ReadAsStringAsync()}");
+        Assert.True(ownerClone.IsSuccessStatusCode,
+            $"the owner's own clone must succeed or this control proves nothing, got {(int)ownerClone.StatusCode}");
+        var ownerCopyBody = await Send("GET", "gateway/skills/bobs-own-copy/body", _keyB, null);
+        Assert.Equal(HttpStatusCode.OK, ownerCopyBody.StatusCode);
+        Assert.Contains(body, await ownerCopyBody.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        // THE LIVE CONTROL FOR ENABLE AND DISABLE (inspection finding I1-04). These two verbs were in
+        // the cross-tenant loop above but were never shown to do anything at all, so a route that had
+        // been removed would have satisfied the security assertion. The owner drives both here.
+        foreach (var verb in new[] { "disable", "enable" })
+        {
+            var ownerToggle = await Send("POST", $"gateway/skills/{sid}/{verb}", _keyB, "{}");
+            _out.WriteLine($"CONTROL POST /gateway/skills/{{id}}/{verb} (owner B) -> {(int)ownerToggle.StatusCode}");
+            Assert.True(ownerToggle.IsSuccessStatusCode,
+                $"the owner's own {verb} must succeed or A's refusal of it proves nothing, got {(int)ownerToggle.StatusCode}");
+        }
 
         // INDEPENDENT RE-READ: B's skill survived every attempt, still published, still readable.
         var survivor = await Json(await Send("GET", $"gateway/skills/{sid}", _keyB, null),
@@ -403,6 +454,32 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
         if (body is not null)
             req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+
+    /// <summary>
+    /// Send <paramref name="path"/> WITHOUT client-side path canonicalization, so a traversal-shaped
+    /// request arrives at the server in the shape it was written.
+    ///
+    /// Inspection finding I1-04 exists because of this exact trap. A probe built as
+    /// <c>gateway/skills/{id}/files/../../{name}</c> and handed to <see cref="HttpClient"/> never tests
+    /// what it looks like it tests: <see cref="Uri"/> resolves the dot segments BEFORE the request goes
+    /// out, so the server receives <c>/gateway/skills/{name}</c> and a DIFFERENT route answers. The
+    /// probe then passed on the wrong route's reply, and the catch-all file leg it named was never
+    /// executed at all. Percent-encoding the dots is not enough on its own either, because
+    /// <see cref="Uri"/> unescapes and then normalizes them.
+    ///
+    /// <see cref="UriCreationOptions.DangerousDisablePathAndQueryCanonicalization"/> is the supported way
+    /// to stop that, and it is exactly what a probe of a traversal defence needs: the escape must reach
+    /// the handler under test, or the green means nothing.
+    /// </summary>
+    private Task<HttpResponseMessage> SendRaw(string method, string path, string bearer)
+    {
+        var absolute = new Uri(
+            _http.BaseAddress!.ToString().TrimEnd('/') + "/" + path.TrimStart('/'),
+            new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+        var req = new HttpRequestMessage(new HttpMethod(method), absolute);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
         return _http.SendAsync(req);
     }
 }

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -1,0 +1,408 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The CENSUS CLOSE-OUT probes (tenant-boundary hardening, release 2026-07-31, the brief's item 5).
+///
+/// <see cref="ContextLessDatabaseRouteTenancyTests"/> cross-probed EIGHT context-less database routes and
+/// explicitly refused to generalise to the rest. The phase-4 census re-derived the whole inventory from
+/// the source and reached a written prove-or-deny verdict for every route (the table is in the phase
+/// report). Two FAMILIES came out of that census as "protected by the same mechanism as the proven eight,
+/// but never executed against two tenants":
+///
+///   1. <b>The mission notes pair</b> (<c>GET</c> and <c>PUT /gateway/missions/notes</c>) - Phase 3
+///      verified them by reading the code and named a route-level probe as unfinished business. They are
+///      scoped by the ambient request scope plus the entity global query filter (the architecture's good
+///      seam), never by an explicit tenant argument, so only execution can say the seam is actually in
+///      the path.
+///   2. <b>The skills family</b> - ten context-less routes over <c>SkillStore</c>, the structural twin of
+///      the workflow routes the eight-route file proved. It is the LARGEST unproven family in the census
+///      and it carries an extra mechanism the workflow twin also has: the shared System library
+///      partition, reachable read-only for BUILT-IN ids only (<c>SkillStore.OpenOwningContext</c>). A
+///      probe that did not exercise the built-in arm would leave the interesting half untested.
+///
+/// MECHANICS, taken from <see cref="ContextLessDatabaseRouteTenancyTests"/>: two tenants minted through
+/// the product's own hosted enrollment on ONE real hosted <see cref="GatewayHost"/>, every request over
+/// real HTTP through the real auth middleware, status and media type asserted BEFORE any parse, owner
+/// controls asserting the EXACT SEEDED FINGERPRINT (never a bare 200), and every refusal judged by an
+/// independent RE-READ of the other tenant's state plus a destructibility control - the owner performing
+/// the SAME operation successfully, so a refusal is a refusal and not an inert route.
+///
+/// REVERT-PROVE: drop <c>ApplyTenantScope&lt;MissionNoteEntity&gt;</c> or the three
+/// <c>ApplyTenantScope&lt;Skill*Entity&gt;</c> registrations from <c>GatewayDbContext</c> and the matching
+/// tests here go RED with a cross-tenant fact served.
+/// </summary>
+public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
+{
+    private const string SharedToken = "test-token";
+
+    private readonly ITestOutputHelper _out;
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-census-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public CensusRouteTenancyProbeTests(ITestOutputHelper output) => _out = output;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: SharedToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            cronJobsPath: Path.Combine(_instancesDir, "cron", "cronjobs.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions", "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        var deviceA = HostedTestEnrollment.Enroll(_gateway, "sub-census-a", "census-a@example.com", "dev-ca", "MCA");
+        var deviceB = HostedTestEnrollment.Enroll(_gateway, "sub-census-b", "census-b@example.com", "dev-cb", "MCB");
+        _keyA = deviceA.DeviceKey;
+        _keyB = deviceB.DeviceKey;
+
+        Assert.True(_gateway.TenantBoundary.IsHosted, "The harness must be running the HOSTED tenant boundary.");
+        Assert.NotEqual(deviceA.Tenant.Value, deviceB.Tenant.Value);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    // ================================================================= mission notes (mission_notes table)
+
+    /// <summary>
+    /// GET + PUT /gateway/missions/notes - both context-less (MissionNotesEndpoint.cs:29 and :34,
+    /// handlers <c>()</c> and <c>(MissionNoteBody? req)</c>), scoped ONLY by the ambient request scope and
+    /// the entity global query filter.
+    ///
+    /// The sharpest available probe: BOTH tenants write a note under the SAME mission name (the entity's
+    /// composite key (TenantId, Key) makes that legal), each with a distinctive why-text. If the seam were
+    /// missing, the second write would find and overwrite the first tenant's row - so this catches both a
+    /// cross-tenant READ and a cross-tenant OVERWRITE, and the store's own key lookup
+    /// (<c>e.Key == key</c>, unqualified by tenant) is exactly what makes the overwrite the live hazard.
+    /// There is no per-mission GET, so each tenant's list is asserted as an EXACT one-element set.
+    /// </summary>
+    [Fact]
+    public async Task MissionNotes_ContextLess_KeepEachTenantsNoteUnderTheSameMissionNameSeparate()
+    {
+        const string mission = "shared-mission-name";
+        const string whyA = "tenant-A-why-the-census-probe";
+        const string whyB = "tenant-B-why-the-census-probe";
+
+        // SEED both, A first, under the identical mission name.
+        var seedA = await Json(await Send("PUT", "gateway/missions/notes", _keyA, Body(mission, whyA)),
+            HttpStatusCode.OK, "SEED    PUT /gateway/missions/notes (tenant A)");
+        Assert.Equal(whyA, Str(Obj(seedA, "note"), "why"));
+
+        var seedB = await Json(await Send("PUT", "gateway/missions/notes", _keyB, Body(mission, whyB)),
+            HttpStatusCode.OK, "SEED    PUT /gateway/missions/notes (tenant B, SAME mission name)");
+        Assert.Equal(whyB, Str(Obj(seedB, "note"), "why"));
+
+        // A's list: EXACTLY its own note. Asserted as the full set with the exact seeded fingerprint, so
+        // neither an extra row (B's) nor a replaced why (B's write landing on A's row) can pass.
+        var listA = await Json(await Send("GET", "gateway/missions/notes", _keyA, null),
+            HttpStatusCode.OK, "READ    GET /gateway/missions/notes (tenant A)");
+        AssertExactlyOneNote(listA, mission, whyA);
+
+        // B's list: EXACTLY its own note - the same mission name, its own why.
+        var listB = await Json(await Send("GET", "gateway/missions/notes", _keyB, null),
+            HttpStatusCode.OK, "READ    GET /gateway/missions/notes (tenant B)");
+        AssertExactlyOneNote(listB, mission, whyB);
+
+        // DESTRUCTIBILITY CONTROL: an empty why CLEARS the note (the store's documented delete path). A
+        // clears its own - which must remove A's note and leave B's byte-for-byte. Without this, A's
+        // one-element list above could be an inert route rather than a partitioned one.
+        var clearA = await Json(await Send("PUT", "gateway/missions/notes", _keyA, Body(mission, "")),
+            HttpStatusCode.OK, "CONTROL PUT /gateway/missions/notes (tenant A clears its OWN note)");
+        Assert.True(Bool(clearA, "cleared"), "the owner's own clear reported nothing cleared");
+
+        var emptiedA = await Json(await Send("GET", "gateway/missions/notes", _keyA, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/missions/notes (tenant A, after its OWN clear)");
+        Assert.Empty(Arr(emptiedA, "notes").EnumerateArray());
+
+        // INDEPENDENT RE-READ: B's note survived A's clear of the same key untouched.
+        var survivingB = await Json(await Send("GET", "gateway/missions/notes", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/missions/notes (tenant B, after A cleared the same key)");
+        AssertExactlyOneNote(survivingB, mission, whyB);
+    }
+
+    private static void AssertExactlyOneNote(JsonElement list, string expectedMission, string expectedWhy)
+    {
+        var notes = Arr(list, "notes");
+        Assert.Equal(1, notes.GetArrayLength());
+        var only = notes[0];
+        Assert.Equal(expectedMission, Str(only, "mission"));
+        Assert.Equal(expectedWhy, Str(only, "why"));
+    }
+
+    private static string Body(string mission, string why)
+        => JsonSerializer.Serialize(new { mission, why });
+
+    // ================================================================= skills (skills/skill_versions/skill_files)
+
+    /// <summary>
+    /// The skills READ family, context-less: GET /gateway/skills/{id} (SkillEndpoints.cs:56), /body (:72),
+    /// /files/{**filePath} (:83), /versions (:154), /versions/{version:int} (:160). Tenant B owns a
+    /// published skill with a distinctive body and a distinctive supporting file; tenant A names its id on
+    /// every one of the five routes.
+    ///
+    /// The file leg matters twice over: <c>{**filePath}</c> is a catch-all, and the census verdict is that
+    /// it is an EF string comparison rather than a filesystem path - so this probe also pins that a
+    /// traversal-shaped file name reaches no other tenant's content (it simply matches no row).
+    /// </summary>
+    [Fact]
+    public async Task SkillReadFamily_ContextLess_ServesTheOwnerTheExactSeededSkill_AndIsANotFoundForTheOtherTenant()
+    {
+        const string sid = "bobs-skill";
+        const string body = "# Bobs skill\n\nThe seeded body only tenant B may read.";
+        const string fileName = "reference.md";
+        const string fileContent = "tenant-B-supporting-file-content";
+
+        await SeedPublishedSkill(_keyB, sid, body, fileName, fileContent);
+
+        // OWNER CONTROLS: the exact seeded fingerprint on each of the five routes.
+        var head = await Json(await Send("GET", $"gateway/skills/{sid}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/skills/{id} (owner B)");
+        Assert.Equal(sid, Str(head, "id"));
+        Assert.Equal("Bobs skill", Str(head, "name"));
+
+        var ownerBody = await Send("GET", $"gateway/skills/{sid}/body", _keyB, null);
+        Assert.Equal(HttpStatusCode.OK, ownerBody.StatusCode);
+        Assert.Contains(body, await ownerBody.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        var ownerFile = await Send("GET", $"gateway/skills/{sid}/files/{fileName}", _keyB, null);
+        Assert.Equal(HttpStatusCode.OK, ownerFile.StatusCode);
+        Assert.Contains(fileContent, await ownerFile.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        var versions = await Json(await Send("GET", $"gateway/skills/{sid}/versions", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/skills/{id}/versions (owner B)");
+        Assert.Equal(1, Arr(versions, "versions").GetArrayLength());
+
+        var versionOne = await Json(await Send("GET", $"gateway/skills/{sid}/versions/1", _keyB, null),
+            HttpStatusCode.OK, "CONTROL GET /gateway/skills/{id}/versions/1 (owner B)");
+        Assert.Equal(1, Int(versionOne, "version"));
+
+        // CROSS: tenant A naming tenant B's skill id on every read route. Each must be an ordinary
+        // not-found, and none may carry the seeded body or file content.
+        foreach (var path in new[]
+                 {
+                     $"gateway/skills/{sid}",
+                     $"gateway/skills/{sid}/body",
+                     $"gateway/skills/{sid}/files/{fileName}",
+                     $"gateway/skills/{sid}/versions",
+                     $"gateway/skills/{sid}/versions/1",
+                     // The traversal-shaped file name, on the catch-all leg: the census verdict is that
+                     // this is a database key and never a path, so it must reach nothing either.
+                     $"gateway/skills/{sid}/files/../../{fileName}",
+                 })
+        {
+            var resp = await Send("GET", path, _keyA, null);
+            var text = await resp.Content.ReadAsStringAsync();
+            _out.WriteLine($"CROSS   GET /{path} (tenant A) -> {(int)resp.StatusCode} {text}");
+            Assert.True(resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest,
+                $"/{path}: tenant A must be refused, got {(int)resp.StatusCode}; body was: {text}");
+            Assert.DoesNotContain(body, text, StringComparison.Ordinal);
+            Assert.DoesNotContain(fileContent, text, StringComparison.Ordinal);
+        }
+
+        // INDEPENDENT RE-READ: B's skill is untouched by A's attempts.
+        var stillThere = await Json(await Send("GET", $"gateway/skills/{sid}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/skills/{id} (owner B, after A's reads)");
+        Assert.Equal("Bobs skill", Str(stillThere, "name"));
+    }
+
+    /// <summary>
+    /// The skills WRITE family, context-less: POST /gateway/skills/{id}/publish (:126), /clone (:137),
+    /// /enable (:168), /disable (:173) and DELETE /gateway/skills/{id} (:146). Tenant A names tenant B's
+    /// skill id on each; every attempt must be refused, B's skill must survive each one by an independent
+    /// re-read, and the OWNER must then perform the same archive successfully - the destructibility
+    /// control that makes A's refusals refusals rather than an inert route.
+    /// </summary>
+    [Fact]
+    public async Task SkillWriteFamily_ContextLess_CannotTouchTheOtherTenantsSkill_AndTheOwnerStillCan()
+    {
+        const string sid = "bobs-write-target";
+        const string body = "# Bobs write target\n\nSeeded body.";
+
+        await SeedPublishedSkill(_keyB, sid, body, "notes.md", "supporting");
+
+        // CROSS: every write verb tenant A can name B's id with.
+        foreach (var (method, path) in new[]
+                 {
+                     ("POST", $"gateway/skills/{sid}/publish"),
+                     ("POST", $"gateway/skills/{sid}/enable"),
+                     ("POST", $"gateway/skills/{sid}/disable"),
+                     ("DELETE", $"gateway/skills/{sid}"),
+                 })
+        {
+            var resp = await Send(method, path, _keyA, method == "POST" ? "{}" : null);
+            var text = await resp.Content.ReadAsStringAsync();
+            _out.WriteLine($"CROSS   {method} /{path} (tenant A) -> {(int)resp.StatusCode} {text}");
+            Assert.True(resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest
+                            or HttpStatusCode.Conflict,
+                $"{method} /{path}: tenant A must be refused, got {(int)resp.StatusCode}; body was: {text}");
+        }
+
+        // A's clone attempt of B's id: whatever it answers, it must not have produced a copy of B's
+        // content in A's partition - the clone path is the one write that READS the named skill.
+        var clone = await Send("POST", $"gateway/skills/{sid}/clone?newId=stolen-copy", _keyA, "{}");
+        _out.WriteLine($"CROSS   POST clone (tenant A) -> {(int)clone.StatusCode} {await clone.Content.ReadAsStringAsync()}");
+        var stolen = await Send("GET", "gateway/skills/stolen-copy", _keyA, null);
+        var stolenText = await stolen.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(body, stolenText, StringComparison.Ordinal);
+
+        // INDEPENDENT RE-READ: B's skill survived every attempt, still published, still readable.
+        var survivor = await Json(await Send("GET", $"gateway/skills/{sid}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/skills/{id} (owner B, after A's write attempts)");
+        Assert.Equal(sid, Str(survivor, "id"));
+        var survivorBody = await Send("GET", $"gateway/skills/{sid}/body", _keyB, null);
+        Assert.Equal(HttpStatusCode.OK, survivorBody.StatusCode);
+        Assert.Contains(body, await survivorBody.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        // CONTROL: the owner performs the archive A was refused, and the effect is re-read.
+        var ownerArchive = await Send("DELETE", $"gateway/skills/{sid}", _keyB, null);
+        Assert.Equal(HttpStatusCode.OK, ownerArchive.StatusCode);
+        var gone = await Send("GET", $"gateway/skills/{sid}", _keyB, null);
+        Assert.Equal(HttpStatusCode.NotFound, gone.StatusCode);
+    }
+
+    /// <summary>
+    /// The SHARED LIBRARY arm, which the cross-tenant tests above cannot see: a BUILT-IN skill lives in
+    /// the System partition and is deliberately readable by every tenant (<c>SkillStore.OpenOwningContext</c>,
+    /// the named capability SharedSkillLibraryRead). This asserts the sanctioned sharing is real - both
+    /// tenants read the SAME built-in - so a future change that broke it would be caught here rather than
+    /// read as "isolation improved", and the census's verdict on the built-in arm is executed rather than
+    /// argued.
+    /// </summary>
+    [Fact]
+    public async Task ABuiltInSkill_IsReadableByBothTenants_TheSanctionedSharedLibrary()
+    {
+        var listA = await Json(await Send("GET", "gateway/skills", _keyA, null),
+            HttpStatusCode.OK, "READ    GET /gateway/skills (tenant A)");
+        var builtInIds = Arr(listA, "skills").EnumerateArray()
+            .Where(s => s.TryGetProperty("isBuiltIn", out var b) && b.ValueKind == JsonValueKind.True)
+            .Select(s => Str(s, "id"))
+            .ToList();
+        Assert.NotEmpty(builtInIds); // the seeded library must exist, or the arm below proves nothing
+        var builtIn = builtInIds[0];
+
+        foreach (var key in new[] { _keyA, _keyB })
+        {
+            var head = await Json(await Send("GET", $"gateway/skills/{builtIn}", key, null),
+                HttpStatusCode.OK, $"SHARED  GET /gateway/skills/{builtIn}");
+            Assert.Equal(builtIn, Str(head, "id"));
+
+            var bodyResp = await Send("GET", $"gateway/skills/{builtIn}/body", key, null);
+            Assert.Equal(HttpStatusCode.OK, bodyResp.StatusCode);
+            Assert.NotEmpty(await bodyResp.Content.ReadAsStringAsync());
+        }
+    }
+
+    private async Task SeedPublishedSkill(string key, string id, string body, string fileName, string fileContent)
+    {
+        var draft = JsonSerializer.Serialize(new
+        {
+            id,
+            name = "Bobs skill",
+            summary = "A skill owned by one tenant, named by the other.",
+            triggers = new[] { "census probe" },
+            bodyMarkdown = body,
+            files = new[] { new { fileName, content = fileContent, encoding = "utf8" } },
+            authoredBy = "census-test",
+        });
+
+        var created = await Send("POST", "gateway/skills", key, draft);
+        var createdText = await created.Content.ReadAsStringAsync();
+        Assert.True(created.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK,
+            $"SEED POST /gateway/skills failed: {(int)created.StatusCode} {createdText}");
+
+        var published = await Send("POST", $"gateway/skills/{id}/publish", key, "{}");
+        var publishedText = await published.Content.ReadAsStringAsync();
+        Assert.True(published.StatusCode is HttpStatusCode.OK,
+            $"SEED POST /gateway/skills/{id}/publish failed: {(int)published.StatusCode} {publishedText}");
+    }
+
+    // ================================================================= helpers (per ContextLessDatabaseRouteTenancyTests)
+
+    /// <summary>
+    /// Assert STATUS and MEDIA TYPE first, and only then parse - parsing is itself an assertion about
+    /// format, and the Gateway serves a single-page-application catch-all, so a parse attempted first
+    /// would launder a wrong response into a crash that says nothing about isolation.
+    /// </summary>
+    private async Task<JsonElement> Json(HttpResponseMessage resp, HttpStatusCode expectedStatus, string label)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        var mediaType = resp.Content.Headers.ContentType?.MediaType;
+        _out.WriteLine($"{label} -> {(int)resp.StatusCode} {resp.StatusCode} [{mediaType}]");
+        _out.WriteLine("    " + (body.Length > 600 ? body[..600] + " ...(truncated)" : body));
+
+        Assert.True(expectedStatus == resp.StatusCode,
+            $"{label}: expected HTTP {(int)expectedStatus} but got {(int)resp.StatusCode}; body was: {body}");
+        Assert.True(mediaType == "application/json",
+            $"{label}: expected media type application/json but got '{mediaType}'; body was: {body}");
+
+        return JsonDocument.Parse(body).RootElement.Clone();
+    }
+
+    private static JsonElement Member(JsonElement el, string prop, JsonValueKind expected)
+    {
+        Assert.True(el.ValueKind == JsonValueKind.Object,
+            $"expected a JSON object to read '{prop}' from, but the value was {el.ValueKind}");
+        Assert.True(el.TryGetProperty(prop, out var v), $"the response has no '{prop}' property: {el}");
+        Assert.True(v.ValueKind == expected, $"'{prop}' was {v.ValueKind}, expected {expected}: {el}");
+        return v;
+    }
+
+    private static string Str(JsonElement el, string prop) => Member(el, prop, JsonValueKind.String).GetString()!;
+
+    private static int Int(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Number).GetInt32();
+
+    private static JsonElement Obj(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Object);
+
+    private static JsonElement Arr(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Array);
+
+    private static bool Bool(JsonElement el, string prop)
+    {
+        Assert.True(el.ValueKind == JsonValueKind.Object,
+            $"expected a JSON object to read '{prop}' from, but the value was {el.ValueKind}");
+        Assert.True(el.TryGetProperty(prop, out var v), $"the response has no '{prop}' property: {el}");
+        Assert.True(v.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            $"'{prop}' was {v.ValueKind}, expected a boolean: {el}");
+        return v.GetBoolean();
+    }
+
+    private Task<HttpResponseMessage> Send(string method, string path, string bearer, string? body)
+    {
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -208,22 +208,32 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
             HttpStatusCode.OK, "CONTROL GET /gateway/skills/{id}/versions/1 (owner B)");
         Assert.Equal(1, Int(versionOne, "version"));
 
-        // CROSS: tenant A naming tenant B's skill id on every read route. Each must be an ordinary
-        // not-found, and none may carry the seeded body or file content.
-        foreach (var path in new[]
+        // CROSS: tenant A naming tenant B's skill id on every read route.
+        //
+        // Inspection finding M03-I2-03. These five rows used to accept "NotFound or BadRequest", and a
+        // union of statuses cannot say WHICH decision was reached. SkillEndpoints.Guard deliberately
+        // turns any SkillValidationException into a 400, so a future required field, a model-binding
+        // change, or handler-specific validation would keep these rows green with the tenant lookup
+        // never reached - the exact defect Phase 5a found one row over, in enable and disable. Each row
+        // now asserts the SINGLE outcome a cross-tenant miss actually produces: the ordinary not-found,
+        // with the not-found contract that route really writes. A 400 now fails the test, which is the
+        // point: it would mean the refusal came from somewhere other than the tenant partition.
+        foreach (var (path, expectedError) in new[]
                  {
-                     $"gateway/skills/{sid}",
-                     $"gateway/skills/{sid}/body",
-                     $"gateway/skills/{sid}/files/{fileName}",
-                     $"gateway/skills/{sid}/versions",
-                     $"gateway/skills/{sid}/versions/1",
+                     ($"gateway/skills/{sid}", $"no skill with id '{sid}'"),
+                     ($"gateway/skills/{sid}/body", $"no skill with id '{sid}'"),
+                     ($"gateway/skills/{sid}/files/{fileName}", $"no file '{fileName}' on skill '{sid}'"),
+                     ($"gateway/skills/{sid}/versions", $"no skill with id '{sid}'"),
+                     ($"gateway/skills/{sid}/versions/1", $"no skill with id '{sid}'"),
                  })
         {
             var resp = await Send("GET", path, _keyA, null);
             var text = await resp.Content.ReadAsStringAsync();
             _out.WriteLine($"CROSS   GET /{path} (tenant A) -> {(int)resp.StatusCode} {text}");
-            Assert.True(resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest,
-                $"/{path}: tenant A must be refused, got {(int)resp.StatusCode}; body was: {text}");
+            Assert.True(resp.StatusCode == HttpStatusCode.NotFound,
+                $"/{path}: tenant A must get the ordinary not-found and nothing else, " +
+                $"got {(int)resp.StatusCode}; body was: {text}");
+            Assert.Equal(expectedError, ErrorOf(text));
             Assert.DoesNotContain(body, text, StringComparison.Ordinal);
             Assert.DoesNotContain(fileContent, text, StringComparison.Ordinal);
         }
@@ -302,11 +312,18 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         // Inspection finding I1-04: the clone RESPONSE used to go unasserted entirely. Only the later
         // "no stolen copy" read was checked, which a missing or completely inert clone handler passes
         // just as happily as a working one that correctly refused. The response is now asserted.
+        // Inspection finding M03-I2-03, second half: this row asserted only "not a success status",
+        // which EVERY 4xx and 5xx satisfies - a validation refusal, a routing miss, a method mismatch,
+        // a server fault. Clone has validation and conflict paths around the source lookup, so any of
+        // them could have kept this green while the tenant lookup never ran. It now asserts the one
+        // outcome a cross-tenant clone actually produces and the exact contract it writes.
         var clone = await Send("POST", $"gateway/skills/{sid}/clone?newId=stolen-copy", _keyA, "{}");
         var cloneText = await clone.Content.ReadAsStringAsync();
         _out.WriteLine($"CROSS   POST clone (tenant A) -> {(int)clone.StatusCode} {cloneText}");
-        Assert.False(clone.IsSuccessStatusCode,
-            $"clone of another tenant's skill must not succeed, got {(int)clone.StatusCode}; body was: {cloneText}");
+        Assert.True(clone.StatusCode == HttpStatusCode.NotFound,
+            $"clone of another tenant's skill must be the ordinary not-found and nothing else, " +
+            $"got {(int)clone.StatusCode}; body was: {cloneText}");
+        Assert.Equal($"no skill with id '{sid}'", ErrorOf(cloneText));
         Assert.DoesNotContain(body, cloneText, StringComparison.Ordinal);
 
         var stolen = await Send("GET", "gateway/skills/stolen-copy", _keyA, null);
@@ -440,6 +457,18 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
     }
 
     private static string Str(JsonElement el, string prop) => Member(el, prop, JsonValueKind.String).GetString()!;
+
+    /// <summary>
+    /// The "error" string a refusal body carries. A security row asserts this as well as the status so
+    /// it proves WHICH refusal it got (inspection finding M03-I2-03) - a bare status can be produced by
+    /// a validation path, a routing miss or a method mismatch just as easily as by the tenant lookup
+    /// the row is named for.
+    /// </summary>
+    private static string ErrorOf(string body)
+    {
+        using var doc = JsonDocument.Parse(body);
+        return Str(doc.RootElement, "error");
+    }
 
     private static int Int(JsonElement el, string prop) => Member(el, prop, JsonValueKind.Number).GetInt32();
 

--- a/src/CcDirector.Gateway.Tests/CockpitParityEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/CockpitParityEndpointsTests.cs
@@ -200,36 +200,81 @@ public sealed class CockpitParityEndpointsTests : IDisposable
     }
 
     // ===== /fs/list =====
+    // Tenant-boundary hardening (release 2026-07-31, finding CR-4): the listing is CONTAINED to the working
+    // directories of the sessions this Director hosts. It used to list drive roots and any directory on the
+    // machine, which on a hosted Gateway handed any active device key a full remote directory browse.
+
+    /// <summary>A live session rooted at <see cref="_repoA"/>, making repoA an allowed fs-list root.</summary>
+    private void SeatSessionInRepoA() => _sm.CreateEmbeddedSession(_repoA, null, new ExecuteActionTestBackend());
 
     [Fact]
-    public void Fs_list_without_path_returns_drive_roots()
+    public void Fs_list_without_path_returns_the_session_roots_not_the_drives()
     {
+        SeatSessionInRepoA();
         var listing = Ok<DirectoryListingDto>(
-            CatalogReadExecutor.FsList(new DirectorCommand { Verb = "fs-list", PayloadJson = "" }));
+            CatalogReadExecutor.FsList(_sm, new DirectorCommand { Verb = "fs-list", PayloadJson = "" }));
         Assert.Null(listing.CurrentPath);
-        Assert.NotEmpty(listing.Entries);
-        Assert.All(listing.Entries, e => Assert.True(e.IsDrive));
+        var entry = Assert.Single(listing.Entries);
+        Assert.Equal(Path.GetFullPath(_repoA).TrimEnd('\\', '/'), entry.Path);
+        Assert.False(entry.IsDrive);
     }
 
     [Fact]
-    public void Fs_list_with_path_returns_subdirectories_and_parent()
+    public void Fs_list_without_path_and_without_sessions_lists_nothing()
     {
-        var listing = Ok<DirectoryListingDto>(CatalogReadExecutor.FsList(
+        var listing = Ok<DirectoryListingDto>(
+            CatalogReadExecutor.FsList(_sm, new DirectorCommand { Verb = "fs-list", PayloadJson = "" }));
+        Assert.Null(listing.CurrentPath);
+        Assert.Empty(listing.Entries);
+    }
+
+    [Fact]
+    public void Fs_list_with_a_session_root_returns_subdirectories_and_no_parent_above_the_root()
+    {
+        SeatSessionInRepoA();
+        var listing = Ok<DirectoryListingDto>(CatalogReadExecutor.FsList(_sm,
             new DirectorCommand { Verb = "fs-list", PayloadJson = Payload(new FsListRequest { Path = _repoA }) }));
         Assert.Equal(Path.GetFullPath(_repoA), listing.CurrentPath);
-        Assert.Equal(Path.GetFullPath(_tempRepos), listing.ParentPath);
+        Assert.Null(listing.ParentPath); // the root's own parent is not browsable
         Assert.Equal(2, listing.Entries.Count);
         Assert.Contains(listing.Entries, e => e.Name == "subdir1");
         Assert.Contains(listing.Entries, e => e.Name == "subdir2");
     }
 
     [Fact]
-    public void Fs_list_with_nonexistent_path_returns_400()
+    public void Fs_list_inside_a_session_root_keeps_the_parent_within_the_root()
     {
-        var result = CatalogReadExecutor.FsList(new DirectorCommand
+        SeatSessionInRepoA();
+        var sub = Path.Combine(_repoA, "subdir1");
+        var listing = Ok<DirectoryListingDto>(CatalogReadExecutor.FsList(_sm,
+            new DirectorCommand { Verb = "fs-list", PayloadJson = Payload(new FsListRequest { Path = sub }) }));
+        Assert.Equal(Path.GetFullPath(sub), listing.CurrentPath);
+        Assert.Equal(Path.GetFullPath(_repoA), listing.ParentPath);
+    }
+
+    [Fact]
+    public void Fs_list_outside_every_session_root_is_refused()
+    {
+        // repoB exists on disk but no session is rooted there - the reported CR-4 symptom was that any
+        // real directory on the machine could be listed. It must now be refused, not listed.
+        SeatSessionInRepoA();
+        var result = CatalogReadExecutor.FsList(_sm, new DirectorCommand
         {
             Verb = "fs-list",
-            PayloadJson = Payload(new FsListRequest { Path = Path.Combine(_root, "does-not-exist") }),
+            PayloadJson = Payload(new FsListRequest { Path = _repoB }),
+        });
+        Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        Assert.Contains("outside", result.Error);
+    }
+
+    [Fact]
+    public void Fs_list_with_nonexistent_path_inside_the_root_returns_400()
+    {
+        SeatSessionInRepoA();
+        var result = CatalogReadExecutor.FsList(_sm, new DirectorCommand
+        {
+            Verb = "fs-list",
+            PayloadJson = Payload(new FsListRequest { Path = Path.Combine(_repoA, "does-not-exist") }),
         });
         Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
     }

--- a/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE CONTEXT-LESS ROUTE CENSUS, CLOSED AND EXECUTABLE (tenant-boundary hardening, release
+/// 2026-07-31, the brief's item 5).
+///
+/// A route that takes a path parameter but NO <see cref="HttpContext"/> cannot read the caller's
+/// request, so it cannot resolve a tenant from it. The original census counted such routes, probed a
+/// handful, and refused to generalise - correctly, because eight samples cannot stand for a family. The
+/// gap it left was not a missing test but a missing INVENTORY: nobody could say what the whole set was,
+/// so nobody could say the whole set was safe.
+///
+/// This file closes that by making the inventory a TEST rather than a paragraph. It reads the FINALISED
+/// route table from a real <see cref="GatewayHost"/> - the actual endpoints, with route-group prefixes
+/// applied, and each handler's real parameter list read by reflection - and asserts the context-less set
+/// is EXACTLY the ruled list below. Every entry in that list carries a written verdict naming the
+/// mechanism that keeps one tenant out of another's data, and the report for this phase carries the
+/// evidence per row.
+///
+/// WHY THIS SHAPE, AND NOT A PROSE TABLE. A table in a document is true on the day it is written. This
+/// fails the moment a new context-less route is mapped, so the next person cannot add one without
+/// reaching a verdict about it - which is the property the census was supposed to buy and could not,
+/// because it was prose. It also cannot be fooled by a source-parsing mistake: patterns come from the
+/// route table, not from reading Map calls, so a route mounted under a group prefix is counted at its
+/// real path (the earlier source-derived attempt read /vault/keys/{name} as /{name} and would have
+/// mis-stated the census).
+///
+/// BOTH DEPLOYMENTS ARE COUNTED, because they map different route tables. On HOSTED, the
+/// <c>HostedRouteDeny</c> families (the key vault, the developer exe slots) are not mapped at all - a
+/// verb-less refusal catch-all claims their prefixes - so their routes cannot serve any tenant. That is
+/// a verdict this test EXECUTES rather than asserts on faith: the hosted case must not contain them.
+/// </summary>
+public sealed class ContextLessRouteCensusTests
+{
+    private readonly ITestOutputHelper _out;
+
+    public ContextLessRouteCensusTests(ITestOutputHelper output) => _out = output;
+
+    /// <summary>
+    /// The census of context-less routes on the HOSTED Gateway - the multi-tenant deployment, and so the
+    /// only one where cross-tenant reach is possible at all. Each row's verdict:
+    ///
+    /// EF global tenant filter (the ambient request scope entered by the device-key middleware, plus
+    /// GatewayDbContext's per-entity query filter; GatewayDatabase throws rather than defaulting when no
+    /// scope exists). Executed cross-tenant for every family below - see the phase report's table for
+    /// which test covers which row:
+    ///   /cron/jobs/{id} (+ DELETE, /runs)          cron_jobs, cron_runs
+    ///   /gateway/governance/session-spend/{id}     session_spend
+    ///   /lists/{name} (+ /consumer, /items/...)    worklists, worklist_items
+    ///   /gateway/workflows/{id} and its family     workflows, workflow_versions, workflow_files,
+    ///                                              workflow_tenant_overrides
+    ///   /gateway/workflow-runs/{id}                workflow_runs
+    ///   /gateway/skills/{id} and its family        skills, skill_versions, skill_files,
+    ///                                              skill_tenant_overrides
+    ///
+    /// Hosted deny (the legacy same-machine discovery plane - not a tenant surface at all; refused on
+    /// hosted, gated on the process-level hosted flag and proven by
+    /// <see cref="NullBoundaryHostedGateFailClosedTests"/>):
+    ///   POST /directors/{id}/doorbell, DELETE /directors/{id}/registration
+    /// </summary>
+    private static readonly string[] HostedCensus =
+    {
+        "DELETE /cron/jobs/{id}",
+        "DELETE /directors/{id}/registration",
+        "DELETE /gateway/skills/{id}",
+        "DELETE /gateway/workflows/{id}",
+        "DELETE /lists/{name}/consumer",
+        "DELETE /lists/{name}/items/{source}/{id}",
+        "GET /cron/jobs/{id}",
+        "GET /cron/jobs/{id}/runs",
+        "GET /gateway/governance/session-spend/{sessionId}",
+        "GET /gateway/skills/{id}",
+        "GET /gateway/skills/{id}/body",
+        "GET /gateway/skills/{id}/files/{**filePath}",
+        "GET /gateway/skills/{id}/versions",
+        "GET /gateway/skills/{id}/versions/{version:int}",
+        "GET /gateway/workflow-runs/{id:guid}",
+        "GET /gateway/workflows/{id}",
+        "GET /gateway/workflows/{id}/files/{fileName}",
+        "GET /gateway/workflows/{id}/instructions",
+        "GET /gateway/workflows/{id}/versions",
+        "GET /gateway/workflows/{id}/versions/{version:int}",
+        "GET /lists/{name}",
+        "POST /directors/{id}/doorbell",
+        "POST /gateway/skills/{id}/clone",
+        "POST /gateway/skills/{id}/disable",
+        "POST /gateway/skills/{id}/enable",
+        "POST /gateway/skills/{id}/publish",
+        "POST /gateway/workflows/{id}/clone",
+        "POST /gateway/workflows/{id}/disable",
+        "POST /gateway/workflows/{id}/enable",
+        "POST /gateway/workflows/{id}/publish",
+    };
+
+    /// <summary>
+    /// The two families that exist ONLY off hosted, because <c>HostedRouteDeny</c> takes them off the
+    /// hosted route table entirely. Their verdict is therefore "not reachable on the multi-tenant
+    /// deployment", and the hosted assertion proves it by their ABSENCE there:
+    ///   GET/DELETE /vault/keys/{name}      - the key vault (family "key-vault")
+    ///   DELETE /exes/slots/{n}, POST /exes/slots/{n}/build-start - the developer exe slots
+    ///     (family "exes-slots"); additionally mapped only on Windows.
+    /// On self-host both are single-owner surfaces behind the host-wide credential gate.
+    /// </summary>
+    private static readonly string[] SelfHostOnlyExtras =
+    {
+        "DELETE /exes/slots/{n}",
+        "DELETE /vault/keys/{name}",
+        "GET /vault/keys/{name}",
+        "POST /exes/slots/{n}/build-start",
+    };
+
+    [Fact]
+    public async Task The_hosted_context_less_route_set_is_exactly_the_ruled_census()
+    {
+        var actual = await ContextLessRoutes(hosted: true);
+        foreach (var row in actual) _out.WriteLine(row);
+
+        // If this fails, a context-less route was added, removed, or re-pathed on the HOSTED Gateway.
+        // That is not automatically a defect - but it IS a verdict nobody has reached yet. Establish
+        // which store the route reaches and what confines it to the caller's tenant, write that verdict
+        // into the doc comment above, add a cross-tenant probe if the family has none, and only then
+        // add the row here.
+        Assert.Equal(HostedCensus, actual);
+    }
+
+    [Fact]
+    public async Task The_selfhost_context_less_route_set_adds_only_the_hosted_denied_families()
+    {
+        var actual = await ContextLessRoutes(hosted: false);
+        foreach (var row in actual) _out.WriteLine(row);
+
+        var expected = HostedCensus.Concat(SelfHostOnlyExtras).OrderBy(s => s, StringComparer.Ordinal).ToArray();
+        Assert.Equal(expected, actual);
+
+        // The point of the pair: the key vault and the developer exe slots are context-less routes over
+        // process-global stores with no tenant column at all, and they are reachable on self-host and
+        // NOT on hosted. This asserts that against the OBSERVED hosted route table - re-read here rather
+        // than compared against the ruled constant above, because comparing two constants would be an
+        // assertion this file cannot fail. Each extra must be present in the self-host table (it is, by
+        // the equality above) and ABSENT from the hosted one.
+        var hostedActual = await ContextLessRoutes(hosted: true);
+        foreach (var row in SelfHostOnlyExtras)
+        {
+            Assert.Contains(row, actual);
+            Assert.DoesNotContain(row, hostedActual);
+        }
+    }
+
+    /// <summary>
+    /// The finalised route table of a real host, reduced to the context-less routes: a path parameter in
+    /// the pattern, and no <see cref="HttpContext"/> in the handler's parameter list. The hosted refusal
+    /// catch-alls are excluded by name - they carry no handler method at all and exist precisely to make
+    /// a denied family unreachable, so counting them as census rows would invert their meaning.
+    /// </summary>
+    private static async Task<string[]> ContextLessRoutes(bool hosted)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var dir = Path.Combine(Path.GetTempPath(), "cc-census-routes-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "census-token",
+            authEnabled: true,
+            instancesDirectory: dir,
+            workListsPath: Path.Combine(dir, "worklists", "worklists.json"));
+        try
+        {
+            await gateway.StartAsync();
+
+            return gateway.MappedEndpoints.OfType<RouteEndpoint>()
+                .Select(e => new
+                {
+                    Pattern = "/" + (e.RoutePattern.RawText ?? "").TrimStart('/'),
+                    Methods = e.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? Array.Empty<string>(),
+                    Handler = e.Metadata.GetMetadata<MethodInfo>(),
+                })
+                .Where(r => r.Pattern.Contains('{', StringComparison.Ordinal))
+                .Where(r => !r.Pattern.Contains("hostedDeniedPath", StringComparison.Ordinal))
+                .Where(r => r.Handler is not null
+                            && !r.Handler.GetParameters().Any(p => p.ParameterType == typeof(HttpContext)))
+                .SelectMany(r => r.Methods.DefaultIfEmpty("ANY"), (r, m) => $"{m} {r.Pattern}")
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToArray();
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictionarySuggestionsEndpointTests.cs
@@ -112,7 +112,12 @@ public sealed class DictionarySuggestionsEndpointTests : IDisposable
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add(bindUrl);
-        RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
+        // The boundary is required and non-nullable now (finding I1-01). This is a self-host harness, so it
+        // gets the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        RecordingEndpoints.Map(app,
+            tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            keyVault: null, history: null, audioArchive: null,
             suggestions: suggestions, dismissals: dismissals);
         await app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";

--- a/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
@@ -49,17 +49,22 @@ public sealed class DirectorHubTests : IDisposable
         catch (Exception) { /* best-effort temp cleanup */ }
     }
 
+    // The boundary is required and non-nullable now (finding I1-01). These are self-host hub tests, so they
+    // get the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+    private static CcDirector.Gateway.Tenancy.HostedTenantBoundary SelfHostBoundary() =>
+        new(new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry());
+
     private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId)
     {
         var ctx = new FakeHubCallerContext(connectionId);
-        var hub = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry()) { Context = ctx };
+        var hub = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), SelfHostBoundary()) { Context = ctx };
         return (hub, ctx);
     }
 
     private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId, SnoozeLandingObserver snooze)
     {
         var ctx = new FakeHubCallerContext(connectionId);
-        var hub = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), snoozeLandings: snooze) { Context = ctx };
+        var hub = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), SelfHostBoundary(), snoozeLandings: snooze) { Context = ctx };
         return (hub, ctx);
     }
 
@@ -269,7 +274,22 @@ public sealed class DirectorHubTests : IDisposable
 
     private sealed class FakeHubCallerContext : HubCallerContext
     {
-        public FakeHubCallerContext(string connectionId) => ConnectionId = connectionId;
+        public FakeHubCallerContext(string connectionId)
+        {
+            ConnectionId = connectionId;
+            // The hub resolves its connection tenant through the boundary, which on self-host answers Local
+            // for any request - but only when the connection HAS an HttpContext, exactly as a real SignalR
+            // negotiate does. The fake used to carry none, which was invisible while these tests passed a
+            // null boundary; with the REAL self-host boundary (finding I1-01) an absent HttpContext is an
+            // unresolvable connection and Hello would abort.
+            Features.Set<Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature>(
+                new HttpContextFeatureImpl { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() });
+        }
+
+        private sealed class HttpContextFeatureImpl : Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature
+        {
+            public Microsoft.AspNetCore.Http.HttpContext? HttpContext { get; set; }
+        }
 
         public override string ConnectionId { get; }
         public override string? UserIdentifier => null;

--- a/src/CcDirector.Gateway.Tests/DirectorStreamProducersTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStreamProducersTests.cs
@@ -221,12 +221,19 @@ public sealed class DirectorStreamProducersTests
         finally { sm.Dispose(); }
     }
 
+    // Tenant-boundary hardening (CR-4): the read-file verb is session-scoped now - the command carries the
+    // session id and the path must live inside that session's working directory - so these two tests seat a
+    // real session over a temp directory and read within it. The containment itself (out-of-root refusals,
+    // the screenshot control) is pinned in DirectorUpStreamHandlerContainmentTests.
+
     [Fact]
     public async Task Handler_ReadFile_ReturnsOkWithTotalSize_AndStreamsTheFile()
     {
         var sm = new SessionManager(new AgentOptions());
         var (handler, captured, drained) = NewHandler(sm);
-        var path = Path.Combine(Path.GetTempPath(), "ccd-upstream-read-" + Guid.NewGuid().ToString("N") + ".txt");
+        var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "ccd-upstream-read-" + Guid.NewGuid().ToString("N"))).FullName;
+        var session = sm.CreateEmbeddedSession(dir, null, new ExecuteActionTestBackend());
+        var path = Path.Combine(dir, "read-me.txt");
         try
         {
             var content = Encoding.UTF8.GetBytes("the quick brown fox");
@@ -235,6 +242,7 @@ public sealed class DirectorStreamProducersTests
             var result = handler.Handle(new DirectorCommand
             {
                 Verb = "read-file",
+                SessionId = session.Id.ToString(),
                 PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = "rf-1", Path = path }),
             });
 
@@ -253,7 +261,7 @@ public sealed class DirectorStreamProducersTests
         finally
         {
             sm.Dispose();
-            try { File.Delete(path); } catch { /* best effort */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
         }
     }
 
@@ -262,15 +270,22 @@ public sealed class DirectorStreamProducersTests
     {
         var sm = new SessionManager(new AgentOptions());
         var (handler, _, _) = NewHandler(sm);
+        var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "ccd-upstream-missing-" + Guid.NewGuid().ToString("N"))).FullName;
+        var session = sm.CreateEmbeddedSession(dir, null, new ExecuteActionTestBackend());
         try
         {
             var result = handler.Handle(new DirectorCommand
             {
                 Verb = "read-file",
-                PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = "rf-x", Path = Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N")) }),
+                SessionId = session.Id.ToString(),
+                PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = "rf-x", Path = Path.Combine(dir, "does-not-exist.txt") }),
             });
             Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
         }
-        finally { sm.Dispose(); }
+        finally
+        {
+            sm.Dispose();
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/src/CcDirector.Gateway.Tests/DirectorUpStreamHandlerContainmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorUpStreamHandlerContainmentTests.cs
@@ -1,0 +1,239 @@
+using System.Text;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening (release 2026-07-31, finding CR-4): the <c>read-file</c> stream verb used to
+/// serve ANY absolute path after only <c>File.Exists</c>, so on a hosted Gateway any active device key could
+/// read <c>gateway-token.txt</c>, <c>.ssh</c> keys, or <c>.env</c> files on any machine in the account. These
+/// tests pin the containment: a file read is session-scoped and refused outside the session's working
+/// directory, while the screenshot verb beside it (which was always contained through
+/// <c>ControlEndpoints.ResolveScreenshot</c>) keeps working.
+///
+/// CC_DIRECTOR_ROOT is redirected to an isolated temp dir (screenshots resolve under it), so the tests never
+/// touch the user's real files. In the "DirectorRoot" collection (serializes root-touching tests).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class DirectorUpStreamHandlerContainmentTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _sessionDir;
+    private readonly string _outsideDir;
+    private readonly SessionManager _sm;
+    private readonly Session _session;
+    private readonly List<DirectorStreamFrame> _frames = new();
+    private readonly DirectorUpStreamHandler _handler;
+
+    public DirectorUpStreamHandlerContainmentTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-containment-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        // The session's working directory and a sibling directory OUTSIDE it, both real on disk.
+        _sessionDir = Path.Combine(_root, "session-repo");
+        _outsideDir = Path.Combine(_root, "outside");
+        Directory.CreateDirectory(_sessionDir);
+        Directory.CreateDirectory(_outsideDir);
+
+        _sm = new SessionManager(new AgentOptions());
+        _session = _sm.CreateEmbeddedSession(_sessionDir, null, new ExecuteActionTestBackend());
+
+        _handler = new DirectorUpStreamHandler(_sm, async (_, frames) =>
+        {
+            await foreach (var frame in frames)
+            {
+                lock (_frames) _frames.Add(frame);
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        _sm.Dispose();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private DirectorCommandResult OpenFile(string sessionId, string path) => _handler.Handle(new DirectorCommand
+    {
+        Verb = "read-file",
+        SessionId = sessionId,
+        PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest
+        {
+            StreamId = Guid.NewGuid().ToString("N"),
+            Path = path,
+        }),
+    });
+
+    // ---------------------------------------------------------------- the refusal (the CR-4 fix) ----
+
+    [Fact]
+    public void ReadFile_absolutePathOutsideTheSessionWorkingDirectory_isRefused()
+    {
+        // The reported symptom: an EXISTING file outside the session's working directory (the stand-in for
+        // gateway-token.txt / .ssh / .env) was served whole. It must now be refused, and no producer stream
+        // may have been started for it.
+        var secret = Path.Combine(_outsideDir, "gateway-token.txt");
+        File.WriteAllText(secret, "the-secret");
+
+        var result = OpenFile(_session.Id.ToString(), secret);
+
+        Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        Assert.Contains("outside the session's working directory", result.Error);
+        Assert.Equal(0, _handler.ActiveStreamCount);
+        lock (_frames) Assert.Empty(_frames);
+    }
+
+    [Fact]
+    public void ReadFile_traversalThatResolvesOutsideTheRoot_isRefused()
+    {
+        var secret = Path.Combine(_outsideDir, "escaped.txt");
+        File.WriteAllText(secret, "escaped");
+        var traversal = Path.Combine(_sessionDir, "..", "outside", "escaped.txt");
+
+        var result = OpenFile(_session.Id.ToString(), traversal);
+
+        Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        Assert.Equal(0, _handler.ActiveStreamCount);
+    }
+
+    [Fact]
+    public void ReadFile_unknownSession_isNotFound()
+    {
+        var inside = Path.Combine(_sessionDir, "a.txt");
+        File.WriteAllText(inside, "x");
+
+        var result = OpenFile(Guid.NewGuid().ToString(), inside);
+
+        Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        Assert.Contains("session not found", result.Error);
+    }
+
+    // ------------------------------------------------------- the allowed paths still work (controls) ----
+
+    [Fact]
+    public async Task ReadFile_insideTheSessionWorkingDirectory_streamsTheFile()
+    {
+        var inside = Path.Combine(_sessionDir, "notes", "report.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(inside)!);
+        File.WriteAllText(inside, "contained content");
+
+        var result = OpenFile(_session.Id.ToString(), inside);
+
+        Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+        var open = SessionCommandExecutor.Deserialize<OpenReadResponse>(result.BodyJson);
+        Assert.Equal(new FileInfo(inside).Length, open!.TotalBytes);
+
+        await WaitUntilAsync(() => _handler.ActiveStreamCount == 0, TimeSpan.FromSeconds(5));
+        byte[] data;
+        lock (_frames)
+            data = _frames.Where(f => f.Kind == DirectorStreamFrameType.Binary).SelectMany(f => f.Data!).ToArray();
+        Assert.Equal("contained content", Encoding.UTF8.GetString(data));
+    }
+
+    [Fact]
+    public void ReadFile_missingFileInsideTheRoot_isNotFound()
+    {
+        var result = OpenFile(_session.Id.ToString(), Path.Combine(_sessionDir, "no-such.txt"));
+        Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        Assert.Contains("file not found", result.Error);
+    }
+
+    [Fact]
+    public async Task Screenshot_read_stillWorks()
+    {
+        // The disciplined sibling this fix copied must keep working: a screenshot resolved through
+        // ControlEndpoints.ResolveScreenshot (bare name, inside the screenshots folder) still streams.
+        var dir = CcStorage.Screenshots();
+        Directory.CreateDirectory(dir);
+        var name = "containment-proof.png";
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 1, 2, 3 };
+        await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes);
+
+        var result = _handler.Handle(new DirectorCommand
+        {
+            Verb = "screenshot-file",
+            SessionId = _session.Id.ToString(),
+            PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest
+            {
+                StreamId = Guid.NewGuid().ToString("N"),
+                ScreenshotId = name,
+            }),
+        });
+
+        Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+        await WaitUntilAsync(() => _handler.ActiveStreamCount == 0, TimeSpan.FromSeconds(5));
+        byte[] data;
+        lock (_frames)
+            data = _frames.Where(f => f.Kind == DirectorStreamFrameType.Binary).SelectMany(f => f.Data!).ToArray();
+        Assert.Equal(bytes, data);
+    }
+
+    // -------------------------------------------------------------- the resolver, pinned directly ----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveSessionFile_blankPath_isNull(string? path)
+    {
+        Assert.Null(ControlEndpoints.ResolveSessionFile(@"C:\work\repo", path));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_insideTheRoot_resolves()
+    {
+        var inside = Path.Combine(_sessionDir, "sub", "file.txt");
+        Assert.Equal(Path.GetFullPath(inside), ControlEndpoints.ResolveSessionFile(_sessionDir, inside));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_relativePath_resolvesAgainstTheRoot()
+    {
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(_sessionDir, "file.txt")),
+            ControlEndpoints.ResolveSessionFile(_sessionDir, "file.txt"));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_outsideTheRoot_isNull()
+    {
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_sessionDir, Path.Combine(_outsideDir, "x.txt")));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_traversal_isNull()
+    {
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_sessionDir, Path.Combine(_sessionDir, "..", "outside", "x.txt")));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_siblingWithTheRootAsPrefix_isNull()
+    {
+        // "C:\work\repo-evil" starts with "C:\work\repo" as a STRING; the separator-suffixed comparison
+        // must not be fooled by it.
+        var evilSibling = _sessionDir + "-evil";
+        Directory.CreateDirectory(evilSibling);
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_sessionDir, Path.Combine(evilSibling, "x.txt")));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_theRootItself_isNull()
+    {
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_sessionDir, _sessionDir));
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var attempts = (int)(timeout.TotalMilliseconds / 15) + 1;
+        for (var i = 0; i < attempts && !condition(); i++) await Task.Delay(15);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzTenantLeakTests.cs
@@ -25,9 +25,12 @@ namespace CcDirector.Gateway.Tests;
 /// which is what proves the hosted assertion is about the tenancy branch and not about a Gateway that simply
 /// has no Directors registered.
 ///
-/// Revert-prove: delete the <c>tenantBoundary?.IsHosted == true</c> branch from the <c>/healthz</c> handler in
+/// Revert-prove: delete the <c>GatewayHostedMode.IsHosted</c> branch from the <c>/healthz</c> handler in
 /// <c>GatewayEndpoints.Map</c> and <see cref="Hosted_healthz_reports_no_fleet_counts"/> goes RED - the hosted
-/// probe reports the registered Director again.
+/// probe reports the registered Director again. (The branch gated on the nullable <c>tenantBoundary</c>
+/// argument until the 2026-07-31 tenant-boundary hardening; it now gates on the process-level hosted flag so
+/// a null! boundary cannot reopen the aggregate - <see cref="NullBoundaryHostedGateFailClosedTests"/> pins
+/// that direction.)
 ///
 /// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe.
 /// </summary>

--- a/src/CcDirector.Gateway.Tests/HostedCommQueueDenyTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedCommQueueDenyTests.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Communications.Services;
+using CcDirector.Gateway.Api;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// CR-6, comm-queue half: the /comm-queue surface must be REFUSED IN WHOLE on the hosted Gateway.
+///
+/// The store behind the route is ONE process-global SQLite file (config/comm-queue/communications.db)
+/// with no tenant anywhere - not in the file, not in the store, not in the route - and the route sat
+/// behind only the host-wide authentication gate, which admits ANY enrolled device key from ANY
+/// account. So on shared hosted infrastructure every subscriber could read the operator's outbound
+/// communications queue: draft emails, posts, recipients, personas. The Communication Manager app the
+/// surface backed was retired 2026-07-06 and the comm queue is not part of the hosted launch, so the
+/// family is refused on hosted rather than partitioned, through the shared refusal primitive
+/// (<see cref="Gateway.Tenancy.HostedRouteDeny.ExclusiveGroup"/>) - the same boundary /vault/keys and
+/// /shutdown adopted. On hosted the handler is NEVER MAPPED; one verb-less catch-all refusal claims
+/// everything under /comm-queue, so every request shape - including a body-bound POST, a verb the
+/// family never mapped, and a route added under the prefix later - meets the refusal.
+///
+/// This is the SOURCE-side half of the Wave-2 hostile two-tenant matrix's comm-queue row: the row
+/// turns FAIL to PASS because an enrolled tenant's read is REFUSED, not because the route vanished -
+/// the refusal is asserted as an exact payload, and the self-host control
+/// (<see cref="SelfHostCommQueueControlTests"/>) proves the same route still serves the real queue
+/// off hosted.
+///
+/// A REAL DRAFT IS SEEDED FIRST. A deny tested against an empty queue proves nothing - the refused
+/// read here would otherwise have had nothing to disclose. The seed goes through the production
+/// schema (<see cref="DatabaseService.InitializeAsync"/>) plus one raw insert, because the write API
+/// died with the desktop app.
+///
+/// REVERT-PROOF - the recipe to RUN, not to describe. In
+/// <c>src/CcDirector.Gateway/Api/CommQueueEndpoints.cs</c> change <c>Map</c> to map the route on the
+/// ungrouped builder (<c>outer.MapGet("/comm-queue", ...)</c>) instead of through
+/// <c>HostedRouteDeny.ExclusiveGroup</c>. Rebuild, confirm zero errors, run this class: every hosted
+/// test reddens with the symptom - the enrolled tenant SERVED the operator's queue (200 with the
+/// seeded draft) instead of the refusal - while <see cref="SelfHostCommQueueControlTests"/> stays
+/// green. Restore, rebuild, rerun: all green.
+///
+/// Sets CC_DIRECTOR_ROOT (the storage root the handler resolves the SQLite path through) and
+/// CC_GATEWAY_HOSTED, so it joins the DirectorRoot collection to serialize with every other test
+/// that redirects the root.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class HostedCommQueueDenyTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-hosted-commq-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedCommQueueDenyTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-hosted-commq-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // EXPLICIT, not ambient: this class asserts hosted behaviour, so it states hosted mode itself
+        // and proves the statement took, rather than inheriting whatever the runner left set.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        // The operator's queue holds a real pending draft, so a read that (wrongly) got through would
+        // have something to hand back.
+        await CommQueueTestSeed.SeedAsync(_root);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A fully enrolled, entitled, tenant-bound device key - the strongest caller hosted has. The
+        // point is that even this one is refused: no credential reads the operator's queue on hosted.
+        _key = HostedTestEnrollment.Enroll(_gateway, "sub-commq-a", "a@example.com", "dev-cq-a", "MCQA").DeviceKey;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>
+    /// Every request shape in one theory: the production route in both its query forms, a body-bound
+    /// POST (the shape the primitive's own record says a deny-family probe MUST include, because it is
+    /// precisely the shape a request-time filter cannot answer uniformly), a verb-and-path the family
+    /// never mapped, and a path under the prefix that no route has ever served (the future-route
+    /// property of the exclusive catch-all).
+    /// </summary>
+    [Theory]
+    [InlineData("GET", "comm-queue", null)]                                  // the production read
+    [InlineData("GET", "comm-queue?status=all", null)]                        // every-status form of the read
+    [InlineData("POST", "comm-queue", "{\"status\":\"all\"}")]                // body-bound POST, never mapped
+    [InlineData("DELETE", "comm-queue/42", null)]                             // verb and path never mapped
+    [InlineData("GET", "comm-queue/added/later", null)]                       // a route nobody has written yet
+    public async Task Every_comm_queue_request_shape_is_refused_to_an_enrolled_tenant(
+        string method, string path, string? body)
+    {
+        var resp = await Send(new HttpMethod(method), path, body);
+        await AssertBodyIsNothingButTheRefusal(resp);
+    }
+
+    [Fact]
+    public async Task The_refused_read_did_not_leak_the_seeded_draft_anywhere_in_the_body()
+    {
+        var resp = await Send(HttpMethod.Get, "comm-queue");
+
+        // The refusal is asserted FIRST; on its own, "the body does not contain the draft" is an
+        // absence-only claim that any body which simply is not the queue would satisfy. Pinning the
+        // exact refusal makes this a statement about the guard, not about the string.
+        await AssertBodyIsNothingButTheRefusal(resp);
+        Assert.DoesNotContain(CommQueueTestSeed.SecretDraftContent, await resp.Content.ReadAsStringAsync(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_still_rejected()
+    {
+        // Control: the deny must not have opened the family up as a side effect of mapping before the
+        // host-wide authentication gate. GREEN in both directions of the revert on purpose - a control
+        // that moves with the change under test is not a control.
+        Assert.Equal(HttpStatusCode.Unauthorized, (await _http.GetAsync("comm-queue")).StatusCode);
+    }
+
+    /// <summary>
+    /// AN ALLOW-LIST, NOT A DENY-LIST, and format facts before parsing - same reasoning as
+    /// <see cref="HostedVaultDenyTests.AssertBodyIsNothingButTheRefusal"/>: the property set is
+    /// EXACTLY one error field, so any queue payload key (status, count, stats, items) and anything
+    /// added to the projection later reddens automatically.
+    /// </summary>
+    internal static async Task AssertBodyIsNothingButTheRefusal(HttpResponseMessage resp)
+    {
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+
+        var properties = doc.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "error" }, properties);
+        Assert.Equal(CommQueueEndpoints.RefusalMessage, doc.RootElement.GetProperty("error").GetString());
+    }
+
+    private Task<HttpResponseMessage> Send(HttpMethod method, string path, string? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        if (body is not null)
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return _http.SendAsync(req);
+    }
+}
+
+/// <summary>
+/// The mirror half, without which the deny is indistinguishable from a brick: the SAME route, the SAME
+/// seeded queue, hosted mode explicitly OFF, and the self-update-era read still serves the real
+/// pending draft. A deny that refused everything unconditionally would pass every hosted assertion
+/// while having silently killed the phone's queue view for self-host - this class is what reddens
+/// then. It also anchors the hosted non-disclosure assertion: the draft PROVABLY serves through this
+/// exact route and projection off hosted, so the hosted refusal is withholding something real.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SelfHostCommQueueControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-selfhost-commq-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public SelfHostCommQueueControlTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-selfhost-commq-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        Assert.False(GatewayHostedMode.IsHosted);
+
+        await CommQueueTestSeed.SeedAsync(_root);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task The_seeded_pending_draft_still_serves_on_self_host()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "comm-queue");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        var resp = await _http.SendAsync(req);
+
+        // Format facts first, then the REAL payload - not an empty-queue 200, which would prove only
+        // that some route answered. The seeded draft's content must come back through the projection
+        // (PreviewContent carries the content verbatim at this length), with its status and count.
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("application/json", resp.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("pending_review", doc.RootElement.GetProperty("status").GetString());
+        Assert.Equal(1, doc.RootElement.GetProperty("count").GetInt32());
+        var item = doc.RootElement.GetProperty("items").EnumerateArray().Single();
+        Assert.Equal(CommQueueTestSeed.SecretDraftContent, item.GetProperty("preview").GetString());
+        Assert.Equal(42, item.GetProperty("ticketNumber").GetInt32());
+    }
+
+    [Fact]
+    public async Task The_every_status_form_still_serves_on_self_host()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "comm-queue?status=all");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        var resp = await _http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("all", doc.RootElement.GetProperty("status").GetString());
+        Assert.Equal(1, doc.RootElement.GetProperty("count").GetInt32());
+    }
+}
+
+/// <summary>
+/// Seeds the operator's comm queue at the redirected storage root with ONE pending draft, through the
+/// production schema (<see cref="DatabaseService.InitializeAsync"/>) plus a raw insert - the desktop
+/// Communication Manager that owned the write path was retired, so there is no write API to seed
+/// through. The columns supplied are exactly the NOT NULL set plus the fields the Gateway's slim
+/// projection surfaces (ticket number, status, recipient, content).
+/// </summary>
+internal static class CommQueueTestSeed
+{
+    /// <summary>Distinctive enough that finding it in ANY response body is a disclosure, not a coincidence.</summary>
+    public const string SecretDraftContent =
+        "SECRET outbound draft b7c2: the acquisition closes Friday, hold all announcements";
+
+    public static async Task SeedAsync(string root)
+    {
+        var contentPath = Path.Combine(root, "config", "comm-queue");
+        using (var db = new DatabaseService(contentPath))
+            await db.InitializeAsync();
+
+        await using var connection = new SqliteConnection(
+            $"Data Source={Path.Combine(contentPath, "communications.db")}");
+        await connection.OpenAsync();
+        var insert = connection.CreateCommand();
+        insert.CommandText =
+            "INSERT INTO communications (id, ticket_number, platform, type, persona, content, created_at, status, recipient) " +
+            "VALUES ($id, 42, 'email', 'email', 'operator', $content, $createdAt, 'pending_review', 'board@example.com')";
+        insert.Parameters.AddWithValue("$id", Guid.NewGuid().ToString());
+        insert.Parameters.AddWithValue("$content", SecretDraftContent);
+        insert.Parameters.AddWithValue("$createdAt", DateTime.UtcNow.ToString("o"));
+        await insert.ExecuteNonQueryAsync();
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedLauncherHubTenantTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedLauncherHubTenantTests.cs
@@ -151,7 +151,9 @@ public sealed class HostedLauncherHubTenantTests : IAsyncLifetime
     {
         var request = new HttpRequestMessage(HttpMethod.Post, $"machines/{SharedMachine}/launch")
         {
-            Content = JsonContent.Create(new { app }),
+            // confirmProtected: CR-5 gates every launch behind explicit confirmation; these tests are about
+            // TENANT scoping of the relay, so they confirm and let the partition be the thing under test.
+            Content = JsonContent.Create(new { app, confirmProtected = true }),
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
         return _http.SendAsync(request);

--- a/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
@@ -151,9 +151,15 @@ public sealed class HostedNetworkDiagEndpointTests
                 registry,
                 version: "test",
                 token: "test-token",
-                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
-                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
-                tenantBoundary: null,
+                // The boundary is required and non-nullable now (finding I1-01), so this harness wires the
+                // REAL boundary for the mode it just selected: the hosted arm needs the per-account ambient
+                // context (a hosted process constructing the single-tenant one fails loud by design), and
+                // the self-host arm gets the SingleTenantContext, which always resolves Local.
+                tenantBoundary: hosted
+                    ? new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                        new CcDirector.Core.Tenancy.AsyncLocalTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry())
+                    : new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                        new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
                 collectNetworkDiagnostic: collectNetworkDiagnostic);
             await app.StartAsync();
             var port = BoundPort.Of(app);

--- a/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedNetworkDiagEndpointTests.cs
@@ -151,6 +151,9 @@ public sealed class HostedNetworkDiagEndpointTests
                 registry,
                 version: "test",
                 token: "test-token",
+                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+                tenantBoundary: null,
                 collectNetworkDiagnostic: collectNetworkDiagnostic);
             await app.StartAsync();
             var port = BoundPort.Of(app);

--- a/src/CcDirector.Gateway.Tests/HostedStatsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedStatsServeTests.cs
@@ -222,7 +222,12 @@ internal static class StatsGroupProbeHost
         var app = builder.Build();
         app.Urls.Add("http://127.0.0.1:0");
 
-        var group = StatsPageEndpoint.Map(app, aggregator);
+        // The boundary is required and non-nullable now (finding I1-01). This probe host is used by the
+        // SELF-HOST control tests only, so it gets the REAL self-host boundary: built over the
+        // SingleTenantContext, it always resolves the single Local tenant.
+        var group = StatsPageEndpoint.Map(app, aggregator,
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
         mapIntoGroup?.Invoke(group);
         mapOutsideGroup?.Invoke(app);
 

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -606,7 +606,10 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
             (directorId, req, ct) => Task.FromResult<(bool, SessionDto?, string?)>(
                 (true, new SessionDto { SessionId = SpawnedSessionId }, null)));
 
-        MachineEndpoints.Map(app, launchers, spawner, sendLauncherCommand: null);
+        // Self-host control harness: SelfHostMachineControlTests sets CC_GATEWAY_HOSTED to the non-hosted
+        // values before starting this host, so there is no boundary to pass. The parameter is required
+        // (finding CR-7), so the absence is stated rather than defaulted.
+        MachineEndpoints.Map(app, launchers, spawner, boundary: null, sendLauncherCommand: null);
 
         await app.StartAsync();
         return new MachineGroupProbeHost

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -251,14 +251,57 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
     {
         RegisterAliceLauncher();
 
+        // Tenant-boundary hardening (inspection finding I1-03): this test used to send
+        // args = "/c echo hi" on a HOSTED Gateway, which is exactly the capability that finding
+        // removed - a caller selecting a catalogued command interpreter and supplying the real
+        // command in the argument string. The launch capability itself is unchanged and is still
+        // proven here: the catalogued application starts, and the relay genuinely reaches the
+        // launcher process. Only the caller-supplied argument channel is gone on hosted.
         var resp = await Send("POST", $"machines/{AliceMachine}/launch", _aliceKey,
-            new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi", confirmProtected = true });
+            new { path = @"C:\Windows\System32\cmd.exe", confirmProtected = true });
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
         Assert.Equal("launch", doc.RootElement.GetProperty("verb").GetString());
         Assert.Contains(StubSentinel, doc.RootElement.GetProperty("payload").GetString()!, StringComparison.Ordinal);
         Assert.Equal(new[] { "launch" }, AliceLauncherHits());
+    }
+
+    /// <summary>
+    /// Inspection finding I1-03. The catalogue allowlist alone was never containment: every ordinary
+    /// machine has a command interpreter or script host among its installed applications, so a caller
+    /// could select that catalogued entry and put the real command in the ARGUMENT string, which the
+    /// launcher interpolates into the command line it starts. On a hosted process the launch verb now
+    /// accepts no caller-supplied arguments and no caller-supplied working directory.
+    ///
+    /// The refusal is proven the way everything in this file is proven - by OBSERVING THE ACT, not
+    /// only the status code. A 403 would also be produced by a Gateway that was simply broken, so each
+    /// case additionally asserts that Alice's stub launcher process was NEVER DIALED. The test above is
+    /// the control that proves that instrument is live: the same launcher IS dialed, and DOES return
+    /// its sentinel, when the same tenant asks for the same application with no arguments.
+    /// </summary>
+    [Theory]
+    [InlineData("/c whoami", null)]
+    [InlineData(null, @"C:\Windows\System32")]
+    [InlineData("/c whoami", @"C:\Windows\System32")]
+    public async Task A_hosted_launch_carrying_arguments_or_a_working_directory_is_refused(string? args, string? cwd)
+    {
+        RegisterAliceLauncher();
+
+        var resp = await Send("POST", $"machines/{AliceMachine}/launch", _aliceKey,
+            new { path = @"C:\Windows\System32\cmd.exe", args, cwd, confirmProtected = true });
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        var text = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(text);
+        Assert.Equal("launch_arguments_not_allowed", doc.RootElement.GetProperty("error").GetString());
+
+        // The refusal is EXPLICIT, not a silent drop: the caller is told, rather than having a
+        // different program started on their behalf and reported as success.
+        Assert.Contains("does not accept", text, StringComparison.Ordinal);
+
+        // THE ACT: the launcher process was never reached, so nothing ran.
+        Assert.Empty(AliceLauncherHits());
     }
 
     [Fact]
@@ -320,13 +363,19 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
     [Fact]
     public async Task One_tenant_cannot_execute_code_on_another_tenants_machine()
     {
-        // The sharpest form of the leak: POST /machines/{machine}/launch forwards a caller-supplied path,
-        // arguments and working directory to the launcher, which runs them.
+        // The sharpest form of the leak: POST /machines/{machine}/launch forwards a caller-supplied
+        // program to the launcher, which runs it.
         RegisterAliceLauncher();
 
         // Bob CONFIRMS (CR-5's accident guard is not aimed at him) - the tenant partition alone must refuse.
+        //
+        // The body carries NO args and NO cwd deliberately. Since inspection finding I1-03 a hosted
+        // Gateway refuses those outright, and that refusal fires before the machine is resolved - so a
+        // body carrying them would be answered 403 "arguments not allowed" and this test would no longer
+        // be proving anything about TENANCY. Keeping the body clean means the only thing that can refuse
+        // it is the tenant partition, which is the whole point of this test.
         var resp = await Send("POST", $"machines/{AliceMachine}/launch", _bobKey,
-            new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\", confirmProtected = true });
+            new { path = @"C:\Windows\System32\cmd.exe", confirmProtected = true });
 
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         Assert.Empty(AliceLauncherHits());
@@ -500,14 +549,19 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
 
     /// <summary>A REAL, WELL-FORMED body for each write, so a refusal can never be a validation accident: the
     /// sessions route needs repoPath and register needs machineName/port/token, and either would answer 400
-    /// rather than the status under test.</summary>
+    /// rather than the status under test.
+    ///
+    /// The launch body carries NO args and NO cwd for the same reason. Since inspection finding I1-03 a
+    /// hosted Gateway refuses a launch that supplies either, and that refusal fires before the machine is
+    /// resolved - so a body carrying them would be answered "arguments not allowed" and every row of this
+    /// table would stop testing the thing it names. Well-formed now means clean.</summary>
     private static object? BodyFor(string path) =>
         path.EndsWith("/sessions", StringComparison.Ordinal)
             ? new { repoPath = @"C:\repo", agent = "ClaudeCode" }
             : path.EndsWith("launchers/register", StringComparison.Ordinal)
                 ? new { machineName = AliceMachine, port = 7788, token = "tok", pid = 11, version = "1.0.0" }
                 : path.EndsWith("/launch", StringComparison.Ordinal)
-                    ? new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\", confirmProtected = true }
+                    ? new { path = @"C:\Windows\System32\cmd.exe", confirmProtected = true }
                     : null;
 
     internal static HttpContent JsonBody(object value) =>

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -279,11 +279,25 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
     /// case additionally asserts that Alice's stub launcher process was NEVER DIALED. The test above is
     /// the control that proves that instrument is live: the same launcher IS dialed, and DOES return
     /// its sentinel, when the same tenant asks for the same application with no arguments.
+    ///
+    /// The empty and whitespace-only cases are inspection finding M03-I2B-02. The first version of
+    /// this guard tested IsNullOrWhiteSpace and then forwarded the original object, so those values
+    /// passed a rule that says no caller-supplied arguments and no caller-supplied working directory
+    /// are accepted - and the three cases here only covered non-whitespace values, so nothing caught
+    /// it. An empty working directory is not "no working directory" downstream: it moves the
+    /// launcher's choice from the application's own directory to the process default. The rule is now
+    /// about the FIELD BEING PRESENT rather than about what is in it.
     /// </summary>
     [Theory]
     [InlineData("/c whoami", null)]
     [InlineData(null, @"C:\Windows\System32")]
     [InlineData("/c whoami", @"C:\Windows\System32")]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData(null, "")]
+    [InlineData(null, "   ")]
+    [InlineData("", "")]
+    [InlineData("\t", "\t")]
     public async Task A_hosted_launch_carrying_arguments_or_a_working_directory_is_refused(string? args, string? cwd)
     {
         RegisterAliceLauncher();

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -252,7 +252,7 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
         RegisterAliceLauncher();
 
         var resp = await Send("POST", $"machines/{AliceMachine}/launch", _aliceKey,
-            new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi" });
+            new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi", confirmProtected = true });
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
@@ -324,8 +324,9 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
         // arguments and working directory to the launcher, which runs them.
         RegisterAliceLauncher();
 
+        // Bob CONFIRMS (CR-5's accident guard is not aimed at him) - the tenant partition alone must refuse.
         var resp = await Send("POST", $"machines/{AliceMachine}/launch", _bobKey,
-            new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\" });
+            new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\", confirmProtected = true });
 
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         Assert.Empty(AliceLauncherHits());
@@ -506,7 +507,7 @@ public sealed class HostedTenantMachineControlTests : IAsyncLifetime
             : path.EndsWith("launchers/register", StringComparison.Ordinal)
                 ? new { machineName = AliceMachine, port = 7788, token = "tok", pid = 11, version = "1.0.0" }
                 : path.EndsWith("/launch", StringComparison.Ordinal)
-                    ? new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\" }
+                    ? new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami", cwd = @"C:\", confirmProtected = true }
                     : null;
 
     internal static HttpContent JsonBody(object value) =>
@@ -758,7 +759,7 @@ public sealed class SelfHostMachineControlTests : IDisposable
         probe.SeedStubLauncher(Machine);
 
         var resp = await probe.Http.PostAsync($"/machines/{Machine}/launch",
-            HostedTenantMachineControlTests.JsonBody(new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi" }));
+            HostedTenantMachineControlTests.JsonBody(new { path = @"C:\Windows\System32\cmd.exe", args = "/c echo hi", confirmProtected = true }));
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());

--- a/src/CcDirector.Gateway.Tests/LauncherRegistryEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherRegistryEndpointTests.cs
@@ -226,8 +226,47 @@ public sealed class LauncherRegistryEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Relay_Launch_UnknownMachine_Returns404()
     {
-        var resp = await _http.PostAsJsonAsync("machines/UNKNOWN-MACHINE/launch", new { path = "foo.exe" });
+        var resp = await _http.PostAsJsonAsync("machines/UNKNOWN-MACHINE/launch", new { path = "foo.exe", confirmProtected = true });
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tenant-boundary hardening (release 2026-07-31, finding CR-5): EVERY launch
+    // requires confirmProtected=true, the same flag the restart/stop slot guard
+    // reads. Key possession alone used to be enough to start a program.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Relay_Launch_WithoutConfirmProtected_IsRefused403_BeforeAnyRelay()
+    {
+        // A REGISTERED machine on a dead port: if the relay were attempted the answer would be 502
+        // "unreachable". The 403 with the launch_guard error proves the refusal happened BEFORE any
+        // dial - the reported CR-5 symptom was that this request relayed on key possession alone.
+        var req = BuildRegistrationRequest("LAUNCH-GUARD-MACHINE", port: 1);
+        await _http.PostAsJsonAsync("launchers/register", req);
+
+        var resp = await _http.PostAsJsonAsync("machines/LAUNCH-GUARD-MACHINE/launch",
+            new { path = @"C:\Windows\System32\cmd.exe", args = "/c whoami" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        var json = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("launch_guard", json);
+        Assert.Contains("confirmProtected", json);
+    }
+
+    [Fact]
+    public async Task Relay_Launch_WithConfirmProtected_PassesTheGateAndReachesTheRelay()
+    {
+        // The allowed-path control: with the confirmation present the gate opens and the relay is
+        // attempted - the dead port turns that attempt into 502, which is exactly the proof that the
+        // request got PAST the 403 gate.
+        var req = BuildRegistrationRequest("LAUNCH-CONFIRM-MACHINE", port: 1);
+        await _http.PostAsJsonAsync("launchers/register", req);
+
+        var resp = await _http.PostAsJsonAsync("machines/LAUNCH-CONFIRM-MACHINE/launch",
+            new { path = @"C:\Windows\System32\cmd.exe", confirmProtected = true });
+
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
     }
 
     // -------------------------------------------------------------------------

--- a/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
@@ -72,7 +72,9 @@ public sealed class MachineSpawnOriginStampTests : IDisposable
             await next();
         });
 
-        MachineEndpoints.Map(app, new LauncherRegistry(), spawner);
+        // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+        // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+        MachineEndpoints.Map(app, new LauncherRegistry(), spawner, boundary: null);
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, () => seen);
     }

--- a/src/CcDirector.Gateway.Tests/MissionPartitionWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionPartitionWiringTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// CR-6, missions half - the WIRING proof that completes <see cref="MissionRouteTenantScopingTests"/>.
+///
+/// That class proves the per-request partition over the mapped routes: list, resolve-by-id, create
+/// ownership, and the parent reference, each refusal paired with a permitted control. This class proves
+/// the three properties those tests cannot see:
+///
+///  1. QUARANTINE ON HOSTED (Architect ruling: quarantine on hosted, adopt-as-Local on self-host,
+///     nothing deleted). The hosted <see cref="GatewayHost"/> must construct its mission store with
+///     <c>adoptUnattributedAs: null</c>, so a row written before missions carried an owner matches NO
+///     tenant: never listed, never resolvable, never deletable - and still on disk afterwards. This is
+///     proven through the REAL host construction (GatewayHost.cs decides from GatewayHostedMode.IsHosted),
+///     not by constructing a store with the right argument in the test, which would prove only that the
+///     store honors an argument nobody is proven to pass.
+///  2. THE DELETE LEG of the exit row "tenant A cannot list, resolve, or delete tenant B's missions".
+///     No HTTP delete route exists on the Gateway (MissionStore.Delete has no production route), so the
+///     surface a future route would go through is the store seam the existing routes already use -
+///     <see cref="GatewayHost.Missions"/> - and the property is proven there, with a destructibility
+///     control proving the same operation IS capable of deleting when the owner runs it.
+///  3. THE COMM-QUEUE ROW in the same two-tenant setting: with two enrolled tenants standing, neither
+///     can read the operator's comm queue - the refusal is the exact
+///     <see cref="Api.CommQueueEndpoints.RefusalMessage"/> payload, not a vanished route (the self-host
+///     control for that family is <see cref="SelfHostCommQueueControlTests"/>).
+///
+/// The mirror half of the quarantine is <see cref="SelfHostMissionAdoptionControlTests"/>: the SAME
+/// seeded file, hosted mode off, and the legacy row is the single owner's - listed and resolvable. One
+/// direction alone cannot tell quarantine from a store that lost the row.
+///
+/// Revert-prove (the negative control the phase report records): in GatewayHost.cs change the store
+/// construction to the pre-#1039 single-tenant shape - <c>adoptUnattributedAs: Core.Tenancy.TenantId.Local</c>
+/// unconditionally - and the quarantine tests here go RED (the legacy row surfaces to nobody's benefit:
+/// it is Local's, and Local is exactly the shared partition hosted must never serve). Feed the mission
+/// routes a constant tenant instead of the caller's and MissionRouteTenantScopingTests reddens. Map the
+/// comm-queue on the ungrouped builder and the comm-queue row here reddens with a 200.
+///
+/// The assembly disables test parallelization, so toggling CC_GATEWAY_HOSTED here is safe; it is reset
+/// in DisposeAsync.
+/// </summary>
+public sealed class HostedMissionPartitionWiringTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    /// <summary>Free text a person typed - the thing an unpartitioned list disclosed. Distinctive on purpose.</summary>
+    private const string LegacyMissionName = "Legacy pre-partition mission 77c3 - Contoso payroll rescue";
+
+    private static readonly Guid LegacyMissionId = Guid.Parse("b8a31c2e-7d44-4f0a-9c66-2f5d1e8a9b01");
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private HostedTestDevice _deviceA;
+    private HostedTestDevice _deviceB;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-cr6-wiring-" + Guid.NewGuid().ToString("N"));
+    private string _missionsPath = "";
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+
+        // The legacy row exists BEFORE the host starts, exactly as a pre-#1039 file would: written by a
+        // Gateway that stamped no owner. Seeded on disk rather than through the store, because the store
+        // no longer has an unscoped write to create one with.
+        _missionsPath = Path.Combine(_instancesDir, "missions.json");
+        SeedUnattributedMission(_missionsPath);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: _missionsPath,
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        _deviceA = HostedTestEnrollment.Enroll(
+            _gateway, "sub-wiring-a", "wiring-a@example.com", "dev-wa", "MACHINE-WA");
+        _deviceB = HostedTestEnrollment.Enroll(
+            _gateway, "sub-wiring-b", "wiring-b@example.com", "dev-wb", "MACHINE-WB");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task An_unattributed_mission_is_quarantined_on_hosted_and_stays_on_disk()
+    {
+        // Each tenant holds a real mission of its own, so "the legacy row is absent" is asserted against
+        // NON-EMPTY lists - an empty list satisfies any absence claim and proves nothing.
+        var aMission = await CreateMission(_deviceA.DeviceKey, "A's own mission beside the legacy row");
+        var bMission = await CreateMission(_deviceB.DeviceKey, "B's own mission beside the legacy row");
+
+        var (aStatus, aBody) = await GetRaw("missions", _deviceA.DeviceKey);
+        var (bStatus, bBody) = await GetRaw("missions", _deviceB.DeviceKey);
+        Assert.Equal(HttpStatusCode.OK, aStatus);
+        Assert.Equal(HttpStatusCode.OK, bStatus);
+
+        // The permitted half first: each list really serves, and serves the caller's own record.
+        Assert.Contains(aMission.MissionId, Parse(aBody).Select(m => m.MissionId));
+        Assert.Contains(bMission.MissionId, Parse(bBody).Select(m => m.MissionId));
+
+        // The quarantine: the legacy row is in NEITHER list, by id and by its human-typed name.
+        Assert.DoesNotContain(LegacyMissionId, Parse(aBody).Select(m => m.MissionId));
+        Assert.DoesNotContain(LegacyMissionId, Parse(bBody).Select(m => m.MissionId));
+        Assert.DoesNotContain(LegacyMissionName, aBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(LegacyMissionName, bBody, StringComparison.Ordinal);
+
+        // Not resolvable by id either - for anyone. 404, indistinguishable from a mission that never
+        // existed, so the id cannot even be probed.
+        Assert.Equal(HttpStatusCode.NotFound, (await GetRaw($"missions/{LegacyMissionId}", _deviceA.DeviceKey)).Status);
+        Assert.Equal(HttpStatusCode.NotFound, (await GetRaw($"missions/{LegacyMissionId}", _deviceB.DeviceKey)).Status);
+
+        // The wiring's DIRECT observable: on hosted the legacy row is owned by NOBODY - not even the
+        // Local partition adopts it. Without this line, a GatewayHost that constructed the store the
+        // pre-#1039 single-tenant way (adoptUnattributedAs: Local) on a hosted process would pass every
+        // assertion above, because a Local-owned row is just as absent from tenant A's and B's lists as
+        // a quarantined one. This is the assertion that reddens for that exact miswire.
+        Assert.Null(_gateway.Missions.Get(TenantId.Local, LegacyMissionId));
+
+        // QUARANTINED, NOT DESTROYED: after every refusal above, the row is still in the file for the
+        // deployment operator to inspect or remove out of band. Ruling: nothing is deleted.
+        var fileAfter = File.ReadAllText(_missionsPath);
+        Assert.Contains(LegacyMissionId.ToString(), fileAfter, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(LegacyMissionName, fileAfter, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Another_tenants_mission_cannot_be_deleted_and_the_owners_delete_still_works()
+    {
+        // No HTTP delete route exists (MissionStore.Delete has no production caller), so the seam a
+        // future route would call - the SAME store instance every mapped route uses,
+        // GatewayHost.Missions - is where the property is proven.
+        var bMission = await CreateMission(_deviceB.DeviceKey, "B's mission A will try to delete");
+
+        // The refusal: A deleting B's mission by its true id removes nothing.
+        Assert.False(_gateway.Missions.Delete(_deviceA.Tenant, bMission.MissionId),
+            "tenant A deleted tenant B's mission through the store seam");
+
+        // And B's record genuinely survived - asserted through the route, not the store that just
+        // answered false.
+        var (survivedStatus, survivedBody) = await GetRaw($"missions/{bMission.MissionId}", _deviceB.DeviceKey);
+        Assert.Equal(HttpStatusCode.OK, survivedStatus);
+        Assert.Contains("B's mission A will try to delete", survivedBody, StringComparison.Ordinal);
+
+        // The quarantined legacy row is not deletable by anyone through this API either.
+        Assert.False(_gateway.Missions.Delete(_deviceA.Tenant, LegacyMissionId));
+        Assert.False(_gateway.Missions.Delete(_deviceB.Tenant, LegacyMissionId));
+
+        // DESTRUCTIBILITY CONTROL: the identical call by the OWNER does delete - so the refusals above
+        // stopped a capable operation, they were not a Delete that cannot delete anything.
+        Assert.True(_gateway.Missions.Delete(_deviceB.Tenant, bMission.MissionId),
+            "the owner's own delete no longer works - the refusal above proved nothing");
+        Assert.Equal(HttpStatusCode.NotFound, (await GetRaw($"missions/{bMission.MissionId}", _deviceB.DeviceKey)).Status);
+    }
+
+    [Fact]
+    public async Task Neither_tenant_can_read_the_comm_queue_on_hosted()
+    {
+        // The comm-queue row of the same two-tenant matrix family: with both tenants enrolled and
+        // standing, each read is the EXACT hosted refusal - the same assertion, payload and status the
+        // deny family's own tests pin, so this row grades FAIL-to-PASS rather than route-vanished.
+        foreach (var key in new[] { _deviceA.DeviceKey, _deviceB.DeviceKey })
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, "comm-queue");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            await HostedCommQueueDenyTests.AssertBodyIsNothingButTheRefusal(await _http.SendAsync(req));
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// One row exactly as a pre-#1039 Gateway serialized it: PascalCase properties, no TenantId. Written
+    /// with the same serializer settings the store reads with, so the seed cannot drift from the format.
+    /// </summary>
+    private static void SeedUnattributedMission(string missionsPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(missionsPath)!);
+        var legacyRow = new[]
+        {
+            new
+            {
+                MissionId = LegacyMissionId,
+                MissionName = LegacyMissionName,
+                ParentMissionId = (Guid?)null,
+                CreatedAt = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+                TenantId = (string?)null,
+            },
+        };
+        File.WriteAllText(missionsPath,
+            JsonSerializer.Serialize(legacyRow, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static List<MissionDto> Parse(string body) =>
+        JsonSerializer.Deserialize<List<MissionDto>>(body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new List<MissionDto>();
+
+    private async Task<MissionDto> CreateMission(string deviceKey, string name)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "missions")
+        {
+            Content = JsonContent.Create(new NewMissionRequest { MissionName = name }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(dto);
+        return dto!;
+    }
+
+    private async Task<(HttpStatusCode Status, string Body)> GetRaw(string path, string deviceKey)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        var resp = await _http.SendAsync(req);
+        return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+}
+
+/// <summary>
+/// The adopt-as-Local half of the ruling, and the control without which the quarantine is
+/// indistinguishable from a store that lost the row: the SAME unattributed legacy row, hosted mode
+/// explicitly OFF, and the single owner lists it, resolves it, and its file row is untouched. Self-host
+/// has exactly one tenant by construction, so "the unattributed row is Local's" is a fact about the
+/// deployment, not a guess about the row - which is precisely why the same row must be NOBODY's when
+/// the file is shared.
+/// </summary>
+public sealed class SelfHostMissionAdoptionControlTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string LegacyMissionName = "Legacy pre-partition mission 77c3 - Contoso payroll rescue";
+    private static readonly Guid LegacyMissionId = Guid.Parse("b8a31c2e-7d44-4f0a-9c66-2f5d1e8a9b01");
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-cr6-adopt-" + Guid.NewGuid().ToString("N"));
+    private string _missionsPath = "";
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        Assert.False(GatewayHostedMode.IsHosted);
+
+        _missionsPath = Path.Combine(_instancesDir, "missions.json");
+        Directory.CreateDirectory(_instancesDir);
+        File.WriteAllText(_missionsPath, JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                MissionId = LegacyMissionId,
+                MissionName = LegacyMissionName,
+                ParentMissionId = (Guid?)null,
+                CreatedAt = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+                TenantId = (string?)null,
+            },
+        }, new JsonSerializerOptions { WriteIndented = true }));
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: _missionsPath,
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task The_single_owner_lists_and_resolves_the_legacy_unattributed_mission()
+    {
+        var list = await _http.GetFromJsonAsync<List<MissionDto>>("missions");
+        Assert.NotNull(list);
+        Assert.Contains(list!, m => m.MissionId == LegacyMissionId && m.MissionName == LegacyMissionName);
+
+        var byId = await _http.GetAsync($"missions/{LegacyMissionId}");
+        Assert.Equal(HttpStatusCode.OK, byId.StatusCode);
+        Assert.Contains(LegacyMissionName, await byId.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        // Adoption is a read-side ownership rule, not a rewrite: the row on disk still carries no
+        // TenantId. (A rewrite would silently attribute history, which the ruling forbids.)
+        using var doc = JsonDocument.Parse(File.ReadAllText(_missionsPath));
+        var row = doc.RootElement.EnumerateArray().Single();
+        Assert.True(row.GetProperty("TenantId").ValueKind == JsonValueKind.Null,
+            "the self-host Gateway rewrote the legacy row's owner on disk");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NullBoundaryHostedGateFailClosedTests.cs
+++ b/src/CcDirector.Gateway.Tests/NullBoundaryHostedGateFailClosedTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening (release 2026-07-31, the census sweep's ruling on the six adjacent sites):
+/// the hosted-only gates in <c>GatewayEndpoints.Map</c> that used to read <c>tenantBoundary?.IsHosted ==
+/// true</c> now gate on <see cref="GatewayHostedMode.IsHosted"/> - the PROCESS-level hosted flag - so a
+/// literal <c>null!</c> boundary on a hosted process can no longer fail them OPEN.
+///
+/// Phase 2 (<see cref="OmittedTenantBoundaryFailClosedTests"/>) made the boundary parameter required and
+/// the RESOLVERS fail closed; these six sites were the flagged leftovers that gated hosted-only DENIALS on
+/// the nullable argument itself. With a null boundary on a hosted process, <c>?.</c> answered false and:
+///
+///   - <c>GET /healthz</c> computed and served the fleet-GLOBAL Director/session counts to an anonymous
+///     probe - the exact cross-tenant aggregate the hosted branch exists to withhold;
+///   - the four legacy same-machine discovery-plane legs (<c>POST /directors/register</c>,
+///     <c>POST /directors/{id}/heartbeat</c>, <c>POST /directors/{id}/doorbell</c>,
+///     <c>DELETE /directors/{id}/registration</c>) stayed OPEN - and the register leg is exactly the
+///     Local-shadow path: a hosted caller fabricates a Local registration and can then act as that id;
+///   - the <c>/sessions</c> pushed-roster intersection was skipped (that one is unobservable through the
+///     route on a hosted process, because <c>ResolveReadTenant</c> already answers 403 before the branch
+///     runs - it is converted for the same discipline but CANNOT be probed here; see the phase report).
+///
+/// MECHANICS, per <see cref="OmittedTenantBoundaryFailClosedTests"/>: a minimal host maps the production
+/// <c>GatewayEndpoints.Map</c> with <c>tenantBoundary: null!</c> - the deliberately miswired configuration
+/// the compiler now forces a caller to SPELL OUT - and the refusal is asserted positively (exact status,
+/// exact message, property set as an allow-list). The self-host control runs the IDENTICAL null-boundary
+/// host with hosted mode off and the plane serves, so the refusals are the hosted flag biting, not a dead
+/// plane. The registry is asserted directly for the effect that matters (no shadow row created, the seeded
+/// Local row surviving), never by response shape alone.
+///
+/// REVERT-PROVE: restore any of the six sites to <c>tenantBoundary?.IsHosted == true</c> and its test here
+/// goes RED - the null-boundary hosted twin serves the counts, registers the shadow, heartbeats, records
+/// the doorbell, or removes the registration again. The self-host control stays green in both directions.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED here is safe; it is
+/// restored per helper.
+/// </summary>
+public sealed class NullBoundaryHostedGateFailClosedTests
+{
+    /// <summary>The exact refusal every discovery-plane leg emits on hosted. Asserted as the full payload.</summary>
+    private const string PlaneDenyMessage = "the same-machine HTTP discovery plane is not available on the hosted Gateway";
+
+    private const string LocalSecretMachine = "local-partition-secret-machine";
+
+    // ===== site 1: the /healthz fleet-count redaction ===============================================
+
+    [Fact]
+    public async Task Healthz_withholds_the_fleet_counts_on_hosted_even_when_the_boundary_is_null()
+    {
+        // The disclosure at stake: a Director row in the Local partition. Pre-fix, hosted + null boundary
+        // took the SELF-HOST branch and served "directors": 1 to an anonymous probe - an aggregate over
+        // every account's fleet.
+        await using var host = await NullBoundaryHost.StartAsync(hosted: true, seedLocalDirector: true);
+
+        using var resp = await host.Http.GetAsync("/healthz");
+        var raw = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        // ABSENT, not zero - asserted on the raw body exactly as HealthzTenantLeakTests does, because a
+        // deserialized null cannot tell "field absent" from "field present and null".
+        Assert.DoesNotContain("\"directors\"", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"sessions\"", raw, StringComparison.Ordinal);
+        // Liveness itself still serves - the redaction is the counts, never the probe.
+        Assert.Equal("ok", JsonDocument.Parse(raw).RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Healthz_still_reports_the_counts_on_selfhost_with_the_same_null_boundary()
+    {
+        // The control that pins the gate to the HOSTED FLAG: the identical null-boundary host, hosted mode
+        // off, and the seeded Local Director is counted. Green in both directions of the revert proof.
+        await using var host = await NullBoundaryHost.StartAsync(hosted: false, seedLocalDirector: true);
+
+        using var resp = await host.Http.GetAsync("/healthz");
+        var raw = await resp.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(1, JsonDocument.Parse(raw).RootElement.GetProperty("directors").GetInt32());
+    }
+
+    // ===== sites 2-5: the four legacy discovery-plane legs ==========================================
+
+    [Fact]
+    public async Task Register_is_refused_on_hosted_with_a_null_boundary_and_no_local_shadow_is_created()
+    {
+        await using var host = await NullBoundaryHost.StartAsync(hosted: true, seedLocalDirector: false);
+
+        using var resp = await host.Http.PostAsync("/directors/register", RegistrationBody("shadow-dir"));
+        await AssertPlaneRefusal(resp);
+
+        // The breach the deny exists to stop, asserted at the store: no Local-shadow registration was
+        // written. Pre-fix this is exactly what a hosted caller obtained with a null boundary.
+        Assert.Empty(host.Registry.ListDirectors(TenantId.Local));
+    }
+
+    [Fact]
+    public async Task Heartbeat_doorbell_and_unregister_are_refused_on_hosted_with_a_null_boundary_and_the_local_row_survives()
+    {
+        // One seeded Local registration; all three by-id legs against it. Each must meet the exact plane
+        // refusal, and the row must be byte-alive afterwards - the unregister leg pre-fix REMOVED it.
+        await using var host = await NullBoundaryHost.StartAsync(hosted: true, seedLocalDirector: true);
+
+        using (var heartbeat = await host.Http.PostAsync($"/directors/{NullBoundaryHost.LocalDirectorId}/heartbeat", null))
+            await AssertPlaneRefusal(heartbeat);
+
+        using (var doorbell = await host.Http.PostAsync($"/directors/{NullBoundaryHost.LocalDirectorId}/doorbell",
+                   JsonBody("{\"sessionId\":\"s-1\",\"newState\":\"Idle\"}")))
+            await AssertPlaneRefusal(doorbell);
+
+        using (var unregister = await host.Http.DeleteAsync($"/directors/{NullBoundaryHost.LocalDirectorId}/registration"))
+            await AssertPlaneRefusal(unregister);
+
+        var survivor = host.Registry.Get(TenantId.Local, NullBoundaryHost.LocalDirectorId);
+        Assert.NotNull(survivor);
+        Assert.Equal(LocalSecretMachine, survivor!.MachineName);
+    }
+
+    [Fact]
+    public async Task The_discovery_plane_still_serves_selfhost_with_the_same_null_boundary()
+    {
+        // The self-host control for all four legs, on the identical null-boundary host with hosted mode
+        // off: register creates the row, heartbeat and doorbell answer, unregister removes it. This is
+        // what makes the refusals above the hosted flag biting rather than a plane that no longer exists.
+        await using var host = await NullBoundaryHost.StartAsync(hosted: false, seedLocalDirector: false);
+
+        using (var register = await host.Http.PostAsync("/directors/register", RegistrationBody("selfhost-dir")))
+            Assert.Equal(HttpStatusCode.Created, register.StatusCode);
+        Assert.NotNull(host.Registry.Get(TenantId.Local, "selfhost-dir"));
+
+        using (var heartbeat = await host.Http.PostAsync("/directors/selfhost-dir/heartbeat", null))
+            Assert.Equal(HttpStatusCode.OK, heartbeat.StatusCode);
+
+        using (var doorbell = await host.Http.PostAsync("/directors/selfhost-dir/doorbell",
+                   JsonBody("{\"sessionId\":\"s-1\",\"newState\":\"Idle\"}")))
+            Assert.Equal(HttpStatusCode.OK, doorbell.StatusCode);
+
+        using (var unregister = await host.Http.DeleteAsync("/directors/selfhost-dir/registration"))
+            Assert.Equal(HttpStatusCode.OK, unregister.StatusCode);
+        Assert.Null(host.Registry.Get(TenantId.Local, "selfhost-dir"));
+    }
+
+    // ===== the refusal itself =======================================================================
+
+    /// <summary>
+    /// The plane refusal asserted positively: the concrete 403, the exact message only
+    /// <c>LegacyDiscoveryPlaneUnavailable</c> emits, and the property set as an ALLOW-LIST of exactly one
+    /// error field - a wrong-but-plausible 403 from anywhere else, or a body carrying extra data, fails.
+    /// </summary>
+    private static async Task AssertPlaneRefusal(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.True(HttpStatusCode.Forbidden == resp.StatusCode,
+            $"expected the 403 plane refusal but got {(int)resp.StatusCode}; body was: {body}");
+        var root = JsonDocument.Parse(body).RootElement;
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(PlaneDenyMessage, root.GetProperty("error").GetString());
+    }
+
+    // ===== helpers ==================================================================================
+
+    private static StringContent RegistrationBody(string directorId)
+        => JsonBody("{\"directorId\":\"" + directorId + "\",\"tailnetEndpoint\":\"http://127.0.0.1:1/\"," +
+                    "\"machineName\":\"SHADOW\",\"pid\":1,\"version\":\"test\"}");
+
+    private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
+
+    /// <summary>
+    /// A minimal host mapping the production <see cref="GatewayEndpoints.Map"/> with <c>tenantBoundary:
+    /// null!</c> - the miswire under test - over a real <see cref="DirectorRegistry"/> the tests assert
+    /// directly. The hosted flag is the ONLY variable between the twin configurations, captured at Map
+    /// time and restored immediately (the sites under test read <see cref="GatewayHostedMode"/> live, and
+    /// the assembly runs sequentially).
+    /// </summary>
+    private sealed class NullBoundaryHost : IAsyncDisposable
+    {
+        internal const string LocalDirectorId = "local-director";
+
+        private readonly WebApplication _app;
+        private readonly string _dir;
+        private readonly string? _priorHosted;
+        public DirectorRegistry Registry { get; }
+        public HttpClient Http { get; }
+
+        private NullBoundaryHost(WebApplication app, HttpClient http, DirectorRegistry registry, string dir, string? priorHosted)
+        {
+            _app = app;
+            Http = http;
+            Registry = registry;
+            _dir = dir;
+            _priorHosted = priorHosted;
+        }
+
+        internal static async Task<NullBoundaryHost> StartAsync(bool hosted, bool seedLocalDirector)
+        {
+            var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+
+            var dir = Path.Combine(Path.GetTempPath(), "cc-nullgate-" + Guid.NewGuid().ToString("N"));
+            var registry = new DirectorRegistry(Path.Combine(dir, "directors"));
+            if (seedLocalDirector)
+                registry.RegisterFromStream(LocalDirectorId, "local-partition-secret-machine", "local-user",
+                    "1.0", 11, DateTime.UtcNow, TenantId.Local);
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            GatewayEndpoints.Map(app, registry, "test", "test-token", tenantBoundary: null!);
+            await app.StartAsync();
+
+            return new NullBoundaryHost(app, new HttpClient
+            {
+                BaseAddress = new Uri(app.Urls.First()),
+                Timeout = TimeSpan.FromSeconds(30),
+            }, registry, dir, prior);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Http.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+            try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* cleanup */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
+++ b/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
@@ -14,11 +14,18 @@ using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.History;
 using CcDirector.Gateway.Pairing;
 using CcDirector.Gateway.Prompts;
+using CcDirector.Gateway.Reports;
 using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Skills;
+using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Streaming;
 using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Tests.Data;
 using CcDirector.Gateway.Util;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -41,6 +48,24 @@ namespace CcDirector.Gateway.Tests;
 ///   4. <c>PromptEndpoints.ResolveTenant</c> - probed at <c>GET /prompts</c>.
 ///   5. <c>HostedTenantBoundary</c> itself - a hosted process wiring a boundary that could only answer
 ///      Local now THROWS at construction, and at resolution when hosted mode appeared after construction.
+///
+/// Phase 5a (inspection finding I1-01) extends the census to the sites that still carried an OPTIONAL
+/// nullable boundary defaulting to null, and whose resolvers decided on the ARGUMENT rather than on
+/// <see cref="GatewayHostedMode.IsHosted"/>:
+///
+///   7. <c>SessionWsProxyEndpoints.ResolveTenantOrDenyAsync</c> - the widest per-session surface (terminal
+///      stream, file read, screenshot legs, the catch-all session verbs, director backfill). Probed at
+///      <c>GET /sessions/{sid}/screenshots</c>, with the stand-in tunnel echoing WHICH Director served, so
+///      the assertion is about the partition choice itself.
+///   8. <c>DeviceEnrollmentEndpoint</c> - probed at <c>GET /devices</c> (the full device inventory of the
+///      Local partition is the disclosure).
+///   9. <c>RepoStateEndpoints</c> - probed at <c>POST /gateway/repostate</c> (a wrong-partition WRITE).
+///  10. <c>SkillPlacementEndpoints</c> - probed at <c>GET /gateway/skills/placement</c>.
+///  11. <c>WorkListRunnerEndpoints</c> - probed at <c>POST /lists/{name}/run</c> (reaches Local's
+///      Directors when open).
+///  12. <c>DirectorHub</c> - Hello binds the connection's tenant; an unwired hosted hub used to bind Local,
+///      putting the Director's whole push stream into the shared partition.
+///  13. <c>LauncherHub</c> - same shape for the launcher machine-control plane.
 ///
 /// Each resolver used to answer <see cref="TenantId.Local"/> whenever its boundary argument was absent,
 /// WITHOUT asking <see cref="GatewayHostedMode.IsHosted"/> - so one forgotten optional argument silently
@@ -78,6 +103,7 @@ public sealed class OmittedTenantBoundaryFailClosedTests : IAsyncLifetime
 
     private const string LocalSecretMachine = "local-partition-secret-machine";
     private const string LocalSecretPrompt = "local-partition-secret-prompt-text";
+    private const string LocalSecretScreenshot = "local-partition-secret-screenshot.png";
 
     private readonly string _storageRoot =
         Path.Combine(Path.GetTempPath(), "cc-omitted-boundary-" + Guid.NewGuid().ToString("N"));
@@ -317,6 +343,237 @@ public sealed class OmittedTenantBoundaryFailClosedTests : IAsyncLifetime
             () => boundary.ResolveRequestTenant(new Microsoft.AspNetCore.Http.DefaultHttpContext()));
     }
 
+    // ===== site 7: SessionWsProxyEndpoints, probed at GET /sessions/{sid}/screenshots ===============
+
+    [Fact]
+    public async Task SessionScreenshots_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The widest fail-open surface on the census: this helper's resolver used to decide on the ARGUMENT
+        // (`boundary is null ? TenantId.Local : ...`) with no hosted-mode gate at all, so a null boundary on
+        // hosted served the LOCAL partition to every leg it guards. The seeded disclosure: a session pushed
+        // into the Local partition, and a stand-in tunnel that echoes WHICH Director id it served - so the
+        // assertion is about the partition the route chose, not about an empty store.
+        const string sid = "11111111-1111-1111-1111-111111111111";
+        var unwiredStore = new PushedSessionStore(() => DateTime.UtcNow);
+        unwiredStore.RegisterConnection(TenantId.Local, "local-dir", "conn-local");
+        Assert.True(unwiredStore.ApplyDelta(TenantId.Local, "local-dir", "conn-local", 1,
+            new SessionDto { SessionId = sid })); // the disclosure claim is meaningless if the seed failed
+        DirectorCommandRouter.SendDirectorCommandAsync unwiredSend = (directorId, _, _) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success(
+                "{\"servedBy\":\"" + directorId + "\",\"items\":[\"" + LocalSecretScreenshot + "\"]}"));
+
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => SessionWsProxyEndpoints.Map(app, unwiredStore, new GatewayStreamRegistry(), unwiredSend,
+                new DirectorRegistry(Path.Combine(_storageRoot, "wsproxy-unwired")), tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, $"/sessions/{sid}/screenshots?count=5");
+            AssertRefusal(status, body);
+            Assert.DoesNotContain(LocalSecretScreenshot, body, StringComparison.Ordinal);
+            Assert.DoesNotContain("local-dir", body, StringComparison.Ordinal);
+        }
+
+        // Positive companion: the SAME session id exists in BOTH the Local partition and the caller's own,
+        // owned by differently-named Directors, and the tunnel echoes which one it dispatched to. The wired
+        // twin must serve the caller's OWN Director - so the 403 above is the guard refusing, and the
+        // partition choice (never the Local one) is proven directly rather than inferred from absence.
+        var wiredStore = new PushedSessionStore(() => DateTime.UtcNow);
+        wiredStore.RegisterConnection(TenantId.Local, "local-dir", "conn-local");
+        Assert.True(wiredStore.ApplyDelta(TenantId.Local, "local-dir", "conn-local", 1, new SessionDto { SessionId = sid }));
+        wiredStore.RegisterConnection(_tenant, "own-dir", "conn-own");
+        Assert.True(wiredStore.ApplyDelta(_tenant, "own-dir", "conn-own", 1, new SessionDto { SessionId = sid }));
+        DirectorCommandRouter.SendDirectorCommandAsync wiredSend = (directorId, _, _) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success(
+                "{\"servedBy\":\"" + directorId + "\",\"items\":[]}"));
+
+        await using var wired = await Host.StartAsync(_tenant,
+            app => SessionWsProxyEndpoints.Map(app, wiredStore, new GatewayStreamRegistry(), wiredSend,
+                new DirectorRegistry(Path.Combine(_storageRoot, "wsproxy-wired")), tenantBoundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, $"/sessions/{sid}/screenshots?count=5");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Contains("own-dir", wiredBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("local-dir", wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 8: DeviceEnrollmentEndpoint, probed at GET /devices =================================
+
+    [Fact]
+    public async Task DevicesList_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The disclosure: the Local partition's device inventory (device ids, machine names, issued times).
+        // Before the gate, the unwired hosted host resolved Local and served exactly this list.
+        var unwiredDevices = new DeviceRegistry(Path.Combine(_storageRoot, "devices-unwired.json"));
+        unwiredDevices.Register("local-device", LocalSecretMachine);
+
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => DeviceEnrollmentEndpoint.Map(app, unwiredDevices, tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/devices");
+            AssertRefusal(status, body);
+            Assert.DoesNotContain(LocalSecretMachine, body, StringComparison.Ordinal);
+        }
+
+        // Positive companion: the caller's OWN device (bound to its tenant) is served; the Local
+        // partition's is not.
+        var wiredDevices = new DeviceRegistry(Path.Combine(_storageRoot, "devices-wired.json"));
+        wiredDevices.Register("local-device", LocalSecretMachine);
+        wiredDevices.Register("own-device", "own-machine");
+        wiredDevices.SetAccountBinding("own-device", "sub-own", _tenant.Value);
+
+        await using var wired = await Host.StartAsync(_tenant,
+            app => DeviceEnrollmentEndpoint.Map(app, wiredDevices, tenantBoundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/devices");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Contains("own-machine", wiredBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(LocalSecretMachine, wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 9: RepoStateEndpoints, probed at POST /gateway/repostate ============================
+
+    [Fact]
+    public async Task RepoStatePush_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // A WRITE surface: the hazard is not a read-back but a wrong-partition write - before the gate, an
+        // unwired hosted host stamped the push into the Local partition. The refusal is asserted the same
+        // way; the wired twin proves the identical request is well-formed and lands (stored count served).
+        const string pushBody = """{"directorId":"dir-1","machineName":"M1","repositories":[]}""";
+
+        using var unwiredDb = new GatewayDbTestHarness();
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => RepoStateEndpoints.Map(app, new RepoStateStore(unwiredDb.Open()), tenantBoundary: null!)))
+        {
+            var (status, body) = await Post(unwired.Http, RepoStateEndpoints.Path, pushBody);
+            AssertRefusal(status, body);
+        }
+
+        using var wiredDb = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        await using var wired = await Host.StartAsync(_tenant,
+            app => RepoStateEndpoints.Map(app, new RepoStateStore(wiredDb.Open(ambient)),
+                tenantBoundary: new HostedTenantBoundary(ambient, new DeviceRegistry())));
+        var (wiredStatus, wiredBody) = await Post(wired.Http, RepoStateEndpoints.Path, pushBody);
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(0, JsonDocument.Parse(wiredBody).RootElement.GetProperty("stored").GetInt32());
+    }
+
+    // ===== site 10: SkillPlacementEndpoints, probed at GET /gateway/skills/placement ================
+
+    [Fact]
+    public async Task SkillPlacementReport_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        using var unwiredDb = new GatewayDbTestHarness();
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => SkillPlacementEndpoints.Map(app, new SkillPlacementStore(unwiredDb.Open()), tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, SkillPlacementEndpoints.Path);
+            AssertRefusal(status, body);
+        }
+
+        using var wiredDb = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        await using var wired = await Host.StartAsync(_tenant,
+            app => SkillPlacementEndpoints.Map(app, new SkillPlacementStore(wiredDb.Open(ambient)),
+                tenantBoundary: new HostedTenantBoundary(ambient, new DeviceRegistry())));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, SkillPlacementEndpoints.Path);
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(JsonValueKind.Object, JsonDocument.Parse(wiredBody).RootElement.ValueKind);
+    }
+
+    // ===== site 11: WorkListRunnerEndpoints, probed at POST /lists/{name}/run =======================
+
+    [Fact]
+    public async Task WorkListRun_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The boundary check sits AFTER the body-shape and list-existence checks, so the probe carries a
+        // valid body and a real stored list - the unwired twin's 403 can only be the tenant gate. The wired
+        // twin passes the gate and fails at the NEXT check (no such Director in the caller's tenant, 404),
+        // which is the proof it got past the boundary; before the gate an open unwired host would instead
+        // reach the LOCAL partition's Directors.
+        const string runBody = """{"directorId":"dir-1","repoPath":"C:/repo"}""";
+
+        using var unwiredDb = new GatewayDbTestHarness();
+        var unwiredLists = new WorkListStore(unwiredDb.Open(), Path.Combine(_storageRoot, "worklists-unwired.json"));
+        Assert.True(unwiredLists.Create("boundary-probe"));
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => WorkListRunnerEndpoints.Map(app, unwiredLists,
+                new DirectorRegistry(Path.Combine(_storageRoot, "wlr-unwired")),
+                new WorkListRunnerManager(), sendCommand: null, tenantBoundary: null!)))
+        {
+            var (status, body) = await Post(unwired.Http, "/lists/boundary-probe/run", runBody);
+            AssertRefusal(status, body);
+        }
+
+        using var wiredDb = new GatewayDbTestHarness();
+        var wiredLists = new WorkListStore(wiredDb.Open(), Path.Combine(_storageRoot, "worklists-wired.json"));
+        Assert.True(wiredLists.Create("boundary-probe"));
+        await using var wired = await Host.StartAsync(_tenant,
+            app => WorkListRunnerEndpoints.Map(app, wiredLists,
+                new DirectorRegistry(Path.Combine(_storageRoot, "wlr-wired")),
+                new WorkListRunnerManager(), sendCommand: null, tenantBoundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Post(wired.Http, "/lists/boundary-probe/run", runBody);
+        Assert.Equal(HttpStatusCode.NotFound, wiredStatus);
+        Assert.Contains("no such director", wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 12: DirectorHub - Hello binds the connection's tenant ===============================
+
+    [Fact]
+    public void DirectorHub_Hello_aborts_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The hub used to resolve `_tenantBoundary is null -> TenantId.Local`, so on hosted an unwired hub
+        // bound the Director connection - and its ENTIRE push stream - into the shared Local partition.
+        // The connection arrives authenticated (a bound account identity is stashed on its HttpContext);
+        // the boundary is the only variable.
+        var store = new PushedSessionStore(() => DateTime.UtcNow);
+        var (hub, ctx) = NewDirectorHub("conn-unwired", tenantBoundary: null!, store);
+
+        hub.Hello(new DirectorStreamHello { DirectorId = "dir-x", Version = "t" });
+
+        Assert.True(ctx.Aborted);
+        // The connection never bound, so a push cannot even be expressed - and nothing reached Local.
+        Assert.Throws<HubException>(() => hub.PushDelta(1, new SessionDto { SessionId = "sess-x" }));
+        Assert.Empty(store.SnapshotFresh(TenantId.Local, TimeSpan.FromMinutes(5)));
+
+        // Positive companion: the same connection with the ONE argument supplied binds the caller's own
+        // tenant and its push lands there - never in Local.
+        var wiredStore = new PushedSessionStore(() => DateTime.UtcNow);
+        var (wiredHub, wiredCtx) = NewDirectorHub("conn-wired", WiredBoundary(), wiredStore);
+        wiredHub.Hello(new DirectorStreamHello { DirectorId = "dir-own", Version = "t" });
+        Assert.False(wiredCtx.Aborted);
+        wiredHub.PushDelta(1, new SessionDto { SessionId = "sess-own" });
+        Assert.Empty(wiredStore.SnapshotFresh(TenantId.Local, TimeSpan.FromMinutes(5)));
+        Assert.Single(wiredStore.SnapshotFresh(_tenant, TimeSpan.FromMinutes(5)));
+    }
+
+    // ===== site 13: LauncherHub - Hello binds the launcher's tenant =================================
+
+    [Fact]
+    public void LauncherHub_Hello_aborts_on_hosted_when_the_boundary_was_omitted()
+    {
+        // Same shape as the DirectorHub: an unwired hosted hub used to register the launcher under Local,
+        // exposing the machine-control plane through the shared partition.
+        var registry = new LauncherConnectionRegistry();
+        var (hub, ctx) = NewLauncherHub("conn-launcher-unwired", tenantBoundary: null!, registry, deviceKey: "any-key");
+
+        hub.Hello(new LauncherStreamHello { MachineName = LocalSecretMachine, Port = 1, Version = "t" });
+
+        Assert.True(ctx.Aborted);
+        Assert.False(registry.IsStreamConnected(TenantId.Local, LocalSecretMachine));
+
+        // Positive companion: a device key BOUND to the caller's tenant registers under that tenant only.
+        var wiredDevices = new DeviceRegistry(Path.Combine(_storageRoot, "launcher-devices.json"));
+        var key = wiredDevices.Register("launcher-device", "own-machine").DeviceKey;
+        wiredDevices.SetAccountBinding("launcher-device", "sub-own", _tenant.Value);
+        var wiredRegistry = new LauncherConnectionRegistry();
+        var (wiredHub, wiredCtx) = NewLauncherHub("conn-launcher-wired",
+            new HostedTenantBoundary(new AsyncLocalTenantContext(), wiredDevices), wiredRegistry, key);
+
+        wiredHub.Hello(new LauncherStreamHello { MachineName = "own-machine", Port = 1, Version = "t" });
+
+        Assert.False(wiredCtx.Aborted);
+        Assert.True(wiredRegistry.IsStreamConnected(_tenant, "own-machine"));
+        Assert.False(wiredRegistry.IsStreamConnected(TenantId.Local, "own-machine"));
+    }
+
     // ===== the refusal itself =======================================================================
 
     /// <summary>
@@ -359,6 +616,75 @@ public sealed class OmittedTenantBoundaryFailClosedTests : IAsyncLifetime
     {
         using var resp = await http.GetAsync(path);
         return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> Post(HttpClient http, string path, string json)
+    {
+        using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        using var resp = await http.PostAsync(path, content);
+        return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// A DirectorHub over a fake caller context whose connection arrives AUTHENTICATED - the bound account
+    /// identity is stashed on the connection's HttpContext exactly as the auth middleware does on the
+    /// negotiate request - so the boundary argument is the only variable, same as the HTTP twins above.
+    /// </summary>
+    private (DirectorHub hub, FakeHubCtx ctx) NewDirectorHub(
+        string connId, HostedTenantBoundary tenantBoundary, PushedSessionStore store)
+    {
+        var http = new DefaultHttpContext();
+        http.Items[AuthMiddleware.AuthenticatedDeviceItemKey] = new DeviceCredentialIdentity(
+            "test-device", _tenant.Value, DeviceRegistry.DefaultDeviceType, DeviceRegistry.StatusActive);
+        var ctx = new FakeHubCtx(connId, http);
+        var hub = new DirectorHub(store,
+            new DirectorRegistry(Path.Combine(_storageRoot, "hub-" + connId)),
+            InputStatsHandle.Unavailable("not under test"),
+            new GatewayStreamRegistry(),
+            tenantBoundary)
+        { Context = ctx };
+        return (hub, ctx);
+    }
+
+    /// <summary>
+    /// A LauncherHub over the same fake caller context shape; the launcher resolves its tenant from the RAW
+    /// authenticated device key the auth layer stashes, so that is what the context carries.
+    /// </summary>
+    private static (LauncherHub hub, FakeHubCtx ctx) NewLauncherHub(
+        string connId, HostedTenantBoundary tenantBoundary, LauncherConnectionRegistry registry, string deviceKey)
+    {
+        var http = new DefaultHttpContext();
+        http.Items[AuthMiddleware.DeviceKeyItemKey] = deviceKey;
+        var ctx = new FakeHubCtx(connId, http);
+        var hub = new LauncherHub(registry, tenantBoundary) { Context = ctx };
+        return (hub, ctx);
+    }
+
+    /// <summary>A hub caller context that records Abort and carries an HttpContext, mirroring the shape the
+    /// SignalR transport provides (the same stand-in HostedTenancyActivationTests uses).</summary>
+    private sealed class FakeHubCtx : HubCallerContext
+    {
+        public FakeHubCtx(string connectionId, HttpContext http)
+        {
+            ConnectionId = connectionId;
+            Features.Set<Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature>(
+                new HttpContextFeatureImpl { HttpContext = http });
+        }
+
+        public override string ConnectionId { get; }
+        public override string? UserIdentifier => null;
+        public override System.Security.Claims.ClaimsPrincipal? User => null;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted => CancellationToken.None;
+
+        public bool Aborted { get; private set; }
+        public override void Abort() => Aborted = true;
+
+        private sealed class HttpContextFeatureImpl : Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature
+        {
+            public HttpContext? HttpContext { get; set; }
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
+++ b/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
@@ -1,0 +1,412 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Activity;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.History;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Prompts;
+using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening (release 2026-07-31, finding CR-7), the FAIL-OPEN case at the four remaining
+/// resolver sites and the boundary class itself: a HOSTED Gateway whose endpoints were wired with NO tenant
+/// boundary must REFUSE, never quietly serve the shared Local (self-host) partition.
+///
+/// This extends the pattern of <see cref="DictationOmittedTenantBoundaryTests"/> - the instance of this
+/// defect that was found and closed first - to every site the release review listed:
+///
+///   1. <c>GatewayEndpoints.ResolveReadTenant</c> - the shared resolver behind dozens of routes
+///      (sessions, directors, recordings, settings, wingman voice, machine relays). Probed at
+///      <c>GET /directors</c>, and the machine surface (<c>MachineEndpoints.ReqTenant</c>, which
+///      delegates here) is probed separately at <c>GET /launchers</c>.
+///   2. <c>ActivityEventEndpoints.ResolveTenant</c> - probed at <c>GET /activity-events</c>.
+///   3. <c>HistoryEndpoints.ResolveTenant</c> - probed at <c>GET /history/sessions</c>.
+///   4. <c>PromptEndpoints.ResolveTenant</c> - probed at <c>GET /prompts</c>.
+///   5. <c>HostedTenantBoundary</c> itself - a hosted process wiring a boundary that could only answer
+///      Local now THROWS at construction, and at resolution when hosted mode appeared after construction.
+///
+/// Each resolver used to answer <see cref="TenantId.Local"/> whenever its boundary argument was absent,
+/// WITHOUT asking <see cref="GatewayHostedMode.IsHosted"/> - so one forgotten optional argument silently
+/// collapsed every hosted tenant into the shared Local partition, and nothing failed loud to say so. TWO
+/// DEFENCES ship together, exactly as on the dictation endpoint. The compile-time one: the boundary
+/// parameter is REQUIRED at every Map signature, so the tests below force the miswire with <c>null!</c> -
+/// the accidental version no longer builds. The runtime one, proved here: the resolvers gate on
+/// <see cref="GatewayHostedMode.IsHosted"/> itself and answer null (a REFUSAL) for a missing or
+/// non-hosted-wired boundary on a hosted process.
+///
+/// THE MECHANICS, taken from the dictation class:
+///  - Every request is replayed against an IDENTICAL harness differing ONLY in the boundary argument. The
+///    wired twin answering 200 proves the route exists and the request is well-formed, so the 403 on the
+///    unwired twin is the guard refusing - never a missing route answered 404/405 before endpoint selection,
+///    and never a rejected request shape.
+///  - Both twins run the same stand-in for the auth layer: the request arrives AUTHENTICATED, its device
+///    identity bound to a real minted account tenant. Authentication is not the variable; the boundary is.
+///  - The refusal is asserted POSITIVELY: the concrete 403, the exact deny message, and the response's
+///    property set as an ALLOW-LIST (a substring check cannot see an extra leaked field).
+///  - Where the Local partition can cheaply hold a secret (a Director row, a launcher row, a prompt), it is
+///    seeded FIRST and the refusal body is checked to not carry it - because serving exactly that secret is
+///    what the unwired host did before the fix, and what it does again under the revert proof.
+///
+/// REVERT-PROVE: restore any resolver to <c>boundary is null ? TenantId.Local : ...</c> and its test here
+/// goes RED - the unwired host answers 200 and (where seeded) hands back the Local partition's data. Restore
+/// the <see cref="HostedTenantBoundary"/> guards to silent-Local and both boundary tests go red.
+///
+/// The assembly runs sequentially (TestParallelization), so toggling CC_GATEWAY_HOSTED and CC_DIRECTOR_ROOT
+/// here is safe; both are restored in DisposeAsync.
+/// </summary>
+public sealed class OmittedTenantBoundaryFailClosedTests : IAsyncLifetime
+{
+    /// <summary>The one message every deny path produces. Asserted exactly, so a 403 from anywhere else fails.</summary>
+    private const string DenyMessage = "no tenant is bound to this request";
+
+    private const string LocalSecretMachine = "local-partition-secret-machine";
+    private const string LocalSecretPrompt = "local-partition-secret-prompt-text";
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-omitted-boundary-" + Guid.NewGuid().ToString("N"));
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+    private TenantId _tenant;
+
+    public Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+        Directory.CreateDirectory(_storageRoot);
+
+        // A canonical lowercase minted GUID - the one tenant spelling the registry produces and the
+        // boundary's identity resolution accepts as a real account tenant.
+        _tenant = new TenantId(Guid.NewGuid().ToString("D"));
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+        return Task.CompletedTask;
+    }
+
+    // ===== site 1: GatewayEndpoints.ResolveReadTenant, probed at GET /directors =====================
+
+    [Fact]
+    public async Task DirectorsList_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // THE CONCRETE DISCLOSURE: a Director registered in the LOCAL partition - where every self-host
+        // Director lives. Before the fix the missing boundary resolved to Local and GET /directors handed
+        // this row (machine name, operating system user, process id, liveness) to any authenticated hosted
+        // caller. The wired twin gets the same Local row PLUS one in the caller's own partition, so the
+        // partition choice - not an empty registry - is what each response proves.
+        var unwiredRegistry = new DirectorRegistry(Path.Combine(_storageRoot, "directors-unwired"));
+        unwiredRegistry.RegisterFromStream("local-director", LocalSecretMachine, "local-user", "1.0", 11,
+            DateTime.UtcNow, TenantId.Local);
+
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => GatewayEndpoints.Map(app, unwiredRegistry, "test", "test-token", tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/directors");
+            AssertRefusal(status, body);
+            Assert.DoesNotContain(LocalSecretMachine, body, StringComparison.Ordinal);
+        }
+
+        // Positive companion: identical host, the ONE argument supplied. The caller's own partition is
+        // served - its own Director comes back, the Local partition's does not - so the 403 above is the
+        // guard refusing, not a route that does not exist or a registry with nothing to leak.
+        var wiredRegistry = new DirectorRegistry(Path.Combine(_storageRoot, "directors-wired"));
+        wiredRegistry.RegisterFromStream("local-director", LocalSecretMachine, "local-user", "1.0", 11,
+            DateTime.UtcNow, TenantId.Local);
+        wiredRegistry.RegisterFromStream("own-director", "own-machine", "own-user", "1.0", 12,
+            DateTime.UtcNow, _tenant);
+
+        await using var wired = await Host.StartAsync(_tenant,
+            app => GatewayEndpoints.Map(app, wiredRegistry, "test", "test-token", tenantBoundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/directors");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Contains("own-director", wiredBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(LocalSecretMachine, wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 2: MachineEndpoints.ReqTenant, probed at GET /launchers =============================
+
+    [Fact]
+    public async Task LaunchersList_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // A launcher row in the Local partition: machine name, port, process id - the machine-control
+        // surface's inventory. Registered directly on the registry (the store the route reads), so the
+        // refusal below is about the ROUTE's partition choice, not about an empty store.
+        var unwiredLaunchers = new LauncherRegistry();
+        unwiredLaunchers.Upsert(TenantId.Local, new LauncherRegistrationRequest
+        {
+            MachineName = LocalSecretMachine,
+            Port = 4321,
+            Token = "local-token",
+            Pid = 99,
+            Version = "1.0",
+        });
+
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => MachineEndpoints.Map(app, unwiredLaunchers, Spawner(), boundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/launchers");
+            AssertRefusal(status, body);
+            Assert.DoesNotContain(LocalSecretMachine, body, StringComparison.Ordinal);
+        }
+
+        // Positive companion: the wired twin's list really runs, inside the caller's own (empty) partition.
+        var wiredLaunchers = new LauncherRegistry();
+        wiredLaunchers.Upsert(TenantId.Local, new LauncherRegistrationRequest
+        {
+            MachineName = LocalSecretMachine,
+            Port = 4321,
+            Token = "local-token",
+            Pid = 99,
+            Version = "1.0",
+        });
+
+        await using var wired = await Host.StartAsync(_tenant,
+            app => MachineEndpoints.Map(app, wiredLaunchers, Spawner(), boundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/launchers");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(JsonValueKind.Array, JsonDocument.Parse(wiredBody).RootElement.ValueKind);
+        Assert.DoesNotContain(LocalSecretMachine, wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 3: ActivityEventEndpoints.ResolveTenant, probed at GET /activity-events ============
+
+    [Fact]
+    public async Task ActivityEvents_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        using var unwiredDb = new GatewayDbTestHarness();
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => ActivityEventEndpoints.Map(app, new ActivityEventStore(unwiredDb.Open()), tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/activity-events");
+            AssertRefusal(status, body);
+        }
+
+        // Positive companion: the wired twin serves the caller's own (empty) partition through the SAME
+        // ambient context the boundary enters, which is exactly the production wiring.
+        using var wiredDb = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        var store = new ActivityEventStore(wiredDb.Open(ambient));
+        await using var wired = await Host.StartAsync(_tenant,
+            app => ActivityEventEndpoints.Map(app, store, new HostedTenantBoundary(ambient, new DeviceRegistry())));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/activity-events");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(0, JsonDocument.Parse(wiredBody).RootElement.GetProperty("count").GetInt32());
+    }
+
+    // ===== site 4: HistoryEndpoints.ResolveTenant, probed at GET /history/sessions ==================
+
+    [Fact]
+    public async Task HistorySessions_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        using var unwiredDb = new GatewayDbTestHarness();
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => HistoryEndpoints.Map(app, new SessionHistoryStore(unwiredDb.Open()), tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/history/sessions");
+            AssertRefusal(status, body);
+        }
+
+        using var wiredDb = new GatewayDbTestHarness();
+        var ambient = new AsyncLocalTenantContext();
+        var store = new SessionHistoryStore(wiredDb.Open(ambient));
+        await using var wired = await Host.StartAsync(_tenant,
+            app => HistoryEndpoints.Map(app, store, new HostedTenantBoundary(ambient, new DeviceRegistry())));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/history/sessions");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(0, JsonDocument.Parse(wiredBody).RootElement.GetProperty("count").GetInt32());
+    }
+
+    // ===== site 5: PromptEndpoints.ResolveTenant, probed at GET /prompts ============================
+
+    [Fact]
+    public async Task Prompts_refuses_on_hosted_when_the_boundary_was_omitted()
+    {
+        // The seeded disclosure: a prompt with today's timestamp in the LOCAL partition - the file-backed
+        // log takes the tenant explicitly, so the Local partition is populated without any ambient scope.
+        // GET /prompts defaults to today's range, so before the fix the unwired host answered 200 carrying
+        // this record's full text.
+        var log = new GatewayPromptLog(Path.Combine(_storageRoot, "prompts"));
+        log.Append(TenantId.Local, new[]
+        {
+            new PromptRecord
+            {
+                TsUtc = DateTime.UtcNow,
+                SessionId = "local-session",
+                Role = "user",
+                TimestampFromAgent = true,
+                CharCount = LocalSecretPrompt.Length,
+                WordCount = 1,
+                Text = LocalSecretPrompt,
+            },
+        });
+        Assert.Contains(log.Read(TenantId.Local, DateTime.UtcNow.Date, DateTime.UtcNow.Date),
+            r => r.Text == LocalSecretPrompt); // the disclosure claim below is meaningless if the seed failed
+
+        await using (var unwired = await Host.StartAsync(_tenant,
+            app => PromptEndpoints.Map(app, log, tenantBoundary: null!)))
+        {
+            var (status, body) = await Get(unwired.Http, "/prompts");
+            AssertRefusal(status, body);
+            Assert.DoesNotContain(LocalSecretPrompt, body, StringComparison.Ordinal);
+        }
+
+        // Positive companion: the wired twin reads the SAME log through its own partition - served, and
+        // still not the Local partition's text.
+        await using var wired = await Host.StartAsync(_tenant,
+            app => PromptEndpoints.Map(app, log, tenantBoundary: WiredBoundary()));
+        var (wiredStatus, wiredBody) = await Get(wired.Http, "/prompts");
+        Assert.Equal(HttpStatusCode.OK, wiredStatus);
+        Assert.Equal(0, JsonDocument.Parse(wiredBody).RootElement.GetProperty("count").GetInt32());
+        Assert.DoesNotContain(LocalSecretPrompt, wiredBody, StringComparison.Ordinal);
+    }
+
+    // ===== site 6: HostedTenantBoundary itself ======================================================
+
+    [Fact]
+    public void Boundary_construction_throws_on_a_hosted_process_without_the_ambient_context()
+    {
+        // A hosted process wiring the boundary over the single-tenant context could only ever answer Local -
+        // every account collapsed into one partition. That is a wiring defect and it fails LOUD now. The
+        // positive companion is every wired harness in this class: the same construction over the
+        // AsyncLocalTenantContext, under the same hosted mode, succeeds.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new HostedTenantBoundary(new SingleTenantContext(), new DeviceRegistry()));
+        Assert.Contains("hosted", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Boundary_resolution_throws_when_hosted_mode_appeared_after_construction()
+    {
+        // The one path the constructor guard cannot see: built while the process was NOT hosted (legal -
+        // that is every self-host boundary), resolved after hosted mode turned on. Resolving Local there
+        // is the same silent collapse, so resolution refuses too.
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+        var boundary = new HostedTenantBoundary(new SingleTenantContext(), new DeviceRegistry());
+
+        // Control first, while still self-host: the same boundary resolves Local - so the throws below are
+        // the hosted flip, not a boundary that cannot resolve at all.
+        Assert.True(boundary.ResolveForDeviceKey("any-key")!.Value.IsLocal);
+
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.Throws<InvalidOperationException>(() => boundary.ResolveForDeviceKey("any-key"));
+        Assert.Throws<InvalidOperationException>(
+            () => boundary.ResolveRequestTenant(new Microsoft.AspNetCore.Http.DefaultHttpContext()));
+    }
+
+    // ===== the refusal itself =======================================================================
+
+    /// <summary>
+    /// The refusal, asserted positively: the concrete 403, the exact message only the deny paths emit, and
+    /// the response's property set as an ALLOW-LIST - a substring check for what must be absent cannot see
+    /// an extra field that leaked, and the hazard here is a body carrying another partition's data.
+    /// </summary>
+    private static void AssertRefusal(HttpStatusCode status, string body)
+    {
+        Assert.Equal(HttpStatusCode.Forbidden, status);
+        var root = JsonDocument.Parse(body).RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(DenyMessage, root.GetProperty("error").GetString());
+    }
+
+    // ===== helpers ==================================================================================
+
+    /// <summary>
+    /// A hosted-wired boundary for routes that resolve the tenant from the stashed identity and do not
+    /// enter a store scope shared with a database (directors, launchers, prompts - their stores take the
+    /// tenant explicitly). Sites whose store reads the ambient context build the boundary over that same
+    /// context instead, exactly as production does.
+    /// </summary>
+    private static HostedTenantBoundary WiredBoundary()
+        => new(new AsyncLocalTenantContext(), new DeviceRegistry());
+
+    /// <summary>A spawner whose resolver refuses to be used - GET /launchers never spawns anything.</summary>
+    private static MachineSessionSpawner Spawner()
+        => new(new UnusedResolver(), (directorId, req, ct) =>
+            Task.FromResult<(bool, SessionDto?, string?)>((false, null, "not used by this test")));
+
+    private sealed class UnusedResolver : IDirectorTargetResolver
+    {
+        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+            => throw new NotSupportedException("the launcher list route never resolves a spawn target");
+    }
+
+    private static async Task<(HttpStatusCode status, string body)> Get(HttpClient http, string path)
+    {
+        using var resp = await http.GetAsync(path);
+        return (resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// A minimal host mapping ONLY the site under test. Twin instances are built by the same code with the
+    /// same middleware and differ in EXACTLY ONE argument - the boundary - so a difference in behaviour
+    /// between them can only be that argument. The middleware is the auth layer's stand-in: every request
+    /// arrives authenticated, its device identity bound to a real minted account tenant, which is what
+    /// makes the unwired twin's 403 an authorization refusal rather than a missing login.
+    /// </summary>
+    private sealed class Host : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        public HttpClient Http { get; }
+
+        private Host(WebApplication app, HttpClient http)
+        {
+            _app = app;
+            Http = http;
+        }
+
+        internal static async Task<Host> StartAsync(TenantId tenant, Action<WebApplication> map)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+
+            app.Use(async (ctx, next) =>
+            {
+                ctx.Items[AuthMiddleware.AuthenticatedDeviceItemKey] = new DeviceCredentialIdentity(
+                    "test-device", tenant.Value, DeviceRegistry.DefaultDeviceType, DeviceRegistry.StatusActive);
+                await next();
+            });
+
+            map(app);
+            await app.StartAsync();
+            return new Host(app, new HttpClient
+            {
+                BaseAddress = new Uri(app.Urls.First()),
+                Timeout = TimeSpan.FromSeconds(30),
+            });
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Http.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PathContainmentFilesystemRootTests.cs
+++ b/src/CcDirector.Gateway.Tests/PathContainmentFilesystemRootTests.cs
@@ -1,0 +1,170 @@
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening, Phase 5b, independent inspection finding M03-I2B-04: the Phase 5a
+/// containment fix introduced a REGRESSION for a session whose working directory is a filesystem
+/// root.
+///
+/// <see cref="ControlEndpoints.ResolveSessionFile"/> trimmed the trailing separator off the root
+/// before resolving it. That is harmless for an ordinary directory and destructive for a root: on
+/// Windows <c>D:\</c> trimmed becomes <c>D:</c>, which is DRIVE-RELATIVE and resolves to that
+/// drive's current directory rather than to the drive's root; on Unix <c>/</c> trimmed becomes the
+/// empty string, which resolves to the process current directory. Either way the real-identity
+/// comparison then ran against a completely different directory, and every file under the session's
+/// actual working directory was refused.
+///
+/// The failure direction was fail-CLOSED, so nothing was disclosed - but a session with a
+/// filesystem-root working directory served its files before this branch and could not after it,
+/// and no test covered the case. These are that missing case.
+///
+/// The decisive test uses the root of the drive the TEST PROCESS runs on, because that drive is
+/// guaranteed to have a per-drive current directory that is not the root (the test host's current
+/// directory is the test binary's own folder). That is what makes the pre-fix behaviour observably
+/// wrong rather than accidentally right: on a drive whose current directory happens to BE the root,
+/// the trimmed form resolves back to the root and the defect hides.
+/// </summary>
+public sealed class PathContainmentFilesystemRootTests
+{
+    /// <summary>
+    /// The root of the filesystem the test process is running on - "D:\" on Windows, "/" on Unix.
+    /// </summary>
+    private static string ProcessDriveRoot =>
+        Path.GetPathRoot(Environment.CurrentDirectory)
+        ?? throw new InvalidOperationException("the current directory has no path root");
+
+    [Fact]
+    public void ResolveSessionFile_workingDirectoryIsAFilesystemRoot_servesAPathBeneathIt()
+    {
+        var root = ProcessDriveRoot;
+
+        // The premise this test rests on, asserted rather than assumed: the process current
+        // directory is NOT the filesystem root, so the drive-relative spelling of the root
+        // ("D:" on Windows, "" on Unix) resolves somewhere else entirely. Without this, the
+        // pre-fix code would resolve the root correctly by accident and the test would prove
+        // nothing about the defect it is named for.
+        Assert.NotEqual(
+            root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            Environment.CurrentDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+        // A path directly beneath the root and outside the current directory. It deliberately does
+        // NOT exist: ResolveSessionFile decides containment, and the caller decides existence, so
+        // creating a file at a drive root (which needs privilege the test host may not have) would
+        // add a dependency that proves nothing extra.
+        var candidate = Path.Combine(root, "ccd-fsroot-" + Guid.NewGuid().ToString("N"), "notes.txt");
+
+        var resolved = ControlEndpoints.ResolveSessionFile(root, candidate);
+
+        Assert.Equal(candidate, resolved);
+    }
+
+    [Fact]
+    public void ResolveSessionFile_workingDirectoryIsAFilesystemRoot_stillRefusesAnotherFilesystem()
+    {
+        // The fix must widen the root back to the whole filesystem it names - not to EVERYTHING.
+        //
+        // Windows has one root per volume, so a path on another volume is genuinely outside a
+        // filesystem-root working directory and must still be refused. Unix has exactly ONE root, so
+        // there is no "other filesystem" to name in a path and every absolute path really is beneath
+        // "/" - a session whose working directory is "/" is a session over the whole machine, which
+        // is what its owner asked for. Both statements are asserted; neither host silently skips.
+        var root = ProcessDriveRoot;
+        var candidate = Path.Combine(
+            OperatingSystem.IsWindows()
+                ? (string.Equals(root, @"C:\", StringComparison.OrdinalIgnoreCase) ? @"Z:\" : @"C:\")
+                : root,
+            "ccd-fsroot-" + Guid.NewGuid().ToString("N"),
+            "notes.txt");
+
+        var resolved = ControlEndpoints.ResolveSessionFile(root, candidate);
+
+        if (OperatingSystem.IsWindows())
+            Assert.Null(resolved);
+        else
+            Assert.Equal(candidate, resolved);
+    }
+
+    [Fact]
+    public void ResolveSessionFile_realFileBeneathAFilesystemRootWorkingDirectory_isServed()
+    {
+        // The same case with a file that genuinely exists on disk, so the resolution runs through
+        // real filesystem components rather than the non-existent-suffix path.
+        var temp = Path.Combine(Path.GetTempPath(), "ccd-fsroot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try
+        {
+            var file = Path.Combine(temp, "notes.txt");
+            File.WriteAllText(file, "beneath a filesystem-root working directory");
+
+            var root = Path.GetPathRoot(file)
+                       ?? throw new InvalidOperationException("the temp file has no path root");
+
+            Assert.Equal(file, ControlEndpoints.ResolveSessionFile(root, file));
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ListDirectory_allowedRootIsAFilesystemRoot_listsADirectoryBeneathIt()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), "ccd-fsroot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(temp, "child"));
+        try
+        {
+            var root = Path.GetPathRoot(temp)
+                       ?? throw new InvalidOperationException("the temp directory has no path root");
+
+            var listing = ControlEndpoints.ListDirectory(temp, new[] { root });
+
+            Assert.Equal(temp, listing.CurrentPath);
+            Assert.Contains(listing.Entries, e => e.Name == "child");
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // ---------------------------------------------------------------- the pure decisions ----
+
+    [Fact]
+    public void NormalizeDirectoryPath_keepsTheSeparatorOnAFilesystemRoot()
+    {
+        var root = ProcessDriveRoot;
+        Assert.Equal(root, ControlEndpoints.NormalizeDirectoryPath(root));
+    }
+
+    [Fact]
+    public void NormalizeDirectoryPath_trimsAnOrdinaryDirectory()
+    {
+        var withSeparator = Path.Combine(ProcessDriveRoot, "repo") + Path.DirectorySeparatorChar;
+        var expected = Path.Combine(ProcessDriveRoot, "repo");
+
+        Assert.Equal(expected, ControlEndpoints.NormalizeDirectoryPath(withSeparator));
+    }
+
+    [Fact]
+    public void ContainmentPrefix_doesNotDoubleTheSeparatorOnAFilesystemRoot()
+    {
+        var root = ProcessDriveRoot;
+
+        var prefix = ControlEndpoints.ContainmentPrefix(root);
+
+        Assert.Equal(root, prefix);
+        Assert.True(Path.Combine(root, "anything").StartsWith(prefix, StringComparison.Ordinal),
+            $"a path beneath the root must begin with the containment prefix; prefix was '{prefix}'");
+    }
+
+    [Fact]
+    public void ContainmentPrefix_addsExactlyOneSeparatorToAnOrdinaryDirectory()
+    {
+        var dir = Path.Combine(ProcessDriveRoot, "repo");
+
+        Assert.Equal(dir + Path.DirectorySeparatorChar, ControlEndpoints.ContainmentPrefix(dir));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PathContainmentHardLinkTests.cs
+++ b/src/CcDirector.Gateway.Tests/PathContainmentHardLinkTests.cs
@@ -1,0 +1,335 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening, Phase 5b, inspection finding M03-I2-01: HARD LINKS defeated the
+/// Phase 5a containment fix completely.
+///
+/// Phase 5a resolved reparse points - symbolic links and directory junctions - and reported that the
+/// containment decision was now made on "the real filesystem identity". It was not. A hard link is a
+/// second directory entry for the SAME file object; it carries ordinary file attributes and no
+/// reparse-point attribute at all. So an in-root name for an outside file resolved to itself, passed
+/// both containment comparisons, and the read served the outside file. The independent inspector
+/// executed this against the branch build and read a seeded secret through an in-root alias.
+///
+/// These tests create REAL hard links on disk - never a simulation - and prove refusal at BOTH
+/// surfaces the inspection named: the session file read and the screenshot read. Each one first
+/// proves the escape is genuine (the alias really does read the outside file's contents), so a
+/// refusal cannot be mistaken for the link having failed to be created. A host that cannot create a
+/// hard link FAILS these tests loudly with the reason; it never skips into a false green.
+///
+/// The false-positive direction is covered too: an ordinary single-named file inside the root must
+/// still be served, or the fix would have closed the boundary by deleting the feature.
+///
+/// In the "DirectorRoot" collection: the screenshot tests redirect CC_DIRECTOR_ROOT to an isolated
+/// temp root, which is process-global state.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class PathContainmentHardLinkTests : IDisposable
+{
+    private const string Secret = "hardlink-secret-only-reachable-outside-the-root";
+
+    private readonly string _base;
+    private readonly string? _prevRoot;
+    private readonly string _root;     // the allowed root (a session working directory stand-in)
+    private readonly string _outside;  // a sibling OUTSIDE the allowed root
+    private readonly string _secret;   // the outside file a hard link will alias into the root
+
+    public PathContainmentHardLinkTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _base = Path.Combine(Path.GetTempPath(), "ccd-hardlink-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _base);
+
+        _root = Path.Combine(_base, "session-repo");
+        _outside = Path.Combine(_base, "outside");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+        _secret = Path.Combine(_outside, "gateway-token.txt");
+        File.WriteAllText(_secret, Secret);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_base)) Directory.Delete(_base, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ------------------------------------------------------- real hard-link creation ----
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateHardLinkW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateHardLinkW(string newFileName, string existingFileName, IntPtr attributes);
+
+    [DllImport("libc", EntryPoint = "link", SetLastError = true)]
+    private static extern int UnixLink(string existingPath, string newPath);
+
+    /// <summary>
+    /// Create a REAL hard link at <paramref name="alias"/> naming the same file object as
+    /// <paramref name="target"/>. Needs no privilege on any supported platform, as long as both
+    /// names are on one volume - which they are here, both being under one temp directory. If the
+    /// link cannot be created the test FAILS with the reason; a security regression test that
+    /// silently skips reads as coverage it does not provide.
+    /// </summary>
+    private static void CreateHardLink(string alias, string target)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            if (!CreateHardLinkW(alias, target, IntPtr.Zero))
+            {
+                Assert.Fail($"test setup: CreateHardLink('{alias}' -> '{target}') failed with Windows error " +
+                            $"{Marshal.GetLastWin32Error()}. This test cannot run without a real hard link, " +
+                            "and must not be skipped: the defect it covers serves an outside file through an " +
+                            "in-root name.");
+            }
+        }
+        else if (UnixLink(target, alias) != 0)
+        {
+            Assert.Fail($"test setup: link('{target}' -> '{alias}') failed with errno " +
+                        $"{Marshal.GetLastWin32Error()}. This test cannot run without a real hard link, " +
+                        "and must not be skipped.");
+        }
+
+        Assert.True(File.Exists(alias), $"test setup: the hard link '{alias}' was not created");
+    }
+
+    /// <summary>
+    /// Prove the escape is REAL before asserting it is refused. Without this, a refusal could equally
+    /// well mean the link was never created, which would make the whole test a false green.
+    /// </summary>
+    private void AssertTheAliasReallyReachesTheOutsideFile(string alias)
+    {
+        Assert.Equal(Secret, File.ReadAllText(alias));
+        Assert.False(File.GetAttributes(alias).HasFlag(FileAttributes.ReparsePoint),
+            "the point of this test is that a hard link carries NO reparse-point attribute - if it does, " +
+            "the platform made a symbolic link and this test is covering the wrong mechanism");
+    }
+
+    // ----------------------------------------- ResolveSessionFile: hard links must not escape ----
+
+    [Fact]
+    public void ResolveSessionFile_hardLinkInsideTheRootNamingAnOutsideFile_isRefused()
+    {
+        var alias = Path.Combine(_root, "innocent.txt");
+        CreateHardLink(alias, _secret);
+        AssertTheAliasReallyReachesTheOutsideFile(alias);
+
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, alias));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_ordinaryFileInsideTheRoot_isStillServed()
+    {
+        // The other failure direction. Refusing every file would also refuse the hard link, and would
+        // be a boundary closed by deleting the feature rather than by containing it.
+        var ordinary = Path.Combine(_root, "notes.txt");
+        File.WriteAllText(ordinary, "an ordinary file with exactly one name");
+
+        var resolved = ControlEndpoints.ResolveSessionFile(_root, ordinary);
+
+        Assert.NotNull(resolved);
+        Assert.Equal("an ordinary file with exactly one name", File.ReadAllText(resolved!));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_hardLinkInsideTheRootNamingAnotherFileInsideTheRoot_isAlsoRefused()
+    {
+        // A hard link whose other name happens to be inside the root is still refused, and that is
+        // deliberate rather than an oversight: nothing at this decision point can enumerate a file's
+        // other names, so "the other name is also inside" is not a fact the code can establish. The
+        // honest answer to a file with two names is that its containment cannot be proven.
+        var real = Path.Combine(_root, "real.txt");
+        File.WriteAllText(real, "inside the root");
+        var alias = Path.Combine(_root, "alias.txt");
+        CreateHardLink(alias, real);
+
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, alias));
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, real));
+    }
+
+    // ------------------------------------------- ResolveScreenshot: hard links must not escape ----
+
+    private void PinScreenshotsFolder(string shotsDir)
+    {
+        Directory.CreateDirectory(shotsDir);
+        Directory.CreateDirectory(CcStorage.Config());
+        File.WriteAllText(CcStorage.ConfigJson(), JsonSerializer.Serialize(new
+        {
+            screenshots = new { source_directory = shotsDir },
+        }));
+    }
+
+    [Fact]
+    public void ResolveScreenshot_hardLinkPlantedInsideTheScreenshotsFolder_isRefused()
+    {
+        var shots = Path.Combine(_base, "shots");
+        PinScreenshotsFolder(shots);
+        var outsideImage = Path.Combine(_outside, "private.png");
+        File.WriteAllText(outsideImage, Secret);
+
+        var alias = Path.Combine(shots, "innocent.png");
+        CreateHardLink(alias, outsideImage);
+        Assert.Equal(Secret, File.ReadAllText(alias));
+
+        // Bare name, allowed extension, legal lexical prefix, no reparse point to follow - every
+        // check Phase 5a added passes, and the file is somewhere else entirely.
+        Assert.Null(ControlEndpoints.ResolveScreenshot("innocent.png"));
+    }
+
+    [Fact]
+    public void ResolveScreenshot_ordinaryImageInsideTheScreenshotsFolder_isStillServed()
+    {
+        var shots = Path.Combine(_base, "shots-ok");
+        PinScreenshotsFolder(shots);
+        var image = Path.Combine(shots, "capture.png");
+        File.WriteAllText(image, "an ordinary screenshot");
+
+        var resolved = ControlEndpoints.ResolveScreenshot("capture.png");
+
+        Assert.NotNull(resolved);
+        Assert.Equal(image, resolved);
+    }
+
+    // ------------------------------------------------------ the identity primitive itself ----
+
+    [Fact]
+    public void NameCount_ordinaryFile_isOne()
+    {
+        var file = Path.Combine(_root, "one-name.txt");
+        File.WriteAllText(file, "x");
+
+        Assert.Equal(1, FilesystemIdentity.NameCount(file));
+        Assert.True(FilesystemIdentity.HasExactlyOneName(file));
+    }
+
+    [Fact]
+    public void NameCount_hardLinkedFile_isTwo()
+    {
+        var file = Path.Combine(_root, "two-names.txt");
+        File.WriteAllText(file, "x");
+        CreateHardLink(Path.Combine(_root, "the-other-name.txt"), file);
+
+        Assert.Equal(2, FilesystemIdentity.NameCount(file));
+        Assert.False(FilesystemIdentity.HasExactlyOneName(file));
+    }
+
+    [Fact]
+    public void NameCount_fileThatDoesNotExist_isUndeterminableRatherThanOne()
+    {
+        // The contract callers depend on: "I could not tell" is null, never a confident 1.
+        Assert.Null(FilesystemIdentity.NameCount(Path.Combine(_root, "no-such-file.txt")));
+        Assert.Null(FilesystemIdentity.HasExactlyOneName(Path.Combine(_root, "no-such-file.txt")));
+    }
+
+    // -------------------------------------------------------- canonical spelling and case ----
+
+    [Fact]
+    public void CanonicalPath_foldsARequestedSpellingOntoTheRealOnDiskName()
+    {
+        // The second half of M03-I2-01. On Windows the containment comparison used to be
+        // unconditionally case-insensitive, which is wrong on a directory carrying the NTFS
+        // per-directory case-sensitive flag. The fix folds both sides onto the filesystem's own
+        // spelling and compares ordinally, so neither case rule has to be guessed at.
+        var real = Path.Combine(_root, "MixedCaseDir");
+        Directory.CreateDirectory(real);
+        File.WriteAllText(Path.Combine(real, "File.txt"), "x");
+
+        var shouted = Path.Combine(_root, "MIXEDCASEDIR", "FILE.TXT");
+        var canonical = FilesystemIdentity.CanonicalPath(shouted);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Compare the tail rather than the whole path: the canonical form of the temp directory
+            // above it is the filesystem's business, and the property under test is that the two
+            // shouted components fold back onto their real spelling.
+            Assert.NotNull(canonical);
+            Assert.EndsWith(Path.Combine("MixedCaseDir", "File.txt"), canonical!, StringComparison.Ordinal);
+        }
+        else
+        {
+            // On Unix the path is already the identity - there is no case folding to do, and the
+            // shouted spelling simply names nothing.
+            Assert.Equal(shouted, canonical);
+        }
+    }
+
+    [Fact]
+    public void ResolveSessionFile_aDifferentlyCasedSpellingOfALegalFile_isStillServedOnACaseInsensitiveHost()
+    {
+        // The fix must not refuse a legal request just because the caller shouted it. On a
+        // case-INSENSITIVE filesystem the shouted spelling folds onto the one real name and resolves;
+        // on a case-SENSITIVE one it names nothing and the caller gets an ordinary not-found.
+        var real = Path.Combine(_root, "CasedFile.txt");
+        File.WriteAllText(real, "cased-content");
+        var shouted = Path.Combine(_root, "CASEDFILE.TXT");
+
+        var resolved = ControlEndpoints.ResolveSessionFile(_root, shouted);
+
+        if (File.Exists(shouted))
+        {
+            Assert.NotNull(resolved);
+            Assert.Equal("cased-content", File.ReadAllText(resolved!));
+        }
+        else
+        {
+            // A case-sensitive host: nothing is there, and containment answers on the name alone.
+            Assert.Equal(shouted, resolved);
+        }
+    }
+
+    [Fact]
+    public void CanonicalPath_pathWhoseTailDoesNotExist_keepsTheTailAndFoldsTheRest()
+    {
+        var real = Path.Combine(_root, "RealDir");
+        Directory.CreateDirectory(real);
+
+        var canonical = FilesystemIdentity.CanonicalPath(Path.Combine(_root, "RealDir", "missing", "x.txt"));
+
+        Assert.NotNull(canonical);
+        Assert.EndsWith(Path.Combine("RealDir", "missing", "x.txt"), canonical!, StringComparison.Ordinal);
+    }
+
+    // ------------------------------------- the Unix field search, exercised on any machine ----
+
+    [Fact]
+    public void LocateCountingField_findsThePositionThatCountsOneTwoThree()
+    {
+        // The Unix half of NameCount cannot hard-code a struct offset: libc's "struct stat" differs by
+        // operating system, architecture and entry point, and a wrong offset would silently read some
+        // other field. It locates the link count empirically instead - stat, add a name, stat, add
+        // another, stat - and keeps every buffer position that counted 1, 2, 3. That search is the
+        // part that decides, so it is exercised here on synthetic buffers, on every build machine,
+        // including this Windows one where the interop around it never runs.
+        var first = new byte[64];
+        var second = new byte[64];
+        var third = new byte[64];
+        // Noise everywhere else, so a position only survives by genuinely counting.
+        for (var i = 0; i < 64; i++) { first[i] = 0xAB; second[i] = 0xCD; third[i] = 0xEF; }
+        BitConverter.GetBytes((ulong)1).CopyTo(first, 16);
+        BitConverter.GetBytes((ulong)2).CopyTo(second, 16);
+        BitConverter.GetBytes((ulong)3).CopyTo(third, 16);
+
+        var found = FilesystemIdentity.LocateCountingField(first, second, third);
+
+        Assert.Contains((16, 8), found);
+        // Every surviving position must agree with the real one - that is the property UnixNameCount
+        // relies on when it refuses on disagreement.
+        Assert.All(found, f => Assert.Equal(16, f.Offset));
+    }
+
+    [Fact]
+    public void LocateCountingField_findsNothingWhenNoPositionCounts()
+    {
+        var first = new byte[64];
+        var second = new byte[64];
+        var third = new byte[64];
+        for (var i = 0; i < 64; i++) { first[i] = 0x11; second[i] = 0x22; third[i] = 0x33; }
+
+        Assert.Empty(FilesystemIdentity.LocateCountingField(first, second, third));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PathContainmentLinkEscapeTests.cs
+++ b/src/CcDirector.Gateway.Tests/PathContainmentLinkEscapeTests.cs
@@ -1,0 +1,310 @@
+using System.Diagnostics;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening (Phase 5a, inspection finding I1-02): the file-containment decisions in
+/// <see cref="ControlEndpoints"/> used to be LEXICAL - a normalized-string prefix test - so a symbolic
+/// link or directory junction planted UNDER an allowed root kept a perfectly legal prefix while the
+/// actual read followed the link anywhere on disk (Path.GetFullPath never touches the filesystem).
+/// The comparisons were also unconditionally case-insensitive, which on a case-sensitive filesystem
+/// accepts a case-variant path as though it were inside the root.
+///
+/// These tests plant REAL links on disk - directory junctions and symbolic links, never a simulation -
+/// and prove the escape is refused at all three sites (<see cref="ControlEndpoints.ResolveSessionFile"/>,
+/// <see cref="ControlEndpoints.ListDirectory"/>, <see cref="ControlEndpoints.ResolveScreenshot"/>),
+/// prove that legal links which stay INSIDE the boundary keep working (a containment fix must not
+/// refuse the legitimate namespace), and pin the platform-correct case comparison through the pure
+/// decision function so both platform branches are testable on any one build machine.
+///
+/// A host that cannot create any real link FAILS these tests loudly instead of skipping them - a
+/// silently skipped security regression test reads as coverage it does not provide. On Windows a
+/// directory JUNCTION needs no privilege at all; a FILE symbolic link needs Developer Mode or
+/// elevation, so the file-link test says exactly that if it cannot run.
+///
+/// In the "DirectorRoot" collection: the screenshot tests redirect CC_DIRECTOR_ROOT to an isolated
+/// temp root, which is process-global state.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class PathContainmentLinkEscapeTests : IDisposable
+{
+    private readonly string _base;
+    private readonly string? _prevRoot;
+    private readonly string _root;     // the allowed root (a session working directory stand-in)
+    private readonly string _outside;  // a sibling OUTSIDE the allowed root
+    private readonly string _secret;   // an existing file outside the root (the stand-in for a token/key file)
+
+    public PathContainmentLinkEscapeTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _base = Path.Combine(Path.GetTempPath(), "ccd-linkescape-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _base);
+
+        _root = Path.Combine(_base, "session-repo");
+        _outside = Path.Combine(_base, "outside");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+        _secret = Path.Combine(_outside, "gateway-token.txt");
+        File.WriteAllText(_secret, "the-secret");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        // Directory.Delete(recursive) removes reparse points without following them, so the
+        // outside targets survive until the whole base dir goes.
+        try { if (Directory.Exists(_base)) Directory.Delete(_base, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ------------------------------------------------------------------- real-link creation ----
+
+    /// <summary>
+    /// Create a REAL directory link on disk. A symbolic link is tried first (works unprivileged on
+    /// Unix, and on Windows with Developer Mode); a Windows host without that privilege falls back
+    /// to a directory JUNCTION, which never needs elevation. If no real link can be created the
+    /// test FAILS LOUDLY - it must never silently skip into a false green.
+    /// </summary>
+    private static void CreateDirectoryLink(string link, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(link, target);
+            return;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (!OperatingSystem.IsWindows())
+                Assert.Fail($"Could not create a directory symbolic link on this Unix host ({ex.Message}). " +
+                            "This security regression test needs a REAL link and must not be skipped.");
+        }
+
+        var psi = new ProcessStartInfo("cmd.exe", $"/c mklink /J \"{link}\" \"{target}\"")
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using var p = Process.Start(psi);
+        p!.WaitForExit(15000);
+        if (!Directory.Exists(link))
+            Assert.Fail("Could not create a real directory link (symbolic link AND junction both failed). " +
+                        "This security regression test needs a REAL link and must not be skipped.");
+    }
+
+    /// <summary>
+    /// Create a REAL file symbolic link. There is no unprivileged Windows fallback for a FILE link
+    /// (junctions are directory-only), so a host without Developer Mode or elevation fails loudly
+    /// with the reason, never skips.
+    /// </summary>
+    private static void CreateFileLink(string link, string target)
+    {
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Assert.Fail($"This host cannot create a FILE symbolic link ({ex.Message}). On Windows that needs " +
+                        "Developer Mode or elevation. The link-escape regression cannot be proven without a real " +
+                        "link, so this test fails loudly instead of silently skipping into a false green.");
+        }
+    }
+
+    // ------------------------------------------------ ResolveSessionFile: links must not escape ----
+
+    [Fact]
+    public void ResolveSessionFile_linkedDirectoryUnderTheRootEscapingIt_isRefused()
+    {
+        // A directory link INSIDE the working directory pointing OUTSIDE it. The candidate path has a
+        // perfectly legal lexical prefix; only the real filesystem namespace crosses the boundary.
+        var link = Path.Combine(_root, "innocent-subdir");
+        CreateDirectoryLink(link, _outside);
+        var candidate = Path.Combine(link, "gateway-token.txt");
+        // Prove the link REALLY escapes: the filesystem read reaches the outside secret.
+        Assert.True(File.Exists(candidate), "test setup: the planted link must actually reach the outside file");
+
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, candidate));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_pathThatIsItselfALinkOutOfTheRoot_isRefused()
+    {
+        // The requested path IS the link (the leaf component), not a path through one.
+        var link = Path.Combine(_root, "leaf-link");
+        CreateDirectoryLink(link, _outside);
+
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, link));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_fileSymbolicLinkUnderTheRootEscapingIt_isRefused()
+    {
+        // The most direct form of the reported attack: a FILE symbolic link inside the working
+        // directory whose target is the secret outside it.
+        var link = Path.Combine(_root, "alias.txt");
+        CreateFileLink(link, _secret);
+        Assert.True(File.Exists(link), "test setup: the planted file link must actually reach the outside file");
+
+        Assert.Null(ControlEndpoints.ResolveSessionFile(_root, link));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_linkInsideTheRootPointingInsideTheRoot_stillResolves()
+    {
+        // The other failure direction: a containment fix must not refuse the LEGITIMATE namespace.
+        // A link that stays inside the root resolves and serves.
+        var realSub = Path.Combine(_root, "real-sub");
+        Directory.CreateDirectory(realSub);
+        var inner = Path.Combine(realSub, "inner.txt");
+        File.WriteAllText(inner, "inner-content");
+        var alias = Path.Combine(_root, "alias-sub");
+        CreateDirectoryLink(alias, realSub);
+
+        var resolved = ControlEndpoints.ResolveSessionFile(_root, Path.Combine(alias, "inner.txt"));
+
+        Assert.NotNull(resolved);
+        Assert.Equal("inner-content", File.ReadAllText(resolved!));
+    }
+
+    [Fact]
+    public void ResolveSessionFile_workingDirectoryItselfBehindALink_stillServesItsFiles()
+    {
+        // Root-side symmetry: when the session's working directory is itself reached through a link,
+        // resolving only the candidate would make every legal file look out-of-root. Both sides are
+        // resolved, so the real identities still nest.
+        var actualRoot = Path.Combine(_base, "actual-root");
+        Directory.CreateDirectory(actualRoot);
+        File.WriteAllText(Path.Combine(actualRoot, "f.txt"), "through-the-alias");
+        var rootAlias = Path.Combine(_base, "root-alias");
+        CreateDirectoryLink(rootAlias, actualRoot);
+
+        var resolved = ControlEndpoints.ResolveSessionFile(rootAlias, Path.Combine(rootAlias, "f.txt"));
+
+        Assert.NotNull(resolved);
+        Assert.Equal("through-the-alias", File.ReadAllText(resolved!));
+    }
+
+    // --------------------------------------------------- ListDirectory: links must not escape ----
+
+    [Fact]
+    public void ListDirectory_linkedDirectoryUnderTheRootEscapingIt_isRefused()
+    {
+        Directory.CreateDirectory(Path.Combine(_outside, "loot"));
+        var link = Path.Combine(_root, "browse-me");
+        CreateDirectoryLink(link, _outside);
+        Assert.True(Directory.Exists(link), "test setup: the planted link must actually reach the outside directory");
+
+        Assert.Throws<UnauthorizedAccessException>(() => ControlEndpoints.ListDirectory(link, new[] { _root }));
+    }
+
+    [Fact]
+    public void ListDirectory_linkInsideTheRootPointingInsideTheRoot_stillLists()
+    {
+        var realSub = Path.Combine(_root, "list-real");
+        Directory.CreateDirectory(Path.Combine(realSub, "child"));
+        var alias = Path.Combine(_root, "list-alias");
+        CreateDirectoryLink(alias, realSub);
+
+        var listing = ControlEndpoints.ListDirectory(alias, new[] { _root });
+
+        Assert.Contains(listing.Entries, e => e.Name == "child");
+    }
+
+    // ------------------------------------------------ ResolveScreenshot: links must not escape ----
+
+    private void PinScreenshotsFolder(string shotsDir)
+    {
+        // Same pinning pattern as ScreenshotEndpointsTests: point CcStorage.Screenshots() into the
+        // isolated temp root via config.json so nothing touches the user's real screenshots.
+        Directory.CreateDirectory(shotsDir);
+        Directory.CreateDirectory(CcStorage.Config());
+        File.WriteAllText(CcStorage.ConfigJson(), JsonSerializer.Serialize(new
+        {
+            screenshots = new { source_directory = shotsDir },
+        }));
+    }
+
+    [Fact]
+    public void ResolveScreenshot_fileLinkPlantedInsideTheScreenshotsFolder_isRefused()
+    {
+        // The one escape the bare-name gate cannot stop: a FILE symbolic link INSIDE the screenshots
+        // folder, carrying an innocent image-extension name, targeting a secret elsewhere on disk.
+        var shotsDir = Path.Combine(_base, "shots");
+        PinScreenshotsFolder(shotsDir);
+        var link = Path.Combine(shotsDir, "innocent.png");
+        CreateFileLink(link, _secret);
+        Assert.True(File.Exists(link), "test setup: the planted link must actually reach the outside file");
+
+        Assert.Null(ControlEndpoints.ResolveScreenshot("innocent.png"));
+    }
+
+    [Fact]
+    public void ResolveScreenshot_realFileInsideTheScreenshotsFolder_stillResolves()
+    {
+        var shotsDir = Path.Combine(_base, "shots-real");
+        PinScreenshotsFolder(shotsDir);
+        var real = Path.Combine(shotsDir, "real.png");
+        File.WriteAllBytes(real, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+        var resolved = ControlEndpoints.ResolveScreenshot("real.png");
+
+        Assert.NotNull(resolved);
+        Assert.True(string.Equals(Path.GetFullPath(real), resolved, ControlEndpoints.PathContainmentComparison),
+            $"expected {real}, got {resolved}");
+    }
+
+    // ------------------------------------------------------- case sensitivity is platform-correct ----
+
+    [Fact]
+    public void PathContainmentComparisonFor_windowsFileSystem_isCaseInsensitive()
+    {
+        Assert.Equal(StringComparison.OrdinalIgnoreCase, ControlEndpoints.PathContainmentComparisonFor(windowsFileSystem: true));
+    }
+
+    [Fact]
+    public void PathContainmentComparisonFor_nonWindowsFileSystem_isCaseSensitive()
+    {
+        // The I1-02 defect: both containment comparisons were unconditionally OrdinalIgnoreCase, so on
+        // a case-sensitive filesystem a path differing only by case was accepted as inside the root.
+        Assert.Equal(StringComparison.Ordinal, ControlEndpoints.PathContainmentComparisonFor(windowsFileSystem: false));
+    }
+
+    [Fact]
+    public void PathContainmentComparison_isWiredToTheHostPlatform()
+    {
+        // The pure decision above covers both branches; this pins the seam - the property the
+        // production sites actually read is fed by the real platform question.
+        Assert.Equal(
+            ControlEndpoints.PathContainmentComparisonFor(OperatingSystem.IsWindows()),
+            ControlEndpoints.PathContainmentComparison);
+    }
+
+    [Fact]
+    public void ResolveSessionFile_caseVariantOfTheRoot_followsThePlatformRule()
+    {
+        // Behavioral leg: a candidate spelled with a case-variant of the root's last segment. On a
+        // Windows host the filesystem treats it as the same directory, so it resolves; anywhere else
+        // it must be refused. (On a Windows build machine only the first branch executes - the
+        // non-Windows branch is carried by PathContainmentComparisonFor_nonWindowsFileSystem above.)
+        File.WriteAllText(Path.Combine(_root, "case-file.txt"), "case");
+        var caseVariantRoot = Path.Combine(Path.GetDirectoryName(_root)!, Path.GetFileName(_root)!.ToUpperInvariant());
+        var candidate = Path.Combine(caseVariantRoot, "case-file.txt");
+
+        var resolved = ControlEndpoints.ResolveSessionFile(_root, candidate);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.NotNull(resolved);
+            Assert.Equal("case", File.ReadAllText(resolved!));
+        }
+        else
+        {
+            Assert.Null(resolved);
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Prompts/PromptEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/Prompts/PromptEndpointsTests.cs
@@ -30,7 +30,9 @@ public sealed class PromptEndpointsTests : IAsyncLifetime
         _app = builder.Build();
         _app.Urls.Add("http://127.0.0.1:0");
 
-        PromptEndpoints.Map(_app, new GatewayPromptLog(_dir));
+        // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+        // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+        PromptEndpoints.Map(_app, new GatewayPromptLog(_dir), tenantBoundary: null);
         await _app.StartAsync();
 
         _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };

--- a/src/CcDirector.Gateway.Tests/RecordingCompletenessGateHttpTests.cs
+++ b/src/CcDirector.Gateway.Tests/RecordingCompletenessGateHttpTests.cs
@@ -108,7 +108,11 @@ public sealed class RecordingCompletenessGateHttpTests
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add(bindUrl);
-        RecordingEndpoints.Map(app);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        RecordingEndpoints.Map(app,
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
         await app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
         try

--- a/src/CcDirector.Gateway.Tests/RecordingEndpointsE2ETests.cs
+++ b/src/CcDirector.Gateway.Tests/RecordingEndpointsE2ETests.cs
@@ -45,7 +45,11 @@ public sealed class RecordingEndpointsE2ETests
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add(bindUrl);
-        RecordingEndpoints.Map(app);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        RecordingEndpoints.Map(app,
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
         await app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
 

--- a/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
@@ -120,9 +120,11 @@ public sealed class RepositoriesEndpointServeFoldTests
                 registry,
                 version: "test",
                 token: "test-token",
-                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
-                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
-                tenantBoundary: null,
+                // Self-host-only harness. The boundary is required and non-nullable now (finding I1-01), so
+                // it gets the REAL self-host boundary: built over the SingleTenantContext, it always
+                // resolves Local - behaviour identical to the null it used to state.
+                tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                    new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
                 pushedRepositories: store);
             await app.StartAsync();
             var port = BoundPort.Of(app);

--- a/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
+++ b/src/CcDirector.Gateway.Tests/RepositoriesEndpointServeFoldTests.cs
@@ -120,6 +120,9 @@ public sealed class RepositoriesEndpointServeFoldTests
                 registry,
                 version: "test",
                 token: "test-token",
+                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+                tenantBoundary: null,
                 pushedRepositories: store);
             await app.StartAsync();
             var port = BoundPort.Of(app);

--- a/src/CcDirector.Gateway.Tests/RosterServesLastKnownTests.cs
+++ b/src/CcDirector.Gateway.Tests/RosterServesLastKnownTests.cs
@@ -398,6 +398,9 @@ public sealed class RosterServesLastKnownTests
                 registry,
                 version: "test",
                 token: "test-token",
+                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
+                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
+                tenantBoundary: null,
                 owners: owners,
                 pushedSessions: store,
                 streamStaleAfter: StaleAfter,

--- a/src/CcDirector.Gateway.Tests/RosterServesLastKnownTests.cs
+++ b/src/CcDirector.Gateway.Tests/RosterServesLastKnownTests.cs
@@ -398,9 +398,11 @@ public sealed class RosterServesLastKnownTests
                 registry,
                 version: "test",
                 token: "test-token",
-                // Self-host-only harness: this host never runs hosted, so there is no boundary to pass. The
-                // parameter is required (finding CR-7), so the absence is stated rather than defaulted.
-                tenantBoundary: null,
+                // Self-host-only harness. The boundary is required and non-nullable now (finding I1-01), so
+                // it gets the REAL self-host boundary: built over the SingleTenantContext, it always
+                // resolves Local - behaviour identical to the null it used to state.
+                tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                    new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
                 owners: owners,
                 pushedSessions: store,
                 streamStaleAfter: StaleAfter,

--- a/src/CcDirector.Gateway.Tests/ShellPrefixAllowlistTests.cs
+++ b/src/CcDirector.Gateway.Tests/ShellPrefixAllowlistTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening (release 2026-07-31, the brief's item 5, second half): the shell surfaces
+/// (/mobile, the legacy /m mount, the Cockpit's /assets) used to pass the auth gate BY PREFIX in every
+/// HTTP method, so any future route mapped under those prefixes was silently public. The gate now passes
+/// them through the explicit allowlist in <c>AuthMiddleware.IsPublicShellSurfaceRequest</c>: the GET/HEAD
+/// shell and asset surfaces, and the two exact enrollment POSTs. Everything else under the prefixes is
+/// credential-gated by default.
+///
+/// This class proves the GATED half - the requests that used to sail through by prefix and now meet the
+/// credential gate - and that the gate is what changed (the same request WITH a credential reaches
+/// routing and gets routing's own answer). The PUBLIC half - the shell loading, the 301 mount, both
+/// enrollment POSTs reaching their endpoint - is already pinned by <see cref="MobileAuthServingTests"/>
+/// and <see cref="CockpitAuthServingTests"/>, which are the other-direction controls for the revert
+/// proof: they must stay green under BOTH gate shapes.
+///
+/// REVERT-PROVE: restore the pre-fix prefix opens in AuthMiddleware.Run (everything under /mobile, /m,
+/// /assets passing in every method) and every gated-half test here goes RED - the anonymous request gets
+/// routing's 404 instead of the gate's 401 - while the public-half suites stay green (the prefix opens
+/// served a strict superset of the allowlist).
+/// </summary>
+public sealed class ShellPrefixAllowlistTests : IAsyncLifetime
+{
+    private const string Token = "test-token-allowlist";
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-allowlist-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        _http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+        };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    [Theory]
+    // A non-GET request to a route nobody has written under each shell prefix: under the old prefix
+    // opens these passed the gate anonymously and got routing's 404; now the gate itself answers 401.
+    [InlineData("POST", "/mobile/api/future-route")]
+    [InlineData("PUT", "/mobile/settings")]
+    [InlineData("DELETE", "/m/anything")]
+    [InlineData("POST", "/m/api/future-route")]
+    [InlineData("PUT", "/assets/index-abc123.js")]
+    [InlineData("POST", "/assets/upload")]
+    // The enrollment allowlist is EXACT paths: a sibling path next to the real mint seam is not public.
+    [InlineData("POST", "/mobile/enroll/extra")]
+    [InlineData("POST", "/m/enroll/extra")]
+    public async Task A_non_allowlisted_request_under_a_shell_prefix_requires_a_credential(string method, string path)
+    {
+        using var req = new HttpRequestMessage(new HttpMethod(method), path);
+        if (method is "POST" or "PUT")
+            req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        using var res = await _http.SendAsync(req);
+        var body = await res.Content.ReadAsStringAsync();
+
+        // The GATE's own refusal: 401 with the JSON body for a non-browser caller - never routing's 404
+        // (which is what the prefix opens produced) and never a serve.
+        Assert.True(HttpStatusCode.Unauthorized == res.StatusCode,
+            $"{method} {path}: expected the credential gate's 401 but got {(int)res.StatusCode}; body was: {body}");
+        Assert.Equal("application/json", res.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task The_same_non_allowlisted_request_with_a_credential_reaches_routing()
+    {
+        // The discriminator that makes the 401s above the GATE refusing, not a route that never existed:
+        // the identical request WITH the machine token passes the gate and gets routing's own answer for
+        // a route nobody has written - 404/405, and specifically NOT the gate's 401.
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/mobile/api/future-route");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        using var res = await _http.SendAsync(req);
+        Assert.NotEqual(HttpStatusCode.Unauthorized, res.StatusCode);
+        Assert.True(res.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed,
+            $"expected routing's own 404/405 for an unmapped route, got {(int)res.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Head_requests_on_the_shell_surfaces_stay_public()
+    {
+        // HEAD rides the GET allowlist arm (a browser or service worker may probe the shell). Not gated:
+        // whatever the shell handler answers, it is never the gate's 401 and never a sign-in redirect.
+        foreach (var path in new[] { "/mobile", "/mobile/signin", "/m", "/assets/index-abc123.js" })
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Head, path);
+            using var res = await _http.SendAsync(req);
+            Assert.True(res.StatusCode != HttpStatusCode.Unauthorized
+                        && res.StatusCode != HttpStatusCode.Redirect
+                        && res.StatusCode != HttpStatusCode.Found,
+                $"HEAD {path} must not be auth-gated; got {(int)res.StatusCode}");
+        }
+    }
+
+    [Fact]
+    public async Task A_get_client_route_under_mobile_stays_public()
+    {
+        // The GET surface under /mobile IS the phone app (client routes are arbitrary and a signed-in
+        // phone's navigations carry no credential either), so an anonymous deep-link GET is never gated.
+        // 200 (shell served) or 404 (mobile app not staged into this build) both prove the gate passed it;
+        // 401 or a redirect to sign-in would be the break the allowlist must not introduce.
+        using var res = await _http.GetAsync("/mobile/sessions/some-session");
+        Assert.True(res.StatusCode is HttpStatusCode.OK or HttpStatusCode.NotFound,
+            $"an anonymous GET client route under /mobile must be served or absent, never gated; got {(int)res.StatusCode}");
+    }
+}
+
+/// <summary>
+/// The completeness guard for the shell-prefix allowlist: the allowlist in
+/// <c>AuthMiddleware.IsPublicShellSurfaceRequest</c> is complete ONLY while the endpoints mapped under
+/// /mobile, /m and /assets are exactly the set it was written against. This pins that set from the real
+/// host's finalised route table (<see cref="GatewayHost.MappedEndpoints"/>), so mapping a NEW route under
+/// a shell prefix fails this test until the route is consciously ruled - added to the allowlist if it
+/// must be public, or left credential-gated and admitted here.
+/// </summary>
+public sealed class ShellPrefixRouteSurfaceGuardTests : IAsyncLifetime
+{
+    private GatewayHost _gateway = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-routeguard-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "guard-token", authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    [Fact]
+    public void The_shell_prefixes_carry_exactly_the_endpoints_the_allowlist_was_written_against()
+    {
+        var underShellPrefixes = _gateway.MappedEndpoints
+            .OfType<RouteEndpoint>()
+            .Select(e => new
+            {
+                Pattern = e.RoutePattern.RawText ?? "",
+                Methods = e.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? Array.Empty<string>(),
+            })
+            .Where(e => IsUnderShellPrefix(e.Pattern))
+            .SelectMany(e => e.Methods.DefaultIfEmpty("ANY"), (e, m) => $"{m} {Normalize(e.Pattern)}")
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToArray();
+
+        // THE RULED SET. Every row here has a written verdict in the allowlist's doc comment:
+        //   - the four GET shell/redirect routes are public via the GET/HEAD arm;
+        //   - the two enrollment POSTs are public via the exact-path arm;
+        // and NOTHING serves under /assets as an endpoint (the Cockpit assets are static-file middleware,
+        // which is why the /assets arm of the allowlist has no endpoint rows to pin).
+        //
+        // If this assertion fails, a route was added under a shell prefix. That is not automatically a
+        // defect - but it IS a ruling nobody has made yet. Decide whether the new route is public
+        // (add it to AuthMiddleware.IsPublicShellSurfaceRequest with a written reason) or credential-gated
+        // (the default), and only then admit it to this list.
+        Assert.Equal(new[]
+        {
+            "GET /m",
+            "GET /m/{*path}",
+            "GET /mobile",
+            "GET /mobile/{*path}",
+            "POST /m/enroll",
+            "POST /mobile/enroll",
+        }, underShellPrefixes);
+    }
+
+    private static bool IsUnderShellPrefix(string pattern)
+    {
+        var p = "/" + pattern.TrimStart('/');
+        return p.Equals("/mobile", StringComparison.OrdinalIgnoreCase)
+               || p.StartsWith("/mobile/", StringComparison.OrdinalIgnoreCase)
+               || p.Equals("/m", StringComparison.OrdinalIgnoreCase)
+               || p.StartsWith("/m/", StringComparison.OrdinalIgnoreCase)
+               || p.Equals("/assets", StringComparison.OrdinalIgnoreCase)
+               || p.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string pattern) => "/" + pattern.TrimStart('/');
+}

--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -58,7 +58,11 @@ public sealed class StatsPageEndpointTests : IDisposable
             app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
         }
 
-        StatsPageEndpoint.Map(app, agg);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        StatsPageEndpoint.Map(app, agg,
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
         await app.StartAsync();
         var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
         return (app, http);

--- a/src/CcDirector.Gateway.Tests/StatsSessionOriginFeedTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsSessionOriginFeedTests.cs
@@ -46,7 +46,12 @@ public sealed class StatsSessionOriginFeedTests : IDisposable
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add("http://127.0.0.1:0");
-        StatsPageEndpoint.Map(app, new GatewayInputStatsAggregator(), sessionHistory: history);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        StatsPageEndpoint.Map(app, new GatewayInputStatsAggregator(),
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            sessionHistory: history);
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });
     }

--- a/src/CcDirector.Gateway.Tests/SuggestionEmailBlockEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/SuggestionEmailBlockEndpointTests.cs
@@ -61,7 +61,12 @@ public sealed class SuggestionEmailBlockEndpointTests : IDisposable
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add(bindUrl);
-        RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
+        // The boundary is required and non-nullable now (finding I1-01). This is a self-host harness, so it
+        // gets the REAL self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        RecordingEndpoints.Map(app,
+            tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            keyVault: null, history: null, audioArchive: null,
             suggestions: suggestions, dismissals: dismissals, emailComposer: composer);
         await app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";
@@ -138,7 +143,11 @@ public sealed class SuggestionEmailBlockEndpointTests : IDisposable
         builder.Logging.ClearProviders();
         var app = builder.Build();
         app.Urls.Add(bindUrl);
-        RecordingEndpoints.Map(app, tenantBoundary: null, keyVault: null, history: null, audioArchive: null,
+        // Real self-host boundary, same reasoning as the harness above (finding I1-01).
+        RecordingEndpoints.Map(app,
+            tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            keyVault: null, history: null, audioArchive: null,
             suggestions: suggestions, dismissals: dismissals, emailComposer: composer);
         await app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(app)}";

--- a/src/CcDirector.Gateway.Tests/TranscriptionBatchEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionBatchEndpointTests.cs
@@ -51,7 +51,11 @@ public sealed class TranscriptionBatchEndpointTests : IAsyncLifetime
         builder.Logging.ClearProviders();
         _app = builder.Build();
         _app.Urls.Add(bindUrl);
-        TranscriptionBatchEndpoint.Map(_app, new KeyVault(_vaultPath));
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        TranscriptionBatchEndpoint.Map(_app, new KeyVault(_vaultPath),
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
         await _app.StartAsync();
         var baseUrl = $"http://127.0.0.1:{BoundPort.Of(_app)}";
 

--- a/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
@@ -180,6 +180,17 @@ public sealed class TunnelMechanismProofTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task ReadFile_outsideTheSessionWorkingDirectory_is400_overTheTunnel()
+    {
+        // Tenant-boundary hardening (CR-4): the session's working directory is the temp root, so a path that
+        // resolves to its PARENT is outside the allowed root and must be refused end to end over the tunnel.
+        var outside = Path.Combine(Path.GetTempPath(), "..", "cc-outside-" + Guid.NewGuid().ToString("N") + ".txt");
+        var resp = await _http.GetAsync($"sessions/{_sid}/file?path={Uri.EscapeDataString(outside)}");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("outside the session's working directory", await resp.Content.ReadAsStringAsync());
+    }
+
     // ---------------------------------------------------------- real up-stream producers over the wire ----
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceQualityEndpointTests.cs
@@ -47,7 +47,12 @@ public sealed class VoiceQualityEndpointTests : IDisposable
         app.Urls.Add("http://127.0.0.1:0");
 
         var log = new MicrophoneQualityLog(Path.Combine(_root, "quality"));
-        VoiceQualityEndpoint.Map(app, tenantBoundary: null, logOverride: log);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        VoiceQualityEndpoint.Map(app,
+            tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            logOverride: log);
 
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, log);

--- a/src/CcDirector.Gateway.Tests/VoiceTestEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceTestEndpointTests.cs
@@ -54,7 +54,12 @@ public sealed class VoiceTestEndpointTests : IDisposable
 
         var vault = new KeyVault(Path.Combine(_root, "test.vault"));
         var store = new VoiceTestClipStore(Path.Combine(_root, "clips"));
-        VoiceTestEndpoint.Map(app, new GatewayTranscriptionService(vault), tenantBoundary: null, storeOverride: store);
+        // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+        // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+        VoiceTestEndpoint.Map(app, new GatewayTranscriptionService(vault),
+            tenantBoundary: new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
+            storeOverride: store);
 
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, store);

--- a/src/CcDirector.Gateway.Tests/VoiceUploadLimitsTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadLimitsTests.cs
@@ -72,7 +72,11 @@ public sealed class VoiceUploadLimitsTests : IDisposable
             (_, _, _) => throw new InvalidOperationException("the brain must not be reached by an upload-size test"),
             vault,
             voice,
-            tenantSettings);
+            tenantSettings,
+            // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+            // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()));
 
         await app.StartAsync();
         return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });

--- a/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
@@ -81,6 +81,10 @@ public sealed class WingmanTtsStatusPassthroughTests
             vault,
             voice,
             tenantSettings,
+            // The boundary is required and non-nullable now (finding I1-01). Self-host harness, so the REAL
+            // self-host boundary: built over the SingleTenantContext, it always resolves Local.
+            new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+                new CcDirector.Core.Tenancy.SingleTenantContext(), new CcDirector.Gateway.Pairing.DeviceRegistry()),
             ttsHttpClient: new HttpClient(upstream) { Timeout = Timeout.InfiniteTimeSpan },
             // The stall test proves a never-answering upstream becomes 504 rather than 502. What is under
             // test is WHICH status comes back, not how long the Gateway is willing to wait - so the deadline

--- a/src/CcDirector.Gateway/Activity/ActivityEventEndpoints.cs
+++ b/src/CcDirector.Gateway/Activity/ActivityEventEndpoints.cs
@@ -24,7 +24,10 @@ namespace CcDirector.Gateway.Activity;
 public static class ActivityEventEndpoints
 {
     public static void Map(IEndpointRouteBuilder app, ActivityEventStore store,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // REQUIRED, not defaulted (tenant-boundary hardening, release 2026-07-31, finding CR-7): the boundary
+        // is a security argument, and when it was optional a forgotten argument silently served the Local
+        // partition on hosted. A self-host-only caller must state the absence with an explicit null.
+        Tenancy.HostedTenantBoundary? tenantBoundary)
     {
         ArgumentNullException.ThrowIfNull(store);
 
@@ -77,10 +80,19 @@ public static class ActivityEventEndpoints
 
     /// <summary>
     /// Resolve the request's tenant from the AUTHENTICATED device key the auth middleware stashed - the same
-    /// seam the prompt log uses. Null means DENY on hosted; self-host, or no boundary (tests), is Local.
+    /// seam the prompt log uses. Null means DENY. Gated on <see cref="GatewayHostedMode.IsHosted"/> ITSELF,
+    /// never on whether a boundary was passed in (finding CR-7): deciding on the argument fails open, so on
+    /// hosted a missing or non-hosted-wired boundary resolves null - a refusal, never Local. Self-host is
+    /// Local exactly as before.
     /// </summary>
     private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
-        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+    {
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
 
     /// <summary>
     /// Enter the resolved tenant's ambient scope for the store call: the store reaches the database through

--- a/src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs
@@ -56,7 +56,9 @@ internal static class AccountCreditsEndpoint
     /// </param>
     /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
     public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountCreditsClient credits,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, Tenancy.TenantRegistry? tenants = null)
     {
         if (credits is null) throw new ArgumentNullException(nameof(credits));
 

--- a/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
@@ -71,7 +71,9 @@ internal static class AccountDevicesEndpoint
     /// the hosted path FAILS CLOSED with a 503. Ignored off hosted mode.
     /// </param>
     public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, DeviceRegistryClient devices, string thisDeviceName,
-        Pairing.DeviceRegistry localDevices, Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Pairing.DeviceRegistry localDevices, Tenancy.HostedTenantBoundary tenantBoundary)
     {
         if (devices is null) throw new ArgumentNullException(nameof(devices));
         if (thisDeviceName is null) throw new ArgumentNullException(nameof(thisDeviceName));

--- a/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
@@ -60,7 +60,9 @@ internal static class AccountEmailEndpoint
     /// - never a fabricated success and never a fabricated sign-out.
     /// </param>
     public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNotifyClient notify,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null,
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, Tenancy.TenantRegistry? tenants = null,
         AccountNotifyByTenantClient? byTenant = null)
     {
         if (notify is null) throw new ArgumentNullException(nameof(notify));

--- a/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
@@ -56,8 +56,12 @@ internal static class AccountLogoutEndpoint
     /// Gateway does NOT fall back to the self-host answer - the hosted path fails closed. Ignored off hosted.
     /// </param>
     /// <param name="tenants">The tenant registry, read on hosted for the caller's display email.</param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, Func<CancellationToken, Task>? onBeforeLogout = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account,
+        // REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional hook so it cannot sit
+        // in a defaulted tail: a forgotten boundary must be a compile error, never a silent default.
+        // Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, Func<CancellationToken, Task>? onBeforeLogout = null,
+        Tenancy.TenantRegistry? tenants = null)
     {
         app.MapPost("/account/logout", async (HttpContext ctx) =>
         {

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -70,8 +70,12 @@ internal static class AccountStatusEndpoint
     /// Null disables that lookup, which yields a signed-in answer with the identity absent - never a
     /// signed-out one.
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNicknameClient? nickname = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Tenancy.TenantRegistry? tenants = null)
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account,
+        // REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional nickname client so it
+        // cannot sit in a defaulted tail: a forgotten boundary must be a compile error, never a silent
+        // default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, AccountNicknameClient? nickname = null,
+        Tenancy.TenantRegistry? tenants = null)
     {
         // Per-account nickname cache so this hard-polled endpoint hits the cloud at most once per TTL.
         // Captured in the closure (Map runs once per host) and guarded by its own lock.

--- a/src/CcDirector.Gateway/Api/CommQueueEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/CommQueueEndpoints.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using CcDirector.Core.Communications.Services;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Tenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -21,14 +22,85 @@ namespace CcDirector.Gateway.Api;
 /// moving the live data come in later steps. The underlying store is the existing
 /// SQLite at config/comm-queue/communications.db; SQLite tolerates concurrent readers,
 /// so the desktop Comm Manager keeps working while this serves reads.
+///
+/// DENIED IN WHOLE ON HOSTED (CR-6). The store behind this surface is ONE process-global
+/// SQLite file at the shared storage root. It carries no tenant anywhere: not in the file,
+/// not in the store, not in the route. The route sits behind only the host-wide
+/// authentication gate, and that gate admits ANY enrolled device key from ANY account - so
+/// on shared hosted infrastructure every subscriber could read the operator's outbound
+/// communications queue: draft emails, posts, recipients, personas. The Communication
+/// Manager app this surface backed was retired 2026-07-06 and the comm queue is not part
+/// of the hosted launch, so there is no per-tenant answer to serve and the whole family is
+/// refused rather than partitioned.
+///
+/// The deny is expressed through <see cref="HostedRouteDeny.ExclusiveGroup"/>, the ONE
+/// hosted-refusal boundary every deny family on this Gateway adopts (the same primitive
+/// /vault/keys and /shutdown use). On hosted the handler is NEVER MAPPED: the exclusive
+/// prefix maps one verb-less catch-all refusal over everything under /comm-queue plus a
+/// root refusal at the prefix itself, so every request shape - a valid request, a wrong
+/// verb, a malformed body, and a route added under the prefix LATER - meets the refusal.
+/// The exclusivity claim is CHECKED at startup by HostedRefusalRouteSpace. Off hosted the
+/// real handler maps byte-identically to before, which is the self-host control.
 /// </summary>
 internal static class CommQueueEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app)
+    /// <summary>The prefix this family owns outright; the exclusive catch-all claims everything under it.</summary>
+    internal const string Prefix = "/comm-queue";
+
+    /// <summary>The exact refusal string served on hosted, shared with the tests so they assert what is served.</summary>
+    internal const string RefusalMessage = "the comm queue is not available on the hosted Gateway";
+
+    /// <summary>
+    /// This family's refusal payload. Validated on construction, so a malformed payload fails the
+    /// Gateway at startup rather than serving a refusal a caller cannot act on. 404 rather than 403:
+    /// on hosted there is no per-tenant comm queue, so this surface does not exist as a concept and
+    /// "not here" is the truthful answer; 403 would imply some credential could reach it, and none can.
+    /// </summary>
+    private static HostedDenial Denial() => new(
+        family: "comm-queue",
+        message: RefusalMessage,
+        reason: "the comm queue is one process-global SQLite store with no tenant in the file, the store or " +
+                "the route, and the host-wide auth gate admits any enrolled device key from any account - so " +
+                "one subscriber could read the operator's outbound communications drafts, recipients and " +
+                "personas; the Communication Manager app it backed was retired 2026-07-06 and the queue is " +
+                "not part of the hosted launch",
+        unDenyInstruction: "do NOT simply remove this deny: the queue store is still process-global and data " +
+                "may have kept accumulating behind the refusal. If the comm queue is ever revived for hosted, " +
+                "first migrate it to a tenant-scoped store the way every sibling concept (work lists, " +
+                "workflows, cron, mission notes) already is, then purge or attribute whatever accumulated in " +
+                "the global SQLite file, and only then restore a tenant-scoped route",
+        statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>
+    /// Maps the comm-queue route and RETURNS the denied group it was mapped through.
+    ///
+    /// The route is mapped through the group HANDLE (<see cref="HostedDenyGroup"/>), never through the
+    /// ungrouped builder: the handle is obtainable only from <see cref="HostedRouteDeny.ExclusiveGroup"/>,
+    /// and <see cref="MapRoutes"/> takes only the handle, so a route mapped around the refusal is not
+    /// expressible there without changing this method's plumbing. The return value exists so the
+    /// future-route property is statable from outside this file: a test can map a brand-new route through
+    /// the returned handle and show the refusal already covers routes nobody has written yet.
+    /// </summary>
+    public static HostedDenyGroup Map(IEndpointRouteBuilder outer)
+    {
+        FileLog.Write($"[CommQueueEndpoints] mapping {Prefix}; hosted={GatewayHostedMode.IsHosted} - on hosted the whole group is refused via the shared refusal primitive");
+
+        var group = HostedRouteDeny.ExclusiveGroup(outer, Prefix, Denial());
+        MapRoutes(group);
+        return group;
+    }
+
+    /// <summary>
+    /// The comm-queue read route, mapped relative to the <see cref="Prefix"/> so the full path is
+    /// <c>/comm-queue</c> exactly as before. Takes the denied GROUP HANDLE and nothing else: the
+    /// ungrouped route builder is deliberately out of scope here so no route can be mapped around the
+    /// hosted refusal.
+    /// </summary>
+    private static void MapRoutes(HostedDenyGroup app)
     {
         // GET /comm-queue?status=pending_review
         //   status defaults to pending_review; "all" returns every status.
-        app.MapGet("/comm-queue", async (string? status) =>
+        app.MapGet("", async (string? status) =>
         {
             var filter = string.IsNullOrWhiteSpace(status) ? "pending_review" : status.Trim();
             FileLog.Write($"[CommQueueEndpoints] GET /comm-queue: status={filter}");

--- a/src/CcDirector.Gateway/Api/DeviceEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DeviceEnrollmentEndpoint.cs
@@ -25,9 +25,10 @@ internal static class DeviceEnrollmentEndpoint
 {
     public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices,
         // MTR-12: the auth-boundary tenant binder. The listing is scoped to the REQUEST's own tenant, resolved
-        // from the AUTHENTICATED per-device key the auth middleware stashed (never from client input). Null
-        // (self-host, tests) is the single Local tenant, so its own devices list exactly as before.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // from the AUTHENTICATED per-device key the auth middleware stashed (never from client input).
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary)
     {
         if (devices is null) throw new ArgumentNullException(nameof(devices));
 
@@ -37,7 +38,10 @@ internal static class DeviceEnrollmentEndpoint
             // full multi-tenant device inventory (every id / machine name / issued time across every tenant). On
             // self-host every caller is the single Local tenant (unchanged behaviour); on hosted a request with no
             // bound tenant is DENIED (403) - never a fall-back to Local, and never another tenant's devices.
-            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            // Resolved through the gated shared resolver (finding I1-01): deciding on the argument
+            // (`tenantBoundary is null ? TenantId.Local : ...`) fails OPEN - a hosted process handed a null
+            // boundary would answer the shared Local partition's full device inventory.
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (tenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -391,6 +391,9 @@ internal static class GatewayEndpoints
 
         // Read-only view of the Communication Manager approval queue (see the phone's
         // pending drafts remotely). Step 1 of centralizing the comm queue on the Gateway.
+        // HOSTED DENY (CR-6): the queue is one process-global SQLite with no tenant anywhere, so on
+        // hosted the whole /comm-queue family is refused through the shared refusal primitive
+        // (HostedRouteDeny.ExclusiveGroup, inside CommQueueEndpoints.Map); self-host is untouched.
         CommQueueEndpoints.Map(app);
 
         // Local-machine exe/slot management (the "Exes" page). Defect 6: it gets the snooze registry so its

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -49,7 +49,15 @@ internal static class GatewayEndpoints
     /// <param name="turnJobs">Issue #376: the async voice-turn job store (singleton owned by
     /// <see cref="GatewayHost"/>). When present, the submit/poll routes are mapped via
     /// <see cref="GatewayVoiceTurnEndpoint"/>; null (old callers) maps nothing.</param>
-    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, string version, string token, bool authEnabled = false, Func<bool>? requestShutdown = null,
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, string version, string token,
+        // Hosted Multi-Tenancy (session-serving PR1): the auth-boundary tenant binder. On the hosted Gateway
+        // the request-scoped reads resolve the caller's tenant from its authenticated device key and DENY
+        // (403) when it has none - never falling back to Local. REQUIRED, not defaulted (tenant-boundary
+        // hardening, release 2026-07-31, finding CR-7): the boundary is a security argument, and when it was
+        // optional one forgotten argument silently collapsed every hosted tenant into the Local partition.
+        // A caller that genuinely has none (a self-host-only test host) must SAY so with an explicit null.
+        Tenancy.HostedTenantBoundary? tenantBoundary,
+        bool authEnabled = false, Func<bool>? requestShutdown = null,
         Action<string, string, string>? onSessionState = null,
         Func<TenantId, string, bool>? voiceGeneratingFor = null,
         Func<TenantId, string, bool>? voiceAudioReadyFor = null,
@@ -125,11 +133,6 @@ internal static class GatewayEndpoints
         // (old callers, tests) leaves the endpoint to record the registry only, and the periodic sweep
         // reconciles the desktop.
         Fleet.FleetDisplayStateObserver? fleetDisplayState = null,
-        // Hosted Multi-Tenancy (session-serving PR1): the auth-boundary tenant binder. When non-null on the
-        // hosted Gateway, the request-scoped session reads (/sessions, /sessions/{sid}) resolve the caller's
-        // tenant from its authenticated device key and DENY (403) when it has none - never falling back to
-        // Local. Null (self-host, older callers, tests) keeps the single-tenant Local behavior.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
         // Production-readiness B2 (process-control): the seam the DELETE /directors/{id} FORCE-KILL branch
         // calls to kill a Director's process tree by pid. Null (production) uses the real
         // Process.GetProcessById(pid).Kill(entireProcessTree:true). A test injects a recorder that observes
@@ -3367,10 +3370,26 @@ internal static class GatewayEndpoints
     /// Resolve a request's tenant for a session READ (Hosted Multi-Tenancy, session-serving PR1). Null means
     /// the caller must be DENIED (403): on the hosted Gateway an authenticated request whose device key has no
     /// bound tenant is refused, NEVER served the Local partition (which would be a wrong-tenant read waiting to
-    /// happen). Self-host, or no boundary (older callers / tests), is always Local - behavior unchanged.
+    /// happen). Self-host is always Local - behavior unchanged.
+    ///
+    /// GATED ON <see cref="GatewayHostedMode.IsHosted"/> ITSELF, never on whether a boundary was passed in
+    /// (tenant-boundary hardening, release 2026-07-31, finding CR-7 - the same shape
+    /// <c>GatewayDictationEndpoint.ResolveTenant</c> already carries). Deciding on the argument fails OPEN:
+    /// the boundary is a SECURITY argument, and this resolver used to answer <see cref="TenantId.Local"/>
+    /// whenever it was absent, so ONE forgotten argument at any of the dozens of call sites that thread it
+    /// silently collapsed every hosted tenant into the Local partition - with nothing failing loud to say so.
+    /// On hosted, a missing boundary and a boundary that is not hosted-wired both resolve to null, and null
+    /// is a REFUSAL. The second defence is that the boundary parameter is REQUIRED at every Map signature
+    /// that threads it here, so omitting it is a compile error rather than a runtime downgrade.
     /// </summary>
     internal static TenantId? ResolveReadTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
-        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+    {
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
 
     /// <summary>
     /// MTR-01 (Codex round 1): the answer for the legacy same-machine HTTP discovery plane (register /

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -52,11 +52,13 @@ internal static class GatewayEndpoints
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, string version, string token,
         // Hosted Multi-Tenancy (session-serving PR1): the auth-boundary tenant binder. On the hosted Gateway
         // the request-scoped reads resolve the caller's tenant from its authenticated device key and DENY
-        // (403) when it has none - never falling back to Local. REQUIRED, not defaulted (tenant-boundary
-        // hardening, release 2026-07-31, finding CR-7): the boundary is a security argument, and when it was
-        // optional one forgotten argument silently collapsed every hosted tenant into the Local partition.
-        // A caller that genuinely has none (a self-host-only test host) must SAY so with an explicit null.
-        Tenancy.HostedTenantBoundary? tenantBoundary,
+        // (403) when it has none - never falling back to Local. REQUIRED AND NON-NULLABLE (tenant-boundary
+        // hardening, release 2026-07-31, findings CR-7 and I1-01): the boundary is a security argument, and
+        // when it was optional one forgotten argument silently collapsed every hosted tenant into the Local
+        // partition. Under nullable-warnings-as-errors, passing a possibly-null value here is a compile
+        // error too. A self-host process constructs the boundary over the SingleTenantContext, which always
+        // resolves Local - so there is no legitimate caller with nothing to pass.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         bool authEnabled = false, Func<bool>? requestShutdown = null,
         Action<string, string, string>? onSessionState = null,
         Func<TenantId, string, bool>? voiceGeneratingFor = null,

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -435,7 +435,10 @@ internal static class GatewayEndpoints
             //
             // Self-host is untouched: one tenant, one owner, and the counts are what the Director's own
             // connectivity self-test and the settings gateway probe read.
-            if (tenantBoundary?.IsHosted == true)
+            //
+            // Gated on the PROCESS-level hosted flag, never on the nullable boundary argument: a caller
+            // passing a literal null! boundary on a hosted process must not reopen the aggregate.
+            if (GatewayHostedMode.IsHosted)
             {
                 // Directors/Sessions left NULL, which OMITS them from the JSON (HealthDto). Leaving them to
                 // serialize as 0 would state a fleet of zero to every probe on hosted - false rather than
@@ -694,8 +697,10 @@ internal static class GatewayEndpoints
             // tenant. Left open on hosted, POST /directors/register is exactly the Local-shadow path: a hosted
             // caller could fabricate a Local registration for an arbitrary director id and then read that id's
             // Local event ring. Make the whole plane explicitly UNAVAILABLE on hosted (403) so the shadow can
-            // never be created; self-host is unchanged.
-            if (tenantBoundary?.IsHosted == true)
+            // never be created; self-host is unchanged. Gated on the PROCESS-level hosted flag, never on
+            // the nullable boundary argument, so a null! boundary on a hosted process cannot reopen the
+            // plane (the same discipline as HostedRouteDeny).
+            if (GatewayHostedMode.IsHosted)
                 return LegacyDiscoveryPlaneUnavailable();
             if (req is null || string.IsNullOrEmpty(req.DirectorId))
                 return Results.BadRequest(new { error = "directorId is required" });
@@ -714,8 +719,9 @@ internal static class GatewayEndpoints
         {
             // MTR-01 (Codex round 1): part of the legacy same-machine discovery plane - unavailable on hosted
             // (see /directors/register). This also replaces the pre-fix 410 that an unbound hosted request got
-            // here with the correct 403 for a plane that does not serve hosted accounts.
-            if (tenantBoundary?.IsHosted == true)
+            // here with the correct 403 for a plane that does not serve hosted accounts. Gated on the
+            // process-level hosted flag so a null! boundary cannot reopen it (see /directors/register).
+            if (GatewayHostedMode.IsHosted)
                 return LegacyDiscoveryPlaneUnavailable();
             var ok = registry.Heartbeat(id);
             if (!ok)
@@ -760,8 +766,9 @@ internal static class GatewayEndpoints
             // MTR-01 (Codex round 1): the doorbell is a leg of the legacy same-machine HTTP discovery plane -
             // unavailable on hosted (see /directors/register), where leaving it open would let a hosted caller
             // inject into a bare-id event ring. On self-host its entries are always keyed to the Local tenant
-            // (see DirectorRegistry.Upsert), so it resolves within Local and records under Local.
-            if (tenantBoundary?.IsHosted == true)
+            // (see DirectorRegistry.Upsert), so it resolves within Local and records under Local. Gated on
+            // the process-level hosted flag so a null! boundary cannot reopen it (see /directors/register).
+            if (GatewayHostedMode.IsHosted)
                 return LegacyDiscoveryPlaneUnavailable();
             if (registry.Get(TenantId.Local, id) is null)
                 return Results.StatusCode(StatusCodes.Status410Gone);
@@ -805,8 +812,9 @@ internal static class GatewayEndpoints
         {
             // MTR-01 (Codex round 1): part of the legacy same-machine discovery plane - unavailable on hosted
             // (see /directors/register). Left open, an unbound hosted caller holding the shared machine token
-            // could remove a Local registration; on hosted there is no such plane to unregister from.
-            if (tenantBoundary?.IsHosted == true)
+            // could remove a Local registration; on hosted there is no such plane to unregister from. Gated
+            // on the process-level hosted flag so a null! boundary cannot reopen it (see /directors/register).
+            if (GatewayHostedMode.IsHosted)
                 return LegacyDiscoveryPlaneUnavailable();
             FileLog.Write($"[GatewayEndpoints] DELETE /directors/{id}/registration");
             var removed = registry.Remove(id);
@@ -937,7 +945,9 @@ internal static class GatewayEndpoints
             // above is confined to this tenant's partition (every id here belongs to reqTenant); it is a
             // pushed-vs-registered filter, not the tenant boundary. On self-host it is skipped, so a
             // registered-but-unpushed Director still surfaces (unchanged).
-            if (tenantBoundary?.IsHosted == true && pushedSessions is not null)
+            // Gated on the process-level hosted flag (never the nullable boundary argument): with a null!
+            // boundary on a hosted process this filter must still apply.
+            if (GatewayHostedMode.IsHosted && pushedSessions is not null)
             {
                 var mine = new HashSet<string>(pushedSessions.DirectorIdsFor(reqTenant.Value), StringComparer.OrdinalIgnoreCase);
                 directors = directors.Where(d => mine.Contains(d.DirectorId)).ToList();

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -126,6 +126,10 @@ internal static class GatewayWingmanVoiceEndpoint
         KeyVault vault,
         WingmanVoiceService voice,
         TenantSettingsResolver tenantSettings,
+        // REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional tail so it cannot sit
+        // in a defaulted position: a forgotten boundary must be a compile error, never a silent default.
+        // Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         SessionOwnerCache? owners = null,
@@ -136,7 +140,6 @@ internal static class GatewayWingmanVoiceEndpoint
         Voice.VoiceUploadStore? uploadStore = null,
         Transcription.TranscriptionHistoryLog? history = null,
         Transcription.TranscriptionAudioArchive? audioArchive = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
         Transcription.TranscriptStore? transcripts = null)
     {
         // The speech transport: the shared static in production, an injected stub in a test. This is the

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -457,6 +457,26 @@ internal static class MachineEndpoints
             try { body = await ctx.Request.ReadFromJsonAsync<LaunchRelayBody>(ct); }
             catch { /* treat as null -> launcher will 400 */ }
 
+            // Tenant-boundary hardening (release 2026-07-31, finding CR-5): starting a program on a machine is
+            // always a protected action, so EVERY launch requires the same explicit confirmation the sibling
+            // restart/stop slot guard demands - it used to relay on key possession alone, which made a stolen
+            // key remote code execution across the account. This is the accident guard; the authorization half
+            // is the launcher's installed-applications allowlist (AppCatalog.ResolveLaunchPath), enforced in
+            // the launcher process itself so no relay arm can bypass it.
+            if (body?.ConfirmProtected != true)
+            {
+                var reason = "launch guard: refusing to start a program without confirmProtected=true";
+                FileLog.Write($"[MachineEndpoints] RELAY_REFUSED machine={machine} verb=launch reason={reason}");
+                return Results.Json(new
+                {
+                    error = "launch_guard",
+                    detail = reason,
+                    machine,
+                    verb = "launch",
+                    hint = "Set confirmProtected=true to confirm starting a program on this machine.",
+                }, statusCode: 403);
+            }
+
             var outcome = await LauncherLifecycleRelay.SendLaunchAsync(
                 tenant, machine, body, launchers, sendLauncherCommand, ct);
             return ToResult(machine, "launch", outcome);
@@ -665,6 +685,12 @@ internal sealed class LaunchRelayBody
     public string? Args { get; init; }
     public string? Cwd { get; init; }
     public bool Headless { get; init; }
+
+    /// <summary>
+    /// Tenant-boundary hardening (CR-5): the explicit confirmation every launch requires, the same flag the
+    /// restart/stop slot guard reads. Without it the route refuses with 403 before any relay arm runs.
+    /// </summary>
+    public bool ConfirmProtected { get; init; }
 }
 
 /// <summary>Response body returned by the Gateway for relay calls.</summary>

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -138,6 +138,12 @@ internal static class MachineEndpoints
     /// </summary>
     public static void Map(IEndpointRouteBuilder outer, LauncherRegistry launchers,
         MachineSessionSpawner spawner,
+        // The tenant boundary. Every launcher-registry read/write and every relay is scoped to the CALLING
+        // tenant, resolved from the authenticated device key (never the machine name in the path or body).
+        // REQUIRED, not defaulted (tenant-boundary hardening, release 2026-07-31, finding CR-7): the boundary
+        // is a security argument, and when it was optional a forgotten argument silently served the Local
+        // partition on hosted. A self-host-only caller must state the absence with an explicit null.
+        HostedTenantBoundary? boundary,
         LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null,
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store. When non-null, a
         // mission-scoped spawn (req.MissionId set) is validated against it here - the Gateway is the source
@@ -151,11 +157,7 @@ internal static class MachineEndpoints
         // spawn with no explicit run auto-seats onto the mission's run. After a successful spawn the new
         // session is recorded as a run PARTICIPANT - the persisted run-to-session membership governance
         // reads. Null (old callers, tests) seats nothing and changes nothing.
-        Workflows.WorkflowRunStore? workflowRuns = null,
-        // The tenant boundary. Every launcher-registry read/write and every relay is scoped to the CALLING
-        // tenant, resolved from the authenticated device key (never the machine name in the path or body).
-        // Null on self-host, where the single tenant is Local and every authenticated caller resolves to it.
-        HostedTenantBoundary? boundary = null)
+        Workflows.WorkflowRunStore? workflowRuns = null)
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
 

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -496,12 +496,22 @@ internal static class MachineEndpoints
             // The refusal is EXPLICIT rather than a silent drop: quietly discarding the arguments would
             // start a DIFFERENT program than the caller asked for and report success, which is its own
             // failure mode and a worse one to debug.
-            if (GatewayHostedMode.IsHosted
-                && (!string.IsNullOrWhiteSpace(body?.Args) || !string.IsNullOrWhiteSpace(body?.Cwd)))
+            // The rule is about the FIELD BEING PRESENT, not about what is in it (inspection finding
+            // M03-I2B-02). The first version of this guard tested IsNullOrWhiteSpace and then
+            // forwarded the original object, so an empty or whitespace-only value passed a rule that
+            // says no caller-supplied arguments and no caller-supplied working directory are
+            // accepted. That is not merely untidy: an EMPTY working directory is not "no working
+            // directory" downstream - it moves the launcher's choice from the application's own
+            // directory to the process default, which is a caller-influenced change to how the
+            // program starts. A JSON null is treated as absent because it is indistinguishable from
+            // an omitted property and carries nothing from the caller either way.
+            var suppliedArgs = body?.Args is not null;
+            var suppliedCwd = body?.Cwd is not null;
+            if (GatewayHostedMode.IsHosted && (suppliedArgs || suppliedCwd))
             {
-                var supplied = !string.IsNullOrWhiteSpace(body?.Args) && !string.IsNullOrWhiteSpace(body?.Cwd)
+                var supplied = suppliedArgs && suppliedCwd
                     ? "arguments and a working directory"
-                    : !string.IsNullOrWhiteSpace(body?.Args) ? "arguments" : "a working directory";
+                    : suppliedArgs ? "arguments" : "a working directory";
                 var reason = $"launch guard: this hosted service does not accept {supplied} on a launch request";
                 FileLog.Write($"[MachineEndpoints] RELAY_REFUSED machine={machine} verb=launch reason={reason}");
                 return Results.Json(new

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -479,6 +479,42 @@ internal static class MachineEndpoints
                 }, statusCode: 403);
             }
 
+            // Tenant-boundary hardening (release 2026-07-31, inspection finding I1-03). On a HOSTED
+            // process the launch verb accepts NO caller-supplied arguments and no caller-supplied working
+            // directory: the catalogue entry ALONE determines what runs.
+            //
+            // Why: the catalogue allowlist on its own was never containment. Every ordinary machine has a
+            // command interpreter or script host in its installed applications, so a caller could select
+            // that catalogued entry and put the real command in the argument string - the launcher
+            // interpolates it into the command line it starts. That is arbitrary code execution wearing an
+            // installed application's name, which is the capability this mission exists to remove.
+            //
+            // Self-host is deliberately UNCHANGED - the desktop and the local agent keep passing arguments,
+            // so no capability is deleted, only narrowed on the surface a stolen tenant credential can reach.
+            // This is reversible when the credential-authority tiers land (the named gap from ruling 6).
+            //
+            // The refusal is EXPLICIT rather than a silent drop: quietly discarding the arguments would
+            // start a DIFFERENT program than the caller asked for and report success, which is its own
+            // failure mode and a worse one to debug.
+            if (GatewayHostedMode.IsHosted
+                && (!string.IsNullOrWhiteSpace(body?.Args) || !string.IsNullOrWhiteSpace(body?.Cwd)))
+            {
+                var supplied = !string.IsNullOrWhiteSpace(body?.Args) && !string.IsNullOrWhiteSpace(body?.Cwd)
+                    ? "arguments and a working directory"
+                    : !string.IsNullOrWhiteSpace(body?.Args) ? "arguments" : "a working directory";
+                var reason = $"launch guard: this hosted service does not accept {supplied} on a launch request";
+                FileLog.Write($"[MachineEndpoints] RELAY_REFUSED machine={machine} verb=launch reason={reason}");
+                return Results.Json(new
+                {
+                    error = "launch_arguments_not_allowed",
+                    detail = reason,
+                    machine,
+                    verb = "launch",
+                    hint = "Start the application by its catalogue name or path with no args and no cwd. "
+                         + "The catalogue entry determines what runs.",
+                }, statusCode: 403);
+            }
+
             var outcome = await LauncherLifecycleRelay.SendLaunchAsync(
                 tenant, machine, body, launchers, sendLauncherCommand, ct);
             return ToResult(machine, "launch", outcome);

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -111,7 +111,10 @@ internal static class RecordingEndpoints
     /// </summary>
     public static void Map(
         IEndpointRouteBuilder outer,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // The auth-boundary tenant binder. REQUIRED AND NON-NULLABLE (finding I1-01): when this defaulted to
+        // null, a forgotten argument compiled cleanly and the resolver behind it decided on the argument. A
+        // self-host caller constructs the boundary over the SingleTenantContext, which always resolves Local.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         KeyVault? keyVault = null,
         TranscriptionHistoryLog? history = null,
         TranscriptionAudioArchive? audioArchive = null,
@@ -136,7 +139,7 @@ internal static class RecordingEndpoints
     /// </summary>
     private static void MapRoutes(
         IEndpointRouteBuilder app,
-        Tenancy.HostedTenantBoundary? tenantBoundary,
+        Tenancy.HostedTenantBoundary tenantBoundary,
         KeyVault? keyVault,
         TranscriptionHistoryLog? history,
         TranscriptionAudioArchive? audioArchive,

--- a/src/CcDirector.Gateway/Api/RepoStateEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RepoStateEndpoints.cs
@@ -30,14 +30,18 @@ internal static class RepoStateEndpoints
     public const string Path = "/gateway/repostate";
 
     public static void Map(IEndpointRouteBuilder app, RepoStateStore store,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Func<DateTime>? utcNow = null)
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, Func<DateTime>? utcNow = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         var now = utcNow ?? (() => DateTime.UtcNow);
 
         app.MapPost(Path, (HttpContext ctx, RepoStatePushRequest? request) =>
         {
-            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            // Resolved through the gated shared resolver (finding I1-01): deciding on the argument fails
+            // OPEN - a hosted process handed a null boundary would write the push into the Local partition.
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (tenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -51,8 +51,13 @@ internal static class SessionWsProxyEndpoints
         Streaming.GatewayStreamRegistry streamRegistry,
         DirectorCommandRouter.SendDirectorCommandAsync sendCommand,
         Discovery.DirectorRegistry registry,
-        TimeSpan? streamStaleAfter = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional staleness knob so it
+        // cannot sit in a defaulted tail: this helper serves the terminal stream, the file read, the
+        // screenshot legs, the catch-all session verbs and the director backfill - the widest per-session
+        // surface on the Gateway - so a forgotten boundary must be a compile error, never a silent default.
+        // Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
+        TimeSpan? streamStaleAfter = null)
     {
         var tunnel = new TunnelStreamLegs(streamRegistry, sendCommand);
         var stale = streamStaleAfter ?? TimeSpan.FromSeconds(10);
@@ -61,7 +66,7 @@ internal static class SessionWsProxyEndpoints
         // terminal-input unary verbs. See TunnelStreamLegs for the wire translation.
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
         {
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
@@ -75,7 +80,7 @@ internal static class SessionWsProxyEndpoints
         // a Range request re-fetches the whole file (tracked follow-up); never a silent truncation.
         app.MapGet("/sessions/{sid}/file", async (string sid, HttpContext ctx) =>
         {
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is { } loc)
             {
@@ -91,7 +96,7 @@ internal static class SessionWsProxyEndpoints
         // routing key for the machine-wide screenshots folder on the owning Director.
         app.Map("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
         {
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
@@ -115,7 +120,7 @@ internal static class SessionWsProxyEndpoints
         // caps the newest-first rows.
         app.MapGet("/sessions/{sid}/screenshots", async (string sid, HttpContext ctx) =>
         {
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
@@ -140,7 +145,7 @@ internal static class SessionWsProxyEndpoints
             // when the id is not the caller's Director. Gating BEFORE the dispatch is what guarantees no verb
             // ever reaches another tenant's Director over the tunnel, and it routes the id through the only
             // registry accessor there is (Get(tenant, id)) - there is no bare-id path to evade.
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (registry.Get(reqTenant.Value, id) is null)
             {
@@ -170,7 +175,7 @@ internal static class SessionWsProxyEndpoints
             // Resolving the tenant at the locate isolates BOTH the read verbs and the write verbs the catch-all
             // dispatches (resize, clear-context, voice-mode, ...): a wrong-tenant session is never located, so
             // the dispatch never runs against another account's session.
-            var reqTenant = ResolveTenantOrDeny(ctx, tenantBoundary);
+            var reqTenant = await ResolveTenantOrDenyAsync(ctx, tenantBoundary);
             if (reqTenant is null) return;
             if (pushedSessions.TryLocate(reqTenant.Value, sid, stale) is not { } loc)
             {
@@ -186,15 +191,26 @@ internal static class SessionWsProxyEndpoints
 
     /// <summary>
     /// Hosted Multi-Tenancy (session-serving PR1): resolve the request's tenant from the authenticated device
-    /// key. On self-host (or when no boundary is wired) this is always Local. On hosted a null means no tenant
-    /// is bound to the request - the leg writes 403 and returns null so the caller denies, never reading the
-    /// Local partition (which on hosted would be a wrong-tenant read that surfaces another account's session).
+    /// key. On self-host this is always Local. On hosted a null means no tenant is bound to the request - the
+    /// leg writes the standard 403 deny and returns null so the caller denies, never reading the Local
+    /// partition (which on hosted would be a wrong-tenant read that surfaces another account's session).
+    ///
+    /// Resolved through the gated shared resolver (finding I1-01): this helper used to decide on the ARGUMENT
+    /// (<c>boundary is null ? TenantId.Local : ...</c>), which fails OPEN - a hosted process handed a null
+    /// boundary answered Local, exposing every per-session leg (terminal, file, screenshots, the catch-all
+    /// verbs, backfill) to the shared partition. <see cref="GatewayEndpoints.ResolveReadTenant"/> gates on
+    /// <see cref="GatewayHostedMode.IsHosted"/> itself, so on hosted a missing or non-hosted-wired boundary
+    /// is a REFUSAL. The second defence is that <see cref="Map"/> takes the boundary as a required
+    /// non-nullable argument, so omitting it is a compile error rather than a runtime downgrade.
     /// </summary>
-    private static TenantId? ResolveTenantOrDeny(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
+    private static async Task<TenantId?> ResolveTenantOrDenyAsync(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
     {
-        var tenant = boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        var tenant = GatewayEndpoints.ResolveReadTenant(ctx, boundary);
         if (tenant is null && !ctx.Response.HasStarted)
+        {
             ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await ctx.Response.WriteAsJsonAsync(new { error = "no tenant is bound to this request" }, ctx.RequestAborted);
+        }
         return tenant;
     }
 

--- a/src/CcDirector.Gateway/Api/SkillPlacementEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SkillPlacementEndpoints.cs
@@ -24,14 +24,18 @@ internal static class SkillPlacementEndpoints
     public const string Path = "/gateway/skills/placement";
 
     public static void Map(IEndpointRouteBuilder app, SkillPlacementStore store,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null, Func<DateTime>? utcNow = null)
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary, Func<DateTime>? utcNow = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         var now = utcNow ?? (() => DateTime.UtcNow);
 
         app.MapPost(Path, (HttpContext ctx, SkillPlacementPushRequest? request) =>
         {
-            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            // Resolved through the gated shared resolver (finding I1-01): deciding on the argument fails
+            // OPEN - a hosted process handed a null boundary would write the report into the Local partition.
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (tenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -65,7 +69,8 @@ internal static class SkillPlacementEndpoints
 
         app.MapGet(Path, (HttpContext ctx) =>
         {
-            var tenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            // Gated resolver, same reasoning as the POST above (finding I1-01).
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (tenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);

--- a/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionAnalysisEndpoint.cs
@@ -40,7 +40,9 @@ internal static class TranscriptionAnalysisEndpoint
 
     public static void Map(
         IEndpointRouteBuilder outer,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         TranscriptionHistoryReader? reader = null,
         TranscriptionAudioArchive? audioArchive = null)
     {
@@ -59,7 +61,7 @@ internal static class TranscriptionAnalysisEndpoint
 
     private static void MapRoutes(
         IEndpointRouteBuilder app,
-        Tenancy.HostedTenantBoundary? tenantBoundary,
+        Tenancy.HostedTenantBoundary tenantBoundary,
         TranscriptionHistoryReader? reader,
         TranscriptionAudioArchive? audioArchive)
     {

--- a/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionBatchEndpoint.cs
@@ -35,9 +35,12 @@ internal static class TranscriptionBatchEndpoint
     public static void Map(
         IEndpointRouteBuilder app,
         KeyVault vault,
+        // REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional tail so it cannot sit
+        // in a defaulted position: a forgotten boundary must be a compile error, never a silent default.
+        // Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         TranscriptionHistoryLog? history = null,
         TranscriptionAudioArchive? audioArchive = null,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
         TranscriptStore? transcripts = null)
     {
         app.MapPost("/transcription", async (HttpContext ctx) =>

--- a/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/VoiceQualityEndpoint.cs
@@ -43,7 +43,9 @@ internal static class VoiceQualityEndpoint
 
     public static void Map(
         IEndpointRouteBuilder app,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         MicrophoneQualityLog? logOverride = null)
     {
         var group = app.MapGroup(Prefix);

--- a/src/CcDirector.Gateway/Api/VoiceTestEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/VoiceTestEndpoint.cs
@@ -51,7 +51,9 @@ internal static class VoiceTestEndpoint
     public static void Map(
         IEndpointRouteBuilder app,
         GatewayTranscriptionService transcription,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten boundary must be a compile error, never a
+        // silent default. Self-host callers construct it over the SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         VoiceTestClipStore? storeOverride = null)
     {
         var group = app.MapGroup(Prefix);

--- a/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkListRunnerEndpoints.cs
@@ -37,8 +37,10 @@ internal static class WorkListRunnerEndpoints
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand,
         // MTR-01: the auth-boundary tenant binder. This route spawns a drain (sessions) on a target Director,
         // so it must resolve that Director in the REQUEST's own tenant - a client-supplied directorId can only
-        // ever name a Director the caller owns. Null (self-host, tests) is the single Local tenant, unchanged.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // ever name a Director the caller owns. REQUIRED AND NON-NULLABLE (finding I1-01): a forgotten
+        // boundary must be a compile error, never a silent default. Self-host callers construct it over the
+        // SingleTenantContext.
+        Tenancy.HostedTenantBoundary tenantBoundary)
     {
         app.MapPost("/lists/{name}/run", async (string name, HttpContext ctx) =>
         {
@@ -65,7 +67,9 @@ internal static class WorkListRunnerEndpoints
             // Gate on existence only; the run itself dispatches the create verb down the stream.
             // MTR-01: resolve the target Director in the REQUEST's own tenant (403 with no bound tenant, 404 for
             // an id the caller does not own) so a drain cannot be started on another tenant's Director.
-            var reqTenant = tenantBoundary is null ? TenantId.Local : tenantBoundary.ResolveRequestTenant(ctx);
+            // Resolved through the gated shared resolver (finding I1-01): deciding on the argument fails
+            // OPEN - a hosted process handed a null boundary would resolve Local and reach Local's Directors.
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
             if (reqTenant is null)
                 return Results.Json(new { error = "no tenant is bound to this request" },
                     statusCode: StatusCodes.Status403Forbidden);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2514,7 +2514,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // Gateway Cleanup mission: the cut removed the DirectorEndpointClient argument (_client) - the
         // Gateway no longer dials Directors over HTTP, so Map no longer takes an HTTP client. The
         // network-diagnostics rollup store is threaded in as a named argument on the tunnel-only signature.
-        GatewayEndpoints.Map(_app, Registry, version, Token, AuthEnabled,
+        GatewayEndpoints.Map(_app, Registry, version, Token,
+            // The auth-boundary tenant binder - REQUIRED (finding CR-7): request-scoped reads resolve the
+            // caller's tenant through it, and on hosted a request with no bound tenant is denied, never Local.
+            _tenantBoundary,
+            AuthEnabled,
             netDiagRollup: _netDiagRollup,
             // Issue #2017: the snooze-default consumer at POST /sessions/{sid}/hold reads the caller tenant's
             // default through the resolver instead of the process-global config.
@@ -2731,10 +2735,7 @@ public sealed class GatewayHost : IAsyncDisposable
             fleetDisplayState: FleetDisplayState,
             // Workflows mission (phase 4, issue #1771): creating a mission also opens a workflow run of
             // the built-in "mission" workflow, pinned to its published version - the outcome spine.
-            workflowRuns: _workflowRuns,
-            // Hosted Multi-Tenancy (session-serving PR1): the read endpoints resolve the request's tenant from
-            // the authenticated device key through this boundary and deny (403) when hosted binds none.
-            tenantBoundary: _tenantBoundary);
+            workflowRuns: _workflowRuns);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -3098,14 +3099,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // /machines/{machine}/director/restart|start|stop to reach that machine's Director.
         // launcher-persistent-join: pass the stream-send hook only when stream mode is on. The relay tries
         // this first and falls back to the REST relay when it returns null (stream off, or launcher offline).
-        MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner, SendLauncherCommandAsync,
+        MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner,
+            // Tenant boundary - REQUIRED (finding CR-7): every launcher-registry read/write and relay is
+            // scoped to the calling tenant, and on hosted an unbound request is denied, never Local.
+            _tenantBoundary,
+            SendLauncherCommandAsync,
             // Gateway Cleanup mission (Wave 4b): validate a mission-scoped spawn against the Gateway store and
             // stamp the resolved mission name onto the create request forwarded to the Director.
             missions: Missions,
             // Workflows mission (phase 5b): seat spawns on workflow runs and record participants.
-            workflowRuns: _workflowRuns,
-            // Tenant boundary: every launcher-registry read/write is scoped to the calling tenant.
-            boundary: _tenantBoundary);
+            workflowRuns: _workflowRuns);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -61,6 +61,15 @@ public sealed class GatewayHost : IAsyncDisposable
     public string Token { get; }
     public DirectorRegistry Registry { get; }
 
+    /// <summary>
+    /// The finalised route table, captured after every endpoint is mapped (StartAsync). Internal, for the
+    /// route-surface guard tests: the shell-prefix auth allowlist (AuthMiddleware.IsPublicShellSurfaceRequest)
+    /// is complete only while the endpoint set under /mobile, /m and /assets is exactly the set it was
+    /// written against, and the guard test pins that set here.
+    /// </summary>
+    internal IReadOnlyList<Microsoft.AspNetCore.Http.Endpoint> MappedEndpoints { get; private set; }
+        = Array.Empty<Microsoft.AspNetCore.Http.Endpoint>();
+
     // The process's ONE system capability, minted here in the composition root. Passed to the internal
     // system passes that legitimately read across tenants; never handed to a request handler. The guard
     // test (SystemScopeGuardTests) enforces that SystemScope.Grant() is called nowhere else.
@@ -3225,6 +3234,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // with the pre-start test harness, so reverting it to the DI composite reddens the tie tests rather
         // than silently regressing this path.
         Tenancy.HostedRefusalRouteSpace.ValidateBeforeStart(_app);
+
+        // The finalised route table, kept for the route-surface guard tests (the auth allowlist for the
+        // shell prefixes is complete ONLY while the set of endpoints mapped under /mobile, /m and /assets
+        // stays exactly what the allowlist was written against - the guard pins that set, so a new route
+        // under a shell prefix fails a test until it is consciously ruled public or gated).
+        MappedEndpoints = Tenancy.HostedRefusalRouteSpace.SelectFinalisedEndpoints(_app);
 
         await _app.StartAsync();
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2953,8 +2953,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #1856: the boundary and the tenant registry make this endpoint tenant-bearing on hosted, where
         // it must answer about the CALLER's enrollment rather than about a Gateway credential hosted does not
         // hold. On self-host the boundary reports not-hosted and the endpoint behaves exactly as before.
-        AccountStatusEndpoint.Map(_app, Account, new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
-            tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
+        AccountStatusEndpoint.Map(_app, Account, _tenantBoundary,
+            nickname: new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
+            tenants: TenantRegistry);
 
         // Gateway Centralization Phase 3 (issue #648): POST /account/logout CLEARS the Gateway-hosted
         // DevThrottle credential through the same reused DevThrottleAccountService (Account). The account
@@ -3043,7 +3044,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // through this one endpoint - it resolves the mode + key and runs the right provider (in-process
         // Whisper, or the resolved provider-compatible batch endpoint). Optional ?correct=true also runs
         // the validated dictionary correction, keeping that out of the callers too.
-        TranscriptionBatchEndpoint.Map(_app, _keyVault, _transcriptionHistory, _transcriptionAudioArchive, _tenantBoundary, _transcripts);
+        TranscriptionBatchEndpoint.Map(_app, _keyVault, _tenantBoundary, _transcriptionHistory, _transcriptionAudioArchive, _transcripts);
 
         // Read-only analysis over the LOCAL minimized transcription history: latency percentiles, cleanup
         // behaviour, most-corrected terms, and word frequencies, so any agent can query the Gateway to
@@ -3173,7 +3174,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // broken deploy, and the reason is what tells an operator whether to fix a setting or a database.
         if (InputStats is not null)
         {
-            Stats.StatsPageEndpoint.Map(_app, InputStats, SessionConcurrency, _tenantSettingsResolver, _tenantBoundary, _sessionHistory);
+            Stats.StatsPageEndpoint.Map(_app, InputStats, _tenantBoundary, SessionConcurrency, _tenantSettingsResolver, _sessionHistory);
         }
         else
         {

--- a/src/CcDirector.Gateway/History/HistoryEndpoints.cs
+++ b/src/CcDirector.Gateway/History/HistoryEndpoints.cs
@@ -31,7 +31,10 @@ public static class HistoryEndpoints
     public const int MaxRangeDays = 31;
 
     public static void Map(IEndpointRouteBuilder app, SessionHistoryStore store,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null)
+        // REQUIRED, not defaulted (tenant-boundary hardening, release 2026-07-31, finding CR-7): the boundary
+        // is a security argument, and when it was optional a forgotten argument silently served the Local
+        // partition on hosted. A self-host-only caller must state the absence with an explicit null.
+        Tenancy.HostedTenantBoundary? tenantBoundary)
     {
         ArgumentNullException.ThrowIfNull(store);
 
@@ -172,8 +175,19 @@ public static class HistoryEndpoints
 
     private static DateTime EndOfDay(DateTime day) => day.Date.AddDays(1).AddTicks(-1);
 
+    /// <summary>
+    /// Null means DENY. Gated on <see cref="GatewayHostedMode.IsHosted"/> ITSELF, never on whether a boundary
+    /// was passed in (finding CR-7): deciding on the argument fails open, so on hosted a missing or
+    /// non-hosted-wired boundary resolves null - a refusal, never Local. Self-host is Local as before.
+    /// </summary>
     private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
-        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+    {
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
 
     private static IDisposable EnterScope(TenantId tenant, Tenancy.HostedTenantBoundary? boundary)
         => boundary is null ? NoScope.Instance : boundary.EnterScope(tenant);

--- a/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptEndpoints.cs
@@ -32,7 +32,8 @@ namespace CcDirector.Gateway.Prompts;
 public static class PromptEndpoints
 {
     public static void Map(IEndpointRouteBuilder app, GatewayPromptLog log,
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
+        // REQUIRED, not defaulted (finding CR-7): a forgotten boundary must be a compile error, never Local.
+        Tenancy.HostedTenantBoundary? tenantBoundary,
         History.SessionHistoryRecorder? history = null)
     {
         var store = log ?? throw new ArgumentNullException(nameof(log));
@@ -118,7 +119,16 @@ public static class PromptEndpoints
     /// callers and tests), is always Local.
     /// </summary>
     private static TenantId? ResolveTenant(HttpContext ctx, Tenancy.HostedTenantBoundary? boundary)
-        => boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+    {
+        // Finding CR-7: gated on GatewayHostedMode.IsHosted itself, never on whether a boundary was passed
+        // in - deciding on the argument fails open. On hosted a missing or non-hosted-wired boundary
+        // resolves null, a refusal. Self-host is Local exactly as before.
+        if (!GatewayHostedMode.IsHosted)
+            return boundary is null ? TenantId.Local : boundary.ResolveRequestTenant(ctx);
+        if (boundary is null || !boundary.IsHosted)
+            return null;
+        return boundary.ResolveRequestTenant(ctx);
+    }
 
     /// <summary>Enter the resolved tenant's ambient scope for a database-writing side effect (the
     /// history recorder); the file-backed prompt log itself takes the tenant explicitly. No boundary

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -120,15 +120,17 @@ public static class StatsPageEndpoint
     /// answers 403 when no tenant resolves.
     /// </summary>
     public static RouteGroupBuilder Map(IEndpointRouteBuilder outer, GatewayInputStatsAggregator aggregator,
+        // The tenant boundary the data route resolves the CALLER's tenant through. REQUIRED AND NON-NULLABLE
+        // (finding I1-01), and moved AHEAD of the optional tail so it cannot sit in a defaulted position: a
+        // forgotten boundary must be a compile error, never a silent default. Self-host callers construct it
+        // over the SingleTenantContext, which always resolves the single Local tenant; on hosted it resolves
+        // the authenticated device key's tenant and the route answers 403 when there is none - never Local.
+        Tenancy.HostedTenantBoundary tenantBoundary,
         GatewaySessionConcurrencyStats? concurrency = null,
         // Issue #2017: the per-tenant settings resolver. The display time zone is read for the caller's tenant
         // (TimeZone(tenant)) instead of the process-global config. Null (older callers, tests) keeps the global
         // read, byte-identical to before.
         Settings.TenantSettingsResolver? tenantSettings = null,
-        // The tenant boundary the data route resolves the CALLER's tenant through. Null (self-host, older
-        // callers, tests) means the single Local tenant; on hosted it resolves the authenticated device key's
-        // tenant and answers 403 when there is none - never falling back to Local.
-        Tenancy.HostedTenantBoundary? tenantBoundary = null,
         // The durable work-history store (devthrottle_internal issue #982), source of the session-origin
         // counts. Null (older callers, tests) omits that block from the feed entirely rather than serving
         // zeroes - a zero here would read as "no agent ever started a session", which is a different and

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -48,10 +48,17 @@ public sealed class DirectorHub : Hub
 
     private readonly DirectorConnectionRegistry? _connections;
 
+    // The boundary is REQUIRED AND NON-NULLABLE (finding I1-01), and moved AHEAD of the optional tail so it
+    // cannot sit in a defaulted position: constructing this hub without one must be a compile error, never a
+    // silent default. In production SignalR resolves it from dependency injection (GatewayHost registers the
+    // singleton); a self-host process registers a boundary built over the SingleTenantContext, which always
+    // resolves Local. The FIELD stays nullable because a miswire is still expressible with a forced null, and
+    // the runtime gate in ResolveConnectionTenant must hold even then.
     public DirectorHub(PushedSessionStore store, DirectorRegistry registry, Stats.InputStatsHandle inputStats,
-        GatewayStreamRegistry streamRegistry, Snooze.SnoozeLandingObserver? snoozeLandings = null,
+        GatewayStreamRegistry streamRegistry, HostedTenantBoundary tenantBoundary,
+        Snooze.SnoozeLandingObserver? snoozeLandings = null,
         Fleet.FleetRoleObserver? fleetRoles = null, Fleet.FleetDisplayStateObserver? fleetDisplayState = null,
-        HostedTenantBoundary? tenantBoundary = null, DirectorConnectionRegistry? connections = null,
+        DirectorConnectionRegistry? connections = null,
         PushedRepositoryStore? repositoryStore = null, RepoHistoryStore? repoHistory = null,
         History.SessionHistoryRecorder? sessionHistory = null)
     {
@@ -374,9 +381,22 @@ public sealed class DirectorHub : Hub
     /// </summary>
     private TenantId? ResolveConnectionTenant()
     {
-        if (_tenantBoundary is null)
-            return TenantId.Local;
+        // GATED ON GatewayHostedMode.IsHosted ITSELF, never on whether a boundary was wired (finding I1-01,
+        // the same shape GatewayEndpoints.ResolveReadTenant carries). Deciding on the field fails OPEN: a
+        // hosted process whose hub was constructed without a boundary would resolve TenantId.Local and bind
+        // the Director's whole push stream into the shared partition. On hosted, a missing or
+        // non-hosted-wired boundary resolves to null, and null is a REFUSAL - Hello aborts the connection.
+        // The second defence is the required non-nullable constructor parameter.
+        if (!GatewayHostedMode.IsHosted)
+        {
+            if (_tenantBoundary is null)
+                return TenantId.Local;
+            var selfHostContext = Context.GetHttpContext();
+            return selfHostContext is null ? null : _tenantBoundary.ResolveRequestTenant(selfHostContext);
+        }
 
+        if (_tenantBoundary is null || !_tenantBoundary.IsHosted)
+            return null;
         var httpContext = Context.GetHttpContext();
         return httpContext is null ? null : _tenantBoundary.ResolveRequestTenant(httpContext);
     }

--- a/src/CcDirector.Gateway/Streaming/LauncherHub.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherHub.cs
@@ -33,7 +33,13 @@ public sealed class LauncherHub : Hub
     private readonly LauncherConnectionRegistry _registry;
     private readonly HostedTenantBoundary? _tenantBoundary;
 
-    public LauncherHub(LauncherConnectionRegistry registry, HostedTenantBoundary? tenantBoundary = null)
+    // REQUIRED AND NON-NULLABLE (finding I1-01): the boundary is a security argument, so constructing this
+    // hub without one must be a compile error, never a silent default. In production SignalR resolves it from
+    // dependency injection (GatewayHost registers the singleton); a self-host process registers a boundary
+    // built over the SingleTenantContext, which always resolves Local. The FIELD stays nullable because a
+    // miswire is still expressible with a forced null, and the runtime gate in ResolveConnectionTenant must
+    // hold even then.
+    public LauncherHub(LauncherConnectionRegistry registry, HostedTenantBoundary tenantBoundary)
     {
         _registry = registry;
         _tenantBoundary = tenantBoundary;
@@ -79,16 +85,24 @@ public sealed class LauncherHub : Hub
     }
 
     /// <summary>The tenant that owns this connection, from the authenticated device key (never the payload).
-    /// On self-host (no boundary) this is <see cref="TenantId.Local"/>; on hosted a key with no bound tenant
-    /// returns null and the connection is aborted.</summary>
+    /// On self-host this is <see cref="TenantId.Local"/>; on hosted a key with no bound tenant returns null
+    /// and the connection is aborted.
+    ///
+    /// GATED ON <see cref="GatewayHostedMode.IsHosted"/> ITSELF, never on whether a boundary was wired
+    /// (finding I1-01, the same shape <c>GatewayEndpoints.ResolveReadTenant</c> carries). Deciding on the
+    /// field fails OPEN: a hosted process whose hub was constructed without a boundary would resolve
+    /// <see cref="TenantId.Local"/> and register the launcher into the shared partition. On hosted, a missing
+    /// or non-hosted-wired boundary resolves to null, and null is a REFUSAL - Hello aborts the connection.
+    /// The second defence is the required non-nullable constructor parameter.</summary>
     private TenantId? ResolveConnectionTenant()
     {
-        if (_tenantBoundary is null)
-            return TenantId.Local;
-
         var key = Context.GetHttpContext()?.Items.TryGetValue(AuthMiddleware.DeviceKeyItemKey, out var value) == true
             ? value as string
             : null;
+        if (!GatewayHostedMode.IsHosted)
+            return _tenantBoundary is null ? TenantId.Local : _tenantBoundary.ResolveForDeviceKey(key);
+        if (_tenantBoundary is null || !_tenantBoundary.IsHosted)
+            return null;
         return _tenantBoundary.ResolveForDeviceKey(key);
     }
 

--- a/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
+++ b/src/CcDirector.Gateway/Tenancy/HostedTenantBoundary.cs
@@ -27,6 +27,17 @@ public sealed class HostedTenantBoundary
     {
         _ambient = tenantContext as AsyncLocalTenantContext;
         _devices = devices ?? throw new ArgumentNullException(nameof(devices));
+
+        // Tenant-boundary hardening (release 2026-07-31, finding CR-7): a HOSTED process whose boundary is
+        // built over anything but the AsyncLocalTenantContext could only ever answer Local - every resolution
+        // it performed would silently collapse the account partitions into one. That is a wiring defect, not
+        // a state to operate in, so it fails LOUD at construction rather than open at resolution.
+        if (GatewayHostedMode.IsHosted && _ambient is null)
+            throw new InvalidOperationException(
+                "This Gateway is running in hosted mode, but the tenant boundary was constructed without the " +
+                "per-account ambient tenant context (AsyncLocalTenantContext). A boundary wired this way can " +
+                "only resolve the Local partition, which on hosted collapses every account into one. Construct " +
+                "it over the hosted tenant context.");
     }
 
     /// <summary>True on the hosted Gateway (per-account, fail-closed); false on self-host (always Local).</summary>
@@ -41,7 +52,10 @@ public sealed class HostedTenantBoundary
     public TenantId? ResolveForDeviceKey(string? deviceKey)
     {
         if (_ambient is null)
+        {
+            ThrowIfHostedWithoutAmbientContext();
             return TenantId.Local;
+        }
 
         var resolution = _devices.ResolveCredential(deviceKey);
         return resolution.Kind == DeviceCredentialResolutionKind.Active
@@ -60,12 +74,30 @@ public sealed class HostedTenantBoundary
     public TenantId? ResolveRequestTenant(Microsoft.AspNetCore.Http.HttpContext ctx)
     {
         if (_ambient is null)
+        {
+            ThrowIfHostedWithoutAmbientContext();
             return TenantId.Local;
+        }
 
         var identity = ctx?.Items.TryGetValue(Util.AuthMiddleware.AuthenticatedDeviceItemKey, out var value) == true
             ? value as DeviceCredentialIdentity
             : null;
         return ResolveIdentity(identity);
+    }
+
+    /// <summary>
+    /// The resolution-time half of the CR-7 guard. The constructor already refuses a hosted process wiring a
+    /// Local-only boundary; this catches the one remaining path - a boundary built while the process was NOT
+    /// hosted, resolved after hosted mode turned on (the environment variable is read live). Resolving Local
+    /// there would silently collapse every account into one partition, so it throws instead.
+    /// </summary>
+    private static void ThrowIfHostedWithoutAmbientContext()
+    {
+        if (GatewayHostedMode.IsHosted)
+            throw new InvalidOperationException(
+                "This Gateway is running in hosted mode, but the tenant boundary has no per-account ambient " +
+                "tenant context, so it could only resolve the Local partition. Refusing to resolve: on hosted " +
+                "this would collapse every account into one partition.");
     }
 
     private static TenantId? ResolveIdentity(DeviceCredentialIdentity? identity)

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -12,14 +12,14 @@ namespace CcDirector.Gateway.Util;
 ///                     /devices/enroll-signed-in (epic #1069: carries its own loopback + signed-in
 ///                     guards, so a token-less fresh device can earn its first key), the credential-free
 ///                     cloud sign-in start front door /account/sign-in-start (issue #1076, GET + POST -
-///                     it reads/returns no credential and no account data), the mobile app
-///                     shell /mobile + everything under /mobile/ (which includes the enroll path
-///                     POST /mobile/enroll - it carries its own account-scoped authorization) plus the
-///                     legacy /m + /m/ mount it re-based from (still public so the Gateway's 301 to
-///                     /mobile and the back-compat POST /m/enroll stay reachable pre-credential), the desktop
-///                     Cockpit sign-in surface /signin + /device-callback and the shell's static
-///                     assets under /assets/ (issue #1088 - see below), and the JSON /cockpit endpoint
-///                     (a program GET, NOT a browser navigation - see below).
+///                     it reads/returns no credential and no account data), the shell surfaces via the
+///                     EXPLICIT allowlist in IsPublicShellSurfaceRequest - the GET/HEAD phone shell
+///                     under /mobile, the GET/HEAD legacy /m redirect mount, the exact enrollment POSTs
+///                     (/mobile/enroll + /m/enroll, each carrying its own account-scoped authorization),
+///                     and the GET/HEAD Cockpit static assets under /assets/ (issue #1088) - plus the
+///                     desktop Cockpit sign-in surface /signin + /device-callback, and the JSON /cockpit
+///                     endpoint (a program GET, NOT a browser navigation - see below). Any OTHER method
+///                     or route under those shell prefixes is credential-gated by default.
 /// Authenticated:      every other route (Bearer header OR cc-gateway-token cookie OR, per
 ///                     issue #469, a per-device key issued at enrollment).
 ///
@@ -168,6 +168,53 @@ internal static class AuthMiddleware
         Api.ReportRecipientsEndpoint.Path,
     };
 
+    /// <summary>
+    /// The EXPLICIT allowlist of credential-less request shapes on the shell surfaces. These paths were
+    /// auth-opened BY PREFIX until the 2026-07-31 tenant-boundary hardening - everything under /mobile,
+    /// /m and /assets passed the gate in every HTTP method, so any future route mapped under those
+    /// prefixes would have been silently public. Now the public set is spelled out, and a new route under
+    /// a shell prefix is credential-gated by default unless it is added here on purpose.
+    ///
+    /// What is public, and why it is the complete day-one set (the endpoints actually mapped under these
+    /// prefixes are pinned by ShellPrefixRouteSurfaceGuardTests, so this list and the route table cannot
+    /// drift apart silently):
+    ///
+    ///  - GET/HEAD /mobile and /mobile/** - the phone app shell (MobileApp.ServeAsync): a static file
+    ///    strictly inside wwwroot/mobile, or the index shell for every client-side route. The GET surface
+    ///    IS the app - client routes are arbitrary and grow with the app, and a signed-in phone's
+    ///    NAVIGATIONS carry no credential either (the per-device key lives in the app, not in a cookie) -
+    ///    so the whole GET surface must load pre-credential (issues #806/#908: the shell carries no
+    ///    secret; every data endpoint stays credential-gated). Method-scoped: a future POST/PUT/DELETE
+    ///    route under /mobile is NOT public.
+    ///  - GET/HEAD /m and /m/** - the legacy mount: pure 301 redirects onto /mobile (owner ruling
+    ///    2026-07-20), reachable pre-credential so an installed phone app on the old path is not walled
+    ///    out.
+    ///  - POST /mobile/enroll and POST /m/enroll - the enrollment mint seam, EXACT paths only. Public at
+    ///    this gate because each carries its OWN account-scoped authorization (the verified cloud account
+    ///    token) inside the endpoint.
+    ///  - GET/HEAD /assets/** - the desktop Cockpit shell's Vite content-hashed JavaScript/CSS (issue
+    ///    #1088): the /signin screen cannot render before any credential exists unless its script and
+    ///    styles load. Static files only, no secrets, no data.
+    /// </summary>
+    private static bool IsPublicShellSurfaceRequest(string method, string path)
+    {
+        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method))
+        {
+            if (string.Equals(path, "/mobile", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("/mobile/", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(path, "/m", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("/m/", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith(CockpitAssetsPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return HttpMethods.IsPost(method)
+               && (string.Equals(path, "/mobile/enroll", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(path, "/m/enroll", StringComparison.OrdinalIgnoreCase));
+    }
+
     public static async Task Run(HttpContext ctx, RequireToken cfg, Func<Task> next)
     {
         var path = ctx.Request.Path.Value ?? "";
@@ -184,32 +231,10 @@ internal static class AuthMiddleware
 
         if (!isCockpitBrowserShell && PublicPaths.Contains(path)) { await next(); return; }
 
-        // Issue #806 / #908: the mobile app shell (/mobile and its built assets) carries no secret. It
-        // must load without the global gate so the Sign in screen can render before the phone has any
-        // credential; the phone then enrolls (POST /mobile/enroll, itself under /mobile/ and carrying its
-        // own authorization - an account-scoped device key) and authenticates its OWN API calls (e.g.
-        // /sessions) with the per-device key it receives. The master token is no longer injected into
-        // the shell (issue #908), so reaching /mobile grants no access on its own - the data endpoints stay
-        // Bearer/cookie-gated on that per-device key.
-        //
-        // The legacy /m mount stays public too: the app re-based from /m to /mobile (owner ruling
-        // 2026-07-20), and the Gateway 301s /m -> /mobile and keeps POST /m/enroll as a back-compat route.
-        // Both the redirect and that route must be reachable before the device holds any credential,
-        // exactly as /mobile is - so an installed phone PWA still on the old path is not walled out.
-        if (string.Equals(path, "/mobile", StringComparison.OrdinalIgnoreCase)
-            || path.StartsWith("/mobile/", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(path, "/m", StringComparison.OrdinalIgnoreCase)
-            || path.StartsWith("/m/", StringComparison.OrdinalIgnoreCase))
-        {
-            await next();
-            return;
-        }
-
-        // Issue #1088: the desktop Cockpit shell's static assets (Vite's content-hashed JavaScript/CSS
-        // under /assets/) are public, exactly like the /m assets above - the /signin screen cannot
-        // render before any credential exists unless its script and styles load. The files carry no
-        // secret and no data; every data endpoint stays credential-gated below.
-        if (path.StartsWith(CockpitAssetsPrefix, StringComparison.OrdinalIgnoreCase))
+        // The shell surfaces (/mobile, the legacy /m mount, the Cockpit's /assets) pass the gate through
+        // ONE explicit allowlist of the public request shapes that exist today - never by prefix alone.
+        // See IsPublicShellSurfaceRequest for the list and the reasoning per entry.
+        if (IsPublicShellSurfaceRequest(ctx.Request.Method, path))
         {
             await next();
             return;

--- a/src/CcDirector.Launcher.Tests/AppCatalogTests.cs
+++ b/src/CcDirector.Launcher.Tests/AppCatalogTests.cs
@@ -160,14 +160,47 @@ public sealed class AppCatalogTests : IDisposable
     }
 
     [Fact]
-    public void ResolveLaunchPath_PathGiven_WinsOverTheApplicationName()
+    public void ResolveLaunchPath_CataloguedPath_WinsOverTheApplicationName()
     {
+        // Tenant-boundary hardening (CR-5): the path form is an allowlist lookup now. A path that IS a
+        // catalogue entry still wins over the name beside it, exactly as the free path form used to.
         CreateApp("Chrome");
+        var edge = CreateApp("Edge");
 
-        var (path, error) = CatalogOverRoot().ResolveLaunchPath(@"C:\explicit\thing.exe", "Chrome");
+        var (path, error) = CatalogOverRoot().ResolveLaunchPath(edge, "Chrome");
 
         Assert.Null(error);
-        Assert.Equal(@"C:\explicit\thing.exe", path);
+        Assert.Equal(edge, path);
+    }
+
+    /// <summary>
+    /// The CR-5 refusal: a path that is not an entry of this machine's installed-applications catalogue is
+    /// refused, whatever it points at. This is what stops a stolen key being remote code execution - the
+    /// caller can no longer start an executable it dropped or found on the machine.
+    /// </summary>
+    [Fact]
+    public void ResolveLaunchPath_UncataloguedPath_IsRefusedWithAReason()
+    {
+        CreateApp("Chrome");
+        var dropped = Path.Combine(_root, "dropped-payload.exe");
+        File.WriteAllText(dropped, "");
+
+        var (path, error) = CatalogOverRoot().ResolveLaunchPath(dropped, null);
+
+        Assert.Null(path);
+        Assert.Contains("not in the installed-applications catalogue", error);
+        Assert.Contains(Environment.MachineName, error);
+    }
+
+    [Fact]
+    public void ResolveLaunchPath_CataloguedPath_IsAcceptedCaseInsensitively()
+    {
+        var chrome = CreateApp("Chrome");
+
+        var (path, error) = CatalogOverRoot().ResolveLaunchPath(chrome.ToUpperInvariant(), null);
+
+        Assert.Null(error);
+        Assert.Equal(chrome, path);
     }
 
     [Fact]

--- a/src/CcDirector.Launcher.Tests/LinuxDesktopEntryLaunchTests.cs
+++ b/src/CcDirector.Launcher.Tests/LinuxDesktopEntryLaunchTests.cs
@@ -1,0 +1,312 @@
+using CcDirector.Launcher;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// Tenant-boundary hardening, Phase 5b, inspection finding M03-I2-02: the catalogue-only launch rule
+/// deleted generic launch on Linux.
+///
+/// On Linux the application catalogue is the desktop entry directories, so every catalogue entry is a
+/// ".desktop" FILE. Phase 1 narrowed the launch verb to accept only a catalogued path - correct - but
+/// the launcher then sent every non-Windows path down the macOS arm, which starts a path as a plain
+/// executable. A ".desktop" file is data describing a program, not the program, so after Phase 1 the
+/// only paths Linux accepted were paths the launcher could not start, and callers could no longer name
+/// the real executable either. No Linux application could be launched at all.
+///
+/// The tests that should have caught it could not: every non-Windows launch test began by returning
+/// early on a Windows host, and this repository is built and tested on Windows. So they passed by not
+/// running. Every test in this file runs on EVERY host, because the platform is an argument to the
+/// decision rather than something read from the machine, and each one exercises the real handoff -
+/// from a desktop entry sitting in a catalogue root, through the catalogue lookup, to the
+/// ProcessStartInfo that would start the program.
+/// </summary>
+public sealed class LinuxDesktopEntryLaunchTests : IDisposable
+{
+    private readonly string _root;
+    private readonly LaunchService _svc = new();
+
+    public LinuxDesktopEntryLaunchTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "ccd-desktop-entries-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string WriteEntry(string fileName, string contents)
+    {
+        var path = Path.Combine(_root, fileName);
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    private AppCatalog LinuxCatalogue() =>
+        new(new[] { (_root, "desktop-entries") }, LaunchPlatform.Linux);
+
+    private const string Firefox = """
+        [Desktop Entry]
+        Type=Application
+        Name=Firefox Web Browser
+        Exec=/usr/bin/firefox %u
+        Terminal=false
+        """;
+
+    // ------------------------------------------- the handoff the inspection said was missing ----
+
+    [Fact]
+    public void CatalogueEntryToProcessStart_startsTheProgramTheEntryNames_notTheDesktopFile()
+    {
+        // The whole finding in one test: a catalogued Linux application, looked up by name exactly as
+        // a caller would, and turned into a process start. Before the fix the resolved path WAS the
+        // start target, so nothing could ever run.
+        var entry = WriteEntry("firefox.desktop", Firefox);
+
+        var (path, error) = LinuxCatalogue().ResolveLaunchPath(null, "firefox");
+
+        Assert.Null(error);
+        Assert.Equal(entry, path);
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = path! }, LaunchPlatform.Linux);
+
+        Assert.Equal("/usr/bin/firefox", psi.FileName);
+        Assert.NotEqual(entry, psi.FileName);
+        Assert.False(psi.UseShellExecute, "a desktop entry's program is spawned directly, never through a shell");
+    }
+
+    [Fact]
+    public void CatalogueOnLinux_admitsDesktopEntries()
+    {
+        WriteEntry("firefox.desktop", Firefox);
+        WriteEntry("notes.txt", "not an application");
+
+        var found = LinuxCatalogue().Search(null, 50);
+
+        Assert.Contains(found.Apps, a => a.Name == "firefox");
+        Assert.DoesNotContain(found.Apps, a => a.Name == "notes");
+    }
+
+    [Fact]
+    public void CatalogueEntryPath_isAcceptedAsALaunchPath_andStillResolvesToItsProgram()
+    {
+        // The other way a caller names a target: the catalogued path itself.
+        var entry = WriteEntry("firefox.desktop", Firefox);
+
+        var (path, error) = LinuxCatalogue().ResolveLaunchPath(entry, null);
+
+        Assert.Null(error);
+        Assert.Equal(entry, path);
+        Assert.Equal("/usr/bin/firefox", _svc.BuildStartInfoFor(new LaunchRequest { Path = path! }, LaunchPlatform.Linux).FileName);
+    }
+
+    [Fact]
+    public void UncataloguedExecutablePath_isStillRefused()
+    {
+        // The security property Phase 1 established must survive the fix: naming the real executable
+        // out of a desktop entry is not a way around the allowlist.
+        WriteEntry("firefox.desktop", Firefox);
+
+        var (path, error) = LinuxCatalogue().ResolveLaunchPath("/usr/bin/firefox", null);
+
+        Assert.Null(path);
+        Assert.NotNull(error);
+        Assert.Contains("catalogue", error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------- the Exec line itself ----
+
+    [Fact]
+    public void FieldCodes_areStrippedFromTheStartedCommand()
+    {
+        var entry = WriteEntry("viewer.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Exec=/usr/bin/viewer --mode=read %F
+            """);
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux);
+
+        Assert.Equal("/usr/bin/viewer", psi.FileName);
+        Assert.Equal(new[] { "--mode=read" }, psi.ArgumentList);
+    }
+
+    [Fact]
+    public void QuotedArgumentsInTheExecLine_stayOneArgument()
+    {
+        var entry = WriteEntry("titled.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Exec="/opt/my apps/tool" --title "two words" %u
+            """);
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux);
+
+        Assert.Equal("/opt/my apps/tool", psi.FileName);
+        Assert.Equal(new[] { "--title", "two words" }, psi.ArgumentList);
+    }
+
+    [Fact]
+    public void PathKey_becomesTheWorkingDirectory()
+    {
+        var entry = WriteEntry("worker.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Exec=/usr/bin/worker
+            Path=/var/lib/worker
+            """);
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux);
+
+        Assert.Equal("/var/lib/worker", psi.WorkingDirectory);
+    }
+
+    [Fact]
+    public void OnlyTheDesktopEntryGroupIsRead_notADesktopActionGroup()
+    {
+        // An entry may carry extra action groups describing OTHER programs. Reading one of those
+        // would start something the caller did not name.
+        var entry = WriteEntry("multi.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Exec=/usr/bin/real-program
+
+            [Desktop Action NewWindow]
+            Name=New Window
+            Exec=/usr/bin/something-else --new-window
+            """);
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux);
+
+        Assert.Equal("/usr/bin/real-program", psi.FileName);
+    }
+
+    [Fact]
+    public void SelfHostArguments_areAppendedAsSeparateArgumentListEntries()
+    {
+        // Self-host callers still pass arguments (a hosted caller cannot - the Gateway refuses those
+        // before any launcher sees them). They must arrive as separate argument-list entries, never
+        // concatenated into a command string where a space could become a new word.
+        var entry = WriteEntry("firefox.desktop", Firefox);
+
+        var psi = _svc.BuildStartInfoFor(
+            new LaunchRequest { Path = entry, Args = "--profile \"my profile\"" }, LaunchPlatform.Linux);
+
+        Assert.Equal("/usr/bin/firefox", psi.FileName);
+        Assert.Equal(new[] { "--profile", "my profile" }, psi.ArgumentList);
+        Assert.Equal("", psi.Arguments);
+    }
+
+    // ------------------------------------------------------- entries that must be refused ----
+
+    [Fact]
+    public void ALinkTypeEntry_isRefusedExplicitly()
+    {
+        var entry = WriteEntry("bookmark.desktop", """
+            [Desktop Entry]
+            Type=Link
+            Name=A bookmark
+            URL=https://example.com
+            """);
+
+        var ex = Assert.Throws<NotSupportedException>(
+            () => _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux));
+        Assert.Contains("Type=Application", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ATerminalTrueEntry_isRefusedExplicitlyRatherThanGuessingAnEmulator()
+    {
+        var entry = WriteEntry("editor.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Exec=/usr/bin/vim
+            Terminal=true
+            """);
+
+        var ex = Assert.Throws<NotSupportedException>(
+            () => _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux));
+        Assert.Contains("terminal emulator", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnEntryWithNoExecLine_isRefused()
+    {
+        var entry = WriteEntry("empty.desktop", """
+            [Desktop Entry]
+            Type=Application
+            Name=Nothing to run
+            """);
+
+        Assert.Throws<InvalidOperationException>(
+            () => _svc.BuildStartInfoFor(new LaunchRequest { Path = entry }, LaunchPlatform.Linux));
+    }
+
+    // --------------------------------------------- the rest of the Linux arm, unchanged ----
+
+    [Fact]
+    public void APlainExecutableOnLinux_isStillSpawnedDirectly()
+    {
+        // The capability that existed before the allowlist and must not be lost: a real program path.
+        var exe = Path.Combine(_root, "tool");
+        File.WriteAllText(exe, "#!/bin/sh\n");
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = exe, Args = "--foo bar" }, LaunchPlatform.Linux);
+
+        Assert.Equal(exe, psi.FileName);
+        Assert.False(psi.UseShellExecute);
+        Assert.Equal(new[] { "--foo", "bar" }, psi.ArgumentList);
+    }
+
+    [Fact]
+    public void AShellScriptOnLinux_isRoutedThroughBash()
+    {
+        var script = Path.Combine(_root, "run.sh");
+        File.WriteAllText(script, "#!/bin/bash\n");
+
+        var psi = _svc.BuildStartInfoFor(new LaunchRequest { Path = script, Args = "one two" }, LaunchPlatform.Linux);
+
+        Assert.Equal("/bin/bash", psi.FileName);
+        Assert.Equal(new[] { script, "one", "two" }, psi.ArgumentList);
+    }
+
+    [Fact]
+    public void AWindowsBatchFileOnLinux_isRefused()
+    {
+        var bat = Path.Combine(_root, "go.bat");
+        File.WriteAllText(bat, "echo hi");
+
+        Assert.Throws<NotSupportedException>(
+            () => _svc.BuildStartInfoFor(new LaunchRequest { Path = bat }, LaunchPlatform.Linux));
+    }
+
+    // ------------------------------------------------- the Exec parser, on its own terms ----
+
+    [Fact]
+    public void ParseExec_doublePercent_isALiteralPercent()
+    {
+        Assert.Equal(new[] { "/usr/bin/x", "100%" }, DesktopEntry.ParseExec("/usr/bin/x 100%%"));
+    }
+
+    [Fact]
+    public void ParseExec_unknownFieldCode_isRefusedRatherThanGuessed()
+    {
+        Assert.Throws<InvalidOperationException>(() => DesktopEntry.ParseExec("/usr/bin/x %z"));
+    }
+
+    [Fact]
+    public void ParseExec_unterminatedQuote_isRefused()
+    {
+        Assert.Throws<InvalidOperationException>(() => DesktopEntry.ParseExec("\"/usr/bin/x --flag"));
+    }
+
+    [Fact]
+    public void ParseExec_escapedQuoteInsideAQuotedArgument_survives()
+    {
+        Assert.Equal(
+            new[] { "/usr/bin/x", "say \"hi\"" },
+            DesktopEntry.ParseExec("""/usr/bin/x "say \"hi\"" """));
+    }
+}

--- a/src/CcDirector.Launcher/AppCatalog.cs
+++ b/src/CcDirector.Launcher/AppCatalog.cs
@@ -36,6 +36,7 @@ public sealed class AppCatalog
     private const int MaximumDepth = 6;
 
     private readonly IReadOnlyList<(string Root, string Source)>? _rootsOverride;
+    private readonly LaunchPlatform _platform;
 
     /// <summary>The production catalogue, reading this machine's real application directories.</summary>
     public AppCatalog() : this(null) { }
@@ -45,7 +46,24 @@ public sealed class AppCatalog
     /// searched the real Start Menu would assert on whatever the machine running it happens to have installed,
     /// which is a test of the machine rather than of the catalogue.
     /// </summary>
-    public AppCatalog(IReadOnlyList<(string Root, string Source)>? roots) => _rootsOverride = roots;
+    public AppCatalog(IReadOnlyList<(string Root, string Source)>? roots)
+        : this(roots, LaunchService.CurrentPlatform) { }
+
+    /// <summary>
+    /// Build a catalogue that decides what counts as an installed application by the platform passed in
+    /// rather than by the machine it is running on.
+    ///
+    /// Inspection finding M03-I2-02: the Linux half of this catalogue - the half that yields ".desktop"
+    /// entries - could not be exercised at all from the Windows machine this repository is built on,
+    /// because <see cref="IsAppFile"/> read the operating system directly. So the handoff from a
+    /// catalogue entry to a started process was never tested on the platform where the entry is a data
+    /// file rather than a program, which is exactly where it was broken.
+    /// </summary>
+    internal AppCatalog(IReadOnlyList<(string Root, string Source)>? roots, LaunchPlatform platform)
+    {
+        _rootsOverride = roots;
+        _platform = platform;
+    }
 
     /// <summary>
     /// Search the catalogue. An empty query returns everything, up to the limit.
@@ -213,7 +231,7 @@ public sealed class AppCatalog
         foreach (var (root, source) in Roots())
         {
             if (!Directory.Exists(root)) continue;
-            foreach (var app in WalkRoot(root, source, skipped))
+            foreach (var app in WalkRoot(root, source, skipped, _platform))
             {
                 if (seenPaths.Add(app.Path))
                     found.Add(app);
@@ -235,7 +253,7 @@ public sealed class AppCatalog
             yield break;
         }
 
-        if (OperatingSystem.IsWindows())
+        if (_platform == LaunchPlatform.Windows)
         {
             yield return (Environment.GetFolderPath(Environment.SpecialFolder.StartMenu), "start-menu-user");
             yield return (Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu), "start-menu-machine");
@@ -244,7 +262,7 @@ public sealed class AppCatalog
 
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-        if (OperatingSystem.IsMacOS())
+        if (_platform == LaunchPlatform.MacOs)
         {
             yield return ("/Applications", "applications");
             yield return ("/System/Applications", "applications-system");
@@ -267,7 +285,8 @@ public sealed class AppCatalog
     /// condition rather than a fault. It is recorded in <paramref name="skipped"/> and reported to the caller,
     /// so an incomplete catalogue announces itself instead of looking like a shorter one.
     /// </summary>
-    private static IEnumerable<InstalledAppDto> WalkRoot(string root, string source, List<string> skipped)
+    private static IEnumerable<InstalledAppDto> WalkRoot(
+        string root, string source, List<string> skipped, LaunchPlatform platform)
     {
         var queue = new Queue<(string Directory, int Depth)>();
         queue.Enqueue((root, 0));
@@ -289,7 +308,7 @@ public sealed class AppCatalog
 
             foreach (var entry in entries)
             {
-                if (IsAppBundle(entry))
+                if (IsAppBundle(entry, platform))
                 {
                     yield return new InstalledAppDto
                     {
@@ -307,7 +326,7 @@ public sealed class AppCatalog
                     continue;
                 }
 
-                if (IsAppFile(entry))
+                if (IsAppFile(entry, platform))
                 {
                     yield return new InstalledAppDto
                     {
@@ -321,20 +340,18 @@ public sealed class AppCatalog
     }
 
     /// <summary>True for a macOS application bundle, which is a directory that must be treated as one item.</summary>
-    private static bool IsAppBundle(string path) =>
-        OperatingSystem.IsMacOS()
+    internal static bool IsAppBundle(string path, LaunchPlatform platform) =>
+        platform == LaunchPlatform.MacOs
         && path.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
         && Directory.Exists(path);
 
-    /// <summary>True for a file that represents a startable application on this operating system.</summary>
-    private static bool IsAppFile(string path)
+    /// <summary>True for a file that represents a startable application on the given operating system.</summary>
+    internal static bool IsAppFile(string path, LaunchPlatform platform) => platform switch
     {
-        if (OperatingSystem.IsWindows())
-            return path.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase);
-        if (OperatingSystem.IsMacOS())
-            return false;
-        return path.EndsWith(".desktop", StringComparison.OrdinalIgnoreCase);
-    }
+        LaunchPlatform.Windows => path.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase),
+        LaunchPlatform.MacOs => false,
+        _ => path.EndsWith(".desktop", StringComparison.OrdinalIgnoreCase),
+    };
 
     /// <summary>
     /// True for a symbolic link or junction. These are stepped over so a link pointing at an ancestor cannot

--- a/src/CcDirector.Launcher/AppCatalog.cs
+++ b/src/CcDirector.Launcher/AppCatalog.cs
@@ -153,13 +153,39 @@ public sealed class AppCatalog
     /// call it, so the two ways of asking this launcher to start something cannot come to different answers -
     /// the same rule the lifecycle verbs already follow by sharing <see cref="DirectorSupervisor"/>.
     ///
-    /// A path wins when both are given, because a path is unambiguous and a name is a lookup.
+    /// A path wins when both are given, because a path is unambiguous and a name is a lookup - but the path
+    /// is an ALLOWLIST LOOKUP, not a free launch. Tenant-boundary hardening (release 2026-07-31, finding
+    /// CR-5): the launch target must be an entry of this machine's installed-applications catalogue - the
+    /// same list GET /apps reports - so a caller holding a key cannot start an arbitrary executable it
+    /// dropped or found on the machine. The check lives here, in the launcher process that actually starts
+    /// the program, so neither relay arm (the loopback route or the Gateway command stream) can bypass it.
     /// </summary>
     /// <returns>The path to start, or an error naming why nothing could be started.</returns>
     public (string? Path, string? Error) ResolveLaunchPath(string? path, string? app)
     {
         if (!string.IsNullOrWhiteSpace(path))
-            return (path, null);
+        {
+            string full;
+            try
+            {
+                full = System.IO.Path.GetFullPath(path.Trim());
+            }
+            catch (ArgumentException)
+            {
+                return (null, $"'{path}' is not a valid path");
+            }
+
+            var match = Enumerate(new List<string>())
+                .FirstOrDefault(a => string.Equals(a.Path, full, StringComparison.OrdinalIgnoreCase));
+            if (match is null)
+            {
+                FileLog.Write($"[AppCatalog] ResolveLaunchPath REFUSED uncatalogued path: {full}");
+                return (null, $"'{path}' is not in the installed-applications catalogue on " +
+                              $"{Environment.MachineName}. Only catalogued applications can be started; " +
+                              "pick one from the apps list by name, or by its catalogued path.");
+            }
+            return (match.Path, null);
+        }
 
         if (string.IsNullOrWhiteSpace(app))
             return (null, "either path or app is required");

--- a/src/CcDirector.Launcher/DesktopEntry.cs
+++ b/src/CcDirector.Launcher/DesktopEntry.cs
@@ -1,0 +1,166 @@
+using System.Text;
+
+namespace CcDirector.Launcher;
+
+/// <summary>
+/// A Linux desktop entry - the ".desktop" file that IS the catalogue entry on Linux - and the one
+/// thing the launcher needs from it: which program to start.
+///
+/// Tenant-boundary hardening, Phase 5b, inspection finding M03-I2-02. Phase 1 narrowed the launch
+/// verb so that only a catalogued application can be started. On Linux the catalogue is the desktop
+/// entry directories, and every entry in it is a ".desktop" FILE - which is data describing a
+/// program, not the program. The launcher then handed that file to the macOS arm, which starts a
+/// path as a plain executable. So after the allowlist landed, the only paths Linux would accept were
+/// paths the launcher could not start, and a caller could no longer name the real executable either.
+/// That is a product capability deleted on a supported platform, which the mission brief forbids -
+/// the allowlist was right, the handoff behind it was not.
+///
+/// This class is the handoff: read the entry, take its own Exec line, and start THAT. The security
+/// property is unchanged and is the reason the parsing lives here rather than in the caller - what
+/// runs comes from the catalogued file on the machine, never from anything the caller sent.
+/// </summary>
+internal sealed record DesktopEntry(string Type, string? Exec, string? WorkingDirectory, bool Terminal)
+{
+    /// <summary>
+    /// The field codes the Desktop Entry Specification defines for an Exec line. They are
+    /// placeholders a desktop environment fills in with the files or URLs a user dropped on the
+    /// icon - there is no such thing here, so an argument carrying one is dropped entirely.
+    /// </summary>
+    private const string FieldCodes = "fFuUdDnNickvm";
+
+    /// <summary>
+    /// Read the "[Desktop Entry]" group of a desktop entry file. Only that group is read: an entry
+    /// may also carry "[Desktop Action ...]" groups describing extra menu items, and those are a
+    /// different program to start, not this one.
+    /// </summary>
+    internal static DesktopEntry Read(string path)
+    {
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Desktop entry not found: {path}", path);
+
+        string? type = null, exec = null, workingDirectory = null, terminal = null;
+        var inDesktopEntryGroup = false;
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            if (line[0] == '[')
+            {
+                inDesktopEntryGroup = string.Equals(line, "[Desktop Entry]", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (!inDesktopEntryGroup)
+                continue;
+
+            var separator = line.IndexOf('=');
+            if (separator <= 0)
+                continue;
+
+            var key = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+            switch (key)
+            {
+                case "Type": type = value; break;
+                case "Exec": exec = value; break;
+                case "Path": workingDirectory = value; break;
+                case "Terminal": terminal = value; break;
+            }
+        }
+
+        // Type is required of every entry. Exec is NOT required here, because a Link or Directory
+        // entry legitimately has none - refusing those on a missing Exec would report the wrong
+        // reason for something this launcher declines for a different and clearer one.
+        if (string.IsNullOrWhiteSpace(type))
+            throw new InvalidOperationException($"Desktop entry has no Type: {path}");
+
+        return new DesktopEntry(
+            type,
+            string.IsNullOrWhiteSpace(exec) ? null : exec,
+            string.IsNullOrWhiteSpace(workingDirectory) ? null : workingDirectory,
+            string.Equals(terminal, "true", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Split an Exec value into the argument vector it describes: the program first, then its own
+    /// arguments. Quoting follows the specification - a double quote groups, and inside quotes a
+    /// backslash escapes a quote, a backtick, a dollar sign or another backslash.
+    ///
+    /// An argument containing a FIELD CODE is dropped whole. Field codes stand for the files or URLs
+    /// a desktop environment would substitute, and there are none here; dropping the argument rather
+    /// than the two characters avoids handing the program a half-written option like "--file=" that
+    /// it never asked for.
+    ///
+    /// A percent sign that is neither "%%" nor a defined field code is a MALFORMED entry - the
+    /// specification requires a literal percent to be written "%%" - and it is refused rather than
+    /// guessed at. Refusing to start something is recoverable; starting the wrong thing is not.
+    /// </summary>
+    internal static IReadOnlyList<string> ParseExec(string exec)
+    {
+        var arguments = new List<string>();
+        var current = new StringBuilder();
+        var argumentStarted = false;
+        var argumentHadFieldCode = false;
+        var inQuotes = false;
+
+        void Flush()
+        {
+            if (!argumentHadFieldCode && (argumentStarted || current.Length > 0))
+                arguments.Add(current.ToString());
+            current.Clear();
+            argumentStarted = false;
+            argumentHadFieldCode = false;
+        }
+
+        for (var i = 0; i < exec.Length; i++)
+        {
+            var c = exec[i];
+
+            if (inQuotes)
+            {
+                if (c == '\\' && i + 1 < exec.Length && "\"`$\\".Contains(exec[i + 1]))
+                {
+                    current.Append(exec[++i]);
+                    continue;
+                }
+                if (c == '"') { inQuotes = false; continue; }
+                current.Append(c);
+                continue;
+            }
+
+            if (c == '"') { inQuotes = true; argumentStarted = true; continue; }
+
+            if (char.IsWhiteSpace(c)) { Flush(); continue; }
+
+            if (c == '%')
+            {
+                if (i + 1 >= exec.Length)
+                    throw new InvalidOperationException(
+                        $"Desktop entry Exec line ends with a bare percent sign, which the Desktop Entry " +
+                        $"Specification does not allow: {exec}");
+                var code = exec[++i];
+                if (code == '%') { current.Append('%'); argumentStarted = true; continue; }
+                if (FieldCodes.Contains(code)) { argumentHadFieldCode = true; continue; }
+                throw new InvalidOperationException(
+                    $"Desktop entry Exec line carries an unknown field code '%{code}'. A literal percent " +
+                    $"must be written '%%', so this entry is malformed and will not be started: {exec}");
+            }
+
+            current.Append(c);
+            argumentStarted = true;
+        }
+
+        if (inQuotes)
+            throw new InvalidOperationException($"Desktop entry Exec line has an unterminated quote: {exec}");
+
+        Flush();
+
+        if (arguments.Count == 0)
+            throw new InvalidOperationException($"Desktop entry Exec line names no program to start: {exec}");
+
+        return arguments;
+    }
+}

--- a/src/CcDirector.Launcher/LaunchService.cs
+++ b/src/CcDirector.Launcher/LaunchService.cs
@@ -40,14 +40,36 @@ public sealed class LaunchService
     /// Build a ProcessStartInfo for the given launch request. No real spawn - pure,
     /// unit-testable seam.
     /// </summary>
-    public ProcessStartInfo BuildStartInfo(LaunchRequest request)
+    public ProcessStartInfo BuildStartInfo(LaunchRequest request) =>
+        BuildStartInfoFor(request, CurrentPlatform);
+
+    /// <summary>The platform this launcher is running on, as the launch rules see it.</summary>
+    internal static LaunchPlatform CurrentPlatform =>
+        OperatingSystem.IsWindows() ? LaunchPlatform.Windows
+        : OperatingSystem.IsMacOS() ? LaunchPlatform.MacOs
+        : LaunchPlatform.Linux;
+
+    /// <summary>
+    /// <see cref="BuildStartInfo"/> with the platform passed in rather than read from the machine.
+    ///
+    /// This seam exists because of inspection finding M03-I2-02, and the finding was as much about
+    /// the TESTS as about the code. Every non-Windows launch test began by returning early on a
+    /// Windows host, so on the machine this repository is built and tested on they all passed
+    /// without running - a silent skip that reads as coverage. Worse, the production code sent
+    /// EVERY non-Windows path down the macOS arm, so there was no Linux behaviour to cover even if
+    /// they had run. With the platform as an argument, all three arms are exercised on any one
+    /// machine, and the Linux desktop-entry handoff is proven rather than assumed.
+    /// </summary>
+    internal ProcessStartInfo BuildStartInfoFor(LaunchRequest request, LaunchPlatform platform)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (string.IsNullOrWhiteSpace(request.Path))
             throw new ArgumentException("Path must not be empty.", nameof(request));
 
-        if (!OperatingSystem.IsWindows())
+        if (platform == LaunchPlatform.MacOs)
             return BuildStartInfoMac(request);
+        if (platform == LaunchPlatform.Linux)
+            return BuildStartInfoLinux(request);
 
         if (!File.Exists(request.Path))
             throw new FileNotFoundException($"Executable not found: {request.Path}", request.Path);
@@ -157,6 +179,109 @@ public sealed class LaunchService
     }
 
     /// <summary>
+    /// The Linux half of <see cref="BuildStartInfo"/>.
+    ///
+    /// The case that matters is the desktop entry, because on Linux that IS what the application
+    /// catalogue contains (inspection finding M03-I2-02). A ".desktop" file describes a program; it
+    /// is not the program, and running it as an executable does nothing. So the entry is read and
+    /// the command on its own Exec line is started instead.
+    ///
+    /// The security property Phase 1 established is preserved exactly: what runs is decided by the
+    /// catalogued file ON THIS MACHINE and nothing else. The caller named a catalogue entry; the
+    /// entry named its program. A hosted caller cannot supply arguments or a working directory at
+    /// all - the Gateway refuses those before the request reaches any launcher - and the arguments a
+    /// self-host caller may still pass are added as separate argument-list entries, never
+    /// concatenated into a command string where they could be re-read as extra words.
+    /// </summary>
+    private static ProcessStartInfo BuildStartInfoLinux(LaunchRequest request)
+    {
+        var ext = Path.GetExtension(request.Path).ToUpperInvariant();
+        if (ext is ".CMD" or ".BAT")
+            throw new NotSupportedException($"Windows batch files cannot be launched on Linux: {request.Path}");
+
+        if (!File.Exists(request.Path))
+            throw new FileNotFoundException($"Executable not found: {request.Path}", request.Path);
+
+        if (ext == ".DESKTOP")
+            return BuildStartInfoLinuxDesktopEntry(request);
+
+        if (ext == ".SH")
+        {
+            // Route shell scripts through bash so a missing execute bit never fails the launch -
+            // the same rule the macOS arm uses, for the same reason.
+            var script = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                WorkingDirectory = request.Cwd ?? Path.GetDirectoryName(request.Path) ?? "",
+                UseShellExecute = false,
+            };
+            script.ArgumentList.Add(request.Path);
+            foreach (var arg in SplitArguments(request.Args ?? ""))
+                script.ArgumentList.Add(arg);
+            return script;
+        }
+
+        // A plain executable named directly. This is the form that worked before the catalogue
+        // allowlist landed and it still works: the launcher runs with no controlling terminal, so
+        // the child starts with clean standard input and output.
+        var psi = new ProcessStartInfo
+        {
+            FileName = request.Path,
+            WorkingDirectory = request.Cwd ?? Path.GetDirectoryName(request.Path) ?? "",
+            UseShellExecute = false,
+        };
+        foreach (var arg in SplitArguments(request.Args ?? ""))
+            psi.ArgumentList.Add(arg);
+        return psi;
+    }
+
+    /// <summary>
+    /// Turn a catalogued Linux desktop entry into the process start it describes. See
+    /// <see cref="DesktopEntry"/> for why this is the fix for a deleted capability rather than a
+    /// widening of the allowlist.
+    /// </summary>
+    private static ProcessStartInfo BuildStartInfoLinuxDesktopEntry(LaunchRequest request)
+    {
+        var entry = DesktopEntry.Read(request.Path);
+
+        if (!string.Equals(entry.Type, "Application", StringComparison.Ordinal))
+            throw new NotSupportedException(
+                $"Only a Type=Application desktop entry names a program to start. '{request.Path}' is " +
+                $"Type={entry.Type}, which describes a link or a directory, so there is nothing to launch.");
+
+        if (entry.Terminal)
+            throw new NotSupportedException(
+                $"'{request.Path}' is a Terminal=true desktop entry: it must be run inside a terminal " +
+                "emulator, and which emulator this machine uses is not something the launcher can " +
+                "determine. Trying a list of likely ones would start the program under whichever " +
+                "happened to be installed, or silently start it with no terminal at all. Launch it " +
+                "from a session instead.");
+
+        if (entry.Exec is null)
+            throw new InvalidOperationException(
+                $"'{request.Path}' has no Exec line, so it names no program to start.");
+
+        var argv = DesktopEntry.ParseExec(entry.Exec);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = argv[0],
+            // Path= in the entry is the working directory its author chose for the program. A
+            // self-host caller may still override it; a hosted caller cannot supply one at all.
+            WorkingDirectory = request.Cwd ?? entry.WorkingDirectory ?? "",
+            UseShellExecute = false,
+        };
+        for (var i = 1; i < argv.Count; i++)
+            psi.ArgumentList.Add(argv[i]);
+        foreach (var arg in SplitArguments(request.Args ?? ""))
+            psi.ArgumentList.Add(arg);
+
+        FileLog.Write($"[LaunchService] desktop entry {request.Path} starts {argv[0]} " +
+                      $"with {psi.ArgumentList.Count} arguments");
+        return psi;
+    }
+
+    /// <summary>
     /// Split a single argument string into argv entries: whitespace separates, double
     /// quotes group. Needed on macOS where /usr/bin/open and /bin/bash take an argument
     /// LIST (ProcessStartInfo.ArgumentList), while the request carries one string.
@@ -203,6 +328,18 @@ public sealed class LaunchService
 
     /// <summary>PIDs of processes launched since this service instance was created.</summary>
     public IReadOnlyList<int> LaunchedPids => _launched.Keys.ToList();
+}
+
+/// <summary>
+/// The operating system a launch decision is being made for. Passed in rather than read from the
+/// machine so every arm is testable on any one build machine - see
+/// <see cref="LaunchService.BuildStartInfoFor"/>.
+/// </summary>
+internal enum LaunchPlatform
+{
+    Windows,
+    MacOs,
+    Linux,
 }
 
 /// <summary>A request to launch an executable.</summary>

--- a/tools/cc-devthrottle/src/machine_ops.py
+++ b/tools/cc-devthrottle/src/machine_ops.py
@@ -187,7 +187,11 @@ def launch(machine: str, app: Optional[str], path: Optional[str], args: Optional
     if not app and not path:
         _fail("Name what to start: --app \"Chrome\" or --path \"C:\\\\Tools\\\\thing.exe\".")
 
-    body = {"app": app, "path": path, "args": args, "cwd": cwd, "headless": headless}
+    # confirmProtected carries this command's explicit intent through the relay: the Gateway refuses any
+    # launch without it (tenant-boundary hardening, CR-5). Typing `machine launch` IS the confirmation -
+    # the flag exists to stop programs being started as a side effect of something else.
+    body = {"app": app, "path": path, "args": args, "cwd": cwd, "headless": headless,
+            "confirmProtected": True}
     try:
         payload = director.post_json(f"fleet/machines/{machine}/launch", body, timeout=60)
     except director.DirectorError as err:

--- a/tools/cc-devthrottle/tests/test_machine_ops.py
+++ b/tools/cc-devthrottle/tests/test_machine_ops.py
@@ -178,3 +178,6 @@ def test_launch_by_name_posts_the_application_to_the_right_machine(monkeypatch):
     assert captured["path"] == "fleet/machines/SOREN_NORTH/launch"
     assert captured["body"]["app"] == "Google Chrome"
     assert captured["body"]["path"] is None
+    # The Gateway refuses any launch without this explicit confirmation (tenant-boundary hardening,
+    # CR-5); the typed command carries it, so the capability keeps working end to end.
+    assert captured["body"]["confirmProtected"] is True


### PR DESCRIPTION
Closes the four ways one tenant on the hosted Gateway could reach another tenant's things, plus the operational edge around them. Nineteen commits, each a fix with its regression test in the same commit, every fix watched failing on purpose against predictions written beforehand.

## What was wrong, and what now happens

**Any active device key could read any file on any machine in the account.** The tunnel's file-read verb served whatever absolute path a caller named after only an existence check, while the screenshot verb beside it already defended itself. The read is now contained on the Director, where the filesystem is actually touched, and the decision is made on the file's real identity: reparse points are resolved through every path component, paths are folded to the spelling the filesystem itself uses and compared ordinally, and a file with more than one name is refused because nothing at that moment can establish where its other name points.

**A stolen key was remote code execution.** `POST /machines/{machine}/launch` started a program on key possession alone. It now requires explicit confirmation, the target must be an application the machine actually has catalogued, and on a hosted process the caller supplies no arguments and no working directory at all - the catalogue entry alone decides what runs. Self-host is unchanged. On Linux a catalogued desktop entry now starts the program it names rather than the file that names it.

**Every tenant could read every tenant's missions and the operator's communications queue.** The queue is refused in whole on hosted through the shared refusal primitive; self-host serves it exactly as before. Missions were already partitioned, which is now verified end to end rather than assumed, with unattributed rows quarantined on hosted and adopted by the single owner on self-host.

**One forgotten argument collapsed every hosted tenant into one partition.** The tenant resolver answered the shared Local partition whenever its boundary argument was missing, and the argument was optional on around seventy-five routes. Every resolver now denies on a hosted process, and the argument is required on every signature that threads it, so a forgotten one is a compile error.

Alongside these: the context-less route census is now an executable assertion over the real route table on both deployments rather than a paragraph, the shell prefix auth-opens are an explicit method-scoped allowlist with a route-surface guard, and six hosted-only branches that trusted a nullable argument now gate on the process-level flag.

## Evidence

Full Gateway suite **5113 passed, 0 failed** measured on this exact tree; Launcher 110/110 on both frameworks; desktop app builds clean. Every fix was proven red-first: the fix committed, then broken on purpose, with the expected reds and the expected greens written down before the run. The final round predicted twelve reds across four batched faults and eleven for the Linux launch fault, and got exactly those and nothing else.

Two independent reviews from a different model family failed this branch before it was fit to merge - the first found three serious defects including that a claimed compile-time guarantee did not exist, the second found that a plain hard link still walked out of the contained folder. Both were fixed. A third reviewer independently reached the same hard-link finding.

## What this does NOT close, stated plainly

**The caller still chooses the folder that containment contains to.** A session's working directory is accepted on the strength of being non-blank and existing, so a device key can root a session at a drive or a home folder and every read is then correctly reported as inside it. Containment works; it is pointed wherever the caller asks. Filed as thefrederiksen/devthrottle_internal#1284 with the evidence and a suggested hosted-only shape, because fixing it properly means deciding allowed roots on the server and that changes how sessions are created everywhere.

**There are no credential authority levels.** Every device key in an account has equal authority, which is why the launch verb is narrowed rather than authorized.

**The Unix link count has never executed** - this is a Windows build machine, and the check locates the field empirically at startup. It fails closed, which is also the risk: a machine where it cannot calibrate would refuse every file and look exactly like the check working. Filed as thefrederiksen/devthrottle_internal#1282; one suite run on either platform settles it.

Also open and unchanged: the time-of-check to time-of-use race at the containment sites, the residual that a catalogued shell is still a shell, the global queue file behind the hosted deny, and the deployed-digest hostile matrix which is deliberately the next wave.

A hard-linked file inside a session folder is now refused even when its other name is innocent - the pnpm `node_modules` case. Correct under the rule, and a visible narrowing.
