### PR TITLE
fix(settings): keep the Tools list badges clear of the scrollbar

### DIFF
--- a/src/CcDirector.Avalonia/Controls/ToolsView.axaml
+++ b/src/CcDirector.Avalonia/Controls/ToolsView.axaml
@@ -121,7 +121,11 @@
                     </ListBox.Styles>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <Grid ColumnDefinitions="*,Auto" Margin="10,7">
+                            <!-- The right margin is a gutter for the scrollbar. This app keeps
+                                 scrollbars visible at all times (App.axaml) and Avalonia paints
+                                 the bar OVER the content, so a row that runs to its own edge puts
+                                 the status badge underneath the bar. -->
+                            <Grid ColumnDefinitions="*,Auto" Margin="10,7,20,7">
                                 <StackPanel Grid.Column="0">
                                     <TextBlock Text="{Binding Name}" Foreground="#DDDDDD"
                                                FontSize="13" FontWeight="Medium" />
@@ -183,7 +187,10 @@
 
                         <!-- Overview -->
                         <TabItem Header="Overview">
-                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0">
+                            <!-- Padding, not Margin: it insets the CONTENT from the always-visible
+                                 scrollbar, which is painted over the content area. -->
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0"
+                                          Padding="0,0,20,0">
                                 <StackPanel Spacing="10">
                                     <TextBlock x:Name="DetailDescription" Text="" Foreground="#CCCCCC"
                                                FontSize="13" TextWrapping="Wrap" />
@@ -227,7 +234,8 @@
 
                         <!-- Tests -->
                         <TabItem Header="Tests">
-                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0"
+                                          Padding="0,0,20,0">
                                 <StackPanel Spacing="6">
                                     <TextBlock x:Name="TestsHint" Foreground="#777777" FontSize="11"
                                                Text="Click Run Tests to execute the read-only health checks." />
@@ -254,7 +262,8 @@
 
                         <!-- Skills -->
                         <TabItem Header="Skills">
-                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,10,0,0"
+                                          Padding="0,0,20,0">
                                 <StackPanel Spacing="6">
                                     <TextBlock Foreground="#777777" FontSize="11"
                                                Text="Claude Code skills that drive or use this tool." />


### PR DESCRIPTION
The status badges on the Tools tab sat right up against the scrollbar, touching it.

This app keeps scrollbars visible at all times (`App.axaml`), and Avalonia paints the bar
over the content area rather than beside it, so any row that runs to its own edge puts its
right-hand column underneath the bar.

- Tool list rows get a right gutter (`Margin="10,7"` -> `Margin="10,7,20,7"`).
- The Overview, Tests and Skills panels had the same defect - their text ran under the bar
  once the content overflowed - so their scroll viewers get `Padding="0,0,20,0"`.

Verified in the running app: a throwaway Director built from this branch, driven to
Settings -> Tools and captured with no one at the keyboard. Measured on the pixels, same
badge and same row: the gap was 0 px before and is 6 px now.

Tests were not run for this one - it is a three-attribute spacing change to one XAML file,
with no code path touched, and the owner asked to merge it directly.