### PR TITLE
The deploy skill is the only path, and it covers the Cockpit and mobile

### DIFF
--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-hosted-gateway
-description: Release the live hosted Gateway (the cloud service at devthrottle-gw.azurewebsites.net) by starting its GitHub deploy, watching it finish, and confirming the live service comes back healthy. This is the CLOUD Gateway, not the downloadable desktop app. Triggers on "release the gateway", "deploy the gateway", "push the gateway live", "update the hosted gateway", "redeploy the gateway".
+description: The ONLY way to deploy the hosted Gateway, the Cockpit and the mobile app - all three ship in one image, so this one skill covers all three. Starts the GitHub deploy, watches it, and reports the measured outage. This is the CLOUD Gateway, not the downloadable desktop app. Triggers on "release the gateway", "deploy the gateway", "push the gateway live", "update the hosted gateway", "redeploy the gateway", "deploy the cockpit", "update the cockpit", "ship the cockpit", "deploy mobile", "deploy the mobile app", "deploy to production".
 ---
 
 # Deploy the hosted Gateway
@@ -8,6 +8,11 @@ description: Release the live hosted Gateway (the cloud service at devthrottle-g
 Updates the live cloud Gateway that DevThrottle clients talk to. It rebuilds the
 Gateway container and pushes it live to Azure, then confirms the service is
 healthy again.
+
+**It covers the Cockpit and the mobile app too.** They are built INTO the Gateway
+container image (`wwwroot/c` and `wwwroot/mobile` - see the repo-root `Dockerfile`).
+There is no separate Cockpit deploy and no separate mobile deploy. If someone asks
+you to "deploy the Cockpit", this is the skill.
 
 This is NOT the desktop-app release. Cutting a version and building the
 downloadable `cc-director.exe` is a different job - use the `release-manager`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,31 @@ When using any cc-* tool, check `docs/cli-reference.md` for exact flags before c
 4. Write a test
 5. Read [docs/CodingStyle.md](docs/CodingStyle.md)
 
+## THERE IS EXACTLY ONE WAY TO DEPLOY THE GATEWAY, THE COCKPIT AND THE MOBILE APP
+
+**Use the `deploy-hosted-gateway` skill. Never any other way.**
+
+All three ship in ONE container image - the Cockpit and the mobile app are built into the Gateway image
+(`wwwroot/c` and `wwwroot/mobile`, see the repo-root `Dockerfile`). "Deploy the Cockpit" and "deploy
+mobile" mean this same one path. There is no separate Cockpit deploy and no separate mobile deploy.
+
+**FORBIDDEN, for every agent:**
+- `az webapp config container set`, `az webapp restart`, `az webapp deployment slot swap`, or any other
+  hand-rolled `az` command against `devthrottle-gw`
+- deploying from the Azure Portal
+- building an image and pinning it by hand
+
+**Why this is a rule and not a preference.** The deploy workflow warms a staging slot and swaps, so the
+cutover costs 0.0 seconds - measured. It refuses any ref that is not main. It refuses a commit whose
+checks have FAILED. It measures the real external outage at ~0.1s resolution and fails the run if it
+exceeds the budget. And it serialises against the rollback and provisioning workflows, because two
+containers on one shared file share corrupted a database on 2026-07-30 and took the service down for 32
+minutes. A hand-rolled deploy has none of that.
+
+If the skill cannot do what is needed, that is a gap to FIX IN THE WORKFLOW. Say so and stop.
+
+Rolling back is also a workflow (`rollback-hosted-gateway.yml`). Never swap by hand.
+
 ## NEVER MENTION CLAUDE ANYWHERE IN GITHUB - ABSOLUTE
 
 **NO Claude / Claude Code / Anthropic / AI attribution EVER appears in anything


### PR DESCRIPTION
The skill said it was the only way to update the live Gateway but never said what that *includes*. Anyone asked to "deploy the Cockpit" had nothing telling them it was the same act - and inventing a separate path is exactly how a hand-rolled deploy happens.

The Cockpit and mobile app are built **into** the Gateway image (`wwwroot/c`, `wwwroot/mobile`). One image, one deploy, one skill. Both are now in the skill's triggers.

Adds a CLAUDE.md rule naming the forbidden alternatives explicitly, with the reason attached.

Paired with devthrottle_internal#1237, which disables the second deploy path that still existed there (`step3-azure-deploy/deploy.sh` pinned an image straight onto production - it now refuses).