### PR TITLE
The PATH repair proves it has something to point at

### DIFF
--- a/docs/setup-health-check.md
+++ b/docs/setup-health-check.md
@@ -193,6 +193,77 @@ Built and proven:
 Not yet done: the end-to-end proof in a running Director (badge appears on this machine, banner shows,
 button clears both), which needs a slot Director launched against the live fault.
 
+## What happened when the button was pressed, 2026-08-01 10:43
+
+It did exactly what it was built to do and could not have worked. From that Director's own log:
+
+```
+10:43:16.273 [FleetToolPathRepair] PutFirstOnPath: ...\instances\default\bin
+10:43:16.278 [FleetToolPathRepair] PutFirstOnPath done: ...\instances\default\bin is now first
+10:43:16.278 [FleetToolReachability] RunAsync: probing cc-devthrottle against http://127.0.0.1:7879
+10:43:17.430 [FleetToolReachability] cc-devthrottle at ...\cc-director\bin\cc-devthrottle.CMD
+             FAILED to reach http://127.0.0.1:7879: Error: missing or invalid token
+```
+
+PATH was repaired correctly - registry and running process both - and the re-check resolved the same
+stale copy again, because `instances\default\bin` was **empty**. That Director's own tools had never
+been installed. Three minutes later, on the machine's own evidence:
+
+```
+10:44:19.283 [ToolReconciler] drift found: missingShims=8
+10:44:21.214 [ToolHealthProbe] cc-devthrottle FAILED: binary missing:
+             ...\instances\default\pyenv\Scripts\cc-devthrottle.exe
+```
+
+and on disk, `instances\default\pyenv` was created at 10:44:25 and the shims at 10:46:20 - both after
+the button was pressed. `ExecutableResolver` walks PATH in order and skips a directory with no match,
+so promoting an empty one changes the order and nothing about what resolves.
+
+**The root cause: the guard tested the container, not the contents.** `PutFirstOnPath` required only
+`Directory.Exists(binDir)`, and the directory had existed - empty - since the instance home was
+created. The check above it could see that PATH pointed at another install; it could not see that we
+had nothing to point at, because it never asked about our own copy.
+
+The wider fault on that machine was bigger than PATH order: this Director had no tools at all. The
+banner named a symptom of that and offered a fix for the symptom.
+
+### What changed
+
+1. **The check asks a second question.** `FleetToolReachability` now runs the same functional probe
+   against `expectedBinDir` directly, by full path, whenever the PATH probe fails. `OwnVerdict` splits
+   two faults that look identical from outside: PATH resolves someone else's WORKING copy (repoint), or
+   we have no working copy (install first, then repoint). It also puts in the log the line whose absence
+   made this undiagnosable from the panel: *this Director has no cc-devthrottle of its own*.
+2. **The button's precondition is provable.** `CanRepairByRepointingPath` requires our own copy to have
+   passed. When it has not, the banner says the tools are not installed and the button installs them
+   before touching PATH. `PutFirstOnPath` independently refuses a directory holding no `cc-devthrottle`,
+   before it writes anything.
+3. **The repair leaves ONE entry per command line.** Two entries serve nobody - only the first can win,
+   and the loser waits to win again the moment the order shifts. Superseded DevThrottle directories come
+   out of the user PATH: the flat pre-migration `<root>\bin`, anything under the temp directory (a
+   wizard test harness had leaked `...\Temp\wizard-harness-home-29ef...\cc-director\bin` onto the real
+   user PATH), and install bins gone from disk. **Another live instance's bin is left alone** - a second
+   Director in its own instance home is legitimate, and removing its tools to tidy ours would be
+   sabotage dressed as hygiene. Entries are decided on the EXPANDED path and written back RAW.
+   Nothing on disk is touched.
+4. **Sessions no longer depend on machine PATH order.** `SessionManager` puts this Director's own bin
+   first on every session's PATH, in the same breath as the `CC_DIRECTOR_API` address the session must
+   call. Machine PATH is shared state any other install can win; a session should not have to find us
+   when we can tell it. The PATH repair is now a convenience for the user's own terminals rather than
+   the mechanism the product depends on.
+5. **The panel cannot sit on a stale verdict.** The tools health pass is computed once per run, so the
+   verdict handed to the Tools page could be minutes old and describe a machine an intervening repair
+   had already healed - which is exactly what the screenshot behind this work was showing. The page
+   re-asks on load and repaints.
+
+### Why the original could not have caught this
+
+The design rule "the verdict is FUNCTIONAL, never structural" was applied to the check and not to the
+repair. The check ran a tool and read its exit code; the repair asked whether a directory existed. One
+of those is a fact about behaviour and the other is a fact about shape, and the shape was true while
+the behaviour was absent. The lesson generalises past PATH: **when a remedy depends on a resource, the
+guard must exercise the resource, not confirm its container.**
+
 ## Two hazards handled, worth not re-introducing
 
 **The user PATH must be written RAW.** Reading it through `Environment.GetEnvironmentVariable` returns

--- a/scripts/test-local.ps1
+++ b/scripts/test-local.ps1
@@ -88,6 +88,15 @@ foreach ($proj in $toRun) {
     $args = @("test", (Join-Path $repoRoot $proj), "--no-build", "-c", $Configuration, "--nologo", "-v", "q") + $filterArgs
     $p = Start-Process -FilePath "dotnet" -ArgumentList $args -NoNewWindow -PassThru `
                        -RedirectStandardOutput $out -RedirectStandardError "$out.err"
+
+    # Touching .Handle keeps the process handle OPEN, which is the only reason ExitCode is readable
+    # after the process ends. Without it Start-Process -PassThru hands back an object whose ExitCode
+    # is EMPTY once the child exits - and "$null -eq 0" is false, so every project was classified
+    # FAIL. This script is the merge gate, and it was reporting "RESULT: FAILED in 7 project(s)"
+    # over seven lines that each said "Passed!  - Failed: 0". A gate that fails on green is worse
+    # than no gate: it trains everyone to ignore it, or to go and wait fifty minutes for CI.
+    $null = $p.Handle
+
     $running += [pscustomobject]@{ Name = $name; Process = $p; Log = $out }
     Write-Host "  started $name"
 }

--- a/src/CcDirector.Avalonia/Controls/ToolsView.axaml
+++ b/src/CcDirector.Avalonia/Controls/ToolsView.axaml
@@ -72,9 +72,12 @@
                                VerticalAlignment="Center" />
                 </StackPanel>
 
-                <!-- The two things a reversible change to shared machine state has to say up front. -->
+                <!-- What a change to shared machine state has to say up front. Superseded entries now
+                     come OUT of PATH - two entries for one command line serve nobody, only the first
+                     can win - so this says exactly how far that goes: PATH entries, never files, and
+                     never another live install's. -->
                 <TextBlock Foreground="#B08585" FontSize="10" TextWrapping="Wrap"
-                           Text="Nothing is deleted. The other install stays on PATH behind this one. Sessions already running keep the old PATH until they restart." />
+                           Text="Nothing on disk is deleted. Superseded DevThrottle entries are removed from your PATH and the files stay where they are; another install that is still in use is left alone. Sessions already running keep the old PATH until they restart." />
             </StackPanel>
         </Border>
 

--- a/src/CcDirector.Avalonia/Controls/ToolsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/ToolsView.axaml.cs
@@ -37,7 +37,9 @@ public partial class ToolsView : UserControl
     // Director the verdict was reached about.
     private string? _controlApiBaseUrl;
     private string? _expectedBinDir;
+    private FleetToolCheck? _fleetToolCheck;
     private Func<Task>? _onFleetToolRepaired;
+    private Func<Task<FleetToolCheck?>>? _refreshFleetToolCheck;
 
     public ToolsView()
     {
@@ -50,6 +52,24 @@ public partial class ToolsView : UserControl
         if (_loaded) return;
         _loaded = true;
         await LoadCatalogAsync();
+
+        // Re-ask the reachability question now the page is up. The window's verdict can be minutes old
+        // - a tool repair may have healed the machine since - and a banner reporting a fault that is
+        // already fixed is indistinguishable, to the person reading it, from a fix that did not work.
+        // Painted first, refreshed after: the page never waits on a probe that can take seconds.
+        if (_refreshFleetToolCheck is { } refresh)
+        {
+            try
+            {
+                RenderFleetToolStatus(await refresh());
+            }
+            catch (Exception ex)
+            {
+                // A failed re-probe leaves the verdict we were handed standing. It must not read as a
+                // pass, and it must not take the page down.
+                FileLog.Write($"[ToolsView] fleet tool re-check FAILED: {ex.Message}");
+            }
+        }
     }
 
     /// <summary>Reload the catalog and re-run the checks. Called after a repair changes what is
@@ -70,16 +90,35 @@ public partial class ToolsView : UserControl
     /// re-check against the same endpoint after a repair.</param>
     /// <param name="onRepaired">Invoked after a successful repair so the owning window re-drives its
     /// own badge rather than being left showing a fault the user has just fixed.</param>
+    /// <param name="refresh">Re-runs the Director's own check and returns its fresh verdict. Called
+    /// once when the page loads, so an open panel cannot sit on a verdict the machine has outgrown.</param>
     public void ShowFleetToolStatus(
-        FleetToolCheck? check, string? controlApiBaseUrl, Func<Task>? onRepaired = null)
+        FleetToolCheck? check,
+        string? controlApiBaseUrl,
+        Func<Task>? onRepaired = null,
+        Func<Task<FleetToolCheck?>>? refresh = null)
     {
         _controlApiBaseUrl = controlApiBaseUrl;
         _onFleetToolRepaired = onRepaired;
+        _refreshFleetToolCheck = refresh;
         RenderFleetToolStatus(check);
     }
 
+    /// <summary>
+    /// Paint the fault, and say which of the TWO faults it is. They look identical from the outside -
+    /// a session cannot reach this Director - and they have different repairs:
+    ///
+    ///   PATH resolves someone else's WORKING copy   -> repoint PATH (ours is ready and waiting)
+    ///   we have no working copy of our own          -> install ours FIRST, then repoint
+    ///
+    /// Telling them apart is the whole fix. Offering "Repoint PATH" for the second one is what shipped:
+    /// the button dutifully reordered PATH around a directory that was empty, resolution fell through
+    /// it to the same stale install, and it reported the failure it was pressed to fix.
+    /// </summary>
     private void RenderFleetToolStatus(FleetToolCheck? check)
     {
+        _fleetToolCheck = check;
+
         if (check is not { Verdict: FleetToolVerdict.CannotReachDirector })
         {
             PathFaultBanner.IsVisible = false;
@@ -90,15 +129,36 @@ public partial class ToolsView : UserControl
         _expectedBinDir = check.ExpectedBinDir;
         PathFaultResolved.Text = check.ResolvedPath ?? "(not resolved)";
         PathFaultExpected.Text = check.ExpectedBinDir ?? "(unknown)";
-        PathFaultExplanation.Text = check.IsDifferentInstall
-            ? "The command line on your PATH belongs to another install, so agents in your sessions "
-              + "report \"cannot connect to DevThrottle\" even though this Director is healthy and connected."
-            // Same install, still refused: repointing PATH will not help, so say what was actually seen
-            // rather than offering a fix for a fault this is not.
-            : $"The command line on your PATH could not authenticate against this Director: {check.Detail}";
 
-        // Only offer the button for the fault it actually repairs.
-        PathFaultFixButton.IsVisible = check.IsDifferentInstall;
+        if (check.OwnToolsAreMissingOrBroken)
+        {
+            PathFaultExplanation.Text =
+                "This Director's own command-line tools are not installed and working, so PATH order is "
+                + $"not the problem: there is nothing here to point at yet ({check.OwnDetail}) Installing "
+                + "them is the repair; repointing PATH on its own would change nothing.";
+            PathFaultFixButton.Content = "Install tools, then repoint PATH";
+            PathFaultFixButton.IsVisible = true;
+        }
+        else if (check.CanRepairByRepointingPath)
+        {
+            PathFaultExplanation.Text =
+                "The command line on your PATH belongs to another install, so agents in your sessions "
+                + "report \"cannot connect to DevThrottle\" even though this Director is healthy and "
+                + "connected. This Director's own copy is installed and works.";
+            PathFaultFixButton.Content = "Repoint PATH to this install";
+            PathFaultFixButton.IsVisible = true;
+        }
+        else
+        {
+            // Same install and still refused, or no install directory to compare against. Repointing
+            // repairs neither, so state what was seen and offer nothing rather than a button that
+            // cannot work.
+            PathFaultExplanation.Text =
+                $"The command line on your PATH could not authenticate against this Director: {check.Detail}";
+            PathFaultFixButton.IsVisible = false;
+        }
+
+        PathFaultFixButton.IsEnabled = true;
         PathFaultProgress.Text = "";
     }
 
@@ -118,6 +178,30 @@ public partial class ToolsView : UserControl
                 PathFaultProgress.Text = "No install directory to repoint to.";
                 PathFaultFixButton.IsEnabled = true;
                 return;
+            }
+
+            // When the fault is that we have no working tools of our own, install them BEFORE touching
+            // PATH. Repointing first would put an empty directory in front and report success.
+            if (_fleetToolCheck is { OwnToolsAreMissingOrBroken: true })
+            {
+                PathFaultProgress.Text = "Installing this Director's tools...";
+                var progress = new Progress<string>(message => PathFaultProgress.Text = message);
+                var installed = await Task.Run(() =>
+                    new CcDirector.Setup.Engine.ToolUpdater(CcDirector.Setup.Engine.InstallLayout.Default())
+                        .RepairPythonToolsAsync(progress));
+
+                FileLog.Write(
+                    $"[ToolsView] PATH fault: tool install success={installed.Success}, {installed.Message}");
+                if (!installed.Success)
+                {
+                    PathFaultProgress.Text = $"Could not install the tools: {installed.Message}";
+                    PathFaultFixButton.IsEnabled = true;
+                    return;
+                }
+
+                // The catalog behind this banner is now describing a toolset that no longer exists.
+                await LoadCatalogAsync();
+                PathFaultProgress.Text = "Repointing PATH...";
             }
 
             var repair = await Task.Run(() => FleetToolPathRepair.PutFirstOnPath(binDir));

--- a/src/CcDirector.Avalonia/Controls/ToolsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/ToolsView.axaml.cs
@@ -134,8 +134,9 @@ public partial class ToolsView : UserControl
         {
             PathFaultExplanation.Text =
                 "This Director's own command-line tools are not installed and working, so PATH order is "
-                + $"not the problem: there is nothing here to point at yet ({check.OwnDetail}) Installing "
-                + "them is the repair; repointing PATH on its own would change nothing.";
+                + "not the problem - there is nothing here to point at yet. "
+                + $"{check.OwnDetail} Installing them is the repair; putting an empty directory on PATH "
+                + "would change nothing.";
             PathFaultFixButton.Content = "Install tools, then repoint PATH";
             PathFaultFixButton.IsVisible = true;
         }
@@ -166,9 +167,14 @@ public partial class ToolsView : UserControl
     {
         try
         {
-            // Immediate feedback before any awaited work (responsive-UI rule).
+            // Immediate feedback before any awaited work (responsive-UI rule), and it has to name the
+            // step actually starting: installing the tools takes minutes, and "Repointing PATH..."
+            // sitting there through all of it describes work that has not begun.
+            var installFirst = _fleetToolCheck is { OwnToolsAreMissingOrBroken: true };
             PathFaultFixButton.IsEnabled = false;
-            PathFaultProgress.Text = "Repointing PATH...";
+            PathFaultProgress.Text = installFirst
+                ? "Installing this Director's tools..."
+                : "Repointing PATH...";
 
             // The directory the verdict named as ours. Re-deriving it here from a different source is how
             // the banner and the check come to disagree about which directory the repair is even for.
@@ -182,9 +188,8 @@ public partial class ToolsView : UserControl
 
             // When the fault is that we have no working tools of our own, install them BEFORE touching
             // PATH. Repointing first would put an empty directory in front and report success.
-            if (_fleetToolCheck is { OwnToolsAreMissingOrBroken: true })
+            if (installFirst)
             {
-                PathFaultProgress.Text = "Installing this Director's tools...";
                 var progress = new Progress<string>(message => PathFaultProgress.Text = message);
                 var installed = await Task.Run(() =>
                     new CcDirector.Setup.Engine.ToolUpdater(CcDirector.Setup.Engine.InstallLayout.Default())

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4288,6 +4288,15 @@ public partial class MainWindow : Window
             {
                 await RefreshFleetToolReachabilityAsync();
                 await DriveToolsSyncAsync();
+            },
+            // The verdict above is whatever the last tools health pass reached, and that pass is
+            // computed once per run - so it can be minutes old and describe a machine an intervening
+            // repair has already healed. The page re-asks on load and repaints, which is the
+            // difference between "still broken" and "fixed a while ago" for the person reading it.
+            async () =>
+            {
+                await RefreshFleetToolReachabilityAsync();
+                return _lastFleetToolCheck;
             });
 
         if (onGatewayTab)

--- a/src/CcDirector.Core.Tests/Setup/FleetToolPathRepairTests.cs
+++ b/src/CcDirector.Core.Tests/Setup/FleetToolPathRepairTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using CcDirector.Core.Setup;
 using Xunit;
 
@@ -93,5 +94,197 @@ public class FleetToolPathRepairTests
     public void PutFirstOnPath_EmptyDirectory_Throws()
     {
         Assert.Throws<ArgumentException>(() => FleetToolPathRepair.PutFirstOnPath("  "));
+    }
+
+    [Fact]
+    public void PutFirstOnPath_DirectoryThatExistsButHoldsNoTool_RefusesAndSaysWhy()
+    {
+        // THE BUG, at the layer that could have stopped it. On 2026-08-01 this directory existed and
+        // was empty - that Director's tools had never been installed - and the old guard, which asked
+        // only whether the directory EXISTED, waved it through. PATH was reordered around an empty
+        // directory, which changes the order and nothing about what resolves.
+        //
+        // It must refuse, and it must refuse BEFORE it writes anything: this test would edit the
+        // developer's real user PATH if it did not.
+        var empty = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"fleet-bin-empty-{Guid.NewGuid():N}"));
+        try
+        {
+            var result = FleetToolPathRepair.PutFirstOnPath(empty.FullName);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("not installed", result.Detail, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(empty.FullName, result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            empty.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HoldsFleetTool_EmptyDirectory_IsFalse_AndWithTheToolPresent_IsTrue()
+    {
+        // The distinction the whole fix turns on: a container is not its contents.
+        var dir = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"fleet-bin-{Guid.NewGuid():N}"));
+        try
+        {
+            Assert.False(FleetToolPathRepair.HoldsFleetTool(dir.FullName));
+
+            var shim = Path.Combine(dir.FullName, OperatingSystem.IsWindows()
+                ? "cc-devthrottle.cmd"
+                : "cc-devthrottle");
+            File.WriteAllText(shim, "");
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(shim, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            Assert.True(FleetToolPathRepair.HoldsFleetTool(dir.FullName));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    // ---- The PATH cleanup: one entry per command line, and never someone else's ----
+
+    private static readonly string Root = Path.Combine("C:", "cc-director");
+    private static readonly string OurBin = Path.Combine(Root, "instances", "default", "bin");
+    private static readonly string LegacyBin = Path.Combine(Root, "bin");
+    private static readonly string OtherInstanceBin = Path.Combine(Root, "instances", "slot-5", "bin");
+    private static readonly string TempRoot = Path.Combine("C:", "temp");
+
+    /// <summary>Every directory listed exists and holds the tool; nothing else does.</summary>
+    private static FleetToolPathRepair.PathRewrite RewriteWith(
+        string path, params string[] existingToolDirs)
+    {
+        bool Exists(string dir) => existingToolDirs.Any(
+            d => string.Equals(d.TrimEnd(Path.DirectorySeparatorChar), dir.TrimEnd(Path.DirectorySeparatorChar),
+                StringComparison.OrdinalIgnoreCase));
+
+        return FleetToolPathRepair.Rewrite(path, OurBin, Exists, Exists, TempRoot);
+    }
+
+    [Fact]
+    public void Rewrite_TheSupersededFlatBinOfOurOwnInstall_IsRemoved()
+    {
+        // Two entries for one command line serve nobody: only the first can ever win, and the loser
+        // waits to win again the moment the order shifts.
+        var result = RewriteWith(P(LegacyBin, @"C:\windows", OurBin), LegacyBin, OurBin);
+
+        Assert.Equal(P(OurBin, @"C:\windows"), result.Path);
+        Assert.Equal(new[] { LegacyBin }, result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_AnotherLiveInstancesBin_IsKept()
+    {
+        // A second Director in its own instance home is legitimate on this machine. Ours goes in
+        // front, which is all that is needed; removing theirs would be sabotage dressed as hygiene.
+        var result = RewriteWith(P(OtherInstanceBin, OurBin), OtherInstanceBin, OurBin);
+
+        Assert.Equal(P(OurBin, OtherInstanceBin), result.Path);
+        Assert.Empty(result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_AToolDirectoryUnderTheTempDirectory_IsRemoved()
+    {
+        // There is one of these on the machine that prompted this work: a wizard test harness left
+        // ...\Temp\wizard-harness-home-29ef...\cc-director\bin on the real user PATH.
+        var leaked = Path.Combine(TempRoot, "wizard-harness-home-abc", "cc-director", "bin");
+
+        var result = RewriteWith(P(leaked, OurBin), leaked, OurBin);
+
+        Assert.Equal(P(OurBin), result.Path);
+        Assert.Equal(new[] { leaked }, result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_AnInstallBinThatIsGoneFromDisk_IsRemoved()
+    {
+        var vanished = Path.Combine("C:", "old", "cc-director", "bin");
+
+        var result = RewriteWith(P(vanished, OurBin), OurBin);
+
+        Assert.Equal(P(OurBin), result.Path);
+        Assert.Equal(new[] { vanished }, result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_AMissingDirectoryThatIsNothingToDoWithUs_IsKept()
+    {
+        // An entry whose network drive is unmapped this morning is not ours to tidy away. The removal
+        // rule only ever fires on the shape no other product writes.
+        var unrelated = Path.Combine("Z:", "team", "bin");
+
+        var result = RewriteWith(P(unrelated, OurBin), OurBin);
+
+        Assert.Equal(P(OurBin, unrelated), result.Path);
+        Assert.Empty(result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_ADirectoryInsideOurInstallThatHoldsNoTool_IsKept()
+    {
+        // The install ROOT is on this machine's PATH as well as its bin. It is not a tool directory,
+        // so it is not ours to remove - being near our files is not the same as being ours.
+        var result = RewriteWith(P(Root, OurBin), Root, OurBin);
+
+        Assert.Contains(Root, result.Path, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(result.Removed);
+    }
+
+    [Fact]
+    public void Rewrite_DecidesOnTheEXPANDEDPathButWritesBackTheRAWOne()
+    {
+        // Both halves matter. Deciding on the raw text would miss %LOCALAPPDATA%\cc-director\bin -
+        // the exact entry we are here to remove. Writing back the expanded text would bake today's
+        // expansion into the user's PATH permanently and destroy every variable reference in it.
+        var variable = $"CCTEST_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(variable, Root);
+        try
+        {
+            var rawLegacy = $"%{variable}%" + Path.DirectorySeparatorChar + "bin";
+            var rawKeeper = $"%{variable}%" + Path.DirectorySeparatorChar + "notes";
+
+            var result = FleetToolPathRepair.Rewrite(
+                P(rawLegacy, rawKeeper, OurBin), OurBin,
+                directoryExists: _ => true,
+                holdsFleetTool: dir => dir.EndsWith("bin", StringComparison.OrdinalIgnoreCase),
+                tempRoot: TempRoot);
+
+            // Decided on the expanded form: the variable entry WAS recognised as the legacy bin.
+            Assert.Equal(new[] { rawLegacy }, result.Removed);
+            // Written back raw: the survivor still carries its variable, not this morning's expansion.
+            Assert.Contains(rawKeeper, result.Path, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                Path.Combine(Root, "notes"), result.Path, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void Rewrite_RunTwice_IsStable()
+    {
+        var once = RewriteWith(P(LegacyBin, @"C:\windows", OurBin), LegacyBin, OurBin);
+        var twice = RewriteWith(once.Path, LegacyBin, OurBin);
+
+        Assert.Equal(once.Path, twice.Path);
+        Assert.Empty(twice.Removed);
+    }
+
+    [Fact]
+    public void PathWithOwnToolsFirst_RemovesNothingFromTheSessionsInheritedPath()
+    {
+        // What a session gets is a PREFERENCE, not a cleanup: the user's own PATH reaches the session
+        // intact, and only which copy of OUR command line wins is decided for them.
+        var result = FleetToolPathRepair.PathWithOwnToolsFirst(OurBin, P(LegacyBin, @"C:\windows"));
+
+        Assert.Equal(P(OurBin, LegacyBin, @"C:\windows"), result);
     }
 }

--- a/src/CcDirector.Core.Tests/Setup/FleetToolPathRepairTests.cs
+++ b/src/CcDirector.Core.Tests/Setup/FleetToolPathRepairTests.cs
@@ -230,7 +230,16 @@ public class FleetToolPathRepairTests
     {
         // The install ROOT is on this machine's PATH as well as its bin. It is not a tool directory,
         // so it is not ours to remove - being near our files is not the same as being ours.
-        var result = RewriteWith(P(Root, OurBin), Root, OurBin);
+        //
+        // The shared helper cannot express this case: it answers "exists" and "holds the tool" from
+        // one list, so it can only describe directories where those two agree. Here they must NOT -
+        // the root exists AND holds nothing - which is exactly the distinction being tested.
+        var result = FleetToolPathRepair.Rewrite(
+            P(Root, OurBin), OurBin,
+            directoryExists: _ => true,
+            holdsFleetTool: dir => !string.Equals(
+                dir.TrimEnd(Path.DirectorySeparatorChar), Root, StringComparison.OrdinalIgnoreCase),
+            tempRoot: TempRoot);
 
         Assert.Contains(Root, result.Path, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(result.Removed);

--- a/src/CcDirector.Core.Tests/Setup/FleetToolReachabilityTests.cs
+++ b/src/CcDirector.Core.Tests/Setup/FleetToolReachabilityTests.cs
@@ -50,6 +50,17 @@ public class FleetToolReachabilityTests : IDisposable
     private static FleetToolReachability WithResolved(string? resolvedPath)
         => new(TimeSpan.FromSeconds(30), _ => resolvedPath);
 
+    /// <summary>
+    /// Resolve the bare command name one way and an explicit path another, which is the whole point of
+    /// the second probe: PATH's answer and our own copy are different questions with different answers.
+    /// </summary>
+    private static FleetToolReachability WithPathAndOwn(string? onPath, string? ours)
+        => new(TimeSpan.FromSeconds(30),
+            command => command == FleetToolReachability.ToolName ? onPath : ours);
+
+    private static readonly string OurBinDir =
+        Path.Combine("C:", "cc-director", "instances", "default", "bin");
+
     [Fact]
     public async Task RunAsync_ToolNotOnPath_ReportsNotFound()
     {
@@ -103,6 +114,103 @@ public class FleetToolReachabilityTests : IDisposable
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => reachability.RunAsync("", expectedBinDir: null));
+    }
+
+    [Fact]
+    public async Task RunAsync_PathToolFails_AndOurOwnCopyWorks_IsRepairableByRepointingPath()
+    {
+        var stale = StubTool(exitCode: 1, "Error: missing or invalid token");
+        var ours = StubTool(exitCode: 0, "ok");
+
+        var check = await WithPathAndOwn(onPath: stale, ours: ours).RunAsync("http://127.0.0.1:7879", OurBinDir);
+
+        Assert.Equal(FleetToolVerdict.CannotReachDirector, check.Verdict);
+        Assert.Equal(FleetToolVerdict.Working, check.OwnVerdict);
+        Assert.True(check.CanRepairByRepointingPath);
+        Assert.False(check.OwnToolsAreMissingOrBroken);
+    }
+
+    [Fact]
+    public async Task RunAsync_PathToolFails_AndWeHaveNoCopyOfOurOwn_IsNotRepairableByRepointingPath()
+    {
+        // THE FAILURE THIS EXISTS FOR, 2026-08-01 on SOREN_NORTH. PATH resolved a stale install's
+        // cc-devthrottle and this Director's own bin directory was EMPTY - its tools had never been
+        // installed. The panel saw only "PATH points somewhere else", offered "Repoint PATH", and the
+        // repair put an empty directory in front: resolution fell straight through it to the same
+        // stale copy and reported the same "missing or invalid token" it had been pressed to fix.
+        //
+        // Repointing must not be offered here. There is nothing to point at.
+        var stale = StubTool(exitCode: 1, "Error: missing or invalid token");
+
+        var check = await WithPathAndOwn(onPath: stale, ours: null).RunAsync("http://127.0.0.1:7879", OurBinDir);
+
+        Assert.Equal(FleetToolVerdict.CannotReachDirector, check.Verdict);
+        Assert.Equal(FleetToolVerdict.NotFound, check.OwnVerdict);
+        Assert.False(check.CanRepairByRepointingPath);
+        Assert.True(check.OwnToolsAreMissingOrBroken);
+        Assert.Contains(OurBinDir, check.OwnDetail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsync_PathToolFails_AndOurOwnCopyAlsoFails_IsNotRepairableByRepointingPath()
+    {
+        // Our tools are installed and broken. Reordering PATH would hand sessions a second copy that
+        // fails the same way, so the button must stay away from this one too.
+        var stale = StubTool(exitCode: 1, "Error: missing or invalid token");
+        var oursBroken = StubTool(exitCode: 1, "ModuleNotFoundError: no module named cc_shared");
+
+        var check = await WithPathAndOwn(onPath: stale, ours: oursBroken)
+            .RunAsync("http://127.0.0.1:7879", OurBinDir);
+
+        Assert.Equal(FleetToolVerdict.CannotReachDirector, check.OwnVerdict);
+        Assert.False(check.CanRepairByRepointingPath);
+        Assert.True(check.OwnToolsAreMissingOrBroken);
+        Assert.Contains("ModuleNotFoundError", check.OwnDetail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunAsync_PathToolWorks_LeavesOurOwnCopyUnasked()
+    {
+        // Nothing is wrong, so there is no second question - and an unasked question must report as
+        // Unchecked, never as a pass.
+        var working = StubTool(exitCode: 0, "ok");
+
+        var check = await WithPathAndOwn(onPath: working, ours: null).RunAsync("http://127.0.0.1:7879", OurBinDir);
+
+        Assert.Equal(FleetToolVerdict.Working, check.Verdict);
+        Assert.Equal(FleetToolVerdict.Unchecked, check.OwnVerdict);
+        Assert.False(check.CanRepairByRepointingPath);
+        Assert.False(check.OwnToolsAreMissingOrBroken);
+    }
+
+    [Fact]
+    public async Task RunAsync_NoBinDirOfOurOwn_ReportsOurCopyAsUncheckedRatherThanMissing()
+    {
+        // A development build has no install directory. "We have no tools" would be a claim the check
+        // cannot support, and it would light this banner on every developer machine.
+        var stale = StubTool(exitCode: 1, "Error: missing or invalid token");
+
+        var check = await WithPathAndOwn(onPath: stale, ours: null)
+            .RunAsync("http://127.0.0.1:7879", expectedBinDir: null);
+
+        Assert.Equal(FleetToolVerdict.Unchecked, check.OwnVerdict);
+        Assert.False(check.OwnToolsAreMissingOrBroken);
+        Assert.False(check.CanRepairByRepointingPath);
+    }
+
+    [Fact]
+    public void CanRepairByRepointingPath_OurOwnCopyWorksButPathResolvedItAnyway_IsFalse()
+    {
+        // Same install, still refused. Repointing PATH at the directory it already resolves repairs
+        // nothing, so the fault must not be offered a fix that cannot touch it.
+        var check = new FleetToolCheck(
+            FleetToolVerdict.CannotReachDirector,
+            ResolvedPath: Path.Combine(OurBinDir, "cc-devthrottle.cmd"),
+            ExpectedBinDir: OurBinDir,
+            Detail: "missing or invalid token",
+            OwnVerdict: FleetToolVerdict.Working);
+
+        Assert.False(check.CanRepairByRepointingPath);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -576,6 +576,26 @@ public sealed class SessionManager : IDisposable
             if (!string.IsNullOrEmpty(DirectorId))
                 envVars["CC_DIRECTOR_ID"] = DirectorId;
 
+            // Put THIS Director's own cc-* tools first on the session's PATH.
+            //
+            // The address above is useless to a session holding a command line that cannot use it.
+            // Machine PATH is shared state: any other install, an unfinished migration, or a test rig
+            // that leaked an entry can put a different copy of cc-devthrottle in front of ours, and
+            // then every agent in every session reports "cannot connect to DevThrottle" while this
+            // Director is healthy and connected. That is not hypothetical - it is what happened on the
+            // machine this was written for, and repairing the machine PATH afterwards could only ever
+            // fix it for sessions started later.
+            //
+            // So the session is not asked to find us. It is TOLD, in the same breath as the address it
+            // must call. Nothing is removed from the user's PATH here - only which copy of our own
+            // command line wins - and this leaves the machine PATH itself untouched.
+            var ownToolBin = Path.Combine(Instances.InstanceContext.InstanceHome, "bin");
+            if (Directory.Exists(ownToolBin))
+            {
+                envVars["PATH"] = Setup.FleetToolPathRepair.PathWithOwnToolsFirst(
+                    ownToolBin, Environment.GetEnvironmentVariable("PATH"));
+            }
+
             // The credential that goes with the address above. Bound to THIS session's id and
             // least-privilege: it reads this session and the safe discovery set, and it is refused on
             // spawn, shutdown, prompting another session, another session's terminal, and settings.

--- a/src/CcDirector.Core/Setup/FleetToolPathRepair.cs
+++ b/src/CcDirector.Core/Setup/FleetToolPathRepair.cs
@@ -87,23 +87,49 @@ public static class FleetToolPathRepair
         }
     }
 
+    /// <summary>
+    /// The user PATH exactly as it is STORED, with every %VARIABLE% intact.
+    ///
+    /// Public because it is the only safe way to read it, and more than one component needs to.
+    /// <c>Environment.GetEnvironmentVariable("Path", User)</c> returns the value with variables
+    /// already expanded; anything that reads it that way and writes the result back bakes today's
+    /// expansion into the user's PATH permanently and silently destroys every variable reference in
+    /// it. That is not a hypothetical - it is what the install finalizer did until this was shared.
+    /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static string ReadUserPathRaw()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(UserEnvironmentKey)
+            ?? throw new IOException($"The user environment registry key ({UserEnvironmentKey}) is not readable.");
+        return key.GetValue(PathValueName, "", RegistryValueOptions.DoNotExpandEnvironmentNames) as string ?? "";
+    }
+
+    /// <summary>
+    /// Write the user PATH back, keeping it expandable when it carries variables. Pass a value that
+    /// came from <see cref="ReadUserPathRaw"/> and was edited without expanding anything.
+    /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static void WriteUserPathRaw(string value)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(UserEnvironmentKey, writable: true)
+            ?? throw new IOException($"The user environment registry key ({UserEnvironmentKey}) is not writable.");
+
+        // A value holding %VARIABLE% must be stored as ExpandString or the variables stop resolving.
+        var kind = value.Contains('%') ? RegistryValueKind.ExpandString : key.GetValueKind(PathValueName);
+        key.SetValue(PathValueName, value, kind);
+    }
+
     // PutFirstOnPath refuses every non-Windows caller before reaching here; this states that for the
     // platform analyzer, which cannot see the guard across the method boundary.
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     private static string RepairPersistedPath(string binDir)
     {
-        using var key = Registry.CurrentUser.OpenSubKey(UserEnvironmentKey, writable: true)
-            ?? throw new IOException($"The user environment registry key ({UserEnvironmentKey}) is not readable.");
-
-        // DoNotExpandEnvironmentNames is the whole point: %USERPROFILE% must survive as %USERPROFILE%.
-        var raw = key.GetValue(PathValueName, "", RegistryValueOptions.DoNotExpandEnvironmentNames) as string ?? "";
-        var kind = raw.Contains('%') ? RegistryValueKind.ExpandString : key.GetValueKind(PathValueName);
-
+        var raw = ReadUserPathRaw();
         var rewrite = Rewrite(raw, binDir);
         if (string.Equals(raw, rewrite.Path, StringComparison.Ordinal))
             return $"{binDir} was already first on the user PATH, and nothing superseded was left behind it.";
 
-        key.SetValue(PathValueName, rewrite.Path, kind);
+        WriteUserPathRaw(rewrite.Path);
 
         var removed = rewrite.Removed.Count == 0
             ? "Nothing else needed removing."

--- a/src/CcDirector.Core/Setup/FleetToolPathRepair.cs
+++ b/src/CcDirector.Core/Setup/FleetToolPathRepair.cs
@@ -28,14 +28,26 @@ public sealed record PathRepairResult(bool Succeeded, string Detail);
 ///    stale tool until it restarted - the badge would not clear, and the button would read as broken.
 ///    Sessions ALREADY running keep the old PATH; nothing can repair those in place, and the panel
 ///    says so rather than implying otherwise.
+///
+/// 3. It refuses to promote a directory that holds no cc-devthrottle. This is the one that was
+///    missing. The old guard asked only whether the directory EXISTED - and on the machine this was
+///    written for it existed and was empty, because that Director's tools had never been installed.
+///    PATH was reordered perfectly, resolution fell through the empty directory to the same stale
+///    install, and the repair reported the failure it had just been asked to fix. A container is not
+///    its contents.
 /// </summary>
 public static class FleetToolPathRepair
 {
     private const string UserEnvironmentKey = "Environment";
     private const string PathValueName = "Path";
 
+    /// <summary>The command whose presence makes a directory a DevThrottle tool directory.</summary>
+    private const string ToolName = "cc-devthrottle";
+
     /// <summary>
-    /// Move <paramref name="binDir"/> to the front of the user PATH and of this process's PATH.
+    /// Move <paramref name="binDir"/> to the front of the user PATH and of this process's PATH, and
+    /// remove the superseded DevThrottle tool directories left behind it (see
+    /// <see cref="IsSuperseded"/>). Only PATH entries are removed - nothing on disk is touched.
     /// </summary>
     public static PathRepairResult PutFirstOnPath(string binDir)
     {
@@ -48,6 +60,17 @@ public static class FleetToolPathRepair
         if (!OperatingSystem.IsWindows())
             throw new PlatformNotSupportedException(
                 "Persisting a PATH change is Windows-only here; on macOS and Linux the shell profile owns PATH.");
+
+        // The precondition the original repair assumed. Promoting an empty directory changes the order
+        // of PATH and nothing about what resolves, so it looks like a repair and is not one.
+        if (!HoldsFleetTool(binDir))
+        {
+            var refusal =
+                $"This Director's own tools are not installed - there is no {ToolName} in {binDir}. " +
+                "Install the tools first; putting an empty directory on PATH would change nothing.";
+            FileLog.Write($"[FleetToolPathRepair] PutFirstOnPath REFUSED: {refusal}");
+            return new PathRepairResult(false, refusal);
+        }
 
         try
         {
@@ -76,19 +99,184 @@ public static class FleetToolPathRepair
         var raw = key.GetValue(PathValueName, "", RegistryValueOptions.DoNotExpandEnvironmentNames) as string ?? "";
         var kind = raw.Contains('%') ? RegistryValueKind.ExpandString : key.GetValueKind(PathValueName);
 
-        var updated = MoveToFront(raw, binDir);
-        if (string.Equals(raw, updated, StringComparison.Ordinal))
-            return $"{binDir} was already first on the user PATH.";
+        var rewrite = Rewrite(raw, binDir);
+        if (string.Equals(raw, rewrite.Path, StringComparison.Ordinal))
+            return $"{binDir} was already first on the user PATH, and nothing superseded was left behind it.";
 
-        key.SetValue(PathValueName, updated, kind);
-        return $"{binDir} is now first on the user PATH. The previous install is still on PATH behind it.";
+        key.SetValue(PathValueName, rewrite.Path, kind);
+
+        var removed = rewrite.Removed.Count == 0
+            ? "Nothing else needed removing."
+            : $"Removed {rewrite.Removed.Count} superseded DevThrottle entr{(rewrite.Removed.Count == 1 ? "y" : "ies")} " +
+              $"from your PATH: {string.Join("; ", rewrite.Removed)}. The files are still on disk.";
+        return $"{binDir} is now first on the user PATH. {removed}";
     }
 
     private static void RepairProcessPath(string binDir)
     {
         var current = Environment.GetEnvironmentVariable("PATH") ?? "";
-        Environment.SetEnvironmentVariable("PATH", MoveToFront(current, binDir));
+        Environment.SetEnvironmentVariable("PATH", Rewrite(current, binDir).Path);
     }
+
+    /// <summary>The rewritten PATH and the entries dropped from it, so the panel can name them.</summary>
+    internal sealed record PathRewrite(string Path, IReadOnlyList<string> Removed);
+
+    /// <summary>Rewrite against the real machine: real directories, the real temp root.</summary>
+    internal static PathRewrite Rewrite(string path, string ownBinDir)
+        => Rewrite(path, ownBinDir, Directory.Exists, HoldsFleetTool, System.IO.Path.GetTempPath());
+
+    /// <summary>
+    /// Put <paramref name="ownBinDir"/> first and drop the superseded DevThrottle tool directories.
+    ///
+    /// Two entries pointing at two copies of the same command line serve nobody: only the first can
+    /// ever win, and the loser sits there waiting to win again the moment the order shifts. So the
+    /// repair leaves ONE. What it will not touch is another LIVE install's directory - a second
+    /// Director in its own instance home is legitimate on this machine, and removing its tools from
+    /// PATH to tidy ours up would be sabotage dressed as hygiene.
+    /// </summary>
+    /// <param name="directoryExists">Existence test, taking an EXPANDED path.</param>
+    /// <param name="holdsFleetTool">Whether an existing (expanded) directory holds cc-devthrottle.</param>
+    /// <param name="tempRoot">The machine temp directory, or null to skip the temp rule.</param>
+    internal static PathRewrite Rewrite(
+        string path,
+        string ownBinDir,
+        Func<string, bool> directoryExists,
+        Func<string, bool> holdsFleetTool,
+        string? tempRoot)
+    {
+        var normalizedOwn = Normalize(ownBinDir);
+        var kept = new List<string>();
+        var removed = new List<string>();
+
+        foreach (var segment in (path ?? "").Split(System.IO.Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(segment)) continue;
+
+            // Our own entry comes out here and goes back at the front below, so a repeated repair
+            // cannot accumulate duplicates.
+            if (string.Equals(Normalize(segment), normalizedOwn, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Expand ONLY to ask questions about the disk. The raw text is what gets written back:
+            // %USERPROFILE% must still be %USERPROFILE% afterwards.
+            var expanded = Expand(segment);
+
+            if (IsFleetToolDirectory(expanded, directoryExists, holdsFleetTool)
+                && IsSuperseded(expanded, normalizedOwn, directoryExists, tempRoot))
+            {
+                removed.Add(segment.Trim());
+                continue;
+            }
+
+            kept.Add(segment);
+        }
+
+        kept.Insert(0, ownBinDir);
+        return new PathRewrite(string.Join(System.IO.Path.PathSeparator, kept), removed);
+    }
+
+    /// <summary>
+    /// Is this PATH entry a DevThrottle tool directory at all? An existing directory answers for
+    /// itself - it holds cc-devthrottle or it does not. A directory that is GONE cannot be asked, so
+    /// it is recognised by shape instead, and only by a shape no other product writes: a "bin"
+    /// directory inside a cc-director install. Nothing outside that shape is ever a candidate for
+    /// removal, so an ordinary entry whose drive happens to be unplugged is left exactly where it is.
+    /// </summary>
+    private static bool IsFleetToolDirectory(
+        string expanded, Func<string, bool> directoryExists, Func<string, bool> holdsFleetTool)
+        => directoryExists(expanded) ? holdsFleetTool(expanded) : LooksLikeAnInstallBin(expanded);
+
+    /// <summary>
+    /// Has this tool directory been superseded by ours? Three ways, all facts rather than guesses:
+    /// it is gone from disk; it lives in the temp directory (a test rig or an unpacked bundle that
+    /// leaked into the real user PATH - there is one on the machine that prompted this); or it is the
+    /// flat pre-migration bin of our own install root, which the move to per-instance homes left
+    /// behind and ahead of us.
+    /// </summary>
+    private static bool IsSuperseded(
+        string expanded, string normalizedOwn, Func<string, bool> directoryExists, string? tempRoot)
+    {
+        if (!directoryExists(expanded)) return true;
+        if (IsUnder(expanded, tempRoot)) return true;
+
+        var legacy = LegacyFlatBinFor(normalizedOwn);
+        return legacy is not null
+               && string.Equals(Normalize(expanded), legacy, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The pre-migration bin of the install our own bin belongs to. Storage moved from
+    /// <c>&lt;root&gt;\bin</c> to <c>&lt;root&gt;\instances\&lt;slug&gt;\bin</c>; when our directory has
+    /// that shape, <c>&lt;root&gt;\bin</c> is the copy the migration superseded and left in front of
+    /// us. When it does not (a development build), there is no such directory and nothing is claimed.
+    /// </summary>
+    private static string? LegacyFlatBinFor(string normalizedOwnBinDir)
+    {
+        var instanceHome = System.IO.Path.GetDirectoryName(normalizedOwnBinDir);
+        var instancesDir = instanceHome is null ? null : System.IO.Path.GetDirectoryName(instanceHome);
+        if (instancesDir is null) return null;
+        if (!string.Equals(
+                new DirectoryInfo(instancesDir).Name, "instances", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var root = System.IO.Path.GetDirectoryName(instancesDir);
+        return root is null ? null : Normalize(System.IO.Path.Combine(root, "bin"));
+    }
+
+    private static bool LooksLikeAnInstallBin(string expanded)
+    {
+        var normalized = Normalize(expanded);
+        if (!string.Equals(
+                SafeName(normalized), "bin", StringComparison.OrdinalIgnoreCase)) return false;
+
+        return normalized.Split(
+                System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar)
+            .Any(part => string.Equals(part, "cc-director", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string SafeName(string path)
+    {
+        try { return new DirectoryInfo(path).Name; }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return "";
+        }
+    }
+
+    private static bool IsUnder(string candidate, string? root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return false;
+        var normalizedRoot = Normalize(root) + System.IO.Path.DirectorySeparatorChar;
+        return (Normalize(candidate) + System.IO.Path.DirectorySeparatorChar)
+            .StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Expand(string segment)
+    {
+        try { return Environment.ExpandEnvironmentVariables(segment.Trim().Trim('"')); }
+        catch (ArgumentException) { return segment.Trim(); }
+    }
+
+    /// <summary>Does this directory hold a runnable cc-devthrottle? The whole question, on disk.</summary>
+    internal static bool HoldsFleetTool(string directory)
+    {
+        try
+        {
+            return ExecutableResolver.Resolve(System.IO.Path.Combine(directory, ToolName)) is not null;
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The PATH a session we spawn should get: our own tools first, whatever the machine PATH says.
+    /// Nothing is removed here - a session inherits the user's PATH and we only guarantee which copy
+    /// of our own command line wins.
+    /// </summary>
+    public static string PathWithOwnToolsFirst(string binDir, string? currentPath)
+        => MoveToFront(currentPath ?? "", binDir);
 
     /// <summary>
     /// Return <paramref name="path"/> with <paramref name="entry"/> at the front and any existing copy

--- a/src/CcDirector.Core/Setup/FleetToolReachability.cs
+++ b/src/CcDirector.Core/Setup/FleetToolReachability.cs
@@ -26,13 +26,41 @@ public enum FleetToolVerdict
 /// <summary>
 /// One reachability run. <see cref="ResolvedPath"/> and <see cref="ExpectedBinDir"/> are what the
 /// explanation panel shows; they never decide the verdict.
+///
+/// <see cref="OwnVerdict"/> is the SECOND question, and it is the one whose absence cost a morning:
+/// "never mind what PATH gives me - does MY OWN copy work?" Without it the panel could only see that
+/// PATH pointed somewhere else, so it offered to repoint PATH at a directory that was empty. The
+/// repair reordered PATH exactly as asked, resolution fell straight through the empty directory to
+/// the same stale install, and the button reported the same failure it started with.
 /// </summary>
 public sealed record FleetToolCheck(
     FleetToolVerdict Verdict,
     string? ResolvedPath,
     string? ExpectedBinDir,
-    string Detail)
+    string Detail,
+    FleetToolVerdict OwnVerdict = FleetToolVerdict.Unchecked,
+    string OwnDetail = "")
 {
+    /// <summary>
+    /// True only when repointing PATH is a repair that can actually work: PATH resolves someone
+    /// else's copy, and OURS is present and proven to drive this Director.
+    ///
+    /// This is the precondition the button was missing. "PATH points at another install" was treated
+    /// as sufficient, which it is not - it is only half of it. The other half is that we have
+    /// something worth pointing at.
+    /// </summary>
+    public bool CanRepairByRepointingPath
+        => Verdict == FleetToolVerdict.CannotReachDirector
+           && OwnVerdict == FleetToolVerdict.Working
+           && IsDifferentInstall;
+
+    /// <summary>
+    /// True when this Director has no working cc-devthrottle of its own, so PATH order is not the
+    /// fault and reordering it would repair nothing. The remedy is to install our tools first.
+    /// </summary>
+    public bool OwnToolsAreMissingOrBroken
+        => OwnVerdict is FleetToolVerdict.NotFound or FleetToolVerdict.CannotReachDirector;
+
     /// <summary>
     /// True when the resolved tool belongs to a different install than this Director's. Explanation
     /// only - a development build legitimately runs from outside any install directory, so this must
@@ -133,9 +161,12 @@ public sealed class FleetToolReachability
         if (resolved is null)
         {
             FileLog.Write($"[FleetToolReachability] {ToolName} is not on PATH");
+            var (missingOwnVerdict, missingOwnDetail) =
+                await ProbeOwnCopyAsync(expectedBinDir, controlApiBaseUrl, ct);
             return new FleetToolCheck(
                 FleetToolVerdict.NotFound, null, expectedBinDir,
-                $"Nothing named {ToolName} is on this machine's PATH.");
+                $"Nothing named {ToolName} is on this machine's PATH.",
+                missingOwnVerdict, missingOwnDetail);
         }
 
         var (exitCode, output) = await RunProbeAsync(resolved, controlApiBaseUrl, ct);
@@ -152,7 +183,51 @@ public sealed class FleetToolReachability
         var detail = FirstMeaningfulLine(output) ?? $"exit {exitCode}";
         FileLog.Write(
             $"[FleetToolReachability] {ToolName} at {resolved} FAILED to reach {controlApiBaseUrl}: {detail}");
-        return new FleetToolCheck(FleetToolVerdict.CannotReachDirector, resolved, expectedBinDir, detail);
+
+        // PATH gave us something that does not work. That alone does not say whether OUR copy would,
+        // and the two faults have different repairs - so ask the second question before reporting.
+        var (ownVerdict, ownDetail) = await ProbeOwnCopyAsync(expectedBinDir, controlApiBaseUrl, ct);
+        return new FleetToolCheck(
+            FleetToolVerdict.CannotReachDirector, resolved, expectedBinDir, detail, ownVerdict, ownDetail);
+    }
+
+    /// <summary>
+    /// Run the same functional probe against THIS Director's own copy, addressed by its full path so
+    /// PATH cannot answer for it.
+    ///
+    /// It runs only when PATH has already failed, because it exists to tell two faults apart: PATH
+    /// resolves someone else's working copy (repoint), or we have no working copy to point at
+    /// (install first, then repoint). Nothing structural is consulted - a directory that exists and a
+    /// tool that runs are different claims, and it was the first standing in for the second that made
+    /// the repair impossible.
+    /// </summary>
+    private async Task<(FleetToolVerdict Verdict, string Detail)> ProbeOwnCopyAsync(
+        string? expectedBinDir, string controlApiBaseUrl, CancellationToken ct)
+    {
+        // A development build has no install directory of its own. No directory is not a fault, and it
+        // is not a pass either - it is a question that cannot be asked here.
+        if (string.IsNullOrWhiteSpace(expectedBinDir))
+            return (FleetToolVerdict.Unchecked, "");
+
+        var own = _resolve(Path.Combine(expectedBinDir, ToolName));
+        if (own is null)
+        {
+            FileLog.Write(
+                $"[FleetToolReachability] this Director has no {ToolName} of its own in {expectedBinDir}");
+            return (FleetToolVerdict.NotFound, $"There is no {ToolName} in {expectedBinDir}.");
+        }
+
+        var (exitCode, output) = await RunProbeAsync(own, controlApiBaseUrl, ct);
+        if (exitCode == 0)
+        {
+            FileLog.Write($"[FleetToolReachability] this Director's own {ToolName} at {own} reached it");
+            return (FleetToolVerdict.Working, "reached this Director");
+        }
+
+        var detail = FirstMeaningfulLine(output) ?? $"exit {exitCode}";
+        FileLog.Write(
+            $"[FleetToolReachability] this Director's own {ToolName} at {own} FAILED to reach it: {detail}");
+        return (FleetToolVerdict.CannotReachDirector, detail);
     }
 
     private async Task<(int ExitCode, string Output)> RunProbeAsync(

--- a/tools/cc-director-setup-engine.Tests/InstallFinalizerPathTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstallFinalizerPathTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The user PATH is permanent machine state, and this is the component that writes to it. The write
+/// itself is not exercised here - a test that edited the developer's real PATH would be a worse bug
+/// than the one being fixed - so these pin the decision that comes before the write.
+/// </summary>
+public class InstallFinalizerPathTests
+{
+    [Fact]
+    public void IsUnderTemp_AnInstallInTheTempDirectory_IsRecognised()
+    {
+        // FOUND BY DOING IT. Standing up a test Director whose root was under the temp directory put
+        // that throwaway bin into the real user PATH, where it outlives the directory: the same
+        // machine was already carrying ...\Temp\wizard-harness-home-29ef...\cc-director\bin from an
+        // earlier harness, pointing at a directory that no longer exists.
+        var rig = Path.Combine(Path.GetTempPath(), "some-harness-root", "instances", "default", "bin");
+
+        Assert.True(InstallFinalizer.IsUnderTemp(rig));
+    }
+
+    [Fact]
+    public void IsUnderTemp_AnOrdinaryInstall_IsNot()
+    {
+        // The guard must not fire on the real thing, or an ordinary install stops putting its tools on
+        // PATH at all - a far worse failure than the leak it prevents.
+        var real = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "cc-director", "instances", "default", "bin");
+
+        Assert.False(InstallFinalizer.IsUnderTemp(real));
+    }
+
+    [Fact]
+    public void IsUnderTemp_ADirectoryMerelyNamedLikeTemp_IsNot()
+    {
+        // Compared on full paths, not by looking for the word. A project directory called "temp" is
+        // somebody's real work, not scratch space.
+        Assert.False(InstallFinalizer.IsUnderTemp(Path.Combine("C:", "work", "temp", "bin")));
+    }
+
+    [Fact]
+    public void IsUnderTemp_NothingToJudge_IsNotTreatedAsTemp()
+    {
+        // A path that cannot be resolved cannot support the claim, and refusing to add it on a guess
+        // would break an ordinary install. Absence of an answer is not a yes.
+        Assert.False(InstallFinalizer.IsUnderTemp(""));
+        Assert.False(InstallFinalizer.IsUnderTemp("   "));
+    }
+}

--- a/tools/cc-director-setup-engine/InstallFinalizer.cs
+++ b/tools/cc-director-setup-engine/InstallFinalizer.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Versioning;
+using CcDirector.Core.Setup;
 
 namespace CcDirector.Setup.Engine;
 
@@ -11,19 +12,67 @@ namespace CcDirector.Setup.Engine;
 /// </summary>
 public static class InstallFinalizer
 {
-    /// <summary>Add the tools bin dir to the user PATH if not already present. Returns true if it changed.</summary>
+    /// <summary>
+    /// Add the tools bin dir to the user PATH if not already present. Returns true if it changed.
+    ///
+    /// TWO THINGS THIS HAS TO GET RIGHT, both learned from damage this method did:
+    ///
+    /// 1. It reads and writes the RAW stored value. It used to go through
+    ///    <c>Environment.GetEnvironmentVariable("Path", User)</c>, which returns the PATH with every
+    ///    %VARIABLE% already expanded, and wrote that back - baking one moment's expansion into the
+    ///    user's PATH permanently and destroying every variable reference in it. The raw accessors on
+    ///    <see cref="FleetToolPathRepair"/> are the single safe way to touch it.
+    ///
+    /// 2. It refuses to write a throwaway root into permanent machine state. Every Director repairs
+    ///    its own tools, and a Director running from a temporary root (a test rig, a wizard harness,
+    ///    an unpacked bundle) would otherwise append ITS temporary bin to the real user PATH, where it
+    ///    outlives the directory by months. That is exactly how
+    ///    <c>...\Temp\wizard-harness-home-29ef...\cc-director\bin</c> came to be on a live machine's
+    ///    PATH, pointing at a directory that no longer exists.
+    /// </summary>
     [SupportedOSPlatform("windows")]
     public static bool AddBinToPath(InstallLayout layout)
     {
         ArgumentNullException.ThrowIfNull(layout);
-        var current = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.User) ?? "";
+
+        if (IsUnderTemp(layout.BinDir))
+        {
+            EngineLog.Write(
+                "[InstallFinalizer] NOT adding to PATH - this install lives under the temp directory "
+                + $"and would outlive itself there: {layout.BinDir}");
+            return false;
+        }
+
+        var current = FleetToolPathRepair.ReadUserPathRaw();
         var updated = ComputePathWith(current, layout.BinDir);
         if (updated == current) return false;
-        // SetEnvironmentVariable(User) persists to the registry and broadcasts WM_SETTINGCHANGE, so new
-        // processes pick it up (existing shells still need to be reopened).
-        Environment.SetEnvironmentVariable("Path", updated, EnvironmentVariableTarget.User);
+
+        FleetToolPathRepair.WriteUserPathRaw(updated);
         EngineLog.Write($"[InstallFinalizer] added to PATH: {layout.BinDir}");
         return true;
+    }
+
+    /// <summary>
+    /// Is this directory inside the machine's temp directory? Compared on full paths so a directory
+    /// merely NAMED like temp is not caught, and case-insensitively because Windows paths are.
+    /// </summary>
+    internal static bool IsUnderTemp(string directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory)) return false;
+        try
+        {
+            var temp = Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar)
+                       + Path.DirectorySeparatorChar;
+            var full = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar)
+                       + Path.DirectorySeparatorChar;
+            return full.StartsWith(temp, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            // A path we cannot resolve cannot support the claim that it is under temp, and refusing to
+            // add it on a guess would break an ordinary install.
+            return false;
+        }
     }
 
     /// <summary>Create (or overwrite) the Start Menu shortcut for the Director. No-op if its exe is absent.</summary>


### PR DESCRIPTION
## What happened

"Repoint PATH to this install" reordered PATH around a directory that was empty and reported the failure it had just been pressed to fix.

From that Director's own log:

```
10:43:16.273 [FleetToolPathRepair] PutFirstOnPath: ...\instances\default\bin
10:43:16.278 [FleetToolPathRepair] PutFirstOnPath done: ...\instances\default\bin is now first
10:43:16.278 [FleetToolReachability] RunAsync: probing cc-devthrottle against http://127.0.0.1:7879
10:43:17.430 [FleetToolReachability] cc-devthrottle at ...\cc-director\bin\cc-devthrottle.CMD
             FAILED to reach http://127.0.0.1:7879: Error: missing or invalid token
```

PATH was repaired correctly - registry and running process both - and the re-check resolved the same stale copy again, because `instances\default\bin` was **empty**: that Director's tools had never been installed. Three minutes later the machine said so itself - `ToolReconciler` reported `missingShims=8`, `ToolHealthProbe` reported the pyenv binary missing, and the pyenv directory was created at 10:44:25, a minute after the button was pressed.

`ExecutableResolver` walks PATH in order and skips a directory with no match, so promoting an empty one changes the order and nothing about what resolves.

**Root cause: the guard tested the container, not the contents.** `PutFirstOnPath` required only `Directory.Exists(binDir)`. The check above it could see that PATH pointed at another install; it could not see that we had nothing to point at, because it never asked about our own copy.

## What changed

**1. The check asks a second question.** When the PATH probe fails, the same functional probe now runs against this Director's own copy, addressed by full path. That splits two faults that look identical from outside and have different repairs, and puts in the log the line whose absence made this undiagnosable: *this Director has no cc-devthrottle of its own*.

**2. The banner names which fault it is.** No working copy of our own means the button installs the tools first, then repoints. `PutFirstOnPath` independently refuses a directory holding no `cc-devthrottle`, before it writes anything.

**3. One entry per command line.** Two entries serve nobody - only the first can win, and the loser waits to win again the moment the order shifts. Superseded DevThrottle directories come out of the user PATH: the flat pre-migration `<root>\bin`, anything under the temp directory, and install bins gone from disk. **Another live instance's bin is left alone.** Entries are decided on the expanded path and written back raw, so `%USERPROFILE%` survives. Nothing on disk is touched.

**4. Sessions stop depending on machine PATH order.** `SessionManager` puts this Director's own bin first on every session's PATH, in the same breath as the `CC_DIRECTOR_API` address the session must call. The PATH repair becomes a convenience for the user's own terminals rather than the mechanism the product depends on.

**5. The panel cannot sit on a stale verdict.** The tools health pass is computed once per run, so the verdict handed to the Tools page could describe a machine an intervening repair had already healed - which is what the screenshot behind this work was showing. The page re-asks on load and repaints.

## Two further defects, both found by proving this one

**The installer leaks throwaway roots into the user PATH.** Standing up a test Director to photograph the banner put its own temporary bin into the real user PATH. The same machine was already carrying `...\Temp\wizard-harness-home-29ef...\cc-director\bin` from an earlier harness, pointing at a directory that no longer exists. This is where the duplicates come from - cleaning PATH while this keeps appending to it is a mop under a running tap. `AddBinToPath` now refuses a bin under the temp directory. It also read and wrote PATH through `Environment.GetEnvironmentVariable("Path", User)`, which returns variables already **expanded**, and wrote that back - the exact hazard `FleetToolPathRepair` goes to the registry to avoid, living in the component that touches PATH far more often. The raw accessors now live in one place and both callers use them.

**The local merge gate reports FAILED on a fully green run.** `scripts/test-local.ps1` printed `RESULT: FAILED in 7 project(s)` over seven lines that each said `Passed! - Failed: 0`. `Start-Process -PassThru` returns a process whose `ExitCode` is empty once the child exits unless the handle is kept open, so `ExitCode -eq 0` was never true. Verified directly: the same run reports `[]` without the handle retained and `[0]` with it. This is the gate the repository tells everyone to trust instead of waiting fifty minutes for continuous integration.

## Proof

**Local suite, with the fixed gate: `RESULT: ALL GREEN`.** Gateway 5147, Core 4188, Avalonia 353, Engine 63, HostedAgent 88, Launcher 110, Terminal 24. Zero failures.

`CcDirector.Setup.Engine.Tests` is **not** among the seven projects `test-local.ps1` runs (continuous integration does run it), so it was run directly: 453 pass.

**Fault injection.** Restoring the old `CanRepairByRepointingPath` turned both regression tests red. Making the prune rule indiscriminate turned "another live instance is kept" red. Making the temp guard never fire turned its test red. Each was reverted immediately. One of those reds exposed a flaw in a new test of mine - its fixture answered "exists" and "holds the tool" from one list, so it could not express the case it claimed to test - fixed in its own commit.

**Live, in a running Director.** A rig Director on an isolated root reproduced the exact failing state (PATH resolving the stale copy, its own bin empty):

```
[FleetToolReachability] cc-devthrottle at ...\cc-director\bin\cc-devthrottle.CMD
    FAILED to reach http://127.0.0.1:7880: Error: missing or invalid token
[FleetToolReachability] this Director has no cc-devthrottle of its own in ...\instances\default\bin
```

and the banner offered **"Install tools, then repoint PATH"** where the shipped code offered "Repoint PATH to this install".

**Dry run against the real machine PATH** (read-only): the repair would remove `...\cc-director\bin` and a dead rig path, and keep `...\cc-director` - which is on PATH but is not a tool directory, so it is not ours to remove.

## Not proven here

The repoint branch was not exercised end to end in a live Director: making the rig's own copy authenticate would have required minting a rig credential, and pressing the button writes the real user PATH. That branch is the behaviour that already shipped, and it is covered by unit tests. The install-first branch - the one that was wrong - is what the live rig demonstrates.
