### PR TITLE
Gateway deploy: stop a refused connection from taking the live site down, and gate what may ship

### DIFF
--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -16,12 +16,21 @@ version numbers, release notes, tags, or the mailing list.
 
 ## What you must know first
 
+- **This workflow is the ONLY way to update the live Gateway.** Do not pin an
+  image, restart the site, change app settings, or touch the staging slot by hand
+  with `az`, and do not do it in the Azure Portal. Those paths skip the warmed
+  hand-off, the outage measurement and the refusals below, and a hand-driven
+  change is how you get an unmeasured outage on live sessions. If this workflow
+  cannot do what is needed, that is a gap to fix in the workflow, not to work
+  around. The emergency swap-back is also a workflow
+  (`rollback-hosted-gateway.yml`) - use it rather than swapping by hand.
 - **A person authorizes the go-live.** Starting this deploy pushes new code to
   the live service. Get an explicit go from the human before you start it. Do not
   start it on your own initiative.
-- **It deploys whatever commit you start it against.** By default that is the
-  current tip of `main`. There is no separate "staging" - main goes straight to
-  the live service when someone runs this.
+- **It will only ship green main.** The run refuses, in seconds and before it
+  touches anything, if it was started against any ref other than `refs/heads/main`,
+  or if the commit being shipped has a check that failed or has not finished. If it
+  refuses for a pending check, wait for continuous integration and start it again.
 - **It does not set up any infrastructure.** The Azure resource group, container
   registry, database connection, and storage are already provisioned and persist
   across deploys. This deploy only: rebuild the image, point the live service at
@@ -68,23 +77,21 @@ curl -s -m 20 -o /dev/null -w "HTTP %{http_code}\n" https://devthrottle-gw.azure
 
 A `200` means the live Gateway is up.
 
-**Expected gotcha - a brief blip right after restart.** For a minute or two after
-the restart, this check can return `502` or no response (`000`) while the fresh
-container boots and runs its database migrations. This is normal cold-start
-behavior, NOT a failed deploy. Do not panic and do not report failure. Poll every
-15 seconds until it returns `200`:
+**A blip here is NOT normal, and must not be waved through.** This used to say a
+minute or two of `502`/`000` was expected cold-start behaviour and told you not to
+report it. That was wrong, and it trained people to accept the exact failure that
+took the live service down for 38.5 seconds on 2 August 2026 (issue #2383).
 
-```
-for i in $(seq 1 12); do
-  code=$(curl -s -m 20 -o /dev/null -w "%{http_code}" https://devthrottle-gw.azurewebsites.net/healthz)
-  echo "attempt $i: HTTP $code"
-  [ "$code" = "200" ] && { echo RECOVERED; break; }
-  sleep 15
-done
-```
+The deploy is a **warmed slot swap**: the old instance keeps serving until the new
+one is proven healthy, so a healthy deploy has **no user-visible gap at all**.
+Three consecutive deploys measured `Longest unavailable stretch: 0.0s` over a
+ten-minute watch. There is no cold start on the user path, because the user is
+never moved onto a cold instance.
 
-If it is still not `200` after a few minutes, then it is a real problem - see
-Troubleshooting.
+So if `/healthz` does not answer `200` immediately after the run goes green,
+something went wrong with the hand-off. Say so; do not wait it out. The run itself
+now fails if the external outage exceeds five seconds, so a green run already
+means production stayed up.
 
 ### 5. Report plainly
 

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -41,6 +41,7 @@ on:
 permissions:
   id-token: write   # required for the Azure OIDC login
   contents: read
+  checks: read      # required to read the shipping commit's check runs (the green-only gate)
 
 env:
   AZURE_RG: rg-devthrottle-hosted-gateway
@@ -134,6 +135,75 @@ jobs:
       - name: Short SHA
         id: short
         run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      # ---- THE TWO GATES ON WHAT MAY REACH PRODUCTION ------------------------------------------
+      # This workflow is the ONLY supported way to update the live Gateway, so the conditions on what
+      # it will ship are the conditions on what can reach production at all. Both refusals are here,
+      # BEFORE the Azure login and the build, so a refused deploy costs seconds and touches nothing.
+      #
+      # 1. MAIN ONLY. workflow_dispatch will happily run against any branch or tag the caller picks,
+      #    which meant an unreviewed branch could be built and swapped into production without ever
+      #    having been merged. Production ships what is on main, or it does not ship.
+      - name: Refuse to deploy anything but main
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "REFUSED: this run was started against '$GITHUB_REF'."
+            echo "The live Gateway ships main and only main. Merge the change first, then deploy main."
+            exit 1
+          fi
+          echo "Ref check passed: deploying refs/heads/main at ${{ steps.short.outputs.short }}."
+
+      # 2. GREEN ONLY. Nothing previously checked that the commit being shipped had passing tests -
+      #    a red commit on main was as deployable as a green one. Ask GitHub for this exact commit's
+      #    check runs and refuse unless every completed one succeeded. A commit whose checks have not
+      #    finished is also refused: "not yet known to be good" is not "good", and the deploy can be
+      #    re-run in a few minutes. Queued or in-progress runs are reported so the refusal is
+      #    actionable rather than mysterious.
+      - name: Refuse to deploy a commit whose checks are not green
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+
+          # THIS run's own jobs are check runs on the same commit and are necessarily still in progress,
+          # so they must be excluded or the gate refuses itself. Exclude by RUN ID rather than by job
+          # name: the name is a human string that will be edited one day, and the failure mode of an
+          # out-of-date name here is a deploy that can never start.
+          all=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs" --paginate \
+                  --jq '.check_runs[] | [.name, .status, (.conclusion // ""), (.details_url // "")] | @tsv')
+
+          others=$(printf '%s\n' "$all" \
+                   | grep -v "/actions/runs/${GITHUB_RUN_ID}/" || true)
+
+          if [ -z "$others" ]; then
+            echo "REFUSED: commit ${sha} has no check runs of its own."
+            echo "Continuous integration must have run on this commit before it can ship."
+            exit 1
+          fi
+
+          echo "Checks on ${sha}:"
+          printf '%s\n' "$others" | awk -F'\t' '{ printf "  %s: %s %s\n", $1, $2, $3 }'
+
+          # neutral and skipped are passes: a check that deliberately did not apply to this commit has
+          # not failed it. Anything else completed and not successful is a refusal.
+          failed=$(printf '%s\n' "$others" \
+                   | awk -F'\t' '$2 == "completed" && $3 != "success" && $3 != "neutral" && $3 != "skipped" { print "  "$1" ("$3")" }')
+          pending=$(printf '%s\n' "$others" \
+                    | awk -F'\t' '$2 != "completed" { print "  "$1" ("$2")" }')
+
+          if [ -n "$failed" ]; then
+            echo "REFUSED: these checks did not pass on the commit being shipped:"
+            printf '%s\n' "$failed"
+            exit 1
+          fi
+          if [ -n "$pending" ]; then
+            echo "REFUSED: these checks have not finished on the commit being shipped:"
+            printf '%s\n' "$pending"
+            echo "Wait for continuous integration to finish, then start the deploy again."
+            exit 1
+          fi
+          echo "Check gate passed: every check on ${sha} is green."
 
       - name: Azure login (OIDC, no stored secret)
         uses: azure/login@v2
@@ -486,16 +556,33 @@ jobs:
       # and puts the SITE into Stopped. Two of the three were caught only because someone happened to be
       # polling by hand.
       #
-      # Two things are watched, because /healthz alone is not enough. Through the whole failing window the
-      # front door was still being served by the warmed instance, so an external poll looked perfect while
-      # the site was being driven to Stopped underneath it. The SITE STATE is the earlier and truer signal.
+      # Two things are watched, because neither alone is enough.
+      #
+      # CORRECTION (issue #2383). This comment used to claim the site state was "the earlier and truer
+      # signal". It is not, and trusting it would have hidden the worst outage we have had. On 2 August
+      # the platform genuinely stopped the site for 21 seconds - 12:57:49 to 12:58:10, spanning a sample
+      # at 12:57:50 - and EVERY site-state sample still read `Running`. The reason is that
+      # `az webapp show --query state` reports the DESIRED state in Azure Resource Manager (has anyone
+      # deliberately stopped this site), not whether a container is up. It cannot see a
+      # platform-initiated stop, which is the failure that actually takes production down.
+      #
+      # The EXTERNAL POLL is the signal that caught it, and it is the one the budget is judged on. The
+      # site-state sample stays because it is the only thing that catches a deliberate stop, and it costs
+      # nothing - but it is the weaker of the two and must not be read as a clean bill of health.
       # `az webapp show` READS; nothing in this step writes.
       - name: Watch production past the swap and measure the true outage
         id: outage
         if: needs.deploy.outputs.readiness_outcome == 'healthy'
         env:
           WATCH_SECONDS: '600'
-          MAX_ACCEPTABLE_OUTAGE_SECONDS: '30'
+          # FIVE, not thirty (issue #2383). A healthy deploy costs about ZERO - runs 30702895726,
+          # 30698993031 and 30679971846 each measured "Longest unavailable stretch: 0.0s" across the
+          # full watch - because the warmed hand-off is what the extra App Service tier was bought for.
+          # So this is not a cost curve to leave slack in: either the hand-off happened and the number
+          # is a rounding error, or it did not and the number is tens of seconds. Thirty sat squarely
+          # in the gap and would have passed a twenty-nine-second outage as a green deploy. Anything
+          # above a couple of seconds means the hand-off did not happen and is worth failing over.
+          MAX_ACCEPTABLE_OUTAGE_SECONDS: '5'
         run: |
           STATE_LOG=/tmp/site-state.log; : > "$STATE_LOG"
           echo "Watching for ${WATCH_SECONDS}s past the swap (the failure window is 2-4 minutes out)..."

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -348,13 +348,21 @@ jobs:
           # 8 seconds after the swap always measured 0.0s and always missed it.
           # It is stopped at the end of this job and its log handed to the `watch` job as an artifact, which
           # resumes polling and joins the two records. See "Hand the production poll record to the watch job".
+          # SAMPLE FAST (issue #2383). The bar this deploy is judged against is a ONE-SECOND outage, and
+          # an instrument that samples once a second cannot resolve it: a gap shorter than the interval
+          # falls entirely between two samples and reads as a clean 0.0s. That is a null result being
+          # mistaken for proof, and it is the difference between "we measured no outage" and "we could
+          # not have seen one". The cadence is the sleep PLUS the request round trip plus the process
+          # spawns below, so it is not 0.1s in practice - which is exactly why the analysis step measures
+          # the ACHIEVED interval from these timestamps and prints it beside the verdict. A run that could
+          # not resolve the bar says so itself rather than presenting a confident zero.
           ( while :; do
               t=$(date +%s.%N)
-              body=$(curl -s -m 5 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
+              body=$(curl -s -m 2 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
               code=$(printf '%s' "$body" | tail -n1)
               commit=$(printf '%s' "$body" | sed '$d' | jq -r '.commit // empty' 2>/dev/null || echo "")
               echo "$t $code ${commit:-none}" >> "$LOG"
-              sleep 1
+              sleep 0.1
             done ) & POLL=$!
           echo "$POLL" > /tmp/swap-poll.pid
 
@@ -519,13 +527,21 @@ jobs:
         if: needs.deploy.outputs.readiness_outcome == 'healthy'
         run: |
           LOG=/tmp/watch-poll.log; : > "$LOG"
+          # SAMPLE FAST (issue #2383). The bar this deploy is judged against is a ONE-SECOND outage, and
+          # an instrument that samples once a second cannot resolve it: a gap shorter than the interval
+          # falls entirely between two samples and reads as a clean 0.0s. That is a null result being
+          # mistaken for proof, and it is the difference between "we measured no outage" and "we could
+          # not have seen one". The cadence is the sleep PLUS the request round trip plus the process
+          # spawns below, so it is not 0.1s in practice - which is exactly why the analysis step measures
+          # the ACHIEVED interval from these timestamps and prints it beside the verdict. A run that could
+          # not resolve the bar says so itself rather than presenting a confident zero.
           ( while :; do
               t=$(date +%s.%N)
-              body=$(curl -s -m 5 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
+              body=$(curl -s -m 2 -w '\n%{http_code}' "${GATEWAY_URL}/healthz" 2>/dev/null || printf '\n000')
               code=$(printf '%s' "$body" | tail -n1)
               commit=$(printf '%s' "$body" | sed '$d' | jq -r '.commit // empty' 2>/dev/null || echo "")
               echo "$t $code ${commit:-none}" >> "$LOG"
-              sleep 1
+              sleep 0.1
             done ) & echo "$!" > /tmp/watch-poll.pid
           echo "Watch-side poller started at $(date -u +%H:%M:%S)."
 
@@ -705,6 +721,41 @@ jobs:
 
           echo "--- site state samples ---"; cat "$STATE_LOG"
           echo "Longest unavailable stretch: ${longest}s   Total unavailable: ${total}s"
+
+          # THE INSTRUMENT'S OWN RESOLUTION, reported beside the verdict (issue #2383). A measured outage
+          # of 0.0s is a NULL result, and a null is only ever as strong as the instrument behind it: if the
+          # samples were 1.2s apart, "no gap" cannot rule out a one-second outage - which is precisely the
+          # bar this deploy is held to. So every run states the sampling interval it actually achieved, and
+          # a run too coarse to resolve the bar says so instead of presenting a confident zero.
+          #
+          # No heredoc here on purpose: a heredoc terminator has to sit at column 0, which would end this
+          # YAML block scalar early and break the whole workflow file.
+          gaps=$(awk '{ if (p != "") printf "%.4f\n", $1 - p; p = $1 }' "$LOG" | sort -n)
+          if [ -z "$gaps" ]; then
+            # Fewer than two samples means there is no interval at all. That is not a fine resolution, it
+            # is NO measurement, and it must never read as the healthy case - which is precisely the
+            # confusion this reporting exists to prevent.
+            echo "Sampling: $(wc -l < "$LOG" 2>/dev/null || echo 0) sample(s) - too few to measure an interval."
+            echo "NOTE: the availability record is UNUSABLE for judging the one-second bar. Fewer than two"
+            echo "      samples means no gap could have been observed at all."
+            echo "sample_median_interval=unmeasured" >> "$GITHUB_OUTPUT"
+            echo "sample_max_interval=unmeasured" >> "$GITHUB_OUTPUT"
+          else
+            samples=$(printf '%s\n' "$gaps" | wc -l); samples=$((samples + 1))
+            med_gap=$(printf '%s\n' "$gaps" | awk '{ a[NR] = $1 } END { printf "%.3f", a[int((NR + 1) / 2)] }')
+            max_gap=$(printf '%s\n' "$gaps" | awk 'END { printf "%.3f", $1 }')
+            echo "Sampling: ${samples} samples, median interval ${med_gap}s, worst interval ${max_gap}s"
+            echo "sample_median_interval=${med_gap}" >> "$GITHUB_OUTPUT"
+            echo "sample_max_interval=${max_gap}" >> "$GITHUB_OUTPUT"
+            if awk -v m="$max_gap" 'BEGIN { exit !(m > 1.0) }'; then
+              echo "NOTE: the worst gap between samples was ${max_gap}s, which is COARSER than the one-second"
+              echo "      bar. A 0.0s reading from this run does not rule out an outage shorter than that."
+              echo "      The join between the deploy and watch jobs is the usual reason - it is a real hole"
+              echo "      in the record, roughly ten to thirty seconds wide, and it is declared not hidden."
+            else
+              echo "Resolution is finer than the one-second bar, so a 0.0s reading is meaningful at that bar."
+            fi
+          fi
           echo "true_outage_seconds=$longest" >> "$GITHUB_OUTPUT"
           echo "total_unavailable_seconds=$total" >> "$GITHUB_OUTPUT"
           echo "site_state_left_running=${bad_state:-no}" >> "$GITHUB_OUTPUT"

--- a/src/CcDirector.Gateway.Tests/GatewayDatabaseOpenResilienceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayDatabaseOpenResilienceTests.cs
@@ -1,0 +1,97 @@
+using CcDirector.Gateway.Data;
+using Npgsql;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The two pure helpers behind the deploy-outage fix (issue #2383).
+///
+/// On 2 August 2026 a deploy stopped the live site for 38.5 seconds: the container App Service starts
+/// after a swap got one refused PostgreSQL connection, treated it as terminal, never bound its port, and
+/// the platform stopped the site - killing the healthy container that was serving. The root cause is
+/// still unknown because the only thing recorded was the word "PostgresException".
+///
+/// These pin the two properties that make that not happen again and make the next one readable:
+///   - the connection pool is bounded, so a swap's four containers cannot exhaust the server, and an
+///     operator who set a size on purpose still wins;
+///   - a failure describes what the SERVER said, without ever putting the connection string in a log.
+/// The retry itself is exercised by its bounded window rather than by a unit test - it needs a refusing
+/// server, and standing one up to prove a sleep loop would test the harness, not the fix.
+/// </summary>
+public sealed class GatewayDatabaseOpenResilienceTests
+{
+    private const string BareConnection = "Host=db.example.com;Database=postgres;Username=u;Password=p";
+
+    [Fact]
+    public void WithBoundedPool_CapsAConnectionStringThatSaysNothingAboutPooling()
+    {
+        // Npgsql's default is 100 per pool, and a Gateway container runs two pools. Unbounded, a swap's
+        // four containers ask for far more than the sixty the server allows.
+        var bounded = new NpgsqlConnectionStringBuilder(
+            GatewayDatabase.WithBoundedPool(BareConnection, GatewayDatabase.DefaultMaxPoolSize));
+
+        Assert.Equal(GatewayDatabase.DefaultMaxPoolSize, bounded.MaxPoolSize);
+    }
+
+    [Fact]
+    public void WithBoundedPool_KeepsEverythingElseAboutTheConnection()
+    {
+        // Capping the pool must not quietly rewrite where we connect or as whom.
+        var bounded = new NpgsqlConnectionStringBuilder(
+            GatewayDatabase.WithBoundedPool(BareConnection, GatewayDatabase.DefaultMaxPoolSize));
+
+        Assert.Equal("db.example.com", bounded.Host);
+        Assert.Equal("postgres", bounded.Database);
+        Assert.Equal("u", bounded.Username);
+        Assert.Equal("p", bounded.Password);
+    }
+
+    [Theory]
+    [InlineData("Maximum Pool Size=42")]
+    [InlineData("MaxPoolSize=42")]
+    public void WithBoundedPool_LeavesAnOperatorsOwnPoolSizeAlone(string poolClause)
+    {
+        // This is a ceiling for the unconfigured case, not an override. Someone who sized the pool
+        // deliberately - in either accepted spelling - keeps their number.
+        var stated = $"{BareConnection};{poolClause}";
+
+        var result = new NpgsqlConnectionStringBuilder(
+            GatewayDatabase.WithBoundedPool(stated, GatewayDatabase.DefaultMaxPoolSize));
+
+        Assert.Equal(42, result.MaxPoolSize);
+    }
+
+    [Fact]
+    public void DescribeFailure_ReportsWhatTheServerActuallySaid()
+    {
+        // The whole root cause of the 2 August outage is unknowable because only the type name was
+        // logged. SqlState and MessageText are PostgreSQL's own code and text for the error.
+        var ex = new PostgresException(
+            messageText: "remaining connection slots are reserved",
+            severity: "FATAL",
+            invariantSeverity: "FATAL",
+            sqlState: "53300");
+
+        var described = GatewayDatabase.DescribeFailure(ex);
+
+        Assert.Contains("53300", described);
+        Assert.Contains("remaining connection slots are reserved", described);
+    }
+
+    [Fact]
+    public void DescribeFailure_NeverPutsTheConnectionStringInTheLog()
+    {
+        // The reason only the type name was ever logged: a malformed connection string is echoed back by
+        // the parser, so stringifying the exception can leak credentials. That constraint still holds -
+        // the fix widened what is logged for a SERVER error only, and this is the guard on that line.
+        var leaky = new System.ArgumentException(
+            $"Format of the initialization string does not conform: {BareConnection}");
+
+        var described = GatewayDatabase.DescribeFailure(leaky);
+
+        Assert.DoesNotContain("Password", described);
+        Assert.DoesNotContain("db.example.com", described);
+        Assert.Equal(nameof(System.ArgumentException), described);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
@@ -61,25 +61,26 @@ public sealed class GatewayStartFailureTerminationTests
     [Fact]
     public void ExecuteAsync_ConsultsThePolicyAndEndsTheProcess()
     {
+        // SCOPED TO THE ExecuteAsync STATE MACHINE, not the whole type. The type also contains
+        // Environment.Exit(0) from the constructor's ShutdownRequested handler, so a type-wide check stayed
+        // GREEN when the failure-path exit was deleted - it was decoration, and mutation testing caught it.
+        // The async body compiles into a nested <ExecuteAsync>d__N; the constructor's lambda does not.
         var module = ModuleDefinition.ReadModule(typeof(GatewayWorker).Assembly.Location);
         var worker = module.GetType(typeof(GatewayWorker).FullName);
         Assert.NotNull(worker);
 
-        // The async body is compiled into a nested state machine; scan the worker type and its nested types.
+        var stateMachine = worker!.NestedTypes.FirstOrDefault(n => n.Name.Contains("ExecuteAsync"));
+        Assert.NotNull(stateMachine);
+
         var calls = new List<string>();
-        foreach (var type in new[] { worker }.Concat(worker!.NestedTypes))
+        foreach (var method in stateMachine!.Methods)
         {
-            foreach (var method in type.Methods)
+            if (!method.HasBody) continue;
+            foreach (var instruction in method.Body.Instructions)
             {
-                if (!method.HasBody) continue;
-                foreach (var instruction in method.Body.Instructions)
-                {
-                    if (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt)
-                    {
-                        if (instruction.Operand is MethodReference called)
-                            calls.Add($"{called.DeclaringType.FullName}::{called.Name}");
-                    }
-                }
+                if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt)
+                    && instruction.Operand is MethodReference called)
+                    calls.Add($"{called.DeclaringType.FullName}::{called.Name}");
             }
         }
 

--- a/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
@@ -1,0 +1,186 @@
+using System.Reflection;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Data;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The 2 August outage fix (issue #2383), guarded at the two places it actually lives.
+///
+/// WHAT WENT WRONG. GatewayService.StartAsync catches every startup exception, logs it, and does NOT
+/// rethrow. GatewayWorker then awaited Task.Delay(Timeout.Infinite). So a Gateway that could not open its
+/// database stayed ALIVE with nothing listening; the platform waited out its 230-second container start
+/// limit, found no port, and STOPPED THE SITE - killing the healthy container serving beside it. The fix is
+/// not a retry. It is that the PROCESS must end, because a container that exits gets restarted and a
+/// container that is alive and silent gets waited out.
+///
+/// WHY THESE TESTS AND NOT THE PREVIOUS ONES. The first version of this file tested pure helpers only. The
+/// reviewer reverted the real call sites - the two UseNpgsql lines and the DescribeFailure call - and every
+/// test stayed green. Those tests were decoration. Each test below was checked by mutating the exact
+/// production LINE it claims to guard, confirming by diff that the mutation was really in the file, and
+/// requiring a RED before the mutation was reverted.
+/// </summary>
+public sealed class GatewayStartFailureTerminationTests
+{
+    // ---- the termination policy ------------------------------------------------------------------
+    // Guards: GatewayWorker.MustTerminate. Mutating it to `=> false` reddens FailedMustEndTheProcess.
+
+    [Fact]
+    public void AFailedStart_MustEndTheProcess()
+    {
+        Assert.True(GatewayWorker.MustTerminate(GatewayServiceState.Failed));
+    }
+
+    [Theory]
+    [InlineData(GatewayServiceState.Running)]
+    [InlineData(GatewayServiceState.Starting)]
+    [InlineData(GatewayServiceState.Stopped)]
+    public void AnyOtherState_MustNotEndTheProcess(GatewayServiceState state)
+    {
+        // A Gateway that started must never be killed by this rule, and a deliberate stop is not a failure.
+        Assert.False(GatewayWorker.MustTerminate(state));
+    }
+
+    [Fact]
+    public void TheFailureExitCode_IsNonZero()
+    {
+        // The platform decides what to do from the exit code; zero reads as a clean, intended shutdown,
+        // which is exactly the wrong signal for a Gateway that could not start.
+        Assert.NotEqual(0, GatewayWorker.StartFailureExitCode);
+    }
+
+    // ---- the termination WIRING ------------------------------------------------------------------
+    // The policy above is worthless if nothing calls it, and that call sits inside an async state machine
+    // that cannot be invoked from a test without ending the test run. So the wiring is read out of the
+    // compiled IL: ExecuteAsync's state machine must call BOTH MustTerminate and Environment.Exit.
+    // Deleting either from GatewayWorker reddens this.
+
+    [Fact]
+    public void ExecuteAsync_ConsultsThePolicyAndEndsTheProcess()
+    {
+        var module = ModuleDefinition.ReadModule(typeof(GatewayWorker).Assembly.Location);
+        var worker = module.GetType(typeof(GatewayWorker).FullName);
+        Assert.NotNull(worker);
+
+        // The async body is compiled into a nested state machine; scan the worker type and its nested types.
+        var calls = new List<string>();
+        foreach (var type in new[] { worker }.Concat(worker!.NestedTypes))
+        {
+            foreach (var method in type.Methods)
+            {
+                if (!method.HasBody) continue;
+                foreach (var instruction in method.Body.Instructions)
+                {
+                    if (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt)
+                    {
+                        if (instruction.Operand is MethodReference called)
+                            calls.Add($"{called.DeclaringType.FullName}::{called.Name}");
+                    }
+                }
+            }
+        }
+
+        Assert.Contains(calls, c => c.EndsWith("GatewayWorker::MustTerminate"));
+        Assert.Contains(calls, c => c == "System.Environment::Exit");
+    }
+
+    // ---- wiring guards for the sites the previous tests left unguarded ---------------------------
+    // The reviewer reverted the two UseNpgsql lines and the DescribeFailure call and every test stayed
+    // green. These close the DELETION case at both sites by reading the compiled IL.
+    //
+    // WHAT THESE DO NOT CATCH, stated plainly rather than implied: they prove the bounding helper and the
+    // redacting describer are CALLED on those paths. They cannot prove which value reaches UseNpgsql, so a
+    // mutation that keeps the call and passes the raw connection string instead of the bounded one stays
+    // green. That is a dataflow property, and proving it needs an integration test against a real server
+    // (PostgresProviderProofTests is where such a proof belongs) rather than a metadata scan. Claiming
+    // otherwise is what made the first version of this file decoration.
+
+    private static List<string> CallsIn(Type type, string? methodName = null)
+    {
+        var module = ModuleDefinition.ReadModule(type.Assembly.Location);
+        var target = module.GetType(type.FullName);
+        Assert.NotNull(target);
+        var calls = new List<string>();
+        foreach (var t in new[] { target! }.Concat(target!.NestedTypes))
+        {
+            foreach (var m in t.Methods)
+            {
+                if (!m.HasBody) continue;
+                if (methodName is not null && !m.Name.Contains(methodName) && !t.Name.Contains(methodName)) continue;
+                foreach (var i in m.Body.Instructions)
+                {
+                    if ((i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+                        && i.Operand is MethodReference r)
+                        calls.Add($"{r.DeclaringType.Name}::{r.Name}");
+                }
+            }
+        }
+        return calls;
+    }
+
+    [Fact]
+    public void TheGatewayStore_BoundsItsPoolAndRedactsItsFailures()
+    {
+        var calls = CallsIn(typeof(GatewayDatabase));
+        Assert.Contains(calls, c => c == "GatewayDatabase::WithBoundedPool");
+        Assert.Contains(calls, c => c == "GatewayDatabase::DescribeFailure");
+    }
+
+    [Fact]
+    public void TheStatisticsStore_BoundsItsPoolToo()
+    {
+        // The second Npgsql pool in every container - the one that roughly doubled the connection demand
+        // and turned a slow post-swap boot into a refused one.
+        var statsStore = typeof(GatewayDatabase).Assembly.GetType("CcDirector.Gateway.Stats.Data.GatewayStatsStore");
+        Assert.NotNull(statsStore);
+        Assert.Contains(CallsIn(statsStore!), c => c == "GatewayDatabase::WithBoundedPool");
+    }
+
+}
+
+/// <summary>
+/// The redaction boundary around the connection-string parse, in its own class because it SETS the
+/// process-wide <c>CC_GATEWAY_DB_CONNECTION</c>. It joins the collection that exists for exactly that
+/// hazard: a concurrent test constructing a GatewayDatabase would otherwise read this test's value
+/// mid-flight and select the wrong provider. The value is also saved and restored in a finally, as that
+/// collection's own tests do.
+/// </summary>
+[Collection("GatewayDatabase provider env var")]
+public sealed class GatewayConnectionStringRedactionTests
+{
+    // ---- the redaction boundary around the connection-string parse -------------------------------
+    // Guards the REAL production line: GatewayDatabase's constructor calling WithBoundedPool inside a
+    // redacting try/catch. Removing that try/catch reddens this, because Npgsql's own message carries the
+    // offending keyword and would reach the caller - and GatewayService.StartAsync writes ex.Message
+    // straight to disk.
+    //
+    // The secret is placed in KEYWORD position because that is the position Npgsql echoes. Measured:
+    // "SUPERSECRET=x" throws "Couldn't set supersecret (Parameter 'supersecret')". The value position does
+    // not echo, so a test using it would pass whether or not the boundary existed.
+
+    [Fact]
+    public void AnUnparseableConnectionString_NeverPutsItsTextInTheError()
+    {
+        const string secret = "hunter2secretfragment";
+        var previous = Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, $"{secret}=x");
+
+            var ex = Assert.ThrowsAny<Exception>(
+                () => new GatewayDatabase(new CcDirector.Core.Tenancy.SingleTenantContext()));
+
+            // Case-INSENSITIVE: Npgsql lowercases the keyword it echoes, so a case-sensitive check would
+            // pass while the secret sat in the log. That is how this leak was nearly missed.
+            Assert.DoesNotContain(secret, ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(secret, ex.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, previous);
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
@@ -92,52 +92,61 @@ public sealed class GatewayStartFailureTerminationTests
     // The reviewer reverted the two UseNpgsql lines and the DescribeFailure call and every test stayed
     // green. These close the DELETION case at both sites by reading the compiled IL.
     //
-    // WHAT THESE DO NOT CATCH, stated plainly rather than implied: they prove the bounding helper and the
-    // redacting describer are CALLED on those paths. They cannot prove which value reaches UseNpgsql, so a
-    // mutation that keeps the call and passes the raw connection string instead of the bounded one stays
-    // green. That is a dataflow property, and proving it needs an integration test against a real server
-    // (PostgresProviderProofTests is where such a proof belongs) rather than a metadata scan. Claiming
-    // otherwise is what made the first version of this file decoration.
+    // WHAT AN IL GUARD CANNOT DO, stated in full rather than as the one limitation that came to mind first.
+    // An earlier version of this note said only that dataflow is unprovable; that was narrower than the
+    // truth and would have read as considered while leaving three other holes unmentioned:
+    //
+    //  1. PRESENCE IS NOT REACHABILITY. It proves the call instruction exists in the compiled method. It
+    //     proves nothing about whether execution ever gets there - a call behind a condition that is never
+    //     true is still in the IL. This is the same defect as the swallowed exception one level up, which
+    //     is why the termination path also has an end-to-end test above that drives the real sequence and
+    //     asserts the resulting state. Where a guard below has no such end-to-end partner, it is proving
+    //     the weaker property, and that is a real gap rather than a technicality.
+    //  2. PRESENCE IS NOT DATAFLOW. It cannot prove WHICH value reaches UseNpgsql, so a mutation that keeps
+    //     the call and passes the raw connection string stays green. Proving that needs an integration test
+    //     against a real server, where PostgresProviderProofTests lives.
+    //  3. PRESENCE IS NOT ORDER. Nothing here proves the bounding happens BEFORE the provider is built.
+    //
+    // Hole (4) - a call sitting in some unrelated method of the same type - is closed below by scoping each
+    // scan to the ONE method that must make the call, rather than to the whole type. That hole was not
+    // hypothetical: the first version of the termination guard scanned the whole GatewayWorker type and was
+    // satisfied by the constructor's Environment.Exit(0), so deleting the failure-path exit left it green.
 
-    private static List<string> CallsIn(Type type, string? methodName = null)
+    private static List<string> CallsInMethod(Type type, string methodName)
     {
         var module = ModuleDefinition.ReadModule(type.Assembly.Location);
         var target = module.GetType(type.FullName);
         Assert.NotNull(target);
+
+        var methods = target!.Methods.Where(m => m.Name == methodName && m.HasBody).ToList();
+        Assert.True(methods.Count > 0, $"no method body named '{methodName}' on {type.FullName}");
+
         var calls = new List<string>();
-        foreach (var t in new[] { target! }.Concat(target!.NestedTypes))
-        {
-            foreach (var m in t.Methods)
-            {
-                if (!m.HasBody) continue;
-                if (methodName is not null && !m.Name.Contains(methodName) && !t.Name.Contains(methodName)) continue;
-                foreach (var i in m.Body.Instructions)
-                {
-                    if ((i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
-                        && i.Operand is MethodReference r)
-                        calls.Add($"{r.DeclaringType.Name}::{r.Name}");
-                }
-            }
-        }
+        foreach (var m in methods)
+            foreach (var i in m.Body.Instructions)
+                if ((i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt) && i.Operand is MethodReference r)
+                    calls.Add($"{r.DeclaringType.Name}::{r.Name}");
         return calls;
     }
 
     [Fact]
-    public void TheGatewayStore_BoundsItsPoolAndRedactsItsFailures()
+    public void TheGatewayStoreConstructor_BoundsItsPoolAndRedactsItsFailures()
     {
-        var calls = CallsIn(typeof(GatewayDatabase));
+        // Scoped to the CONSTRUCTOR, which is where both calls belong. Moving either into a helper that
+        // nothing calls would keep a type-wide scan green.
+        var calls = CallsInMethod(typeof(GatewayDatabase), ".ctor");
         Assert.Contains(calls, c => c == "GatewayDatabase::WithBoundedPool");
         Assert.Contains(calls, c => c == "GatewayDatabase::DescribeFailure");
     }
 
     [Fact]
-    public void TheStatisticsStore_BoundsItsPoolToo()
+    public void TheStatisticsStoreProvider_BoundsItsPoolToo()
     {
         // The second Npgsql pool in every container - the one that roughly doubled the connection demand
-        // and turned a slow post-swap boot into a refused one.
+        // and turned a slow post-swap boot into a refused one. Scoped to BuildProvider for the same reason.
         var statsStore = typeof(GatewayDatabase).Assembly.GetType("CcDirector.Gateway.Stats.Data.GatewayStatsStore");
         Assert.NotNull(statsStore);
-        Assert.Contains(CallsIn(statsStore!), c => c == "GatewayDatabase::WithBoundedPool");
+        Assert.Contains(CallsInMethod(statsStore!, "BuildProvider"), c => c == "GatewayDatabase::WithBoundedPool");
     }
 
 }
@@ -161,6 +170,51 @@ public sealed class GatewayConnectionStringRedactionTests
     // The secret is placed in KEYWORD position because that is the position Npgsql echoes. Measured:
     // "SUPERSECRET=x" throws "Couldn't set supersecret (Parameter 'supersecret')". The value position does
     // not echo, so a test using it would pass whether or not the boundary existed.
+
+    /// <summary>
+    /// THE END-TO-END LINK, and the one an IL guard cannot give. An IL guard proves the exit call exists in
+    /// the assembly; it proves nothing about whether anything ever REACHES it - which is the same defect as
+    /// the swallowed exception, one level up. So this drives the real path: a Gateway whose database cannot
+    /// be opened must leave <see cref="GatewayService.StartAsync"/> in the state the termination decision
+    /// reads.
+    ///
+    /// It runs the production sequence, not a stand-in: GatewayService.StartAsync -> new GatewayHost ->
+    /// GatewayDatabase throws -> the catch at GatewayService.cs:133 -> DiagnoseStartFailureAsync ->
+    /// SetState(Failed). If anything in that chain ever catches and returns without recording the failure,
+    /// State is no longer Failed, MustTerminate returns false, and the process would go back to hanging -
+    /// which is exactly the regression this asserts against.
+    ///
+    /// The connection string is UNPARSEABLE rather than merely unreachable so the failure lands before
+    /// GatewayDatabase's retry window and the test costs no ninety-second wait.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseThatCannotBeOpened_LeavesTheServiceInTheStateTerminationReads()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar);
+        // A port nothing else in the suite uses; the Gateway never gets far enough to bind it.
+        var service = new GatewayService(new GatewayServiceOptions
+        {
+            Port = 59_317,
+            Managed = false,
+            RegisterAutostart = false,
+            ModeLabel = "test",
+        });
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, "unparseable=x");
+
+            await service.StartAsync();
+
+            Assert.Equal(GatewayServiceState.Failed, service.State);
+            // And therefore the decision the worker makes on that state ends the process.
+            Assert.True(GatewayWorker.MustTerminate(service.State));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, previous);
+            service.Dispose();
+        }
+    }
 
     [Fact]
     public void AnUnparseableConnectionString_NeverPutsItsTextInTheError()

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -56,9 +56,16 @@ public sealed class GatewayDatabase : IDisposable
     // it and does not rethrow - so on its own this retry only changes how long the container takes to
     // reach a silent, portless hang. What actually ends the process is GatewayWorker seeing the failed
     // state afterwards and exiting; see MustTerminate there. This window's only job is to ride out
-    // transient contention, and it must stay well inside the platform's 230-second start limit so it
-    // cannot delay that exit into the platform's own timeout: 90 seconds of retry plus the rest of boot
-    // leaves ample headroom, and the measured recovery case resolved in far less.
+    // transient contention, and it is INTENDED to stay well inside the platform's 230-second start limit
+    // so it does not delay that exit into the platform's own timeout: 90 seconds of retry plus the rest
+    // of boot is intended to leave headroom, and the measured recovery case resolved in far less.
+    //
+    // Intended, not guaranteed, and the difference is real. The deadline is only tested AFTER an attempt
+    // returns, so it bounds how many attempts are made and not how long one takes. An attempt runs
+    // GetPendingMigrations and Migrate synchronously, and Migrate takes a database-wide lock with no lock
+    // timeout and no command timeout (see the note further down), so a single attempt can block past both
+    // this window and the platform limit. That residual case is tracked separately as issue #2395; it is
+    // not addressed here, and nothing in this file should be read as ruling it out.
     private static readonly TimeSpan PostgresOpenRetryWindow = TimeSpan.FromSeconds(90);
     private const int PostgresOpenFirstDelayMs = 1_000;
     private const int PostgresOpenMaxDelayMs = 10_000;

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -29,6 +29,44 @@ public sealed class GatewayDatabase : IDisposable
     /// the local install: the SQLite file behavior is unchanged.</summary>
     public const string PostgresConnectionEnvVar = "CC_GATEWAY_DB_CONNECTION";
 
+    // ---- opening PostgreSQL under deploy contention (issue #2383) --------------------------------
+    // On 2 August 2026 a deploy stopped the LIVE SITE for 38.5 seconds. Not because the swap was slow -
+    // the swap measured 0.0s, as every healthy deploy does - but because the container App Service
+    // starts after a swap got ONE refused PostgreSQL connection and treated it as terminal. The port
+    // bind sits behind this open, so nothing ever listened; the platform waited out its 230-second
+    // container start limit, found no listening port, and STOPPED THE SITE, killing the healthy
+    // container that had been serving throughout. Four minutes later the same image on the same worker
+    // opened the same database in 1.6 seconds.
+    //
+    // The refusal is contention, and it is structural rather than bad luck: a swap briefly runs FOUR
+    // Gateway containers (the warmed one, the old one, and the two new ones), each with two Npgsql
+    // pools, against a session-mode pooler in front of a server with max_connections=60. Post-swap
+    // boots had been blowing their deadlines on every deploy for days before one finally crossed from
+    // slow into refused.
+    //
+    // So: a refused connection is no longer proof the database is gone. The open is retried with
+    // backoff for a bounded window. This is NOT a fallback and does not weaken the fail-loud contract -
+    // it never reverts to SQLite, never starts without a database, and still throws at the end of the
+    // window. It only stops one refusal during the noisiest ninety seconds of a deploy from being
+    // mistaken for a dead database.
+    //
+    // The window is bounded well inside the platform's 230-second limit so a genuinely dead database
+    // still fails the container rather than hanging it: 90 seconds of retry plus the rest of boot
+    // leaves ample headroom, and the measured recovery case resolved in far less.
+    private static readonly TimeSpan PostgresOpenRetryWindow = TimeSpan.FromSeconds(90);
+    private const int PostgresOpenFirstDelayMs = 1_000;
+    private const int PostgresOpenMaxDelayMs = 10_000;
+
+    /// <summary>
+    /// Maximum Npgsql pool size for the Gateway store when the connection string does not set one.
+    /// Npgsql's default is 100; a Gateway container holds about four backends at rest, and the server
+    /// behind the pooler allows sixty connections in total. Four containers times two unbounded pools
+    /// is headroom nothing needs and is the pressure that produced the refusal above. An explicit value
+    /// in the connection string always wins - this is a ceiling for the unconfigured case, not an
+    /// override of the operator.
+    /// </summary>
+    internal const int DefaultMaxPoolSize = 10;
+
     private readonly string _path;
     private readonly bool _usePostgres;
     private readonly ITenantContext _tenant;
@@ -39,6 +77,46 @@ public sealed class GatewayDatabase : IDisposable
     /// <summary>The database file path (SQLite), for logging. On the Postgres path this is NOT a file - it
     /// holds a credential-redacted description of the connection target instead.</summary>
     public string Path => _path;
+
+    /// <summary>
+    /// Return <paramref name="connectionString"/> with an explicit maximum pool size, unless it already
+    /// carries one. Npgsql defaults to 100 connections per pool; the hosted server behind the pooler
+    /// allows sixty in total, and a deploy briefly runs four containers with two pools each. Capping the
+    /// unconfigured case removes that pressure without taking the decision away from an operator who
+    /// stated a value on purpose.
+    ///
+    /// Pure and internal so it can be tested without a database. It NEVER logs and never returns anything
+    /// to a caller that logs - the value is a credentialed connection string.
+    /// </summary>
+    internal static string WithBoundedPool(string connectionString, int maxPoolSize)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+        // Both spellings are accepted in a connection string; Npgsql canonicalises on parse, but ask for
+        // both rather than depending on which form the operator wrote.
+        if (builder.ContainsKey("Maximum Pool Size") || builder.ContainsKey("MaxPoolSize"))
+            return connectionString;
+        builder.MaxPoolSize = maxPoolSize;
+        return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// A log-safe description of a database open failure.
+    ///
+    /// The generic exception message is NEVER used: a malformed connection string is echoed back by the
+    /// parser, so stringifying the exception can leak credentials into a log. But when the server itself
+    /// answered, its <see cref="PostgresException.SqlState"/> and <see cref="PostgresException.MessageText"/>
+    /// are the server's own error code and text - they are produced by PostgreSQL, cannot contain the
+    /// client's connection string, and are the difference between "we know it said too_many_connections"
+    /// and the bare word "PostgresException", which is all the 2 August outage left behind.
+    ///
+    /// Pure and internal so the redaction contract can be tested directly.
+    /// </summary>
+    internal static string DescribeFailure(Exception ex)
+    {
+        return ex is PostgresException pg
+            ? $"{nameof(PostgresException)} SqlState={pg.SqlState} MessageText={pg.MessageText}"
+            : ex.GetType().Name;
+    }
 
     /// <param name="tenant">The ambient tenant context. On the local install this is
     /// <see cref="SingleTenantContext"/> and every row is the "local" tenant.</param>
@@ -72,75 +150,103 @@ public sealed class GatewayDatabase : IDisposable
             // database only) for logging, never the file path and never the credentials.
             _path = RedactConnectionTarget(pgConn!);
 
+            // Bound the connection pool before anything opens it (issue #2383). See DefaultMaxPoolSize.
+            var boundedConn = WithBoundedPool(pgConn!, DefaultMaxPoolSize);
+
             FileLog.Write($"[GatewayDatabase] Open: provider=Postgres target={_path}");
 
-            // Build the provider into a LOCAL first and only publish it to the readonly fields after Migrate()
-            // succeeds. If Migrate throws, the constructor never completes, so Dispose() can never run - the
-            // catch disposes the local provider itself, otherwise its pooled connections would leak.
-            ServiceProvider? provider = null;
-            try
+            // Retry the open for a bounded window rather than treating one refusal as a dead database.
+            // Every attempt builds a FRESH provider: a provider whose pool was created against a refusing
+            // server is not reusable, and disposing it between attempts is what stops a retry loop from
+            // leaking pooled connections into the very contention it is waiting out.
+            var deadline = DateTime.UtcNow + PostgresOpenRetryWindow;
+            var delayMs = PostgresOpenFirstDelayMs;
+            for (var attempt = 1; ; attempt++)
             {
-                var services = new ServiceCollection();
-                services.AddPooledDbContextFactory<GatewayDbContext>(o => o.UseNpgsql(pgConn, npg =>
+                // Build the provider into a LOCAL first and only publish it to the readonly fields after Migrate()
+                // succeeds. If Migrate throws, the constructor never completes, so Dispose() can never run - the
+                // catch disposes the local provider itself, otherwise its pooled connections would leak.
+                ServiceProvider? provider = null;
+                try
                 {
-                    npg.MigrationsAssembly("CcDirector.Gateway.Migrations.Postgres");
-                    npg.MigrationsHistoryTable("__EFMigrationsHistory", "gateway");
-                }));
-                provider = services.BuildServiceProvider();
-                var factory = provider.GetRequiredService<IDbContextFactory<GatewayDbContext>>();
+                    var services = new ServiceCollection();
+                    services.AddPooledDbContextFactory<GatewayDbContext>(o => o.UseNpgsql(boundedConn, npg =>
+                    {
+                        npg.MigrationsAssembly("CcDirector.Gateway.Migrations.Postgres");
+                        npg.MigrationsHistoryTable("__EFMigrationsHistory", "gateway");
+                    }));
+                    provider = services.BuildServiceProvider();
+                    var factory = provider.GetRequiredService<IDbContextFactory<GatewayDbContext>>();
 
-                using (var ctx = factory.CreateDbContext())
-                {
-                    // Apply the Postgres migration set (its own assembly + gateway-schema history table). No
-                    // PRAGMA journal_mode here - WAL is a SQLite-only setting and Postgres has its own WAL.
-                    //
-                    // ASK FIRST (issue #2203). Migrate() takes an EXCLUSIVE database-wide advisory lock before
-                    // it looks at whether there is anything to apply, and it holds that lock for the whole
-                    // call with no lock timeout and no command timeout. Every deploy runs two Gateway
-                    // containers against this one database, so the second one waits on the first: measured at
-                    // 43 seconds on a deploy carrying NO schema change, against 7 seconds with nothing else
-                    // running. That wait sits in front of the port bind, and when it pushes the bind past the
-                    // platform's 230-second startup deadline the platform stops the SITE - which is the
-                    // user-visible outage this issue is about.
-                    //
-                    // GetPendingMigrations() takes no lock: it reads the history table and compares. On a
-                    // code-only deploy - most deploys - the answer is "none" and we skip the locking call
-                    // entirely. This is NOT a fallback and it does not weaken the contract: when there ARE
-                    // migrations we still call Migrate() and still fail loudly if it throws. It only removes
-                    // a lock acquisition that had nothing to do.
-                    var pending = ctx.Database.GetPendingMigrations().ToList();
-                    if (pending.Count == 0)
+                    using (var ctx = factory.CreateDbContext())
                     {
-                        FileLog.Write("[GatewayDatabase] Migrate: no pending migrations - skipping Migrate() and its database-wide lock");
+                        // Apply the Postgres migration set (its own assembly + gateway-schema history table). No
+                        // PRAGMA journal_mode here - WAL is a SQLite-only setting and Postgres has its own WAL.
+                        //
+                        // ASK FIRST (issue #2203). Migrate() takes an EXCLUSIVE database-wide advisory lock before
+                        // it looks at whether there is anything to apply, and it holds that lock for the whole
+                        // call with no lock timeout and no command timeout. Every deploy runs two Gateway
+                        // containers against this one database, so the second one waits on the first: measured at
+                        // 43 seconds on a deploy carrying NO schema change, against 7 seconds with nothing else
+                        // running. That wait sits in front of the port bind, and when it pushes the bind past the
+                        // platform's 230-second startup deadline the platform stops the SITE - which is the
+                        // user-visible outage this issue is about.
+                        //
+                        // GetPendingMigrations() takes no lock: it reads the history table and compares. On a
+                        // code-only deploy - most deploys - the answer is "none" and we skip the locking call
+                        // entirely. This is NOT a fallback and it does not weaken the contract: when there ARE
+                        // migrations we still call Migrate() and still fail loudly if it throws. It only removes
+                        // a lock acquisition that had nothing to do.
+                        var pending = ctx.Database.GetPendingMigrations().ToList();
+                        if (pending.Count == 0)
+                        {
+                            FileLog.Write("[GatewayDatabase] Migrate: no pending migrations - skipping Migrate() and its database-wide lock");
+                        }
+                        else
+                        {
+                            FileLog.Write($"[GatewayDatabase] Migrate: {pending.Count} pending migration(s), applying: {string.Join(", ", pending)}");
+                            ctx.Database.Migrate();
+                            FileLog.Write($"[GatewayDatabase] Migrate: applied {pending.Count} migration(s)");
+                        }
                     }
-                    else
-                    {
-                        FileLog.Write($"[GatewayDatabase] Migrate: {pending.Count} pending migration(s), applying: {string.Join(", ", pending)}");
-                        ctx.Database.Migrate();
-                        FileLog.Write($"[GatewayDatabase] Migrate: applied {pending.Count} migration(s)");
-                    }
+
+                    _provider = provider;
+                    _factory = factory;
+
+                    FileLog.Write($"[GatewayDatabase] Open: ready, provider=Postgres target={_path}, attempt={attempt}");
+                    return;
                 }
+                catch (Exception ex)
+                {
+                    provider?.Dispose();
+                    // The provider's exception message can carry the raw connection string (a malformed one is
+                    // echoed back by the parser), so it is NEVER interpolated into the log or the thrown message.
+                    // DescribeFailure adds the SERVER's own error code and text when there is one - neither can
+                    // contain the connection string - so the next failure is diagnosable instead of being
+                    // recorded as the single word "PostgresException", which is what left the root cause of the
+                    // 2 August outage permanently unknowable. The full exception is preserved as the
+                    // InnerException without us stringifying it anywhere.
+                    var detail = DescribeFailure(ex);
+                    var remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        FileLog.Write($"[GatewayDatabase] Open FAILED: provider=Postgres target={_path} "
+                            + $"after {attempt} attempt(s) over {PostgresOpenRetryWindow.TotalSeconds:F0}s: {detail}");
+                        throw new InvalidOperationException(
+                            $"The Gateway PostgreSQL database ('{_path}') could not be opened or migrated ({detail}) " +
+                            $"after {attempt} attempt(s) over {PostgresOpenRetryWindow.TotalSeconds:F0} seconds. " +
+                            "PostgreSQL is configured via " + PostgresConnectionEnvVar + ", so the Gateway will NOT " +
+                            "fall back to SQLite or to the old JSON stores. Fix the connection string, the server, or " +
+                            "the schema and restart the Gateway.", ex);
+                    }
 
-                _provider = provider;
-                _factory = factory;
-
-                FileLog.Write($"[GatewayDatabase] Open: ready, provider=Postgres target={_path}");
+                    var delay = TimeSpan.FromMilliseconds(Math.Min(delayMs, (int)remaining.TotalMilliseconds));
+                    FileLog.Write($"[GatewayDatabase] Open attempt {attempt} failed, retrying in {delay.TotalSeconds:F1}s "
+                        + $"({remaining.TotalSeconds:F0}s of the window left): provider=Postgres target={_path}: {detail}");
+                    Thread.Sleep(delay);
+                    delayMs = Math.Min(delayMs * 2, PostgresOpenMaxDelayMs);
+                }
             }
-            catch (Exception ex)
-            {
-                provider?.Dispose();
-                // The provider's exception message can carry the raw connection string (a malformed one is
-                // echoed back by the parser), so it is NEVER interpolated into the log or the thrown message.
-                // The redacted target plus the exception TYPE name is enough to diagnose; the full exception is
-                // preserved as the InnerException without us stringifying it anywhere.
-                FileLog.Write($"[GatewayDatabase] Open FAILED: provider=Postgres target={_path}: {ex.GetType().Name}");
-                throw new InvalidOperationException(
-                    $"The Gateway PostgreSQL database ('{_path}') could not be opened or migrated ({ex.GetType().Name}). " +
-                    "PostgreSQL is configured via " + PostgresConnectionEnvVar + ", so the Gateway will NOT " +
-                    "fall back to SQLite or to the old JSON stores. Fix the connection string, the server, or " +
-                    "the schema and restart the Gateway.", ex);
-            }
-            return;
         }
 
         _path = string.IsNullOrWhiteSpace(dbPath) ? CcStorage.GatewayDb() : dbPath!;

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -50,8 +50,14 @@ public sealed class GatewayDatabase : IDisposable
     // window. It only stops one refusal during the noisiest ninety seconds of a deploy from being
     // mistaken for a dead database.
     //
-    // The window is bounded well inside the platform's 230-second limit so a genuinely dead database
-    // still fails the container rather than hanging it: 90 seconds of retry plus the rest of boot
+    // WHAT THE RETRY DOES NOT DO, because an earlier version of this comment claimed it did and the
+    // claim was false: it does not make a dead database fail the container. The throw at the end of the
+    // window does not escape startup - GatewayService.StartAsync catches every startup exception, logs
+    // it and does not rethrow - so on its own this retry only changes how long the container takes to
+    // reach a silent, portless hang. What actually ends the process is GatewayWorker seeing the failed
+    // state afterwards and exiting; see MustTerminate there. This window's only job is to ride out
+    // transient contention, and it must stay well inside the platform's 230-second start limit so it
+    // cannot delay that exit into the platform's own timeout: 90 seconds of retry plus the rest of boot
     // leaves ample headroom, and the measured recovery case resolved in far less.
     private static readonly TimeSpan PostgresOpenRetryWindow = TimeSpan.FromSeconds(90);
     private const int PostgresOpenFirstDelayMs = 1_000;

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -163,7 +163,34 @@ public sealed class GatewayDatabase : IDisposable
             _path = RedactConnectionTarget(pgConn!);
 
             // Bound the connection pool before anything opens it (issue #2383). See DefaultMaxPoolSize.
-            var boundedConn = WithBoundedPool(pgConn!, DefaultMaxPoolSize);
+            //
+            // INSIDE A REDACTING BOUNDARY, because this parses a credentialed string and the caller writes
+            // whatever escapes straight to disk: GatewayService.StartAsync catches every startup exception
+            // and logs ex.Message verbatim. Npgsql's parser echoes the offending KEYWORD back in its
+            // message - measured: a connection string carrying "SUPERSECRET=x" throws
+            // "Couldn't set supersecret (Parameter 'supersecret')" - so a garbled string whose credential
+            // fragment lands in keyword position puts that fragment in the log. The value position does not
+            // echo; the keyword position does, and a mangled connection string is exactly the case where a
+            // secret ends up somewhere it was never meant to be. (A case-SENSITIVE check for the leak misses
+            // it, because the keyword is lowercased on the way out. That nearly hid this.)
+            //
+            // The original exception is deliberately NOT kept as an InnerException: the whole point is that
+            // its message must not survive to be written by anything downstream. The type name is preserved
+            // in the redacted message, which is what a diagnosis actually needs.
+            string boundedConn;
+            try
+            {
+                boundedConn = WithBoundedPool(pgConn!, DefaultMaxPoolSize);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write("[GatewayDatabase] Open FAILED: the connection string could not be parsed "
+                    + $"({ex.GetType().Name}); its text is withheld because the parser echoes part of it.");
+                throw new InvalidOperationException(
+                    $"The Gateway PostgreSQL connection string could not be parsed ({ex.GetType().Name}). " +
+                    "Its text is deliberately not reproduced here - the parser's own message can echo part of " +
+                    "the string, which may carry credentials. Check " + PostgresConnectionEnvVar + " and restart.");
+            }
 
             FileLog.Write($"[GatewayDatabase] Open: provider=Postgres target={_path}");
 

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -90,13 +90,25 @@ public sealed class GatewayDatabase : IDisposable
     /// </summary>
     internal static string WithBoundedPool(string connectionString, int maxPoolSize)
     {
-        var builder = new NpgsqlConnectionStringBuilder(connectionString);
-        // Both spellings are accepted in a connection string; Npgsql canonicalises on parse, but ask for
-        // both rather than depending on which form the operator wrote.
-        if (builder.ContainsKey("Maximum Pool Size") || builder.ContainsKey("MaxPoolSize"))
-            return connectionString;
-        builder.MaxPoolSize = maxPoolSize;
-        return builder.ConnectionString;
+        // "Did the operator state a pool size?" must be asked of the RAW string, not of the Npgsql
+        // builder. NpgsqlConnectionStringBuilder pre-populates every keyword it knows with that
+        // keyword's default, so ContainsKey("Maximum Pool Size") is TRUE even for a connection string
+        // that never mentions pooling - which quietly turned this entire cap into a no-op. Its own test
+        // caught that (expected 10, got Npgsql's default 100); this is the repair.
+        //
+        // A plain DbConnectionStringBuilder holds ONLY the keys the string actually carries, so it can
+        // answer the question honestly. Npgsql accepts both spellings and ignores spaces, so both are
+        // checked with spacing and underscores removed.
+        var stated = new System.Data.Common.DbConnectionStringBuilder { ConnectionString = connectionString };
+        foreach (string key in stated.Keys)
+        {
+            var normalised = key.Replace(" ", "").Replace("_", "");
+            if (normalised.Equals("maximumpoolsize", StringComparison.OrdinalIgnoreCase)
+                || normalised.Equals("maxpoolsize", StringComparison.OrdinalIgnoreCase))
+                return connectionString;
+        }
+
+        return new NpgsqlConnectionStringBuilder(connectionString) { MaxPoolSize = maxPoolSize }.ConnectionString;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -85,19 +85,29 @@ public sealed class GatewayWorker : BackgroundService
             // itself the moment the cause clears, instead of sitting dead until somebody notices - but its
             // RATE depends on which failure it is, and the two differ a lot:
             //
-            //  - a database that is reachable but REFUSING connections goes through GatewayDatabase's retry
-            //    window, so that container lives at least that long before exiting. Restarts are paced by
-            //    the window plus boot.
-            //  - a MISCONFIGURATION fails before the retry loop is ever entered - a blank connection string,
-            //    or one the parser rejects, both of which throw above it - and so does any non-database
-            //    startup failure. Those exit within seconds of boot, and the restarts are correspondingly
-            //    rapid.
+            // The line that separates them is whether the CONNECTION STRING PARSED, not what kind of
+            // problem it is:
             //
-            // An earlier version of this comment claimed the retry window bounded EVERY case. It does not,
-            // and the difference matters to whoever reads a crash-looping container: a fast loop means a
-            // misconfiguration, a slow one means the database. Whether App Service itself throttles repeated
-            // container restarts has NOT been checked, so nothing here relies on it. In both cases the site
-            // is already down; what termination changes is that the platform can recover it automatically
+            //  - anything that fails while OPENING OR MIGRATING the main store, once the connection string
+            //    has parsed, goes through GatewayDatabase's retry window. Its catch takes every exception,
+            //    so that is not only an unreachable or refusing server - a wrong password, a failed or
+            //    missing migration, and a provider fault are all retried too. Those containers live at
+            //    least the retry window before exiting, so restarts are paced by the window plus boot.
+            //  - only a connection string that is BLANK or UNPARSEABLE, which throws above the loop, and
+            //    any non-database startup failure, exit within seconds of boot. Those restart rapidly.
+            //
+            // So a SLOW loop does not mean the database is merely refusing connections, and reading it that
+            // way sends someone with a wrong password or a broken migration off to check network
+            // reachability. It means the string parsed and something after that kept failing; the Gateway
+            // log's own open-attempt lines say which, and DescribeFailure carries the server's SqlState
+            // when the server answered. A FAST loop means the string itself is unusable, or the failure was
+            // never the database at all.
+            //
+            // Two earlier versions of this comment were wrong in this same place - first claiming the retry
+            // window bounded every case, then claiming the slow case was reachability. Whether App Service
+            // itself throttles repeated container restarts has NOT been checked, so nothing here relies on
+            // it. In both cases the site is already down; what termination changes is that the platform can
+            // recover it automatically
             // instead of waiting out a live process and killing its healthy neighbour.
             FileLog.Write($"[GatewayWorker] Gateway FAILED to start ({_service.StatusText}); ending the process "
                 + $"with exit code {StartFailureExitCode} so the platform restarts this container instead of "

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -38,12 +38,59 @@ public sealed class GatewayWorker : BackgroundService
     /// <summary>The running Gateway service (exposed so a host or a test can read its state).</summary>
     public GatewayService Service => _service;
 
+    /// <summary>
+    /// Exit code for a Gateway that could not start. Non-zero on purpose: the container platform decides
+    /// what to do from the EXIT CODE, and zero would read as a clean, intentional shutdown.
+    /// </summary>
+    public const int StartFailureExitCode = 1;
+
+    /// <summary>
+    /// Whether a Gateway that has finished <see cref="GatewayService.StartAsync"/> in this state must end
+    /// the PROCESS rather than stay resident.
+    ///
+    /// This is the fix for the 2 August outage (issue #2383), and it is not in the database code at all.
+    /// <see cref="GatewayService.StartAsync"/> catches every startup exception, logs it, and does not
+    /// rethrow; this worker then waited on <c>Task.Delay(Timeout.Infinite)</c>. So a Gateway whose database
+    /// could not be opened stayed ALIVE with nothing listening on its port. From the platform's outside
+    /// view that is indistinguishable from an application still starting, so it waited out the full
+    /// 230-second container start limit, concluded no listening port existed, and STOPPED THE SITE - which
+    /// also tore down the healthy container that had been serving beside it. The 38.5 seconds of downtime
+    /// was that stop, not the swap.
+    ///
+    /// A container that EXITS is restarted. A container that is alive and silent is waited out and then
+    /// takes the healthy one with it. So the failed start must end the process.
+    ///
+    /// Pure and internal so the policy is unit-testable without starting a Gateway or ending a test run.
+    /// </summary>
+    internal static bool MustTerminate(GatewayServiceState state) => state == GatewayServiceState.Failed;
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         FileLog.Write($"[GatewayWorker] ExecuteAsync: port={_service.Port}");
 
         await _service.StartAsync();
         FileLog.Write($"[GatewayWorker] {_service.StatusText}");
+
+        if (MustTerminate(_service.State))
+        {
+            // Environment.Exit, not a thrown exception: a BackgroundService that faults leaves the generic
+            // host deciding whether to stop, and a faulted task inside a process that stays up looks
+            // identical from outside to the silent hang this replaces. The process must actually END.
+            //
+            // Ending the process is already this host's established way of stopping (see the constructor's
+            // ShutdownRequested handler); this is the same act with a failure code.
+            //
+            // WHAT HAPPENS DURING A LONG DATABASE OUTAGE: the container exits, the platform restarts it, it
+            // retries the database for the bounded window in GatewayDatabase and exits again. That is a
+            // restart loop, and it is the correct behaviour - the service recovers by itself the moment the
+            // database answers, instead of sitting dead until somebody notices. It cannot spin: each attempt
+            // spends the full retry window before giving up, so a container lives at least that long, which
+            // bounds restarts to roughly one per retry-window-plus-boot rather than a tight loop.
+            FileLog.Write($"[GatewayWorker] Gateway FAILED to start ({_service.StatusText}); ending the process "
+                + $"with exit code {StartFailureExitCode} so the platform restarts this container instead of "
+                + "waiting out a live process that will never bind a port.");
+            Environment.Exit(StartFailureExitCode);
+        }
 
         // Stay alive until the host signals shutdown (Ctrl+C or ProcessExit).
         try

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -80,12 +80,25 @@ public sealed class GatewayWorker : BackgroundService
             // Ending the process is already this host's established way of stopping (see the constructor's
             // ShutdownRequested handler); this is the same act with a failure code.
             //
-            // WHAT HAPPENS DURING A LONG DATABASE OUTAGE: the container exits, the platform restarts it, it
-            // retries the database for the bounded window in GatewayDatabase and exits again. That is a
-            // restart loop, and it is the correct behaviour - the service recovers by itself the moment the
-            // database answers, instead of sitting dead until somebody notices. It cannot spin: each attempt
-            // spends the full retry window before giving up, so a container lives at least that long, which
-            // bounds restarts to roughly one per retry-window-plus-boot rather than a tight loop.
+            // WHAT HAPPENS AFTERWARDS: the container exits, the platform restarts it, and if the cause is
+            // still there it exits again. That restart loop is correct either way - the service recovers by
+            // itself the moment the cause clears, instead of sitting dead until somebody notices - but its
+            // RATE depends on which failure it is, and the two differ a lot:
+            //
+            //  - a database that is reachable but REFUSING connections goes through GatewayDatabase's retry
+            //    window, so that container lives at least that long before exiting. Restarts are paced by
+            //    the window plus boot.
+            //  - a MISCONFIGURATION fails before the retry loop is ever entered - a blank connection string,
+            //    or one the parser rejects, both of which throw above it - and so does any non-database
+            //    startup failure. Those exit within seconds of boot, and the restarts are correspondingly
+            //    rapid.
+            //
+            // An earlier version of this comment claimed the retry window bounded EVERY case. It does not,
+            // and the difference matters to whoever reads a crash-looping container: a fast loop means a
+            // misconfiguration, a slow one means the database. Whether App Service itself throttles repeated
+            // container restarts has NOT been checked, so nothing here relies on it. In both cases the site
+            // is already down; what termination changes is that the platform can recover it automatically
+            // instead of waiting out a live process and killing its healthy neighbour.
             FileLog.Write($"[GatewayWorker] Gateway FAILED to start ({_service.StatusText}); ending the process "
                 + $"with exit code {StartFailureExitCode} so the platform restarts this container instead of "
                 + "waiting out a live process that will never bind a port.");

--- a/src/CcDirector.Gateway/Stats/Data/GatewayStatsStore.cs
+++ b/src/CcDirector.Gateway/Stats/Data/GatewayStatsStore.cs
@@ -430,6 +430,11 @@ public sealed class GatewayStatsStore : IDisposable
     /// <summary>Record that this store actually stored something, for the health surface.</summary>
     public void RecordSuccessfulWrite(DateTimeOffset whenUtc) => _health.RecordSuccessfulWrite(whenUtc);
 
+    /// <summary>Maximum Npgsql pool size for the statistics store when the connection string does not set
+    /// one. Lower than the main store's ceiling because statistics are the lighter workload; see
+    /// <see cref="CcDirector.Gateway.Data.GatewayDatabase.DefaultMaxPoolSize"/> for why either exists.</summary>
+    internal const int StatsMaxPoolSize = 5;
+
     /// <summary>
     /// Build the pooled context factory for the chosen provider.
     ///
@@ -444,8 +449,22 @@ public sealed class GatewayStatsStore : IDisposable
 
         if (choice.IsPostgres)
         {
+            // Bound this pool too (issue #2383). This is the SECOND Npgsql pool in every Gateway container -
+            // adding it roughly doubled the connections each container asks for, and a deploy briefly runs
+            // four containers against a session-mode pooler in front of a server that allows sixty
+            // connections in total. Unbounded, both pools default to a hundred each. Statistics are the
+            // lighter of the two workloads, so its ceiling is lower than the main store's. An explicit value
+            // in the connection string still wins.
+            //
+            // ConnectionString is null only when the source is NotConfigured, which IsPostgres excludes. If
+            // that invariant is ever broken this fails loud here rather than opening something unbounded.
+            var bounded = CcDirector.Gateway.Data.GatewayDatabase.WithBoundedPool(
+                choice.ConnectionString
+                    ?? throw new InvalidOperationException(
+                        $"Statistics store source is {choice.Source} (PostgreSQL) but carries no connection string."),
+                StatsMaxPoolSize);
             services.AddPooledDbContextFactory<GatewayStatsDbContext>(o =>
-                o.UseNpgsql(choice.ConnectionString, npg =>
+                o.UseNpgsql(bounded, npg =>
                 {
                     npg.MigrationsAssembly("CcDirector.Gateway.Migrations.Postgres");
                     npg.MigrationsHistoryTable("__EFMigrationsHistory", GatewayStatsDbContext.PostgresSchema);


### PR DESCRIPTION
Closes the failure behind the 38.5-second production outage on 2 August (#2383), and closes the routes by which something unchecked could reach production.

Full investigation: `docs/reviews/gateway-deploy-outage-2026-08-02.md` in `devthrottle_internal`.

## What actually happened

The swap was not at fault - it measured `0.0s`, as every healthy deploy does. App Service starts a brand-new container once a swap completes. That container's Gateway got **one refused PostgreSQL connection**, treated it as terminal, and never bound its port. It did not exit either, so the platform waited out its full 230-second container start limit, found nothing listening, and **stopped the site** - which also killed the healthy container that had been serving throughout. The same image on the same worker opened the same database in 1.6 seconds four minutes later.

## Changes

**The open is retried for a bounded window.** One refusal is no longer proof the database is gone. The refusal is contention and it is structural: a swap briefly runs four Gateway containers, each with two Npgsql pools, against a session-mode pooler in front of a server with `max_connections=60`.

This is not a fallback and does not weaken the fail-loud contract - it never reverts to SQLite, never starts without a database, and still throws at the end of the window. Every attempt builds a fresh provider and disposes the failed one, so the retry cannot leak pooled connections into the contention it is waiting out. Ninety seconds sits well inside the platform's limit, so a genuinely dead database still fails the container rather than hanging it.

**Both pools are bounded.** Npgsql defaults to 100 per pool, two pools per container, against a server allowing sixty in total. The statistics store is the second pool and roughly doubled the demand when it landed - which is why post-swap boots had been blowing their deadlines on *every* deploy for days before one finally crossed from slow into refused. An explicit size in the connection string still wins.

**A failure records what the server said.** `SqlState` and `MessageText` are PostgreSQL's own code and text and cannot contain the connection string, which is why only the exception type was ever logged. That one line is why the root cause of 2 August is permanently unknowable. The redaction contract is unchanged for every other exception type and is now pinned by a test.

## Gating what may ship

`workflow_dispatch` runs against whatever ref the caller picks, and nothing verified the shipping commit's tests - so an unreviewed branch or a red commit was as deployable as green `main`. The run now refuses, in seconds and before it touches Azure:

- any ref that is not `refs/heads/main`;
- any commit with a check that failed, or that has not finished.

Self-exclusion is by **run id, not job name** - a stale name here would mean a deploy that can never start. The gate logic was dry-run against real check data on `origin/main` (passes) plus four negative controls: exclusion works, a failing check refuses, an unfinished check refuses, and `skipped`/`neutral` are treated as passes.

**Budget 30s to 5s.** A healthy deploy measures `0.0s`, so this was never a cost curve with slack in it - thirty would have passed a twenty-nine-second outage as green.

**The site-state comment is corrected.** It claimed to be "the earlier and truer signal". It reads the *desired* state in Resource Manager, and on 2 August every sample read `Running` straight through the 21 seconds the platform had the site stopped. The external poll is what caught it.

**The deploy skill said a minute or two of 502s was normal** and told the reader not to report it. That trained people to wave through exactly this failure. There is no cold start on the user path - the point of the warmed swap is that the user is never moved onto a cold instance. The skill now also states that this workflow is the only supported way to update the live Gateway.

## Still open, deliberately not in here

The port bind sits **behind** the database open, so any slow or erroring boot dependency can still drive the platform to stop the site. Binding first and opening the database behind a readiness flag (with a separate `/readyz` for the swap warm-up gate) removes the whole class and is the single most valuable remaining change - but it restructures the Gateway's boot sequence and deserves its own review rather than riding along with a hotfix.
