### PR TITLE
release: v1.9.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,8 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.3</Version>
+    <Version>1.9.4</Version>
   </PropertyGroup>
-
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.
 
@@ -38,8 +37,7 @@
     a guard that covers all of them.
   -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuard.cs"
-             Link="TestInfrastructure\MutationProofPinGuard.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuard.cs" Link="TestInfrastructure\MutationProofPinGuard.cs" />
     <!--
       The per-assembly sentinel, and ONLY the sentinel. Every assembly must prove its own copy of the
       module initializer woke up, because one that silently does not run leaves no trace and every other
@@ -50,17 +48,14 @@
       scheduling in assemblies that have nothing to do with this mechanism. See
       MutationProofPinGuardArmedTests for the incident that prompted the split.
     -->
-    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardArmedTests.cs"
-             Link="TestInfrastructure\MutationProofPinGuardArmedTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardArmedTests.cs" Link="TestInfrastructure\MutationProofPinGuardArmedTests.cs" />
   </ItemGroup>
-
   <!--
     The guard's behavioural suite, compiled into exactly one assembly. Core.Tests because it is the
     fastest of the seven to build and run, has no user-interface threading requirements, and is where
     this unit's proofs have been driven throughout.
   -->
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'CcDirector.Core.Tests'">
-    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardTests.cs"
-             Link="TestInfrastructure\MutationProofPinGuardTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\TestInfrastructure\MutationProofPinGuardTests.cs" Link="TestInfrastructure\MutationProofPinGuardTests.cs" />
   </ItemGroup>
 </Project>

--- a/docs/public/release-notes/v1.9.4.md
+++ b/docs/public/release-notes/v1.9.4.md
@@ -1,0 +1,51 @@
+## v1.9.4 - August 1, 2026
+
+Most of this release is security work on the hosted service, and it is the reason to update. There
+are also two things you will actually see: Brave and Opera now work, and a repository report can go
+straight to your clipboard.
+
+### One customer can no longer reach another customer's things
+
+This only affects the hosted service. If you run your own Gateway, none of it applied to you, and
+nothing here changes how your machine behaves.
+
+Four separate ways one paying customer could reach another are now closed. Every tenant could read
+every other tenant's missions. The outbound-communications queue was shared across all of them. And
+a single forgotten argument in any of roughly seventy-five routes would have quietly collapsed every
+hosted customer into one shared pool, with nothing anywhere to say it had happened - that last one is
+now a compile error rather than something a reviewer has to catch.
+
+Reading a file is contained to the session's own folder, and the check now happens where the disk is
+actually touched, so nothing arriving down the tunnel can go around it. It decides on the real
+identity of a path rather than how the path is spelled, which matters more than it sounds: the first
+version compared text only, and a shortcut planted inside an allowed folder walked straight back out
+of it. A plain hard link did the same thing even after that was fixed. Both are closed, and the tests
+create real shortcuts, junctions and hard links on disk rather than describing them.
+
+Starting a program on one of your machines now needs explicit confirmation, has to be an application
+actually installed there, and on the hosted service carries no caller-supplied arguments at all.
+
+**What is not fixed, stated plainly.** The original goal was that a stolen device key could not read
+secrets on your machines. That is *reduced, not closed.* Containment works, but the caller still
+chooses the folder it is contained to - so a session can be created rooted at an entire drive and
+every read is then correctly reported as being inside its own root. Closing it properly means the
+server deciding which roots are allowed instead of trusting the request, which changes how sessions
+are created everywhere. It was too large to rush at the end of a security run, so it is tracked as
+issue 2357 with the evidence rather than quietly carried. Two independent reviewers found it.
+
+### Brave and Opera
+
+The browser features work with Brave and Opera as well as Chrome and Edge. The browser list also
+appears immediately instead of after a pause, and the empty state now explains what it wants from
+you rather than sitting there blank.
+
+### Copy a repository report
+
+A repository report can be copied straight to your clipboard. Previously the only way to get one out
+was to hand it to an agent, which was a long way round for something you wanted to paste into a
+message.
+
+### The Director checks the tool on PATH can actually drive it
+
+On startup the Director now confirms that the command-line tool it finds on your PATH is one it can
+actually talk to, instead of assuming it and failing later in a way that pointed at the wrong thing.


### PR DESCRIPTION
Version bump and release notes for v1.9.4.

The tag is created only after this merges, so it can never point at a commit that is not on main.

See docs/public/release-notes/v1.9.4.md for what is in this release.