### PR TITLE
A mission lands its own record before it reports

### DIFF
--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -247,6 +247,39 @@ worse than no comment, because the next reader spends their scepticism somewhere
 
 ---
 
+## Land the mission's own record
+
+**The paper trail is part of the work. The Architect lands it on `main` the same way and by the same
+authority as the code - as the last slice, before the report. A mission that reported but never
+committed its record is not finished.**
+
+The record is the brief, the design rulings, the running state note, the handoff notes, the
+inspections, the fix reports, and the evidence files the proofs rest on. If a phase produced it and a
+later reader would need it to know what happened, it is record.
+
+**Why this is a rule and not a tidiness preference.** Law 2 says work that exists in one place is work
+you are one crash away from losing - and then applies it only to code. The record is exempt by
+omission, and it is the part this document's own machinery runs on. The Architect stays lean by
+holding its state in durable files instead of its context, and a fresh Manager is rebuilt from the
+handoff note. Files that were never committed are not durable; they are one disk. The reset strategy
+above is worth exactly what the record behind it is worth.
+
+Measured rather than asserted: as of 2026-08-01, `docs/missions/` in the product repository had been
+committed three times in its whole history, and every one was somebody sweeping up after missions that
+had already reported and gone - most recently 49 files across two missions, in one pull request.
+Nothing here made the record anybody's job, so it was nobody's, and it refilled within days.
+
+**Write it inside the mission worktree.** A record written into the shared checkout is stranded by
+construction: the worktree goes away when the mission ends, the shared tree was never the mission's to
+commit, and the files sit there untracked until an unrelated agent notices months of them at once.
+This is ONE worktree per mission, applied to the paper as well as the code.
+
+**A running mission's record is not yours to sweep.** If you are clearing someone else's leftovers,
+find out what is still seated first and leave those files alone - they land when that mission reports.
+Define what you are touching mechanically, not by eye.
+
+---
+
 ## The QA report - the one time you bother the owner
 
 Written for the owner, not for the repository. Plain English, no abbreviations, no process.

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
@@ -73,6 +73,15 @@ public static class BuiltInWorkflows
                     Reviewer: "Manager",
                     Done: "A merged pull request. Committed and pushed is still in progress."),
                 new WorkflowStep(
+                    Name: "Land the record",
+                    Description: "The Architect lands the mission's own paper trail - brief, rulings, state note, "
+                               + "inspections, fix reports, evidence - as the last slice, from inside the mission "
+                               + "worktree. A record left uncommitted is one disk away from gone, and it is what "
+                               + "the next agent rebuilds the mission from.",
+                    Doer: "Architect",
+                    Reviewer: null,
+                    Done: "The mission's record is merged to the main branch."),
+                new WorkflowStep(
                     Name: "Report",
                     Description: "The quality report goes to the owner. This is the one interruption the mission "
                                + "is allowed to spend.",

--- a/src/CcDirector.Gateway/Workflows/Content/mission.instructions.md
+++ b/src/CcDirector.Gateway/Workflows/Content/mission.instructions.md
@@ -243,6 +243,39 @@ worse than no comment, because the next reader spends their scepticism somewhere
 
 ---
 
+## Land the mission's own record
+
+**The paper trail is part of the work. The Architect lands it on `main` the same way and by the same
+authority as the code - as the last slice, before the report. A mission that reported but never
+committed its record is not finished.**
+
+The record is the brief, the design rulings, the running state note, the handoff notes, the
+inspections, the fix reports, and the evidence files the proofs rest on. If a phase produced it and a
+later reader would need it to know what happened, it is record.
+
+**Why this is a rule and not a tidiness preference.** Law 2 says work that exists in one place is work
+you are one crash away from losing - and then applies it only to code. The record is exempt by
+omission, and it is the part this document's own machinery runs on. The Architect stays lean by
+holding its state in durable files instead of its context, and a fresh Manager is rebuilt from the
+handoff note. Files that were never committed are not durable; they are one disk. The reset strategy
+above is worth exactly what the record behind it is worth.
+
+Measured rather than asserted: as of 2026-08-01, `docs/missions/` in the product repository had been
+committed three times in its whole history, and every one was somebody sweeping up after missions that
+had already reported and gone - most recently 49 files across two missions, in one pull request.
+Nothing here made the record anybody's job, so it was nobody's, and it refilled within days.
+
+**Write it inside the mission worktree.** A record written into the shared checkout is stranded by
+construction: the worktree goes away when the mission ends, the shared tree was never the mission's to
+commit, and the files sit there untracked until an unrelated agent notices months of them at once.
+This is ONE worktree per mission, applied to the paper as well as the code.
+
+**A running mission's record is not yours to sweep.** If you are clearing someone else's leftovers,
+find out what is still seated first and leave those files alone - they land when that mission reports.
+Define what you are touching mechanically, not by eye.
+
+---
+
 ## The QA report - the one time you bother the owner
 
 Written for the owner, not for the repository. Plain English, no abbreviations, no process.


### PR DESCRIPTION
Adds a fifth step to the `mission` built-in workflow - **Land the record** -
plus the section of conduct behind it.

## The gap

Law 2 already argues that work existing in one place is work you are one crash
away from losing. It then applies that only to code on the mission branch. A
mission's own paper trail - brief, design rulings, running state note, handoff
notes, inspections, fix reports, evidence files - was exempt by omission.

That trail is what the workflow's own machinery runs on. The Architect is told
to stay lean by holding state in durable files rather than in its context, and a
fresh Manager is rebuilt from the handoff note. Files nobody ever committed are
not durable; they are one disk. The reset strategy was resting on something the
workflow never required anyone to keep.

## Measured, not assumed

In the product repo, `docs/missions/` had been committed **three times in its
whole history**, and every one was somebody sweeping up after missions that had
already reported and gone. The most recent was 49 files across two missions in a
single pull request. Nothing made the record anybody's job, so it was nobody's,
and it refilled within days.

## What the conduct now says

- The record lands on `main` as the last slice, before the report, by the
  Architect, under the same authority as the code. A mission that reported but
  never committed its record is not finished.
- **Write it inside the mission worktree.** A record written into the shared
  checkout is stranded by construction - the worktree goes away when the mission
  ends and the shared tree was never the mission's to commit.
- **A running mission's record is not yours to sweep.** Whoever clears leftovers
  finds out what is still seated first, and defines what they are touching
  mechanically rather than by eye.

## On the two copies

`.claude/skills/mission/SKILL.md` is the canonical source; the Gateway's
embedded copy is a faithful extraction of it, enforced by
`Mission_instructions_are_a_faithful_extraction_of_the_skill_file`.

That test failed when only the embedded copy had changed, and passed once
`SKILL.md` matched - so the guard is revert-proven by the run itself, not by
assertion. No new version constant is needed: the seeder republishes on a
content-hash change, so this ships with the binary.

## Tests

- `CcDirector.Gateway.Tests` workflow filter: 74/74 pass (was 73/74 with the
  fidelity test red).
- `CcDirector.Core.Tests` workflow filter: 48/48 pass.
- The cockpit `WorkflowsView` test builds its own fixture and is unaffected.