### PR TITLE
Say "no credit card" on the gateway card, and let the line wrap (#1044)

### DIFF
--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -616,8 +616,8 @@
                                      is granted only on an account's first arrival at the hosted gateway
                                      and never twice, so "you get 14 days" would be false for someone
                                      coming back. -->
-                                <TextBlock FontSize="12.5" Foreground="#8A909A"
-                                           Text="Part of Pro. New accounts get 14 days free, no card." />
+                                <TextBlock TextWrapping="Wrap" FontSize="12.5" Foreground="#8A909A"
+                                           Text="Part of Pro. New accounts get 14 days free, no credit card." />
                             </StackPanel>
                         </RadioButton>
 


### PR DESCRIPTION
Follow-up to #2408, owner-reported.

"No card" is shorthand we are fluent in and the reader is not - it makes someone stop and decode (no credit card? a card on the screen?) at the exact moment they are deciding. Spelled out here to match the sweep across the website (devthrottle_internal#1238, 23 instances).

## Also fixes a clipping risk I introduced in #2408

This TextBlock was the only one in the panel without `TextWrapping="Wrap"`. That was harmless when the text was the two words "Part of Pro"; once #2408 made it a sentence it could clip in a narrow card. Now wraps like its neighbours.

## Checks

- `dotnet build src/CcDirector.Avalonia` - succeeded, 0 warnings, 0 errors
- Copy plus one layout attribute; no behaviour change