### PR TITLE
fix(director): stop the FIFO window and the main window sharing one session's terminal

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4398,14 +4398,26 @@ public partial class MainWindow : Window
                 return;
             }
             FileLog.Write("[MainWindow] BtnFifo_Click: opening FIFO window");
-            await new FifoWindow(sm).ShowDialog(this);
 
-            // The FIFO window is full-screen, so attaching a session there resized that
-            // session's PTY to full-screen dimensions. Re-attach the main window's active
-            // session so it re-sends ITS dimensions and redraws cleanly, instead of leaving
-            // the session rendering at the FIFO window's size.
-            if (_activeSession is not null)
-                TerminalHost.Attach(_activeSession.Session);
+            // Hand the terminal over before FIFO opens. FIFO attaches sessions to its OWN
+            // TerminalControl, and the queue routinely contains the session this window is
+            // already showing - so without this both controls hold one session, both poll it,
+            // and both drive Session.Resize against the real ConPTY. FIFO is full-screen and
+            // modal, so there is nothing here to keep drawing anyway.
+            TerminalHost.Detach();
+            try
+            {
+                await new FifoWindow(sm).ShowDialog(this);
+            }
+            finally
+            {
+                // Always re-attach, including when FIFO threw: leaving the main window with a
+                // detached terminal is a blank pane the user cannot recover without switching
+                // sessions. Re-attaching also re-sends OUR dimensions, so a session FIFO resized
+                // to full screen redraws at this window's size.
+                if (_activeSession is not null)
+                    TerminalHost.Attach(_activeSession.Session);
+            }
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -11,6 +11,9 @@
     <InternalsVisibleTo Include="CcDirector.Core.Tests" />
     <InternalsVisibleTo Include="CcDirector.Avalonia.Tests" />
     <InternalsVisibleTo Include="CcDirector.Gateway.Tests" />
+    <!-- Terminal tests construct a Session to drive TerminalControl.Attach, whose whole
+         contract is about session ownership. Session's constructors are internal. -->
+    <InternalsVisibleTo Include="CcDirector.Terminal.Avalonia.Tests" />
     <InternalsVisibleTo Include="TerminalTest" />
   </ItemGroup>
 

--- a/src/CcDirector.Terminal.Avalonia.Tests/TerminalAttachOwnershipTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/TerminalAttachOwnershipTests.cs
@@ -1,0 +1,167 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Terminal.Avalonia.Tests;
+
+/// <summary>
+/// One live terminal view per session.
+///
+/// Attaching a session is not a read - <see cref="TerminalControl.Attach"/> ends by sending
+/// Session.Resize, which resizes the real ConPTY the agent writes into. Two controls attached to
+/// one session each poll it and each resize it to their own grid, so the agent's output reflows
+/// on every repaint.
+///
+/// This shipped: the FIFO takeover window attached sessions to its own terminal while the main
+/// window was still attached to the same session, and the main window "repaired" the geometry
+/// after FIFO closed rather than avoiding the overlap. These tests pin the invariant that made
+/// that a bug, so a future caller that forgets to detach is caught here instead of by a user
+/// watching their transcript reflow.
+/// </summary>
+public sealed class TerminalAttachOwnershipTests
+{
+    private static Session NewSession() =>
+        new(Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new NullBackend(), claudeSessionId: null,
+            activityState: ActivityState.WaitingForInput,
+            createdAt: DateTimeOffset.UtcNow, customName: null, customColor: null);
+
+    private static TerminalControl NewAttachedTerminal()
+    {
+        var terminal = new TerminalControl();
+        var window = new Window { Width = 800, Height = 400, Content = terminal };
+        window.Show();
+        return terminal;
+    }
+
+    [AvaloniaFact]
+    public void Attach_TakesOwnership()
+    {
+        using var session = NewSession();
+        var terminal = NewAttachedTerminal();
+
+        terminal.Attach(session);
+
+        Assert.Same(terminal, TerminalControl.OwnerOf(session.Id));
+    }
+
+    [AvaloniaFact]
+    public void SecondAttach_EvictsTheFirstControl()
+    {
+        // The FIFO case: the main window is showing a session and FIFO attaches the same one.
+        using var session = NewSession();
+        var mainWindowTerminal = NewAttachedTerminal();
+        var fifoTerminal = NewAttachedTerminal();
+
+        mainWindowTerminal.Attach(session);
+        fifoTerminal.Attach(session);
+
+        // Exactly one owner, and it is the newcomer.
+        Assert.Same(fifoTerminal, TerminalControl.OwnerOf(session.Id));
+
+        // And the displaced control is genuinely detached - not merely un-owned - so it has
+        // stopped polling and will not resize the session out from under the new owner.
+        Assert.False(mainWindowTerminal.IsAttachedForTests);
+        Assert.True(fifoTerminal.IsAttachedForTests);
+    }
+
+    [AvaloniaFact]
+    public void EvictedControlDetaching_DoesNotClearTheNewOwner()
+    {
+        // The ordering that makes a naive registry wrong: the evicted control detaches LATER
+        // (its window closes), and must not take the new owner's claim with it.
+        using var session = NewSession();
+        var first = NewAttachedTerminal();
+        var second = NewAttachedTerminal();
+
+        first.Attach(session);
+        second.Attach(session);
+        first.Detach();
+
+        Assert.Same(second, TerminalControl.OwnerOf(session.Id));
+        Assert.True(second.IsAttachedForTests);
+    }
+
+    [AvaloniaFact]
+    public void Detach_ReleasesOwnership()
+    {
+        using var session = NewSession();
+        var terminal = NewAttachedTerminal();
+
+        terminal.Attach(session);
+        terminal.Detach();
+
+        Assert.Null(TerminalControl.OwnerOf(session.Id));
+    }
+
+    [AvaloniaFact]
+    public void ReAttachingSameControl_KeepsOwnershipAndStaysAttached()
+    {
+        // MainWindow re-attaches its own session after FIFO closes. Attach() calls Detach()
+        // internally, so the control must not release and then fail to reclaim itself.
+        using var session = NewSession();
+        var terminal = NewAttachedTerminal();
+
+        terminal.Attach(session);
+        terminal.Attach(session);
+
+        Assert.Same(terminal, TerminalControl.OwnerOf(session.Id));
+        Assert.True(terminal.IsAttachedForTests);
+    }
+
+    [AvaloniaFact]
+    public void SwitchingSessions_ReleasesTheOldOne()
+    {
+        using var first = NewSession();
+        using var second = NewSession();
+        var terminal = NewAttachedTerminal();
+
+        terminal.Attach(first);
+        terminal.Attach(second);
+
+        Assert.Null(TerminalControl.OwnerOf(first.Id));
+        Assert.Same(terminal, TerminalControl.OwnerOf(second.Id));
+    }
+
+    [AvaloniaFact]
+    public void DistinctSessions_DoNotContend()
+    {
+        // The ordinary grid case: separate sessions in separate panes each keep their own view.
+        using var a = NewSession();
+        using var b = NewSession();
+        var paneOne = NewAttachedTerminal();
+        var paneTwo = NewAttachedTerminal();
+
+        paneOne.Attach(a);
+        paneTwo.Attach(b);
+
+        Assert.Same(paneOne, TerminalControl.OwnerOf(a.Id));
+        Assert.Same(paneTwo, TerminalControl.OwnerOf(b.Id));
+        Assert.True(paneOne.IsAttachedForTests);
+        Assert.True(paneTwo.IsAttachedForTests);
+    }
+
+    /// <summary>A backend that starts nothing - the session only needs to exist and have an id.</summary>
+    private sealed class NullBackend : ISessionBackend
+    {
+        public int ProcessId => 0;
+        public string Status => "Test";
+        public bool IsRunning => false;
+        public bool HasExited => true;
+        public CircularTerminalBuffer? Buffer { get; } = new(1024);
+        public event Action<string>? StatusChanged { add { } remove { } }
+        public event Action<int>? ProcessExited { add { } remove { } }
+        public void Start(string executable, string args, string workingDir, short cols, short rows,
+            System.Collections.Generic.Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public System.Threading.Tasks.Task SendTextAsync(string text) => System.Threading.Tasks.Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public System.Threading.Tasks.Task GracefulShutdownAsync(int timeoutMs = 5000)
+            => System.Threading.Tasks.Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -93,6 +93,65 @@ public class TerminalControl : Control
     private AnsiParser? _parser;
     private bool _pendingLayoutAttach;
 
+    // ===== One live terminal view per session =====
+    // Attaching does not just read a session, it OWNS it: Attach() sends Session.Resize, which
+    // resizes the real ConPTY the agent writes into. Two controls attached to one session each
+    // poll it and each resize it to their own grid, so the agent's output reflows on every
+    // repaint - the FIFO window and the main window did exactly this.
+    //
+    // Ownership is therefore explicit and last-attach-wins: whoever attaches takes the session
+    // and the previous holder is detached. Self-healing rather than throwing, because a stray
+    // second view should degrade to "the other one stopped drawing", never to a crash. Every
+    // eviction is logged, so a caller that should have detached first is visible in the log
+    // instead of showing up as mysterious reflow.
+    //
+    // UI-thread only in practice (attach/detach run on the dispatcher), but locked anyway - the
+    // cost is nil and the failure it would prevent is a corrupted static map.
+    private static readonly object _ownerLock = new();
+    private static readonly Dictionary<Guid, TerminalControl> _sessionOwners = new();
+
+    /// <summary>
+    /// Take ownership of a session, detaching whichever control held it before. Returns the
+    /// evicted control, or null when the session was free.
+    /// </summary>
+    private static TerminalControl? ClaimOwnership(Guid sessionId, TerminalControl claimant)
+    {
+        TerminalControl? previous = null;
+        lock (_ownerLock)
+        {
+            if (_sessionOwners.TryGetValue(sessionId, out var held) && !ReferenceEquals(held, claimant))
+                previous = held;
+            _sessionOwners[sessionId] = claimant;
+        }
+        return previous;
+    }
+
+    /// <summary>
+    /// Give up ownership, but only if this control still holds it - a control that was already
+    /// evicted by a later attach must not clear the new owner's claim on its way out.
+    /// </summary>
+    private static void ReleaseOwnership(Guid sessionId, TerminalControl holder)
+    {
+        lock (_ownerLock)
+        {
+            if (_sessionOwners.TryGetValue(sessionId, out var held) && ReferenceEquals(held, holder))
+                _sessionOwners.Remove(sessionId);
+        }
+    }
+
+    /// <summary>Test seam: the control currently owning a session, or null.</summary>
+    internal static TerminalControl? OwnerOf(Guid sessionId)
+    {
+        lock (_ownerLock)
+            return _sessionOwners.TryGetValue(sessionId, out var held) ? held : null;
+    }
+
+    /// <summary>
+    /// Test seam: whether this control still holds a session. Distinct from ownership - an
+    /// evicted control must be genuinely detached (poll timer stopped), not merely un-owned.
+    /// </summary>
+    internal bool IsAttachedForTests => _session is not null;
+
     // Cell grid
     private TerminalCell[,] _cells;
     private int _cols = DefaultCols;
@@ -337,6 +396,17 @@ public class TerminalControl : Control
         FileLog.Write($"[TerminalControl] Attach: sessionId={session.Id}");
 
         Detach();
+
+        // Take the session off any other control still holding it. Two live views resize the
+        // same ConPTY against each other; the caller should have detached first, so say so.
+        var evicted = ClaimOwnership(session.Id, this);
+        if (evicted is not null)
+        {
+            FileLog.Write($"[TerminalControl] Attach: session {session.Id} was still attached to another " +
+                          "terminal - detaching it. The previous holder should have detached first.");
+            evicted.Detach();
+        }
+
         _session = session;
         _bufferPosition = 0;
         _scrollOffset = 0;
@@ -383,6 +453,9 @@ public class TerminalControl : Control
     public void Detach()
     {
         FileLog.Write($"[TerminalControl] Detach: sessionId={_session?.Id}, scrollback={_scrollback.Count}, offset={_scrollOffset}");
+
+        if (_session is not null)
+            ReleaseOwnership(_session.Id, this);
 
         _pollTimer?.Stop();
         _pollTimer = null;


### PR DESCRIPTION
Found while reviewing the panes / tear-off design (devthrottle_internal#1225), which had cited `FifoWindow` as proof that a second window can host a terminal. It does - but it double-attaches.

## The bug

`BtnFifo_Click` opened FIFO **without detaching the main window's `TerminalControl`**. FIFO then attaches sessions to its own control, and its queue is needs-you sessions - routinely including the one already on screen. Two controls then polled one session and both drove `Session.Resize` against the real ConPTY, so the agent's output reflowed to whichever resized last.

Survivable only because FIFO is modal and full-screen, hiding the damage, plus a re-attach afterwards that repaired the geometry FIFO had changed. The comment on that re-attach described the symptom without naming the cause.

## The fix

Detach before showing FIFO; re-attach in a `finally` so a throw inside FIFO cannot leave the main window with a blank terminal.

Then make the invariant real instead of a convention: `Attach()` takes ownership of a session and detaches whichever control held it before. Last attach wins, the evicted control is genuinely detached, and every eviction is logged so a caller that should have detached first shows up in the log rather than as unexplained reflow. Release is identity-checked, so a control evicted earlier cannot clear the new owner's claim when its own window closes later.

## Proof

7 new tests, and **verified by mutation** rather than just green:

- removing the eviction -> `SecondAttach_EvictsTheFirstControl` fails
- dropping the identity check on release -> `EvictedControlDetaching_DoesNotClearTheNewOwner` fails

Suites run locally: Terminal.Avalonia 31/31, Avalonia 353/353.

`CcDirector.Core` grants internals to the terminal test project so a `Session` can be constructed - compile-time visibility only, no runtime change.