### PR TITLE
The access log tags the account with the hash every other line uses, not the raw id

### DIFF
--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1637,16 +1637,24 @@ public sealed class GatewayHost : IAsyncDisposable
     /// you were breached and knowing whose credential to revoke.
     ///
     /// Carries NO key material: DeviceCredentialIdentity holds neither the raw credential nor its
-    /// stored hash, so DT-05 (a credential never reaches the log) still holds. The account identifier
-    /// is already disclosed on /privacy as something service logs may contain. Unauthenticated
+    /// stored hash, so DT-05 (a credential never reaches the log) still holds. Unauthenticated
     /// requests add nothing, so public routes are unchanged.
+    ///
+    /// The account is written through <see cref="TenantId.ToLogString"/>, the one-way hash tag every
+    /// other tenant-bearing line uses. The first version of this method wrote the RAW account id, one
+    /// day after #2343 had gone through the Gateway replacing exactly that with the hash - and it did
+    /// so on the highest-volume line in the process, which would have undone that work at the worst
+    /// possible site. The tag is stable, so two lines from one account still correlate, which is all
+    /// this line needs to do.
     /// </summary>
     private static string DeviceForLog(HttpContext ctx)
     {
         if (ctx.Items.TryGetValue(Util.AuthMiddleware.AuthenticatedDeviceItemKey, out var value)
             && value is Pairing.DeviceCredentialIdentity identity)
         {
-            var tenant = string.IsNullOrEmpty(identity.TenantId) ? "-" : identity.TenantId;
+            var tenant = string.IsNullOrEmpty(identity.TenantId)
+                ? "-"
+                : new TenantId(identity.TenantId).ToLogString();
             return $" device={identity.DeviceId} type={identity.DeviceType} account={tenant}";
         }
 


### PR DESCRIPTION
Fixing a regression I introduced this morning, found by the independent security-depth review of the last two days.

**What went wrong.** #2343 went through the Gateway replacing raw account identifiers in log lines with the one-way tag `TenantId.ToLogString` produces - LauncherHub and ClientErrorEndpoints among them - because the data map that /privacy renders states service logs do not carry them. The access-log device attribution in #2356 then wrote the raw identifier straight back, one day later, and did it on the **highest-volume line in the process**: every authenticated request. That undid deliberate work at the worst possible site.

**The fix.** The account is written through the same tag as every other tenant-bearing line. The tag is stable, so two lines from one account still correlate - which is the only property the attribution needed. The point of that change was to say which device and account a request came from so a stolen credential can be identified and revoked, and a stable tag says that without carrying the identifier itself.

Device id and device type are unchanged: neither is a credential, neither is customer content, and they are what make a file read attributable to something revocable.

**Why it matters beyond tidiness.** While devthrottle#2357 stays open as an accepted risk, this access log is the mechanism that makes a broad read attributable after the fact. It needs to be a log we are willing to keep, and a log full of raw account identifiers on every request is not.