### PR TITLE
Say the trial on the hosted gateway card, not just the price (#1044)

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -608,9 +608,16 @@
                                 <TextBlock TextWrapping="Wrap" FontSize="12.5" Foreground="#5A616B"
                                            Text="Your agents run on your machines. Fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work." />
                                 <!-- State the plan, never assert what this user already owns: on a
-                                     brand-new free account "included with your subscription" is false. -->
+                                     brand-new free account "included with your subscription" is false.
+                                     "Part of Pro" alone was true but read as a paywall on the card the
+                                     user is one click from taking, because it omitted the trial the
+                                     Gateway actually grants (issue #1044). The trial is stated as a
+                                     general fact about new accounts, NOT as a promise to this user: it
+                                     is granted only on an account's first arrival at the hosted gateway
+                                     and never twice, so "you get 14 days" would be false for someone
+                                     coming back. -->
                                 <TextBlock FontSize="12.5" Foreground="#8A909A"
-                                           Text="Part of Pro" />
+                                           Text="Part of Pro. New accounts get 14 days free, no card." />
                             </StackPanel>
                         </RadioButton>
 


### PR DESCRIPTION
Fixes the wording question in devthrottle_internal#1044. Owner approved the change.

## The problem

The Hosted gateway card in the setup wizard is pre-selected, marked RECOMMENDED, and priced `Part of Pro`. That reads as a paywall on the one screen where the user is a single click from continuing - so it discourages the exact path the product wants people on.

## What I established first

The sentence was **true**, not wrong:

- `HostedEnrollmentEndpoint` and `AuthMiddleware` both refuse an account with no paid entitlement and no live trial - 402 `hosted_subscription_required`, with a 503-and-retry path when the entitlement read fails rather than guessing.
- `TrialRegistry` grants every account arriving at the hosted gateway **for the first time** a 14-day Pro trial, no card (`TrialLength = TimeSpan.FromDays(14)`).

So the free account that enrolled in five seconds during the 30 July clean-machine run was the trial working as designed, not a missing paywall. The trial shipped 2026-07-25, five days before that run.

## The change

`Part of Pro` -> `Part of Pro. New accounts get 14 days free, no card.`

Every other surface already says this; the pricing page leads with it. This card was the only place in the funnel that priced hosted without it.

Stated as a general fact about new accounts rather than a promise to the reader, because the trial is granted only on an account's FIRST arrival and never twice - `you get 14 days` would be false for someone coming back. That also keeps the existing rule in the comment above the line: state the plan, never assert what this user already owns.

## Checks

- `dotnet build src/CcDirector.Avalonia` - succeeded, 0 warnings, 0 errors (Avalonia compiles the XAML at build time)
- No test pinned the old string - grepped `src/` before changing it
- Copy only, no behaviour change

## Known and NOT addressed here

The line is still hard-coded text that does not read the entitlement it describes - logged independently as **G3** in the 2026-07-29 onboarding wizard review. If plan or trial terms change, this line will not. Sourcing it is a separate piece of work.