### PR TITLE
release: v1.9.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.4</Version>
+    <Version>1.9.5</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.5.md
+++ b/docs/public/release-notes/v1.9.5.md
@@ -1,0 +1,51 @@
+## v1.9.5 - August 1, 2026
+
+A small release with one thing worth updating for: the repair button that tells you your sessions
+cannot reach this Director now works, and it can no longer tell you it has fixed something it has
+not.
+
+### "Repoint PATH to this install" now repairs the thing it names
+
+When the command-line tool on your PATH belongs to an older install, every agent in every session
+reports "cannot connect to DevThrottle" while the Director itself is healthy and connected. Version
+1.9.4 added the banner that spots this, and a button to fix it. On a machine where that Director's
+own tools had never been installed, the button did nothing and said so in a way that read as the
+product being broken: it reordered your PATH exactly as asked, around a directory that was empty, and
+then reported the same failure it had just been pressed to fix.
+
+Three things changed.
+
+**It checks whether it has anything to point at.** The Director now also runs its OWN copy of the
+tool, directly, and sees whether that one works. Those are two different questions with two different
+answers, and only asking the first one is what made this impossible to diagnose from the screen. If
+there is no working copy to point at, the banner says the tools are not installed and the button
+installs them first. Putting an empty directory at the front of your PATH is no longer something it
+will do.
+
+**It leaves one entry instead of several.** Two entries for the same command line serve nobody - only
+the first can ever win, and the loser sits there waiting to win again the moment the order shifts. So
+the repair now removes the superseded DevThrottle entries it finds behind it: the old pre-upgrade
+one, entries pointing at directories that no longer exist, and ones left in your temporary folder by
+a test run. Nothing on disk is deleted, and another install that is still in use is left alone.
+
+**Sessions no longer depend on your PATH at all.** Each session is now told where this Director's
+tools are when it starts, in the same breath as the address it has to call. Your PATH is shared
+machine state that any other install can win; a session should not have to go looking for us when we
+can simply say. Sessions already running keep the environment they started with - that is true of
+every program on the machine and nothing can change it from outside, so restart a session if it was
+open before you updated.
+
+### The installer stops leaving dead entries in your PATH
+
+Found while proving the above. Every Director keeps its own tools repaired, and each one added its
+tools folder to your PATH - including Directors run from a temporary folder, which then left a path
+pointing into a folder that gets deleted. One machine was carrying two such entries. It also read and
+wrote your PATH with variables such as %USERPROFILE% already expanded, and wrote the expanded text
+back, which permanently replaces those variables with whatever they happened to mean at that moment.
+Both are fixed.
+
+### Also in this release
+
+The access log records an account by the same identifier the rest of the log uses, rather than the
+raw one. A mission's evidence record now outlives the branch it was produced on, so it is still there
+after the branch is deleted.


### PR DESCRIPTION
Version bump and release notes for v1.9.5.

The tag is created only after this merges, so it can never point at a commit that is not on main.

See docs/public/release-notes/v1.9.5.md for what is in this release.