### PR TITLE
fix(tests): the register test expects the terminology skill too

### DIFF
--- a/src/CcDirector.Gateway.Tests/SkillEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/SkillEndpointsTests.cs
@@ -61,7 +61,7 @@ public sealed class SkillEndpointsTests : IAsyncLifetime
         var body = await _http.GetFromJsonAsync<JsonObject>("gateway/skills");
 
         var ids = body!["skills"]!.AsArray().Select(s => (string?)s!["id"]).ToArray();
-        Assert.Equal(new[] { "dev-throttle", "fleet-comms", "move-session" }, ids);
+        Assert.Equal(new[] { "dev-throttle", "fleet-comms", "move-session", "terminology" }, ids);
     }
 
     [Fact]


### PR DESCRIPTION
Main is red. Two tests assert the shipped skill list; the terminology commit updated only `SkillStoreTests` and missed `SkillEndpointsTests`.

CI named the expected value exactly - `Assert.Equal() Failure: Collections differ` on the id array - and this is the same one-line change already made in the store test.

Not verified by running the Gateway suite locally: the machine-wide lock is held by another session's run (`4abb1533`, since 01:10 UTC), so a local run would only queue. Compile-checked, and CI on main is the verification.