### PR TITLE
feat(missions): a mission can adopt a session that already exists

### DIFF
--- a/docs/new_architecture/mission-as-first-class-unit-of-work.md
+++ b/docs/new_architecture/mission-as-first-class-unit-of-work.md
@@ -50,6 +50,124 @@ The Mission object supplies the missing horizontal binding:
 Without a Mission object, "Architect beside Manager" has nothing to hang on and collapses back into
 a chain.
 
+## Attaching a session that ALREADY EXISTS (issue #2387)
+
+A Mission could originally only be joined in the instant a session was spawned
+(`session spawn --mission <id>`). That made the feature miss the case it exists for. A mission's
+shape is DISCOVERED as it runs - that is what makes it a mission rather than a task - so
+attach-at-birth grouped only the work somebody had already planned, which is the work that least
+needs grouping. The case that found it: a release push that began as one coordinating seat and grew
+over a day into about a dozen - an architect and a manager, three review seats, three more for a
+different question, an investigation seat, four independent gate reviewers commissioned one pull
+request at a time, and a session fixing a defect one of them found. All one body of work. None of it
+foreseeable at spawn. None of it representable.
+
+The verb: `cc-devthrottle mission attach <session> <mission>` and `mission detach <session>`, over
+`POST /sessions/{sid}/mission` at the Gateway and `POST /fleet/mission` on a Director.
+
+### The rules, settled
+
+Each of these was decided rather than left implied, because somebody hits every one of them and an
+implied answer gets re-litigated at the worst moment.
+
+1. **Attaching is a MOVE, not a one-way door.** A session that already carries a mission is
+   re-pointed by the same command. Since the first classification of a session is always a guess
+   about work still taking shape, a one-way attach would make every wrong guess permanent until the
+   session was killed.
+2. **The move is REPORTED.** The command names the mission the session LEFT. A move that reports
+   only its destination hides that anything was displaced, which is how a session goes missing from
+   the pod somebody is looking at.
+3. **Detaching is supported.** No mission is the ORDINARY state of a session, so returning to it
+   must not require inventing a mission to park the session in. A session that had no mission is
+   told exactly that, rather than being told it was detached from nothing.
+4. **A refused attach changes nothing.** A mistyped mission id leaves an existing attachment intact
+   rather than clearing it - otherwise the failure looks like nothing happened until somebody goes
+   looking for the pod.
+5. **Attaching a controlling session does NOT bring its children by default; `--with-children`
+   does.** A controller routinely commissions work that is not part of its own mission - a reviewer
+   for one pull request, an investigation seat for something else - and a silent bulk re-parent
+   cannot be undone in one step. With the flag, the walk is TRANSITIVE (children, their children,
+   and so on): stopping at the first level would attach the Manager and leave the Workers behind,
+   which reads as success while producing exactly the split view this feature exists to end. Every
+   session it moves is NAMED, not counted.
+6. **A spawned session INHERITS its controlling session's mission by default.** The fleet already
+   records the controlling relationship, so this costs nothing and would have grouped the release
+   push above for free - every one of those sessions was spawned by a seat already on the mission.
+   An explicit `--mission` wins (stated intent beats a default), `--mission none` is the opt-out
+   (spelled the way `--controlled-by none` is), and the inheritance is never silent: the spawn names
+   the mission, names the session it came from, and says how to undo it.
+
+### The workflow seat moves with the mission
+
+**A Mission is not only a record. It is also a RUN of the built-in `mission` workflow**, and a
+mission-scoped spawn seats the session on that run and records it in the run's participant ledger. The
+seat - `WorkflowRunId` plus the workflow id and its PINNED version - is what decides the conduct the
+agent was told to follow. So the mission link and the seat are two halves of one fact, and an attach
+that moved only the link would leave a session **displayed under one mission while governed by the one
+it left**, taking its conduct from a mission it is no longer in and still counted in that mission's
+participant ledger. That is worse than an inconsistent label, and it would happen in exactly the case
+this feature was built for. (Found by independent review of the first cut, which moved only the link.)
+
+**The rule, and its one exception:**
+
+- A seat that **is a run of the mission being left** belongs to that mission and **follows it**. On a
+  move it becomes the destination mission's run; on a detach it is **cleared**.
+- A seat the caller **chose independently** - spawned with an explicit `--workflow-run` that is not this
+  mission's run - is **preserved untouched**. It was never the mission's to take.
+- A session with **no seat** has nothing to preserve, so it simply gains the destination mission's seat.
+- A destination mission with **no run of its own** (an UNGOVERNED mission, created while the owner had the
+  mission workflow switched off) seats nobody, so the session moves unseated rather than keeping the old
+  seat. A move must not smuggle a seat past a switch the owner deliberately turned off.
+
+**Detach clears the seat rather than refusing.** Refusing to detach while a seat exists was considered
+and rejected: every mission-spawned session is seated, so refusal would make detach impossible for
+precisely the sessions that most need it. A session that has left a mission cannot still be governed by
+that mission's run, and the coherent action - leave the run - exists. Refusal is the right answer only
+where no coherent action does.
+
+**Leaving is recorded, not erased.** The ledger marks the participant as having left (`LeftUtc`). That
+the session *was* in that run is true and stays true.
+
+**The decision is the Gateway's and is made in one place.** Whether a run belongs to a mission is a fact
+about the run store, which only the Gateway holds; a Director asked to decide it would have to guess. The
+Gateway sends the Director a finished answer - move the seat or do not, and which run to sit on - and the
+Director applies it in the *same verb* as the mission, so the two can never land apart. This is also why
+the Director's own `POST /fleet/mission` relays through the Gateway even for a session it hosts itself: a
+second implementation of this rule would drift, and the drift would be invisible until somebody found a
+session governed by a mission it had left.
+
+**The limit, stated because it is real.** Moving the seat corrects the RECORD - what the fleet shows, what
+governs the session, who the run lists. It cannot reach into a running agent's context and replace the
+conduct text that was injected at birth. Only telling the session to fetch its conduct again does that,
+and the command line says so every time a seat moves.
+
+### The tenant boundary, which is the constraint that governs the design
+
+Missions are TENANT-SCOPED and that was hard won (devthrottle_internal issue #1039 fixed a live leak
+where `GET /missions` served every account's list to every account; a mission NAME is free text a
+person typed - customer names, project names, people's names). Attach is the first WRITE that takes
+a mission id from a caller and applies it, so it is exactly the shape that would put the leak back.
+
+`POST /sessions/{sid}/mission` therefore follows `GET /missions/{mid}` line for line: resolve the
+CALLER's own tenant server-side from the authenticated device key, REFUSE when no tenant is bound
+(never fall back to a shared partition), and resolve the mission INSIDE that tenant. The mission is
+resolved BEFORE the session is located, so the refusal is a property of the tenant gate alone and cannot
+be confused with a Director being offline.
+
+**A refusal must not reveal WHICH refusal it is, and that is a security property of the route rather than
+a nicety of its error text.** "No mission has that id" and "that mission belongs to someone else" answer
+identically - same status, same sentence, only the echoed id differing. If they diverged, attaching a
+session to guessed identifiers would enumerate which missions exist in other accounts, one request at a
+time, without ever reading one. The test that holds this compares the two answers TO EACH OTHER rather
+than to a fixed string, so a later edit cannot reword one and leave the other behind.
+`MissionAttachRouteTenantScopingTests` holds it to that, pairing every refusal with a permitted
+request in the same Gateway and asserting that no `attach-mission` command reached the Director.
+
+The Gateway sends the RESOLVED NAME down with the id and the Director stamps it directly, exactly as
+it does for a mission-scoped spawn. A Director must not re-validate against its own mission store:
+that is a different (single-tenant, per-machine) set, so a mission that is real and owned would be
+rejected for being absent from the wrong store - the failure issue #1548 fixed on the spawn path.
+
 ## Naming: Mission -> Task
 
 - The shared root the pod attacks = a **Mission**.

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1640,6 +1640,126 @@ internal static class ControlEndpoints
             });
         });
 
+        // POST /fleet/mission - attach a session that ALREADY EXISTS to a Mission, or DETACH it (issue #2387).
+        // The counterpart of `session spawn --mission`, which could only attach in the instant a session was
+        // born: a mission's real shape is discovered as it runs, so attach-at-birth grouped only the work
+        // somebody had already planned. Attaching is a MOVE - a session that already carries a mission is
+        // re-pointed, and the response says which mission it LEFT, because a move that reports only its
+        // destination hides that anything was displaced.
+        //
+        // A LOCAL target resolves the mission NAME against the GATEWAY - the source of truth for missions,
+        // which are fleet-level - exactly as the local leg of /fleet/spawn does (issue #1548). Without that
+        // the floor would fall through to its local-store bridge and reject a mission that genuinely exists,
+        // telling the human to create one they already have. An unreachable Gateway is reported as
+        // unreachable (502), NEVER as an unknown mission. A REMOTE target is relayed through the Gateway
+        // (POST /sessions/{sid}/mission), which resolves the mission inside the caller's own tenant and routes
+        // the attachment to the owning Director over the tunnel - the same shape as /fleet/role.
+        app.MapPost("/fleet/mission", async (FleetMissionRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            // The session's state BEFORE the call, read while it is still true. Only available when this
+            // Director hosts the session; for a target elsewhere this machine simply never saw it, and
+            // inventing a "(none)" would read as "it had no mission" when the truth is "this machine does
+            // not know".
+            var local = sessionManager.GetSession(toGuid);
+            var previousMissionId = local?.MissionId;
+            var previousMissionName = local?.MissionName;
+
+            // RELAYED THROUGH THE GATEWAY WHETHER OR NOT THE TARGET IS LOCAL, and that is the point.
+            //
+            // Attaching moves TWO things: the mission link and the workflow SEAT, because a Mission is also a
+            // run of the mission workflow and the seat is what pins the conduct the agent follows. Deciding
+            // whether a seat belongs to the mission being left is a fact about the Gateway's run store, so
+            // the Gateway is the only place that can decide it. Routing the local case through the same
+            // endpoint means that rule has exactly ONE implementation - a second copy here would drift, and
+            // the drift would be invisible until a session was found governed by a mission it had left.
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    var relayed = await gw.SetMissionFleetAsync(req.ToSessionId, req.MissionId, ct);
+                    // The seat outcome comes from the GATEWAY, verbatim. This Director must not re-derive
+                    // it: for a session on another machine it never saw the seat the session held before
+                    // the call, so comparing against what it holds would report a PRESERVED seat as a moved
+                    // one - a fact stated by a machine not in a position to know it.
+                    return Results.Json(new FleetMissionResponse
+                    {
+                        Applied = true,
+                        SessionId = relayed.Session?.SessionId ?? req.ToSessionId,
+                        MissionId = relayed.Session?.MissionId,
+                        MissionName = relayed.Session?.MissionName,
+                        WorkflowRunId = relayed.Session?.WorkflowRunId,
+                        WorkflowId = relayed.Session?.WorkflowId,
+                        WorkflowVersion = relayed.Session?.WorkflowVersion,
+                        SeatMoved = relayed.SeatMoved,
+                        SeatNote = relayed.SeatNote,
+                        PreviousMissionId = previousMissionId,
+                        PreviousMissionName = previousMissionName,
+                    });
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/mission relay to {toGuid} FAILED: {ex.Message}");
+                    return Results.Json(new FleetMissionResponse
+                    {
+                        Applied = false, SessionId = req.ToSessionId,
+                        Error = $"Cannot attach the target to the mission via the Gateway: {ex.Message}",
+                    }, statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+
+            // NO GATEWAY. Missions and runs both live at the Gateway, so a Gateway-less Director can only
+            // reach the mission records in its own local store, and can reach no runs at all. It attaches the
+            // mission and says plainly that no seat was moved - the same posture /fleet/spawn already takes
+            // ("a Gateway-less Director seats nothing"), stated rather than silently implied.
+            if (local is null)
+                return Results.Json(new FleetMissionResponse
+                {
+                    Applied = false, SessionId = req.ToSessionId,
+                    Error = "Session not found on this Director and no Gateway is configured.",
+                }, statusCode: StatusCodes.Status404NotFound);
+
+            var command = new DirectorCommand
+            {
+                Verb = "attach-mission",
+                SessionId = req.ToSessionId,
+                // MoveSeat stays false: with no Gateway there is no run store to decide against, and moving a
+                // seat on a guess is worse than leaving one that is visibly stale.
+                PayloadJson = SessionCommandExecutor.Serialize(new SetMissionRequest { MissionId = req.MissionId }),
+            };
+            var missionServices = new SessionCommandServices { MissionStore = missionStore };
+            var result = await SessionCommandExecutor.DispatchAsync(
+                sessionManager, directorId, command, missionServices, cancellationToken: ct);
+            if (result.Status != DirectorCommandStatus.Ok)
+                return Results.Json(new FleetMissionResponse
+                {
+                    Applied = false, SessionId = req.ToSessionId, Error = result.Error ?? "attach failed",
+                }, statusCode: result.Status == DirectorCommandStatus.NotFound
+                    ? StatusCodes.Status404NotFound
+                    : StatusCodes.Status400BadRequest);
+
+            return Results.Json(new FleetMissionResponse
+            {
+                Applied = true,
+                SessionId = req.ToSessionId,
+                MissionId = local.MissionId,
+                MissionName = local.MissionName,
+                WorkflowRunId = local.WorkflowRunId,
+                WorkflowId = local.WorkflowId,
+                WorkflowVersion = local.WorkflowVersion,
+                SeatMoved = false,
+                SeatNote = "No Gateway is configured, so the workflow seat was not moved - workflow runs "
+                         + "live only at the Gateway.",
+                PreviousMissionId = previousMissionId,
+                PreviousMissionName = previousMissionName,
+            });
+        });
+
         // POST /fleet/done - flag a session anywhere in the fleet for teardown (issue #1490). A local target is
         // flagged directly (its Director's reaper removes it after the grace window); a remote target is relayed
         // through the Gateway (POST /sessions/{sid}/request-deletion). Restores `cc-devthrottle session done` -

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -830,6 +830,35 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Attach a session anywhere in the fleet to a Mission - or DETACH it, on a null mission id - via the
+    /// Gateway's POST /sessions/{sid}/mission, which resolves the mission inside the CALLER's own tenant and
+    /// then routes the attachment to the owning Director over the tunnel (issue #2387). The Director's
+    /// loopback POST /fleet/mission relays here for a target it does not host. Throws when the Gateway is
+    /// disabled or the call fails - an unreachable Gateway is never reported as an unknown mission.
+    /// </summary>
+    public async Task<MissionAttachResultDto> SetMissionFleetAsync(string toSessionId, Guid? missionId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] SetMissionFleetAsync: POST /sessions/{toSessionId}/mission mission={missionId?.ToString() ?? "(detach)"}");
+        var body = new SetMissionRequest { MissionId = missionId };
+        using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/mission", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw await RelayFailureAsync(resp, $"mission attach of {toSessionId}", ct);
+
+        // The result carries the SEAT OUTCOME as well as the session, because whether the workflow seat
+        // moved is a fact only the Gateway holds - it knew the seat the session had before the call and
+        // whether that seat belonged to the mission it left. This Director must not re-derive it.
+        var parsed = await resp.Content.ReadFromJsonAsync<MissionAttachResultDto>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway mission attach returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
     /// Flag a session anywhere in the fleet for teardown via the Gateway's POST /sessions/{sid}/request-deletion,
     /// which routes to the owning Director over the tunnel. Issue #1490: the Director's loopback POST /fleet/done
     /// relays here for a non-local target. Throws when the Gateway is disabled or the call fails.

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -758,9 +758,23 @@ internal static class SessionCommandExecutor
     /// <summary>
     /// The <c>attach-mission</c> verb: attach a session to a Mission (or DETACH it on a blank/absent
     /// MissionId). Invalid id -&gt; BadRequest, missing session -&gt; NotFound, unknown Mission -&gt;
-    /// BadRequest. The Mission's display name is resolved through the Mission store and cached onto the
-    /// session. Returns the updated session mapped through the SAME <see cref="ControlEndpoints.Map"/> the
+    /// BadRequest. Returns the updated session mapped through the SAME <see cref="ControlEndpoints.Map"/> the
     /// stream snapshot uses. Mirrors <see cref="SetRole"/>.
+    ///
+    /// The Mission NAME arrives one of two ways, exactly as it does on the create path (see the mission block
+    /// in <see cref="Create"/>), because a Mission is a FLEET-level record whose source of truth is the
+    /// Gateway and not this machine:
+    ///  * GATEWAY path (MissionId AND MissionName both set): the Gateway resolved the mission against its own
+    ///    TENANT-SCOPED store before sending the verb, and that resolution is the authorization. The Director
+    ///    stamps the attachment directly - no local lookup, no second opinion. This is the end state.
+    ///  * TRANSITIONAL BRIDGE (MissionId set, MissionName blank): an old caller naming a mission in the
+    ///    Director's OWN store. The Director resolves it locally exactly as before. Removed with the Director
+    ///    MissionStore in Gateway Cleanup Phase 1.
+    ///
+    /// The Director deliberately does NOT re-validate a Gateway-supplied mission against its local store. It
+    /// could not: the local store is a different (single-tenant, per-machine) set, so a mission that is real
+    /// and owned would be rejected here for being absent from the wrong store - which is exactly the failure
+    /// issue #1548 fixed on the spawn path.
     /// </summary>
     internal static DirectorCommandResult AttachMission(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services)
     {
@@ -773,15 +787,44 @@ internal static class SessionCommandExecutor
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
+        // THE SEAT MOVES WITH THE MISSION, when the Gateway says it should (issue #2387 review).
+        //
+        // A Mission is also a RUN of the built-in "mission" workflow, and a mission-scoped spawn seats the
+        // session on that run - which is what pins the conduct its preamble told it to follow. Changing the
+        // mission link alone would leave a session DISPLAYED under one mission and GOVERNED by the one it
+        // left. The seat therefore rides this same verb, so the two land together and a session is never
+        // momentarily one and not the other.
+        //
+        // The DECISION is the Gateway's, not this Director's: whether the current seat belongs to the
+        // mission being left is a fact about the run store, which lives at the Gateway. This applies what it
+        // was told. MoveSeat=false means "the seat is not the mission's to take" and the seat is untouched.
+        void ApplySeat()
+        {
+            if (request?.MoveSeat == true)
+                session.SeatOnWorkflow(request.WorkflowRunId, request.WorkflowId, request.WorkflowVersion);
+        }
+
         if (request?.MissionId is not Guid missionId)
         {
             // Blank/absent -> detach (mirrors set-role clearing the explicit role).
             session.AttachToMission(null, null);
-            FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} detached");
+            ApplySeat();
+            FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} detached " +
+                          $"(seat {(request?.MoveSeat == true ? "cleared with it" : "left as it was")})");
             return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
         }
 
-        // The Director's store is single-tenant - one machine, one owner - so Local is its whole world.
+        if (!string.IsNullOrWhiteSpace(request.MissionName))
+        {
+            // Gateway path: the mission was resolved inside the caller's own tenant; stamp it.
+            session.AttachToMission(missionId, request.MissionName);
+            ApplySeat();
+            FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} mission={missionId} (resolved by the Gateway)");
+            return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
+        }
+
+        // Transitional bridge. The Director's store is single-tenant - one machine, one owner - so Local is
+        // its whole world.
         var mission = services?.MissionStore?.Get(Core.Tenancy.TenantId.Local, missionId);
         if (mission is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -241,6 +241,93 @@ public sealed class FleetRoleResponse
 }
 
 /// <summary>
+/// Body of POST /fleet/mission on the Director (issue #2387). Attaches a session that ALREADY EXISTS to a
+/// Mission - the counterpart of <c>session spawn --mission</c>, which could only attach in the instant a
+/// session was born. Until this existed a Mission could only ever group work somebody planned in advance,
+/// which is the work that least needs grouping: a mission's real shape is discovered as it runs.
+///
+/// A LOCAL target is attached directly (the Gateway resolves the mission NAME first, as it does for a local
+/// mission-scoped spawn); a target on another machine is relayed through the Gateway
+/// (POST /sessions/{sid}/mission), which routes it to the owning Director over the tunnel.
+/// </summary>
+public sealed class FleetMissionRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet (defaults, at the command line, to the caller).</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>
+    /// The Mission to attach to. Null or absent DETACHES the session, clearing its attachment - the same
+    /// clearing convention <see cref="FleetRoleRequest.Role"/> uses for an explicit role. Detaching is
+    /// deliberately supported: no mission is the ordinary state of a session, so returning to it must not
+    /// require inventing a mission to park the session in.
+    /// </summary>
+    public Guid? MissionId { get; set; }
+}
+
+/// <summary>Response from POST /fleet/mission.</summary>
+public sealed class FleetMissionResponse
+{
+    /// <summary>True when the attachment (or detachment) was applied.</summary>
+    public bool Applied { get; set; }
+
+    /// <summary>The target session's GUID.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The Mission the session is attached to after the call, or null when it was detached.</summary>
+    public Guid? MissionId { get; set; }
+
+    /// <summary>The attached Mission's display name after the call, or null when detached.</summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>
+    /// The Mission the session was attached to BEFORE the call, or null when it had none. Returned so the
+    /// command line can say what the session LEFT: attaching is a move, and a move that reports only its
+    /// destination hides the fact that anything was displaced.
+    /// </summary>
+    public Guid? PreviousMissionId { get; set; }
+
+    /// <summary>The previous Mission's display name, or null when the session had no mission.</summary>
+    public string? PreviousMissionName { get; set; }
+
+    /// <summary>
+    /// The workflow RUN the session is seated on after the call, or null when it is seated on nothing.
+    ///
+    /// A Mission is also a run of the built-in "mission" workflow, and the seat is what pins the CONDUCT the
+    /// agent follows - so a move that changed the mission and left the seat behind would show a session under
+    /// one mission while it was governed by another. The seat therefore travels with the mission, and this
+    /// field plus <see cref="SeatMoved"/> report what happened to it.
+    /// </summary>
+    public Guid? WorkflowRunId { get; set; }
+
+    /// <summary>
+    /// The seated run's workflow id and PINNED version after the call, or null when the session ended up
+    /// seated on nothing. Reported so a caller telling a running session to re-read its conduct can name
+    /// the exact workflow and version rather than handing the human a command with blanks in it to go and
+    /// fill in from somewhere else.
+    /// </summary>
+    public string? WorkflowId { get; set; }
+
+    /// <summary>The seated run's pinned version after the call. See <see cref="WorkflowId"/>.</summary>
+    public int? WorkflowVersion { get; set; }
+
+    /// <summary>
+    /// True when this call also moved (or cleared) the session's workflow seat. False when the seat was left
+    /// alone - either because it was a run the caller chose independently, which was never the mission's to
+    /// take, or because the session ended up on the same run it was already sitting on.
+    /// </summary>
+    public bool SeatMoved { get; set; }
+
+    /// <summary>
+    /// A plain sentence about the seat when there is something the caller must know that the two fields above
+    /// cannot say - most importantly that no seat could be moved at all. Null when there is nothing to add.
+    /// </summary>
+    public string? SeatNote { get; set; }
+
+    /// <summary>Error message when Applied is false.</summary>
+    public string? Error { get; set; }
+}
+
+/// <summary>
 /// Body of POST /fleet/done on the Director (issue #1490). Flags a session anywhere in the fleet for
 /// asynchronous teardown by its owning Director's deletion reaper: flagged locally when the target lives on
 /// this machine, otherwise relayed through the Gateway (POST /sessions/{sid}/request-deletion). Restores the

--- a/src/CcDirector.Gateway.Contracts/MissionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/MissionDto.cs
@@ -41,11 +41,84 @@ public sealed class NewMissionRequest
 }
 
 /// <summary>
-/// Body of POST /sessions/{id}/mission: attach a session to a Mission. <see cref="MissionId"/> is the
-/// Mission the session attaches to; a null/absent value DETACHES the session (clears its attachment),
-/// mirroring how <see cref="SetRoleRequest"/> clears an explicit role.
+/// Body of POST /sessions/{id}/mission: attach a session that ALREADY EXISTS to a Mission (issue #2387).
+/// <see cref="MissionId"/> is the Mission the session attaches to; a null/absent value DETACHES the session
+/// (clears its attachment), mirroring how <see cref="SetRoleRequest"/> clears an explicit role.
+///
+/// Attaching is a MOVE, not a one-way door: a session that already carries a Mission is re-pointed by the
+/// same call. A mission's shape is discovered rather than planned - that is what makes it a mission - so the
+/// first classification of a session is a guess, and a one-way attach would make every wrong guess permanent
+/// until the session was killed. The attachment rules are written up in
+/// docs/new_architecture/mission-as-first-class-unit-of-work.md.
 /// </summary>
 public sealed class SetMissionRequest
 {
     public Guid? MissionId { get; set; }
+
+    /// <summary>
+    /// The Mission's display name, RESOLVED BY THE GATEWAY against its own tenant-scoped store and cached
+    /// onto the session so a client can render the attachment without a second lookup. Present on the
+    /// Gateway path (the end state, exactly like <c>NewSessionRequest.MissionName</c> at spawn); blank on
+    /// the transitional bridge, where the Director resolves the name from its own local store instead.
+    ///
+    /// A Director never TRUSTS this to decide whether the attachment is allowed - the Gateway has already
+    /// resolved the mission inside the caller's own tenant before sending it, and that resolution is the
+    /// authorization. This field only saves the Director a lookup it cannot do correctly anyway (its local
+    /// store is not the fleet's).
+    /// </summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>
+    /// True when this call must also move the session's WORKFLOW SEAT, and false when the seat must be left
+    /// exactly as it is. The Gateway decides which - see the seat block on the attach route - and the
+    /// Director obeys; it has no way to decide correctly, because whether a run belongs to a mission is a
+    /// fact only the Gateway's run store holds.
+    ///
+    /// WHY THE SEAT IS PART OF THIS CALL AT ALL. A Mission is not only a record: it is also a RUN of the
+    /// built-in "mission" workflow, and a mission-scoped spawn seats the session on that run, which is what
+    /// pins the conduct the agent was told to follow. Moving the mission link alone would show a session
+    /// under one mission while it was GOVERNED by the one it left - taking its conduct from the mission it
+    /// is no longer in. That is worse than an inconsistent label, and it would happen in exactly the case
+    /// this feature was built for.
+    /// </summary>
+    public bool MoveSeat { get; set; }
+
+    /// <summary>The workflow run to seat the session on when <see cref="MoveSeat"/> is true. Null clears the
+    /// seat - a mission with no run of its own (an ungoverned mission), or a detach.</summary>
+    public Guid? WorkflowRunId { get; set; }
+
+    /// <summary>The seated run's workflow id, Gateway-resolved. Ignored unless <see cref="MoveSeat"/>.</summary>
+    public string? WorkflowId { get; set; }
+
+    /// <summary>The seated run's PINNED version, Gateway-resolved. Ignored unless <see cref="MoveSeat"/>.</summary>
+    public int? WorkflowVersion { get; set; }
+}
+
+/// <summary>
+/// The result of POST /sessions/{sid}/mission: the updated session, plus WHAT HAPPENED TO ITS WORKFLOW
+/// SEAT.
+///
+/// The seat outcome is returned rather than left to be inferred, and that is deliberate. Only the Gateway
+/// knows the seat the session held before the call and whether that seat belonged to the mission it left,
+/// so only the Gateway can say whether the seat moved. A Director asked to work it out for a session it
+/// does not host would be comparing against a value it never had, and would report a preserved seat as a
+/// moved one - stating a fact it is not in a position to know.
+/// </summary>
+public sealed class MissionAttachResultDto
+{
+    /// <summary>The session as the owning Director reports it after the change.</summary>
+    public SessionDto? Session { get; set; }
+
+    /// <summary>True when the workflow seat was moved or cleared by this call; false when it was left alone.</summary>
+    public bool SeatMoved { get; set; }
+
+    /// <summary>The workflow run the session was seated on BEFORE the call, or null if it was seated on nothing.</summary>
+    public Guid? PreviousWorkflowRunId { get; set; }
+
+    /// <summary>
+    /// A plain sentence about the seat when there is something the caller needs told - a seat preserved
+    /// because it was never the mission's, or a destination mission that seats nobody. Null when the
+    /// outcome speaks for itself.
+    /// </summary>
+    public string? SeatNote { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/MissionAttachRouteTenantScopingTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionAttachRouteTenantScopingTests.cs
@@ -1,0 +1,562 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2387: <c>POST /sessions/{sid}/mission</c> - attaching a session that ALREADY EXISTS to a Mission -
+/// scoped to the CALLER's own tenant, proven over the REAL mapped route, the REAL auth middleware and the
+/// REAL tunnel, with two separately-enrolled accounts.
+///
+/// WHY THIS ROUTE GETS ITS OWN PARTITION FILE. Missions are tenant-scoped and that was hard won:
+/// devthrottle_internal issue #1039 fixed a live leak where <c>GET /missions</c> served every account's list
+/// to every account, and a mission NAME is free text a person typed - customer names, project names, people's
+/// names. The read side is now gated. This route is the first WRITE that takes a mission id from the caller
+/// and applies it, so it is exactly the shape that would put the leak back: a caller who could attach a
+/// session to another account's mission would be writing that account's identifier onto its own session, and
+/// reading the name back out of its own roster. It follows <c>GET /missions/{mid}</c> line for line - resolve
+/// the caller's tenant, refuse when unbound, resolve the mission INSIDE that tenant - and these cases hold it
+/// to that.
+///
+/// HOW THESE CASES ARE WRITTEN, which matters more than the count:
+///
+///  - Every refusal is paired with a PERMITTED request in the same test, in the same Gateway. A route that
+///    refused everybody would satisfy every refusal assertion here while being entirely broken, so a refusal
+///    on its own proves nothing at all.
+///  - A refusal is asserted at TWO levels: the status code, and the fact that the owning Director was never
+///    sent an <c>attach-mission</c> command over the tunnel. A status code alone cannot tell "refused" from
+///    "attached, then reported an error" - and it is the WRITE reaching the Director that would be the breach.
+///  - <see cref="The_attach_detector_itself_detects_an_attach_when_there_is_one"/> is the SELF-TEST. Every
+///    refusal below rests on "no attach-mission reached that Director". That assertion is worth exactly as
+///    much as its ability to come out TRUE, so one case points the same recorder at an attach that genuinely
+///    happens and requires a positive. If it ever goes green-by-absence, nothing else in this file means
+///    anything.
+///
+/// Revert-prove: drop the <c>ResolveReadTenant</c> gate (or resolve the mission with <c>TenantId.Local</c>)
+/// in the route and <see cref="Another_tenants_mission_cannot_be_attached_to_your_own_session"/> goes RED -
+/// A's attach to B's mission stops being a 400 and reaches A's Director carrying B's mission name.
+///
+/// The assembly disables test parallelization, so toggling CC_GATEWAY_HOSTED here is safe; it is reset in
+/// DisposeAsync.
+/// </summary>
+public sealed class MissionAttachRouteTenantScopingTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string SessA = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    private const string SessB = "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dirA = null!;
+    private FakeTunnelDirector _dirB = null!;
+
+    // Every attach-mission PAYLOAD each Director was sent over the tunnel. Recording the payload rather than
+    // just the verb is deliberate: the breach this file guards is a mission id/name from another account
+    // ARRIVING at a Director, so the evidence has to be able to show what was carried, not only that
+    // something was.
+    private readonly ConcurrentQueue<SetMissionRequest> _attachesOnA = new();
+    private readonly ConcurrentQueue<SetMissionRequest> _attachesOnB = new();
+
+    private string _keyA = "";
+    private string _keyB = "";
+    private string _keyUnbound = "";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-2387-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Two accounts enrolled through the product's own hosted enrollment, each atomically bound to its own
+        // canonically minted tenant, plus one registered-but-unbound key for the deny-by-default path.
+        _keyA = HostedTestEnrollment.Enroll(_gateway, "sub-alice", "alice@example.com", "dev-a", "MA").DeviceKey;
+        _keyB = HostedTestEnrollment.Enroll(_gateway, "sub-bob", "bob@example.com", "dev-b", "MB").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-x", "MX").DeviceKey;
+
+        // Each Director authenticates with its OWN device key, so the tunnel Hello binds its tenant and its
+        // pushed session lands in that tenant's partition. Each answers attach-mission with the session it was
+        // told to attach - the shape the real Director core returns.
+        _dirA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "dir-a", "MA",
+            dispatch: Recorder(_attachesOnA, SessA));
+        _dirB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "dir-b", "MB",
+            dispatch: Recorder(_attachesOnB, SessB));
+        await _dirA.PushSnapshotAsync(Sample(SessA));
+        await _dirB.PushSnapshotAsync(Sample(SessB));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dirA.DisposeAsync();
+        await _dirB.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task The_attach_detector_itself_detects_an_attach_when_there_is_one()
+    {
+        // THE SELF-TEST. Every refusal in this file is "no attach-mission was recorded on that Director".
+        // Point the same recorder at an attach that genuinely happens and require a POSITIVE, otherwise a
+        // recorder that never records anything would certify the whole file.
+        var mission = await CreateMission(_keyA, "A mission the caller definitely owns");
+
+        var resp = await Attach(SessA, _keyA, mission.MissionId);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var recorded = Assert.Single(_attachesOnA);
+        Assert.Equal(mission.MissionId, recorded.MissionId);
+
+        // And the Gateway resolved the NAME before sending it, so the Director stamps what the Gateway
+        // authorized instead of consulting its own (different, per-machine) mission store.
+        Assert.Equal("A mission the caller definitely owns", recorded.MissionName);
+    }
+
+    [Fact]
+    public async Task Another_tenants_mission_cannot_be_attached_to_your_own_session()
+    {
+        // THE CASE THIS FILE EXISTS FOR. B creates a mission whose NAME is the kind of free text #1039 was
+        // about. A - holding its own perfectly valid device key, and naming a session it genuinely owns -
+        // tries to attach that session to B's mission.
+        var bMission = await CreateMission(_keyB, "Payments cutover for Northwind");
+
+        var refused = await Attach(SessA, _keyA, bMission.MissionId);
+
+        // The refusal: an id from another account is simply not a mission, and the error says so without
+        // confirming that anybody else has it.
+        Assert.Equal(HttpStatusCode.BadRequest, refused.StatusCode);
+        var body = await refused.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("Northwind", body);
+
+        // And the write never happened: A's OWN Director was never sent the attach, so B's mission name
+        // never travelled to A's machine and cannot be read back out of A's roster.
+        Assert.Empty(_attachesOnA);
+
+        // THE PERMITTED HALF, in the same Gateway and the same breath. A can attach that same session to a
+        // mission of its OWN - so the refusal above is about the mission's owner, not a route that refuses
+        // every attach.
+        var aMission = await CreateMission(_keyA, "A's own mission");
+        var allowed = await Attach(SessA, _keyA, aMission.MissionId);
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+        Assert.Equal(aMission.MissionId, Assert.Single(_attachesOnA).MissionId);
+    }
+
+    [Fact]
+    public async Task Another_tenants_session_cannot_be_attached_to_your_own_mission()
+    {
+        // The other direction, and it is a different gate: the mission is the caller's, the SESSION is not.
+        // A mission id is only half of an attachment - being able to name any session in the fleet would let
+        // one account rearrange another account's work even without ever seeing a foreign mission.
+        var aMission = await CreateMission(_keyA, "A's mission");
+
+        var refused = await Attach(SessB, _keyA, aMission.MissionId);
+
+        Assert.Equal(HttpStatusCode.NotFound, refused.StatusCode);
+        Assert.Empty(_attachesOnB);   // B's Director never saw a command
+
+        // The permitted half: B's OWN key reaches that same session, so the refusal is the tenant gate and
+        // not a session that is unreachable for everybody.
+        var bMission = await CreateMission(_keyB, "B's mission");
+        var allowed = await Attach(SessB, _keyB, bMission.MissionId);
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+        Assert.Equal(bMission.MissionId, Assert.Single(_attachesOnB).MissionId);
+    }
+
+    [Fact]
+    public async Task A_device_key_with_no_bound_tenant_attaches_nothing()
+    {
+        // Deny-by-default. A tenant-unbound hosted credential must never be served the Local partition, and
+        // must reach no Director - not on the attach leg and not on the detach leg.
+        var aMission = await CreateMission(_keyA, "A's mission");
+
+        var attach = await Attach(SessA, _keyUnbound, aMission.MissionId);
+        Assert.True(attach.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            $"an unbound device key was answered {(int)attach.StatusCode}, which is neither a refusal nor a denial");
+
+        var detach = await Attach(SessA, _keyUnbound, null);
+        Assert.True(detach.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            $"an unbound device key was answered {(int)detach.StatusCode} on the detach leg");
+
+        Assert.Empty(_attachesOnA);
+        Assert.Empty(_attachesOnB);
+
+        // The permitted half: the same two calls with a BOUND key both land, so the denials above are about
+        // the credential and not about the route being inert.
+        Assert.Equal(HttpStatusCode.OK, (await Attach(SessA, _keyA, aMission.MissionId)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await Attach(SessA, _keyA, null)).StatusCode);
+        Assert.Equal(2, _attachesOnA.Count);
+    }
+
+    [Fact]
+    public async Task Detaching_carries_no_mission_and_needs_none()
+    {
+        // Detach is the null-mission call. It resolves nothing, so it cannot leak anything - but it must
+        // still reach the Director as a real command, or "detach" would be a no-op that reports success.
+        var resp = await Attach(SessA, _keyA, null);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var recorded = Assert.Single(_attachesOnA);
+        Assert.Null(recorded.MissionId);
+        Assert.Null(recorded.MissionName);
+    }
+
+    [Fact]
+    public async Task An_unknown_mission_id_and_another_tenants_mission_id_are_answered_alike()
+    {
+        // The two must be indistinguishable or the route becomes an existence oracle: attach a session to
+        // every id you can guess, and the ones that answer differently are the ones somebody else owns.
+        var bMission = await CreateMission(_keyB, "B's mission");
+
+        var foreign = await Attach(SessA, _keyA, bMission.MissionId);
+        var nonexistent = await Attach(SessA, _keyA, Guid.NewGuid());
+
+        Assert.Equal(nonexistent.StatusCode, foreign.StatusCode);
+        // Same status AND the same wording apart from the id echoed back, so the shape of the answer does
+        // not distinguish them either.
+        var foreignBody = (await foreign.Content.ReadAsStringAsync()).Replace(bMission.MissionId.ToString(), "<id>");
+        var nonexistentBody = await nonexistent.Content.ReadAsStringAsync();
+        Assert.Equal(foreignBody, ReplaceGuid(nonexistentBody));
+        Assert.Empty(_attachesOnA);
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A fake Director that RECORDS every attach-mission payload it is sent and answers with the session it
+    /// was told to attach. Anything else is a loud failure rather than a shrug: a verb this file did not
+    /// expect arriving at a Director is a finding, not noise.
+    /// </summary>
+    private static Func<DirectorCommand, DirectorCommandResult> Recorder(
+        ConcurrentQueue<SetMissionRequest> log, string sessionId) => cmd =>
+    {
+        if (cmd.Verb != "attach-mission")
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+
+        var payload = JsonSerializer.Deserialize<SetMissionRequest>(cmd.PayloadJson ?? "", JsonOpts)
+                      ?? new SetMissionRequest();
+        log.Enqueue(payload);
+        return FakeTunnelDirector.Ok(new SessionDto
+        {
+            SessionId = sessionId,
+            MissionId = payload.MissionId,
+            MissionName = payload.MissionName,
+        });
+    };
+
+    private static string ReplaceGuid(string body)
+    {
+        // Swap whatever GUID the body echoes for the same placeholder the foreign-id body got, so the two
+        // are compared on their WORDING and not on the id that necessarily differs.
+        return System.Text.RegularExpressions.Regex.Replace(
+            body, "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", "<id>");
+    }
+
+    private Task<HttpResponseMessage> Attach(string sid, string deviceKey, Guid? missionId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, $"sessions/{sid}/mission")
+        {
+            Content = JsonContent.Create(new SetMissionRequest { MissionId = missionId }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return _http.SendAsync(req);
+    }
+
+    private async Task<MissionDto> CreateMission(string deviceKey, string name)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "missions")
+        {
+            Content = JsonContent.Create(new NewMissionRequest { MissionName = name }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(dto);
+        return dto!;
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Working",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+    };
+}
+
+/// <summary>
+/// Issue #2387, the review finding: THE WORKFLOW SEAT MOVES WITH THE MISSION.
+///
+/// A Mission is not only a record - it is also a RUN of the built-in "mission" workflow, and a
+/// mission-scoped spawn seats the session on that run and records it in the run's participant ledger. The
+/// seat is what pins the CONDUCT the agent was told to follow. The first cut of attach changed only
+/// MissionId and MissionName, so a session moved from Mission A to Mission B was DISPLAYED under B while it
+/// was still GOVERNED by A - taking its conduct from a mission it had left, and still sitting in A's
+/// participant ledger as active. Detach had the same shape with no mission shown at all. That is not a
+/// cosmetic inconsistency: the thing this feature exists to make visible would have been actively
+/// misleading in exactly the case it was built for.
+///
+/// These cases drive the REAL route against a REAL run store, so they pin the DECISION (which is the
+/// Gateway's, because only it knows whether a run belongs to a mission) and its consequence at the
+/// Director and in the ledger. The rule and its one exception:
+///  * a seat that IS a run of the mission being left follows the mission;
+///  * a seat the caller chose independently is PRESERVED - it was never the mission's to take.
+///
+/// Revert-prove: delete the seat block from the attach route (leave only the mission fields on the payload)
+/// and <see cref="Moving_a_mission_scoped_session_moves_its_workflow_seat"/> goes RED - the Director is sent
+/// MoveSeat=false and keeps Mission A's run while its mission reads B, which is the defect verbatim.
+/// </summary>
+public sealed class MissionAttachSeatMoveTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string Sess = "33333333-cccc-4ccc-8ccc-cccccccccccc";
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _dir = null!;
+
+    private readonly ConcurrentQueue<SetMissionRequest> _attaches = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-2387-seat-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        // Self-host shape (one owner). The tenant partition of this route is proven next door in
+        // MissionAttachRouteTenantScopingTests; what is under test here is the seat, and a single owner is
+        // the cleanest place to see it.
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", null);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            missionsPath: Path.Combine(_instancesDir, "missions.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _dir = await FakeTunnelDirector.StartAsync(_gateway, Token, "dir-seat", "MS", dispatch: cmd =>
+        {
+            if (cmd.Verb != "attach-mission")
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            var payload = JsonSerializer.Deserialize<SetMissionRequest>(cmd.PayloadJson ?? "", JsonOpts)
+                          ?? new SetMissionRequest();
+            _attaches.Enqueue(payload);
+            return FakeTunnelDirector.Ok(new SessionDto
+            {
+                SessionId = Sess,
+                MissionId = payload.MissionId,
+                MissionName = payload.MissionName,
+                WorkflowRunId = payload.MoveSeat ? payload.WorkflowRunId : null,
+            });
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _dir.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task Moving_a_mission_scoped_session_moves_its_workflow_seat()
+    {
+        var (missionA, runA) = await CreateMissionWithRun("Mission A");
+        var (missionB, runB) = await CreateMissionWithRun("Mission B");
+
+        // A session exactly as a mission-scoped spawn leaves it: in Mission A, seated on A's run.
+        await PushSession(missionA, runA);
+
+        var resp = await Attach(missionB);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var sent = Assert.Single(_attaches);
+        Assert.Equal(missionB, sent.MissionId);
+        // THE FINDING, at the decision point: the Gateway told the Director to move the seat, and named
+        // Mission B's run - not Mission A's, which is what the session would otherwise have kept.
+        Assert.True(sent.MoveSeat, "the Gateway did not tell the Director to move the seat, so the session "
+                                   + "would stay governed by the mission it just left");
+        Assert.Equal(runB, sent.WorkflowRunId);
+        Assert.Equal("mission", sent.WorkflowId);
+        Assert.NotNull(sent.WorkflowVersion);   // the PINNED version travels too, never a moving head
+    }
+
+    [Fact]
+    public async Task Moving_a_session_updates_the_participant_ledger_on_both_runs()
+    {
+        var (missionA, runA) = await CreateMissionWithRun("Mission A");
+        var (missionB, runB) = await CreateMissionWithRun("Mission B");
+        await PushSession(missionA, runA);
+
+        // The control, BEFORE the move: the session really is an active participant of A's run. Without
+        // this the "no longer active on A" assertion below would also pass if it had never been on A.
+        await JoinRun(runA, Sess);
+        Assert.True(await IsActiveParticipant(runA, Sess), "the session was never on run A, so nothing below means anything");
+
+        Assert.Equal(HttpStatusCode.OK, (await Attach(missionB)).StatusCode);
+
+        // Left A, joined B. Leaving is RECORDED rather than erased - that the session was in A is true and
+        // stays true - so the assertion is about being ACTIVE there, not about being absent from the list.
+        Assert.False(await IsActiveParticipant(runA, Sess), "the session is still an active participant of the run it left");
+        Assert.True(await IsActiveParticipant(runB, Sess), "the session did not join the run of the mission it moved to");
+    }
+
+    [Fact]
+    public async Task A_seat_the_caller_chose_independently_is_preserved()
+    {
+        // The exception to the rule. A run that is not this mission's run was never the mission's to take -
+        // a session deliberately seated on some other workflow keeps that seat when its mission changes.
+        var (missionA, _) = await CreateMissionWithRun("Mission A");
+        var (missionB, runB) = await CreateMissionWithRun("Mission B");
+        var independent = await CreateStandaloneRun();
+
+        await PushSession(missionA, independent);
+        await JoinRun(independent, Sess);
+
+        Assert.Equal(HttpStatusCode.OK, (await Attach(missionB)).StatusCode);
+
+        var sent = Assert.Single(_attaches);
+        Assert.Equal(missionB, sent.MissionId);   // the mission still moves
+        Assert.False(sent.MoveSeat, "a run the caller chose independently was taken over by a mission move");
+        Assert.Null(sent.WorkflowRunId);
+
+        // And the ledger is left alone in BOTH directions: still active on the run it chose, and not
+        // quietly enrolled in the destination mission's run it was never seated on.
+        Assert.True(await IsActiveParticipant(independent, Sess),
+            "the session was removed from a run that was never the mission's to take");
+        Assert.False(await IsActiveParticipant(runB, Sess),
+            "the session joined a run it was never seated on");
+    }
+
+    [Fact]
+    public async Task Detaching_clears_the_missions_seat_with_it()
+    {
+        // The semantics question the review asked to be settled rather than implied: a session that has LEFT
+        // a mission cannot still be governed by that mission's workflow run, so the seat goes with it. The
+        // alternative - refusing to detach while a seat exists - would make detach impossible for exactly
+        // the sessions that most need it, since every mission-spawned session is seated.
+        var (missionA, runA) = await CreateMissionWithRun("Mission A");
+        await PushSession(missionA, runA);
+        await JoinRun(runA, Sess);
+
+        Assert.Equal(HttpStatusCode.OK, (await Attach(null)).StatusCode);
+
+        var sent = Assert.Single(_attaches);
+        Assert.Null(sent.MissionId);
+        Assert.True(sent.MoveSeat, "detach left the seat behind, so the session is governed by a mission it is not in");
+        Assert.Null(sent.WorkflowRunId);   // cleared, not moved somewhere else
+        Assert.False(await IsActiveParticipant(runA, Sess));
+    }
+
+    [Fact]
+    public async Task An_unseated_session_simply_gains_the_destination_missions_seat()
+    {
+        // Nothing to preserve, so nothing is preserved. This is the case that would otherwise leave a
+        // session attached to a mission and governed by nothing.
+        var (missionB, runB) = await CreateMissionWithRun("Mission B");
+        await PushSession(missionId: null, runId: null);
+
+        Assert.Equal(HttpStatusCode.OK, (await Attach(missionB)).StatusCode);
+
+        var sent = Assert.Single(_attaches);
+        Assert.True(sent.MoveSeat);
+        Assert.Equal(runB, sent.WorkflowRunId);
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------------
+
+    private async Task<(Guid MissionId, Guid RunId)> CreateMissionWithRun(string name)
+    {
+        var resp = await _http.PostAsJsonAsync("missions", new NewMissionRequest { MissionName = name });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(dto);
+        // A mission IS a run of the mission workflow. If this is ever null the premise of these tests is
+        // gone, so fail here rather than let every case below quietly assert about nothing.
+        Assert.True(dto!.WorkflowRunId.HasValue,
+            "the Gateway created a mission with no workflow run, so there is no seat for a move to carry");
+        return (dto.MissionId, dto.WorkflowRunId!.Value);
+    }
+
+    private async Task<Guid> CreateStandaloneRun()
+    {
+        var resp = await _http.PostAsJsonAsync("gateway/workflow-runs",
+            new NewWorkflowRunRequest { WorkflowId = "standalone", Name = "a run of the caller's own" });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var run = await resp.Content.ReadFromJsonAsync<WorkflowRunDto>();
+        Assert.NotNull(run);
+        return run!.Id;
+    }
+
+    private Task PushSession(Guid? missionId, Guid? runId) => _dir.PushSnapshotAsync(new SessionDto
+    {
+        SessionId = Sess,
+        Agent = "claude",
+        RepoPath = "/repo",
+        ActivityState = "Working",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        MissionId = missionId,
+        WorkflowRunId = runId,
+    });
+
+    private Task<HttpResponseMessage> Attach(Guid? missionId) =>
+        _http.PostAsJsonAsync($"sessions/{Sess}/mission", new SetMissionRequest { MissionId = missionId });
+
+    private async Task JoinRun(Guid runId, string sessionId)
+    {
+        var resp = await _http.PatchAsJsonAsync($"gateway/workflow-runs/{runId}", new PatchWorkflowRunRequest
+        {
+            AddParticipants = new List<WorkflowRunParticipantDto> { new() { SessionId = sessionId } },
+        });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    private async Task<bool> IsActiveParticipant(Guid runId, string sessionId)
+    {
+        var run = await _http.GetFromJsonAsync<WorkflowRunDto>($"gateway/workflow-runs/{runId}", JsonOpts);
+        Assert.NotNull(run);
+        return run!.Participants.Any(p => p.SessionId == sessionId && p.LeftUtc is null);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/MissionCommandTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/MissionCommandTests.cs
@@ -36,12 +36,32 @@ public sealed class MissionCommandTests
         new(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"),
             adoptUnattributedAs: Core.Tenancy.TenantId.Local);
 
-    private static DirectorCommand AttachCommand(string sid, Guid? missionId) => new()
+    private static DirectorCommand AttachCommand(string sid, Guid? missionId, string? missionName = null) => new()
     {
         CommandId = "am1",
         Verb = "attach-mission",
         SessionId = sid,
-        PayloadJson = JsonSerializer.Serialize(new SetMissionRequest { MissionId = missionId }, Json),
+        PayloadJson = JsonSerializer.Serialize(
+            new SetMissionRequest { MissionId = missionId, MissionName = missionName }, Json),
+    };
+
+    /// <summary>An attach that also carries the Gateway's seat decision (issue #2387 review).</summary>
+    private static DirectorCommand AttachWithSeat(
+        string sid, Guid? missionId, string? missionName, bool moveSeat,
+        Guid? runId = null, string? workflowId = null, int? version = null) => new()
+    {
+        CommandId = "am2",
+        Verb = "attach-mission",
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(new SetMissionRequest
+        {
+            MissionId = missionId,
+            MissionName = missionName,
+            MoveSeat = moveSeat,
+            WorkflowRunId = runId,
+            WorkflowId = workflowId,
+            WorkflowVersion = version,
+        }, Json),
     };
 
     private static DirectorCommand CreateCommand(NewSessionRequest req) => new()
@@ -143,6 +163,244 @@ public sealed class MissionCommandTests
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand("not-a-guid", Guid.NewGuid()), services);
 
             Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Issue #2387: the GATEWAY path on the attach verb, matching what create already does. A mission is a
+    // FLEET record whose source of truth is the Gateway; when the Gateway has resolved it inside the caller's
+    // own tenant and sends the NAME with the id, the Director stamps it directly. Proof of "no local lookup":
+    // the id is not in the Director's store - the store is EMPTY - and the attach still succeeds with the
+    // carried name. A local lookup would reject a mission that is real and owned, which is precisely the
+    // failure #1548 fixed on the spawn path.
+    [Fact]
+    public async Task AttachMission_WithMissionNamePresent_StampsDirectly_WithoutStoreLookup()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() }; // empty store
+            var carriedId = Guid.NewGuid(); // never created in this store
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), carriedId, "Gateway Native Mission"), services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected despite the empty store
+            Assert.Equal(carriedId, session.MissionId);
+            Assert.Equal("Gateway Native Mission", session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Issue #2387: ATTACHING IS A MOVE. A session that already carries a mission is re-pointed by the same
+    // verb, and the old attachment is gone rather than accumulated. This is the settled rule, not an accident
+    // of implementation: a mission's shape is discovered as it runs, so the first classification of a session
+    // is always a guess, and a one-way attach would make every wrong guess permanent until the session died.
+    [Fact]
+    public async Task AttachMission_OnAnAlreadyAttachedSession_MovesItToTheNewMission()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var store = NewMissionStore();
+            var first = store.Create(Core.Tenancy.TenantId.Local, "First Mission");
+            var second = store.Create(Core.Tenancy.TenantId.Local, "Second Mission");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), first.MissionId), services);
+            Assert.Equal(first.MissionId, session.MissionId);   // the control: it really was on the first
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), second.MissionId), services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(second.MissionId, session.MissionId);
+            Assert.Equal("Second Mission", session.MissionName);  // the cached name moved with the id
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Issue #2387: a REFUSED attach leaves the session on the mission it already had. Without this, a
+    // mistyped mission id would silently detach a correctly-attached session - a failure that looks like
+    // nothing happened until somebody goes looking for the pod.
+    [Fact]
+    public async Task AttachMission_UnknownMission_LeavesAnExistingAttachmentIntact()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Real Mission");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), mission.MissionId), services);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), Guid.NewGuid()), services);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal("Real Mission", session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ===== The workflow SEAT moves with the mission (issue #2387, review finding) =====
+    //
+    // A Mission is also a RUN of the built-in "mission" workflow, and a mission-scoped spawn seats the
+    // session on that run - which is what pins the conduct its preamble told it to follow. Moving only the
+    // mission link left a session DISPLAYED under one mission and GOVERNED by the one it left, taking its
+    // conduct from a mission it was no longer in. These cases pin the transition itself, so a later edit
+    // cannot quietly go back to moving one without the other.
+
+    [Fact]
+    public async Task AttachMission_WhenTheGatewaySaysMoveTheSeat_MovesMissionAndSeatTogether()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var missionA = Guid.NewGuid();
+            var runA = Guid.NewGuid();
+            var missionB = Guid.NewGuid();
+            var runB = Guid.NewGuid();
+
+            // Seated under A, exactly as a mission-scoped spawn leaves a session.
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), missionA, "Mission A", moveSeat: true, runA, "mission", 8),
+                services);
+            Assert.Equal(missionA, session.MissionId);
+            Assert.Equal(runA, session.WorkflowRunId);      // the control: it really was seated on A's run
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), missionB, "Mission B", moveSeat: true, runB, "mission", 9),
+                services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(missionB, session.MissionId);
+            // THE FINDING, asserted directly: the seat is B's, not A's. Before the fix this stayed runA
+            // while the mission read B - shown under one mission, governed by the other.
+            Assert.Equal(runB, session.WorkflowRunId);
+            Assert.Equal(9, session.WorkflowVersion);       // and the PINNED version moved with it
+
+            // The DTO the clients render carries the same pair, so no surface can disagree with the session.
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(missionB, dto.MissionId);
+            Assert.Equal(runB, dto.WorkflowRunId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_WhenTheGatewaySaysLeaveTheSeat_MovesTheMissionOnly()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var chosenRun = Guid.NewGuid();
+            var missionA = Guid.NewGuid();
+            var missionB = Guid.NewGuid();
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), missionA, "Mission A", moveSeat: true, chosenRun, "release", 3),
+                services);
+
+            // The exception to the rule: a run the caller chose independently was never the mission's to
+            // take, so a move must leave it exactly where it is - id, workflow and pinned version.
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), missionB, "Mission B", moveSeat: false),
+                services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(missionB, session.MissionId);      // the mission moved
+            Assert.Equal(chosenRun, session.WorkflowRunId); // the seat did not
+            Assert.Equal("release", session.WorkflowId);
+            Assert.Equal(3, session.WorkflowVersion);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_Detach_ClearsTheMissionsSeatWithIt()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var mission = Guid.NewGuid();
+            var run = Guid.NewGuid();
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), mission, "Mission A", moveSeat: true, run, "mission", 8),
+                services);
+            Assert.Equal(run, session.WorkflowRunId);
+
+            // Detach: a session that has LEFT a mission cannot still be governed by that mission's run.
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), null, null, moveSeat: true),
+                services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Null(session.MissionId);
+            Assert.Null(session.WorkflowRunId);
+            Assert.Null(session.WorkflowId);
+            Assert.Null(session.WorkflowVersion);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_Detach_LeavesAnIndependentlyChosenSeatAlone()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var chosenRun = Guid.NewGuid();
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), Guid.NewGuid(), "Mission A", moveSeat: true, chosenRun, "release", 3),
+                services);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), null, null, moveSeat: false),
+                services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Null(session.MissionId);                 // detached from the mission
+            Assert.Equal(chosenRun, session.WorkflowRunId); // but still on the run it was put on
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_WithoutASeatDecision_TouchesTheSeatAtAll()
+    {
+        // The compatibility case, and the one that keeps the two decisions separable: a payload that says
+        // nothing about the seat must not clear it. Otherwise every caller that has not been taught about
+        // seats would silently unseat the sessions it attaches.
+        var (sm, session) = NewSession();
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create(Core.Tenancy.TenantId.Local, "Local mission");
+            var services = new SessionCommandServices { MissionStore = store };
+            var run = Guid.NewGuid();
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachWithSeat(session.Id.ToString(), Guid.NewGuid(), "Mission A", moveSeat: true, run, "mission", 8),
+                services);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), mission.MissionId), services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal(run, session.WorkflowRunId);   // untouched, because nothing asked for it to move
         }
         finally { sm.Dispose(); }
     }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -23,6 +23,14 @@ namespace CcDirector.Gateway.Api;
 
 internal static class GatewayEndpoints
 {
+    /// <summary>
+    /// Web-shaped options for the few places this file has to READ a JSON body a Director produced. The
+    /// Director serializes verb results web-shaped (camelCase), so a default-cased reader would silently
+    /// deserialize every property to null - a body that parsed and said nothing, which is worse than one
+    /// that failed.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonWeb = new(JsonSerializerDefaults.Web);
+
     /// <param name="onSessionState">Issue #186: receives every session-state observation
     /// (doorbell ping or heartbeat snapshot entry) as (directorId, sessionId, newState).
     /// The host feeds these to the turn-end watcher (voice auto-refresh, issue #549).</param>
@@ -1824,6 +1832,218 @@ internal static class GatewayEndpoints
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Content(body, "application/json");
         });
+
+        // Issue #2387: attach a session that ALREADY EXISTS to a Mission - or DETACH it. Sessions could only
+        // ever be attached in the instant they were spawned (`session spawn --mission`), so a Mission could
+        // only group work somebody planned in advance, which is the work that least needs grouping. The case
+        // that found this was a release push that grew from one seat to about a dozen over a day: every one of
+        // them was the same body of work and not one was foreseeable at spawn.
+        //
+        // THE TENANT GATE, and it is the whole reason this route is written out longhand rather than folded in
+        // beside /role. Missions are TENANT-SCOPED (devthrottle_internal issue #1039): a mission NAME is free
+        // text a person typed - customer and project names - and a shared hosted store once served every
+        // account's list to every account. This route is a WRITE that names a mission by id, so it must not
+        // become the way back in. It follows GET /missions/{mid} exactly:
+        //   1. Resolve the CALLER's own tenant from the authenticated device key, server-side. A request that
+        //      binds to no tenant is REFUSED (403) - never served the Local partition.
+        //   2. Resolve the mission INSIDE that tenant. Another account's mission id resolves to nothing, and
+        //      "someone else owns it" answers identically to "nobody has it", so the id cannot even be probed.
+        //   3. Only then locate the session, which is itself tenant-scoped by LocateSessionForRequestAsync.
+        // The mission is resolved BEFORE the session on purpose: the refusal is then a property of the tenant
+        // gate alone, and cannot be confused with (or accidentally satisfied by) a Director being offline.
+        //
+        // The Gateway sends the RESOLVED NAME down with the id, so the Director stamps the attachment directly
+        // instead of consulting its own local mission store - which is a different set and would reject a
+        // mission that is real and owned (the failure #1548 fixed on the spawn path).
+        if (missions is not null)
+        {
+            app.MapPost("/sessions/{sid}/mission", async (HttpContext ctx, string sid, SetMissionRequest req, CancellationToken ct) =>
+            {
+                var tenant = ResolveReadTenant(ctx, tenantBoundary);
+                if (tenant is null)
+                {
+                    FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission DENIED - no tenant is bound to this request");
+                    return Results.Json(new { error = "no tenant is bound to this request" },
+                        statusCode: StatusCodes.Status403Forbidden);
+                }
+
+                // Null/absent mission id DETACHES. Nothing to resolve, and nothing to leak.
+                var payload = new SetMissionRequest { MissionId = req?.MissionId };
+                if (req?.MissionId is Guid missionId)
+                {
+                    var mission = missions.Get(tenant.Value, missionId);
+                    if (mission is null)
+                    {
+                        FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission: mission {missionId} is unknown to this tenant");
+                        return Results.BadRequest(new
+                        {
+                            error = $"unknown mission '{missionId}'. List the missions with: cc-devthrottle mission list",
+                        });
+                    }
+                    payload.MissionName = mission.MissionName;
+                }
+
+                var (director, session) = await LocateSessionForRequestAsync(ctx, tenantBoundary, registry, sid, pushedSessions, streamStaleResolved, owners);
+                if (session is null || director is null)
+                    return SessionUnavailable(ctx, tenantBoundary, pushedSessions, sid);
+
+                // ===== THE SEAT MOVES WITH THE MISSION =====
+                //
+                // A Mission is not only a record - it is also a RUN of the built-in "mission" workflow, and a
+                // mission-scoped spawn seats the session on that run and records it in the run's participant
+                // ledger. The seat is what pins the CONDUCT the agent was told to follow. So changing only the
+                // mission link would leave a session DISPLAYED under one mission while GOVERNED by the one it
+                // left, taking its conduct from a mission it is no longer in - and it would do that in exactly
+                // the case this feature was built for. The seat therefore moves here, in the same call.
+                //
+                // THE RULE, and its one exception:
+                //  * A seat that IS a run of the mission being left BELONGS to that mission, and follows it.
+                //  * A seat the caller chose independently (spawned with an explicit --workflow-run that is
+                //    not this mission's run) was never the mission's to take, and is PRESERVED untouched.
+                //  * A session with no seat at all has nothing to preserve, so it simply gains the
+                //    destination mission's seat.
+                //
+                // This decision is made HERE and nowhere else. Whether a run belongs to a mission is a fact
+                // about the run store, which only the Gateway holds; a Director asked to decide it would have
+                // to guess. The Director is sent a finished answer (MoveSeat plus the run to sit on) and
+                // applies it in the same verb as the mission, so the two can never land apart.
+                //
+                // The session facts below are read from the located DTO, which is FRESH by construction: a
+                // session whose Director has not pushed inside the freshness window is answered 503 by
+                // SessionUnavailable above rather than served, so this is a current read and not a snapshot
+                // of unknown age.
+                //
+                // ON THE RUN STORE AND TENANCY, because it looks like a hole and is not. The run store is not
+                // itself partitioned by tenant, so both lookups below reach it by a bare id. Neither id is
+                // caller-supplied: the destination is a mission this route has ALREADY resolved inside the
+                // caller's own tenant, and the held run comes off the session DTO, which the tenant-scoped
+                // locator produced. A caller therefore cannot steer either lookup at a run it does not own.
+                // That the store would answer a foreign id if one reached it is a pre-existing property of
+                // that store and is not made reachable here.
+                var currentRunId = session.WorkflowRunId;
+                var seatIsTheMissions = true;   // no seat -> nothing to preserve
+                if (currentRunId is Guid heldRun)
+                {
+                    // Does the run the session sits on belong to the mission it is in? Only then is it the
+                    // mission's seat. A run whose MissionId does not match (or a run that has since been
+                    // removed) is treated as the caller's own and left alone - the conservative direction:
+                    // preserving a seat we are unsure about is recoverable, silently discarding one is not.
+                    var heldRunRecord = workflowRuns?.Get(heldRun);
+                    seatIsTheMissions = heldRunRecord?.MissionId is Guid ownerMission
+                        && session.MissionId is Guid currentMission
+                        && ownerMission == currentMission;
+                }
+
+                Guid? previousRunId = null;
+                string? seatNote = null;
+                if (seatIsTheMissions)
+                {
+                    previousRunId = currentRunId;
+                    payload.MoveSeat = true;
+                    // The destination mission's run, or none when detaching or when the mission is UNGOVERNED
+                    // (created while the owner had the mission workflow switched off). A mission with no run
+                    // seats nobody, so the session correctly ends up unseated rather than keeping the old seat.
+                    if (payload.MissionId is Guid destination && workflowRuns is not null)
+                    {
+                        var destinationRun = workflowRuns.List(missionId: destination, limit: 1).FirstOrDefault();
+                        if (destinationRun is not null && destinationRun.WorkflowEnabled)
+                        {
+                            payload.WorkflowRunId = destinationRun.Id;
+                            payload.WorkflowId = destinationRun.WorkflowId;
+                            payload.WorkflowVersion = destinationRun.WorkflowVersion;
+                        }
+                        else if (destinationRun is not null)
+                        {
+                            // The owner switched this workflow OFF. The spawn path already refuses to seat
+                            // onto a disabled workflow; a move must not sneak a seat in through the side door.
+                            FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission: mission {destination}'s " +
+                                          $"workflow is OFF - the session moves UNSEATED");
+                            seatNote = "The destination mission's workflow is switched off, so the session "
+                                     + "moved with no workflow seat and is governed by no conduct.";
+                        }
+                        else
+                        {
+                            seatNote = "The destination mission has no workflow run of its own, so the session "
+                                     + "moved with no workflow seat.";
+                        }
+                    }
+                }
+                else
+                {
+                    FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission: session {sid} sits on run " +
+                                  $"{currentRunId} which is not its mission's run - the seat is the caller's own and is PRESERVED");
+                    seatNote = "The session's workflow seat was left alone: it sits on a run that is not this "
+                             + "mission's, so the seat was never the mission's to move.";
+                }
+
+                FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission: mission={payload.MissionId?.ToString() ?? "(detach)"} " +
+                              $"moveSeat={payload.MoveSeat} run={payload.WorkflowRunId?.ToString() ?? "(none)"} director={director.DirectorId}");
+                // Tunnel-only. The Ok stream body is the updated SessionDto JSON; a null or non-Ok result collapses to 502.
+                var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "attach-mission", sid, payload, ct, machineName: director.MachineName);
+                var body = streamResult is not null && streamResult.Ok ? streamResult.BodyJson : null;
+                if (body is null)
+                    return TunnelFailure(streamResult);
+
+                // THE PARTICIPANT LEDGER, after the session write has SUCCEEDED and never before. The ledger is
+                // the persisted record of which sessions a run governed; updating it first would book a move
+                // that might not happen. Leaving is recorded (LeftUtc), not erased - that the session WAS in
+                // the run is true and stays true.
+                //
+                // A ledger write that fails is reported LOUDLY and does not fail the call: the mission and the
+                // seat - the things a human reads and the agent is governed by - are already correct, and
+                // answering 502 here would tell the caller nothing moved when in fact it did. The gap it
+                // leaves is a stale participant row, which is visible in the run and repairable; claiming the
+                // move failed is not.
+                if (payload.MoveSeat && workflowRuns is not null)
+                {
+                    try
+                    {
+                        if (previousRunId is Guid leaving && leaving != payload.WorkflowRunId)
+                            workflowRuns.Patch(leaving, new PatchWorkflowRunRequest
+                            {
+                                LeaveSessionIds = new List<string> { sid },
+                            });
+
+                        if (payload.WorkflowRunId is Guid joining && joining != previousRunId)
+                            workflowRuns.Patch(joining, new PatchWorkflowRunRequest
+                            {
+                                AddParticipants = new List<WorkflowRunParticipantDto>
+                                {
+                                    new()
+                                    {
+                                        SessionId = sid,
+                                        AgentKind = session.Agent ?? "",
+                                        Role = session.ExplicitRole ?? "",
+                                        Machine = director.MachineName ?? "",
+                                    },
+                                },
+                            });
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[GatewayEndpoints] POST /sessions/{sid}/mission: the session moved, but the " +
+                                      $"workflow-run participant ledger was NOT updated: {ex.Message}");
+                        seatNote = "The mission and the workflow seat both moved, but this run's participant "
+                                 + "list could not be updated, so it may still show the session as active.";
+                    }
+                }
+
+                // The seat OUTCOME travels with the result, because only this process knows it: the seat the
+                // session held before the call, and whether it belonged to the mission it left, are facts the
+                // caller never had. A caller left to infer "did the seat move?" from the new state alone would
+                // have to compare against a value it does not hold, and would report a PRESERVED seat as a
+                // moved one.
+                return Results.Json(new MissionAttachResultDto
+                {
+                    Session = JsonSerializer.Deserialize<SessionDto>(body, JsonWeb),
+                    SeatMoved = payload.MoveSeat && previousRunId != payload.WorkflowRunId,
+                    PreviousWorkflowRunId = previousRunId,
+                    SeatNote = seatNote,
+                });
+            });
+
+            FileLog.Write("[GatewayEndpoints] mapped POST /sessions/{sid}/mission (attach an existing session to a Mission)");
+        }
 
         // Record (or clear) the Gateway-owned snooze for this session - "park / un-park" (hold) (Snooze
         // Length mission, docs/architecture/snooze-length-mission-2026-07-11.md). Snooze IS the hold: the

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -198,6 +198,44 @@ _ACTIONS = [
         "args": [],
     },
     {
+        "id": "mission-list",
+        "description": "List the Missions on the Gateway - the named bodies of work sessions attach to.",
+        "command": "cc-devthrottle mission list",
+        "mutatesState": False,
+        "args": [],
+    },
+    {
+        "id": "mission-create",
+        "description": "Create a Mission record on the Gateway and print its id.",
+        "command": 'cc-devthrottle mission create "<name>"',
+        "mutatesState": True,
+        "args": [{"name": "name", "required": True}],
+    },
+    {
+        # Discoverable on purpose. The gap this closed (issue #2387) was that a mission could only be
+        # joined in the instant a session was spawned, so a body of work that GREW - which is most of
+        # them - could never be shown as one. An agent that cannot find this verb is back in that
+        # position, so it belongs in the list an agent reads, not only in the help text.
+        "id": "mission-attach",
+        "description": (
+            "Attach a session that already exists to a Mission, moving it if it already had one. "
+            "Add --with-children to bring everything that session controls."
+        ),
+        "command": "cc-devthrottle mission attach <session> <mission>",
+        "mutatesState": True,
+        "args": [
+            {"name": "session", "required": True},
+            {"name": "mission", "required": True},
+        ],
+    },
+    {
+        "id": "mission-detach",
+        "description": "Detach a session from its Mission, leaving it attached to nothing.",
+        "command": "cc-devthrottle mission detach <session>",
+        "mutatesState": True,
+        "args": [{"name": "session", "required": True}],
+    },
+    {
         "id": "machine-list",
         "description": (
             "List the computers this account can search and start applications on. A computer appears "
@@ -1168,7 +1206,8 @@ def spawn(
         help="Attach the new session to a Mission by its id at spawn (mission-as-first-class-unit-of-work). "
         "The Mission must already exist (create one with 'cc-devthrottle mission create'); an unknown "
         "Mission is rejected by the Director. A mission spawn also auto-seats the session on the "
-        "mission's workflow run.",
+        "mission's workflow run. Omitted, a session spawned with a controlling session INHERITS that "
+        "session's mission (and says so); pass 'none' to opt out and start attached to nothing.",
     ),
     workflow_run: Optional[str] = typer.Option(
         None,
@@ -1202,6 +1241,36 @@ def mission_list(
 ) -> None:
     """List every Mission record on the Gateway."""
     mission_ops.list_missions(json_output)
+
+
+@mission_app.command("attach")
+def mission_attach(
+    session: str = typer.Argument(
+        ..., help="The session to attach: its number, an id prefix, or part of its name."
+    ),
+    mission: str = typer.Argument(
+        ..., help="The Mission to attach it to: its id, an id prefix, or part of its name."
+    ),
+    with_children: bool = typer.Option(
+        False,
+        "--with-children",
+        help="Also attach every session this one controls, all the way down. Off by default: a "
+        "controlling session routinely commissions work that is NOT part of its own mission, and a "
+        "bulk re-parent cannot be undone in one step.",
+    ),
+) -> None:
+    """Attach a session that already exists to a Mission (moving it if it already had one)."""
+    mission_ops.attach_session(session, mission, with_children)
+
+
+@mission_app.command("detach")
+def mission_detach(
+    session: str = typer.Argument(
+        ..., help="The session to detach: its number, an id prefix, or part of its name."
+    ),
+) -> None:
+    """Detach a session from its Mission, leaving it attached to nothing."""
+    mission_ops.detach_session(session)
 
 
 @diag_app.command("network")

--- a/tools/cc-devthrottle/src/mission_ops.py
+++ b/tools/cc-devthrottle/src/mission_ops.py
@@ -6,6 +6,12 @@ FLEET-level concept - they span Directors and machines and nest - so their sourc
 the GATEWAY, like fleet messaging and scheduling, not on any one Director (Gateway Cleanup mission,
 Wave 4b). These commands create and list Mission records via the Gateway Control API
 (POST /missions, GET /missions), mirroring the schedule command style.
+
+ATTACH AND DETACH (issue #2387) go a different way, and deliberately: through this machine's own
+Director, at POST /fleet/mission. A session lives on a Director, so attaching one is a session write
+and follows the same route every other session verb takes - local target attached directly, remote
+target relayed by the Gateway to the owning Director over the tunnel. Going straight to the Gateway
+from here would work only for sessions on other machines, which is the wrong half.
 """
 
 from __future__ import annotations
@@ -131,6 +137,47 @@ class MissionClient:
         return list(data) if isinstance(data, list) else []
 
 
+def _resolve_mission(query: str) -> Dict[str, Any]:
+    """Resolve a Mission by full id, id prefix, or a case-insensitive name match.
+
+    'mission list' prints SHORT ids, so requiring the full identifier would mean copying it out of a
+    JSON dump every time. Only the typing is relaxed: the id that finally reaches the Gateway is the
+    full one from the caller's OWN mission list, and the Gateway resolves it inside the caller's own
+    tenant regardless of what was typed here.
+    """
+    try:
+        missions = MissionClient().list_all()
+    except GatewayError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    wanted = query.strip()
+    lowered = wanted.lower()
+    exact = [m for m in missions if (_field(m, "missionId", "MissionId") or "").lower() == lowered]
+    if exact:
+        return exact[0]
+
+    matches = [
+        m for m in missions
+        if (_field(m, "missionId", "MissionId") or "").lower().startswith(lowered)
+        or lowered in (_field(m, "missionName", "MissionName") or "").lower()
+    ]
+    if not matches:
+        console.print(
+            f"[red]No mission matches '{wanted}'.[/red] "
+            "Run cc-devthrottle mission list to see the missions on the Gateway."
+        )
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        console.print(f"[yellow]'{wanted}' is ambiguous - {len(matches)} missions match:[/yellow]")
+        for m in matches:
+            mid = _field(m, "missionId", "MissionId") or "-"
+            console.print(f"  {_short_id(mid)}  {_field(m, 'missionName', 'MissionName') or '-'}")
+        console.print("Re-run with a longer id prefix or the exact name.")
+        raise typer.Exit(1)
+    return matches[0]
+
+
 def _field(record: Dict[str, Any], *names: str) -> Optional[str]:
     """First present, non-empty value among the given key spellings (camel/Pascal case)."""
     for name in names:
@@ -196,3 +243,236 @@ def list_missions(json_output: bool) -> None:
         parent = _field(mission, "parentMissionId", "ParentMissionId") or "-"
         table.add_row(_short_id(mid) if mid else "-", name, parent)
     console.print(table)
+
+
+# ===== Attach and detach (issue #2387) =====================================================
+#
+# THE RULES, settled here and written up in
+# docs/new_architecture/mission-as-first-class-unit-of-work.md. Each one had to be decided because
+# somebody will hit it, and an implied answer is one that gets re-litigated at the worst moment:
+#
+#  * Attaching is a MOVE, not a one-way door. A session that already carries a mission is
+#    re-pointed by the same command, and the command says which mission it LEFT. The shape of a
+#    mission is discovered as it runs, so the first classification is always a guess; a one-way
+#    attach makes every wrong guess permanent until the session is killed.
+#  * Detaching is supported. No mission is the ORDINARY state of a session, so returning to it must
+#    not require inventing a mission to park the session in.
+#  * Attaching a controlling session does NOT drag its children along by default. A controller
+#    routinely commissions sessions for unrelated work - a reviewer for one pull request, an
+#    investigation seat for something else - and a silent bulk re-parent cannot be undone in one
+#    step. --with-children asks for it explicitly, walks the controlling relationship all the way
+#    down, and NAMES every session it moves rather than reporting a count.
+
+
+def _controlled_subtree(sessions: List[Dict[str, Any]], root_id: str) -> List[Dict[str, Any]]:
+    """Every session controlled by root_id, transitively (children, their children, and so on).
+
+    Transitive rather than one level: the shape this exists for is Architect -> Manager -> Workers,
+    where stopping at the first level would attach the Manager and leave the Workers behind - which
+    reads as "it worked" while producing exactly the split view the whole feature is meant to end.
+    """
+    by_controller: Dict[str, List[Dict[str, Any]]] = {}
+    for s in sessions:
+        controller = (_field(s, "controllerSessionId", "ControllerSessionId") or "").lower()
+        if controller:
+            by_controller.setdefault(controller, []).append(s)
+
+    found: List[Dict[str, Any]] = []
+    seen = {root_id.lower()}
+    frontier = [root_id.lower()]
+    while frontier:
+        current = frontier.pop()
+        for child in by_controller.get(current, []):
+            child_id = (_field(child, "sessionId", "SessionId") or "").lower()
+            # A cycle cannot happen through legitimate spawns, but a corrupted roster must not hang
+            # the command line, so a session is only ever visited once.
+            if not child_id or child_id in seen:
+                continue
+            seen.add(child_id)
+            found.append(child)
+            frontier.append(child_id)
+    return found
+
+
+def _apply_mission(session_id: str, mission_id: Optional[str]) -> Dict[str, Any]:
+    """Attach (or detach, on a null mission id) one session through this Director's POST /fleet/mission."""
+    from cc_shared import director  # local import: keeps this module importable without a Director
+
+    body: Dict[str, Any] = {"toSessionId": session_id}
+    if mission_id:
+        body["missionId"] = mission_id
+    return director.post_json("fleet/mission", body)
+
+
+def _previous_mission(
+    resp: Dict[str, Any], roster_row: Dict[str, Any]
+) -> tuple[Optional[str], Optional[str]]:
+    """The mission a session was on BEFORE the call: (id, name), or (None, None).
+
+    Two sources, in order of authority. A LOCAL target's Director read the attachment off the live
+    session immediately before changing it, so its answer is exact and is used whenever it is there.
+    A REMOTE target is relayed through the Gateway to a Director that this machine never talked to
+    about that session, so nothing on the return path knows what it left - and the roster row the
+    caller was just resolved against does. That row is a snapshot rather than a live read, which is
+    the honest limit of what the second source can claim.
+
+    This is a display line, not a decision: it names what the session left so a move is visible.
+    Nothing branches on it, so the weaker source costs accuracy in the wording and nothing else.
+    """
+    exact_id = _field(resp, "previousMissionId", "PreviousMissionId")
+    if exact_id:
+        return exact_id, _field(resp, "previousMissionName", "PreviousMissionName")
+    return (
+        _field(roster_row, "missionId", "MissionId"),
+        _field(roster_row, "missionName", "MissionName"),
+    )
+
+
+def _seat_moved(resp: Dict[str, Any]) -> bool:
+    """True when the call also moved (or cleared) the session's workflow seat."""
+    value = resp.get("seatMoved", resp.get("SeatMoved"))
+    return bool(value)
+
+
+def _conduct_command(resp: Dict[str, Any]) -> Optional[str]:
+    """The exact command that re-reads the conduct the session is now seated under, or None.
+
+    Named in full rather than left as placeholders. A instruction with blanks in it makes the human go
+    and find two values somewhere else, at the one moment they have been told something is out of step -
+    which is how a warning gets skipped.
+    """
+    workflow = _field(resp, "workflowId", "WorkflowId")
+    version = resp.get("workflowVersion", resp.get("WorkflowVersion"))
+    if not workflow or version is None:
+        return None
+    return f"cc-devthrottle workflow instructions {workflow} --version {version}"
+
+
+def _print_seat_note(resp: Dict[str, Any]) -> None:
+    """Print the Director's sentence about the seat, when it had one to add.
+
+    Passed through verbatim rather than re-worded here. What happened to the seat is decided at the
+    Gateway; a client that paraphrased it would be writing its own account of a decision it did not
+    make, and that is how a surface starts saying something plausible instead of something true.
+    """
+    note = _field(resp, "seatNote", "SeatNote")
+    if note:
+        console.print(f"[yellow]Note:[/yellow] {note}")
+
+
+def _session_label(session: Dict[str, Any]) -> str:
+    from cc_shared import director
+
+    sid = _field(session, "sessionId", "SessionId") or ""
+    name = _field(session, "name", "Name") or "(unnamed)"
+    return f"{name} ({director.short_id(sid)})"
+
+
+def attach_session(target: str, mission_query: str, with_children: bool) -> None:
+    """Attach an EXISTING session (and optionally everything it controls) to a Mission."""
+    from cc_shared import director
+
+    from . import session_ops
+
+    mission = _resolve_mission(mission_query)
+    mission_id = _field(mission, "missionId", "MissionId")
+    mission_name = _field(mission, "missionName", "MissionName") or "(unnamed)"
+    if not mission_id:
+        console.print("[red]Error:[/red] the Gateway returned a mission with no id.")
+        raise typer.Exit(1)
+
+    chosen = session_ops.resolve_session(target, command_name="cc-devthrottle mission attach")
+    session_id = _field(chosen, "sessionId", "SessionId")
+
+    targets = [chosen]
+    if with_children:
+        sessions, _, _, _ = session_ops.fleet_or_exit()
+        targets.extend(_controlled_subtree(sessions, session_id))
+        console.print(
+            f"Attaching {len(targets)} session(s) to mission [bold]{mission_name}[/bold] "
+            f"({_short_id(mission_id)}):"
+        )
+        for s in targets:
+            console.print(f"  {_session_label(s)}")
+
+    failed = 0
+    seat_moved_any = False
+    # The command that re-reads the conduct the sessions are NOW under. Filled from the first move that
+    # reports a workflow and version; the placeholder stands only when the destination seats nobody, which
+    # is the case where there is no conduct to re-read anyway.
+    seat_conduct = "cc-devthrottle workflow instructions <workflow> --version <version>"
+    for s in targets:
+        sid = _field(s, "sessionId", "SessionId")
+        try:
+            resp = _apply_mission(sid, mission_id)
+        except director.DirectorError as err:
+            # Keep going. A partial attach is honest and repeatable; abandoning the rest of the tree
+            # because one session's Director is unreachable would leave the pod split with no record
+            # of where it stopped.
+            console.print(f"[red]Failed:[/red] {_session_label(s)} - {err}")
+            failed += 1
+            continue
+
+        previous_id, previous = _previous_mission(resp, s)
+        moved_from = ""
+        if previous_id and previous_id.lower() != mission_id.lower():
+            moved_from = f" (moved from {previous or _short_id(previous_id)})"
+        console.print(
+            f"[green]Attached[/green] {_session_label(s)} to {mission_name}{moved_from}."
+        )
+        if _seat_moved(resp):
+            seat_moved_any = True
+            seat_conduct = _conduct_command(resp) or seat_conduct
+        _print_seat_note(resp)
+
+    if seat_moved_any:
+        # THE HONEST LIMIT, and it has to be said every time the seat moves. A mission is also a run of
+        # the mission workflow, and the seat pins the conduct the agent follows - moving it corrects the
+        # RECORD (what the fleet shows, what governs the session, who the run lists) but it cannot reach
+        # back into a running agent's context and replace the conduct it was handed at birth. Only telling
+        # the session does that. Saying nothing here would leave a human believing a move was complete
+        # when the agent is still working to the old rules.
+        console.print(
+            "[yellow]Note:[/yellow] the workflow seat moved with the mission, but a session that is "
+            "already running still holds the conduct it was given at birth. Tell it to fetch its "
+            f"conduct again: {seat_conduct}"
+        )
+
+    if failed:
+        raise typer.Exit(1)
+
+
+def detach_session(target: str) -> None:
+    """Detach a session from whatever Mission it is attached to."""
+    from cc_shared import director
+
+    from . import session_ops
+
+    chosen = session_ops.resolve_session(target, command_name="cc-devthrottle mission detach")
+    session_id = _field(chosen, "sessionId", "SessionId")
+
+    try:
+        resp = _apply_mission(session_id, None)
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    previous_id, previous = _previous_mission(resp, chosen)
+    if not previous_id:
+        # Say what is true rather than claiming a change: the session was already attached to nothing.
+        console.print(f"{_session_label(chosen)} was not attached to a mission; nothing changed.")
+        _print_seat_note(resp)
+        return
+    console.print(
+        f"[green]Detached[/green] {_session_label(chosen)} from {previous or _short_id(previous_id)}."
+    )
+    if _seat_moved(resp):
+        # Detach clears the mission's seat with it. A session that has LEFT a mission cannot still be
+        # governed by that mission's workflow run, and cannot still sit in its participant list as active
+        # - so the seat goes too, and the human is told, because the session it names is now running
+        # under no workflow conduct at all.
+        console.print(
+            "Its workflow seat was cleared with the mission: it is no longer governed by that "
+            "mission's workflow run."
+        )
+    _print_seat_note(resp)

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -140,6 +140,23 @@ def _resolve_target(target: str, *, command_name: str) -> Dict[str, Any]:
     return matches[0]
 
 
+def resolve_session(target: str, *, command_name: str) -> Dict[str, Any]:
+    """Resolve one session from the fleet roster, or print why it could not and exit.
+
+    The public door onto the shared resolver above, for sibling command modules (mission attach and
+    detach) that address a session exactly the way the session verbs do - by number, id prefix, or
+    name. It exists so those commands cannot grow a second, subtly different way to name a session:
+    one resolver means one answer to "which session did you mean", including the caveats about a
+    roster that may be incomplete.
+    """
+    return _resolve_target(target, command_name=command_name)
+
+
+def fleet_or_exit() -> Tuple[List[Dict[str, Any]], Optional[bool], Optional[str], Optional[str]]:
+    """The fleet roster, or a printed error and exit - the public door onto the shared fetch."""
+    return _get_fleet()
+
+
 def resolve_target_or_current(target: Optional[str]) -> str:
     """Return the requested session id, defaulting to this session."""
     if target is None or not target.strip():
@@ -583,6 +600,36 @@ def ask_session(target: str, question: str, timeout_ms: int) -> None:
     console.print(answer if answer else "(the target produced no output)")
 
 
+def _controller_mission(controller_session_id: str) -> Optional[Dict[str, Any]]:
+    """The controlling session's roster row, when it exists AND carries a mission; else None.
+
+    Returns the whole row rather than the id so the caller can name the session the mission came
+    from. Missing controller, or a controller attached to nothing, is a plain None - those are
+    ordinary and there is nothing to report.
+
+    A roster this process cannot READ is different, and is reported rather than swallowed: the
+    spawn proceeds unattached (refusing to open a session because an optional grouping could not be
+    looked up would be worse than the ungrouped session), but the human is told, in that order, so
+    the missing mission is never a mystery. One 'mission attach' fixes it afterwards - which is the
+    whole point of this issue existing.
+    """
+    try:
+        sessions, _, _, _ = director.get_fleet()
+    except director.DirectorError as err:
+        console.print(
+            "[yellow]Warning:[/yellow] could not read the fleet list to inherit the controlling "
+            f"session's mission, so the new session starts attached to no mission: {err}"
+        )
+        return None
+
+    wanted = controller_session_id.strip().lower()
+    for s in sessions:
+        if director.field(s, "sessionId", "SessionId").lower() != wanted:
+            continue
+        return s if director.field(s, "missionId", "MissionId") else None
+    return None
+
+
 def spawn_session(
     repo: str,
     agent: str,
@@ -676,8 +723,27 @@ def spawn_session(
     if role:
         body["role"] = role
     # Mission attach at spawn: forward the Mission id; the Director resolves+validates it (unknown -> 400).
-    if mission:
+    #
+    # INHERITANCE (issue #2387). With no --mission, a session that has a CONTROLLER inherits that
+    # controller's mission. Default ON, because the fleet already records the relationship and the case
+    # that found this gap - a release push that grew from one seat to about a dozen in a day - would have
+    # been grouped for free: every one of those sessions was spawned by a seat that already belonged to
+    # the mission. Making it opt-in would mean the grouping only ever happens when somebody remembers,
+    # which is the same failure as attach-at-birth in a different coat.
+    #
+    # Three things keep it honest. An explicit --mission always WINS (it is stated intent, not a
+    # default). --mission none is the OPT-OUT, spelled the same way --controlled-by none is, for the
+    # deliberate case of a child that is not part of its controller's work. And it is never SILENT: the
+    # inheritance is printed, naming the mission and the session it came from, so a wrong inheritance is
+    # visible immediately and one 'mission detach' away.
+    inherited_from: Optional[Dict[str, Any]] = None
+    mission_opt_out = mission is not None and mission.strip().lower() == "none"
+    if mission and not mission_opt_out:
         body["missionId"] = mission
+    elif not mission_opt_out and controller_session_id:
+        inherited_from = _controller_mission(controller_session_id)
+        if inherited_from:
+            body["missionId"] = director.field(inherited_from, "missionId", "MissionId")
     # Workflow seat at spawn (Workflows phase 5b): forward the run id; the Gateway validates it and
     # stamps the workflow id + pinned version, and the seated session's preamble tells the agent to
     # fetch its conduct at exactly that version. A mission spawn auto-seats without this flag.
@@ -716,6 +782,21 @@ def spawn_session(
     label = director.field(resp, "name", "Name") or name or short
     console.print(f"[green]Opened[/green] session {short} ({label}).")
     console.print(f"id: {sid}")
+    if inherited_from is not None:
+        # Never silent. An inherited mission the caller did not ask for is only safe if they can see
+        # it happened, so name the mission AND the session it came from, and say how to undo it.
+        mission_label = (
+            director.field(inherited_from, "missionName", "MissionName")
+            or director.short_id(director.field(inherited_from, "missionId", "MissionId"))
+        )
+        controller_label = (
+            director.field(inherited_from, "name", "Name")
+            or director.short_id(director.field(inherited_from, "sessionId", "SessionId"))
+        )
+        console.print(
+            f"Attached to mission [bold]{mission_label}[/bold], inherited from its controlling "
+            f"session {controller_label}. Undo with: cc-devthrottle mission detach {short}"
+        )
     console.print(
         f'Message it:  cc-devthrottle message send {short} "<message>"'
         f'   |   Ask it:  cc-devthrottle message ask {short} "<question>"'

--- a/tools/cc-devthrottle/tests/test_mission_ops.py
+++ b/tools/cc-devthrottle/tests/test_mission_ops.py
@@ -1,0 +1,294 @@
+"""Tests for `cc-devthrottle mission attach` and `mission detach` (issue #2387).
+
+Attaching a session that ALREADY EXISTS is the half that was missing: a Mission could only be
+joined in the instant a session was spawned, so a body of work that GREW - which is most of them -
+could never be shown as one.
+
+These cases assert the DECISIONS, because each was settled deliberately and each is the kind of
+thing that gets quietly reversed by a later edit if nothing holds it:
+
+  * attaching is a MOVE, and the move is reported (you are told what the session left);
+  * detaching is real, and a session that had no mission is told so rather than being told it was
+    detached from nothing;
+  * --with-children walks the controlling relationship ALL THE WAY DOWN, and does nothing at all
+    without the flag.
+
+No HTTP happens: the Director post and the Gateway mission list are both stubbed.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import mission_ops, session_ops  # noqa: E402
+
+
+def flowed(text: str) -> str:
+    """Collapse Rich's console wrapping so an assertion is about WORDS, not column width.
+
+    Rich wraps to the console width, which can split a mission name across two lines. The reader
+    still sees the name; an assertion that fails because of where the wrap landed is testing the
+    terminal, not the message.
+    """
+    return " ".join(text.split())
+
+
+MISSION_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+OTHER_MISSION_ID = "bbbbbbbb-9999-8888-7777-666666666666"
+
+MISSIONS = [
+    {"missionId": MISSION_ID, "missionName": "Release 1.9.4"},
+    {"missionId": OTHER_MISSION_ID, "missionName": "Voice cleanup"},
+]
+
+# An Architect controlling a Manager controlling two Workers, plus an unrelated session that no one
+# controls. The three-deep shape is the point: stopping at the first level would attach the Manager
+# and leave the Workers behind, which reads as success while producing the split view the whole
+# feature exists to end.
+ARCHITECT = {"sessionId": "sess-architect", "name": "Release - Architect"}
+MANAGER = {"sessionId": "sess-manager", "name": "Release - Manager",
+           "controllerSessionId": "sess-architect"}
+WORKER_ONE = {"sessionId": "sess-worker-1", "name": "Release - Worker one",
+              "controllerSessionId": "sess-manager"}
+WORKER_TWO = {"sessionId": "sess-worker-2", "name": "Release - Worker two",
+              "controllerSessionId": "sess-manager"}
+UNRELATED = {"sessionId": "sess-elsewhere", "name": "Something else entirely"}
+
+ROSTER = [ARCHITECT, MANAGER, WORKER_ONE, WORKER_TWO, UNRELATED]
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Stub the Gateway mission list, the fleet roster, and the Director post; record every call."""
+    calls = []
+
+    def fake_post_json(path, body, timeout=30):
+        assert path == "fleet/mission"
+        calls.append(body)
+        return {
+            "applied": True,
+            "sessionId": body["toSessionId"],
+            "missionId": body.get("missionId"),
+            "missionName": "Release 1.9.4" if body.get("missionId") else None,
+            "previousMissionId": OTHER_MISSION_ID,
+            "previousMissionName": "Voice cleanup",
+        }
+
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(session_ops.director, "get_fleet", lambda: (list(ROSTER), True, None, None))
+    monkeypatch.setattr(session_ops.director, "post_json", fake_post_json)
+    # mission_ops imports the director helper lazily, and it is the SAME module object, so patching
+    # it once here covers both call sites.
+    return calls
+
+
+def test_attach_sends_the_full_mission_id_for_the_named_session(wired):
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+
+    assert wired == [{"toSessionId": "sess-manager", "missionId": MISSION_ID}]
+
+
+def test_a_mission_can_be_named_by_prefix_or_by_name(wired):
+    # Only the TYPING is relaxed. Whatever was typed, the id that goes to the Director is the full
+    # one out of the caller's own mission list.
+    mission_ops.attach_session("sess-manager", "Release", with_children=False)
+    mission_ops.attach_session("sess-manager", MISSION_ID[:8], with_children=False)
+
+    assert [c["missionId"] for c in wired] == [MISSION_ID, MISSION_ID]
+
+
+def test_an_ambiguous_mission_name_is_refused_rather_than_guessed(wired):
+    # Two missions match "e" - refusing is the only honest answer; picking one would attach the
+    # session to a body of work nobody chose.
+    with pytest.raises(typer.Exit):
+        mission_ops.attach_session("sess-manager", "e", with_children=False)
+    assert wired == []
+
+
+def test_the_move_reports_the_mission_the_session_left(wired, capsys, plain):
+    # Attaching is a MOVE. A move that reports only its destination hides that something was
+    # displaced, which is exactly how a session goes missing from the pod somebody is looking at.
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "Release 1.9.4" in out
+    assert "Voice cleanup" in out   # the mission it left, named
+
+
+def test_without_the_flag_only_the_named_session_moves(wired):
+    # The default. A controlling session routinely commissions work that is NOT part of its own
+    # mission, so bringing its children has to be asked for.
+    mission_ops.attach_session("sess-architect", MISSION_ID, with_children=False)
+
+    assert [c["toSessionId"] for c in wired] == ["sess-architect"]
+
+
+def test_with_children_walks_the_whole_controlled_subtree(wired):
+    # Transitive, not one level: the Architect brings the Manager AND both of the Manager's Workers.
+    mission_ops.attach_session("sess-architect", MISSION_ID, with_children=True)
+
+    moved = [c["toSessionId"] for c in wired]
+    assert moved[0] == "sess-architect"                 # the named session first
+    assert set(moved) == {"sess-architect", "sess-manager", "sess-worker-1", "sess-worker-2"}
+    assert "sess-elsewhere" not in moved                # and nothing it does not control
+
+
+def test_with_children_names_every_session_it_moves(wired, capsys, plain):
+    # Names, not a count. "4 sessions attached" is unreviewable; a list can be read and disputed
+    # before the next command is typed.
+    mission_ops.attach_session("sess-architect", MISSION_ID, with_children=True)
+    out = flowed(plain(capsys.readouterr().out))
+
+    for name in ("Release - Architect", "Release - Manager", "Release - Worker one",
+                 "Release - Worker two"):
+        assert name in out
+    assert "Something else entirely" not in out
+
+
+def test_detach_sends_no_mission_id(wired):
+    mission_ops.detach_session("sess-manager")
+
+    assert wired == [{"toSessionId": "sess-manager"}]
+
+
+def test_detach_reports_the_mission_the_session_left(wired, capsys, plain):
+    mission_ops.detach_session("sess-manager")
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "Detached" in out
+    assert "Voice cleanup" in out
+
+
+def test_detaching_a_session_that_had_no_mission_says_nothing_changed(monkeypatch, capsys, plain):
+    # Claiming a detach that did not happen is the small lie that makes the next person distrust
+    # the whole command. Say what is true.
+    monkeypatch.setattr(session_ops.director, "get_fleet", lambda: (list(ROSTER), True, None, None))
+    monkeypatch.setattr(
+        session_ops.director, "post_json",
+        lambda path, body, timeout=30: {"applied": True, "sessionId": body["toSessionId"]},
+    )
+
+    mission_ops.detach_session("sess-manager")
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "nothing changed" in out
+    assert "Detached" not in out
+
+
+def test_the_subtree_walk_survives_a_cycle_in_the_roster():
+    # A cycle cannot happen through legitimate spawns, but a corrupted roster must not hang the
+    # command line. Asserted directly on the walk, because a hang has no failure message.
+    a = {"sessionId": "a", "controllerSessionId": "b"}
+    b = {"sessionId": "b", "controllerSessionId": "a"}
+
+    found = mission_ops._controlled_subtree([a, b], "a")
+
+    assert [s["sessionId"] for s in found] == ["b"]
+
+
+def test_a_remote_attach_still_reports_the_mission_it_left(monkeypatch, capsys, plain):
+    # A remote target is relayed through the Gateway to a Director this machine never talked to
+    # about that session, so nothing on the return path knows what the session left. The roster row
+    # the caller was just resolved against does, so the move is still visible rather than silently
+    # reported as a plain attach.
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(
+        session_ops.director, "get_fleet",
+        lambda: ([dict(MANAGER, missionId=OTHER_MISSION_ID, missionName="Voice cleanup")],
+                 True, None, None),
+    )
+    monkeypatch.setattr(
+        session_ops.director, "post_json",
+        # The relay response: applied, but carrying no previous attachment.
+        lambda path, body, timeout=30: {"applied": True, "sessionId": body["toSessionId"],
+                                        "missionId": body.get("missionId")},
+    )
+
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "moved from Voice cleanup" in out
+
+
+# --- The workflow seat travels with the mission (issue #2387, review finding) ---
+#
+# A Mission is also a run of the mission workflow, and the seat pins the conduct the agent follows.
+# The command line has to SAY what happened to the seat: a move that silently re-governed a session
+# would be the same invisibility the feature exists to end, and a move that says nothing about the
+# already-injected conduct leaves a human believing it is complete when the agent still holds the
+# old rules.
+
+
+def _wire(monkeypatch, response):
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(session_ops.director, "get_fleet", lambda: (list(ROSTER), True, None, None))
+    monkeypatch.setattr(
+        session_ops.director, "post_json", lambda path, body, timeout=30: dict(response)
+    )
+
+
+def test_a_seat_move_warns_that_a_running_agent_still_holds_its_old_conduct(
+    monkeypatch, capsys, plain
+):
+    # The honest limit. Moving the seat fixes the RECORD; it cannot rewrite what is already in a
+    # running agent's context. Saying nothing here would read as "the move is complete".
+    _wire(monkeypatch, {"applied": True, "sessionId": "sess-manager",
+                        "missionId": MISSION_ID, "seatMoved": True,
+                        "workflowId": "mission", "workflowVersion": 9})
+
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "still holds the conduct it was given at birth" in out
+    # The exact command, with the workflow and version FILLED IN. A instruction with blanks makes the
+    # human go and find two values somewhere else at the one moment they were told something is out of
+    # step, which is how a warning gets skipped.
+    assert "cc-devthrottle workflow instructions mission --version 9" in out
+
+
+def test_no_warning_when_the_seat_did_not_move(monkeypatch, capsys, plain):
+    # The control. The warning must be tied to the seat actually moving, or it becomes noise that
+    # gets ignored on the one occasion it matters.
+    _wire(monkeypatch, {"applied": True, "sessionId": "sess-manager",
+                        "missionId": MISSION_ID, "seatMoved": False})
+
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "still holds the conduct" not in out
+
+
+def test_detach_says_the_seat_was_cleared_with_the_mission(monkeypatch, capsys, plain):
+    # Detach clears the mission's seat too, which leaves the session governed by no workflow conduct
+    # at all. That is a fact about how the session will now behave, so it is reported.
+    _wire(monkeypatch, {"applied": True, "sessionId": "sess-manager", "seatMoved": True,
+                        "previousMissionId": OTHER_MISSION_ID,
+                        "previousMissionName": "Voice cleanup"})
+
+    mission_ops.detach_session("sess-manager")
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert "Detached" in out
+    assert "no longer governed by that mission's workflow run" in out
+
+
+def test_the_directors_seat_note_is_passed_through_verbatim(monkeypatch, capsys, plain):
+    # What happened to the seat is decided at the Gateway. A client that re-worded it would be
+    # writing its own account of a decision it did not make - which is how a surface starts saying
+    # something plausible instead of something true.
+    note = "No Gateway is configured, so the workflow seat was not moved."
+    _wire(monkeypatch, {"applied": True, "sessionId": "sess-manager",
+                        "missionId": MISSION_ID, "seatMoved": False, "seatNote": note})
+
+    mission_ops.attach_session("sess-manager", MISSION_ID, with_children=False)
+    out = flowed(plain(capsys.readouterr().out))
+
+    assert note in out

--- a/tools/cc-devthrottle/tests/test_spawn_ops.py
+++ b/tools/cc-devthrottle/tests/test_spawn_ops.py
@@ -36,11 +36,27 @@ def captured(monkeypatch):
     return body
 
 
-def _spawn(monkeypatch, *, cc_session=None, controlled_by=None, standalone=False, role=None):
+def _spawn(
+    monkeypatch,
+    *,
+    cc_session=None,
+    controlled_by=None,
+    standalone=False,
+    role=None,
+    mission=None,
+    roster=None,
+):
     if cc_session is None:
         monkeypatch.delenv("CC_SESSION_ID", raising=False)
     else:
         monkeypatch.setenv("CC_SESSION_ID", cc_session)
+    # Mission inheritance (issue #2387) reads the fleet roster to find the CONTROLLING session's
+    # mission, so every spawn with a controller now consults it. Stubbed here - and defaulting to an
+    # EMPTY roster - so these cases keep asserting what they were written to assert and no test
+    # reaches the network to find out.
+    monkeypatch.setattr(
+        session_ops.director, "get_fleet", lambda: (list(roster or []), True, None, None)
+    )
     session_ops.spawn_session(
         repo="C:/repo",
         agent="ClaudeCode",
@@ -53,6 +69,7 @@ def _spawn(monkeypatch, *, cc_session=None, controlled_by=None, standalone=False
         args=None,
         standalone=standalone,
         role=role,
+        mission=mission,
     )
 
 
@@ -196,3 +213,129 @@ def test_the_director_flag_reaches_spawn_session(monkeypatch, tmp_path):
         app, ["session", "spawn", str(tmp_path), "--name", "n", "--director", "North build"])
     assert result.exit_code == 0, result.output
     assert "North build" in seen["args"]
+# --- Mission inheritance from the controlling session (issue #2387) ---
+#
+# A mission's shape is discovered as it runs, so attaching only at spawn grouped just the work
+# somebody had already planned. The fleet ALREADY records who controls whom, so a spawned child
+# inheriting its controller's mission costs nothing and would have grouped the release push that
+# found this gap - a dozen sessions, none foreseeable at spawn - for free. Default ON, explicit
+# --mission wins, --mission none opts out, and it is never silent.
+
+MANAGER_ON_A_MISSION = {
+    "sessionId": "sess-A",
+    "name": "Release - Manager",
+    "missionId": "aaaaaaaa-1111-2222-3333-444444444444",
+    "missionName": "Release 1.9.4",
+}
+
+
+def test_spawn_inherits_the_controlling_sessions_mission(monkeypatch, captured):
+    # The whole point: no --mission, but the controller is on one, so the child joins it.
+    _spawn(monkeypatch, cc_session="sess-A", roster=[MANAGER_ON_A_MISSION])
+    assert captured.get("missionId") == "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def test_an_explicit_mission_wins_over_the_inherited_one(monkeypatch, captured):
+    # Stated intent beats a default. Inheritance must never quietly override what was asked for.
+    _spawn(
+        monkeypatch,
+        cc_session="sess-A",
+        mission="bbbbbbbb-9999-8888-7777-666666666666",
+        roster=[MANAGER_ON_A_MISSION],
+    )
+    assert captured.get("missionId") == "bbbbbbbb-9999-8888-7777-666666666666"
+
+
+def test_mission_none_opts_out_of_inheritance(monkeypatch, captured):
+    # The opt-out, spelled the same way --controlled-by none is: a deliberate child that is NOT
+    # part of its controller's body of work.
+    _spawn(monkeypatch, cc_session="sess-A", mission="none", roster=[MANAGER_ON_A_MISSION])
+    assert "missionId" not in captured
+
+
+def test_a_controller_on_no_mission_leaves_the_child_unattached(monkeypatch, captured):
+    # Nothing to inherit is the ordinary case and must not invent an attachment.
+    _spawn(
+        monkeypatch,
+        cc_session="sess-A",
+        roster=[{"sessionId": "sess-A", "name": "Standalone seat"}],
+    )
+    assert "missionId" not in captured
+
+
+def test_a_spawn_with_no_controller_inherits_nothing(monkeypatch, captured):
+    # A human/desktop spawn has no controller, so there is no relationship to inherit along - even
+    # when other sessions in the roster are on missions.
+    _spawn(monkeypatch, cc_session=None, roster=[MANAGER_ON_A_MISSION])
+    assert "missionId" not in captured
+
+
+def test_standalone_inherits_nothing_because_it_has_no_controller(monkeypatch, captured):
+    # --standalone drops the controller, and inheritance follows the controller. A deliberate peer
+    # is not silently folded into the mission of the session that happened to start it.
+    _spawn(monkeypatch, cc_session="sess-A", standalone=True, roster=[MANAGER_ON_A_MISSION])
+    assert "missionId" not in captured
+
+
+def test_inheritance_follows_an_explicit_controller_not_the_spawner(monkeypatch, captured):
+    # --controlled-by names who SUPERVISES the child, and that is the relationship a mission is
+    # inherited along. The spawner's own mission is deliberately NOT the answer here: the sharp
+    # case is a session seating a worker under a DIFFERENT manager, where following the spawner
+    # would file the worker under the wrong body of work.
+    spawner = {
+        "sessionId": "sess-A",
+        "name": "Some other seat",
+        "missionId": "cccccccc-0000-0000-0000-000000000000",
+        "missionName": "Not this one",
+    }
+    _spawn(
+        monkeypatch,
+        cc_session="sess-A",
+        controlled_by="sess-A-manager",
+        roster=[spawner, dict(MANAGER_ON_A_MISSION, sessionId="sess-A-manager")],
+    )
+    assert captured.get("missionId") == "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def test_inheritance_is_reported_not_silent(monkeypatch, captured, capsys, plain):
+    # An attachment the caller did not ask for is only safe if they can SEE it happened. The line
+    # has to name the mission and say how to undo it, or a wrong inheritance is invisible.
+    # Asserted against the TEXT, not the rendering: Rich threads style codes through a version
+    # number, so a plain substring check would fail wherever colour is on (issue #1082).
+    _spawn(monkeypatch, cc_session="sess-A", roster=[MANAGER_ON_A_MISSION])
+    out = plain(capsys.readouterr().out)
+    assert "Release 1.9.4" in out
+    assert "mission detach" in out
+
+
+def test_an_unreadable_roster_is_reported_and_the_spawn_still_opens(
+    monkeypatch, captured, capsys, plain
+):
+    # A roster this process cannot read is NOT the same as a controller with no mission, and must
+    # not be reported as one. The session still opens - refusing to start work because an optional
+    # grouping could not be looked up would be the worse failure - but the human is told why it is
+    # unattached, so the missing mission is never a mystery.
+    def boom():
+        raise session_ops.director.DirectorError("Director not reachable")
+
+    monkeypatch.setenv("CC_SESSION_ID", "sess-A")
+    monkeypatch.setattr(session_ops.director, "get_fleet", boom)
+    session_ops.spawn_session(
+        repo="C:/repo",
+        agent="ClaudeCode",
+        prompt=None,
+        name="n",
+        purpose=None,
+        command=None,
+        command_args=None,
+        controlled_by=None,
+        args=None,
+        standalone=False,
+        role=None,
+        mission=None,
+    )
+
+    assert "missionId" not in captured
+    out = plain(capsys.readouterr().out)
+    assert "no mission" in out
+    assert "Opened" in out   # the control: the spawn itself still happened


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1768.

## What was missing

A Mission could only be joined in the instant a session was spawned. `session spawn --mission <id>`
attached at birth, and nothing could attach afterwards - the Gateway had `POST /missions`,
`GET /missions` and `GET /missions/{mid}` and no way to change a session's mission, and the command
line had `mission create` and `mission list` and no `mission attach`.

That made the feature miss the case it exists for. A mission's shape is DISCOVERED as it runs -
that is what makes it a mission rather than a task - so attach-at-birth grouped only the work
somebody had already planned, which is the work that least needs grouping. The release push that
found this began as one coordinating seat and grew over a day into about a dozen: an architect and a
manager, three review seats, three more for a different question, an investigation seat, four
independent gate reviewers commissioned one pull request at a time, and a session fixing a defect one
of them found. One body of work. None of it foreseeable at spawn. None of it representable.

## What this adds

- **`POST /sessions/{sid}/mission` on the Gateway** - attach a session that already exists to a
  Mission, or detach it on a null mission id. Resolves the mission inside the caller's own tenant,
  sends the resolved NAME down with the id, and routes the attachment to the owning Director over the
  tunnel.
- **`POST /fleet/mission` on a Director** - the loopback route the command line uses. A local target
  is attached directly (resolving the mission name against the Gateway first, as the local leg of
  `/fleet/spawn` already does); a target on another machine is relayed through the Gateway.
- **`cc-devthrottle mission attach <session> <mission>` and `mission detach <session>`**, with
  `--with-children`. Sessions are addressed the same way every other session verb addresses them
  (number, id prefix, name); a mission can be named by id, id prefix, or name.
- **Inheritance at spawn**: a session spawned with a controlling session inherits that session's
  mission by default.

The Director already had an `attach-mission` verb; it was reachable from nothing. This wires it up and
teaches it the Gateway path (stamp the id and name the Gateway resolved, instead of consulting the
Director's own single-tenant store, which is a different set - the failure #1548 fixed on the spawn
path).

## The rules, settled and written down

These are in `docs/new_architecture/mission-as-first-class-unit-of-work.md`, which is the document that
owns the attachment rules. Each was decided rather than left implied, because somebody hits every one.

1. **Attaching is a MOVE, not a one-way door.** A session that already carries a mission is re-pointed.
   The first classification of a session is always a guess about work still taking shape; one-way would
   make every wrong guess permanent until the session was killed.
2. **The move is REPORTED** - the command names the mission the session LEFT. A move that reports only
   its destination hides that anything was displaced.
3. **Detaching is supported.** No mission is the ordinary state of a session. A session that had no
   mission is told exactly that rather than told it was detached from nothing.
4. **A refused attach changes nothing** - a mistyped id leaves an existing attachment intact.
5. **Attaching a controlling session does NOT bring its children by default; `--with-children` does.**
   A controller routinely commissions work that is not part of its own mission, and a silent bulk
   re-parent cannot be undone in one step. With the flag the walk is TRANSITIVE: stopping at the first
   level would attach the Manager and leave the Workers behind, which reads as success while producing
   exactly the split view the feature exists to end. Every session it moves is NAMED, not counted.
6. **A spawned session inherits its controlling session's mission by default.** The fleet already
   records the relationship, so this costs nothing and would have grouped the release push above for
   free. `--mission <id>` wins (stated intent beats a default), `--mission none` opts out (spelled the
   way `--controlled-by none` is), and it is never silent: the spawn names the mission, names the
   session it came from, and says how to undo it.

## The workflow seat moves with the mission

Found by independent review of the first cut, and it was the finding that mattered. A Mission is not only
a record - it is also a RUN of the built-in `mission` workflow, and a mission-scoped spawn seats the
session on that run and records it in the run's participant ledger. The seat pins the CONDUCT the agent
follows. Moving only the mission link would have left a session **displayed under one mission while
governed by the one it left**, still counted in that mission's participant ledger - in exactly the case
this feature was built for.

The rule, and its one exception:

- A seat that **is a run of the mission being left** belongs to that mission and follows it: moved on a
  move, **cleared** on a detach.
- A seat the caller **chose independently** (`--workflow-run`) is **preserved**. It was never the
  mission's to take.
- A session with **no seat** has nothing to preserve and simply gains the destination's seat.
- A destination mission whose workflow the owner **switched off** seats nobody. A move must not re-enable
  something the owner deliberately turned off.

**Detach clears the seat rather than refusing.** Refusing while a seat exists was considered and
rejected: every mission-spawned session is seated, so refusal would make detach impossible for precisely
the sessions that need it. Refusal is only right where no coherent action exists, and here one does -
leave the run. Leaving is **recorded** (`LeftUtc`), not erased.

**Decided in one place.** Whether a run belongs to a mission is a fact about the Gateway's run store, so
the Gateway decides and hands the Director a finished answer, applied in the SAME verb as the mission -
two writes that must agree would disagree on a slow network. It is also why `POST /fleet/mission` relays
through the Gateway even for a session the Director hosts itself: a second implementation of this rule
would drift, and the drift would be invisible until somebody found a session governed by a mission it had
left.

**The limit, stated at the point of use.** Moving the seat corrects the RECORD - what the fleet shows,
what governs the session, who the run lists. It cannot reach into a running agent's context and replace
conduct injected at birth. The command line says so every time a seat moves, and names the command to
re-read it.

## The tenant boundary

Missions are tenant-scoped and that was hard won (devthrottle_internal thefrederiksen/devthrottle#1039 fixed a live leak where
`GET /missions` served every account's list to every account; a mission name is free text a person
typed). Attach is the first WRITE that takes a mission id from a caller and applies it, so it is exactly
the shape that would put the leak back.

The route follows `GET /missions/{mid}` line for line: resolve the caller's tenant server-side from the
authenticated device key, refuse with 403 when no tenant is bound (never fall back to a shared
partition), resolve the mission inside that tenant. An id belonging to another account is answered
identically to an id that does not exist. The mission is resolved BEFORE the session is located, so the
refusal is a property of the tenant gate alone and cannot be confused with a Director being offline.

**A refusal must not say WHICH kind of refusal it is.** This is a property of the route, not merely a
detail of a test. If "no mission has that id" and "that mission is not yours" were distinguishable - by
status code, or by wording - then attaching a session to guessed identifiers would enumerate which
missions exist in other people's accounts, one request at a time, without ever reading one. Both answer
400 with the same sentence and only the echoed id differs, and
`An_unknown_mission_id_and_another_tenants_mission_id_are_answered_alike` compares the two answers to
each other rather than to a fixed string, so a later edit cannot reword one without the other.

It is a literal route rather than an entry in the `/sessions/{sid}/{**rest}` catch-all deliberately: the
catch-all passes the raw request body straight through to the owning Director, which for this verb would
mean shipping a caller-supplied mission id with no tenant resolution at all.

`MissionAttachRouteTenantScopingTests` holds it to that, in the shape
`MissionStoreTenantPartitionTests` and `MissionRouteTenantScopingTests` established: two separately
enrolled accounts over the real routes, the real auth middleware and the real tunnel; every refusal
paired with a permitted request in the same Gateway; every refusal asserted at two levels (the status
code AND the fact that no `attach-mission` command reached the Director); and a self-test that points
the same recorder at an attach that genuinely happens and requires a positive, so a recorder that
records nothing cannot certify the file.

Revert-prove: drop the `ResolveReadTenant` gate, or resolve the mission with `TenantId.Local`, and
`Another_tenants_mission_cannot_be_attached_to_your_own_session` goes red - the attach to another
account's mission stops being a 400 and reaches the Director carrying that account's mission name.

## Which tests carry positive controls

Listed explicitly so a reviewer can check they are able to FAIL rather than infer it. Every case below
pairs the claim with something that must come out the other way in the same fixture.

**`MissionAttachRouteTenantScopingTests`** (the tenant partition)

| Case | The control |
|---|---|
| `The_attach_detector_itself_detects_an_attach_when_there_is_one` | **The self-test.** Every refusal below rests on "no `attach-mission` reached that Director". This points the same recorder at an attach that genuinely happens and requires a positive - a recorder that records nothing cannot certify the file. |
| `Another_tenants_mission_cannot_be_attached_to_your_own_session` | The same session attaching to a mission of its OWN succeeds (200, command recorded) in the same Gateway. |
| `Another_tenants_session_cannot_be_attached_to_your_own_mission` | B's own key reaches that same session (200, command recorded on B's Director). |
| `A_device_key_with_no_bound_tenant_attaches_nothing` | The identical attach AND detach with a BOUND key both land, two commands recorded. |
| `An_unknown_mission_id_and_another_tenants_mission_id_are_answered_alike` | Comparative: the two refusals are asserted equal to each other in status and wording, so neither can drift into an existence oracle. |
| `Detaching_carries_no_mission_and_needs_none` | Asserts the command ARRIVES with a null mission, so detach cannot be a no-op that reports success. |

**`MissionAttachSeatMoveTests`** (the seat, over a real run store)

| Case | The control |
|---|---|
| `Moving_a_session_updates_the_participant_ledger_on_both_runs` | Asserts the session **is** an active participant of run A *before* the move - "the session was never on run A, so nothing below means anything". |
| `Moving_a_mission_scoped_session_moves_its_workflow_seat` | The fixture fails loud if a created mission has no run, so the premise cannot silently vanish and leave the case asserting about nothing. |
| `A_seat_the_caller_chose_independently_is_preserved` | Asserted in BOTH directions: still active on the run it chose, and NOT enrolled in the destination mission's run. |
| `Detaching_clears_the_missions_seat_with_it` | The session is joined to run A first, so "no longer active" is a change and not a starting state. |
| `An_unseated_session_simply_gains_the_destination_missions_seat` | A positive claim in its own right. |

**`MissionCommandTests`** (the Director core)

`AttachMission_OnAnAlreadyAttachedSession_MovesItToTheNewMission`,
`AttachMission_WhenTheGatewaySaysMoveTheSeat_MovesMissionAndSeatTogether` and
`AttachMission_Detach_ClearsTheMissionsSeatWithIt` each assert the starting state first, so the change is
a change. `AttachMission_UnknownMission_LeavesAnExistingAttachmentIntact` attaches to a real mission
first. `AttachMission_WithMissionNamePresent_StampsDirectly_WithoutStoreLookup` proves "no local lookup"
by succeeding against an EMPTY store - a lookup would have rejected it.
`AttachMission_WithoutASeatDecision_TouchesTheSeatAtAll` is the compatibility control: a payload silent
about the seat must not clear one.

**Command line** - `test_no_warning_when_the_seat_did_not_move` is the control for the stale-conduct
warning (it must be tied to the seat actually moving, or it becomes noise ignored on the one occasion it
matters). `test_without_the_flag_only_the_named_session_moves` is the control for `--with-children`;
`test_a_spawn_with_no_controller_inherits_nothing` and
`test_standalone_inherits_nothing_because_it_has_no_controller` are the controls for inheritance.

## Deliberately not in this change

- **No user interface.** The issue asks for an endpoint and a command; the Cockpit and phone still show
  a mission but cannot change one. That is worth doing and is a separate piece of work.
- **`mission list` is unchanged.** A count of attached sessions would make an attach checkable without
  reading JSON, but `mission list` talks only to the Gateway today and adding it would give a
  Gateway-only command a dependency on a running Director.
