### PR TITLE
A Director says which one it is, and can be addressed by name

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -645,7 +645,8 @@ COMMANDS:
   session list     List every session in the fleet.
   session whoami   Show this session's own fleet identity.
   session rename   Rename a session, defaulting to the current session.
-  session spawn    Open a new session on the local Director.
+  session spawn    Open a new session - here, on another computer, or on one named Director.
+  director list    List every Director this account runs, with the id --director accepts.
   message send     Send a message to one session, or broadcast with all.
   message ask      Ask one session a question and print its answer.
   skill list       List every skill in the fleet library.
@@ -743,13 +744,43 @@ OPTIONS:
   --agent TEXT          Agent CLI: ClaudeCode (default), Pi, Codex, Gemini, OpenCode, Grok, Copilot, RawCli
   --prompt TEXT         First prompt to send once the session is ready
   --name TEXT           Custom display name for the session
-  --type TEXT           Session type: Developer, Implementation, Discuss, Product, QA, Support
+  --purpose TEXT        What the session is FOR; used to build the name when --name is omitted
+  --machine TEXT        Start it on ANOTHER COMPUTER: the Gateway routes to a Director there
+  --director TEXT       Start it on ONE named Director, by Director id or display name
   --command TEXT        For --agent RawCli: the executable to run (e.g. cmd, pwsh)
   --command-args TEXT   For --agent RawCli: arguments for the command
 ```
 
 Prints the new session's short id and full GUID; the session then appears in
 `cc-devthrottle session list`. A non-existent repository path exits non-zero with a clear error.
+
+**`--machine` picks a computer; `--director` picks a Director.** They are not the same question. One
+computer runs several named Director instances, so `--machine SOREN_NORTH` resolves to whichever
+Director on that machine the Gateway lists first - fine when any will do, a coin toss when it will
+not. `--director` names exactly one, by its Director id or its display name, and needs no
+`--machine`: a Director identifies the computer it runs on.
+
+A named Director that is not registered fails loudly naming it, and a display name that matches two
+Directors fails listing both. Neither ever falls back to another Director, and neither auto-launches
+one (`--machine` does) - a session opened quietly on the wrong Director is the failure this exists to
+prevent, and nothing in the reply would reveal it.
+
+Giving both narrows rather than overrides: `--machine` filters the Directors a name may match, which
+is how you disambiguate a display name two machines share. Naming a Director together with a machine
+it does not run on is therefore a contradiction and fails - the alternative is honouring half of what
+you asked for without saying which half.
+
+```
+USAGE: cc-devthrottle director list [OPTIONS]
+
+OPTIONS:
+  --json -j  Output raw JSON.
+```
+
+Lists every Director this account is running, on every machine: its name, its machine, and its
+Director id. Prefer the **id** when handing a target to another agent - it survives a rename and
+cannot collide with a second Director sharing a display name. A Director's own toolbar has a Copy
+button that puts those same three facts on the clipboard, for pasting to an agent.
 
 ### Skill Commands
 

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -77,10 +77,12 @@
                 <!-- Right group: this Director's identity + global destinations + Settings -->
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
                             Spacing="2" VerticalAlignment="Center">
-                    <!-- Director connection info (machine name + port + copy for agents).
-                         This identifies the WHOLE application's Director (its Control API
-                         address), so it belongs on the app-wide toolbar, not in the
-                         per-session blue header. Always visible, even with no session. -->
+                    <!-- WHICH Director this is: its own name, plus a Copy that hands another
+                         agent the command to open a session on it. This identifies the WHOLE
+                         application's Director, so it belongs on the app-wide toolbar, not in
+                         the per-session blue header. Always visible, even with no session.
+                         (It showed the machine name and Control API port until nothing reached
+                         a Director by port any more, and one machine ran several Directors.) -->
                     <StackPanel x:Name="DirectorInfoPanel" Orientation="Horizontal"
                                 VerticalAlignment="Center" Margin="0,0,4,0">
                         <TextBlock x:Name="DirectorInfoText"
@@ -99,7 +101,7 @@
                                 Foreground="White"
                                 BorderThickness="0"
                                 Cursor="Hand"
-                                ToolTip.Tip="Copy Control API URL so other agents can reach this Director" />
+                                ToolTip.Tip="Copy this Director's name, id, and machine - paste it to an agent so it can reach this Director" />
                     </StackPanel>
 
                     <Border Width="1" Height="18" Background="#3C3C3C"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -582,69 +582,49 @@ public partial class MainWindow : Window
         return dialog.WantsNewSession;
     }
 
-    private global::Avalonia.Threading.DispatcherTimer? _directorInfoTimer;
-
     private void InitDirectorInfo()
     {
         FileLog.Write("[MainWindow] InitDirectorInfo");
-        // The Director address lives on the always-visible app toolbar now, so it must
-        // resolve even though the Control API binds its port on a background task that may
-        // finish after the window loads. Set what we know now, then poll until the port is
-        // bound (it never changes once set), so the toolbar is never stuck on "...".
-        if (TrySetDirectorInfo())
-            return;
-
-        _directorInfoTimer = new global::Avalonia.Threading.DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(500),
-        };
-        _directorInfoTimer.Tick += (_, _) =>
-        {
-            if (TrySetDirectorInfo())
-            {
-                _directorInfoTimer?.Stop();
-                _directorInfoTimer = null;
-            }
-        };
-        _directorInfoTimer.Start();
+        // This Director's NAME, on the always-visible app toolbar - the one thing that tells this
+        // Director apart from the others on the same machine. It is known before the window opens
+        // (the instance is resolved in Program.Main), so there is nothing to wait for.
+        //
+        // It used to read "MACHINE:port" and poll until the Control API bound its port. Both are gone:
+        // the machine name cannot distinguish this Director from its neighbours, and nothing reaches a
+        // Director by port any more - the fleet goes through the Gateway.
+        DirectorInfoText.Text = DirectorHandle.Label(InstanceContext.DisplayName, Environment.MachineName);
     }
 
     /// <summary>
-    /// Sets the toolbar Director address from the Control API port. Returns true once the
-    /// port is bound (a real value was written), false while it is still starting.
+    /// Puts this Director's identity on the clipboard - name, id, machine - so it can be pasted to
+    /// another agent, which is then told what to do with it.
+    ///
+    /// This button used to copy the Control API URL, from when reaching a Director meant dialling its
+    /// port directly. Nothing does that now, so what it copied could not be used for anything.
     /// </summary>
-    private bool TrySetDirectorInfo()
-    {
-        var app = global::Avalonia.Application.Current as App;
-        var port = app?.ControlApiHost?.Port;
-        if (port is > 0)
-        {
-            DirectorInfoText.Text = $"{Environment.MachineName}:{port.Value}";
-            return true;
-        }
-        DirectorInfoText.Text = $"{Environment.MachineName}:...";
-        return false;
-    }
-
     private async void BtnCopyDirectorInfo_Click(object? sender, RoutedEventArgs e)
     {
         FileLog.Write("[MainWindow] BtnCopyDirectorInfo_Click");
         try
         {
             var app = global::Avalonia.Application.Current as App;
-            var port = app?.ControlApiHost?.Port;
-            if (port is null or 0)
+            var directorId = app?.ControlApiHost?.DirectorId;
+            if (string.IsNullOrWhiteSpace(directorId))
             {
-                ShowNotification("Control API not started yet.");
+                // No id yet means the Control API has not been constructed. The id is the whole point
+                // of the copy - handing over the other two lines without it identifies nothing.
+                ShowNotification("This Director has no id yet - it is still starting.");
                 return;
             }
-            var url = await Task.Run(() =>
-                TailscaleIdentity.ResolveAdvertisedControlApiEndpoint(port.Value));
+
+            var text = DirectorHandle.Identity(
+                InstanceContext.DisplayName, directorId, Environment.MachineName);
+
             var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
             if (clipboard == null) { ShowNotification("Clipboard unavailable."); return; }
-            await clipboard.SetTextAsync(url);
-            ShowNotification($"Copied: {url}");
-            FileLog.Write($"[MainWindow] BtnCopyDirectorInfo_Click: copied {url}");
+            await clipboard.SetTextAsync(text);
+            ShowNotification("Copied this Director's name, id, and machine.");
+            FileLog.Write($"[MainWindow] BtnCopyDirectorInfo_Click: copied identity of {directorId}");
             BtnCopyDirectorInfo.Content = "Copied!";
             await Task.Delay(1500);
             BtnCopyDirectorInfo.Content = "Copy";

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -11,6 +11,7 @@ using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Fleet;
 using CcDirector.Core.History;
+using CcDirector.Core.Instances;
 using CcDirector.Core.Network;
 using CcDirector.Core.Security;
 using CcDirector.Core.Sessions;
@@ -680,6 +681,129 @@ internal static class ControlEndpoints
             }
         });
 
+        // Resolve a named Director - id or display name - to exactly ONE registered Director, or to the
+        // failure to report. Used by POST /fleet/spawn before it chooses the local or the relay leg.
+        //
+        // The registry is the Gateway's, because it is the only list that contains anything but this
+        // process. A machine, when the caller gave one, NARROWS the match - it is how a display name that
+        // two machines happen to share is disambiguated, and it means a target naming this Director but a
+        // different machine is a contradiction that fails rather than quietly honoring one half of it.
+        async Task<(string? DirectorId, string? MachineName, IResult? Failure)> ResolveNamedDirectorAsync(
+            string named, string? machine, CancellationToken ct)
+        {
+            var machineIsThisOne = string.IsNullOrEmpty(machine)
+                || string.Equals(machine, "local", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+
+            // THIS DIRECTOR'S OWN ID NEEDS NO REGISTRY. An id is issued by the system and unique in the
+            // fleet, and id matching wins over display names everywhere, so a caller naming this exact id
+            // can only mean this process - which is holding the request and can say so first-hand.
+            //
+            // This is not the local-first shortcut the review removed. That one matched a NAME, which is
+            // free text a sibling can also hold, so answering it locally was a guess. An id cannot be
+            // held by a sibling. Consulting the Gateway for it would make a provably-correct local spawn
+            // depend on a healthy roster - failing during a Gateway outage, and during the ordinary lag
+            // before a just-started Director appears in the list, with "no Director is registered", which
+            // would be false: it is the one answering you.
+            if (DirectorHandle.MatchesId(named, directorId) && machineIsThisOne)
+            {
+                FileLog.Write($"[ControlEndpoints] ResolveNamedDirectorAsync: '{named}' is this Director's own id");
+                return (directorId, Environment.MachineName, null);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+            {
+                // With no Gateway there is no fleet: this process is the only Director it could possibly
+                // reach, so it is the only candidate - and being the only candidate, its display name
+                // cannot be ambiguous either. Anything else genuinely cannot be resolved from here, and
+                // says so. (An id naming this Director was already answered above.)
+                if (DirectorHandle.MatchesDisplayName(named, InstanceContext.DisplayName) && machineIsThisOne)
+                    return (directorId, Environment.MachineName, null);
+
+                FileLog.Write($"[ControlEndpoints] ResolveNamedDirectorAsync: '{named}' is not this Director and no Gateway is configured");
+                return (null, null, Results.Json(
+                    new { error = $"Cannot start a session on Director '{named}': no Gateway is configured on this Director, so it can see no Director but itself." },
+                    statusCode: StatusCodes.Status502BadGateway));
+            }
+
+            List<DirectorDto> known;
+            try
+            {
+                known = await gw.ListDirectorsAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                // An unreachable Gateway is NOT an unknown Director. Reporting it as one would send the
+                // caller looking for a name that is perfectly correct.
+                FileLog.Write($"[ControlEndpoints] ResolveNamedDirectorAsync FAILED: '{named}': {ex.Message}");
+                return (null, null, Results.Json(
+                    new { error = $"Cannot start a session on Director '{named}': the Gateway could not be reached to find out which Director that is. {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway));
+            }
+
+            var matches = DirectorHandle
+                .Pick(known, named, d => d.DirectorId, d => d.DisplayName)
+                .Where(d => string.IsNullOrEmpty(machine)
+                         || string.Equals(d.MachineName, machine, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var on = string.IsNullOrEmpty(machine) ? "" : $" on '{machine}'";
+
+            if (matches.Count == 0)
+            {
+                FileLog.Write($"[ControlEndpoints] ResolveNamedDirectorAsync: no Director '{named}'{on}");
+                return (null, null, Results.BadRequest(new
+                {
+                    error = $"no Director '{named}'{on} is registered. It is either not running or is named "
+                          + "something else - list what is registered with: cc-devthrottle director list",
+                }));
+            }
+
+            if (matches.Count > 1)
+            {
+                var listed = string.Join(", ", matches.Select(m => $"{m.DirectorId} ({m.MachineName})"));
+                FileLog.Write($"[ControlEndpoints] ResolveNamedDirectorAsync: '{named}'{on} is ambiguous: {listed}");
+                return (null, null, Results.BadRequest(new
+                {
+                    error = $"'{named}'{on} names {matches.Count} Directors ({listed}). Name one by its Director id.",
+                }));
+            }
+
+            return (matches[0].DirectorId, matches[0].MachineName, null);
+        }
+
+        // GET /fleet/directors - every Director this account has registered, on every machine. The list
+        // behind `cc-devthrottle director list`, and the one an agent reads to turn a Director name it was
+        // given into something it can spawn on.
+        //
+        // A Gateway relay with no local fallback, for the same reason /fleet/machines is one: this Director
+        // knows only itself, and answering a fleet-wide question with a list of one would read as "there is
+        // only one Director" rather than "I cannot see the others from here".
+        app.MapGet("/fleet/directors", async (CancellationToken ct) =>
+        {
+            FileLog.Write("[ControlEndpoints] GET /fleet/directors");
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+            {
+                FileLog.Write("[ControlEndpoints] GET /fleet/directors: no Gateway configured");
+                return Results.Json(new { error = "No Gateway is configured, so this Director cannot see the other Directors." },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+            try
+            {
+                var directors = await gw.ListDirectorsAsync(ct);
+                FileLog.Write($"[ControlEndpoints] GET /fleet/directors: {directors.Count} Directors");
+                return Results.Json(directors);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/directors relay FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot reach the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
         async Task<IResult> RelayMachineQueryAsync(string machine, string verb, HttpContext ctx, CancellationToken ct)
         {
             var gw = gatewayClientProvider?.Invoke();
@@ -920,12 +1044,18 @@ internal static class ControlEndpoints
             }
         });
 
-        // POST /fleet/spawn - "start a session on another computer". The body is a NewSessionRequest whose
-        // Machine field selects the target: empty / "local" / this Director's own machine name spawns
-        // LOCALLY (unchanged local behavior); any other machine name routes the spawn through the Gateway to
-        // a Director on that machine (first available, auto-launched if none is running). A remote spawn
-        // FAILS LOUD when no Gateway is configured or the machine is off / unreachable - it NEVER falls back
-        // to a local spawn.
+        // POST /fleet/spawn - "start a session on another computer, or on one particular Director". The body
+        // is a NewSessionRequest whose Machine and Director fields select the target:
+        //
+        //   Director set   -> ONE named Director (by id or display name). Naming THIS Director spawns
+        //                     locally; naming another routes to it through the Gateway, which pins the
+        //                     create to that Director and never substitutes another or launches one.
+        //   Machine only   -> empty / "local" / this machine spawns LOCALLY; any other machine name routes
+        //                     through the Gateway to a Director on that machine (first available,
+        //                     auto-launched if none is running).
+        //
+        // A remote spawn FAILS LOUD when no Gateway is configured or the target is off / unreachable - it
+        // NEVER falls back to a local spawn.
         app.MapPost("/fleet/spawn", async (NewSessionRequest req, CancellationToken ct) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
@@ -942,9 +1072,52 @@ internal static class ControlEndpoints
                 req.OriginSurface = SessionOriginSurfaces.Cli;
 
             var machine = req.Machine?.Trim();
-            var isLocal = string.IsNullOrEmpty(machine)
-                || string.Equals(machine, "local", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+            var named = req.Director?.Trim();
+
+            bool isLocal;
+            // The id we expect the session to land on, once a named target has been RESOLVED. Null for an
+            // ordinary machine spawn, which names no Director and therefore has nothing to check.
+            string? expectedDirectorId = null;
+
+            if (string.IsNullOrEmpty(named))
+            {
+                isLocal = string.IsNullOrEmpty(machine)
+                    || string.Equals(machine, "local", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                // A NAMED target is RESOLVED AGAINST THE FLEET BEFORE the local leg is chosen - never by
+                // asking "is that name mine?" first.
+                //
+                // Deciding locally first looks equivalent and is not: display names are unrestricted text,
+                // so this Director and a remote one can BOTH be called "Build box". A local-first check
+                // claims that name, spawns here, and reports success - the caller is never told there were
+                // two, and `--machine REMOTE` would not save them either, because a local-first branch has
+                // no reason to look at the machine. Silently landing on the wrong Director is the exact
+                // failure this whole feature exists to prevent, so the fleet decides and the local leg is
+                // just "the resolved Director happens to be me".
+                var resolved = await ResolveNamedDirectorAsync(named, machine, ct);
+                if (resolved.Failure is not null)
+                    return resolved.Failure;
+
+                expectedDirectorId = resolved.DirectorId;
+                machine = resolved.MachineName;
+                isLocal = string.Equals(expectedDirectorId, directorId, StringComparison.OrdinalIgnoreCase);
+
+                // PIN THE RELAY TO THE RESOLVED ID, not the name the caller typed. The Gateway resolves
+                // this field again on its side, so relaying a display name means the name is resolved
+                // TWICE, against two reads of the registry taken at different moments - and a name is
+                // not a stable handle. If the Director holding it disconnects between the two reads and
+                // a sibling on the same machine carries the same name, the second resolve legitimately
+                // finds the sibling and the session opens there. Substituting the id makes the second
+                // resolve an exact identity match on the Director this one chose, so the two cannot
+                // disagree, and it is the same value the post-relay check compares against.
+                req.Director = expectedDirectorId;
+
+                FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: director '{named}' resolved to " +
+                              $"{expectedDirectorId} on machine={machine} (local={isLocal})");
+            }
 
             if (isLocal)
             {
@@ -1079,6 +1252,55 @@ internal static class ControlEndpoints
             try
             {
                 var dto = await gw.SpawnOnMachineAsync(machine!, req, ct);
+
+                // A Gateway that predates Director targeting IGNORES req.Director and hands the create to
+                // the machine's FIRST Director. That is the exact failure this feature exists to prevent,
+                // and it is invisible from here: the reply is an ordinary 201 with a session id. So check
+                // it. The reply says which Director took the session, and the caller named one - when they
+                // disagree, say so instead of reporting a success that went somewhere else.
+                //
+                // A BLANK returned id fails the check too, and that is the important half. SessionDto's
+                // DirectorId defaults to empty, so "no id" is a shape an older or partial Gateway really
+                // does return - and skipping the check on it would fail OPEN in precisely the case the
+                // check exists for: an old Gateway, which is the one least likely to fill the field in.
+                // Silence is not evidence of correct placement.
+                //
+                // The session IS running, so this reports rather than pretending it is not: rolling that
+                // back would mean killing a session on a Director the caller did not choose, on the word
+                // of one field. Naming what came back is what lets them decide.
+                if (expectedDirectorId is not null
+                    && !string.Equals(dto.DirectorId, expectedDirectorId, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Two different reports, because the response proves two different things. A
+                    // DIFFERENT id is proof the session went elsewhere. A MISSING id proves only that
+                    // placement cannot be confirmed - a Gateway may honor the target and still omit the
+                    // field - so saying "it is too old and picked the machine's first one" would state a
+                    // cause that was never observed, and could send the caller to close a session that
+                    // is exactly where they asked for it.
+                    var mismatched = !string.IsNullOrWhiteSpace(dto.DirectorId);
+                    var error = mismatched
+                        ? $"Session {dto.SessionId} was started, but NOT on Director '{named}' "
+                          + $"({expectedDirectorId}) - it landed on {dto.DirectorId}. The Gateway does not "
+                          + "honor a named Director and picked the machine's first one. Update the Gateway, "
+                          + "or close that session and start it from the Director you want."
+                        : $"Session {dto.SessionId} was started, but it CANNOT BE CONFIRMED to be on "
+                          + $"Director '{named}' ({expectedDirectorId}): the Gateway did not say which "
+                          + "Director took it. It may be correctly placed - an older Gateway both ignores "
+                          + "the target and omits this field, so check where the session actually opened "
+                          + "before closing it.";
+
+                    FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: asked for Director '{named}' " +
+                                  $"({expectedDirectorId}); Gateway returned " +
+                                  (mismatched ? $"a different Director {dto.DirectorId}" : "no Director id"));
+
+                    return Results.Json(new
+                    {
+                        error,
+                        sessionId = dto.SessionId,
+                        directorId = dto.DirectorId,
+                    }, statusCode: StatusCodes.Status502BadGateway);
+                }
+
                 return Results.Json(dto, statusCode: StatusCodes.Status201Created);
             }
             catch (Exception ex)

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -400,6 +400,39 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Every Director this tenant has registered (GET /directors), across all its machines - the list a
+    /// caller needs to turn a Director NAME into the machine it runs on, and the list behind
+    /// <c>cc-devthrottle director list</c>. One machine may appear several times: each named instance
+    /// registers its own Director.
+    /// </summary>
+    public async Task<List<DirectorDto>> ListDirectorsAsync(CancellationToken ct = default)
+    {
+        FileLog.Write("[GatewayClient] ListDirectorsAsync: GET /directors");
+        if (!_config.IsEnabled)
+        {
+            // Logged BEFORE the guard rather than after it: a method that throws before its own entry
+            // line leaves no trace it was ever called, which is the case a reader most needs to see.
+            FileLog.Write("[GatewayClient] ListDirectorsAsync FAILED: no Gateway is configured");
+            throw new InvalidOperationException("Gateway is not configured; cannot list Directors.");
+        }
+        try
+        {
+            using var resp = await _http.GetAsync("directors", ct);
+            if (!resp.IsSuccessStatusCode)
+                throw await RelayFailureAsync(resp, "GET /directors", ct);
+            var list = await resp.Content.ReadFromJsonAsync<List<DirectorDto>>(ct)
+                       ?? throw new InvalidOperationException("Gateway GET /directors returned an unparsable body.");
+            FileLog.Write($"[GatewayClient] ListDirectorsAsync: {list.Count} Directors");
+            return list;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayClient] ListDirectorsAsync FAILED: {ex.Message}");
+            throw;
+        }
+    }
+
+    /// <summary>
     /// The launchers this tenant has registered (GET /launchers) - the list of machines it can search and
     /// start things on. NULL on 404, which on this route means a Gateway that still has the launcher family
     /// denied rather than one that never had it.

--- a/src/CcDirector.Core.Tests/Instances/DirectorHandleTests.cs
+++ b/src/CcDirector.Core.Tests/Instances/DirectorHandleTests.cs
@@ -1,0 +1,159 @@
+using CcDirector.Core.Instances;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Instances;
+
+/// <summary>
+/// Tests for <see cref="DirectorHandle"/> - the shared rule for what NAMES a Director, used by the
+/// toolbar that hands a handle out, the Director floor that decides whether a named target is itself,
+/// and (in the same shape) the Gateway resolve that finds it in the registry.
+///
+/// The test that matters most is the round trip: the Copy button's text has to carry a handle the
+/// matcher accepts. If those two drift the paste fails on the FAR side of the fleet, in someone else's
+/// session, where whoever pressed Copy will never see it.
+/// </summary>
+public sealed class DirectorHandleTests
+{
+    private const string Id = "6f0a2b41-1c33-4f9e-9a10-2b7d5e8c1234";
+
+    private const string OtherId = "11111111-2222-3333-4444-555555555555";
+
+    private sealed record Dir(string DirectorId, string DisplayName);
+
+    private static List<Dir> Pick(string? token, params Dir[] fleet)
+        => DirectorHandle.Pick(fleet, token, d => d.DirectorId, d => d.DisplayName);
+
+    [Fact]
+    public void MatchesId_isCaseInsensitive_andIgnoresSurroundingSpace()
+    {
+        Assert.True(DirectorHandle.MatchesId(Id.ToUpperInvariant(), Id));
+        Assert.True(DirectorHandle.MatchesId($"  {Id}  ", Id));
+        Assert.False(DirectorHandle.MatchesId(OtherId, Id));
+    }
+
+    [Fact]
+    public void MatchesDisplayName_isCaseInsensitive()
+    {
+        Assert.True(DirectorHandle.MatchesDisplayName("north BUILD", "North build"));
+        Assert.False(DirectorHandle.MatchesDisplayName("North daily", "North build"));
+    }
+
+    // A blank token is the ABSENCE of a target, not a wildcard. Were it a match, every ordinary spawn -
+    // which names no Director at all - would be claimed by whichever Director asked itself first, and
+    // --machine routing would quietly stop working.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankToken_namesNothing(string? token)
+    {
+        Assert.False(DirectorHandle.MatchesId(token, Id));
+        Assert.False(DirectorHandle.MatchesDisplayName(token, "North build"));
+        Assert.Empty(Pick(token, new Dir(Id, "North build")));
+    }
+
+    // An instance with no display name must not match on its empty name, or EVERY unnamed Director in
+    // the fleet would answer to the same blank handle.
+    [Fact]
+    public void DoesNotMatchAnEmptyDisplayName()
+        => Assert.False(DirectorHandle.MatchesDisplayName("   x   ", displayName: ""));
+
+    [Fact]
+    public void Pick_findsByIdAndByDisplayName()
+    {
+        var fleet = new[] { new Dir(Id, "North build"), new Dir(OtherId, "North daily") };
+
+        Assert.Equal(Id, Pick(Id, fleet).Single().DirectorId);
+        Assert.Equal(OtherId, Pick("north DAILY", fleet).Single().DirectorId);
+        Assert.Empty(Pick("North experiments", fleet));
+    }
+
+    [Fact]
+    public void Pick_returnsEveryDirectorSharingADisplayName_soTheCallerCanRefuse()
+        => Assert.Equal(2, Pick("Build box", new Dir(Id, "Build box"), new Dir(OtherId, "Build box")).Count);
+
+    // ID PRECEDENCE. A display name is free text, so one Director can be named the literal id of
+    // another - by accident or to hijack it. With equal-rank matching, a request carrying A's id comes
+    // back ambiguous (or resolves to B), which destroys the one guarantee the id exists to give: that
+    // it cannot collide. An exact id match must win outright, with display names never consulted.
+    [Fact]
+    public void Pick_anIdMatchWins_evenWhenAnotherDirectorIsNamedThatId()
+    {
+        var impostor = new Dir(OtherId, Id);          // B's display name IS A's id
+        var owner = new Dir(Id, "North build");
+
+        var picked = Pick(Id, impostor, owner);       // the impostor is listed FIRST
+
+        Assert.Equal(Id, Assert.Single(picked).DirectorId);
+    }
+
+    [Fact]
+    public void Label_prefersTheDisplayName()
+        => Assert.Equal("North build", DirectorHandle.Label("North build", "SOREN_NORTH"));
+
+    [Fact]
+    public void Label_fallsBackToTheMachineName_whenTheInstanceIsUnnamed()
+    {
+        Assert.Equal("SOREN_NORTH", DirectorHandle.Label(null, "SOREN_NORTH"));
+        Assert.Equal("SOREN_NORTH", DirectorHandle.Label("   ", "SOREN_NORTH"));
+    }
+
+    [Fact]
+    public void Label_neverRendersBlank()
+        => Assert.False(string.IsNullOrWhiteSpace(DirectorHandle.Label(null, null)));
+
+    // The Control API port is gone from the label on purpose (nothing dials a Director by port). A test
+    // rather than a comment, because the old format is the thing a future edit would restore by reflex.
+    [Fact]
+    public void Label_carriesNoPortNumber()
+        => Assert.DoesNotContain(":", DirectorHandle.Label("North build", "SOREN_NORTH"));
+
+    [Fact]
+    public void Identity_statesTheName_theId_andTheMachine()
+    {
+        var text = DirectorHandle.Identity("North build", Id, "SOREN_NORTH");
+
+        Assert.Equal(
+            "Director: North build\n"
+          + $"Director ID: {Id}\n"
+          + "Machine: SOREN_NORTH", text);
+    }
+
+    // THE ROUND TRIP. The id in the clipboard text must be one the matcher accepts - being pasted
+    // somewhere that resolves it is the only thing this text is for. A copy that hands out an id the
+    // resolver rejects fails on the FAR side of the fleet, in someone else's session.
+    [Fact]
+    public void Identity_carriesAnIdThatMatchesBack()
+    {
+        var text = DirectorHandle.Identity("North build", Id, "SOREN_NORTH");
+
+        var line = text.Split('\n').Single(l => l.StartsWith("Director ID:", StringComparison.Ordinal));
+        var handed = line["Director ID:".Length..].Trim();
+
+        Assert.Equal(Id, Pick(handed, new Dir(Id, "North build")).Single().DirectorId);
+    }
+
+    // It states facts and stops. What to DO with this Director is the pasting person's instruction, and
+    // a command baked in here could not be run as pasted anyway - the Director cannot know which
+    // repository is meant.
+    [Fact]
+    public void Identity_isNotACommand()
+    {
+        var text = DirectorHandle.Identity("North build", Id, "SOREN_NORTH");
+
+        Assert.DoesNotContain("cc-devthrottle", text);
+        Assert.DoesNotContain("--director", text);
+        Assert.Equal(3, text.Split('\n').Length);
+    }
+
+    // An unnamed instance still identifies itself: the label falls back to the machine, and the id -
+    // the line that actually addresses it - is unaffected either way.
+    [Fact]
+    public void Identity_worksForAnUnnamedInstance()
+    {
+        var text = DirectorHandle.Identity(null, Id, "SOREN_NORTH");
+
+        Assert.Contains("Director: SOREN_NORTH", text);
+        Assert.Contains($"Director ID: {Id}", text);
+    }
+}

--- a/src/CcDirector.Core/Instances/DirectorHandle.cs
+++ b/src/CcDirector.Core/Instances/DirectorHandle.cs
@@ -1,0 +1,118 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Instances;
+
+/// <summary>
+/// How a Director is NAMED - the one place that decides which handles identify a Director, what the
+/// toolbar shows, and what its Copy button puts on the clipboard.
+///
+/// One machine runs several named Director instances, so the machine name cannot identify one: it says
+/// which computer, not which Director. Two handles do, and they are the two a caller can actually be
+/// given - the Director id (immutable, unambiguous, survives a rename and a restart) and the display
+/// name (editable, the label the owner reads in the menu and the Fleet Map).
+///
+/// WHY ONE CLASS AND NOT THREE. The toolbar's Copy button hands another agent a spawn command, the
+/// Director floor decides whether a named target is ITSELF, and the Gateway resolves the same name
+/// against its registry. Those three have to agree on what a handle is: if the button emits a handle
+/// the resolver does not accept, the paste fails on the far side, where nobody is watching. They agree
+/// here or they drift.
+///
+/// The Gateway's own resolve (<c>RegistryDirectorTargetResolver</c>) matches the same two fields
+/// against its registry rows, which is the same rule applied to rows this process cannot see.
+/// </summary>
+public static class DirectorHandle
+{
+    /// <summary>
+    /// Does <paramref name="token"/> match this Director's ID? Case-insensitive; a blank token matches
+    /// nothing (it is the ABSENCE of a target, and treating it as a match would silently claim every
+    /// untargeted spawn).
+    /// </summary>
+    public static bool MatchesId(string? token, string? directorId)
+        => token?.Trim() is { Length: > 0 } wanted && Same(wanted, directorId);
+
+    /// <summary>
+    /// Does <paramref name="token"/> match this Director's DISPLAY NAME? Same blank rule. Callers must
+    /// not use this without first ruling out an id match - see <see cref="Pick{T}"/> for why.
+    /// </summary>
+    public static bool MatchesDisplayName(string? token, string? displayName)
+        => token?.Trim() is { Length: > 0 } wanted && Same(wanted, displayName);
+
+    /// <summary>
+    /// The Directors that <paramref name="token"/> names, with ID PRECEDENCE: if any candidate's id
+    /// matches exactly, that is the answer and display names are never consulted. Only when no id
+    /// matches does the token fall through to display names, which may legitimately return several.
+    ///
+    /// WHY PRECEDENCE, NOT "EITHER". A display name is unrestricted text the owner types, so one
+    /// Director can be named the literal id of another - by accident or on purpose. Matching both at
+    /// equal rank then breaks the one guarantee the id exists to provide: a request carrying A's id
+    /// would come back ambiguous, or resolve to B. An id is issued by the system and unique in the
+    /// fleet; a name is not, so the id decides first and alone.
+    ///
+    /// Returns every match so the caller can tell "none" from "several" and report each loudly - this
+    /// deliberately does not pick one, because picking among genuine duplicates is the guess that lands
+    /// a session on a Director nobody chose.
+    /// </summary>
+    public static List<T> Pick<T>(IEnumerable<T> candidates, string? token,
+        Func<T, string?> idOf, Func<T, string?> displayNameOf)
+    {
+        var all = candidates.ToList();
+        var byId = all.Where(c => MatchesId(token, idOf(c))).ToList();
+        var picked = byId.Count > 0
+            ? byId
+            : all.Where(c => MatchesDisplayName(token, displayNameOf(c))).ToList();
+
+        // The one method here that DECIDES something, so the one that is logged: which token was
+        // resolved, against how many candidates, to how many matches, and on which handle. That is
+        // exactly what a reader needs when a spawn lands somewhere unexpected. The four methods above
+        // are pure predicates and formatters with no failure mode of their own - logging each call
+        // would bury this line under one entry per candidate per resolve and tell a reader nothing the
+        // outcome here does not already say.
+        FileLog.Write($"[DirectorHandle] Pick: token='{token}', candidates={all.Count}, " +
+                      $"matched={picked.Count} by {(byId.Count > 0 ? "id" : "display name")}");
+        return picked;
+    }
+
+    /// <summary>
+    /// What the toolbar shows: the Director's own name. Falls back to the machine name when the
+    /// instance has no display name, because a blank label identifies nothing at all - and never to
+    /// the id, which no owner recognises on sight.
+    ///
+    /// The Control API PORT was here for years and is deliberately gone: it was the address another
+    /// agent dialled, nothing dials a Director by port any more (the fleet is reached through the
+    /// Gateway), and a number nobody uses reads as identity while telling you nothing about which of
+    /// this machine's Directors you are looking at.
+    /// </summary>
+    public static string Label(string? displayName, string? machineName)
+    {
+        var name = displayName?.Trim();
+        if (!string.IsNullOrEmpty(name))
+            return name;
+
+        var machine = machineName?.Trim();
+        return string.IsNullOrEmpty(machine) ? "Director" : machine;
+    }
+
+    /// <summary>
+    /// The clipboard text: WHO this Director is, so another agent can be told to reach it. Three
+    /// labelled facts and nothing else - the name a person reads, the id anything addressing it should
+    /// carry, and the machine it runs on.
+    ///
+    /// DELIBERATELY NOT A COMMAND. What the recipient should DO with this Director is the pasting
+    /// person's instruction, not ours: they may want a session opened, a question asked, or nothing at
+    /// all. A command baked in here would also have to invent the one thing this Director cannot know -
+    /// which repository is meant - so it could never be run as pasted anyway. The same shape as the
+    /// per-session copy, which likewise states facts and leaves the instruction to the human.
+    /// </summary>
+    public static string Identity(string? displayName, string? directorId, string? machineName)
+    {
+        var machine = machineName?.Trim();
+
+        return $"Director: {Label(displayName, machineName)}\n"
+             + $"Director ID: {directorId?.Trim() ?? ""}\n"
+             + $"Machine: {(string.IsNullOrEmpty(machine) ? "(unknown)" : machine)}";
+    }
+
+    private static bool Same(string wanted, string? candidate)
+        => !string.IsNullOrWhiteSpace(candidate)
+           && string.Equals(wanted, candidate.Trim(), StringComparison.OrdinalIgnoreCase);
+}

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -203,6 +203,32 @@ public sealed class NewSessionRequest
     public string? Machine { get; set; }
 
     /// <summary>
+    /// Optional target DIRECTOR for spawn routing - "start a session on THAT Director, not merely on
+    /// that computer". One machine runs several named Director instances, so <see cref="Machine"/>
+    /// alone cannot say which one: it resolves to the first available Director on the machine. This
+    /// field names ONE - by its Director id or its display name, matched case-insensitively, with the
+    /// ID WINNING outright when it matches - and the resolve is pinned to it.
+    ///
+    /// Those two handles and no others. The instance SLUG (the <c>--instance</c> value) is deliberately
+    /// not accepted: it is not carried on <see cref="DirectorDto"/>, so the Gateway could not resolve
+    /// it, and a handle that worked only when the target happened to be the local Director would fail
+    /// on the far side of the fleet for reasons the caller could not see.
+    ///
+    /// FAIL LOUD, NEVER SUBSTITUTE. A named Director that is not registered is an error naming it; a
+    /// name that matches two Directors is an error listing both. Neither falls back to another
+    /// Director, and neither auto-launches one: the caller asked for a specific Director, and quietly
+    /// starting a session somewhere else is exactly the wrong answer.
+    ///
+    /// <see cref="Machine"/>, when both are given, NARROWS the match rather than being overridden by
+    /// it. That is how a display name two machines happen to share is disambiguated - and it means a
+    /// Director named alongside a machine it does not run on is a contradiction that fails, rather
+    /// than one half of the caller's instruction being honored silently.
+    ///
+    /// Null or empty leaves machine routing exactly as it was.
+    /// </summary>
+    public string? Director { get; set; }
+
+    /// <summary>
     /// Scheduled-run auto-dismiss (issue #1200). When true, this session is an AUTOMATED run that should
     /// close ITSELF once it finishes with nothing that needs a human: the agent ends its run by emitting a
     /// <c>CC-DISMISS</c> verdict block (see <c>Session.DismissVerdict</c>), and on <c>done</c> the Gateway

--- a/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
+++ b/src/CcDirector.Gateway.Tests/CronWorkListTriggerTests.cs
@@ -162,7 +162,7 @@ public sealed class CronWorkListTriggerTests : IDisposable
     {
         private readonly string? _directorId;
         public FakeResolver(string? directorId) { _directorId = directorId; }
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct) =>
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct) =>
             Task.FromResult(string.IsNullOrEmpty(_directorId)
                 ? new DirectorTargetResult(null, "no director on machine")
                 : new DirectorTargetResult(_directorId, null));

--- a/src/CcDirector.Gateway.Tests/DirectorCronSessionStarterTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorCronSessionStarterTests.cs
@@ -19,7 +19,7 @@ public sealed class DirectorCronSessionStarterTests
     {
         private readonly DirectorTargetResult _result;
         public StubResolver(DirectorTargetResult result) => _result = result;
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct) =>
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct) =>
             Task.FromResult(_result);
     }
 

--- a/src/CcDirector.Gateway.Tests/FleetSpawnNamedDirectorTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSpawnNamedDirectorTests.cs
@@ -1,0 +1,382 @@
+using System.Net;
+using System.Net.Http.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Director floor's routing decision for <c>POST /fleet/spawn</c> when the caller names ONE
+/// Director (<c>session spawn --director</c>): is it me, and if not, where does it run?
+///
+/// Driven through the REAL endpoint against a Kestrel stub standing in for the Gateway, because the
+/// decision is made in the endpoint and nowhere else - a test of the pieces would stay green while the
+/// route dropped the field, resolved the wrong Director, or reported a spawn that landed elsewhere.
+///
+/// The stub's Director list deliberately holds TWO Directors on ONE machine, which is the case the
+/// machine name cannot answer and this feature exists for.
+/// </summary>
+public sealed class FleetSpawnNamedDirectorTests
+{
+    private const string LocalDirectorId = "11111111-1111-1111-1111-111111111111";
+    private const string OtherDirectorId = "22222222-2222-2222-2222-222222222222";
+    private const string FirstOnMachineId = "33333333-3333-3333-3333-333333333333";
+
+    /// <summary>
+    /// The machine the tests treat as REMOTE. Derived from this host's own name rather than written as
+    /// a literal, because a literal is only remote until somebody's machine is called that - and then
+    /// the endpoint takes its LOCAL branch, never calls the stub, and the test fails for a reason that
+    /// has nothing to do with the code. (A literal "SOREN_NORTH" did exactly that on this repository's
+    /// own test host.)
+    /// </summary>
+    private static readonly string RemoteMachine = Environment.MachineName + "-REMOTE";
+
+    /// <summary>The machine the local Director reports as its own - what the endpoint compares against.</summary>
+    private static readonly string LocalMachine = Environment.MachineName;
+
+    private sealed class GatewayStub
+    {
+        public NewSessionRequest? SpawnBody { get; set; }
+        public string? SpawnMachine { get; set; }
+        /// <summary>The Director the stub claims took the session - how an OLD Gateway that ignored the
+        /// named target is simulated: it answers with a different Director than the one asked for.</summary>
+        public string LandsOn { get; set; } = OtherDirectorId;
+        /// <summary>Extra rows spliced into the Director list, for the duplicate-name cases.</summary>
+        public List<DirectorDto> Extra { get; } = new();
+        /// <summary>Make the Director list answer 500 - a Gateway that is present but cannot be read,
+        /// which is how an outage and a not-yet-registered Director look from the floor.</summary>
+        public bool DirectorsFail { get; set; }
+    }
+
+    private static async Task<(WebApplication app, string url, GatewayStub stub)> StartGatewayStubAsync()
+    {
+        var stub = new GatewayStub();
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+        var app = builder.Build();
+
+        app.MapGet("/directors", () => stub.DirectorsFail
+            ? Results.Json(new { error = "roster unavailable" }, statusCode: 500)
+            : Results.Json(new List<DirectorDto>
+        {
+            // First on the remote machine, and NOT the one the tests name: a resolve that ignored the
+            // name would land here, which is what makes these assertions meaningful rather than
+            // order-lucky.
+            new() { DirectorId = FirstOnMachineId, MachineName = RemoteMachine, DisplayName = "North daily" },
+            new() { DirectorId = OtherDirectorId, MachineName = RemoteMachine, DisplayName = "North build" },
+            new() { DirectorId = LocalDirectorId, MachineName = LocalMachine, DisplayName = "This one" },
+        }.Concat(stub.Extra)));
+
+        app.MapPost("/machines/{machine}/sessions", (string machine, NewSessionRequest body) =>
+        {
+            stub.SpawnMachine = machine;
+            stub.SpawnBody = body;
+            return Results.Json(new SessionDto
+            {
+                SessionId = Guid.NewGuid().ToString(),
+                DirectorId = stub.LandsOn,
+                MachineName = machine,
+            }, statusCode: 201);
+        });
+
+        await app.StartAsync();
+        return (app, app.Urls.First(), stub);
+    }
+
+    private static async Task<(WebApplication app, HttpClient http, SessionManager sm)> StartDirectorAsync(
+        GatewayClient gateway)
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+        var app = builder.Build();
+        ControlEndpoints.Map(app, sm, LocalDirectorId, "1.0.0-test", () => Task.CompletedTask,
+            gatewayClientProvider: () => gateway);
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) }, sm);
+    }
+
+    private static async Task<(HttpResponseMessage resp, GatewayStub stub)> SpawnAsync(
+        object body, Action<GatewayStub>? arrange = null)
+    {
+        var (gwApp, url, stub) = await StartGatewayStubAsync();
+        await using var _ = gwApp;
+        arrange?.Invoke(stub);
+        using var gateway = new GatewayClient(new GatewayConfig { Url = url }, LocalDirectorId, 7879, "1.0.0");
+        var (director, http, sm) = await StartDirectorAsync(gateway);
+        await using var __ = director;
+        using var ___ = http;
+        using var ____ = sm;
+
+        var resp = await http.PostAsJsonAsync("/fleet/spawn", body);
+        // Read the body before the stub is disposed - the caller asserts on it.
+        await resp.Content.LoadIntoBufferAsync();
+        return (resp, stub);
+    }
+
+    // Naming THIS Director keeps the spawn local: it is resolved against the fleet, comes back as this
+    // Director, and is never relayed. The stub records no spawn - the assertion that separates "handled
+    // here" from "went out and came back".
+    //
+    // This is the plain good path and is NOT by itself a proof of the new flag - a request naming this
+    // machine takes the local branch on origin/main too. The proofs that distinguish new from old are
+    // the contradiction, duplicate-name and hijack tests below.
+    [Fact]
+    public async Task NamingThisDirectorById_spawnsLocally()
+    {
+        var (resp, stub) = await SpawnAsync(new
+        {
+            repoPath = @"C:\definitely\not\a\repo",
+            machine = LocalMachine,
+            director = LocalDirectorId,
+        });
+
+        Assert.Null(stub.SpawnBody);
+        // The repo path is bogus, so the LOCAL create is what rejects it - proof it took the local leg
+        // rather than being relayed. A relay would have returned the stub's 201.
+        Assert.NotEqual(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    // A Director must be able to answer for its OWN id with no working Gateway. The id is issued by the
+    // system and unique, so this process can prove the target is itself - and making that depend on a
+    // healthy roster would fail a provably-correct local spawn during a Gateway outage, or during the
+    // ordinary lag before a just-started Director appears in the list, with "no Director is registered".
+    // That message would be false: it is the Director answering the call.
+    [Fact]
+    public async Task ItsOwnId_resolvesWithoutTheGateway_evenWhenTheRosterCannotBeRead()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\definitely\not\a\repo", director = LocalDirectorId },
+            s => s.DirectorsFail = true);          // the roster call answers 500
+
+        Assert.Null(stub.SpawnBody);
+        Assert.NotEqual(HttpStatusCode.Created, resp.StatusCode);
+        // Rejected by the LOCAL create for the bogus path, not by a roster failure.
+        Assert.DoesNotContain("Gateway", await resp.Content.ReadAsStringAsync());
+    }
+
+    // The same outage, with a DISPLAY NAME. This one cannot be answered locally: a sibling Director may
+    // hold the same name, and only the roster can say. It must fail loudly rather than assume.
+    [Fact]
+    public async Task ADisplayName_cannotBeResolvedWhenTheRosterCannotBeRead()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\repo", director = "This one" },
+            s => s.DirectorsFail = true);
+
+        Assert.NotEqual(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Null(stub.SpawnBody);
+    }
+
+    // A named Director and a machine that CONTRADICT each other. The id identifies a Director that runs
+    // here; the machine field says somewhere else. Honoring either half silently would put the session
+    // somewhere the caller did not fully ask for, so the machine narrows the match to nothing and it
+    // fails - the same rule the Gateway resolver applies.
+    [Fact]
+    public async Task NamingThisDirector_withAMachineItDoesNotRunOn_failsRatherThanPickingAHalf()
+    {
+        var (resp, stub) = await SpawnAsync(new
+        {
+            repoPath = @"C:\repo",
+            machine = RemoteMachine,
+            director = LocalDirectorId,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Null(stub.SpawnBody);
+    }
+
+    // THE DUPLICATE-NAME TRAP. This Director and a remote one are BOTH called "Build box". Deciding
+    // locally first - "is that name mine? yes" - claims the name, spawns here, and reports success,
+    // and the caller is never told there were two. The name must be resolved against the fleet, which
+    // sees both and refuses.
+    [Fact]
+    public async Task ADisplayNameSharedWithThisDirector_isAmbiguous_notQuietlyLocal()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\definitely\not\a\repo", director = "Build box" },
+            s =>
+            {
+                s.Extra.Add(new DirectorDto
+                {
+                    DirectorId = LocalDirectorId, MachineName = LocalMachine, DisplayName = "Build box",
+                });
+                s.Extra.Add(new DirectorDto
+                {
+                    DirectorId = OtherDirectorId, MachineName = RemoteMachine, DisplayName = "Build box",
+                });
+            });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains(LocalDirectorId, body);
+        Assert.Contains(OtherDirectorId, body);
+        Assert.Null(stub.SpawnBody);
+    }
+
+    // The same duplicate name, with --machine naming the REMOTE one. A local-first decision ignores the
+    // machine entirely and still spawns here; resolving against the fleet narrows to the remote row and
+    // relays there.
+    [Fact]
+    public async Task ADuplicateDisplayName_isDisambiguatedByTheMachine_andRelays()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\repo", machine = RemoteMachine, director = "Build box" },
+            s =>
+            {
+                s.Extra.Add(new DirectorDto
+                {
+                    DirectorId = LocalDirectorId, MachineName = LocalMachine, DisplayName = "Build box",
+                });
+                s.Extra.Add(new DirectorDto
+                {
+                    DirectorId = OtherDirectorId, MachineName = RemoteMachine, DisplayName = "Build box",
+                });
+                s.LandsOn = OtherDirectorId;
+            });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Equal(RemoteMachine, stub.SpawnMachine);
+        // And the relay carries the id of the remote twin, so the Gateway's own resolve cannot pick the
+        // local one that shares the name.
+        Assert.Equal(OtherDirectorId, stub.SpawnBody!.Director);
+    }
+
+    // ID PRECEDENCE at the endpoint, framed so equal-precedence matching gets it WRONG. One remote
+    // Director's DISPLAY NAME is set to ANOTHER remote Director's id - free text, so nothing stops it.
+    // Naming that id must resolve to its owner and relay there. Matching ids and names at equal rank
+    // would find two candidates and refuse a request that is perfectly unambiguous, which is the
+    // guarantee the id exists to provide.
+    //
+    // Both candidates are REMOTE on purpose: a local one would be answered by the own-id shortcut and
+    // the precedence rule would never be exercised.
+    [Fact]
+    public async Task AnIdResolvesToItsOwner_evenWhenAnotherDirectorIsNamedThatId()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\repo", director = OtherDirectorId },
+            s =>
+            {
+                s.Extra.Add(new DirectorDto
+                {
+                    // The impostor: its display name IS the id being asked for.
+                    DirectorId = "44444444-4444-4444-4444-444444444444",
+                    MachineName = RemoteMachine,
+                    DisplayName = OtherDirectorId,
+                });
+                s.LandsOn = OtherDirectorId;
+            });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Equal(OtherDirectorId, stub.SpawnBody!.Director);   // pinned to the owner, not the impostor
+    }
+
+    // Naming ANOTHER Director with no machine: the floor asks the Gateway which machine it runs on and
+    // relays there, carrying the RESOLVED ID rather than the display name the caller typed.
+    //
+    // Relaying the name would resolve it TWICE, against two reads of the registry taken moments apart,
+    // and a display name is not a stable handle: if the Director holding it drops out in between and a
+    // sibling on that machine carries the same name, the Gateway's own resolve legitimately finds the
+    // sibling and the session opens there. The id cannot move between Directors, so the second resolve
+    // can only agree with the first.
+    [Fact]
+    public async Task NamingAnotherDirector_relaysTheResolvedId_notTheDisplayName()
+    {
+        var (resp, stub) = await SpawnAsync(new
+        {
+            repoPath = @"C:\repo",
+            director = "North build",
+        });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Equal(RemoteMachine, stub.SpawnMachine);
+        Assert.NotNull(stub.SpawnBody);
+        Assert.Equal(OtherDirectorId, stub.SpawnBody!.Director);
+    }
+
+    [Fact]
+    public async Task NamingADirectorThatIsNotRegistered_failsLoud_andSpawnsNothing()
+    {
+        var (resp, stub) = await SpawnAsync(new
+        {
+            repoPath = @"C:\repo",
+            director = "North experiments",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("North experiments", await resp.Content.ReadAsStringAsync());
+        // The one that matters: no session was started anywhere, on any Director.
+        Assert.Null(stub.SpawnBody);
+    }
+
+    // THE SILENT FAILURE. A Gateway that predates Director targeting ignores the name and hands the
+    // create to the machine's first Director, answering with an ordinary 201. Without this check the
+    // caller is told the spawn succeeded and never learns it went somewhere else.
+    [Fact]
+    public async Task WhenTheGatewayIgnoresTheNamedDirector_theCallerIsTold_notReportedAsSuccess()
+    {
+        var (resp, _) = await SpawnAsync(
+            new { repoPath = @"C:\repo", director = "North build" },
+            stub => stub.LandsOn = FirstOnMachineId);   // an old Gateway: first on the machine
+
+        Assert.NotEqual(HttpStatusCode.Created, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("North build", body);
+        Assert.Contains(FirstOnMachineId, body);        // names where it actually landed
+    }
+
+    // THE SAME FAILURE, WEARING NOTHING. A Gateway that ignores the target may also return no Director
+    // id at all - the field defaults to empty on the contract, so "no answer" is a real response shape,
+    // and it is likeliest from exactly the old Gateway this check exists for. Treating absence as
+    // permission would fail OPEN in the one case that matters. Silence is not proof of placement.
+    [Fact]
+    public async Task WhenTheGatewayReturnsNoDirectorId_thatIsNotProofOfCorrectPlacement()
+    {
+        var (resp, _) = await SpawnAsync(
+            new { repoPath = @"C:\repo", director = "North build" },
+            stub => stub.LandsOn = "");                 // an old Gateway: no id in the reply
+
+        Assert.NotEqual(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Contains("North build", await resp.Content.ReadAsStringAsync());
+    }
+
+    // The same reply, when the Gateway DID honor the target, must not trip the check - a false alarm
+    // here would report every correct targeted spawn as a failure.
+    [Fact]
+    public async Task WhenTheGatewayHonorsTheNamedDirector_theSpawnIsReportedAsSuccess()
+    {
+        var (resp, _) = await SpawnAsync(
+            new { repoPath = @"C:\repo", director = "North build" },
+            stub => stub.LandsOn = OtherDirectorId);    // "North build" itself
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    // An ordinary machine spawn must be untouched by all of this: no Director name, no lookup, and the
+    // relay carries no name that would pin the Gateway and disable its launch-on-demand. A BLANK
+    // returned Director id must not trip the new check either - an untargeted spawn has nothing to
+    // check against, and tripping here would break every ordinary remote spawn in the fleet.
+    [Fact]
+    public async Task AnOrdinaryMachineSpawn_isUnchanged_andNamesNoDirector()
+    {
+        var (resp, stub) = await SpawnAsync(
+            new { repoPath = @"C:\repo", machine = RemoteMachine },
+            s => s.LandsOn = "");
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        Assert.Equal(RemoteMachine, stub.SpawnMachine);
+        Assert.True(string.IsNullOrEmpty(stub.SpawnBody!.Director));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedTenantMachineControlTests.cs
@@ -624,7 +624,7 @@ internal sealed class MachineGroupProbeHost : IAsyncDisposable
     {
         public int ResolveCount { get; private set; }
 
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
         {
             ResolveCount++;
             return Task.FromResult(new DirectorTargetResult("d-probe", null));

--- a/src/CcDirector.Gateway.Tests/LauncherAutoStartTenantScopeTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherAutoStartTenantScopeTests.cs
@@ -168,7 +168,7 @@ public sealed class LauncherAutoStartTenantScopeTests
             launchTimeout: TimeSpan.FromMilliseconds(50),
             pollInterval: TimeSpan.FromMilliseconds(10));
 
-        await resolver.ResolveAsync(Machine, CancellationToken.None);
+        await resolver.ResolveAsync(Machine, director: null, CancellationToken.None);
 
         Assert.Equal(Bob, seenByLauncher);
     }
@@ -188,7 +188,7 @@ public sealed class LauncherAutoStartTenantScopeTests
             pollInterval: TimeSpan.FromMilliseconds(10));
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => resolver.ResolveAsync(Machine, CancellationToken.None));
+            () => resolver.ResolveAsync(Machine, director: null, CancellationToken.None));
         Assert.Contains("no tenant scope", ex.Message, StringComparison.OrdinalIgnoreCase);
 
         // And it denied BEFORE reaching out to any machine.

--- a/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
@@ -23,13 +23,15 @@ public sealed class MachineSessionSpawnerTests
         private readonly DirectorTargetResult _result;
         public int ResolveCount { get; private set; }
         public string? LastMachine { get; private set; }
+        public string? LastDirector { get; private set; }
 
         public StubResolver(DirectorTargetResult result) => _result = result;
 
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
         {
             ResolveCount++;
             LastMachine = machine;
+            LastDirector = director;
             return Task.FromResult(_result);
         }
     }
@@ -66,6 +68,42 @@ public sealed class MachineSessionSpawnerTests
         Assert.Equal("d-new", seenDirectorId);
         Assert.Same(request, seenReq);
         Assert.Equal("MACHINE_A", resolver.LastMachine);
+    }
+
+    // A spawn that named ONE Director must reach the resolver as a named target. The spawner is the only
+    // thing between the request body and the resolve, so if it drops req.Director the resolve quietly
+    // falls back to "first Director on the machine" - which on a machine running several instances lands
+    // the session somewhere else and reports success. That failure is invisible from the caller's side:
+    // it gets a session id back either way.
+    [Fact]
+    public async Task Spawn_RequestNamesADirector_ThatNamePinsTheResolve()
+    {
+        var resolver = new StubResolver(new DirectorTargetResult("d-slot-5", null));
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
+            Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-1" }, null)));
+
+        var request = new NewSessionRequest { RepoPath = @"C:\repo", Director = "North build" };
+        var (ok, _, _, directorId) = await spawner.SpawnOnMachineAsync("MACHINE_A", request, CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.Equal("North build", resolver.LastDirector);
+        Assert.Equal("d-slot-5", directorId);
+    }
+
+    // The other direction of the same guard: an ORDINARY machine spawn must NOT arrive at the resolver
+    // carrying a name. A resolver handed a stray name pins to it and stops launching on demand, so a
+    // cron job or a plain --machine spawn would fail on a machine whose Director is not running yet.
+    [Fact]
+    public async Task Spawn_RequestNamesNoDirector_ResolvesByMachineAlone()
+    {
+        var resolver = new StubResolver(new DirectorTargetResult("d-first", null));
+        var spawner = new MachineSessionSpawner(resolver, (directorId, req, ct) =>
+            Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-2" }, null)));
+
+        await spawner.SpawnOnMachineAsync(
+            "MACHINE_A", new NewSessionRequest { RepoPath = @"C:\repo" }, CancellationToken.None);
+
+        Assert.True(string.IsNullOrEmpty(resolver.LastDirector));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSpawnOriginStampTests.cs
@@ -45,7 +45,7 @@ public sealed class MachineSpawnOriginStampTests : IDisposable
     /// <summary>A resolver that always finds a Director, so the relay reaches the create step.</summary>
     private sealed class AlwaysFound : IDirectorTargetResolver
     {
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
             => Task.FromResult(new DirectorTargetResult("dir-1", null));
     }
 

--- a/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
+++ b/src/CcDirector.Gateway.Tests/OmittedTenantBoundaryFailClosedTests.cs
@@ -608,7 +608,7 @@ public sealed class OmittedTenantBoundaryFailClosedTests : IAsyncLifetime
 
     private sealed class UnusedResolver : IDirectorTargetResolver
     {
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
             => throw new NotSupportedException("the launcher list route never resolves a spawn target");
     }
 

--- a/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/RegistryDirectorTargetResolverTests.cs
@@ -61,7 +61,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var resolver = new RegistryDirectorTargetResolver(
             _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
-        var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
+        var result = await resolver.ResolveAsync("MACHINE_A", director: null, CancellationToken.None);
 
         Assert.Null(result.Error);
         Assert.Equal("d-7882", result.DirectorId);
@@ -81,7 +81,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var resolver = new RegistryDirectorTargetResolver(
             _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
-        var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
+        var result = await resolver.ResolveAsync("MACHINE_A", director: null, CancellationToken.None);
 
         Assert.Null(result.Error);
         Assert.Equal("d-new", result.DirectorId);
@@ -101,7 +101,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var resolver = new RegistryDirectorTargetResolver(
             _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
-        var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
+        var result = await resolver.ResolveAsync("MACHINE_A", director: null, CancellationToken.None);
 
         Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
@@ -116,7 +116,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var resolver = new RegistryDirectorTargetResolver(
             _ => directors, () => TenantId.Local, launcher, TimeSpan.FromMilliseconds(120), FastPoll);
 
-        var result = await resolver.ResolveAsync("MACHINE_A", CancellationToken.None);
+        var result = await resolver.ResolveAsync("MACHINE_A", director: null, CancellationToken.None);
 
         Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
@@ -130,7 +130,7 @@ public sealed class RegistryDirectorTargetResolverTests
         var resolver = new RegistryDirectorTargetResolver(
             _ => new List<DirectorDto>(), () => TenantId.Local, launcher, FastTimeout, FastPoll);
 
-        var result = await resolver.ResolveAsync("   ", CancellationToken.None);
+        var result = await resolver.ResolveAsync("   ", director: null, CancellationToken.None);
 
         Assert.Null(result.DirectorId);
         Assert.NotNull(result.Error);
@@ -163,13 +163,13 @@ public sealed class RegistryDirectorTargetResolverTests
         var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch when one is running"));
 
         var asAlice = new RegistryDirectorTargetResolver(ForTenant, () => TenantA, launcher, FastTimeout, FastPoll);
-        var resolvedForAlice = await asAlice.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        var resolvedForAlice = await asAlice.ResolveAsync("SHARED_MACHINE", director: null, CancellationToken.None);
         Assert.Null(resolvedForAlice.Error);
         Assert.Equal("d-alice", resolvedForAlice.DirectorId);   // A's own Director, never B's
 
         // Symmetric: B resolving the same machine gets B's Director, never A's.
         var asBob = new RegistryDirectorTargetResolver(ForTenant, () => TenantB, launcher, FastTimeout, FastPoll);
-        var resolvedForBob = await asBob.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        var resolvedForBob = await asBob.ResolveAsync("SHARED_MACHINE", director: null, CancellationToken.None);
         Assert.Equal("d-bob", resolvedForBob.DirectorId);
 
         // Revert-proof: a tenant-BLIND reader (the pre-fix fleet-global list, B first) resolves B's Director for
@@ -177,8 +177,139 @@ public sealed class RegistryDirectorTargetResolverTests
         // order, is what protects A: reverting the resolver to ignore the tenant reddens the assertion above.
         var fleetGlobal = new[] { dirB, dirA };
         var blind = new RegistryDirectorTargetResolver(_ => fleetGlobal, () => TenantA, launcher, FastTimeout, FastPoll);
-        var blindPick = await blind.ResolveAsync("SHARED_MACHINE", CancellationToken.None);
+        var blindPick = await blind.ResolveAsync("SHARED_MACHINE", director: null, CancellationToken.None);
         Assert.Equal("d-bob", blindPick.DirectorId);            // the leak, demonstrated
+    }
+
+    // ---- Naming ONE Director: "start it on THAT Director", not "on that computer" --------------------
+    //
+    // A machine that runs several named instances is the case the machine name cannot answer. The
+    // fixture below is deliberately built so a machine-only resolve gets the WRONG one: the named
+    // Director is second in the list, so a resolve that ignored the name would return the first and
+    // still report success. That is the failure these tests exist to catch - it is silent.
+
+    private static DirectorDto Named(string id, string machine, string displayName) => new()
+    {
+        DirectorId = id, MachineName = machine, ControlEndpoint = "", DisplayName = displayName, Version = "0.9.10",
+    };
+
+    private static readonly DirectorDto[] TwoOnOneMachine =
+    {
+        Named("d-first", "SOREN_NORTH", "North daily"),
+        Named("d-slot-5", "SOREN_NORTH", "North build"),
+    };
+
+    [Fact]
+    public async Task Resolve_byDisplayName_picksThatDirector_notTheMachinesFirst()
+    {
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch: it is running"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => TwoOnOneMachine, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", "North build", CancellationToken.None);
+
+        Assert.Null(result.Error);
+        Assert.Equal("d-slot-5", result.DirectorId);   // the SECOND row: the name decided, not the order
+        Assert.Equal(0, launcher.StartCount);
+    }
+
+    [Fact]
+    public async Task Resolve_byDirectorId_isCaseInsensitive_andNeedsNoMachine()
+    {
+        // The id identifies the machine by itself, so a caller holding only an id can spawn without
+        // knowing where it runs - which is the whole point of handing an id to another agent.
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => TwoOnOneMachine, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync(machine: "", "D-SLOT-5", CancellationToken.None);
+
+        Assert.Null(result.Error);
+        Assert.Equal("d-slot-5", result.DirectorId);
+    }
+
+    [Fact]
+    public async Task Resolve_namedDirectorNotRegistered_failsLoud_neverSubstitutesOrLaunches()
+    {
+        // The substitution this forbids is the dangerous one: another Director IS running on that
+        // machine, so a resolver that fell back would succeed, and the session would open on the wrong
+        // Director with nothing in the reply to say so. The launcher cannot start a PARTICULAR named
+        // instance either, so launching here would start the wrong one and then spawn into it.
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch a named target"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => TwoOnOneMachine, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", "North experiments", CancellationToken.None);
+
+        Assert.Null(result.DirectorId);
+        Assert.NotNull(result.Error);
+        Assert.Contains("North experiments", result.Error!);
+        Assert.Equal(0, launcher.StartCount);
+    }
+
+    [Fact]
+    public async Task Resolve_nameMatchesTwoDirectors_failsLoud_listingBoth()
+    {
+        // Display names are editable free text, so two machines can carry the same one. Picking either
+        // would be a guess the caller cannot see; the error names both ids so they can pick.
+        var twins = new[]
+        {
+            Named("d-a", "MACHINE_A", "Build box"),
+            Named("d-b", "MACHINE_B", "Build box"),
+        };
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => twins, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync(machine: "", "Build box", CancellationToken.None);
+
+        Assert.Null(result.DirectorId);
+        Assert.NotNull(result.Error);
+        Assert.Contains("d-a", result.Error!);
+        Assert.Contains("d-b", result.Error!);
+    }
+
+    // ID PRECEDENCE in the GATEWAY resolver, which is where the create is finally pinned. A Director's
+    // display name is free text, so it can be set to another Director's id - and with ids and names
+    // matched at equal rank, asking for that id finds TWO candidates and the resolve refuses a request
+    // that is perfectly unambiguous. Without this case the resolver's tests pass just as well against
+    // the old equal-precedence matching, which is to say they were not testing the rule at all.
+    [Fact]
+    public async Task Resolve_byId_isNotMadeAmbiguousByAnotherDirectorsDisplayName()
+    {
+        var fleet = new[]
+        {
+            Named("d-impostor", "SOREN_NORTH", "d-slot-5"),   // display name IS the id being asked for
+            Named("d-slot-5", "SOREN_NORTH", "North build"),
+        };
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => fleet, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", "d-slot-5", CancellationToken.None);
+
+        Assert.Null(result.Error);
+        Assert.Equal("d-slot-5", result.DirectorId);
+    }
+
+    [Fact]
+    public async Task Resolve_namedDirector_staysInsideTheCallersTenant()
+    {
+        // The same partition rule the machine match follows. Display names are free text another
+        // account may have chosen too, so a fleet-global name match would resolve across the boundary
+        // on the caller's behalf - and an ID match would do it with no collision needed at all.
+        var mine = new[] { Named("d-mine", "SHARED_MACHINE", "Build box") };
+        var theirs = new[] { Named("d-theirs", "SHARED_MACHINE", "Build box") };
+        IEnumerable<DirectorDto> ForTenant(TenantId t) => t == TenantA ? mine : theirs;
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+
+        var asAlice = new RegistryDirectorTargetResolver(ForTenant, () => TenantA, launcher, FastTimeout, FastPoll);
+
+        Assert.Equal("d-mine", (await asAlice.ResolveAsync("", "Build box", CancellationToken.None)).DirectorId);
+        // Bob's Director id, asked for by Alice, is not found - not resolved and quietly used.
+        var reachingAcross = await asAlice.ResolveAsync("", "d-theirs", CancellationToken.None);
+        Assert.Null(reachingAcross.DirectorId);
+        Assert.NotNull(reachingAcross.Error);
     }
 
     [Fact]
@@ -191,6 +322,6 @@ public sealed class RegistryDirectorTargetResolverTests
             _ => new[] { Director("d-x", "M", "") }, () => (TenantId?)null, launcher, FastTimeout, FastPoll);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => resolver.ResolveAsync("M", CancellationToken.None));
+            () => resolver.ResolveAsync("M", director: null, CancellationToken.None));
     }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelSpawnerDriverProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelSpawnerDriverProofTests.cs
@@ -40,7 +40,7 @@ public sealed class TunnelSpawnerDriverProofTests
     {
         private readonly DirectorTargetResult _result;
         public StubResolver(DirectorTargetResult result) => _result = result;
-        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct) => Task.FromResult(_result);
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct) => Task.FromResult(_result);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronWorkListRunner.cs
@@ -67,9 +67,11 @@ public sealed class DirectorCronWorkListRunner : ICronWorkListRunner
             return CronWorkListOutcome.AlreadyClaimed;
         }
 
-        // Resolve the target MACHINE to a Director (launching one if none is running, #503).
+        // Resolve the target MACHINE to a Director (launching one if none is running, #503). A cron job
+        // targets a machine and no particular Director, so it names none and keeps the launch-on-demand
+        // behavior it has always had.
         var machine = job.Target.Machine;
-        var target = await _resolver.ResolveAsync(machine, ct);
+        var target = await _resolver.ResolveAsync(machine, director: null, ct);
         // Tunnel-only: a resolved DirectorId is the target; a blank control endpoint is still reachable
         // over the tunnel. Fail only on the resolver's error or a missing DirectorId, NOT on an endpoint
         // (the same stale REST-era guard issue #1727 removed from the machine-session spawn path).

--- a/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
+++ b/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Instances;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
@@ -15,14 +16,26 @@ namespace CcDirector.Gateway.Running;
 public sealed record DirectorTargetResult(string? DirectorId, string? Error);
 
 /// <summary>
-/// Resolves a cron job's target MACHINE to a runnable Director (epic #479, #503): picks the first
-/// reachable Director on that machine, and if none is running asks the launcher to start one and
-/// waits (bounded) for it to register. Behind an interface so the firing engine is unit-testable
-/// without a live registry/launcher. Production is <see cref="RegistryDirectorTargetResolver"/>.
+/// Resolves a spawn's target to a runnable Director (epic #479, #503).
+///
+/// TWO WAYS TO NAME THE TARGET, and they behave differently on purpose:
+///   - BY MACHINE (<paramref name="director"/> blank): picks the first reachable Director on that
+///     machine, and if none is running asks the launcher to start one and waits (bounded) for it to
+///     register. "Any Director on that computer will do."
+///   - BY DIRECTOR (<paramref name="director"/> set): pins the resolve to ONE named Director - by id
+///     or display name - and NEVER launches or substitutes. One machine runs several named instances,
+///     so the machine name alone cannot say which; a caller that named one meant that one.
+///
+/// Behind an interface so the firing engine is unit-testable without a live registry/launcher.
+/// Production is <see cref="RegistryDirectorTargetResolver"/>.
 /// </summary>
 public interface IDirectorTargetResolver
 {
-    Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct);
+    /// <param name="machine">The target machine. Blank is an error UNLESS <paramref name="director"/>
+    /// names a Director, which identifies its machine by itself.</param>
+    /// <param name="director">Optional Director id or display name. When set, the resolve is pinned to
+    /// that one Director: unknown or ambiguous is an error naming it, never another Director.</param>
+    Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct);
 }
 
 /// <summary>
@@ -79,15 +92,20 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
         _pollInterval = pollInterval ?? TimeSpan.FromSeconds(3);
     }
 
-    public async Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+    public async Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(machine))
-            return new DirectorTargetResult(null, "no target machine");
-
         // Resolve the tenant ONCE, at the top, and carry it through both the registry reads and the launch.
         // Reading it separately per step would let a resolve that starts in one scope finish in another, and
         // would leave the LAUNCH - the one step that reaches another machine - with no tenant at all.
         var tenant = RequireTenant();
+
+        // A NAMED Director answers the whole question, machine included, so it is resolved first and
+        // separately: no launcher, no first-available, no fallback of any kind.
+        if (!string.IsNullOrWhiteSpace(director))
+            return PickNamed(tenant, machine, director.Trim());
+
+        if (string.IsNullOrWhiteSpace(machine))
+            return new DirectorTargetResult(null, "no target machine");
 
         var d = PickReachable(tenant, machine);
         if (d is not null)
@@ -131,6 +149,56 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
     /// longer requires a non-empty ControlEndpoint or an advertised-endpoint reachability state (both are
     /// artifacts of the deleted HTTP-dial path).
     /// </summary>
+    /// <summary>
+    /// Resolve ONE named Director - by id or by display name, case-insensitively - within the caller's
+    /// tenant, optionally narrowed to a machine. A named Director identifies its own machine, so
+    /// <paramref name="machine"/> is only a further filter and may be blank.
+    ///
+    /// THREE OUTCOMES, ALL LOUD. Exactly one match resolves. No match is an error naming what was asked
+    /// for - it is NOT "use another Director on that machine", and it is NOT a launch: the launcher
+    /// starts "a Director on a machine" and has no way to start a PARTICULAR named instance, so calling
+    /// it here would start the wrong one and then silently spawn the session there. Two matches is an
+    /// error listing both, because picking either would be a guess the caller cannot see.
+    /// </summary>
+    private DirectorTargetResult PickNamed(TenantId tenant, string? machine, string director)
+    {
+        // Same tenant confinement as the machine match: another tenant's Director may carry the same
+        // display name, and resolving to it would cross the partition on the caller's behalf.
+        //
+        // DirectorHandle.Pick applies ID PRECEDENCE - an exact id match wins outright and display names
+        // are not consulted - so a Director renamed to another's id cannot make that id ambiguous. It is
+        // the same rule the Director floor resolves with, from one implementation, because a floor and a
+        // Gateway that disagreed about what a name means would route a session somewhere the caller was
+        // never told about.
+        var candidates = DirectorHandle
+            .Pick(_listDirectors(tenant), director, x => x.DirectorId, x => x.DisplayName)
+            .Where(x => string.IsNullOrWhiteSpace(machine)
+                     || string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var on = string.IsNullOrWhiteSpace(machine) ? "" : $" on '{machine}'";
+
+        if (candidates.Count == 0)
+        {
+            FileLog.Write($"[RegistryDirectorTargetResolver] no Director '{director}'{on} in tenant={tenant.Value}");
+            return new DirectorTargetResult(null,
+                $"no Director '{director}'{on} is registered. It is either not running or is named " +
+                "something else - list what is registered with: cc-devthrottle director list");
+        }
+
+        if (candidates.Count > 1)
+        {
+            var listed = string.Join(", ", candidates.Select(c => $"{c.DirectorId} ({c.MachineName})"));
+            FileLog.Write($"[RegistryDirectorTargetResolver] '{director}'{on} is ambiguous: {listed}");
+            return new DirectorTargetResult(null,
+                $"'{director}' names {candidates.Count} Directors ({listed}). Name one by its Director id.");
+        }
+
+        var chosen = candidates[0];
+        FileLog.Write($"[RegistryDirectorTargetResolver] '{director}' resolved to {chosen.DirectorId} on {chosen.MachineName}");
+        return new DirectorTargetResult(chosen.DirectorId, null);
+    }
+
     private DirectorDto? PickReachable(TenantId tenant, string machine)
     {
         // Confine the machine-name match to the caller's OWN tenant partition (audit H1, gap audit-e): a

--- a/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
+++ b/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
@@ -61,7 +61,12 @@ public sealed class MachineSessionSpawner
         if (req is null)
             throw new ArgumentNullException(nameof(req));
 
-        var target = await _resolver.ResolveAsync(machine, ct);
+        // req.Director, when set, names ONE Director and pins the resolve to it (machine alone resolves
+        // to the first Director on the machine, which on a machine running several named instances is a
+        // coin toss). Passed through the same single resolve-then-create path rather than a second one,
+        // so a targeted spawn keeps the tenant scoping, the mission stamping and the workflow seat it
+        // already had - the only thing that changes is WHICH Director gets the create.
+        var target = await _resolver.ResolveAsync(machine, req.Director, ct);
         // Tunnel-only: a resolved DirectorId IS the target - delivery is by id over the tunnel, so a
         // Director with a blank control endpoint is perfectly reachable. Fail only when the resolver
         // reported an error (machine off / unreachable / launch failed) or resolved no Director at all;

--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -130,6 +130,28 @@ The Director names the session at birth and returns the final id and name. See t
 skill for the full flag set (`--agent`, `--role`, `--mission`, `--machine`, `--controlled-by`, and the
 display-name convention).
 
+### Opening a session on ONE particular Director
+
+`--machine` names a computer, and one computer runs several named Director instances - so it lands on
+whichever the Gateway lists first. When you were told to use a specific Director, name it:
+
+```
+cc-devthrottle director list          # names, machines, and the Director id to use
+cc-devthrottle session spawn D:\Repos\myrepo \
+  --director 6f0a2b41-1c33-4f9e-9a10-2b7d5e8c1234 \
+  --name "myrepo - fix auth bug #123"
+```
+
+`--director` takes the Director id or its display name and needs no `--machine` - a Director
+identifies the computer it runs on. Prefer the id: it survives a rename and cannot collide with a
+second Director sharing a name. A person handing you a Director will usually paste its toolbar Copy
+output, which is three lines - `Director:`, `Director ID:`, `Machine:`. Take the id from there and
+use it verbatim.
+
+An unregistered name fails loudly, and a name matching two Directors fails listing both. Neither
+falls back to another Director - if you get one of those errors, run `director list` and pick, rather
+than dropping the flag and spawning wherever.
+
 ## Closing a session (including closing yourself)
 
 A session can close itself. When an agent has finished its work and nothing is waiting on the

--- a/src/CcDirector.Gateway/Skills/Content/fleet-comms.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/fleet-comms.skill.md
@@ -27,7 +27,16 @@ cc-devthrottle session spawn D:\path\to\repo --purpose "implement #799"
 cc-devthrottle session spawn D:\path\to\repo --name "Frontend review"
 cc-devthrottle session spawn D:\path\to\repo --purpose "run the test suite" --agent ClaudeCode --prompt "Run the tests and report failures."
 cc-devthrottle session spawn D:\path\to\repo --name "frontend" --agent RawCli --command cmd
+cc-devthrottle director list
+cc-devthrottle session spawn D:\path\to\repo --name "build" --director "North build"
 ```
+
+`--machine <name>` starts the session on another COMPUTER; `--director <id-or-name>` starts it on ONE
+named Director. They answer different questions: a computer runs several named Director instances, so
+`--machine` lands on whichever is listed first. Name the Director when it has to be that one -
+`director list` gives you the id, and a Director's toolbar Copy button hands out its name, id, and
+machine for pasting. An unregistered or ambiguous name fails loudly and never falls back to another
+Director.
 
 Always name your session. On this fleet many sessions run in the SAME checkout, so a session with
 no name displays as the bare folder name and is impossible to tell apart. Lead with `--name`

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -50,6 +50,11 @@ machine_app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+director_app = typer.Typer(
+    help="List the Directors this account is running, on every machine.",
+    add_completion=False,
+    no_args_is_help=True,
+)
 mission_app = typer.Typer(
     help="Create and list Missions (the unit of work sessions attach to).",
     add_completion=False,
@@ -100,6 +105,7 @@ app.add_typer(session_app, name="session")
 app.add_typer(repo_app, name="repo")
 app.add_typer(worktree_app, name="worktree")
 app.add_typer(machine_app, name="machine")
+app.add_typer(director_app, name="director")
 app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
 app.add_typer(settings_app, name="settings")
@@ -168,10 +174,28 @@ _ACTIONS = [
     },
     {
         "id": "session-spawn",
-        "description": "Open a new session on the local Director.",
-        "command": "cc-devthrottle session spawn <repo>",
+        "description": (
+            "Open a new session. By default on the local Director; --machine <name> starts it on "
+            "another computer, and --director <id-or-name> starts it on ONE named Director (a machine "
+            "runs several, and only this says which)."
+        ),
+        "command": "cc-devthrottle session spawn <repo> [--machine <name>] [--director <id-or-name>]",
         "mutatesState": True,
-        "args": [{"name": "repo", "required": True}],
+        "args": [
+            {"name": "repo", "required": True},
+            {"name": "machine", "required": False},
+            {"name": "director", "required": False},
+        ],
+    },
+    {
+        "id": "director-list",
+        "description": (
+            "List every Director this account is running, on every machine, with the id and name that "
+            "'session spawn --director' accepts. A machine appears once per named Director instance."
+        ),
+        "command": "cc-devthrottle director list",
+        "mutatesState": False,
+        "args": [],
     },
     {
         "id": "machine-list",
@@ -830,6 +854,16 @@ def machine_list(
     list_machines(json_output)
 
 
+@director_app.command("list")
+def director_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+) -> None:
+    """List every Director this account is running, with the id to pass to 'session spawn --director'."""
+    from .machine_ops import list_directors
+
+    list_directors(json_output)
+
+
 @machine_app.command("apps")
 def machine_apps(
     machine: str = typer.Argument(..., help="The computer to look on."),
@@ -1118,6 +1152,16 @@ def spawn(
         "machine (first available, auto-launched if none is running); an off/unreachable machine fails "
         "loudly with no local fallback.",
     ),
+    director: Optional[str] = typer.Option(
+        None,
+        "--director",
+        help="Start the session on ONE named Director, by its Director id or its display name. One "
+        "machine runs several Directors, so --machine alone lands on whichever is first; this lands on "
+        "the one you named, wherever it runs (no --machine needed - though giving one narrows which "
+        "Directors the name may match). A Director that is not running, or a name that matches two, "
+        "fails loudly - it never falls back to another Director. List them with "
+        "'cc-devthrottle director list'; a Director's own toolbar Copy button hands you its id.",
+    ),
     mission: Optional[str] = typer.Option(
         None,
         "--mission",
@@ -1134,10 +1178,10 @@ def spawn(
         "its PINNED version. Unknown run ids are rejected.",
     ),
 ) -> None:
-    """Open a new session on the local Director, or on another computer with --machine, and print its id."""
+    """Open a new session - here, on another computer with --machine, or on one Director with --director."""
     spawn_session(
         repo, agent, prompt, name, purpose, command, command_args, controlled_by, args, standalone, role,
-        machine, mission, workflow_run,
+        machine, mission, workflow_run, director,
     )
 
 

--- a/tools/cc-devthrottle/src/machine_ops.py
+++ b/tools/cc-devthrottle/src/machine_ops.py
@@ -88,6 +88,48 @@ def list_machines(json_output: bool) -> None:
     console.print(f"{len(rows)} machines")
 
 
+def list_directors(json_output: bool) -> None:
+    """Every Director this account is running, on every machine - and how to name one.
+
+    A machine can appear several times: each named Director instance registers its own row. The NAME
+    column is what a person reads; the DIRECTOR ID is what `session spawn --director` should carry,
+    because it survives a rename and cannot collide with a second Director called the same thing.
+    """
+    rows: List[Dict[str, Any]] = _call("fleet/directors") or []
+    if json_output:
+        print(json.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        console.print(
+            "No Directors are registered. A Director appears here once it is running and has "
+            "connected to the Gateway."
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold", box=box.ASCII)
+    table.add_column("NAME")
+    table.add_column("MACHINE")
+    # The id is the whole point of this table - it is what you paste into --director - so it WRAPS
+    # rather than truncating. An ellipsised GUID looks like a value and is not one: pasting it fails
+    # at the far end with "no Director ... is registered", which reads as a fleet problem.
+    table.add_column("DIRECTOR ID", overflow="fold", no_wrap=False)
+    table.add_column("VERSION")
+    for row in rows:
+        machine_name = str(director.field(row, "machineName", "MachineName") or "-")
+        # An unnamed instance falls back to its machine name, exactly as the Director's own toolbar
+        # does - the alternative is a blank cell in the column you pick a Director from.
+        name = str(director.field(row, "displayName", "DisplayName") or "").strip() or machine_name
+        table.add_row(
+            name,
+            machine_name,
+            str(director.field(row, "directorId", "DirectorId") or "-"),
+            str(director.field(row, "version", "Version") or "-"),
+        )
+    console.print(table)
+    console.print(f"{len(rows)} Directors")
+
+
 def list_apps(machine: str, query: Optional[str], limit: int, json_output: bool) -> None:
     """What is installed on one machine."""
     path = f"fleet/machines/{machine}/apps?q={query or ''}&limit={limit}"

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -598,8 +598,11 @@ def spawn_session(
     machine: Optional[str] = None,
     mission: Optional[str] = None,
     workflow_run: Optional[str] = None,
+    # NOT named `director`: this module's Director-client is imported under that name and a parameter
+    # would shadow it, breaking every director.post_json call in here.
+    director_target: Optional[str] = None,
 ) -> None:
-    """Open a new session on the local Director, or on another computer when a remote --machine is given."""
+    """Open a new session here, on another computer (--machine), or on one named Director (--director)."""
     # Automatic roles: a SESSION-initiated spawn (CC_SESSION_ID present) DEFAULTS to a Worker controlled by
     # the spawner, so it stays quiet and reports to its manager instead of nagging the human. The opt-out
     # (guard 1) is --standalone / --controlled-by none: a deliberate human-facing PEER with no controller. A
@@ -687,10 +690,18 @@ def spawn_session(
     # Director on that machine (first available, auto-launched if none is running). An off/unreachable machine
     # fails loudly (DirectorError -> red error + exit 1) with NO local fallback. The old POST /sessions route
     # was removed from the Director floor in the tunnel-only cut.
+    #
+    # --director names ONE Director instead of "some Director on that computer", which is the only way
+    # to be specific on a machine running several named instances. It is sent alongside the machine and
+    # settled at the Director floor: naming the LOCAL Director spawns locally, and naming another one
+    # routes to exactly it. Passed through verbatim - resolving a Director name here would mean this
+    # tool holding a second copy of the matching rule the Gateway already applies.
     target_machine = machine.strip() if machine else ""
+    target_director = director_target.strip() if director_target else ""
 
     try:
-        resp = director.post_json("fleet/spawn", {"machine": target_machine, **body})
+        resp = director.post_json(
+            "fleet/spawn", {"machine": target_machine, "director": target_director, **body})
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)

--- a/tools/cc-devthrottle/tests/test_spawn_ops.py
+++ b/tools/cc-devthrottle/tests/test_spawn_ops.py
@@ -145,3 +145,54 @@ def test_an_explicit_controller_does_not_change_who_made_the_call(monkeypatch, c
     _spawn(monkeypatch, cc_session="sess-A", controlled_by="explicit-manager-id")
     assert captured.get("controllerSessionId") == "explicit-manager-id"
     assert captured.get("parentSessionId") == "sess-A"
+
+
+# ---- --director: naming ONE Director instead of a computer -------------------------------------
+#
+# A machine runs several named Director instances, so --machine lands on whichever the Gateway
+# resolves first. --director names one. The CLI's whole job here is to pass the name through
+# untouched: it holds no copy of the matching rule, so these assert the wire body, which is the
+# only thing it actually decides.
+
+
+def test_director_is_sent_on_the_wire(monkeypatch, captured):
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    session_ops.spawn_session(
+        repo="C:/repo", agent="ClaudeCode", prompt=None, name="n", purpose=None,
+        command=None, command_args=None, director_target="North build",
+    )
+    assert captured.get("director") == "North build"
+    # No --machine needed: a named Director identifies its own machine, and the floor resolves it.
+    assert captured.get("machine") == ""
+
+
+def test_director_and_machine_can_be_sent_together(monkeypatch, captured):
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    session_ops.spawn_session(
+        repo="C:/repo", agent="ClaudeCode", prompt=None, name="n", purpose=None,
+        command=None, command_args=None, machine="SOREN_NORTH",
+        director_target="6f0a2b41-1c33-4f9e-9a10-2b7d5e8c1234",
+    )
+    assert captured.get("machine") == "SOREN_NORTH"
+    assert captured.get("director") == "6f0a2b41-1c33-4f9e-9a10-2b7d5e8c1234"
+
+
+def test_an_ordinary_spawn_names_no_director(monkeypatch, captured):
+    # The other direction: an untargeted spawn must not arrive carrying a name, or the Gateway would
+    # pin to it and stop launching a Director on demand.
+    _spawn(monkeypatch, cc_session=None)
+    assert captured.get("director") == ""
+
+
+def test_the_director_flag_reaches_spawn_session(monkeypatch, tmp_path):
+    # The wiring itself: typer option -> spawn_session. Asserted through the CLI because the flag
+    # name and the (deliberately differently-named) parameter are only connected in cli.py - a
+    # mismatch there is invisible to every test that calls spawn_session directly.
+    import src.cli as cli_module
+
+    seen = {}
+    monkeypatch.setattr(cli_module, "spawn_session", lambda *a, **k: seen.update(args=a, kwargs=k))
+    result = runner.invoke(
+        app, ["session", "spawn", str(tmp_path), "--name", "n", "--director", "North build"])
+    assert result.exit_code == 0, result.output
+    assert "North build" in seen["args"]


### PR DESCRIPTION
The Director toolbar showed `MACHINE_NAME:port` with a Copy button that copied the Control API URL.
Both are dead: nothing reaches a Director by port any more (the fleet goes through the Gateway), and
one machine runs several named Director instances, so the machine name cannot say which Director you
are looking at.

## What changed

**The toolbar shows the Director's own name** - its named-instance display name, falling back to the
machine name when the instance is unnamed. No port.

**Copy hands over identity, not a command.** Three lines - `Director:`, `Director ID:`, `Machine:` -
for pasting to an agent that is then told what to do with them. What to DO with a Director is the
pasting person's instruction, and a command baked in could never run as pasted anyway: this Director
cannot know which repository is meant.

**That id can now be used.** A Director can be addressed directly:

```
cc-devthrottle director list                                   names, machines, ids
cc-devthrottle session spawn <repo> --director <id-or-name>
```

`--director` takes the Director id or its display name and needs no `--machine`, since a Director
identifies the computer it runs on. Giving both NARROWS the match rather than overriding it, which is
how a display name two machines share is disambiguated.

## Why it is more code than it sounds

Every failure mode here is silent: the session opens on the wrong Director and still reports success.
So targeting is pinned at each step where it could drift.

- **The name is resolved against the fleet BEFORE the local leg is chosen.** Asking "is that name
  mine?" first lets this Director claim a display name a sibling also holds, spawn here, and report
  success - and `--machine` would not save the caller either, because a local-first branch has no
  reason to look at it.
- **An id beats a display name everywhere.** Display names are free text, so a Director can be named
  the literal id of another. With equal-rank matching, that makes a perfectly unambiguous id come
  back ambiguous, or resolve to the impostor.
- **The relay carries the RESOLVED ID, not the name.** The Gateway resolves this field again on its
  side, so relaying a name means resolving it twice against two reads of the registry taken moments
  apart. A name can move between Directors in that window; an id cannot.
- **A Director answers for its own id without the Gateway.** An id is unique and system-issued, so
  this process can prove the target is itself. Requiring the roster would fail a provably-correct
  local spawn during a Gateway outage, or during the lag before a fresh Director registers, with
  "no Director is registered" - which would be false.
- **A reply that cannot confirm placement is not a success.** A Gateway too old to honour a named
  target starts the session on the machine's first Director and answers 201. The reply is checked
  against the resolved id; a different id is reported as landing elsewhere, and a MISSING id is
  reported as unconfirmed rather than diagnosed as an old Gateway, because omitting the field does
  not prove the target was ignored.

Unknown names fail naming them. Ambiguous names fail listing every candidate. A Director named
alongside a machine it does not run on is a contradiction that fails. Nothing auto-launches a
substitute, and nothing falls back to another Director.

## Deployment note

The pinning for any Director other than the one you are talking to happens on the GATEWAY. Until the
hosted Gateway is redeployed, targeting another Director is refused by the check above rather than
silently landing elsewhere. The local case works with the app alone.

## Verification

- All seven test suites run locally. 192 command-line tests pass.
- New coverage: the duplicate-display-name trap, id-versus-display-name hijack at both the floor and
  the Gateway resolver, a blank Director id in the relay reply, a Gateway roster that cannot be read,
  and the contradiction case. Each is framed so the pre-fix code fails it.
- Driven live on a running Director: targeting by name and by id both land locally, an unknown name
  is refused with nothing started, and an id paired with the wrong machine is refused as a
  contradiction. The log confirms the own-id path resolves without the roster.
- Two independent adversarial review passes; nine findings, all fixed.
