### PR TITLE
WIP - wizard git notice, Source Control view, and window sizing (pieces 3 and 4 of a split; do not merge)

### DIFF
--- a/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
@@ -71,6 +71,29 @@ public class GitChangesViewFailedReadTests
     }
 
     /// <summary>
+    /// The branch bar is filled by a SEPARATE read on its own timer, so a failed changes read used
+    /// to leave it standing: last known branch, ahead and behind counts, presented as current, right
+    /// beside a line saying nothing could be read. Stale numbers next to an admission of ignorance
+    /// are worse than no numbers.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AFailedRead_TakesTheStaleBranchBarDownWithIt()
+    {
+        var gone = Path.Combine(Path.GetTempPath(), "cc-director-changes-view-tests", Guid.NewGuid().ToString("N"));
+
+        var view = new GitChangesView();
+        view.Attach(gone);
+        // Stand in for an earlier successful sync read, which is what puts the bar up.
+        view.BranchBar.IsVisible = true;
+
+        await view.RefreshAsync();
+
+        Assert.True(view.ProblemText.IsVisible);
+        Assert.False(view.BranchBar.IsVisible, "the branch bar stayed up showing stale counts beside a failed read");
+        view.Detach();
+    }
+
+    /// <summary>
     /// A successful read clears the accusation. A machine that has been fixed must stop being told
     /// it is broken - and a problem line that never goes away is its own defect.
     /// </summary>

--- a/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
@@ -43,6 +43,30 @@ public class GitChangesViewFailedReadTests
     }
 
     /// <summary>
+    /// A folder that is gone - deleted, or on a drive that has been unplugged - is the other way this
+    /// page used to go quiet. It returned before reading anything and left the previous repository's
+    /// changes, or the "No changes detected" empty state, describing a folder that is not there.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AFolderThatIsNoLongerOnDisk_SaysSo()
+    {
+        // A path that is simply not there - the state a deleted folder or an unplugged drive leaves
+        // behind. Nothing is created and nothing has to be cleaned up, so this test cannot fail on
+        // Windows holding a handle open rather than on the behaviour under test.
+        var gone = Path.Combine(Path.GetTempPath(), "cc-director-changes-view-tests", Guid.NewGuid().ToString("N"));
+
+        var view = new GitChangesView();
+        view.Attach(gone);
+
+        await view.RefreshAsync();
+
+        Assert.True(view.ProblemText.IsVisible);
+        Assert.Contains("no longer on disk", view.ProblemText.Text ?? "");
+        Assert.False(view.EmptyText.IsVisible);
+        view.Detach();
+    }
+
+    /// <summary>
     /// A successful read clears the accusation. A machine that has been fixed must stop being told
     /// it is broken - and a problem line that never goes away is its own defect.
     /// </summary>

--- a/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
@@ -1,0 +1,101 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Avalonia.Controls;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The Source Control tab's Changes page says when it could NOT read, instead of leaving "No changes
+/// detected" on the screen (devthrottle_internal issue #1048).
+///
+/// "No changes detected" is a statement about the repository. When the read fails nothing has been
+/// established about the repository at all, so the page was asserting something it had not observed -
+/// and the two states were indistinguishable to the user.
+///
+/// The failure injected here is a folder that is not a git checkout, because that fails the read on
+/// a machine that HAS git and so can be reproduced anywhere. It is the same branch a machine with no
+/// git takes: that git-is-absent reaches this branch as a failed read is proved separately, in
+/// CcDirector.Core.Tests GitAbsentTests.
+/// </summary>
+public class GitChangesViewFailedReadTests
+{
+    [AvaloniaFact]
+    public async Task AFailedRead_SaysSo_RatherThanClaimingThereAreNoChanges()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-director-changes-view-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var view = new GitChangesView();
+            view.Attach(dir);
+
+            await view.RefreshAsync();
+
+            Assert.True(view.ProblemText.IsVisible);
+            Assert.Contains("could not be read", view.ProblemText.Text ?? "");
+            Assert.False(view.EmptyText.IsVisible);
+            view.Detach();
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>
+    /// A successful read clears the accusation. A machine that has been fixed must stop being told
+    /// it is broken - and a problem line that never goes away is its own defect.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AGoodReadAfterABadOne_ClearsTheProblemLine()
+    {
+        var repo = Path.Combine(Path.GetTempPath(), "cc-director-changes-view-tests", Guid.NewGuid().ToString("N"));
+        var notARepo = Path.Combine(Path.GetTempPath(), "cc-director-changes-view-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repo);
+        Directory.CreateDirectory(notARepo);
+        try
+        {
+            await RunGitAsync(repo, "init");
+
+            var view = new GitChangesView();
+
+            view.Attach(notARepo);
+            await view.RefreshAsync();
+            Assert.True(view.ProblemText.IsVisible);
+
+            view.Attach(repo);
+            await view.RefreshAsync();
+
+            Assert.False(view.ProblemText.IsVisible);
+            Assert.True(view.EmptyText.IsVisible);
+            view.Detach();
+        }
+        finally
+        {
+            TryDelete(repo);
+            TryDelete(notARepo);
+        }
+    }
+
+    private static async Task RunGitAsync(string workingDirectory, params string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        await proc.WaitForExitAsync();
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* a git object store on Windows can hold a handle a moment longer; the temp folder is disposable */ }
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GitChangesViewFailedReadTests.cs
@@ -61,7 +61,11 @@ public class GitChangesViewFailedReadTests
         await view.RefreshAsync();
 
         Assert.True(view.ProblemText.IsVisible);
-        Assert.Contains("no longer on disk", view.ProblemText.Text ?? "");
+        Assert.Contains("cannot be reached", view.ProblemText.Text ?? "");
+        // And it stops short of naming a cause. Directory.Exists is false for a folder that was
+        // deleted AND for one that is merely unreachable or unreadable, so "no longer on disk" -
+        // which is what this said first - asserted something nothing here established.
+        Assert.DoesNotContain("no longer on disk", view.ProblemText.Text ?? "");
         Assert.False(view.EmptyText.IsVisible);
         view.Detach();
     }

--- a/src/CcDirector.Avalonia.Tests/WizardGitNoticeTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WizardGitNoticeTests.cs
@@ -1,0 +1,84 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The setup wizard's Code step tells the user when git is missing, and says nothing when it cannot
+/// tell (devthrottle_internal issue #1048).
+///
+/// The owner's ruling is the whole specification: detect and tell, never force, never install, and
+/// everything works without it. So the only thing this screen does about git is show one sentence,
+/// and it shows it only for a DEFINITE absence.
+/// </summary>
+public class WizardGitNoticeTests
+{
+    private static FirstRunWizardDialog Wizard() => new(new AgentOptions());
+
+    private static GitPresence With(GitAvailability availability)
+        => new(availability, availability == GitAvailability.Present ? "C:\\Program Files\\Git\\cmd\\git.exe" : null,
+            availability == GitAvailability.Present ? "git version 2.45.1" : null, "test");
+
+    [AvaloniaFact]
+    public void NoticeIsHiddenBeforeAnythingHasBeenDetected()
+    {
+        var wizard = Wizard();
+
+        // A screen that accuses the machine before it has looked is worse than one that never does.
+        Assert.False(wizard.CodeNoGitPanel.IsVisible);
+        Assert.Null(wizard.DetectedGitPresence);
+    }
+
+    [AvaloniaFact]
+    public void GitMissing_ShowsTheRecommendation()
+    {
+        var wizard = Wizard();
+
+        wizard.ApplyGitPresence(With(GitAvailability.NotFound));
+
+        Assert.True(wizard.CodeNoGitPanel.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void GitPresent_SaysNothing()
+    {
+        var wizard = Wizard();
+
+        wizard.ApplyGitPresence(With(GitAvailability.Present));
+
+        Assert.False(wizard.CodeNoGitPanel.IsVisible);
+    }
+
+    /// <summary>
+    /// The state the whole three-way split exists for. A probe that could not reach a verdict must
+    /// leave the screen silent - telling someone with git installed that they have not got it is the
+    /// failure this avoids, and it is the one a two-state detector cannot avoid.
+    /// </summary>
+    [AvaloniaFact]
+    public void GitUndetermined_SaysNothing()
+    {
+        var wizard = Wizard();
+
+        wizard.ApplyGitPresence(With(GitAvailability.Undetermined));
+
+        Assert.False(wizard.CodeNoGitPanel.IsVisible);
+    }
+
+    /// <summary>
+    /// Part two of issue #1048: the clean-machine acknowledgement must hold on a machine that cannot
+    /// clone. "Clone your first repository" was advice the reader could not act on; making a folder
+    /// always works, and is exactly what the clean-machine walk did.
+    /// </summary>
+    [AvaloniaFact]
+    public void TheCleanMachineAcknowledgementDoesNotRequireGit()
+    {
+        var wizard = Wizard();
+
+        var text = wizard.CodeNoneAckText.Text ?? "";
+
+        Assert.Contains("Make a folder", text);
+        Assert.DoesNotContain("When you clone", text);
+    }
+}

--- a/src/CcDirector.Avalonia.Tests/WizardGitNoticeTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WizardGitNoticeTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Headless.XUnit;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Git;
+using CcDirector.Core.Onboarding;
 using Xunit;
 
 namespace CcDirector.Avalonia.Tests;
@@ -64,6 +65,22 @@ public class WizardGitNoticeTests
         wizard.ApplyGitPresence(With(GitAvailability.Undetermined));
 
         Assert.False(wizard.CodeNoGitPanel.IsVisible);
+    }
+
+    /// <summary>
+    /// THE WIRING. Every other test here drives ApplyGitPresence directly, so deleting the detection
+    /// call from ShowStep would leave all of them green - the reviewer's point, and it was right.
+    /// This one proves that arriving at the Code step is what starts the probe.
+    /// </summary>
+    [AvaloniaFact]
+    public void ArrivingAtTheCodeStep_StartsTheGitProbe()
+    {
+        var wizard = Wizard();
+        Assert.False(wizard.GitProbeStarted);
+
+        wizard.ShowStepForTests(WizardStep.Code);
+
+        Assert.True(wizard.GitProbeStarted, "reaching the Code step did not start git detection");
     }
 
     /// <summary>

--- a/src/CcDirector.Avalonia.Tests/WizardWindowFitTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WizardWindowFitTests.cs
@@ -41,6 +41,31 @@ public class WizardWindowFitTests
     /// </summary>
     private const double TheOldFixedHeight = 640;
 
+    /// <summary>
+    /// THE WIRING. Every other test here calls WindowFit.Fit itself, so deleting the two production
+    /// calls in the wizard would leave them all green - the reviewer's point, and it was right. The
+    /// headless display is roomier than anything under test, so nothing is ever clamped against it
+    /// and the call is unobservable; forcing a small work area makes it observable.
+    /// </summary>
+    [AvaloniaFact]
+    public void TheWizardActuallyFitsItselfToTheDisplayItOpensOn()
+    {
+        WindowFitter.WorkAreaOverride = new WorkArea(0, 0, 1024, 720, 1.0);
+        try
+        {
+            var wizard = new FirstRunWizardDialog(new AgentOptions());
+
+            Assert.True(
+                wizard.Height <= 720,
+                $"the wizard opened at {wizard.Height} against 720 of work area - it never fitted itself");
+            Assert.True(wizard.Width <= 1024);
+        }
+        finally
+        {
+            WindowFitter.WorkAreaOverride = null;
+        }
+    }
+
     [AvaloniaFact]
     public void TheWizardAsksForMoreRoomThanTheOldFixedHeight()
     {

--- a/src/CcDirector.Avalonia.Tests/WizardWindowFitTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WizardWindowFitTests.cs
@@ -1,0 +1,130 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The setup wizard sizes itself to the display it opens on (devthrottle_internal issue #1046).
+///
+/// The issue asked one open question - is the wizard fixed, or does it grow with the desktop - and
+/// the answer was that it was FIXED: the markup declared 900x640 and nothing anywhere assigned the
+/// window's Width or Height, so the 916x679 frame the clean-machine walk photographed at 1024x768
+/// was the size it would have been on any monitor. That makes the clipping a defect at every
+/// resolution, not a small-screen one.
+///
+/// These tests bind the size DECLARED IN THE MARKUP to what WindowFit does with it, which is the
+/// join a test on either half alone would miss.
+/// </summary>
+public class WizardWindowFitTests
+{
+    /// <summary>
+    /// What the window frame costs over the client area on Windows 11, measured on issue #1049. It
+    /// is the client that Width and Height set and the FRAME that has to fit the desktop, and the
+    /// difference is most of what a window overflows a small screen by.
+    /// </summary>
+    private static readonly FrameOverhead WindowsFrame = new(16, 39);
+
+    /// <summary>The size the wizard would open at with all the room in the world.</summary>
+    private static (double Width, double Height) DeclaredPreference()
+    {
+        // The headless display is roomier than the wizard asks for, so nothing is clamped and what
+        // comes back is the preference as declared. Reading it from a real instance is the point:
+        // a number copied into the test could not notice the markup changing underneath it.
+        var wizard = new FirstRunWizardDialog(new AgentOptions());
+        return (wizard.Width, wizard.Height);
+    }
+
+    /// <summary>
+    /// The old fixed height, kept here as the thing that has to be beaten rather than as a target.
+    /// At 640 the Welcome step showed four and a bit of its five items.
+    /// </summary>
+    private const double TheOldFixedHeight = 640;
+
+    [AvaloniaFact]
+    public void TheWizardAsksForMoreRoomThanTheOldFixedHeight()
+    {
+        var (_, height) = DeclaredPreference();
+
+        Assert.True(
+            height > TheOldFixedHeight,
+            $"the wizard still prefers {height}, which is no more than the {TheOldFixedHeight} that clipped its lists");
+    }
+
+    /// <summary>
+    /// The display the defect was photographed on. The wizard used to take 640 of client height there
+    /// and leave the rest of the desktop empty; now it takes what the work area allows.
+    /// </summary>
+    [AvaloniaFact]
+    public void OnTheDisplayTheDefectWasFoundOn_TheWizardUsesTheRoomThatIsThere()
+    {
+        var (width, height) = DeclaredPreference();
+        // 1024x768 with a 48 pixel taskbar.
+        var area = new WorkArea(0, 0, 1024, 720, 1.0);
+
+        var placement = WindowFit.Fit(width, height, area, WindowsFrame);
+
+        Assert.True(
+            placement.Height > TheOldFixedHeight,
+            $"at 1024x768 the wizard would still open only {placement.Height} tall");
+        Assert.True(
+            placement.Height + WindowsFrame.Height <= area.LogicalHeight,
+            "the frame must fit inside the work area, not merely the client area");
+    }
+
+    /// <summary>
+    /// The SMALLEST display the product supports, settled by the owner on issue #1049. The old fixed
+    /// size did not fit it: 640 of client plus a 39 pixel frame is 679, against 672 of work area. So
+    /// the wizard ran off the bottom of the minimum supported desktop, which nothing had noticed.
+    /// </summary>
+    [AvaloniaFact]
+    public void OnTheSmallestSupportedDisplay_TheWholeFrameFits()
+    {
+        var (width, height) = DeclaredPreference();
+        var area = new WorkArea(0, 0, 1280, (int)WindowFit.SupportedMinimumWorkAreaHeight, 1.0);
+
+        var placement = WindowFit.Fit(width, height, area, WindowsFrame);
+
+        Assert.True(
+            placement.Height + WindowsFrame.Height <= area.LogicalHeight,
+            $"the frame is {placement.Height + WindowsFrame.Height} tall against {area.LogicalHeight} of work area");
+        Assert.True(placement.Width + WindowsFrame.Width <= area.LogicalWidth);
+        // The old fixed size, for contrast: this is what did NOT fit.
+        Assert.True(TheOldFixedHeight + WindowsFrame.Height > area.LogicalHeight);
+    }
+
+    /// <summary>
+    /// On an ordinary desktop the wizard gets exactly what it asked for. Clamping is for displays
+    /// that cannot hold the preference; it must not shrink a window that fits.
+    /// </summary>
+    [AvaloniaFact]
+    public void OnAnOrdinaryDesktop_ThePreferredSizeIsKeptWhole()
+    {
+        var (width, height) = DeclaredPreference();
+        // 1920x1080 with a 48 pixel taskbar.
+        var area = new WorkArea(0, 0, 1920, 1032, 1.0);
+
+        var placement = WindowFit.Fit(width, height, area, WindowsFrame);
+
+        Assert.Equal(width, placement.Width);
+        Assert.Equal(height, placement.Height);
+    }
+
+    /// <summary>
+    /// A 1080p laptop at 150% Windows scaling reports a 1920x1032 PHYSICAL work area and offers only
+    /// 1280x688 of the space a window is actually sized in. Reading the physical number as logical
+    /// would make exactly this machine look roomy enough when it is not.
+    /// </summary>
+    [AvaloniaFact]
+    public void OnAScaledDisplay_TheWizardIsFittedToTheLogicalSpace()
+    {
+        var (width, height) = DeclaredPreference();
+        var area = new WorkArea(0, 0, 1920, 1032, 1.5);
+
+        var placement = WindowFit.Fit(width, height, area, WindowsFrame);
+
+        Assert.True(
+            placement.Height + WindowsFrame.Height <= area.LogicalHeight,
+            $"the frame is {placement.Height + WindowsFrame.Height} tall against {area.LogicalHeight:F0} of logical work area");
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/GitChangesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/GitChangesView.axaml
@@ -201,6 +201,18 @@
                            FontSize="12"
                            Margin="8,12,0,0"
                            IsVisible="True" />
+
+                <!-- The state that used to be indistinguishable from the one above. When the git
+                     read FAILS - most plainly on a machine with no git at all - this page returned
+                     early and left "No changes detected" on the screen, which is a statement about
+                     the repository and was not true: nothing had been read. This says what actually
+                     happened instead (devthrottle_internal issue #1048). -->
+                <TextBlock x:Name="ProblemText"
+                           Foreground="#B48A54"
+                           FontSize="12"
+                           TextWrapping="Wrap"
+                           Margin="8,12,8,0"
+                           IsVisible="False" />
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
@@ -167,9 +167,28 @@ public partial class GitChangesView : UserControl
     /// </summary>
     internal async Task RefreshAsync()
     {
-        if (_repoPath == null || !Directory.Exists(_repoPath)) return;
+        // Pinned for the whole call. _repoPath is mutable and Attach can point this view at a
+        // different folder while the read below is in flight; every decision after the await is made
+        // against the folder this refresh actually asked about, and the result is thrown away if the
+        // view has since moved on. Without that, a slow FAILED read of folder A lands after folder B
+        // has loaded cleanly and wipes B's results with A's problem line.
+        var repoPath = _repoPath;
+        if (repoPath == null) return;
 
-        var result = await _provider.GetStatusAsync(_repoPath);
+        if (!Directory.Exists(repoPath))
+        {
+            // Also NOT a silent return. A folder that has been deleted, or a removable drive that
+            // has been unplugged, used to leave whatever the last repository showed still on the
+            // screen - or the "No changes detected" empty state, which is a claim about a repository
+            // that is not there any more.
+            ShowProblem($"This folder is no longer on disk: {repoPath}");
+            return;
+        }
+
+        var result = await _provider.GetStatusAsync(repoPath);
+        if (!string.Equals(repoPath, _repoPath, StringComparison.OrdinalIgnoreCase))
+            return;
+
         if (!result.Success)
         {
             // NOT a silent return. The old early exit left the page showing "No changes detected",
@@ -182,7 +201,7 @@ public partial class GitChangesView : UserControl
         ClearProblem();
 
         // Skip expensive tree rebuild if git output hasn't changed
-        var rawOutput = _provider.GetCachedRawOutput(_repoPath);
+        var rawOutput = _provider.GetCachedRawOutput(repoPath);
         if (rawOutput != null && rawOutput == _lastRawOutput)
             return;
         _lastRawOutput = rawOutput;

--- a/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
@@ -46,6 +46,14 @@ public partial class GitChangesView : UserControl
     private string? _repoPath;
     private string? _lastRawOutput;
 
+    // Which ATTACHMENT is current. Bumped by every Attach and every Detach, captured by each refresh
+    // when it starts, and compared when it finishes. Comparing the repository PATH instead was not
+    // enough: attaching to A, then B, then A again let A's first, slow result land on A's second
+    // attachment; two refreshes of the SAME folder could finish out of order; and comparing paths
+    // case-insensitively conflates genuinely different folders on a case-sensitive filesystem. An
+    // attachment is a thing with an identity, so it gets one.
+    private int _attachGeneration;
+
     /// <summary>Raised when the user requests to view a file.</summary>
     public event Action<string>? ViewFileRequested;
 
@@ -59,6 +67,7 @@ public partial class GitChangesView : UserControl
         FileLog.Write($"[GitChangesView] Attach: {repoPath}");
         Detach();
         _repoPath = repoPath;
+        _attachGeneration++;
 
         _pollTimer = new DispatcherTimer
         {
@@ -87,6 +96,8 @@ public partial class GitChangesView : UserControl
         _syncTimer = null;
         _repoPath = null;
         _lastRawOutput = null;
+        // Detaching ends the current attachment, so anything still in flight for it is stale too.
+        _attachGeneration++;
 
         StagedTree.ItemsSource = null;
         ChangesTree.ItemsSource = null;
@@ -167,12 +178,12 @@ public partial class GitChangesView : UserControl
     /// </summary>
     internal async Task RefreshAsync()
     {
-        // Pinned for the whole call. _repoPath is mutable and Attach can point this view at a
-        // different folder while the read below is in flight; every decision after the await is made
-        // against the folder this refresh actually asked about, and the result is thrown away if the
-        // view has since moved on. Without that, a slow FAILED read of folder A lands after folder B
-        // has loaded cleanly and wipes B's results with A's problem line.
+        // Pinned for the whole call, along with WHICH attachment asked. Every decision after the
+        // await is made against the folder this refresh actually asked about, and the result is
+        // dropped if the view has moved on since. Without that, a slow FAILED read of folder A lands
+        // after folder B has loaded cleanly and wipes B's results with A's problem line.
         var repoPath = _repoPath;
+        var generation = _attachGeneration;
         if (repoPath == null) return;
 
         if (!Directory.Exists(repoPath))
@@ -181,13 +192,17 @@ public partial class GitChangesView : UserControl
             // has been unplugged, used to leave whatever the last repository showed still on the
             // screen - or the "No changes detected" empty state, which is a claim about a repository
             // that is not there any more.
-            ShowProblem($"This folder is no longer on disk: {repoPath}");
+            //
+            // The wording stops short of what was checked. Directory.Exists returns false for a
+            // folder that was deleted AND for one that is merely unreachable or unreadable - a
+            // network share that is down, a permission that was withdrawn - so saying "no longer on
+            // disk" would state a cause we have not established.
+            ShowProblem($"This folder cannot be reached: {repoPath}");
             return;
         }
 
         var result = await _provider.GetStatusAsync(repoPath);
-        if (!string.Equals(repoPath, _repoPath, StringComparison.OrdinalIgnoreCase))
-            return;
+        if (generation != _attachGeneration) return;
 
         if (!result.Success)
         {
@@ -238,6 +253,10 @@ public partial class GitChangesView : UserControl
         ChangesTree.ItemsSource = null;
         StagedSection.IsVisible = false;
         EmptyText.IsVisible = false;
+        // The branch bar too. It is filled by a SEPARATE read on its own timer, so leaving it up
+        // beside a problem line shows the last branch, ahead and behind counts this view happened to
+        // learn - stale numbers presented as current, next to a line saying nothing could be read.
+        BranchBar.IsVisible = false;
         _lastRawOutput = null;
 
         ProblemText.Text = string.IsNullOrWhiteSpace(reason)

--- a/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GitChangesView.axaml.cs
@@ -93,6 +93,8 @@ public partial class GitChangesView : UserControl
         StagedSection.IsVisible = false;
         EmptyText.IsVisible = true;
         BranchBar.IsVisible = false;
+        ProblemText.IsVisible = false;
+        ProblemText.Text = "";
     }
 
     private async void PollTimer_Tick(object? sender, EventArgs e)
@@ -159,12 +161,25 @@ public partial class GitChangesView : UserControl
             BehindMainText.Text = $"{status.MainBranchName} v{status.BehindMainCount}";
     }
 
-    private async Task RefreshAsync()
+    /// <summary>
+    /// Re-read the repository's changed files. Internal rather than private so a test can await the
+    /// one refresh instead of racing the poll timer that Attach starts.
+    /// </summary>
+    internal async Task RefreshAsync()
     {
         if (_repoPath == null || !Directory.Exists(_repoPath)) return;
 
         var result = await _provider.GetStatusAsync(_repoPath);
-        if (!result.Success) return;
+        if (!result.Success)
+        {
+            // NOT a silent return. The old early exit left the page showing "No changes detected",
+            // which claims the repository is clean - on a machine with no git nothing had been read
+            // at all, so the page stated as fact something it had not established (issue #1048).
+            ShowProblem(result.Error);
+            return;
+        }
+
+        ClearProblem();
 
         // Skip expensive tree rebuild if git output hasn't changed
         var rawOutput = _provider.GetCachedRawOutput(_repoPath);
@@ -190,6 +205,35 @@ public partial class GitChangesView : UserControl
 
         ChangesBadge.Text = result.UnstagedChanges.Count.ToString();
         EmptyText.IsVisible = result.StagedChanges.Count == 0 && result.UnstagedChanges.Count == 0;
+    }
+
+    /// <summary>
+    /// Say that the changes could not be read, and WHY, instead of leaving a stale or empty list
+    /// that reads as "there is nothing to show". The reason comes from the provider whole - this
+    /// view never composes its own explanation of a failure it did not observe.
+    /// </summary>
+    private void ShowProblem(string? reason)
+    {
+        FileLog.Write($"[GitChangesView] ShowProblem: {reason}");
+        StagedTree.ItemsSource = null;
+        ChangesTree.ItemsSource = null;
+        StagedSection.IsVisible = false;
+        EmptyText.IsVisible = false;
+        _lastRawOutput = null;
+
+        ProblemText.Text = string.IsNullOrWhiteSpace(reason)
+            ? "Changes could not be read for this folder."
+            : $"Changes could not be read: {reason}";
+        ProblemText.IsVisible = true;
+    }
+
+    /// <summary>Clear the problem line once a read succeeds, so a fixed machine stops being accused.</summary>
+    private void ClearProblem()
+    {
+        if (!ProblemText.IsVisible) return;
+        FileLog.Write("[GitChangesView] ClearProblem");
+        ProblemText.IsVisible = false;
+        ProblemText.Text = "";
     }
 
     internal static List<GitTreeNode> BuildTree(IReadOnlyList<GitFileEntry> files)

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="CcDirector.Avalonia.FirstRunWizardDialog"
         Title="Set up DevThrottle"
-        Width="900" Height="640"
+        Width="900" Height="860"
         MinWidth="760" MinHeight="560"
         WindowStartupLocation="CenterOwner"
         CanResize="True"
@@ -16,6 +16,17 @@
       screen, one primary button per screen, a quiet skip, a bottom-left Back link.
     -->
     <Window.Styles>
+        <!-- WHEN A LIST IS TOO TALL, SAY SO. Every scrolling area in this wizard keeps its scrollbar
+             instead of fading it out. The theme default is an overlay bar that appears on hover, so
+             a list whose last row is cut in half looks exactly like a list that ends there - which
+             is what a 1024x768 machine saw on Welcome and on the Done receipt
+             (devthrottle_internal issue #1046). Sizing the window to the display is the main fix;
+             this is what makes the remaining case, a display too small for the content at any size,
+             legible rather than silently truncated. -->
+        <Style Selector="ScrollViewer">
+            <Setter Property="AllowAutoHide" Value="False" />
+        </Style>
+
         <!-- Big centered hero title. -->
         <Style Selector="TextBlock.wtitle">
             <Setter Property="Foreground" Value="#16181D" />
@@ -382,6 +393,26 @@
                         <Button x:Name="CodeKeepLookingButton" Classes="quietLink" IsVisible="False"
                                 Content="Keep looking" HorizontalAlignment="Center"
                                 Click="BtnKeepLookingForCode_Click" />
+                        <!-- GIT IS RECOMMENDED, NEVER REQUIRED (devthrottle_internal issue #1048).
+                             A clean Windows machine has no git, and this wizard used to say nothing
+                             about that while advising the one action that needs it. This is a
+                             SENTENCE, not a warning, not a blocker and not a dialog: nothing here
+                             stops, nothing turns red, and the primary button is untouched. It says
+                             what we found, says git is worth having, and leaves the choice - other
+                             version control exists and a plain folder works perfectly well.
+                             It is shown ONLY when git was definitely not found. A machine we could
+                             not read says nothing at all, because "you have no git" is a claim about
+                             somebody's computer and we do not make one we have not established. -->
+                        <StackPanel x:Name="CodeNoGitPanel" IsVisible="False" Spacing="2" Margin="0,2,0,6">
+                            <TextBlock x:Name="CodeNoGitText" FontSize="12.5" Foreground="#5A616B"
+                                       TextWrapping="Wrap" TextAlignment="Center"
+                                       HorizontalAlignment="Center" MaxWidth="540"
+                                       Text="We could not find git on this machine. Nothing here needs it - DevThrottle works with any folder, and it is your choice which version control you use, if any - but git is highly recommended: it is what most projects use to clone code and keep a history of changes." />
+                            <Button x:Name="CodeNoGitLink" Classes="quietLink"
+                                    Content="Where to get git" HorizontalAlignment="Center"
+                                    Click="BtnGetGit_Click" />
+                        </StackPanel>
+
                         <!-- The manual path: always present, works the same on Windows and macOS. -->
                         <Border Background="#FFFFFF" BorderBrush="#E6E8EC" BorderThickness="1"
                                 CornerRadius="10" Padding="16,13">
@@ -404,9 +435,16 @@
                                 Content="I don't have code on this machine yet"
                                 HorizontalAlignment="Center" Margin="0,4,0,0"
                                 Click="BtnNoCodeYet_Click" />
+                        <!-- The old wording said "when you clone or create your first repository",
+                             which on a machine with no git advises an action the person cannot take
+                             (issue #1048). Making a folder always works, needs nothing installed,
+                             and is exactly what the clean-machine walk did: a plain folder with two
+                             files in it, no git anywhere. Cloning is still named, as the other way
+                             in for anyone who has the tools for it - it is simply no longer the
+                             only route offered. -->
                         <TextBlock x:Name="CodeNoneAckText" Classes="hint" IsVisible="False"
                                    HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="480"
-                                   Text="No problem - nothing here is required. When you clone or create your first repository, add its folder from the Repositories view and DevThrottle picks it up." />
+                                   Text="No problem - nothing here is required. Make a folder for your code, or bring a repository onto this machine, then add that folder from the Repositories view and DevThrottle picks it up." />
                     </StackPanel>
                 </ScrollViewer>
                 <!-- The proof number: how many repositories the added folders will surface. -->

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -407,7 +407,7 @@
                             <TextBlock x:Name="CodeNoGitText" FontSize="12.5" Foreground="#5A616B"
                                        TextWrapping="Wrap" TextAlignment="Center"
                                        HorizontalAlignment="Center" MaxWidth="540"
-                                       Text="We could not find git on this machine. Nothing here needs it - DevThrottle works with any folder, and it is your choice which version control you use, if any - but git is highly recommended: it is what most projects use to clone code and keep a history of changes." />
+                                       Text="We could not find git on this machine - nothing named git is on your PATH. Nothing here needs it: DevThrottle works with any folder, and it is your choice which version control you use, if any. But git is highly recommended - it is what most projects use to clone code and keep a history of changes." />
                             <Button x:Name="CodeNoGitLink" Classes="quietLink"
                                     Content="Where to get git" HorizontalAlignment="Center"
                                     Click="BtnGetGit_Click" />

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -165,6 +165,13 @@ public partial class FirstRunWizardDialog : Window
     /// <summary>The git verdict this run reached, or null before the probe has answered.</summary>
     internal GitPresence? DetectedGitPresence => _gitPresence;
 
+    /// <summary>
+    /// Whether the Code step has started the git probe. Exposed so a test can prove that ARRIVING at
+    /// the step is what triggers detection - without it, every wizard test drives ApplyGitPresence
+    /// directly and deleting the detection call from ShowStep leaves them all green.
+    /// </summary>
+    internal bool GitProbeStarted => _gitProbeRan;
+
     // Browsers step (issue #1012): whether browser-harness resolves on this machine, the ONE browser
     // this step sets up (more are added from the rail - signing in is interactive and cannot be
     // batched), whether a run is in flight, and the last failure. The failure is held rather than

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -16,6 +16,7 @@ using CcDirector.Core.Agents;
 using CcDirector.Core.Browsers;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.GatewayConnection;
+using CcDirector.Core.Git;
 using System.Text.Json.Nodes;
 using Avalonia.Platform.Storage;
 using CcDirector.Core.Onboarding;
@@ -154,6 +155,16 @@ public partial class FirstRunWizardDialog : Window
     // on disk - it only stops the step, and the Done receipt, from reading as a failure.
     private bool _codeNoneOnThisMachine;
 
+    // What this machine knows about git, and whether we have asked yet (issue #1048). The verdict is
+    // three-state on purpose and the screen reads only its ShouldAdviseInstallingGit ruling - this
+    // dialog never re-derives "missing" from the parts. Detection is a PATH lookup plus one
+    // subprocess, so it runs once for the life of the wizard and off the user interface thread.
+    private GitPresence? _gitPresence;
+    private bool _gitProbeRan;
+
+    /// <summary>The git verdict this run reached, or null before the probe has answered.</summary>
+    internal GitPresence? DetectedGitPresence => _gitPresence;
+
     // Browsers step (issue #1012): whether browser-harness resolves on this machine, the ONE browser
     // this step sets up (more are added from the rail - signing in is interactive and cannot be
     // batched), whether a run is in flight, and the last failure. The failure is held rather than
@@ -218,9 +229,29 @@ public partial class FirstRunWizardDialog : Window
         _isReview = !FirstRunWizardModel.ShouldShow();
 
         InitializeComponent();
+
+        // The size declared in the markup is a PREFERENCE, not a promise. It used to be the whole
+        // story: a fixed 900x640 with no reference to the display, which is why the Welcome step
+        // promised five things and showed four and a bit, and the Done receipt hid the row saying we
+        // are about to start emailing you every morning (devthrottle_internal issue #1046). Shrink
+        // it to the display before the window is ever shown, the same way the main window does.
+        WindowFitter.FitBeforeShow(this, "FirstRunWizardDialog");
+
         BuildDots();
         BuildWelcomeScreen();
         ShowStep(_model.Current);
+    }
+
+    /// <summary>
+    /// Re-fit once the window exists and the frame can be measured. Identical in purpose to the main
+    /// window's, and deliberately the same code: on Windows 11 the frame is 39 device independent
+    /// pixels taller than the client area, which is most of what a window overflows a small desktop
+    /// by, and it cannot be known before the window is shown.
+    /// </summary>
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        WindowFitter.FitOnOpened(this, "FirstRunWizardDialog");
     }
 
     /// <summary>Create one progress dot per present step. Colours are refreshed on every step change.</summary>
@@ -373,6 +404,11 @@ public partial class FirstRunWizardDialog : Window
                 PrimaryButton.IsVisible = true;
                 if (!_codeScanRan)
                     _ = ScanCodeFoldersAsync();
+                // Independent of the folder sweep on purpose: whether this machine has git is true
+                // or false whatever the sweep finds, and the sentence must not wait on a ten-second
+                // disk walk to appear (issue #1048).
+                if (!_gitProbeRan)
+                    _ = DetectGitForWizardAsync();
                 break;
 
             case WizardStep.Screenshots:
@@ -1462,6 +1498,67 @@ public partial class FirstRunWizardDialog : Window
         catch (Exception ex)
         {
             FileLog.Write($"[FirstRunWizardDialog] BtnBrowseCodeFolder_Click FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Ask this machine about git, once, and show the recommendation if - and only if - git is
+    /// definitely not here (issue #1048).
+    ///
+    /// DevThrottle does not need git and will never install it. A user may prefer another version
+    /// control system, or none: that is their call, and the wizard's job is to make sure they are
+    /// not the last to know that the tool most projects assume is absent. So this step DETECTS and
+    /// TELLS. It never blocks, never offers to install, and never changes the machine.
+    /// </summary>
+    private async Task DetectGitForWizardAsync()
+    {
+        FileLog.Write("[FirstRunWizardDialog] DetectGitForWizardAsync");
+        _gitProbeRan = true;
+        try
+        {
+            // Off the user interface thread: the probe is a PATH walk plus a subprocess, and this
+            // product's first rule is that no user action waits on either.
+            var presence = await Task.Run(() => GitPresenceDetector.DetectAsync(CancellationToken.None));
+            if (_closed) return;
+            ApplyGitPresence(presence);
+        }
+        catch (Exception ex)
+        {
+            // The detector answers "undetermined" rather than throwing, so reaching here means
+            // something else broke. Nothing on the screen changes: the notice stays hidden, which is
+            // the same thing "we could not tell" produces, and is the only honest state.
+            FileLog.Write($"[FirstRunWizardDialog] DetectGitForWizardAsync FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Render the git verdict. The panel follows the verdict's own ruling and nothing else - there
+    /// is deliberately no second opinion formed here about what "missing" means.
+    /// Internal so the test can drive all three states without a machine that lacks git.
+    /// </summary>
+    internal void ApplyGitPresence(GitPresence presence)
+    {
+        _gitPresence = presence;
+        CodeNoGitPanel.IsVisible = presence.ShouldAdviseInstallingGit;
+        FileLog.Write(
+            $"[FirstRunWizardDialog] ApplyGitPresence: availability={presence.Availability}, " +
+            $"advising={presence.ShouldAdviseInstallingGit}, detail={presence.Detail}");
+    }
+
+    /// <summary>Open the git download page. Opening a page is the whole of what we do about git.</summary>
+    private void BtnGetGit_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write("[FirstRunWizardDialog] BtnGetGit_Click");
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://git-scm.com/downloads") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[FirstRunWizardDialog] BtnGetGit_Click FAILED: {ex.Message}");
+            CodeNoGitText.Text =
+                "We could not find git on this machine, and could not open your browser either. "
+                + "You can download git from git-scm.com/downloads. It is highly recommended, but nothing here needs it.";
         }
     }
 

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml.cs
@@ -1502,8 +1502,10 @@ public partial class FirstRunWizardDialog : Window
     }
 
     /// <summary>
-    /// Ask this machine about git, once, and show the recommendation if - and only if - git is
-    /// definitely not here (issue #1048).
+    /// Ask this machine about git, once, and show the recommendation if - and only if - nothing
+    /// named git resolves on this process's PATH (issue #1048). That is the same lookup every git
+    /// call in the product does, so it is exactly the condition under which DevThrottle cannot run
+    /// git - not a claim to have searched the whole disk.
     ///
     /// DevThrottle does not need git and will never install it. A user may prefer another version
     /// control system, or none: that is their call, and the wizard's job is to make sure they are
@@ -1517,7 +1519,9 @@ public partial class FirstRunWizardDialog : Window
         try
         {
             // Off the user interface thread: the probe is a PATH walk plus a subprocess, and this
-            // product's first rule is that no user action waits on either.
+            // product's first rule is that no user action waits on either. Nothing on this step is
+            // gated on the answer, so a PATH entry that never responds costs the sentence, not the
+            // step - the user can carry straight on.
             var presence = await Task.Run(() => GitPresenceDetector.DetectAsync(CancellationToken.None));
             if (_closed) return;
             ApplyGitPresence(presence);

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -219,7 +219,7 @@ public partial class MainWindow : Window
         // title bar overhead is unknown. Size against the work area alone here - that alone stops a
         // window very much larger than the desktop ever existing - and correct it in OnOpened,
         // where the frame can be measured.
-        ApplyFit(FrameOverhead.None, movePosition: false, stage: "pre-show");
+        WindowFitter.FitBeforeShow(this, "MainWindow");
     }
 
     /// <summary>
@@ -231,71 +231,7 @@ public partial class MainWindow : Window
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
-
-        var frame = FrameSize is { } size
-            ? new FrameOverhead(
-                Math.Max(0, size.Width - ClientSize.Width),
-                Math.Max(0, size.Height - ClientSize.Height))
-            : FrameOverhead.None;
-
-        ApplyFit(frame, movePosition: true, stage: "opened");
-    }
-
-    /// <summary>
-    /// Shrinks the window to the work area of the display it is on and centres it there.
-    ///
-    /// Issue #1049: the window opened at a fixed 1400x900 regardless of the screen. On a small
-    /// display that left it larger than the desktop and inset from the corner, so it ran off the
-    /// right and bottom edges - putting Settings off the right edge and unclickable, and with it
-    /// every "you can change this later in Settings" promise the setup wizard makes. The supported
-    /// minimum is a 1280x720 display, about 1280x672 of work area once the taskbar is subtracted.
-    /// </summary>
-    private void ApplyFit(FrameOverhead frame, bool movePosition, string stage)
-    {
-        var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary ?? Screens.All.FirstOrDefault();
-        if (screen is null)
-        {
-            // Desktop Avalonia always reports at least one display. Nothing to fit against means
-            // something is wrong with the windowing platform, so say so loudly rather than
-            // silently opening at a size that may not fit.
-            FileLog.Write($"[MainWindow] ApplyFit ({stage}) FAILED: the windowing platform reported no display; leaving the window as declared");
-            return;
-        }
-
-        var area = new WorkArea(
-            screen.WorkingArea.X,
-            screen.WorkingArea.Y,
-            screen.WorkingArea.Width,
-            screen.WorkingArea.Height,
-            screen.Scaling);
-
-        var placement = WindowFit.Fit(Width, Height, area, frame);
-
-        FileLog.Write(
-            $"[MainWindow] ApplyFit ({stage}): workArea={area.Width}x{area.Height} physical, scaling={area.Scaling}, " +
-            $"logical={area.LogicalWidth:F0}x{area.LogicalHeight:F0}, frame={frame.Width:F0}x{frame.Height:F0}, " +
-            $"desired={Width}x{Height}, chosen={placement.Width:F0}x{placement.Height:F0} at {placement.X},{placement.Y}");
-
-        Width = placement.Width;
-        Height = placement.Height;
-
-        if (!movePosition)
-            return;
-
-        // The platform applies its own default placement as part of showing the window, and that
-        // happens AFTER OnOpened - measured on 30 July 2026, a Position assigned here was honoured
-        // when the size also changed and silently discarded when it did not, landing the window on
-        // a different monitor. Posting the move puts it after the show completes, so it holds
-        // either way. Centring is part of the fix, not decoration: a window as tall as the work
-        // area is pushed off the bottom by any default offset at all.
-        WindowStartupLocation = WindowStartupLocation.Manual;
-        Dispatcher.UIThread.Post(
-            () =>
-            {
-                Position = new PixelPoint(placement.X, placement.Y);
-                FileLog.Write($"[MainWindow] ApplyFit ({stage}): position applied at {Position.X},{Position.Y}");
-            },
-            DispatcherPriority.Loaded);
+        WindowFitter.FitOnOpened(this, "MainWindow");
     }
 
     private void OnAlphaModeChanged()

--- a/src/CcDirector.Avalonia/WindowFitter.cs
+++ b/src/CcDirector.Avalonia/WindowFitter.cs
@@ -24,6 +24,15 @@ namespace CcDirector.Avalonia;
 internal static class WindowFitter
 {
     /// <summary>
+    /// Substitutes the work area a window is fitted against. A TEST SEAM, and the only way to prove
+    /// that a window CALLS this at all: the headless display is roomier than anything under test, so
+    /// with the real work area nothing is ever clamped and deleting the production call sites leaves
+    /// every assertion green. Setting a small work area here makes the call observable.
+    /// Null in production, always.
+    /// </summary>
+    internal static WorkArea? WorkAreaOverride;
+
+    /// <summary>
     /// Fit before the window is shown. The platform frame does not exist yet, so the border and
     /// title bar overhead is unknown and the size is clamped against the work area alone - enough to
     /// stop a window very much larger than the desktop ever existing. Position is left alone,
@@ -51,6 +60,12 @@ internal static class WindowFitter
 
     private static void Apply(Window window, FrameOverhead frame, bool movePosition, string stage, string logPrefix)
     {
+        if (WorkAreaOverride is { } forced)
+        {
+            ApplyTo(window, forced, frame, movePosition, stage, logPrefix);
+            return;
+        }
+
         var screens = window.Screens;
         var screen = screens?.ScreenFromWindow(window) ?? screens?.Primary ?? screens?.All.FirstOrDefault();
         if (screen is null)
@@ -69,6 +84,12 @@ internal static class WindowFitter
             screen.WorkingArea.Height,
             screen.Scaling);
 
+        ApplyTo(window, area, frame, movePosition, stage, logPrefix);
+    }
+
+    private static void ApplyTo(
+        Window window, WorkArea area, FrameOverhead frame, bool movePosition, string stage, string logPrefix)
+    {
         var placement = WindowFit.Fit(window.Width, window.Height, area, frame);
 
         FileLog.Write(

--- a/src/CcDirector.Avalonia/WindowFitter.cs
+++ b/src/CcDirector.Avalonia/WindowFitter.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// Applies <see cref="WindowFit"/> to a real Avalonia window: reads the display it is on, clamps the
+/// window to that work area, and centres it there.
+///
+/// This is the Avalonia-touching half of the fix made for the main window on issue #1049, lifted out
+/// of MainWindow so the setup wizard can use THE SAME code rather than a second copy of it
+/// (devthrottle_internal issue #1046 - the wizard had the identical defect, a size declared in
+/// markup with no reference to the display). Two copies of a placement rule drift, and the three
+/// things this has to get right were each measured rather than assumed; they are not worth
+/// rediscovering a second time.
+///
+/// The pure decision stays in <see cref="WindowFit"/>, which is tested without a UI thread or a
+/// monitor. This class is only the plumbing to and from it.
+/// </summary>
+internal static class WindowFitter
+{
+    /// <summary>
+    /// Fit before the window is shown. The platform frame does not exist yet, so the border and
+    /// title bar overhead is unknown and the size is clamped against the work area alone - enough to
+    /// stop a window very much larger than the desktop ever existing. Position is left alone,
+    /// because a Position set before Show is discarded.
+    /// </summary>
+    public static void FitBeforeShow(Window window, string logPrefix)
+        => Apply(window, FrameOverhead.None, movePosition: false, stage: "pre-show", logPrefix);
+
+    /// <summary>
+    /// Fit again once the window exists, when two things are knowable that were not before: how much
+    /// bigger the frame is than the client area, and which display the window actually opened on.
+    /// Both were measured to matter on issue #1049 - the frame is 39 device independent pixels taller
+    /// than the client on Windows 11.
+    /// </summary>
+    public static void FitOnOpened(Window window, string logPrefix)
+    {
+        var frame = window.FrameSize is { } size
+            ? new FrameOverhead(
+                Math.Max(0, size.Width - window.ClientSize.Width),
+                Math.Max(0, size.Height - window.ClientSize.Height))
+            : FrameOverhead.None;
+
+        Apply(window, frame, movePosition: true, stage: "opened", logPrefix);
+    }
+
+    private static void Apply(Window window, FrameOverhead frame, bool movePosition, string stage, string logPrefix)
+    {
+        var screens = window.Screens;
+        var screen = screens?.ScreenFromWindow(window) ?? screens?.Primary ?? screens?.All.FirstOrDefault();
+        if (screen is null)
+        {
+            // Desktop Avalonia always reports at least one display. Nothing to fit against means
+            // something is wrong with the windowing platform, so say so loudly rather than silently
+            // opening at a size that may not fit.
+            FileLog.Write($"[{logPrefix}] ApplyFit ({stage}) FAILED: the windowing platform reported no display; leaving the window as declared");
+            return;
+        }
+
+        var area = new WorkArea(
+            screen.WorkingArea.X,
+            screen.WorkingArea.Y,
+            screen.WorkingArea.Width,
+            screen.WorkingArea.Height,
+            screen.Scaling);
+
+        var placement = WindowFit.Fit(window.Width, window.Height, area, frame);
+
+        FileLog.Write(
+            $"[{logPrefix}] ApplyFit ({stage}): workArea={area.Width}x{area.Height} physical, scaling={area.Scaling}, " +
+            $"logical={area.LogicalWidth:F0}x{area.LogicalHeight:F0}, frame={frame.Width:F0}x{frame.Height:F0}, " +
+            $"desired={window.Width}x{window.Height}, chosen={placement.Width:F0}x{placement.Height:F0} at {placement.X},{placement.Y}");
+
+        window.Width = placement.Width;
+        window.Height = placement.Height;
+
+        if (!movePosition)
+            return;
+
+        // The platform applies its own default placement as part of showing the window, and that
+        // happens AFTER OnOpened - measured on 30 July 2026, a Position assigned there was honoured
+        // when the size also changed and silently discarded when it did not, landing the window on a
+        // different monitor. Posting the move puts it after the show completes, so it holds either
+        // way. Centring is part of the fix, not decoration: a window as tall as the work area is
+        // pushed off the bottom by any default offset at all.
+        window.WindowStartupLocation = WindowStartupLocation.Manual;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                window.Position = new PixelPoint(placement.X, placement.Y);
+                FileLog.Write($"[{logPrefix}] ApplyFit ({stage}): position applied at {window.Position.X},{window.Position.Y}");
+            },
+            DispatcherPriority.Loaded);
+    }
+}

--- a/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
@@ -92,6 +92,51 @@ public class GitAbsentTests
     }
 
     /// <summary>
+    /// The read provider the Source Control view renders. When the launch itself fails it has to
+    /// pass the REASON through - it used to report a fixed "Failed to start git process", which
+    /// threw away why and was also what it said when git ran perfectly well and exited non-zero.
+    ///
+    /// The launch is failed here with a working directory that does not exist, because that fails on
+    /// a machine that HAS git and so reproduces anywhere. It is the same wiring the missing-git case
+    /// takes: both arrive as ProcessRunner reporting Started=false with an operating system code.
+    /// </summary>
+    [Fact]
+    public async Task GitStatusProvider_WhenGitCannotBeLaunched_ReportsWhy()
+    {
+        var missingDirectory = Path.Combine(Path.GetTempPath(), "devthrottle-no-such-directory-" + Guid.NewGuid().ToString("N"));
+
+        var result = await new GitStatusProvider().GetStatusAsync(missingDirectory);
+
+        Assert.False(result.Success);
+        Assert.StartsWith("git could not be started", result.Error);
+        Assert.NotEqual("Failed to start git process", result.Error);
+    }
+
+    /// <summary>
+    /// The branch bar's provider. It reported "Failed to start git process" for BOTH a launch that
+    /// never happened and a git that ran and exited non-zero - so a folder that is simply not a
+    /// checkout was described as a machine that could not start git.
+    /// </summary>
+    [Fact]
+    public async Task GitSyncStatusProvider_WhenGitRanAndFailed_DoesNotClaimItNeverStarted()
+    {
+        var notARepo = Path.Combine(Path.GetTempPath(), "devthrottle-not-a-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(notARepo);
+        try
+        {
+            var status = await new GitSyncStatusProvider().GetSyncStatusAsync(notARepo);
+
+            Assert.False(status.Success);
+            Assert.NotEqual("Failed to start git process", status.Error);
+            Assert.Contains("exited", status.Error!);
+        }
+        finally
+        {
+            try { Directory.Delete(notARepo, recursive: true); } catch { /* disposable temp folder */ }
+        }
+    }
+
+    /// <summary>
     /// The detector against the real machine. Every other test here injects the two machine-touching
     /// steps; this one runs neither injected, so PATH resolution, the subprocess and the version
     /// banner are all exercised together. It asserts Present because the machines this suite runs on

--- a/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
@@ -1,0 +1,114 @@
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Git;
+
+/// <summary>
+/// What happens when git is not on the machine at all (devthrottle_internal issue #1048).
+///
+/// These run a REAL subprocess launch against an executable name that resolves nowhere, so the
+/// operating system fails it for exactly the reason it fails on a clean Windows install: Process.Start
+/// throws Win32Exception with ERROR_FILE_NOT_FOUND. It does NOT return false - which is why the
+/// missing-git path had never been exercised and why every one of these call sites let the exception
+/// out to callers written against a result object.
+///
+/// The assertion in every case is the same: a RESULT that says why, never an exception.
+/// </summary>
+public class GitAbsentTests
+{
+    /// <summary>A command name no machine has. Deliberately not a path, so PATH resolution is what fails.</summary>
+    private const string NoSuchExecutable = "devthrottle-no-such-git-executable";
+
+    private static string ADirectoryThatExists() => Path.GetTempPath();
+
+    [Fact]
+    public async Task GitCommandRunner_WithNoGit_ReturnsAFailedResultRatherThanThrowing()
+    {
+        var runner = new GitCommandRunner(NoSuchExecutable);
+
+        var result = await runner.RunAsync(ADirectoryThatExists(), new[] { "worktree", "list", "--porcelain" });
+
+        Assert.False(result.Success);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Equal("git is not installed on this machine, or is not on PATH", result.Error);
+    }
+
+    /// <summary>
+    /// The worktree inventory is what the Source Control tab's Worktrees page renders. With no git it
+    /// must come back as an explicit failure carrying the reason, not as an empty list - an empty list
+    /// would render as "this repository has no worktrees", which is a statement nothing established.
+    /// </summary>
+    [Fact]
+    public async Task WorktreeInventory_WithNoGit_FailsWithTheReasonRatherThanLookingEmpty()
+    {
+        var service = new WorktreeInventoryService(new GitCommandRunner(NoSuchExecutable));
+
+        var inventory = await service.GetInventoryAsync(ADirectoryThatExists(), fetchPrune: false);
+
+        Assert.False(inventory.Success);
+        Assert.Empty(inventory.Worktrees);
+        Assert.Contains("git is not installed on this machine, or is not on PATH", inventory.Error);
+    }
+
+    [Fact]
+    public async Task GitWriteService_Commit_WithNoGit_ReturnsAFailedResultRatherThanThrowing()
+    {
+        var service = new GitWriteService(NoSuchExecutable);
+
+        var result = await service.CommitAsync(ADirectoryThatExists(), "a message");
+
+        Assert.False(result.Success);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Equal("git is not installed on this machine, or is not on PATH", result.Error);
+    }
+
+    [Fact]
+    public async Task GitWriteService_Stage_WithNoGit_ReturnsAFailedResultRatherThanThrowing()
+    {
+        var service = new GitWriteService(NoSuchExecutable);
+
+        var result = await service.StageAsync(ADirectoryThatExists(), Array.Empty<string>());
+
+        Assert.False(result.Success);
+        Assert.Equal("git is not installed on this machine, or is not on PATH", result.Error);
+    }
+
+    /// <summary>
+    /// ProcessRunner documents that Started is false when the process could not start. Before this it
+    /// could not be: Start throws for a missing executable rather than returning false, so the branch
+    /// naming that case was unreachable and each caller carried its own catch-all instead.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRunner_WithAMissingExecutable_ReportsNotStartedWithTheOperatingSystemCode()
+    {
+        var result = await ProcessRunner.RunAsync(NoSuchExecutable, new[] { "--version" }, ADirectoryThatExists());
+
+        Assert.False(result.Started);
+        Assert.Equal(-1, result.ExitCode);
+        // 2 is ERROR_FILE_NOT_FOUND. Carrying the code is what lets a caller say "not installed"
+        // without guessing at the wording of an operating system message.
+        Assert.Equal(2, result.StartErrorCode);
+    }
+
+    /// <summary>
+    /// The detector against the real machine. Every other test here injects the two machine-touching
+    /// steps; this one runs neither injected, so PATH resolution, the subprocess and the version
+    /// banner are all exercised together. It asserts Present because the machines this suite runs on
+    /// have git - a red here means either git really has gone missing or the detector has stopped
+    /// recognising a working one, and both are worth being told about.
+    /// </summary>
+    [Fact]
+    public async Task GitPresenceDetector_OnThisMachine_ReachesADefiniteVerdict()
+    {
+        // This machine HAS git, so the detector must say so. The value of running it for real is that
+        // it exercises the whole path - PATH resolution, the subprocess, the version banner - which
+        // the injected-probe tests above deliberately do not.
+        var presence = await GitPresenceDetector.DetectAsync();
+
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+        Assert.NotNull(presence.ExecutablePath);
+        Assert.Contains("git version", presence.Version!, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitAbsentTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace CcDirector.Core.Tests.Git;
 
 /// <summary>
-/// What happens when git is not on the machine at all (devthrottle_internal issue #1048).
+/// What happens when git cannot be launched (devthrottle_internal issue #1048).
 ///
 /// These run a REAL subprocess launch against an executable name that resolves nowhere, so the
 /// operating system fails it for exactly the reason it fails on a clean Windows install: Process.Start
@@ -117,7 +117,7 @@ public class GitAbsentTests
     /// never happened and a git that ran and exited non-zero - so a folder that is simply not a
     /// checkout was described as a machine that could not start git.
     /// </summary>
-    [Fact]
+    [RequiresGitFact]
     public async Task GitSyncStatusProvider_WhenGitRanAndFailed_DoesNotClaimItNeverStarted()
     {
         var notARepo = Path.Combine(Path.GetTempPath(), "devthrottle-not-a-repo-" + Guid.NewGuid().ToString("N"));
@@ -140,10 +140,10 @@ public class GitAbsentTests
     /// The detector against the real machine. Every other test here injects the two machine-touching
     /// steps; this one runs neither injected, so PATH resolution, the subprocess and the version
     /// banner are all exercised together. It asserts Present because the machines this suite runs on
-    /// have git - a red here means either git really has gone missing or the detector has stopped
-    /// recognising a working one, and both are worth being told about.
+    /// have git. It SKIPS on a machine without one rather than failing: a git-less machine is a
+    /// supported machine, and a suite that reddens there reports a regression that has not happened.
     /// </summary>
-    [Fact]
+    [RequiresGitFact]
     public async Task GitPresenceDetector_OnThisMachine_ReachesADefiniteVerdict()
     {
         // This machine HAS git, so the detector must say so. The value of running it for real is that

--- a/src/CcDirector.Core.Tests/Git/GitPresenceMacOsTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceMacOsTests.cs
@@ -1,0 +1,143 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Git;
+
+/// <summary>
+/// Apple's shim is TWO states wearing one path, and the detector has to tell them apart WITHOUT
+/// running it (devthrottle_internal issue #1048).
+///
+/// On macOS <c>/usr/bin/git</c> exists on every Mac. With the developer tools installed it dispatches
+/// to the real git and behaves exactly like git; without them, running it puts Apple's install dialog
+/// on the screen. The first version of this guard could not distinguish the two and refused both -
+/// which traded a dialog for permanent silence on the commonest Mac configuration there is. Losing
+/// the answer on a machine that HAS git is not the same as staying quiet on one that has not.
+///
+/// The question "will running the shim prompt?" is answerable by looking at the filesystem, with no
+/// process started at all. That is what these tests pin.
+/// </summary>
+public class GitPresenceMacOsTests
+{
+    private const string RealGitBehindTheShim = "/Library/Developer/CommandLineTools/usr/bin/git";
+
+    private static Task<GitVersionProbe> AnAppleGitBanner()
+        => Task.FromResult(new GitVersionProbe(true, 0, "git version 2.39.5 (Apple Git-154)"));
+
+    /// <summary>
+    /// A stock Mac WITH the developer tools. The real git is on disk, so the shim dispatches rather
+    /// than prompting - it is safe to run, and the wizard gets a real answer instead of a shrug.
+    /// </summary>
+    [Fact]
+    public async Task MacWithDeveloperTools_IsProbed_AndReportedPresent()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleShimPath,
+            (_, _) => { probeWasCalled = true; return AnAppleGitBanner(); },
+            path => path == RealGitBehindTheShim,
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled, "a Mac with working git was never probed, so the wizard learns nothing about it");
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+        Assert.Equal("git version 2.39.5 (Apple Git-154)", presence.Version);
+    }
+
+    /// <summary>The same, with a full Xcode rather than the standalone Command Line Tools.</summary>
+    [Fact]
+    public async Task MacWithXcode_IsProbed_AndReportedPresent()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleShimPath,
+            (_, _) => { probeWasCalled = true; return AnAppleGitBanner(); },
+            path => path == "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled);
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+    }
+
+    /// <summary>
+    /// A stock Mac WITHOUT the developer tools. Nothing is behind the shim, so running it would
+    /// prompt. The assertion that matters is not the verdict - it is that the probe IS NEVER CALLED.
+    /// A detector with a side effect on the user's machine is not a detector.
+    /// </summary>
+    [Fact]
+    public async Task MacWithoutDeveloperTools_IsNeverLaunched_AndSaysNothing()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleShimPath,
+            (_, _) => { probeWasCalled = true; return AnAppleGitBanner(); },
+            _ => false,
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.False(probeWasCalled, "Apple's shim was executed with nothing behind it; that can open the install dialog");
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+    }
+
+    /// <summary>
+    /// A Mac whose git comes from Homebrew resolves elsewhere. It is not Apple's shim, so the
+    /// filesystem question does not arise and it is probed like anything else.
+    /// </summary>
+    [Fact]
+    public async Task MacWithHomebrewGit_IsProbedWhateverTheDeveloperToolsAreDoing()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => "/opt/homebrew/bin/git",
+            (_, _) => { probeWasCalled = true; return Task.FromResult(new GitVersionProbe(true, 0, "git version 2.45.1")); },
+            _ => false,
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled);
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+    }
+
+    /// <summary>
+    /// The same path on a machine that is not a Mac is not Apple's shim and carries none of its
+    /// behaviour, so no filesystem question is asked and it is probed normally.
+    /// </summary>
+    [Fact]
+    public async Task OffMacOs_TheSamePathIsProbedNormally()
+    {
+        var probeWasCalled = false;
+
+        await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleShimPath,
+            (_, _) => { probeWasCalled = true; return Task.FromResult(new GitVersionProbe(true, 0, "git version 2.45.1")); },
+            _ => false,
+            isMacOs: false,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled);
+    }
+
+    /// <summary>
+    /// A caller who has asked to stop gets a cancellation, not a verdict - including on the early
+    /// returns, which used to hand back an answer without ever checking.
+    /// </summary>
+    [Fact]
+    public async Task APreCancelledCall_DoesNotReturnAVerdictFromAnEarlyReturn()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            GitPresenceDetector.DetectAsync(
+                _ => null,   // the NotFound early return, which never awaited anything
+                (_, _) => AnAppleGitBanner(),
+                _ => false,
+                isMacOs: false,
+                cts.Token));
+    }
+}

--- a/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
@@ -114,6 +114,69 @@ public class GitPresenceTests
     }
 
     /// <summary>
+    /// A DETECTOR WITH A SIDE EFFECT ON THE USER'S MACHINE IS NOT A DETECTOR.
+    ///
+    /// On macOS /usr/bin/git is Apple's Command Line Tools shim. A Mac without those tools still has
+    /// that file, and RUNNING it puts Apple's "install the developer tools?" dialog on the screen -
+    /// so the probe itself would force a prompt the owner's ruling rules out. The assertion that
+    /// matters is not the verdict, it is that the probe IS NEVER CALLED: nothing is launched, so
+    /// nothing can prompt.
+    /// </summary>
+    [Fact]
+    public async Task OnMacOs_TheDeveloperToolsStubIsNeverLaunched()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleStubPath,
+            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.39.5 (Apple Git-154)"); },
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.False(probeWasCalled, "the macOS developer-tools stub was executed; that can open Apple's install dialog");
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        // And therefore the wizard says nothing at all on such a machine.
+        Assert.False(presence.ShouldAdviseInstallingGit);
+    }
+
+    /// <summary>
+    /// The guard is narrow on purpose. A Mac whose git comes from Homebrew resolves somewhere else
+    /// and must still be probed normally, or every Mac would fall into "we could not tell".
+    /// </summary>
+    [Fact]
+    public async Task OnMacOs_AGitThatIsNotTheStubIsStillProbed()
+    {
+        var probeWasCalled = false;
+
+        var presence = await GitPresenceDetector.DetectAsync(
+            _ => "/opt/homebrew/bin/git",
+            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.45.1"); },
+            isMacOs: true,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled);
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+    }
+
+    /// <summary>
+    /// The same path on a machine that is not a Mac is not Apple's stub and carries none of its
+    /// behaviour, so it is probed like anything else.
+    /// </summary>
+    [Fact]
+    public async Task OffMacOs_TheSamePathIsProbedNormally()
+    {
+        var probeWasCalled = false;
+
+        await GitPresenceDetector.DetectAsync(
+            _ => GitPresenceDetector.AppleStubPath,
+            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.45.1"); },
+            isMacOs: false,
+            CancellationToken.None);
+
+        Assert.True(probeWasCalled);
+    }
+
+    /// <summary>
     /// The one ruling the user interface is allowed to read. Stated as a table so that a later change
     /// making Undetermined advise an install fails here rather than on somebody's screen.
     /// </summary>

--- a/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
@@ -106,11 +106,11 @@ public class GitPresenceTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            GitPresenceDetector.DetectAsync(
-                _ => "C:\\Program Files\\Git\\cmd\\git.exe",
-                (_, ct) => { ct.ThrowIfCancellationRequested(); return Answers(true, 0, "git version 2.45.1"); },
-                cts.Token));
+        // The REAL detector, not the injected probe: the catch that has to let cancellation through
+        // lives inside the real version probe, so a test that supplies its own probe never reaches
+        // it and would pass whatever that catch did.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => GitPresenceDetector.DetectAsync(cts.Token));
     }
 
     /// <summary>
@@ -150,12 +150,27 @@ public class GitPresenceTests
     [Fact]
     public void LaunchFailure_CodeThree_IsOnlyAMissingFileOnWindows()
     {
-        var message = GitLaunchFailure.Describe(3, "No such process");
+        // The platform is passed in rather than read from the machine. On Windows the two rules -
+        // the correct one and "code 3 means missing everywhere" - produce identical output, so a
+        // test that read the real platform could not fail here however wrong the rule became.
+        Assert.Equal(
+            "git is not installed on this machine, or is not on PATH",
+            GitLaunchFailure.Describe(3, "The system cannot find the path specified", isWindows: true));
 
-        if (OperatingSystem.IsWindows())
-            Assert.Equal("git is not installed on this machine, or is not on PATH", message);
-        else
-            Assert.DoesNotContain("not installed", message);
+        var onPosix = GitLaunchFailure.Describe(3, "No such process", isWindows: false);
+        Assert.Equal("git could not be started: No such process", onPosix);
+        Assert.DoesNotContain("not installed", onPosix);
+    }
+
+    /// <summary>Code 2 means "no such file" on both platforms, so it reads the same on both.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LaunchFailure_CodeTwo_SaysNotInstalledOnEveryPlatform(bool isWindows)
+    {
+        Assert.Equal(
+            "git is not installed on this machine, or is not on PATH",
+            GitLaunchFailure.Describe(2, "No such file or directory", isWindows));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
@@ -81,6 +81,39 @@ public class GitPresenceTests
     }
 
     /// <summary>
+    /// The banner must be what the program LEADS with, not a phrase buried in its output. A warning
+    /// that merely mentions the words would otherwise be accepted as a working git, and the sentence
+    /// stored as the version would be the warning.
+    /// </summary>
+    [Theory]
+    [InlineData("warning: git version could not be determined")]
+    [InlineData("note: run --help for the git version banner")]
+    public async Task MentionsTheWordsWithoutLeadingWithThem_IsUndetermined(string output)
+    {
+        var presence = await Detect("C:\\decoy\\git.exe", (_, _) => Answers(true, 0, output));
+
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        Assert.Null(presence.Version);
+    }
+
+    /// <summary>
+    /// The caller asking to stop is not a verdict about the machine. It has to come back out as a
+    /// cancellation, not as a confident-looking "we could not tell".
+    /// </summary>
+    [Fact]
+    public async Task CallerCancellation_Propagates_RatherThanBecomingAVerdict()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            GitPresenceDetector.DetectAsync(
+                _ => "C:\\Program Files\\Git\\cmd\\git.exe",
+                (_, ct) => { ct.ThrowIfCancellationRequested(); return Answers(true, 0, "git version 2.45.1"); },
+                cts.Token));
+    }
+
+    /// <summary>
     /// The one ruling the user interface is allowed to read. Stated as a table so that a later change
     /// making Undetermined advise an install fails here rather than on somebody's screen.
     /// </summary>
@@ -88,7 +121,7 @@ public class GitPresenceTests
     [InlineData(GitAvailability.Present, false)]
     [InlineData(GitAvailability.NotFound, true)]
     [InlineData(GitAvailability.Undetermined, false)]
-    public void OnlyADefiniteAbsenceAdvisesInstallingGit(GitAvailability availability, bool expected)
+    public void OnlyGitFailingToResolveOnPathAdvisesInstallingGit(GitAvailability availability, bool expected)
     {
         var presence = new GitPresence(availability, null, null, "");
 
@@ -99,14 +132,30 @@ public class GitPresenceTests
     /// "Not installed" is a claim about the machine and is made ONLY for the operating system codes
     /// that mean the file is not there. A refusal to run is a different fact and keeps its own words.
     /// </summary>
-    [Theory]
-    [InlineData(2)]
-    [InlineData(3)]
-    public void LaunchFailure_FileNotFoundCodes_SayNotInstalled(int nativeErrorCode)
+    [Fact]
+    public void LaunchFailure_NoSuchFile_SaysNotInstalled()
     {
-        var message = GitLaunchFailure.Describe(nativeErrorCode, "The system cannot find the file specified");
+        // Code 2 is ERROR_FILE_NOT_FOUND on Windows and ENOENT on POSIX - the same meaning on both,
+        // which is why it is the one code read on every platform.
+        var message = GitLaunchFailure.Describe(2, "The system cannot find the file specified");
 
         Assert.Equal("git is not installed on this machine, or is not on PATH", message);
+    }
+
+    /// <summary>
+    /// Code 3 is Windows ERROR_PATH_NOT_FOUND but POSIX ESRCH, "no such process", which says nothing
+    /// about whether git is installed. Reading it as a missing install would tell a Mac user to
+    /// reinstall software that is already on their disk.
+    /// </summary>
+    [Fact]
+    public void LaunchFailure_CodeThree_IsOnlyAMissingFileOnWindows()
+    {
+        var message = GitLaunchFailure.Describe(3, "No such process");
+
+        if (OperatingSystem.IsWindows())
+            Assert.Equal("git is not installed on this machine, or is not on PATH", message);
+        else
+            Assert.DoesNotContain("not installed", message);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
@@ -114,69 +114,6 @@ public class GitPresenceTests
     }
 
     /// <summary>
-    /// A DETECTOR WITH A SIDE EFFECT ON THE USER'S MACHINE IS NOT A DETECTOR.
-    ///
-    /// On macOS /usr/bin/git is Apple's Command Line Tools shim. A Mac without those tools still has
-    /// that file, and RUNNING it puts Apple's "install the developer tools?" dialog on the screen -
-    /// so the probe itself would force a prompt the owner's ruling rules out. The assertion that
-    /// matters is not the verdict, it is that the probe IS NEVER CALLED: nothing is launched, so
-    /// nothing can prompt.
-    /// </summary>
-    [Fact]
-    public async Task OnMacOs_TheDeveloperToolsStubIsNeverLaunched()
-    {
-        var probeWasCalled = false;
-
-        var presence = await GitPresenceDetector.DetectAsync(
-            _ => GitPresenceDetector.AppleStubPath,
-            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.39.5 (Apple Git-154)"); },
-            isMacOs: true,
-            CancellationToken.None);
-
-        Assert.False(probeWasCalled, "the macOS developer-tools stub was executed; that can open Apple's install dialog");
-        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
-        // And therefore the wizard says nothing at all on such a machine.
-        Assert.False(presence.ShouldAdviseInstallingGit);
-    }
-
-    /// <summary>
-    /// The guard is narrow on purpose. A Mac whose git comes from Homebrew resolves somewhere else
-    /// and must still be probed normally, or every Mac would fall into "we could not tell".
-    /// </summary>
-    [Fact]
-    public async Task OnMacOs_AGitThatIsNotTheStubIsStillProbed()
-    {
-        var probeWasCalled = false;
-
-        var presence = await GitPresenceDetector.DetectAsync(
-            _ => "/opt/homebrew/bin/git",
-            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.45.1"); },
-            isMacOs: true,
-            CancellationToken.None);
-
-        Assert.True(probeWasCalled);
-        Assert.Equal(GitAvailability.Present, presence.Availability);
-    }
-
-    /// <summary>
-    /// The same path on a machine that is not a Mac is not Apple's stub and carries none of its
-    /// behaviour, so it is probed like anything else.
-    /// </summary>
-    [Fact]
-    public async Task OffMacOs_TheSamePathIsProbedNormally()
-    {
-        var probeWasCalled = false;
-
-        await GitPresenceDetector.DetectAsync(
-            _ => GitPresenceDetector.AppleStubPath,
-            (_, _) => { probeWasCalled = true; return Answers(true, 0, "git version 2.45.1"); },
-            isMacOs: false,
-            CancellationToken.None);
-
-        Assert.True(probeWasCalled);
-    }
-
-    /// <summary>
     /// The one ruling the user interface is allowed to read. Stated as a table so that a later change
     /// making Undetermined advise an install fails here rather than on somebody's screen.
     /// </summary>

--- a/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitPresenceTests.cs
@@ -1,0 +1,122 @@
+using CcDirector.Core.Git;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Git;
+
+/// <summary>
+/// The git detector behind the setup wizard's Code step (devthrottle_internal issue #1048).
+///
+/// The behaviour under test is not "does this machine have git" - it is that the detector has THREE
+/// answers and never launders the third into one of the other two. A machine we could not read must
+/// not be reported as a machine without git, because the product then tells someone something false
+/// about their own computer.
+/// </summary>
+public class GitPresenceTests
+{
+    private static Task<GitVersionProbe> Answers(bool ran, int exitCode, string output)
+        => Task.FromResult(new GitVersionProbe(ran, exitCode, output));
+
+    private static Task<GitPresence> Detect(
+        string? resolvesTo,
+        Func<string, CancellationToken, Task<GitVersionProbe>>? probe = null)
+        => GitPresenceDetector.DetectAsync(
+            _ => resolvesTo,
+            probe ?? ((_, _) => Answers(true, 0, "git version 2.45.1.windows.1")),
+            CancellationToken.None);
+
+    [Fact]
+    public async Task NothingOnPath_IsNotFound()
+    {
+        var presence = await Detect(resolvesTo: null);
+
+        Assert.Equal(GitAvailability.NotFound, presence.Availability);
+        Assert.True(presence.ShouldAdviseInstallingGit);
+    }
+
+    [Fact]
+    public async Task ResolvesAndReportsItsVersion_IsPresent()
+    {
+        var presence = await Detect("C:\\Program Files\\Git\\cmd\\git.exe");
+
+        Assert.Equal(GitAvailability.Present, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+        Assert.Equal("git version 2.45.1.windows.1", presence.Version);
+    }
+
+    /// <summary>
+    /// A FILE EXISTING IS NOT A WORKING INSTALL. A stale shim, a zero-byte placeholder or a
+    /// half-removed install still resolves on PATH; only running it settles the question.
+    /// </summary>
+    [Fact]
+    public async Task ResolvesButWillNotRun_IsUndetermined_AndSaysNothing()
+    {
+        var presence = await Detect(
+            "C:\\stale\\git.exe",
+            (_, _) => Answers(ran: false, exitCode: -1, "The system cannot find the file specified"));
+
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+    }
+
+    [Fact]
+    public async Task ResolvesButExitsNonZero_IsUndetermined_AndSaysNothing()
+    {
+        var presence = await Detect("C:\\broken\\git.exe", (_, _) => Answers(true, 128, "fatal: something"));
+
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+    }
+
+    /// <summary>
+    /// Exit zero says SOMETHING ran, not that git ran. Anything on PATH under the name "git" that
+    /// exits cleanly would otherwise be accepted as a working git install.
+    /// </summary>
+    [Fact]
+    public async Task ExitsZeroWithoutIdentifyingItself_IsUndetermined_AndSaysNothing()
+    {
+        var presence = await Detect("C:\\decoy\\git.exe", (_, _) => Answers(true, 0, "usage: helper [options]"));
+
+        Assert.Equal(GitAvailability.Undetermined, presence.Availability);
+        Assert.False(presence.ShouldAdviseInstallingGit);
+    }
+
+    /// <summary>
+    /// The one ruling the user interface is allowed to read. Stated as a table so that a later change
+    /// making Undetermined advise an install fails here rather than on somebody's screen.
+    /// </summary>
+    [Theory]
+    [InlineData(GitAvailability.Present, false)]
+    [InlineData(GitAvailability.NotFound, true)]
+    [InlineData(GitAvailability.Undetermined, false)]
+    public void OnlyADefiniteAbsenceAdvisesInstallingGit(GitAvailability availability, bool expected)
+    {
+        var presence = new GitPresence(availability, null, null, "");
+
+        Assert.Equal(expected, presence.ShouldAdviseInstallingGit);
+    }
+
+    /// <summary>
+    /// "Not installed" is a claim about the machine and is made ONLY for the operating system codes
+    /// that mean the file is not there. A refusal to run is a different fact and keeps its own words.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void LaunchFailure_FileNotFoundCodes_SayNotInstalled(int nativeErrorCode)
+    {
+        var message = GitLaunchFailure.Describe(nativeErrorCode, "The system cannot find the file specified");
+
+        Assert.Equal("git is not installed on this machine, or is not on PATH", message);
+    }
+
+    [Fact]
+    public void LaunchFailure_AnyOtherCode_KeepsTheRealReason()
+    {
+        // 5 is ERROR_ACCESS_DENIED: git is right there, and calling that "not installed" would send
+        // the user off to reinstall something that is already on the machine.
+        var message = GitLaunchFailure.Describe(5, "Access is denied");
+
+        Assert.Equal("git could not be started: Access is denied", message);
+        Assert.DoesNotContain("not installed", message);
+    }
+}

--- a/src/CcDirector.Core.Tests/Git/RequiresGitFactAttribute.cs
+++ b/src/CcDirector.Core.Tests/Git/RequiresGitFactAttribute.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace CcDirector.Core.Tests.Git;
+
+/// <summary>
+/// A test that cannot run without a working git on the machine, and SKIPS rather than fails when
+/// there is not one.
+///
+/// This exists because of what it is testing. The whole point of the work behind these tests is that
+/// a machine with no git is a SUPPORTED machine - so a suite that goes red on one is reporting a
+/// product regression that has not happened, which is the same category of mistake as the defect
+/// being fixed, committed by the person fixing it. An integration test that needs git is legitimate;
+/// it just has to say so instead of failing.
+///
+/// Note what this does NOT do: it never skips the tests that prove the missing-git behaviour itself.
+/// Those inject a command name that resolves nowhere, so they run everywhere and are exactly the
+/// tests a git-less machine most needs to keep.
+/// </summary>
+public sealed class RequiresGitFactAttribute : FactAttribute
+{
+    public RequiresGitFactAttribute()
+    {
+        if (!GitOnThisMachine.IsAvailable)
+            Skip = "no working git on this machine - this is an integration test, and a machine without git is supported";
+    }
+}
+
+/// <summary>Whether this machine has a git that resolves and runs. Answered once per test run.</summary>
+public static class GitOnThisMachine
+{
+    private static readonly Lazy<bool> Available = new(() =>
+    {
+        try
+        {
+            var presence = CcDirector.Core.Git.GitPresenceDetector.DetectAsync().GetAwaiter().GetResult();
+            return presence.Availability == CcDirector.Core.Git.GitAvailability.Present;
+        }
+        catch
+        {
+            // If we cannot even ask, treat git as unavailable and skip. A test harness that throws
+            // here must not turn into a product failure.
+            return false;
+        }
+    });
+
+    public static bool IsAvailable => Available.Value;
+}

--- a/src/CcDirector.Core/Git/GitCommandRunner.cs
+++ b/src/CcDirector.Core/Git/GitCommandRunner.cs
@@ -29,6 +29,22 @@ public sealed class GitCommandResult
 /// </summary>
 public class GitCommandRunner
 {
+    private readonly string _executable;
+
+    /// <summary>Runs the <c>git</c> on this machine's PATH. This is the only production form.</summary>
+    public GitCommandRunner() : this("git") { }
+
+    /// <summary>
+    /// Runs <paramref name="executable"/> instead of <c>git</c>. A TEST SEAM, and the only way to
+    /// reach the missing-git branch on a machine that has git: pass a name that resolves nowhere and
+    /// the launch fails for precisely the reason it fails on a clean Windows install. Production
+    /// never calls this - every call site uses the parameterless constructor above.
+    /// </summary>
+    public GitCommandRunner(string executable)
+    {
+        _executable = executable;
+    }
+
     /// <summary>
     /// Runs <c>git &lt;args&gt;</c> in <paramref name="workingDirectory"/> and returns its result.
     /// </summary>
@@ -39,7 +55,7 @@ public class GitCommandRunner
 
         var psi = new ProcessStartInfo
         {
-            FileName = "git",
+            FileName = _executable,
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -56,7 +72,24 @@ public class GitCommandRunner
         proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
         proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
 
-        proc.Start();
+        // A machine with no git is a supported machine (devthrottle_internal issue #1048), and on one
+        // Process.Start does not return false - it THROWS Win32Exception "The system cannot find the
+        // file specified". Unguarded, that exception left this method by a route none of its callers
+        // expect: every one of them is written against a GitCommandResult carrying Success=false, and
+        // the class already returns exactly that for the other reason a command cannot run (the
+        // working directory being absent, above). Reporting the missing git the same way keeps one
+        // contract instead of two, and puts a sentence a person can act on where the surfaces that
+        // render it - the Worktrees page, the branch services - already display the Error.
+        try
+        {
+            proc.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            FileLog.Write($"[GitCommandRunner] git could not be started: {ex.Message}");
+            return new GitCommandResult { Success = false, ExitCode = -1, Error = GitLaunchFailure.Describe(ex) };
+        }
+
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
         try

--- a/src/CcDirector.Core/Git/GitPresence.cs
+++ b/src/CcDirector.Core/Git/GitPresence.cs
@@ -1,0 +1,201 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// What this machine can be said to know about git. THREE states, not two.
+///
+/// The third state is the point. A detector that answers only "yes" or "no" has to fold every
+/// inconclusive outcome into one of them, and both choices tell the user something false: folded
+/// into "present" it says nothing when git really is missing, and folded into "absent" it tells
+/// someone with git installed that they have not got it. When the probe cannot reach a verdict the
+/// honest answer is that we do not know, and the caller says nothing at all.
+/// </summary>
+public enum GitAvailability
+{
+    /// <summary>A git executable resolved on PATH AND ran and identified itself. Only this is "yes".</summary>
+    Present,
+
+    /// <summary>Nothing named git resolves on this machine's PATH. This is a definite "no".</summary>
+    NotFound,
+
+    /// <summary>
+    /// Something is there but it did not answer: the launch failed, the probe timed out, it exited
+    /// non-zero, or what came back was not a git version. We do not know, and we do not guess.
+    /// </summary>
+    Undetermined,
+}
+
+/// <summary>
+/// The finished verdict about git on this machine: the state, what was found, and why.
+/// <see cref="ShouldAdviseInstallingGit"/> is the whole ruling the user interface reads - a view
+/// never re-derives it from the parts.
+/// </summary>
+/// <param name="Availability">The three-state verdict.</param>
+/// <param name="ExecutablePath">The resolved executable, when one was found. Null otherwise.</param>
+/// <param name="Version">The version line git printed, when it ran and identified itself.</param>
+/// <param name="Detail">Why the verdict is what it is - for the log, never for the screen.</param>
+public readonly record struct GitPresence(
+    GitAvailability Availability,
+    string? ExecutablePath,
+    string? Version,
+    string Detail)
+{
+    /// <summary>
+    /// Whether to tell the user that git is missing and recommended. TRUE ONLY for
+    /// <see cref="GitAvailability.NotFound"/> - never for <see cref="GitAvailability.Undetermined"/>,
+    /// because a machine we could not read is not a machine without git, and saying so would be a
+    /// statement about someone's computer that we have not established.
+    /// </summary>
+    public bool ShouldAdviseInstallingGit => Availability == GitAvailability.NotFound;
+}
+
+/// <summary>
+/// The one sentence the product shows when a git command could not be launched at all.
+///
+/// It lives in ONE place because it is rendered by three of them - the read services, the write
+/// services, and the desktop Source Control view - and a sentence copied three times is a sentence
+/// that can only be corrected in one of them.
+/// </summary>
+public static class GitLaunchFailure
+{
+    /// <summary>Windows ERROR_FILE_NOT_FOUND: there is no such executable.</summary>
+    private const int FileNotFound = 2;
+
+    /// <summary>Windows ERROR_PATH_NOT_FOUND: the directory the executable would be in is not there.</summary>
+    private const int PathNotFound = 3;
+
+    /// <summary>
+    /// Describe why git did not launch, WITHOUT over-claiming. "Not installed" is said only for the
+    /// two operating-system codes that actually mean the file is not there; every other reason - a
+    /// permission refusal, a corrupt image, an execution policy - reports itself in its own words
+    /// rather than being relabelled as a missing install.
+    /// </summary>
+    /// <param name="nativeErrorCode">The operating system's own error number from the failed launch.</param>
+    /// <param name="reason">What the failure said, used verbatim for every code but the two below.</param>
+    public static string Describe(int nativeErrorCode, string? reason)
+    {
+        if (nativeErrorCode is FileNotFound or PathNotFound)
+            return "git is not installed on this machine, or is not on PATH";
+        return string.IsNullOrWhiteSpace(reason)
+            ? "git could not be started"
+            : $"git could not be started: {reason}";
+    }
+
+    /// <summary>The same rule, for a launch failure that arrived as an exception.</summary>
+    public static string Describe(System.ComponentModel.Win32Exception ex)
+        => Describe(ex.NativeErrorCode, ex.Message);
+}
+
+/// <summary>The raw outcome of running <c>git --version</c>: did it run at all, and what came back.</summary>
+/// <param name="Ran">False when the process could not be started or did not finish in time.</param>
+/// <param name="ExitCode">The exit code, meaningful only when <paramref name="Ran"/> is true.</param>
+/// <param name="Output">Everything the probe printed, trimmed. Empty when it did not run.</param>
+public readonly record struct GitVersionProbe(bool Ran, int ExitCode, string Output);
+
+/// <summary>
+/// Decides whether git is usable on this machine, for the first-run wizard's Code step
+/// (devthrottle_internal issue #1048).
+///
+/// It is deliberately a TWO-part test, because a file existing is not a working install:
+///   1. resolve the name on PATH the way the operating system would, then
+///   2. RUN it and require it to identify itself as git.
+/// A stale shim, a broken install, or a zero-byte placeholder passes step one and fails step two,
+/// and each of those lands in <see cref="GitAvailability.Undetermined"/> rather than being reported
+/// as a working git.
+///
+/// This detector NEVER installs anything and never changes the machine. DevThrottle works without
+/// git - a plain folder is a perfectly good code folder - so the only product of this class is a
+/// sentence on a screen.
+/// </summary>
+public static class GitPresenceDetector
+{
+    /// <summary>The command name looked up on PATH.</summary>
+    public const string GitCommand = "git";
+
+    /// <summary>
+    /// How long the probe waits for <c>git --version</c>. Generous for a command that normally
+    /// answers in milliseconds, and short enough that a wedged executable cannot hold the Code step.
+    /// A timeout is <see cref="GitAvailability.Undetermined"/>, never "absent".
+    /// </summary>
+    public static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Detect git on this machine, using the real PATH and a real subprocess.</summary>
+    public static Task<GitPresence> DetectAsync(CancellationToken ct = default)
+        => DetectAsync(c => ExecutableResolver.Resolve(c), RunVersionAsync, ct);
+
+    /// <summary>
+    /// The rule, with the two machine-touching steps injected so every branch is reachable in a
+    /// test without needing a machine that genuinely lacks git.
+    /// </summary>
+    internal static async Task<GitPresence> DetectAsync(
+        Func<string, string?> resolve,
+        Func<string, CancellationToken, Task<GitVersionProbe>> probe,
+        CancellationToken ct)
+    {
+        var path = resolve(GitCommand);
+        if (path is null)
+        {
+            FileLog.Write("[GitPresenceDetector] DetectAsync: git does not resolve on PATH");
+            return new GitPresence(GitAvailability.NotFound, null, null, "git does not resolve on PATH");
+        }
+
+        var result = await probe(path, ct);
+
+        if (!result.Ran)
+        {
+            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} did not run: {result.Output}");
+            return new GitPresence(GitAvailability.Undetermined, path, null,
+                $"{path} resolved but did not run: {result.Output}");
+        }
+
+        if (result.ExitCode != 0)
+        {
+            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} exited {result.ExitCode}");
+            return new GitPresence(GitAvailability.Undetermined, path, null,
+                $"{path} exited {result.ExitCode}");
+        }
+
+        // Exit zero is not enough on its own: it says something ran, not that git ran. Requiring the
+        // version banner is what makes the difference between a working git and any other program
+        // that happens to sit on PATH under that name and exit cleanly.
+        if (!result.Output.Contains("git version", StringComparison.OrdinalIgnoreCase))
+        {
+            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} did not identify itself as git");
+            return new GitPresence(GitAvailability.Undetermined, path, null,
+                $"{path} ran but did not print a git version");
+        }
+
+        var version = result.Output.Split('\n')[0].Trim();
+        FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} -> {version}");
+        return new GitPresence(GitAvailability.Present, path, version, version);
+    }
+
+    /// <summary>
+    /// Run <c>&lt;path&gt; --version</c> and capture what it says. Every way of failing to get an
+    /// answer - the launch throwing, the timeout, a broken pipe - comes back as Ran=false, so the
+    /// rule above turns it into Undetermined instead of a claim about the machine.
+    /// </summary>
+    private static async Task<GitVersionProbe> RunVersionAsync(string path, CancellationToken ct)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(ProbeTimeout);
+        try
+        {
+            var r = await ProcessRunner.RunAsync(path, new[] { "--version" }, null, timeout.Token);
+            if (!r.Started)
+                return new GitVersionProbe(false, -1, r.StandardError);
+            return new GitVersionProbe(true, r.ExitCode, (r.StandardOutput + "\n" + r.StandardError).Trim());
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // OUR timeout fired, not the caller's cancellation. That is an unreadable machine, not a
+            // cancelled request, so it is reported as a failure to run rather than rethrown.
+            return new GitVersionProbe(false, -1, $"timed out after {ProbeTimeout.TotalSeconds:F0} seconds");
+        }
+        catch (Exception ex)
+        {
+            return new GitVersionProbe(false, -1, ex.Message);
+        }
+    }
+}

--- a/src/CcDirector.Core/Git/GitPresence.cs
+++ b/src/CcDirector.Core/Git/GitPresence.cs
@@ -147,15 +147,28 @@ public static class GitPresenceDetector
 
     /// <summary>Detect git on this machine, using the real PATH and a real subprocess.</summary>
     public static Task<GitPresence> DetectAsync(CancellationToken ct = default)
-        => DetectAsync(c => ExecutableResolver.Resolve(c), RunVersionAsync, ct);
+        => DetectAsync(c => ExecutableResolver.Resolve(c), RunVersionAsync, OperatingSystem.IsMacOS(), ct);
 
     /// <summary>
     /// The rule, with the two machine-touching steps injected so every branch is reachable in a
     /// test without needing a machine that genuinely lacks git.
     /// </summary>
+    internal static Task<GitPresence> DetectAsync(
+        Func<string, string?> resolve,
+        Func<string, CancellationToken, Task<GitVersionProbe>> probe,
+        CancellationToken ct)
+        => DetectAsync(resolve, probe, OperatingSystem.IsMacOS(), ct);
+
+    /// <summary>
+    /// The rule with the platform passed in as well. The macOS branch is the reason this exists: it
+    /// is never taken on Windows, so on the machines this suite runs on there would otherwise be NO
+    /// test that can fail if the guard is deleted - and that guard is the one stopping the detector
+    /// from putting an installer dialog on a Mac user's screen.
+    /// </summary>
     internal static async Task<GitPresence> DetectAsync(
         Func<string, string?> resolve,
         Func<string, CancellationToken, Task<GitVersionProbe>> probe,
+        bool isMacOs,
         CancellationToken ct)
     {
         var path = resolve(GitCommand);
@@ -169,7 +182,7 @@ public static class GitPresenceDetector
         // it when the tools are absent puts up Apple's "install the developer tools?" dialog. This
         // detector's entire remit is to say one sentence and change nothing, so it must not be the
         // thing that offers to install software. Nothing is claimed about such a machine either way.
-        if (IsAppleCommandLineToolsStub(path))
+        if (IsAppleCommandLineToolsStub(path, isMacOs))
         {
             FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} is the macOS developer-tools stub; not running it");
             return new GitPresence(GitAvailability.Undetermined, path, null,
@@ -220,9 +233,11 @@ public static class GitPresenceDetector
     /// outcome. A Mac with git from Homebrew or elsewhere resolves to that path instead and is probed
     /// normally.
     /// </summary>
-    private static bool IsAppleCommandLineToolsStub(string path)
-        => OperatingSystem.IsMacOS()
-           && string.Equals(path, "/usr/bin/git", StringComparison.Ordinal);
+    private static bool IsAppleCommandLineToolsStub(string path, bool isMacOs)
+        => isMacOs && string.Equals(path, AppleStubPath, StringComparison.Ordinal);
+
+    /// <summary>Where Apple puts its Command Line Tools shims.</summary>
+    internal const string AppleStubPath = "/usr/bin/git";
 
     /// <summary>
     /// Run <c>&lt;path&gt; --version</c> and capture what it says. Every way of failing to get an

--- a/src/CcDirector.Core/Git/GitPresence.cs
+++ b/src/CcDirector.Core/Git/GitPresence.cs
@@ -16,7 +16,13 @@ public enum GitAvailability
     /// <summary>A git executable resolved on PATH AND ran and identified itself. Only this is "yes".</summary>
     Present,
 
-    /// <summary>Nothing named git resolves on this machine's PATH. This is a definite "no".</summary>
+    /// <summary>
+    /// Nothing named git resolves on this process's PATH. That is the same lookup every git call in
+    /// the product makes, so it is exactly the condition under which DevThrottle cannot run git. It
+    /// is NOT a claim to have searched the disk: a git installed somewhere the PATH does not reach
+    /// lands here too, and telling that user to set git up is still the right advice, because until
+    /// it is on the PATH nothing here can use it.
+    /// </summary>
     NotFound,
 
     /// <summary>
@@ -42,7 +48,7 @@ public readonly record struct GitPresence(
     string Detail)
 {
     /// <summary>
-    /// Whether to tell the user that git is missing and recommended. TRUE ONLY for
+    /// Whether to tell the user that git could not be found and is recommended. TRUE ONLY for
     /// <see cref="GitAvailability.NotFound"/> - never for <see cref="GitAvailability.Undetermined"/>,
     /// because a machine we could not read is not a machine without git, and saying so would be a
     /// statement about someone's computer that we have not established.
@@ -59,23 +65,34 @@ public readonly record struct GitPresence(
 /// </summary>
 public static class GitLaunchFailure
 {
-    /// <summary>Windows ERROR_FILE_NOT_FOUND: there is no such executable.</summary>
+    /// <summary>
+    /// Code 2. Windows ERROR_FILE_NOT_FOUND, and POSIX ENOENT. It means the same thing on both -
+    /// there is no such file - which is why it is the one code read on every platform.
+    /// </summary>
     private const int FileNotFound = 2;
 
-    /// <summary>Windows ERROR_PATH_NOT_FOUND: the directory the executable would be in is not there.</summary>
-    private const int PathNotFound = 3;
+    /// <summary>
+    /// Code 3. WINDOWS ONLY: ERROR_PATH_NOT_FOUND. On POSIX the same number is ESRCH, "no such
+    /// process", which says nothing at all about whether git is installed - reading it as a missing
+    /// install on macOS would tell a Mac user to reinstall software that is sitting on their disk.
+    /// </summary>
+    private const int PathNotFoundWindowsOnly = 3;
 
     /// <summary>
     /// Describe why git did not launch, WITHOUT over-claiming. "Not installed" is said only for the
-    /// two operating-system codes that actually mean the file is not there; every other reason - a
-    /// permission refusal, a corrupt image, an execution policy - reports itself in its own words
+    /// codes that actually mean the file is not there on THIS operating system; every other reason -
+    /// a permission refusal, a corrupt image, an execution policy - reports itself in its own words
     /// rather than being relabelled as a missing install.
     /// </summary>
     /// <param name="nativeErrorCode">The operating system's own error number from the failed launch.</param>
-    /// <param name="reason">What the failure said, used verbatim for every code but the two below.</param>
+    /// <param name="reason">What the failure said, used verbatim for every other code.</param>
     public static string Describe(int nativeErrorCode, string? reason)
     {
-        if (nativeErrorCode is FileNotFound or PathNotFound)
+        var meansThereIsNoSuchFile =
+            nativeErrorCode == FileNotFound
+            || (OperatingSystem.IsWindows() && nativeErrorCode == PathNotFoundWindowsOnly);
+
+        if (meansThereIsNoSuchFile)
             return "git is not installed on this machine, or is not on PATH";
         return string.IsNullOrWhiteSpace(reason)
             ? "git could not be started"
@@ -140,6 +157,17 @@ public static class GitPresenceDetector
             return new GitPresence(GitAvailability.NotFound, null, null, "git does not resolve on PATH");
         }
 
+        // DO NOT RUN APPLE'S STUB. On macOS /usr/bin/git is a Command Line Tools shim, and executing
+        // it when the tools are absent puts up Apple's "install the developer tools?" dialog. This
+        // detector's entire remit is to say one sentence and change nothing, so it must not be the
+        // thing that offers to install software. Nothing is claimed about such a machine either way.
+        if (IsAppleCommandLineToolsStub(path))
+        {
+            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} is the macOS developer-tools stub; not running it");
+            return new GitPresence(GitAvailability.Undetermined, path, null,
+                $"{path} is the macOS developer-tools stub and running it can prompt an install, so it was not run");
+        }
+
         var result = await probe(path, ct);
 
         if (!result.Ran)
@@ -159,17 +187,34 @@ public static class GitPresenceDetector
         // Exit zero is not enough on its own: it says something ran, not that git ran. Requiring the
         // version banner is what makes the difference between a working git and any other program
         // that happens to sit on PATH under that name and exit cleanly.
-        if (!result.Output.Contains("git version", StringComparison.OrdinalIgnoreCase))
+        //
+        // The banner has to be the START of the first line, not merely present somewhere in the
+        // output. Real git prints "git version 2.45.1" and nothing before it; a program whose
+        // warning text happens to CONTAIN those words would otherwise be accepted as git, and the
+        // line stored as its version would be the warning.
+        var firstLine = result.Output.Split('\n')[0].Trim();
+        if (!firstLine.StartsWith("git version ", StringComparison.OrdinalIgnoreCase))
         {
             FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} did not identify itself as git");
             return new GitPresence(GitAvailability.Undetermined, path, null,
                 $"{path} ran but did not print a git version");
         }
 
-        var version = result.Output.Split('\n')[0].Trim();
-        FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} -> {version}");
-        return new GitPresence(GitAvailability.Present, path, version, version);
+        FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} -> {firstLine}");
+        return new GitPresence(GitAvailability.Present, path, firstLine, firstLine);
     }
+
+    /// <summary>
+    /// Whether this path is Apple's Command Line Tools shim at <c>/usr/bin/git</c>. On a Mac without
+    /// the tools installed that file EXISTS and running it opens Apple's install dialog, so it is the
+    /// one executable this detector refuses to launch. The consequence is accepted deliberately: on a
+    /// Mac whose git lives there we reach no verdict and say nothing, which is the quiet, honest
+    /// outcome. A Mac with git from Homebrew or elsewhere resolves to that path instead and is probed
+    /// normally.
+    /// </summary>
+    private static bool IsAppleCommandLineToolsStub(string path)
+        => OperatingSystem.IsMacOS()
+           && string.Equals(path, "/usr/bin/git", StringComparison.Ordinal);
 
     /// <summary>
     /// Run <c>&lt;path&gt; --version</c> and capture what it says. Every way of failing to get an
@@ -192,6 +237,13 @@ public static class GitPresenceDetector
             // OUR timeout fired, not the caller's cancellation. That is an unreadable machine, not a
             // cancelled request, so it is reported as a failure to run rather than rethrown.
             return new GitVersionProbe(false, -1, $"timed out after {ProbeTimeout.TotalSeconds:F0} seconds");
+        }
+        catch (OperationCanceledException)
+        {
+            // The CALLER cancelled. That must propagate: turning it into a verdict would hand a
+            // caller who asked to stop a confident-looking answer about the machine instead. This
+            // has to sit ABOVE the general catch below, which would otherwise swallow it.
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Core/Git/GitPresence.cs
+++ b/src/CcDirector.Core/Git/GitPresence.cs
@@ -87,10 +87,18 @@ public static class GitLaunchFailure
     /// <param name="nativeErrorCode">The operating system's own error number from the failed launch.</param>
     /// <param name="reason">What the failure said, used verbatim for every other code.</param>
     public static string Describe(int nativeErrorCode, string? reason)
+        => Describe(nativeErrorCode, reason, OperatingSystem.IsWindows());
+
+    /// <summary>
+    /// The rule with the platform passed in. Exposed because the Windows-only reading of code 3 is
+    /// otherwise UNFALSIFIABLE on Windows: a test running here cannot tell the correct rule from one
+    /// that reads code 3 as a missing file everywhere, so the guard would have no test that can fail.
+    /// </summary>
+    internal static string Describe(int nativeErrorCode, string? reason, bool isWindows)
     {
         var meansThereIsNoSuchFile =
             nativeErrorCode == FileNotFound
-            || (OperatingSystem.IsWindows() && nativeErrorCode == PathNotFoundWindowsOnly);
+            || (isWindows && nativeErrorCode == PathNotFoundWindowsOnly);
 
         if (meansThereIsNoSuchFile)
             return "git is not installed on this machine, or is not on PATH";

--- a/src/CcDirector.Core/Git/GitPresence.cs
+++ b/src/CcDirector.Core/Git/GitPresence.cs
@@ -147,30 +147,35 @@ public static class GitPresenceDetector
 
     /// <summary>Detect git on this machine, using the real PATH and a real subprocess.</summary>
     public static Task<GitPresence> DetectAsync(CancellationToken ct = default)
-        => DetectAsync(c => ExecutableResolver.Resolve(c), RunVersionAsync, OperatingSystem.IsMacOS(), ct);
+        => DetectAsync(c => ExecutableResolver.Resolve(c), RunVersionAsync, File.Exists, OperatingSystem.IsMacOS(), ct);
 
     /// <summary>
-    /// The rule, with the two machine-touching steps injected so every branch is reachable in a
-    /// test without needing a machine that genuinely lacks git.
+    /// The rule, with the machine-touching steps injected so every branch is reachable in a test
+    /// without needing a machine that genuinely lacks git.
     /// </summary>
     internal static Task<GitPresence> DetectAsync(
         Func<string, string?> resolve,
         Func<string, CancellationToken, Task<GitVersionProbe>> probe,
         CancellationToken ct)
-        => DetectAsync(resolve, probe, OperatingSystem.IsMacOS(), ct);
+        => DetectAsync(resolve, probe, File.Exists, OperatingSystem.IsMacOS(), ct);
 
     /// <summary>
-    /// The rule with the platform passed in as well. The macOS branch is the reason this exists: it
-    /// is never taken on Windows, so on the machines this suite runs on there would otherwise be NO
-    /// test that can fail if the guard is deleted - and that guard is the one stopping the detector
-    /// from putting an installer dialog on a Mac user's screen.
+    /// The rule with the platform and the file check passed in as well. The macOS branches are the
+    /// reason this exists: they are never taken on Windows, so on the machines this suite runs on
+    /// there would otherwise be NO test that can fail if they are deleted - and one of them is what
+    /// stops the detector putting an installer dialog on a Mac user's screen.
     /// </summary>
     internal static async Task<GitPresence> DetectAsync(
         Func<string, string?> resolve,
         Func<string, CancellationToken, Task<GitVersionProbe>> probe,
+        Func<string, bool> fileExists,
         bool isMacOs,
         CancellationToken ct)
     {
+        // Before anything else. A caller who has asked to stop must not get a verdict back - the
+        // early returns below would otherwise hand out a confident answer after cancellation.
+        ct.ThrowIfCancellationRequested();
+
         var path = resolve(GitCommand);
         if (path is null)
         {
@@ -178,15 +183,27 @@ public static class GitPresenceDetector
             return new GitPresence(GitAvailability.NotFound, null, null, "git does not resolve on PATH");
         }
 
-        // DO NOT RUN APPLE'S STUB. On macOS /usr/bin/git is a Command Line Tools shim, and executing
-        // it when the tools are absent puts up Apple's "install the developer tools?" dialog. This
-        // detector's entire remit is to say one sentence and change nothing, so it must not be the
-        // thing that offers to install software. Nothing is claimed about such a machine either way.
-        if (IsAppleCommandLineToolsStub(path, isMacOs))
+        // APPLE'S SHIM IS TWO STATES, NOT ONE - and telling them apart WITHOUT RUNNING IT is the
+        // whole of this branch.
+        //
+        // On macOS /usr/bin/git is a Command Line Tools shim. It exists on every Mac. When the tools
+        // are installed it dispatches to the real git and behaves exactly like git; when they are
+        // not, RUNNING it puts up Apple's "install the developer tools?" dialog. So the shim is not
+        // one situation to be avoided - it is a working git and a prompting stub wearing the same
+        // path, and the first version of this guard could not tell them apart. It refused both,
+        // which traded a dialog for permanent silence on the commonest Mac configuration there is:
+        // we no longer merely stayed quiet, we lost the answer on a machine that HAS git.
+        //
+        // The tools ship the real executable at a known location, and the shim dispatches to it. So
+        // the question "will running the shim prompt?" is answerable by LOOKING, with no process
+        // started at all: if the real git is on disk the shim is safe to run, and if it is not, we
+        // launch nothing and say nothing. Silence stays the right answer for a Mac with no developer
+        // tools; it was never the right answer for a Mac with working git.
+        if (IsAppleCommandLineToolsShim(path, isMacOs) && !DeveloperToolsGitExists(fileExists))
         {
-            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} is the macOS developer-tools stub; not running it");
+            FileLog.Write($"[GitPresenceDetector] DetectAsync: {path} is Apple's shim and no developer-tools git is installed behind it; not running it");
             return new GitPresence(GitAvailability.Undetermined, path, null,
-                $"{path} is the macOS developer-tools stub and running it can prompt an install, so it was not run");
+                $"{path} is Apple's developer-tools shim with nothing behind it, and running it can prompt an install, so it was not run");
         }
 
         var result = await probe(path, ct);
@@ -233,11 +250,29 @@ public static class GitPresenceDetector
     /// outcome. A Mac with git from Homebrew or elsewhere resolves to that path instead and is probed
     /// normally.
     /// </summary>
-    private static bool IsAppleCommandLineToolsStub(string path, bool isMacOs)
-        => isMacOs && string.Equals(path, AppleStubPath, StringComparison.Ordinal);
+    private static bool IsAppleCommandLineToolsShim(string path, bool isMacOs)
+        => isMacOs && string.Equals(path, AppleShimPath, StringComparison.Ordinal);
 
-    /// <summary>Where Apple puts its Command Line Tools shims.</summary>
-    internal const string AppleStubPath = "/usr/bin/git";
+    /// <summary>
+    /// Whether a real git is installed behind Apple's shim. Purely a look at the filesystem - no
+    /// process is started, which is the point: this is the question that decides whether starting
+    /// one is safe.
+    /// </summary>
+    private static bool DeveloperToolsGitExists(Func<string, bool> fileExists)
+        => DeveloperToolsGitPaths.Any(fileExists);
+
+    /// <summary>Where Apple's shim lives. Present on every Mac, whether or not anything is behind it.</summary>
+    internal const string AppleShimPath = "/usr/bin/git";
+
+    /// <summary>
+    /// Where the REAL git lands when the developer tools are installed - the standalone Command Line
+    /// Tools, then a full Xcode. If either is on disk, the shim dispatches instead of prompting.
+    /// </summary>
+    internal static readonly string[] DeveloperToolsGitPaths =
+    {
+        "/Library/Developer/CommandLineTools/usr/bin/git",
+        "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+    };
 
     /// <summary>
     /// Run <c>&lt;path&gt; --version</c> and capture what it says. Every way of failing to get an

--- a/src/CcDirector.Core/Git/GitStatusProvider.cs
+++ b/src/CcDirector.Core/Git/GitStatusProvider.cs
@@ -153,7 +153,10 @@ public class GitStatusProvider
             // scan could not stop it.
             var r = await ProcessRunner.RunAsync("git", new[] { "status", "--porcelain=v1", "-u" }, repoPath, ct);
             if (!r.Started)
-                return ("", "Failed to start git process", -1);
+                // Carries the REASON, not just the fact. On a machine with no git this is the
+                // sentence the Source Control view puts on the screen (issue #1048); it used to be
+                // the fixed "Failed to start git process", which threw the reason away.
+                return ("", GitLaunchFailure.Describe(r.StartErrorCode, r.StandardError), -1);
             return (r.StandardOutput, r.StandardError, r.ExitCode);
         }
         catch (OperationCanceledException)

--- a/src/CcDirector.Core/Git/GitSyncStatusProvider.cs
+++ b/src/CcDirector.Core/Git/GitSyncStatusProvider.cs
@@ -21,11 +21,11 @@ public class GitSyncStatusProvider
     {
         try
         {
-            var output = await RunGitAsync(repoPath, new[] { "status", "--branch", "--porcelain=v2" }, ct);
-            if (output == null)
-                return new GitSyncStatus { Success = false, Error = "Failed to start git process" };
+            var read = await RunGitAsync(repoPath, new[] { "status", "--branch", "--porcelain=v2" }, ct);
+            if (read.Output == null)
+                return new GitSyncStatus { Success = false, Error = read.Problem };
 
-            var status = ParseBranchHeaders(output);
+            var status = ParseBranchHeaders(read.Output);
 
             // Determine behind-main count if not on main
             if (!status.IsDetachedHead && !IsMainBranch(status.BranchName))
@@ -33,8 +33,8 @@ public class GitSyncStatusProvider
                 var mainBranch = await DetectMainBranchAsync(repoPath, ct);
                 if (mainBranch != null)
                 {
-                    var countOutput = await RunGitAsync(repoPath, new[] { "rev-list", "--count", $"HEAD..origin/{mainBranch}" }, ct);
-                    if (countOutput != null && int.TryParse(countOutput.Trim(), out var count))
+                    var countRead = await RunGitAsync(repoPath, new[] { "rev-list", "--count", $"HEAD..origin/{mainBranch}" }, ct);
+                    if (countRead.Output != null && int.TryParse(countRead.Output.Trim(), out var count))
                     {
                         return new GitSyncStatus
                         {
@@ -138,11 +138,11 @@ public class GitSyncStatusProvider
     private async Task<string?> DetectMainBranchAsync(string repoPath, CancellationToken ct)
     {
         var result = await RunGitAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/main" }, ct);
-        if (result != null)
+        if (result.Output != null)
             return "main";
 
         result = await RunGitAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/master" }, ct);
-        if (result != null)
+        if (result.Output != null)
             return "master";
 
         return null;
@@ -151,14 +151,24 @@ public class GitSyncStatusProvider
     private static bool IsMainBranch(string branchName) =>
         branchName is "main" or "master";
 
-    private async Task<string?> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
+    /// <summary>
+    /// One git read. <c>Output</c> is null unless the command both launched and exited zero;
+    /// <c>Problem</c> then says which of those two it was. Keeping them apart is the point: the
+    /// caller used to report "Failed to start git process" for BOTH, so a git that ran perfectly
+    /// well and exited non-zero was described as never having started (issue #1048).
+    /// </summary>
+    private readonly record struct GitRead(string? Output, string Problem);
+
+    private async Task<GitRead> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
     {
         // ProcessRunner drains BOTH pipes (the old code never drained stderr, so a git command that
         // filled its error pipe could deadlock) and honors cancellation by killing the child so a
         // superseded scan does not leave git processes behind (issue 516).
         var r = await ProcessRunner.RunAsync("git", args, repoPath, ct);
         if (!r.Started)
-            return null;
-        return r.ExitCode == 0 ? r.StandardOutput : null;
+            return new GitRead(null, GitLaunchFailure.Describe(r.StartErrorCode, r.StandardError));
+        if (r.ExitCode != 0)
+            return new GitRead(null, $"git {string.Join(' ', args)} exited {r.ExitCode}: {r.StandardError.Trim()}");
+        return new GitRead(r.StandardOutput, "");
     }
 }

--- a/src/CcDirector.Core/Git/GitWriteService.cs
+++ b/src/CcDirector.Core/Git/GitWriteService.cs
@@ -23,6 +23,22 @@ public sealed class GitWriteResult
 /// </summary>
 public sealed class GitWriteService
 {
+    private readonly string _executable;
+
+    /// <summary>Runs the <c>git</c> on this machine's PATH. This is the only production form.</summary>
+    public GitWriteService() : this("git") { }
+
+    /// <summary>
+    /// Runs <paramref name="executable"/> instead of <c>git</c>. A TEST SEAM, and the only way to
+    /// reach the missing-git branch on a machine that has git: pass a name that resolves nowhere and
+    /// the launch fails for precisely the reason it fails on a clean Windows install. Production
+    /// never calls this.
+    /// </summary>
+    public GitWriteService(string executable)
+    {
+        _executable = executable;
+    }
+
     /// <summary>Stage paths (<c>git add -- &lt;paths&gt;</c>), or everything when paths is empty (<c>git add -A</c>).</summary>
     public Task<GitWriteResult> StageAsync(string repoPath, IReadOnlyList<string> paths, CancellationToken ct = default)
         => paths.Count == 0
@@ -64,14 +80,14 @@ public sealed class GitWriteService
         return args.ToArray();
     }
 
-    private static async Task<GitWriteResult> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
+    private async Task<GitWriteResult> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return new GitWriteResult { Success = false, Error = $"repo path not found: {repoPath}" };
 
         var psi = new ProcessStartInfo
         {
-            FileName = "git",
+            FileName = _executable,
             WorkingDirectory = repoPath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -88,7 +104,22 @@ public sealed class GitWriteService
         proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
         proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
 
-        proc.Start();
+        // On a machine with no git, Process.Start THROWS Win32Exception rather than returning false.
+        // Unguarded it escaped every caller of stage / unstage / discard / commit - the desktop Source
+        // Control buttons, the Control API git verbs, and through them the Cockpit and the phone -
+        // none of which catches it: they all read GitWriteResult.Success. Reported as a failed result
+        // it reaches all three surfaces as the sentence below instead of an unhandled exception
+        // (devthrottle_internal issue #1048).
+        try
+        {
+            proc.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            FileLog.Write($"[GitWriteService] git could not be started: {ex.Message}");
+            return new GitWriteResult { Success = false, ExitCode = -1, Error = GitLaunchFailure.Describe(ex) };
+        }
+
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
         await proc.WaitForExitAsync(ct);

--- a/src/CcDirector.Core/Git/PullRequestService.cs
+++ b/src/CcDirector.Core/Git/PullRequestService.cs
@@ -172,7 +172,10 @@ public sealed class PullRequestService
             // cancellation - a CLI that fills its stderr pipe (an auth prompt, a stack of warnings)
             // can no longer deadlock the capture, and a cancelled call leaves no orphaned process.
             var r = await ProcessRunner.RunAsync(exe, args, workingDir, ct);
-            return r.Started ? (r.ExitCode, r.StandardOutput, r.StandardError) : (-1, "", $"{exe} could not start");
+            // ProcessRunner puts WHY it could not start into StandardError (a missing executable
+            // reads "The system cannot find the file specified"). Passing that through keeps the
+            // reason, which a bare "could not start" threw away.
+            return (r.ExitCode, r.StandardOutput, r.StandardError);
         }
         catch (OperationCanceledException)
         {

--- a/src/CcDirector.Core/Utilities/ProcessRunner.cs
+++ b/src/CcDirector.Core/Utilities/ProcessRunner.cs
@@ -15,8 +15,14 @@ namespace CcDirector.Core.Utilities;
 /// </summary>
 public static class ProcessRunner
 {
-    /// <summary>The captured result. <see cref="Started"/> is false when the process could not start.</summary>
-    public readonly record struct Result(int ExitCode, string StandardOutput, string StandardError, bool Started);
+    /// <summary>
+    /// The captured result. <see cref="Started"/> is false when the process could not start, and
+    /// <see cref="StartErrorCode"/> then carries the operating system's own error number so the
+    /// caller can tell "there is no such executable" apart from "it exists and refused to run" -
+    /// a distinction the message text alone cannot be trusted to carry.
+    /// </summary>
+    public readonly record struct Result(
+        int ExitCode, string StandardOutput, string StandardError, bool Started, int StartErrorCode = 0);
 
     /// <summary>
     /// Starts <paramref name="fileName"/> with <paramref name="args"/> in
@@ -41,8 +47,21 @@ public static class ProcessRunner
             psi.ArgumentList.Add(a);
 
         using var proc = new Process { StartInfo = psi };
-        if (!proc.Start())
-            return new Result(-1, "", $"{fileName} could not start", Started: false);
+
+        // Start does NOT return false when the executable is missing - it throws Win32Exception ("The
+        // system cannot find the file specified"). Without this catch the Started=false result was
+        // unreachable for the one case it names, and every caller had to carry its own catch-all to
+        // survive a machine with no git (devthrottle_internal issue #1048). Catching it here is what
+        // makes the documented contract on Started true.
+        try
+        {
+            if (!proc.Start())
+                return new Result(-1, "", $"{fileName} could not start", Started: false);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            return new Result(-1, "", ex.Message, Started: false, StartErrorCode: ex.NativeErrorCode);
+        }
 
         // Start draining BOTH pipes immediately and concurrently - neither read waits on the other.
         var outTask = proc.StandardOutput.ReadToEndAsync(ct);


### PR DESCRIPTION
## SPLIT DONE. This pull request is now pieces three and four, and it is NOT ready.

The owner approved splitting by RISK rather than by subject. Two pieces have left this pull request
and are open on their own:

| Piece | Where | State |
|---|---|---|
| 1. The clean-machine reword | **#2421** | Ready. Zero dependencies, never faulted in three rounds. |
| 2. The git launch guards | **#2422** | Ready. The part that fixes the real defect; not one finding across three rounds. |
| 3. `GitPresenceDetector` + the Code step notice + the Source Control view | **here** | Open findings - see below. |
| 4. The wizard window sizing | **here** | Blocked on devthrottle_internal#1241. |

**Do not merge this one.** It carries the work every review round has faulted. Its history and the
three review threads below are kept deliberately: the reasoning is worth more than the diff, and
whoever picks pieces three and four up should inherit the findings rather than rediscover them.

### What is still open on piece three

1. **The macOS probe runs Apple's shim instead of the path it just proved safe.** Having established
   that a real git exists behind `/usr/bin/git`, the code goes on to probe `/usr/bin/git` anyway. The
   fix does the hard half and throws it away.
2. **The developer-tools paths are a proxy, not the fact.** `DEVELOPER_DIR`, `xcode-select`, or an
   Xcode installed elsewhere all break the inference. "One of two hard-coded files exists" is not the
   same statement as "this shim will dispatch without prompting", and the comment asserts the latter.
3. **`RequiresGitFact` is circular.** Its availability check calls the very detector the gated test
   asserts on, so a regression from `Present` to `Undetermined` SKIPS instead of failing, and the
   blanket catch turns a detector exception into a skip too. A false green built inside work whose
   subject is false greens.
4. **`CallerCancellation_Propagates` no longer reaches the catch it names** - the pre-cancellation
   check added in the same round short-circuits it. It passes and proves nothing.
5. **`ArrivingAtTheCodeStep_StartsTheGitProbe`** passes if the `Task.Run` that runs the detector is
   deleted, so long as the flag assignment stays.
6. **The attachment generation does not order two refreshes of the SAME attachment**, though the
   comment claims it does. The counter would have to move per refresh, not per attachment.
7. **`AFailedRead_TakesTheStaleBranchBarDownWithIt`** proves a synchronous assignment, not the
   separate-timer race it describes - an in-flight sync read can still put the bar back.
8. **`AGoodReadAfterABadOne_ClearsTheProblemLine`** still shells `git init` under a plain fact, so it
   fails rather than skips on a supported git-less machine.
9. **Nothing exercises the attachment-generation guard at all.**
10. **The PATH walk is outside the probe timeout.** Detection runs off the user interface thread and
    nothing on the step waits for it, so the cost is the sentence rather than the step - but an
    unresponsive PATH entry blocks unbounded.

### What is still open on piece four

- **devthrottle_internal#1241 blocks it.** The two-stage fitter writes its clamped size into
  `Width`/`Height`, so the second stage reads an already-clamped value as the preference and a window
  clamped for the wrong screen can never grow back. That is pre-existing and shipped in v1.9.6, and I
  filed it separately - but the reviewer's counter is accepted: deferring existing debt is
  legitimate, adding a second caller of a known-defective mechanism is not, and this pull request
  puts `FirstRunWizardDialog` onto it.
- **The height assertion is `> 640`**, which 641 satisfies. It pins the direction, not sufficiency.
  A faithful content-fit assertion needs real font metrics the headless Avalonia platform does not
  provide; the only evidence of sufficiency is the screenshots in the history below.

### What IS established here, and should not be re-derived

- The wizard was a **fixed 900x640 at every resolution** - the markup declared it and nothing
  assigned `Width` or `Height` anywhere. devthrottle_internal#1046's open question is answered: the
  clipping is not a small-screen defect, and its title is wrong to scope it to 1024x768.
- `UpdateSourceControlTabVisibility: hasGit=False` in the #1048 thread is **not** git detection. It
  tests `Directory.Exists(repo/.git)` - whether the FOLDER is a checkout. A checkout copied onto a
  machine with no git still shows the Source Control tab.
- On the running application the wizard measured **916x899** where it was 916x679, with all five
  Welcome items and all seven Done receipt rows visible, including the morning-report line.
- 26 guards were revert-proven across four passes, each mutation confirmed present by diff first.

---

<details><summary>The original description, kept for the record</summary>

Closes the two first-run wizard issues from the clean-machine walk of v1.8.7.

> ## PROPOSED: split this into four, by RISK rather than by subject
>
> **Recommendation, pending the owner's decision - nothing here is settled.** Three independent
> review rounds have blocked this pull request. Recording the proposed split and how it was drawn,
> because the reasoning is worth more than the outcome and should not die with the session.
>
> This change has outgrown the two issues it was opened for. Part three's instruction - exercise the
> git paths nobody had exercised - was right and found a real defect, but the work it produced has a
> defect surface of its own, and that is what every round has faulted.
>
> | Piece | Ship when | Why |
> |---|---|---|
> | The clean-machine reword (`CodeNoneAckText`) | **Immediately** | The only piece with genuinely zero dependencies. No round has ever faulted it. |
> | The three launch guards - `GitCommandRunner`, `GitWriteService`, `ProcessRunner` | **Own pull request, own review** | They fix the actual defect the issue asked about, and they have earned it (below). |
> | `GitPresenceDetector`, the Code step notice, and their tests | **Separate work** | Where every finding across three rounds actually lives. |
> | The window sizing | **Blocked on devthrottle_internal#1241** | See below - this pull request adds a second caller of a known-defective mechanism. |
>
> **Two corrections that moved this line, both drawn from what the rounds said rather than from how
> the change is organised:**
>
> 1. **The Code step notice is not "just copy" and cannot ship alone.** The git-is-recommended
>    sentence needs `GitPresenceDetector`, so it inherits the macOS regression and the circular skip
>    attribute. Only the clean-machine reword is dependency-free. Shipping the notice as copy would
>    have shipped both open findings with it.
> 2. **The launch guards are the most settled code here, not the risky half.** Across three rounds
>    not one finding has landed on `GitCommandRunner`, `GitWriteService`, or `ProcessRunner`
>    themselves. (`GitLaunchFailure`, the shared message helper they call, was faulted once in round
>    one over reading Windows error numbers on macOS; that is fixed and has been clean since.) They
>    are also the part that repairs a real fault on a real machine - `Process.Start` throwing rather
>    than returning false, so the exception escapes into callers written against a result object.
>    Holding them back would defer the only thing here that fixes something, on the strength of
>    findings belonging to a different component: judging a part by the reputation of the whole,
>    which is a sibling of the fault this whole pull request keeps catching.
>
> **On the window sizing.** devthrottle_internal#1241 was filed as a separate issue because the
> two-stage fitter defect is pre-existing and shipped in v1.9.6. The reviewer's counter is better
> than that argument and is accepted: deferring existing debt is legitimate, but ADDING a second
> caller of a known-defective mechanism is not, and putting `FirstRunWizardDialog` onto that fitter
> does exactly that. thefrederiksen/devthrottle_internal#738 therefore blocks this half rather than sitting beside it.

## The ruling this implements

The owner settled the design: **detect and tell, never force, never install, and everything must
work without git.** Another version control system, or none at all, is a legitimate choice. What is
not acceptable is that a user finds out from the command line that the tool the product just told
them to use is not on their machine.

## Part one - tell them (#1048)

The Code step now says, in one sentence and only when git is definitely absent, that we could not
find it, that nothing here needs it, and that it is highly recommended - with a link to where to get
it. It is a sentence on the screen they are already looking at: not a warning, not a modal, not a
gate. The primary button is untouched.

Detection is deliberately **three-state**. Resolving a name on PATH is not enough, because a file
existing is not a working install, so it resolves the name the way the operating system would and
then **runs** it and requires it to identify itself. Anything that leaves the question open - a
launch that fails, a timeout, a non-zero exit, an executable that answers without printing a git
version - is `Undetermined`, and `Undetermined` says **nothing at all**. Folding it into "absent"
would tell someone who has git that they have not got it, which is a claim about their computer that
we have not established.

## Part two - stop advising the impossible (#1048)

"When you clone or create your first repository" was advice a machine with no git cannot act on.
Making a folder always works, needs nothing installed, and is exactly what the clean-machine walk
did: a plain folder with two files in it, no git anywhere. Cloning is still named as the other way
in; it is just no longer the only route offered.

## Part three - make it actually work without git

The issue flagged the Director's Source Control button and said outright that it was not exercised.
It is now, and it was not fine.

**`Process.Start` does not return false when git is missing - it throws `Win32Exception`.** So the
missing-git branch had never run, and the exception left three places by a route none of their
callers expects, every one of which is written against a result object:

| Where | What it did with no git | Now |
|---|---|---|
| `GitCommandRunner` | Threw into the worktree inventory, the branch / diff / history services and the repository monitor | Returns the failed result its callers already handle, so the Worktrees page reports the reason it already knows how to render |
| `GitWriteService` | Threw out of stage, unstage, discard and commit - desktop buttons, Control API git verbs, and through them the Cockpit and the phone | Same fix, so all three surfaces get a sentence instead of an exception |
| `ProcessRunner` | Documented a `Started=false` result it could never produce | Produces it, which is what makes the two read providers honest without a catch-all |
| `GitChangesView` | **Returned silently** and left "No changes detected" on screen - a statement about the repository, when nothing had been read | Says what happened, and clears itself when a read succeeds |
| `GitStatusProvider` / `GitSyncStatusProvider` | Reported a fixed "Failed to start git process" - also shown when git ran perfectly well and exited non-zero | Carry the real reason, and tell a failed launch apart from a non-zero exit |

Paths checked and **left alone** because they were already correct: `CodeFolderScout` (reads `.git`
directories on disk, never runs git - which is why the wizard's folder sweep works on a clean
machine), `WingmanService.GitSnapshotAsync` (catches and reports `git_failed`),
`GitHubUrls.ResolveRepoNameCached` (catches, caches the miss, groups by folder name),
`WorktreeInventoryService` and `WorktreesView` (already render "Could not read worktrees: ...").

**One correction to the issue thread, because it corrects a shared mental model and not just code.**
`UpdateSourceControlTabVisibility: hasGit=False` does **not** show that the product detects the
absence of git. It tests `Directory.Exists(repo/.git)` - whether the FOLDER is a checkout, not
whether git is INSTALLED. Anyone reading that thread would inherit the belief that the product
already knows when git is missing and acts on it. It does not, and that is precisely why the Source
Control tab is offered on a machine that cannot run a single git command.

The sentence shown for a failed launch lives in one place and does not over-claim: "not installed"
is said only for the two operating system codes that mean the file is not there. A permission
refusal keeps its own words rather than sending someone off to reinstall software already on the
machine.

## Issue thefrederiksen/devthrottle#1046 - the wizard fits the display

That issue asked one open question: is the window fixed, or does it grow with the desktop. **It was
fixed.** The markup declared `900x640` and nothing anywhere assigned the window's `Width` or
`Height`, so the 916x679 frame photographed at 1024x768 is the size it would be on any monitor. The
clipping is a defect at every resolution, and the issue's title is wrong to scope it to small
screens.

It now uses the same `WindowFit` fold the main window got in abca6682a, lifted out of `MainWindow`
so there is one copy rather than two: clamp to the work area before the window is shown, re-fit once
the frame can be measured, centre. The old fixed size did not even fit the smallest supported
display - 640 of client plus a 39 pixel frame is 679, against 672 of work area - which nothing had
noticed. Every scrolling area in the wizard also keeps its scrollbar instead of fading it out, so a
list too tall for the display reads as truncated rather than as a list that ends there.

## Evidence

**Revert-proof: 19 guards across three passes, every one mutated in the real production line and
confirmed red.** Each mutation was verified present by diff before its tests ran, because a mutation
that never applied gives a green that reads exactly like a finding. The later passes are described
in the comments below; two of them caught tests of mine that could not fail, including the macOS
guard, whose branch is never taken on Windows and which therefore had no test able to catch its own
deletion. The first twelve:

| Mutation | Turned red |
|---|---|
| `GitCommandRunner`: remove the missing-git guard | yes (2 tests) |
| `GitWriteService`: remove the missing-git guard | yes (2) |
| `ProcessRunner`: remove the failed-launch guard | yes (2) |
| Detector: fold `Undetermined` into `NotFound` | yes |
| `ShouldAdviseInstallingGit` becomes "anything but Present" | yes (4) |
| `GitLaunchFailure`: claim "not installed" for every code | yes |
| `GitStatusProvider`: restore the fixed launch message | yes |
| `GitSyncStatusProvider`: restore the fixed launch message | yes |
| Wizard: show the git notice unconditionally | yes (2) |
| Wizard: restore the clone-only acknowledgement | yes |
| Wizard: restore the fixed 640 height | yes (2) |
| `GitChangesView`: restore the silent early return | yes (2) |

**Run on the real application**, not only in tests. A Director on a throwaway instance home, so the
first-run wizard opens for real:

```
[FirstRunWizardDialog] ApplyFit (pre-show): workArea=1920x1032 ... desired=900x860, chosen=900x860
[FirstRunWizardDialog] ApplyFit (opened):   ... frame=16x39, desired=900x860, chosen=900x860 at 502,66
[MainWindow] ApplyFit (opened): ... desired=1400x900, chosen=1400x900 at 252,46
```

The wizard measured **916x899** where it used to be 916x679, and the main window is unchanged by the
extraction. Both screens the issue named were photographed whole:

- **Welcome** shows all five items, including "A browser for your agents" and its explanatory line.
- **Done** shows all seven receipt rows, including "Morning report - Every morning at 7:00 Eastern",
  the consent-adjacent row that was below the fold.

## What is NOT proven, and what is still exposed

Read this section before relying on anything above.

- **A REMAINING EXPOSURE, not a limitation of the testing.** Everything here is scoped to the
  DETECTOR and to the surfaces listed in the table. The rest of the product still launches bare
  `git` whenever a repository is open - the repository monitor, the branch and history services,
  the worktree inventory. On macOS those launches resolve to `/usr/bin/git`, so on a Mac without the
  Command Line Tools **they can still raise Apple's install dialog**. That is pre-existing behaviour
  and is unchanged by this pull request; the detector is now the one place that refuses to do it.
  Whoever picks up the macOS story next should start here rather than rediscovering it.
- **This has not been run on a Mac.** What is proven is that the detector does not launch
  `/usr/bin/git` on macOS. That launching it prompts is Apple's documented shim behaviour, not
  something observed here.
- **The git notice was never photographed on a running Director.** The walk to reach the Code step
  with git removed from the process PATH was abandoned for time. Its behaviour is covered by tests
  at both levels - the three-state detector, and the wizard panel following the verdict for all
  three states - but nobody has looked at the rendered sentence.
- **The wizard sizing tests do not prove the wizard CALLS the fitter.** They bind the size declared
  in the markup to what `WindowFit` does with it; the headless display is roomier than anything
  under test, so the wiring cannot be exercised there. The wiring proof is the running application:
  the `ApplyFit` log lines and the two screenshots above.
- **`height > 640` would be satisfied by 641.** The threshold pins the direction, not the
  sufficiency. Sufficiency is the photographed Welcome and Done screens.
- **The fitted size was measured on one display** (1920x1080). Behaviour at 1024x768 and at the
  1280x720 minimum is computed by the tested fold, not observed.
- **Several tests need real git** and would fail on a machine without it. Deliberate - they are
  integration tests, and a red on a git-less machine is informative rather than misleading.

## Unrelated defect found on the way

`scripts/agent-session-isolation.ps1` cannot launch a Director any more. It waits for
`Kestrel listening on http://0.0.0.0:<port>` in the log; the Director now binds loopback only and
writes `http://127.0.0.1:<port>`, so the launch always times out after 120 seconds and stops the
process it just started. Not touched here.

Closes devthrottle_internal#1048
Closes devthrottle_internal#1046

</details>
