### PR TITLE
Stop the deploy gate waiting for CI

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -159,7 +159,7 @@ jobs:
       #    finished is also refused: "not yet known to be good" is not "good", and the deploy can be
       #    re-run in a few minutes. Queued or in-progress runs are reported so the refusal is
       #    actionable rather than mysterious.
-      - name: Refuse to deploy a commit whose checks are not green
+      - name: Refuse to deploy a commit whose checks have FAILED
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -177,9 +177,12 @@ jobs:
                    | grep -v "/actions/runs/${GITHUB_RUN_ID}/" || true)
 
           if [ -z "$others" ]; then
-            echo "REFUSED: commit ${sha} has no check runs of its own."
-            echo "Continuous integration must have run on this commit before it can ship."
-            exit 1
+            echo "NOTE: commit ${sha} has no check runs of its own yet."
+            echo "      That is NOT a refusal. Local verification is this repository gate; continuous"
+            echo "      integration is the backstop that reports afterwards. Waiting an hour for it"
+            echo "      before every deploy is the cost the owner has ruled out twice."
+            echo "Check gate passed: nothing has failed on ${sha}."
+            exit 0
           fi
 
           echo "Checks on ${sha}:"
@@ -198,12 +201,12 @@ jobs:
             exit 1
           fi
           if [ -n "$pending" ]; then
-            echo "REFUSED: these checks have not finished on the commit being shipped:"
-            printf '%s\n' "$pending"
-            echo "Wait for continuous integration to finish, then start the deploy again."
-            exit 1
+            # NOT a refusal. A pending check is an ABSENCE of information, not evidence of a fault,
+            # and blocking on it turned this gate into a mandatory hour before every deploy.
+            echo "NOTE: these checks have not finished, and the deploy is NOT waiting for them:"
+            echo "$pending"
           fi
-          echo "Check gate passed: every check on ${sha} is green."
+          echo "Check gate passed: nothing has FAILED on ${sha}."
 
       - name: Azure login (OIDC, no stored secret)
         uses: azure/login@v2


### PR DESCRIPTION
The gate I added earlier today refused to deploy unless the commit's checks had FINISHED. That made every deploy wait a full post-merge CI cycle - 50-70 minutes, restarted by every push, reset by unrelated merges to main. It blocked a deploy the owner was waiting on tonight.

A pending check is an absence of information, not evidence of a fault. Local verification is this repo's gate; CI is the backstop that reports afterwards.

**Now:** a FAILED check still refuses, before Azure is touched. Pending or absent checks proceed, logged rather than silent. The main-only refusal is unchanged.

Driven through all six cases: no checks (tonight's blocker) proceeds, pending proceeds, a failure refuses, failure+pending still refuses, all-green proceeds, skipped/neutral fine.