### PR TITLE
Make the two-minute test budget a hard, enforced ceiling

### DIFF
--- a/scripts/test-local.ps1
+++ b/scripts/test-local.ps1
@@ -74,7 +74,6 @@ if ($Gateway -and $Parked) {
 #   HostedAgent          36s                      Launcher    2s      Terminal 11s
 # They start together, so the default costs about the slowest one.
 $defaultProjects = @(
-    "src\CcDirector.Gateway.UnitTests\CcDirector.Gateway.UnitTests.csproj",
     "src\CcDirector.Avalonia.Tests\CcDirector.Avalonia.Tests.csproj",
     "src\CcDirector.Engine.Tests\CcDirector.Engine.Tests.csproj",
     "src\CcDirector.HostedAgent.Tests\CcDirector.HostedAgent.Tests.csproj",
@@ -89,8 +88,24 @@ $defaultProjects = @(
 $gatewayProject = "src\CcDirector.Gateway.Tests\CcDirector.Gateway.Tests.csproj"
 $parkedProjects = @(
     $gatewayProject,
-    "src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj"
+    "src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj",
+    # Parked on measurement, not on principle - and the measurement is worth keeping because it says what
+    # would bring it back. 2762 tests, about 2 minutes on a quiet machine and 3 to 5 with the fleet busy.
+    # Raising its thread cap does NOT fix it: 24 threads ran it in 149 seconds against 120 at four, and
+    # brought the flakiness back. It uses about ONE core's worth of CPU throughout. It is not compute-bound,
+    # it is SLEEP-bound - the wall clock is Task.Delay and Thread.Sleep inside the tests, which no amount of
+    # hardware shortens. It comes back when those waits are replaced by injected clocks, not before.
+    "src\CcDirector.Gateway.UnitTests\CcDirector.Gateway.UnitTests.csproj"
 )
+
+# THE TWO-MINUTE BUDGET IS ENFORCED, NOT DOCUMENTED. A suite that exceeds it is KILLED and the run is
+# failed, naming it. This is a hard ceiling because the soft version did not hold: the budget was written
+# in a comment, Core.Tests drifted to eleven minutes on a quiet machine and thirty-three on a busy one, and
+# the gate became something people worked around instead of ran. A number that nothing checks is a wish.
+#
+# Exceeding it is not a test failure and must not be read as one - it is a statement that the suite no
+# longer belongs in the default run. Park it, and put it back the day it fits.
+$BudgetSeconds = 120
 
 $toRun = @()
 if ($Gateway) {
@@ -164,8 +179,18 @@ if ($toRun -contains $gatewayProject) {
 Write-Host ""
 
 $failed = @()
+$overBudget = @()
 foreach ($r in $running) {
-    $r.Process.WaitForExit()
+    # Wait only up to the budget. A suite that has not finished by then is over the ceiling: kill it, so a
+    # single slow project cannot hold the whole gate, and record it separately from a real failure.
+    # -Parked deliberately suspends the ceiling: that run is the release gate and is EXPECTED to be slow.
+    if ($Parked -or $Gateway) {
+        $r.Process.WaitForExit()
+    } elseif (-not $r.Process.WaitForExit($BudgetSeconds * 1000)) {
+        $overBudget += $r.Name
+        try { $r.Process.Kill($true) } catch { }
+        try { $r.Process.WaitForExit(10000) | Out-Null } catch { }
+    }
     $summary = ""
     if (Test-Path $r.Log) {
         $summary = (Select-String -Path $r.Log -Pattern "^(Passed!|Failed!)" -ErrorAction SilentlyContinue |
@@ -200,6 +225,17 @@ foreach ($r in $running) {
 Write-Host ""
 Write-Host "TRX files: $logDir"
 Write-Host ""
+
+if ($overBudget.Count -gt 0) {
+    Write-Host ("RESULT: OVER BUDGET - {0} suite(s) exceeded the {1}-second ceiling and were STOPPED:" -f $overBudget.Count, $BudgetSeconds)
+    foreach ($n in $overBudget) { Write-Host "  $n" }
+    Write-Host ""
+    Write-Host "This is NOT a test failure. It means the suite no longer belongs in the default run."
+    Write-Host "Park it in `$parkedProjects, or make it fit. Do not raise the ceiling to make this go away -"
+    Write-Host "the ceiling is the point, and every second added to it is paid by every person and agent"
+    Write-Host "on every change, forever."
+    exit 1
+}
 
 if ($failed.Count -eq 0) {
     Write-Host "RESULT: all projects exited zero. Check the TRX outcome and totals above before calling it green."


### PR DESCRIPTION
The budget was a comment, and comments do not hold. `Core.Tests` drifted to 11 minutes quiet and 33 busy, and the gate became something worked around rather than run.

**Now enforced.** Each suite gets 120 seconds. One that hasn't finished is killed and the run fails naming it, with a message stating plainly that this is *not* a test failure — it means the suite no longer belongs in the default run. `-Parked` and `-Gateway` suspend the ceiling, since that is the release gate and is expected to be slow.

## It immediately caught a suite I'd have argued to keep

`Gateway.UnitTests` — the 2,762 pure tests split out earlier today — doesn't fit either: ~2 min quiet, 3–5 with the fleet busy. Parked, with the measurement that says what would bring it back.

Raising its thread cap does **not** fix it:

| threads | wall | failures |
|---|---|---|
| 4 | ~120s | 0 |
| 12 | 163s | 1 |
| 24 | 149s | 3 |

More threads made it *slower* and brought back the flakiness the cap was added to remove.

## The real finding, and it is the same in both parked suites

They are not compute-bound, they are **sleep-bound**. `Core.Tests` spends 11 minutes of wall clock to burn **25 seconds of CPU** — about 97% of it waiting — because it is sequential *and* full of real `Task.Delay`/`Thread.Sleep`. `Gateway.UnitTests` draws about one core's worth throughout.

No amount of hardware shortens a sleep. A 24-core machine cannot help a suite that is idle. **These come back when their waits are replaced by injected clocks, not when they are given more threads.**

## Result

Default gate: **631 tests in under a minute**, end to end including the build.

## What it costs

Almost all Gateway and Core coverage is out of the default path; a regression in either can reach main without a local red until `-Parked` runs. That is the deliberate consequence of choosing a gate that is actually run over one that is comprehensive and skipped.