### PR TITLE
release: v1.9.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.5</Version>
+    <Version>1.9.6</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.6.md
+++ b/docs/public/release-notes/v1.9.6.md
@@ -1,0 +1,39 @@
+# v1.9.6 - August 2, 2026
+
+**This release is about the hosted service, and it is the only thing in it.** If you run your own
+Gateway, nothing here changes how your machine behaves. The security work from earlier today shipped
+in v1.9.3, v1.9.4 and v1.9.5; this one finishes the piece those left undone.
+
+## Your statistics come back on the hosted service
+
+Hosted accounts have been unable to see their statistics. The pages did not fail quietly - they
+answered with a plain "unavailable" - but they had nothing behind them. That was a consequence of
+moving the hosted Gateway off its local database file: the writing side moved and the reading side
+did not, so the numbers were being kept and never served.
+
+The reading side now comes out of the hosted database, and it is partitioned: your account is served
+its own totals and nobody else's. The recording side runs through the same session roster the rest of
+the product uses, rather than a separate path that could drift from it.
+
+## A statistics problem can no longer take anything else down with it
+
+Statistics are a background concern, and a background concern should never be able to break the
+things you actually depend on. It could: a failure while recording could surface through the session
+list and through both of the paths a Director uses to talk to the Gateway.
+
+It cannot now. A statistics failure stays inside statistics. The session list and the Director
+connections carry on.
+
+Alongside that, the hosted statistics store now refuses to accept a row that does not say which
+account it belongs to, rather than storing it and leaving the question for later.
+
+## What is proven, and what is not
+
+The work went through six independent inspection rounds; fifteen findings were raised and every one
+is closed or explicitly narrowed in writing.
+
+One boundary is worth stating plainly rather than leaving you to find it. The path where a slow
+startup causes numbers to be published late has never been executed end to end - the side that reads
+those numbers is proven, the side that produces them under that specific timing is not. It is
+recorded as issue 2376 and it is the next thing to be exercised. Statistics work; "fully exercised
+under a slow cold start" is not a claim this release makes.


### PR DESCRIPTION
Hosted statistics, and only that.

**What is in it.** The hosted read path now serves each account its own totals out of the hosted database, partitioned, and the recording side runs through the same session roster the rest of the product uses instead of a separate path that could drift. A statistics failure can no longer surface through the session list or either path a Director uses to reach the Gateway. The hosted statistics store refuses a row that does not name the account it belongs to.

**What is NOT in it, deliberately.** The notes do not claim the tenant boundary, the local trust boundary, prompt retention with export and delete, or the access-log account tagging. Those shipped in v1.9.3, v1.9.4 and v1.9.5 - I checked which tag contains each merge rather than describing them from memory. Repeating them here would be the same defect as v1.9.3's notes, pointing the other way.

**The boundary the notes state plainly.** The path where a slow startup publishes numbers late has never been executed end to end. The reading side is proven; the producing side under that timing is not. That is devthrottle#2376, and the notes say statistics work while explicitly not claiming they are fully exercised under a slow cold start.

**Provenance.** Twenty-four commits from #2377, six independent inspection rounds, fifteen findings all closed or narrowed in writing.

Per docs/architecture/VERSIONING.md the version lives only in Directory.Build.props, so that plus the notes page is the entire diff. The tag is created only after this merges, so it cannot point at a commit that is not on main.