### PR TITLE
fix(wingman): release a session's handler and watcher when it ends

### DIFF
--- a/src/CcDirector.Core.Tests/Wingman/SessionStatusWingmanTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/SessionStatusWingmanTests.cs
@@ -635,6 +635,94 @@ public sealed class SessionStatusWingmanTests
         finally { wingman.Dispose(); manager.Dispose(); }
     }
 
+    // ---------- Session teardown: the class must not outlive the sessions it watched ----------
+    //
+    // This class subscribed to OnSessionCreated and never to OnSessionRemoved, so both of its
+    // per-session dictionaries grew for the life of the Director. The activity-handler entry is a
+    // closure that CAPTURES the Session, so each dead entry rooted the whole Session - its backend,
+    // its 2 MB terminal buffer, and both AnsiParsers with 5,000 scrollback rows each. A heap dump of
+    // a Director at 58 hours uptime found 146 Sessions retained for 9 live: ~1.7 GB, the bulk of the
+    // process heap. Its siblings (TerminalStateDetector, TransientErrorAutoResume) always hooked
+    // removal and sat correctly at the live count.
+    //
+    // These assert the COUNT, not that a teardown method ran. A test that only checked "the removal
+    // handler fired" would pass against a handler that removed from the wrong dictionary.
+
+    [Fact]
+    public void Removing_a_session_releases_both_per_session_entries()
+    {
+        var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        var wingman = new SessionStatusWingman(manager);
+        try
+        {
+            wingman.Start();
+            var (session, _) = CreateBufferSession(manager);
+
+            Assert.Equal(1, wingman.TrackedHandlerCount);
+            Assert.Equal(1, wingman.TrackedWatcherCount);
+
+            manager.RemoveSession(session.Id);
+
+            Assert.Equal(0, wingman.TrackedHandlerCount);
+            Assert.Equal(0, wingman.TrackedWatcherCount);
+        }
+        finally { wingman.Dispose(); manager.Dispose(); }
+    }
+
+    [Fact]
+    public void Tracked_state_matches_the_live_session_count_across_churn()
+    {
+        var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        var wingman = new SessionStatusWingman(manager);
+        try
+        {
+            wingman.Start();
+
+            // Churn many sessions through, keeping only the last three alive. Before the fix this
+            // ended at 12 tracked handlers for 3 live sessions - the leak in miniature.
+            var live = new List<Session>();
+            for (int i = 0; i < 12; i++)
+            {
+                var (s, _) = CreateBufferSession(manager);
+                live.Add(s);
+                if (live.Count > 3)
+                {
+                    var doomed = live[0];
+                    live.RemoveAt(0);
+                    manager.RemoveSession(doomed.Id);
+                }
+            }
+
+            Assert.Equal(3, manager.ListSessions().Count);
+            Assert.Equal(3, wingman.TrackedHandlerCount);
+            Assert.Equal(3, wingman.TrackedWatcherCount);
+        }
+        finally { wingman.Dispose(); manager.Dispose(); }
+    }
+
+    [Fact]
+    public void Dispose_clears_entries_for_sessions_that_already_ended()
+    {
+        var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        var wingman = new SessionStatusWingman(manager);
+        try
+        {
+            wingman.Start();
+            var (session, _) = CreateBufferSession(manager);
+            Assert.Equal(1, wingman.TrackedHandlerCount);
+
+            // Dispose() used to walk ListSessions() - the LIVE sessions - which is precisely the set
+            // that does NOT need clearing. A session removed first was therefore unreachable from
+            // the teardown loop and survived a full Director shutdown.
+            manager.RemoveSession(session.Id);
+            wingman.Dispose();
+
+            Assert.Equal(0, wingman.TrackedHandlerCount);
+            Assert.Equal(0, wingman.TrackedWatcherCount);
+        }
+        finally { wingman.Dispose(); manager.Dispose(); }
+    }
+
     // ---------- Prompt-injection watcher (end-to-end via real buffer) ----------
 
     private static (Session session, BufferOnlyBackend backend) CreateBufferSession(SessionManager manager)

--- a/src/CcDirector.Core/Wingman/SessionStatusWingman.cs
+++ b/src/CcDirector.Core/Wingman/SessionStatusWingman.cs
@@ -59,6 +59,18 @@ public sealed class SessionStatusWingman : IDisposable
     private bool _disposed;
 
     /// <summary>
+    /// How many sessions this class still holds an activity handler for. Exposed for tests, which
+    /// must assert the COUNT rather than that a teardown method ran: a test that only checks
+    /// "OnSessionRemoved was called" passes against a handler that removes from the wrong
+    /// dictionary, which is the shape of the bug this guards.
+    /// </summary>
+    internal int TrackedHandlerCount => _activityHandlers.Count;
+
+    /// <summary>How many prompt-injection watchers are still held. Same reasoning as
+    /// <see cref="TrackedHandlerCount"/>: both dictionaries leaked, so both are asserted.</summary>
+    internal int TrackedWatcherCount => _injectionWatchers.Count;
+
+    /// <summary>
     /// Debounce window between the last buffer write and running the prompt-input
     /// extraction. Long enough that Claude Code's Ink TUI has settled into a
     /// final frame; short enough that the user sees the suggestion almost
@@ -79,6 +91,7 @@ public sealed class SessionStatusWingman : IDisposable
         FileLog.Write("[SessionStatusWingman] Start");
 
         _sessionManager.OnSessionCreated += OnSessionCreated;
+        _sessionManager.OnSessionRemoved += OnSessionRemoved;
 
         // Wire existing sessions (restored from persistence on Director boot).
         foreach (var s in _sessionManager.ListSessions())
@@ -86,6 +99,29 @@ public sealed class SessionStatusWingman : IDisposable
     }
 
     private void OnSessionCreated(Session session) => WireSession(session, isNew: true);
+
+    /// <summary>
+    /// Release everything this class holds for a session that has ended.
+    ///
+    /// Both dictionaries are keyed by session id and both entries reference the Session itself -
+    /// <see cref="_activityHandlers"/> stores a closure that CAPTURES the session, and the
+    /// <see cref="PromptInjectionWatcher"/> holds it directly. Without this hook those entries live
+    /// as long as the Director does, so every session ever opened stays rooted along with its
+    /// backend, its terminal buffer, and its parsers' scrollback.
+    ///
+    /// That was the bug: this class subscribed to OnSessionCreated and never to OnSessionRemoved,
+    /// while its siblings (TerminalStateDetector, TransientErrorAutoResume) always did. On one
+    /// Director at 58 hours uptime it retained 146 Sessions for 9 live ones - about 1.7 GB, the
+    /// bulk of the process heap. The per-session bounds were all correct; the object count was not.
+    /// </summary>
+    private void OnSessionRemoved(Session session)
+    {
+        if (_activityHandlers.TryRemove(session.Id, out var handler))
+            session.OnActivityStateChanged -= handler;
+
+        if (_injectionWatchers.TryRemove(session.Id, out var watcher))
+            watcher.Dispose();
+    }
 
     private void WireSession(Session session, bool isNew)
     {
@@ -194,11 +230,22 @@ public sealed class SessionStatusWingman : IDisposable
         _disposed = true;
 
         _sessionManager.OnSessionCreated -= OnSessionCreated;
+        _sessionManager.OnSessionRemoved -= OnSessionRemoved;
+
+        // Unsubscribe from the sessions that are still live - we need the Session object to detach
+        // the handler, and only the live list can supply it.
         foreach (var s in _sessionManager.ListSessions())
         {
             if (_activityHandlers.TryRemove(s.Id, out var h))
                 s.OnActivityStateChanged -= h;
         }
+
+        // Then drop whatever is left. Anything still here belongs to a session that has already
+        // ended, so there is no Session to detach from - the entry is pure retention. The loop
+        // above walks LIVE sessions only, which is exactly the set that does NOT need clearing;
+        // without this line a dead session's handler survived even a full Director shutdown.
+        _activityHandlers.Clear();
+
         foreach (var kv in _injectionWatchers)
             kv.Value.Dispose();
         _injectionWatchers.Clear();


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1769.

## The bug

`SessionStatusWingman` subscribed to `SessionManager.OnSessionCreated` and **never to
`OnSessionRemoved`**. Its two per-session dictionaries therefore grew for the life of the Director.

The `_activityHandlers` entry is a closure that **captures the Session**, so each stale entry rooted
the whole object graph behind it: the `ConPtyBackend`, the 2 MB `CircularTerminalBuffer`, and both
`AnsiParser` instances with their 5,000-row scrollback each. `_injectionWatchers` leaked the same
way.

Found by heap dump on a Director at 58 hours uptime:

| | Retained | Live sessions |
|---|---|---|
| `Session` | **146** | 9 |
| `ConPtyBackend` | **146** | 9 |
| `CircularTerminalBuffer` | **146** | 9 |
| `PromptInjectionWatcher` | **146** | 9 |
| `SessionLogWriter` | 9 | 9 |
| `TerminalStateDetector+Watcher` | 9 | 9 |
| `TransientErrorAutoResume+Watcher` | 9 | 9 |

`TerminalCell[]` accounted for 1,416 MB - 74% of the heap - with another ~274 MB in the retained
byte buffers. Roughly **1.7 GB of a 1.84 GB heap**, growing with every session ever opened until
the process restarts.

The three sibling registries keyed the same way all hook removal and sit exactly at the live count.
This class was the only one that never learned a session ended. `gcroot` on the oldest dead Session
ends at `SessionStatusWingman -> _activityHandlers -> Action -> <>c__DisplayClass9_0 -> Session`.

**Every per-session bound was already correct and working.** The caps are all real and all enforced.
The bug was the object count those caps get multiplied by - which is why reading the code alone kept
clearing this class, and only counting objects on a live heap found it.

## The change

Matches the pattern the siblings already use:

1. `Start()` subscribes to `OnSessionRemoved` alongside `OnSessionCreated`.
2. New `OnSessionRemoved(Session)` removes the handler and detaches it, then removes and disposes
   the `PromptInjectionWatcher`.
3. `Dispose()` unsubscribes both events, and now clears the dictionaries outright after the
   `ListSessions()` loop.

Point 3 matters on its own: that loop walks the **live** sessions, which is exactly the set that does
NOT need clearing. A session removed earlier was unreachable from it and survived a full Director
shutdown.

## Tests

Three regression tests that assert the retained **count**, not that a teardown method ran - a test
checking only that the removal handler fired would pass against a handler removing from the wrong
dictionary, which is the shape of this bug.

- `Removing_a_session_releases_both_per_session_entries`
- `Tracked_state_matches_the_live_session_count_across_churn` - 12 sessions through, 3 kept alive;
  before the fix this ends at 12 tracked for 3 live
- `Dispose_clears_entries_for_sessions_that_already_ended` - covers the `ListSessions()` blind spot

`TrackedHandlerCount` / `TrackedWatcherCount` are `internal` (the test project already has
`InternalsVisibleTo`).

**Fault-injected to prove the tests are not decorative:** commenting out the two behavioural lines
while keeping the accessors so it still compiles turns all three red (Failed: 3, Passed: 0).
Restoring gives Passed: 3.

## Verification

`.\scripts\test-local.ps1` - all 7 projects, every TRX `outcome=Completed` at or above baseline:

| Project | Passed | Failed |
|---|---|---|
| CcDirector.Gateway.Tests | 5,211 | 0 |
| CcDirector.Core.Tests | 4,208 | 0 |
| CcDirector.Avalonia.Tests | 353 | 0 |
| CcDirector.Engine.Tests | 63 | 0 |
| CcDirector.HostedAgent.Tests | 88 | 0 |
| CcDirector.Launcher.Tests | 110 | 0 |
| CcDirector.Terminal.Avalonia.Tests | 24 | 0 |

10,057 passed, 0 failed, 14 skipped. Build clean, 0 warnings.

## Not covered by this change

A Director already running keeps its retained Sessions until it restarts on a build carrying this
fix - there is no runtime reclaim path, and none is added here.
