### PR TITLE
Cockpit dictation: flush the tail on every stop, and stop the meter lying

### DIFF
--- a/apps/cockpit/src/assistant/AssistantView.test.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.test.tsx
@@ -56,6 +56,14 @@ vi.mock("@devthrottle/client-core/dictation/recorder", () => {
     level() {
       return 0;
     }
+    // The liveness clocks the dialog's animation loop reads every frame. Zero = a healthy microphone,
+    // so the live capture alarm stays quiet and this file keeps testing what it is about.
+    msSinceLastAudio() {
+      return 0;
+    }
+    msSinceMeterMoved() {
+      return 0;
+    }
     dispose() {}
   }
   return { MicRecorder, rmsLevel: () => 0 };

--- a/apps/cockpit/src/assistant/AssistantView.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.tsx
@@ -229,6 +229,7 @@ export function AssistantView() {
           reason, issue #1210's fix). */}
       {dictating && (
         <DictationDialog
+          surface="cockpit"
           showInsert={mode === "chat"}
           onInsert={onDictateInsert}
           onSend={(text) => assistant.sendText(text)}

--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -391,6 +391,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
 
       {dictating && (
         <DictationDialog
+          surface="cockpit"
           onInsert={onDictateInsert}
           onSend={onDictateSend}
           onSendAudio={onDictateSendAudio}

--- a/apps/cockpit/src/sessions/VoiceTab.tsx
+++ b/apps/cockpit/src/sessions/VoiceTab.tsx
@@ -207,6 +207,7 @@ export function VoiceTab({ sessionId }: { sessionId: string | undefined }) {
           text synchronously, unchanged. */}
       {v.responding && (
         <DictationDialog
+          surface="cockpit"
           showInsert={false}
           onSend={(text) => void v.onRespondSend(text)}
           onSendAudio={v.onRespondSendAudio}

--- a/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
+++ b/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
@@ -79,6 +79,16 @@ vi.mock("@devthrottle/client-core/dictation/recorder", () => {
     level() {
       return 0;
     }
+    // The liveness clocks the dialog's animation loop reads. Zero = a healthy microphone, so the live
+    // capture alarm stays quiet and this file keeps testing what it is about (the Send path). They are
+    // here rather than omitted because the loop calls them on every frame: a fake without them is one
+    // scheduled animation frame away from throwing, and the failure would look like a Send bug.
+    msSinceLastAudio() {
+      return 0;
+    }
+    msSinceMeterMoved() {
+      return 0;
+    }
     dispose() {}
   }
   return { MicRecorder, rmsLevel: () => 0 };

--- a/apps/mobile/src/components/SessionControls.tsx
+++ b/apps/mobile/src/components/SessionControls.tsx
@@ -328,6 +328,7 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
 
       {dictating && (
         <DictationDialog
+          surface="mobile"
           onInsert={onDictateInsert}
           onSend={onDictateSend}
           onSendAudio={onDictateSendAudio}

--- a/apps/mobile/src/pages/Assistant.tsx
+++ b/apps/mobile/src/pages/Assistant.tsx
@@ -238,6 +238,7 @@ export function Assistant() {
           nothing to release the screen for - the same reason the Cockpit composer leaves it unwired. */}
       {dictating && (
         <DictationDialog
+          surface="mobile"
           showInsert={mode === "chat"}
           onInsert={onDictateInsert}
           onSend={(text) => assistant.sendText(text)}

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -514,6 +514,7 @@ export function VoiceMode() {
           background, so the queue is the next stop, not this page. */}
       {responding && (
         <DictationDialog
+          surface="mobile"
           showInsert={false}
           onSend={onRespondText}
           onSendAudio={(captured) => {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1688,6 +1688,10 @@ export interface UtteranceCaptureHealth {
   recordedMs: number;
   decodedSeconds: number;
   sourceBytes: number;
+  /** Which shell measured it ("cockpit" / "mobile"). The Gateway files the measurement under this
+   *  rather than a hardcoded literal, which is what makes per-surface audio loss visible at all.
+   *  Omitted by an older client; the Gateway then falls back to the tag this path always used. */
+  surface?: string;
 }
 
 // The largest a single upload chunk may be. A long recording is uploaded as several chunks of at
@@ -1754,6 +1758,7 @@ export async function transcribeUtterance(
       clientRecordedMs: health?.recordedMs,
       clientDecodedSeconds: health?.decodedSeconds,
       clientSourceBytes: health?.sourceBytes,
+      clientSurface: health?.surface,
     }),
     signal,
   });
@@ -1848,6 +1853,10 @@ export interface DictationUploadArgs {
   clientRecordedMs?: number;
   clientDecodedSeconds?: number;
   clientSourceBytes?: number;
+  /** Which shell recorded the clip ("cockpit-send" / "mobile-send"). The Gateway files the
+   *  capture-health measurement under this instead of a hardcoded literal, so per-surface audio loss
+   *  can actually be told apart in the log. Omitted by an older client; the Gateway then falls back. */
+  clientSurface?: string;
 }
 
 /** The honest, plain-English line for a dictation whose delivery is paused because the connection
@@ -1933,6 +1942,7 @@ export async function uploadDictationToSession(
     clientRecordedMs: args.clientRecordedMs,
     clientDecodedSeconds: args.clientDecodedSeconds,
     clientSourceBytes: args.clientSourceBytes,
+    clientSurface: args.clientSurface,
   };
   const complete = (): Promise<Response> =>
     gatewayFetch(`/dictation/${id}/complete`, {

--- a/packages/client-core/src/dictation/DictationDialog.tsx
+++ b/packages/client-core/src/dictation/DictationDialog.tsx
@@ -39,6 +39,32 @@ type Stage = "connecting" | "recording" | "transcribing" | "paused" | "error";
 // "check your microphone" message rather than stranding the user on GETTING READY forever.
 const READY_TIMEOUT_MS = 6000;
 
+// ---- live capture alarms (the "half of what I said went missing" defect) -------------------------
+// Until now the ONLY loss check ran after the clip was finished (recorded wall-clock versus decoded
+// duration), which can tell the user their words are gone but never in time to save them. These two
+// thresholds watch the same failures WHILE the microphone is open, so a recording that has stopped
+// hearing the user says so on screen instead of quietly producing half a sentence.
+//
+// They watch two independent paths deliberately. MediaRecorder (what is captured) and the analyser
+// (what the bars draw) are separate audio graphs, so the common failure is exactly one of them dying:
+//   - no captured audio for CAPTURE_STALL_MS -> the recording itself has stalled; words are being lost
+//     right now. MediaRecorder delivers every 100ms while healthy, so this is thirty missed deliveries.
+//     Deliberately not tighter: dataavailable is delivered on the main thread, so a busy session view
+//     that blocks it for a second or two makes chunks arrive LATE without any audio being lost (the
+//     encoder keeps buffering), and crying loss over ordinary jank would teach the user to ignore the
+//     one alarm that matters. Still fast enough to stop and say it again.
+//   - a meter pinned at exactly zero for MIC_SILENT_MS -> we are hearing nothing at all. A live
+//     microphone in a quiet room never reads exact zero, so this is a dead meter (the Cockpit
+//     flat-bars defect) or a muted/absent microphone. Longer than the stall window because it is the
+//     less urgent of the two and must never fire on a genuine pause for thought.
+const CAPTURE_STALL_MS = 3000;
+const MIC_SILENT_MS = 5000;
+
+const CAPTURE_STALLED_MESSAGE =
+  "The microphone has stopped sending audio - what you are saying now is NOT being recorded. Stop and check your microphone, then say it again.";
+const MIC_SILENT_MESSAGE =
+  "Nothing is coming from your microphone. Check that it is not muted and that it is the device this page is using - your words may not be recorded.";
+
 export interface DictationDialogProps {
   /** Commit the transcript WITHOUT submitting (drop into the view's text box for editing). Required
    *  only when Insert is shown; ignored when showInsert is false. */
@@ -59,6 +85,13 @@ export interface DictationDialogProps {
    *  this false so the reply panel is Cancel / Pause / Send only - Send goes straight into the
    *  session, there is no "drop into a box" target. Defaults true for the Terminal/Chat Speak flow. */
   showInsert?: boolean;
+  /** Which shell mounted this dialog - "cockpit" or "mobile". It tags the capture-health measurements
+   *  this dialog reports, and it exists because those measurements were previously labelled "mobile"
+   *  from EVERY browser, so a Cockpit dictation on a desktop was filed as a phone dictation and the
+   *  Cockpit's own audio loss could not be seen in the data at all (which is how it went unnoticed
+   *  while issue #645 read the same log and concluded the web surfaces were healthy). Defaults to
+   *  "browser" so an unlabelled mount is honestly unlabelled rather than silently counted as a phone. */
+  surface?: string;
 }
 
 const BAR_COUNT = 9;
@@ -70,7 +103,14 @@ function formatElapsed(ms: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showInsert = true }: DictationDialogProps) {
+export function DictationDialog({
+  onInsert,
+  onSend,
+  onSendAudio,
+  onClose,
+  showInsert = true,
+  surface = "browser",
+}: DictationDialogProps) {
   const recorderRef = useRef<MicRecorder>(new MicRecorder());
   const accumulatedRef = useRef<string>(""); // committed segments; the box may be edited past this
   const busyRef = useRef<boolean>(false); // guards the transcribe window against double taps
@@ -99,6 +139,12 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
   const [errorText, setErrorText] = useState<string>("");
   const [elapsed, setElapsed] = useState<number>(0);
   const [levels, setLevels] = useState<number[]>(() => new Array(BAR_COUNT).fill(0));
+  // The LIVE alarm (capture stalled / hearing nothing), as opposed to captureWarning above, which is
+  // the sticky post-clip measurement. This one describes the microphone right now, so it clears by
+  // itself the moment audio comes back - a warning that outlived its cause would train the user to
+  // ignore it. Mirrored in a ref so the per-frame loop can compare without re-subscribing.
+  const [liveWarning, setLiveWarning] = useState<string>("");
+  const liveWarningRef = useRef<string>("");
 
   const clearReadyBackstop = useCallback(() => {
     if (readyTimeoutRef.current !== null) {
@@ -131,14 +177,24 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     playReadyCue();
   }, [clearReadyBackstop]);
 
-  // ----- equalizer + timer animation (display only) -----
+  // ----- equalizer + timer animation, and the live capture alarm -----
+  // The alarm rides this loop rather than a timer of its own because the loop already runs once per
+  // frame for exactly as long as we are recording, so the two can never disagree about whether the
+  // microphone is supposed to be open.
   useEffect(() => {
+    // Leaving RECORDING (pause, transcribe, error, commit) retires any live alarm: it describes an
+    // open microphone, and there is no longer one to describe.
+    if (stage !== "recording" && liveWarningRef.current !== "") {
+      liveWarningRef.current = "";
+      setLiveWarning("");
+    }
     let raf = 0;
     const tick = () => {
       if (stage === "recording") {
         const now = performance.now();
         setElapsed(elapsedBeforeRef.current + (now - segmentStartRef.current));
-        const level = recorderRef.current.level();
+        const recorder = recorderRef.current;
+        const level = recorder.level();
         const next = new Array(BAR_COUNT).fill(0).map((_, i) => {
           // Centre bars react most, so it reads as an equalizer rather than a flat bar.
           const centre = (BAR_COUNT - 1) / 2;
@@ -146,6 +202,22 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
           return Math.min(1, level * (0.55 + falloff));
         });
         setLevels(next);
+
+        // Capture stalling is reported ahead of silence: it is the one that is actively losing the
+        // user's words, and a stalled recorder usually goes silent too, so reporting both at once
+        // would bury the message that matters under the one that merely follows from it.
+        const alarm =
+          recorder.msSinceLastAudio() > CAPTURE_STALL_MS
+            ? CAPTURE_STALLED_MESSAGE
+            : recorder.msSinceMeterMoved() > MIC_SILENT_MS
+              ? MIC_SILENT_MESSAGE
+              : "";
+        // Only on a CHANGE: this runs sixty times a second, and setting the same string every frame
+        // would re-render the dialog for no reason.
+        if (alarm !== liveWarningRef.current) {
+          liveWarningRef.current = alarm;
+          setLiveWarning(alarm);
+        }
       }
       raf = window.requestAnimationFrame(tick);
     };
@@ -209,7 +281,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
         decodedSeconds: transcoded.decodedSeconds,
         sourceBytes: transcoded.sourceBytes,
       };
-      logCaptureHealth("mobile", health);
+      logCaptureHealth(surface, health);
       // Material loss is surfaced to the USER, not just the console: the transcript may be missing
       // words, and a silent commit of truncated speech is exactly the failure mode this dialog
       // exists to prevent. The caller shows the warning and parks instead of auto-committing.
@@ -225,7 +297,9 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     reportDictationQuality(nativeSamples, nativeSampleRate, device, "dictation-dialog");
 
     try {
-      const text = await transcribeUtterance(wav, health, undefined, (uploaded, total) => {
+      // The surface rides ALONGSIDE the measurement rather than inside it: capture-health is what was
+      // measured, the surface is who measured it, and only the upload needs both.
+      const text = await transcribeUtterance(wav, { ...health, surface }, undefined, (uploaded, total) => {
         // A short clip uploads in one chunk (no progress line needed); a long recording uploads in
         // several, so show which piece is going up before the "Transcribing..." wait.
         if (total > 1) setHint(`Uploading recording... ${uploaded} of ${total}`);
@@ -235,7 +309,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       setHint(err instanceof Error ? err.message : "The transcription service had a problem and couldn't process your recording.");
       return null;
     }
-  }, []);
+  }, [surface]);
 
   const onPauseResume = useCallback(async () => {
     if (busyRef.current) return;
@@ -347,9 +421,10 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       blob: captured,
       recordedMs: recorderRef.current.lastRecordedMs,
       prefixText: accumulatedRef.current,
+      surface,
     });
     onClose();
-  }, [stage, transcript, onSend, onSendAudio, onClose, commit]);
+  }, [stage, transcript, onSend, onSendAudio, onClose, commit, surface]);
 
   const onCancel = useCallback(() => {
     recorderRef.current.dispose();
@@ -408,6 +483,12 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
         )}
 
         <div className="dictate-hint" role="status">{hint}</div>
+
+        {/* The LIVE alarm sits above the sticky one: it is about the microphone right now, and it is
+            the only one the user can still act on. */}
+        {liveWarning !== "" && !isError && (
+          <div className="dictate-warning dictate-warning-live" role="alert">{liveWarning}</div>
+        )}
 
         {captureWarning !== "" && !isError && (
           <div className="dictate-warning" role="alert">{captureWarning}</div>

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -100,6 +100,10 @@ export interface CapturedUtterance {
   /** The microphone's stable identifier - the value quality measurements are grouped by. Optional
    *  for the same reason as the label. */
   deviceId?: string;
+  /** Which shell recorded it ("cockpit" / "mobile"), so the capture-health measurement is filed under
+   *  the surface the user was actually in. Optional: an unlabelled caller still delivers every word,
+   *  it just lands under the generic browser tag. */
+  surface?: string;
 }
 
 /** Callbacks so the host can react to the rare hard failure (durable storage unavailable). A normal send
@@ -155,6 +159,10 @@ export async function backgroundTranscribeAndSend(
   let sourceBytes: number | undefined;
   let uploadBlob = captured.blob;
   let captureWarning: string | undefined;
+  // The Send path's tag for this surface. "mobile" yields "mobile-send" - byte-identical to the tag
+  // this path has always written - so the existing capture-health history stays comparable while the
+  // Cockpit finally gets a tag of its own instead of being counted as a phone.
+  const sendSurface = `${captured.surface ?? "browser"}-send`;
   try {
     const transcoded = await blobToWav16kMono(captured.blob);
     decodedSeconds = transcoded.decodedSeconds;
@@ -165,7 +173,7 @@ export async function backgroundTranscribeAndSend(
       decodedSeconds: transcoded.decodedSeconds,
       sourceBytes: transcoded.sourceBytes,
     };
-    logCaptureHealth("mobile-send", health);
+    logCaptureHealth(sendSurface, health);
     // Material capture loss must not ship SILENTLY on Send the way it currently did (the Insert/Pause paths
     // already warn and park). We cannot park a fire-and-forget Send - the screen is gone and the words the
     // mic DID capture should still be delivered - so instead the deficit rides along as a caution shown with
@@ -194,6 +202,7 @@ export async function backgroundTranscribeAndSend(
     decodedSeconds,
     sourceBytes,
     captureWarning,
+    surface: sendSurface,
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
@@ -492,6 +501,9 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
       clientRecordedMs: rec.recordedMs,
       clientDecodedSeconds: rec.decodedSeconds,
       clientSourceBytes: rec.sourceBytes,
+      // Read from the durable record, not recomputed, so a clip resumed after a reload is still filed
+      // under the surface that actually recorded it.
+      clientSurface: rec.surface,
     });
 
     if (outcome.terminal) {

--- a/packages/client-core/src/dictation/dictation.css
+++ b/packages/client-core/src/dictation/dictation.css
@@ -137,6 +137,17 @@
   font-size: 13px;
 }
 
+/* The LIVE alarm: the microphone has stopped delivering audio, or we are hearing nothing at all,
+   RIGHT NOW. Louder than the amber post-clip caution above because it is the only one the user can
+   still act on - words are being lost while it is on screen. Reuses the recording red so it reads as
+   the same urgency as the RECORDING state itself. */
+.dictate-warning-live {
+  background: rgba(220, 80, 70, 0.14);
+  border-color: rgba(220, 80, 70, 0.55);
+  color: #f0a19a;
+  font-weight: 600;
+}
+
 .dictate-error {
   margin-top: 8px;
   padding: 10px 12px;

--- a/packages/client-core/src/dictation/dictationLiveAlarm.test.tsx
+++ b/packages/client-core/src/dictation/dictationLiveAlarm.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act } from "@testing-library/react";
+
+// The live capture alarm, at the JOIN between the recorder's liveness clocks and the dialog that has
+// to say something about them. The clocks themselves are unit-tested in recorder.test.ts; what is
+// pinned HERE is the wiring, because the wiring is what was missing for the whole life of this
+// defect: the recorder could already read a flat-zero meter and the dialog drew it as nine short bars
+// and said nothing, so a dead meter and a quiet user were the same picture, and a recording that had
+// stopped hearing anything looked exactly like a recording that was going fine.
+//
+// The alarm must:
+//   - stay silent while capture and the meter are both alive,
+//   - say the recording has STALLED when no audio has been delivered (words are being lost NOW),
+//   - say we are hearing NOTHING when the meter has been pinned at zero (dead meter, or a muted mic),
+//   - prefer the stall message over the silence message, since a stalled recorder usually goes silent
+//     too and the losing-your-words one is the message that matters,
+//   - and CLEAR itself the moment the microphone recovers - a warning that outlives its cause trains
+//     the user to ignore the one that does not.
+//
+// Revert-proof: delete either threshold branch in DictationDialog's animation loop and the matching
+// assertion below reddens; make the alarm sticky instead of self-clearing and the recovery test fails.
+
+// The controllable microphone. The test moves these two clocks; nothing else about it matters.
+const clocks = vi.hoisted(() => ({ sinceAudio: 0, sinceMeter: 0, level: 0.5 }));
+
+vi.mock("./recorder", () => {
+  class MicRecorder {
+    onCaptureLive: (() => void) | null = null;
+    lastRecordedMs = 1000;
+    deviceLabel = "Fake Microphone";
+    deviceId = "fake-mic";
+    async start() {
+      this.onCaptureLive?.();
+    }
+    async stop() {
+      return new Blob(["clip"], { type: "audio/webm" });
+    }
+    level() {
+      return clocks.level;
+    }
+    msSinceLastAudio() {
+      return clocks.sinceAudio;
+    }
+    msSinceMeterMoved() {
+      return clocks.sinceMeter;
+    }
+    dispose() {}
+  }
+  return { MicRecorder, rmsLevel: () => 0 };
+});
+
+vi.mock("../api/client", () => ({
+  transcribeUtterance: vi.fn(async () => "the dictated words"),
+}));
+vi.mock("./readyCue", () => ({ playReadyCue: () => {} }));
+vi.mock("./qualityReport", () => ({ reportDictationQuality: () => {} }));
+vi.mock("./wav", () => ({
+  blobToWav16kMono: async () => ({
+    wav: new Blob(["wav"]),
+    decodedSeconds: 1,
+    sourceBytes: 1000,
+    nativeSamples: new Float32Array(0),
+    nativeSampleRate: 16000,
+  }),
+}));
+
+import { DictationDialog } from "./DictationDialog";
+
+// Drive requestAnimationFrame by hand. jsdom's own RAF is a timer we would have to race; capturing
+// the callback makes each frame an explicit step, so these tests read as "one frame passes" and can
+// never flake on scheduling.
+let frame: FrameRequestCallback | null = null;
+
+beforeEach(() => {
+  clocks.sinceAudio = 0;
+  clocks.sinceMeter = 0;
+  clocks.level = 0.5;
+  frame = null;
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frame = cb;
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {
+    frame = null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+/** Let one animation frame run. */
+async function tick(): Promise<void> {
+  await act(async () => {
+    frame?.(performance.now());
+  });
+}
+
+/** Mount the dialog and get it into RECORDING (the fake recorder fires capture-live on start). */
+async function openRecording(): Promise<void> {
+  render(<DictationDialog onSend={() => {}} onClose={() => {}} surface="cockpit" />);
+  await act(async () => {}); // let the mount effect's start() settle
+  expect(screen.getByText("RECORDING")).toBeTruthy();
+}
+
+const STALLED = /stopped sending audio/i;
+const SILENT = /Nothing is coming from your microphone/i;
+
+describe("DictationDialog live capture alarm", () => {
+  it("says nothing while capture and the meter are both alive", async () => {
+    await openRecording();
+    await tick();
+
+    expect(screen.queryByText(STALLED)).toBeNull();
+    expect(screen.queryByText(SILENT)).toBeNull();
+  });
+
+  it("reports a stalled recording once no audio has been delivered", async () => {
+    await openRecording();
+    clocks.sinceAudio = 4000; // past CAPTURE_STALL_MS
+    await tick();
+
+    // The wording must tell the user their words are NOT being recorded, not merely that something
+    // is odd - this is the moment the audio is actually going missing.
+    expect(screen.getByText(STALLED)).toBeTruthy();
+  });
+
+  it("reports hearing nothing when the meter is pinned at zero but capture is alive", async () => {
+    await openRecording();
+    clocks.sinceMeter = 6000; // past MIC_SILENT_MS
+    clocks.level = 0;
+    await tick();
+
+    expect(screen.getByText(SILENT)).toBeTruthy();
+    expect(screen.queryByText(STALLED)).toBeNull();
+  });
+
+  it("prefers the stalled message when both clocks are past their thresholds", async () => {
+    // A stalled recorder usually goes silent too. Showing the silence message then would bury the one
+    // that says words are being lost under the one that merely follows from it.
+    await openRecording();
+    clocks.sinceAudio = 4000;
+    clocks.sinceMeter = 6000;
+    clocks.level = 0;
+    await tick();
+
+    expect(screen.getByText(STALLED)).toBeTruthy();
+    expect(screen.queryByText(SILENT)).toBeNull();
+  });
+
+  it("clears the alarm as soon as the microphone recovers", async () => {
+    await openRecording();
+    clocks.sinceAudio = 4000;
+    await tick();
+    expect(screen.getByText(STALLED)).toBeTruthy();
+
+    clocks.sinceAudio = 0; // audio is flowing again
+    await tick();
+
+    expect(screen.queryByText(STALLED)).toBeNull();
+  });
+});

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -32,6 +32,11 @@ export interface PendingDictation {
    *  shown with the delivered `done` status (the Send path's equivalent of the dialog's dropped-audio
    *  warning, so a Send that dropped audio is never silent). Absent on a clean capture. */
   captureWarning?: string;
+  /** The capture-health surface tag for this clip ("cockpit-send" / "mobile-send"), stamped when the
+   *  clip was recorded and stored durably so a resume after a reload still files the measurement under
+   *  the shell that actually recorded it. Absent on records written before this field existed - the
+   *  Gateway then falls back to the tag that path has always used. */
+  surface?: string;
   /** Typed text before the caret (Terminal Speak compose); empty for the voice case. */
   before: string;
   /** Typed text after the caret; empty for the voice case. */

--- a/packages/client-core/src/dictation/recorder.test.ts
+++ b/packages/client-core/src/dictation/recorder.test.ts
@@ -240,3 +240,181 @@ describe("MicRecorder.level suspended-context guard", () => {
     expect(mic.level()).toBeGreaterThan(0);
   });
 });
+
+// ===== stop(): the tail is ASKED FOR, not assumed ==================================================
+// The owner's report was "it didn't finish to the end". MediaRecorder is specified to emit its
+// buffered audio before it fires stop, so resolving on onstop was already collecting the tail - but
+// that was a behaviour being trusted rather than an instruction being given, and the last words are
+// precisely what a user notices missing. These pin that stop() now flushes explicitly, that the
+// flushed bytes are in the returned clip, and that a flush which fails can never stop the stop.
+
+class StopFake {
+  state: "recording" | "inactive" | "paused" = "recording";
+  requestDataCalls = 0;
+  stopCalls = 0;
+  onstop: (() => void) | null = null;
+  /** Set by the test to emulate the browser delivering the buffered tail on requestData. */
+  onRequestData: (() => void) | null = null;
+  /** Set by the test to emulate audio the browser only delivers on stop itself. */
+  onStopDeliver: (() => void) | null = null;
+
+  requestData(): void {
+    this.requestDataCalls += 1;
+    this.onRequestData?.();
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+    this.onStopDeliver?.();
+    this.state = "inactive";
+    this.onstop?.();
+  }
+}
+
+function wireStop(fake: StopFake, chunks: Blob[]): MicRecorder {
+  const mic = new MicRecorder();
+  const anyMic = mic as unknown as { recorder: StopFake; mimeType: string; chunks: Blob[]; startedAt: number };
+  anyMic.recorder = fake;
+  anyMic.mimeType = "audio/webm";
+  anyMic.chunks = chunks;
+  anyMic.startedAt = performance.now();
+  return mic;
+}
+
+describe("MicRecorder.stop", () => {
+  it("flushes the buffered tail before stopping and returns it in the clip", async () => {
+    const fake = new StopFake();
+    const chunks: Blob[] = [bytes(3)]; // already delivered while recording
+    const mic = wireStop(fake, chunks);
+    // The production ondataavailable handler pushes the flushed chunk; emulate that.
+    fake.onRequestData = () => chunks.push(bytes(5));
+
+    const clip = await mic.stop();
+    expect(fake.requestDataCalls).toBe(1);
+    expect(fake.stopCalls).toBe(1);
+    expect(clip.size).toBe(8); // 3 delivered + 5 flushed tail - the last words are in
+  });
+
+  it("still includes audio the browser only delivers on stop itself", async () => {
+    // The flush and the spec's own stop-time delivery are additive, never either/or: whatever the
+    // flush did not take, stop still hands over, and both land in the clip in order.
+    const fake = new StopFake();
+    const chunks: Blob[] = [bytes(2)];
+    const mic = wireStop(fake, chunks);
+    fake.onRequestData = () => chunks.push(bytes(4));
+    fake.onStopDeliver = () => chunks.push(bytes(1));
+
+    const clip = await mic.stop();
+    expect(clip.size).toBe(7);
+  });
+
+  it("stops and returns the clip even when the tail flush throws", async () => {
+    // A recorder that went inactive between the state check and the flush must not strand the turn:
+    // everything already delivered is still the user's audio and still ships.
+    const fake = new StopFake();
+    fake.onRequestData = () => {
+      throw new Error("The MediaRecorder is in an invalid state.");
+    };
+    const mic = wireStop(fake, [bytes(6)]);
+
+    const clip = await mic.stop();
+    expect(fake.stopCalls).toBe(1);
+    expect(clip.size).toBe(6);
+  });
+
+  it("does not ask for a flush when the recorder is no longer recording", async () => {
+    const fake = new StopFake();
+    fake.state = "inactive"; // nothing is buffered in an inactive recorder
+    const mic = wireStop(fake, [bytes(9)]);
+
+    const clip = await mic.stop();
+    expect(fake.requestDataCalls).toBe(0);
+    expect(clip.size).toBe(9);
+  });
+});
+
+// ===== the liveness clocks ========================================================================
+// These are what let the dialog say "the microphone has stopped sending audio" WHILE the user is
+// still talking, instead of only measuring the loss after the clip is finished. Capture liveness and
+// meter liveness are tracked separately on purpose: they are two different audio graphs, and exactly
+// one of them dying is the common case (a dead meter over a healthy recording is the Cockpit
+// flat-bars defect; stalled capture over a live meter is audio genuinely going missing).
+
+function wireLive(state: "recording" | "inactive", lastChunkAgeMs: number, meterAgeMs: number): MicRecorder {
+  const mic = new MicRecorder();
+  const now = performance.now();
+  const anyMic = mic as unknown as {
+    recorder: { state: string };
+    lastChunkAt: number;
+    meterMovedAt: number;
+  };
+  anyMic.recorder = { state };
+  anyMic.lastChunkAt = now - lastChunkAgeMs;
+  anyMic.meterMovedAt = now - meterAgeMs;
+  return mic;
+}
+
+describe("MicRecorder liveness clocks", () => {
+  it("read zero when there is no live recorder, so a stopped mic never reads as stalled", () => {
+    const mic = new MicRecorder();
+    expect(mic.msSinceLastAudio()).toBe(0);
+    expect(mic.msSinceMeterMoved()).toBe(0);
+  });
+
+  it("read zero once the recorder has gone inactive", () => {
+    const mic = wireLive("inactive", 10_000, 10_000);
+    expect(mic.msSinceLastAudio()).toBe(0);
+    expect(mic.msSinceMeterMoved()).toBe(0);
+  });
+
+  it("report how long capture has been silent while recording", () => {
+    const mic = wireLive("recording", 3_000, 0);
+    expect(mic.msSinceLastAudio()).toBeGreaterThanOrEqual(3_000);
+    expect(mic.msSinceMeterMoved()).toBeLessThan(1_000);
+  });
+
+  it("report how long the meter has been pinned at zero while recording", () => {
+    const mic = wireLive("recording", 0, 5_000);
+    expect(mic.msSinceMeterMoved()).toBeGreaterThanOrEqual(5_000);
+    expect(mic.msSinceLastAudio()).toBeLessThan(1_000);
+  });
+
+  // A recorder whose analyser fills every sample with `fill`: 128 is the flat centre line a dead or
+  // muted graph reads (loudness exactly 0), anything else is real sound.
+  function wireMeter(fill: number, meterAgeMs: number): MicRecorder {
+    const mic = new MicRecorder();
+    const anyMic = mic as unknown as {
+      audioCtx: { state: string };
+      analyser: { getByteTimeDomainData: (b: Uint8Array) => void };
+      levelData: Uint8Array;
+      recorder: { state: string };
+      meterMovedAt: number;
+    };
+    anyMic.audioCtx = { state: "running" };
+    anyMic.analyser = {
+      getByteTimeDomainData: (buf: Uint8Array) => {
+        for (let i = 0; i < buf.length; i++) buf[i] = fill;
+      },
+    };
+    anyMic.levelData = new Uint8Array(8);
+    anyMic.recorder = { state: "recording" };
+    anyMic.meterMovedAt = performance.now() - meterAgeMs;
+    return mic;
+  }
+
+  it("treat a reading above zero as proof the meter is alive", () => {
+    // level() resets the meter clock only when the analyser actually reads something.
+    const mic = wireMeter(200, 5_000);
+    expect(mic.level()).toBeGreaterThan(0);
+    expect(mic.msSinceMeterMoved()).toBeLessThan(1_000);
+  });
+
+  it("leave the meter clock running when the analyser reads exact silence", () => {
+    // A dead graph reads the flat centre line forever, which is exactly zero. The clock must KEEP
+    // running through that - it is what turns dead bars into a reported fault rather than a drawing
+    // of silence, which is how the Cockpit meter lied for so long.
+    const mic = wireMeter(128, 5_000);
+    expect(mic.level()).toBe(0);
+    expect(mic.msSinceMeterMoved()).toBeGreaterThanOrEqual(5_000);
+  });
+});

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -116,6 +116,20 @@ export class MicRecorder {
   private startedAt = 0;
   private recordedMs = 0;
 
+  // ---- liveness clocks: what the recorder can no longer hear, WHILE it is still recording -------
+  // The post-clip capture-health check (recordedMs vs decoded duration) can only tell the user their
+  // words were lost AFTER they are gone. These two clocks make the same failures visible during the
+  // recording, when the user can still stop and say it again. They are deliberately independent:
+  // capture and the meter are two different audio paths (MediaRecorder vs the AnalyserNode), so
+  // exactly one of them dying is the common case and the pair tells them apart.
+  //
+  // Anchored at start() rather than at zero, so "nothing for N seconds" is measured from the moment the
+  // microphone opened rather than from the epoch (which would read as stalled on the very first frame).
+  // The thresholds themselves belong to the dialog that shows the alarm, not to the recorder.
+  private lastChunkAt = 0;
+  private meterMovedAt = 0;
+  private capturedBytes = 0;
+
   // The microphone's name and stable id, read at start() and deliberately NOT cleared when the
   // stream is released - the quality report is assembled after stop(), by which time the track is
   // gone. The label starts as the raw track label and is UPGRADED in the background by
@@ -157,6 +171,35 @@ export class MicRecorder {
   /** Wall-clock milliseconds the most recently stopped segment was capturing. 0 before the first stop. */
   get lastRecordedMs(): number {
     return this.recordedMs;
+  }
+
+  /** Total bytes of encoded audio delivered by the current segment. Proof that capture is producing
+   *  something, independent of what the level meter says. */
+  get capturedByteCount(): number {
+    return this.capturedBytes;
+  }
+
+  /**
+   * Milliseconds since MediaRecorder last delivered audio. While recording it delivers every
+   * CHUNK_MS, so a large value means capture has STALLED - the audio being spoken right now is not
+   * reaching the clip. Returns 0 when there is no live recorder, so a stopped or not-yet-started
+   * recorder never reads as stalled.
+   */
+  msSinceLastAudio(): number {
+    if (this.recorder === null || this.recorder.state !== "recording") return 0;
+    return performance.now() - this.lastChunkAt;
+  }
+
+  /**
+   * Milliseconds since the level meter last read above zero. A live microphone in a quiet room still
+   * reads above zero (room noise is never digital silence), so a large value means we are hearing
+   * literally nothing: either the meter's audio graph is dead (the defect that made the Cockpit bars
+   * sit flat while capture worked) or the microphone is muted or gone. Both are worth saying out
+   * loud, and neither should be drawn as "he was quiet". Returns 0 when there is no live recorder.
+   */
+  msSinceMeterMoved(): number {
+    if (this.recorder === null || this.recorder.state !== "recording") return 0;
+    return performance.now() - this.meterMovedAt;
   }
 
   /**
@@ -212,9 +255,17 @@ export class MicRecorder {
     // Reset the capture-health wall-clock; it is anchored at the FIRST real audio below, not here, so a
     // segment that never delivers a chunk reports recordedMs = 0 rather than a stale previous value.
     this.startedAt = 0;
+    // Anchor the liveness clocks at the moment the microphone opened, so the first frames of a fresh
+    // segment read as healthy rather than as a stall that never started.
+    this.lastChunkAt = performance.now();
+    this.meterMovedAt = this.lastChunkAt;
+    this.capturedBytes = 0;
     this.recorder.ondataavailable = (e) => {
       if (e.data && e.data.size > 0) {
         this.chunks.push(e.data);
+        // Capture is alive: this is the only honest proof of it, and it is independent of the meter.
+        this.lastChunkAt = performance.now();
+        this.capturedBytes += e.data.size;
         // The first real chunk is the honest "mic is capturing your voice" moment. Fire once.
         if (!this.captureLiveFired) {
           this.captureLiveFired = true;
@@ -303,12 +354,26 @@ export class MicRecorder {
     // While suspended the read below is the flat centre line and the meter honestly shows zero.
     if (this.audioCtx !== null && this.audioCtx.state === "suspended") void this.audioCtx.resume();
     this.analyser.getByteTimeDomainData(this.levelData);
-    return rmsLevel(this.levelData);
+    const level = rmsLevel(this.levelData);
+    // Any reading above zero proves the meter's audio graph is running. A suspended or otherwise dead
+    // context reads the flat centre line forever, which is exactly zero - so this clock, not the bar
+    // heights, is what tells a dead meter from a quiet room.
+    if (level > 0) this.meterMovedAt = performance.now();
+    return level;
   }
 
   /**
    * Stop the current segment and return the captured audio as one Blob. The microphone is
    * released here, so the next segment calls start() again (a fresh Resume segment).
+   *
+   * The buffered tail is ASKED FOR, not assumed. MediaRecorder is specified to emit its remaining
+   * audio as a final dataavailable before it fires stop, so resolving on onstop already collects the
+   * last words - but that is a behaviour we would be trusting rather than an instruction we gave, and
+   * the last words are exactly what the user notices missing ("it didn't finish to the end"). So we
+   * call requestData() first, which flushes what is buffered right now, and only then stop. The
+   * chunks are concatenated in order, so an extra flush chunk costs nothing and can never duplicate
+   * audio (requestData empties the buffer it emits). Both are inside the same promise, so onstop -
+   * which the browser fires after every delivery - still decides when the clip is complete.
    */
   async stop(): Promise<Blob> {
     const rec = this.recorder;
@@ -316,6 +381,15 @@ export class MicRecorder {
     const mime = this.mimeType || "audio/webm";
     const captured = await new Promise<Blob>((resolve) => {
       rec.onstop = () => resolve(new Blob(this.chunks, { type: mime }));
+      if (rec.state === "recording") {
+        try {
+          rec.requestData();
+        } catch (err) {
+          // The recorder went inactive between the state check and here. Nothing is buffered any
+          // more; stop() below still resolves with every chunk that was delivered.
+          console.warn(`[MicRecorder] stop: tail flush failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
       rec.stop();
     });
     // Freeze the segment wall-clock at stop, before releasing the stream, so capture-health can

--- a/src/CcDirector.Gateway.Tests/MobileCaptureHealthLogTests.cs
+++ b/src/CcDirector.Gateway.Tests/MobileCaptureHealthLogTests.cs
@@ -38,6 +38,55 @@ public sealed class MobileCaptureHealthLogTests
         Assert.Null(ex);
     }
 
+    // ---- SurfaceOr: which shell the measurement is filed under -----------------------------------
+    // Every browser dictation used to be logged as "mobile" / "mobile-send" no matter which shell
+    // recorded it, so a Cockpit dictation on a desktop was indistinguishable from a phone dictation
+    // and per-surface audio loss simply could not be read out of the log. These pin that a reported
+    // surface is honoured, that an absent one falls back to the literal the path always wrote (so an
+    // older client and an already-queued clip keep working), and that the value - which arrives from
+    // a browser and is written into a log line - can never forge a log entry.
+
+    [Fact]
+    public void SurfaceOr_UsesTheReportedSurface()
+    {
+        Assert.Equal("cockpit-send", MobileCaptureHealthLog.SurfaceOr("cockpit-send", "mobile-send"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SurfaceOr_FallsBackWhenTheClientReportedNothing(string? reported)
+    {
+        // An older client, or a clip queued on device before the tag existed. It must keep its
+        // historical tag rather than becoming unlabelled, so the existing history stays comparable.
+        Assert.Equal("mobile-send", MobileCaptureHealthLog.SurfaceOr(reported, "mobile-send"));
+    }
+
+    [Fact]
+    public void SurfaceOr_StripsAnythingThatCouldForgeALogEntry()
+    {
+        // Newlines would append a second, fabricated line to the log; spaces would forge a field break.
+        var cleaned = MobileCaptureHealthLog.SurfaceOr("cockpit\n[MobileCaptureHealth] fake 0: recordedMs=0", "mobile");
+
+        Assert.DoesNotContain("\n", cleaned);
+        Assert.DoesNotContain(" ", cleaned);
+        Assert.StartsWith("cockpit", cleaned);
+    }
+
+    [Fact]
+    public void SurfaceOr_BoundsTheLength()
+    {
+        Assert.True(MobileCaptureHealthLog.SurfaceOr(new string('x', 500), "mobile").Length <= 40);
+    }
+
+    [Fact]
+    public void SurfaceOr_FallsBackWhenNothingUsableSurvivesCleaning()
+    {
+        // A value made entirely of rejected characters is not a surface name; it must not become "".
+        Assert.Equal("mobile", MobileCaptureHealthLog.SurfaceOr("!!! @@@ ###", "mobile"));
+    }
+
     [Fact]
     public void Persist_MissingDecodedSeconds_DoesNotThrow()
     {

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -531,7 +531,8 @@ internal static class GatewayDictationEndpoint
             // helper. The assembled audio byte count is what the server actually transcribed. When the client
             // did not send its measurements this is a no-op. Fire-and-forget - never affects the outcome.
             MobileCaptureHealthLog.Persist(
-                uploadId, "mobile-send", req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes,
+                uploadId, MobileCaptureHealthLog.SurfaceOr(req.ClientSurface, "mobile-send"),
+                req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes,
                 audio.Length, transcript);
             // Compose the final message: any typed text the caret split the dictation around (before /
             // after), any earlier paused dictation segments already turned to text (prefix), and this
@@ -699,6 +700,11 @@ public sealed class DictationCompleteRequest
     public double? ClientRecordedMs { get; set; }
     public double? ClientDecodedSeconds { get; set; }
     public long? ClientSourceBytes { get; set; }
+    /// <summary>Which browser shell recorded the clip ("cockpit-send" / "mobile-send"). Every browser
+    /// used to be logged as "mobile-send" here, which is why per-surface audio loss could not be read
+    /// out of the log. Absent from an older client (or a clip queued before this shipped), which falls
+    /// back to the literal this path always wrote.</summary>
+    public string? ClientSurface { get; set; }
 }
 
 /// <summary>Terminal or retryable outcome of a dictation complete, mapped to an HTTP result.</summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -1142,7 +1142,8 @@ internal static class GatewayWingmanVoiceEndpoint
     /// </summary>
     private static void PersistMobileCaptureHealth(string uploadId, UtteranceCompleteRequest req, int wavBytes, string? cleaned)
         => MobileCaptureHealthLog.Persist(
-            uploadId, "mobile", req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes, wavBytes, cleaned);
+            uploadId, MobileCaptureHealthLog.SurfaceOr(req.ClientSurface, "mobile"),
+            req.ClientRecordedMs, req.ClientDecodedSeconds, req.ClientSourceBytes, wavBytes, cleaned);
 
     /// <summary>Shape a <see cref="WingmanMenu"/> for the JSON response (camelCase the phone reads).</summary>
     private static object MenuJson(WingmanMenu m) => new
@@ -1258,4 +1259,10 @@ public sealed class UtteranceCompleteRequest
     public double? ClientRecordedMs { get; set; }
     public double? ClientDecodedSeconds { get; set; }
     public long? ClientSourceBytes { get; set; }
+
+    /// <summary>Which browser shell recorded the clip ("cockpit" / "mobile"). Every browser used to be
+    /// logged as "mobile" here, so a Cockpit dictation on a desktop was filed as a phone dictation and
+    /// the Cockpit's audio loss could not be separated out at all. Absent from an older client, which
+    /// falls back to the literal this path always wrote.</summary>
+    public string? ClientSurface { get; set; }
 }

--- a/src/CcDirector.Gateway/Api/MobileCaptureHealthLog.cs
+++ b/src/CcDirector.Gateway/Api/MobileCaptureHealthLog.cs
@@ -21,13 +21,31 @@ namespace CcDirector.Gateway.Api;
 internal static class MobileCaptureHealthLog
 {
     /// <summary>
+    /// The surface tag to log: the one the client reported, or <paramref name="fallback"/> (this path's
+    /// historical literal) when the client did not report one - an older client, or a clip that was
+    /// queued on device before the tag existed. Never trusts the value raw: it arrives from a browser
+    /// and is written into a log line, so it is trimmed, bounded, and stripped of anything that could
+    /// forge a second log entry or a field separator. A value that survives none of that falls back.
+    /// </summary>
+    public static string SurfaceOr(string? reported, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(reported)) return fallback;
+        var cleaned = new string(reported.Trim()
+            .Where(c => char.IsLetterOrDigit(c) || c == '-' || c == '_')
+            .Take(40).ToArray());
+        return cleaned.Length == 0 ? fallback : cleaned;
+    }
+
+    /// <summary>
     /// Log one capture-health measurement when the client supplied it. A null <paramref name="recordedMs"/>
     /// means the client did not opt in (or its on-device decode failed), so there is nothing to record and
     /// this is a no-op.
     /// </summary>
     /// <param name="uploadId">The upload id, used to correlate the measurement with the turn.</param>
-    /// <param name="source">Surface tag: "mobile" for the Voice-mode path, "mobile-send" for the durable
-    /// Terminal/Chat Send path, so the two surfaces are told apart in the log.</param>
+    /// <param name="source">Surface tag, from <see cref="SurfaceOr"/>: which shell recorded the clip and
+    /// by which path ("cockpit" / "mobile" for the Voice-mode path, "cockpit-send" / "mobile-send" for the
+    /// durable Terminal/Chat Send path). Both the shell and the path must be distinguishable here, because
+    /// a tag that names only the path is what hid the Cockpit's own audio loss inside the phone's numbers.</param>
     /// <param name="recordedMs">Recording wall-clock the client measured; null when the client did not opt in.</param>
     /// <param name="decodedSeconds">Decoded audio duration the client measured; the deficit yardstick.</param>
     /// <param name="sourceBytes">Size of the client's source (compressed) blob, for reference only.</param>


### PR DESCRIPTION
Cockpit dictation lost the end of what was said and drew flat bars while recording. Three defects behind that, plus the reason none of them showed up in the data.

## The tail is asked for, not assumed

`MicRecorder.stop()` now calls `requestData()` before `stop()`, inside the same promise so `onstop` still decides when the clip is complete. The spec already flushes on stop, but that was a behaviour we were trusting rather than an instruction we gave, and the last words are exactly what a user notices missing. The two are additive, never either/or, and `requestData` empties the buffer it emits so nothing can be duplicated. A flush that throws is logged and the stop proceeds.

Every path that ends a segment - Pause, Insert, Send while recording, fire-and-forget Send - goes through this one `stop()`, so all four flush explicitly.

## The recorder can be caught lying

Two independent clocks: time since MediaRecorder last delivered audio (capture is alive) and time since the meter last read above zero (the meter is alive). Separate on purpose - capture and the bars are separate audio graphs, and the normal failure is exactly one of them dying. A dead meter over a healthy recording is the flat-bars defect; a stalled capture under a live meter is audio genuinely going missing.

## The dialog says what it can no longer hear, while the mic is open

- No audio for 3s: the recording has stalled and words are being lost **now**.
- Meter pinned at exact zero for 5s: nothing is coming from the microphone. A live mic in a quiet room never reads exact zero, so this covers both a dead meter and a muted or wrong device.

The alarm clears itself when audio returns - a warning that outlives its cause just teaches the user to ignore it. Stall wins over silence, since a stalled recorder usually goes silent too.

The stall threshold is deliberately not tighter: `dataavailable` arrives on the main thread, so a busy session view can make chunks arrive late without any audio being lost, and crying loss over ordinary jank would burn the alarm's credibility.

## Why this was invisible

Every browser dictation was filed as `"mobile"` - hardcoded in the client **and** at the Gateway (`GatewayWingmanVoiceEndpoint.cs`, `GatewayDictationEndpoint.cs`), so a Cockpit dictation on a desktop was recorded as a phone dictation. Issue #645 reads that same log and concluded the web surfaces were healthy; there was never a Cockpit number in it to disagree.

The dialog now carries a `surface`, passed at all six mount points and threaded through the send pipeline, the durable record (so a clip resumed after a reload is still filed correctly), the API and both Gateway endpoints. Mobile's tags come out byte-identical (`mobile` / `mobile-send`), so the existing history stays comparable; the Cockpit gets `cockpit` / `cockpit-send`. The Gateway sanitises the value before logging it - it arrives from a browser and goes into a log line.

## Verification

- 868 client-core tests, 255 cockpit tests, typecheck clean on all three workspaces, lint unchanged against a stashed baseline.
- Both shells build; the new code is confirmed present in the shipped bundles, not just the source.
- **Revert-proved.** Removing the explicit flush reddens 2 stop tests; resetting the meter clock unconditionally reddens the dead-meter test; removing the alarm reddens 4 of the 5 dialog tests. Restored and re-ran green.
- The two existing fake recorders in the cockpit tests gained the new methods - they were one scheduled animation frame away from throwing, and that failure would have looked like a Send bug.

## Not fixed here

The capture loss itself (#645). This makes it visible and per-surface first, because there is no honest Cockpit number to fix against yet.

## Watch for on live test

If any browser ever emitted the flushed tail *and* re-emitted it on stop, duplicated words would appear. The spec says `requestData` clears the buffer it emits, and Chromium and Gecko both implement it that way.
