### PR TITLE
The Gateway suite was rebuilding its whole schema once per test: 2 minutes to under one

### DIFF
--- a/scripts/test-local.ps1
+++ b/scripts/test-local.ps1
@@ -74,6 +74,10 @@ if ($Gateway -and $Parked) {
 #   HostedAgent          36s                      Launcher    2s      Terminal 11s
 # They start together, so the default costs about the slowest one.
 $defaultProjects = @(
+    # BACK IN THE DEFAULT RUN. It was parked for exceeding the ceiling at about 2 minutes quiet and 3 to 5
+    # busy; it now finishes in under a minute, because the cost turned out to be the migration set being
+    # rebuilt from scratch once per database-backed test. 2762 tests.
+    "src\CcDirector.Gateway.UnitTests\CcDirector.Gateway.UnitTests.csproj",
     "src\CcDirector.Avalonia.Tests\CcDirector.Avalonia.Tests.csproj",
     "src\CcDirector.Engine.Tests\CcDirector.Engine.Tests.csproj",
     "src\CcDirector.HostedAgent.Tests\CcDirector.HostedAgent.Tests.csproj",
@@ -88,14 +92,7 @@ $defaultProjects = @(
 $gatewayProject = "src\CcDirector.Gateway.Tests\CcDirector.Gateway.Tests.csproj"
 $parkedProjects = @(
     $gatewayProject,
-    "src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj",
-    # Parked on measurement, not on principle - and the measurement is worth keeping because it says what
-    # would bring it back. 2762 tests, about 2 minutes on a quiet machine and 3 to 5 with the fleet busy.
-    # Raising its thread cap does NOT fix it: 24 threads ran it in 149 seconds against 120 at four, and
-    # brought the flakiness back. It uses about ONE core's worth of CPU throughout. It is not compute-bound,
-    # it is SLEEP-bound - the wall clock is Task.Delay and Thread.Sleep inside the tests, which no amount of
-    # hardware shortens. It comes back when those waits are replaced by injected clocks, not before.
-    "src\CcDirector.Gateway.UnitTests\CcDirector.Gateway.UnitTests.csproj"
+    "src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj"
 )
 
 # THE TWO-MINUTE BUDGET IS ENFORCED, NOT DOCUMENTED. A suite that exceeds it is KILLED and the run is

--- a/src/CcDirector.Gateway.Tests/Data/GatewayDbTestHarness.cs
+++ b/src/CcDirector.Gateway.Tests/Data/GatewayDbTestHarness.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Data;
+using Microsoft.Data.Sqlite;
 
 namespace CcDirector.Gateway.Tests.Data;
 
@@ -26,10 +27,59 @@ public sealed class GatewayDbTestHarness : IDisposable
     /// <summary>A path in this harness's directory (for a legacy JSON import file, or any test file).</summary>
     public string LegacyPath(string name) => Path.Combine(_dir, name);
 
+    /// <summary>
+    /// THE MIGRATED SCHEMA, BUILT ONCE PER TEST PROCESS AND THEN COPIED.
+    ///
+    /// Constructing a GatewayDatabase over an empty file runs the whole migration set, and that was the
+    /// single largest cost in this assembly: a database-backed test took about 355 milliseconds against
+    /// 0.45 for a pure one - roughly eight hundred times slower - and well over half the suite is
+    /// database-backed. It was not sleeping and it was not short of cores; it was rebuilding the same
+    /// schema from scratch, once per test, hundreds of times per run.
+    ///
+    /// Migrating once and copying the resulting file is behaviour-preserving rather than a shortcut: the
+    /// copy is produced by the SAME constructor over the same migration set, so every test still opens the
+    /// real schema through the real code path. EF then finds no pending migrations and skips Migrate(),
+    /// which the database already handles as a first-class case. What is removed is the repetition, not a
+    /// step.
+    /// </summary>
+    /// The template is held as BYTES, not as a path, and that detail is load-bearing. The first version
+    /// copied a file and called SqliteConnection.ClearAllPools() to release it - and ClearAllPools is
+    /// PROCESS-GLOBAL. Built lazily on first use, it fired while other tests were already running and
+    /// yanked THEIR pooled connections out from under them: every full run failed exactly one database
+    /// test, a different one each time, all passing in isolation. Reading the bytes once under a sharing
+    /// handle needs no pool clear at all, so nothing outside this type is disturbed - and writing from
+    /// memory is faster than copying a file besides.
+    private static readonly Lazy<byte[]> MigratedTemplate = new(BuildTemplate, isThreadSafe: true);
+
+    private static byte[] BuildTemplate()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-gateway-db-template-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "template.db");
+        // Construct and dispose: the constructor is what applies the migrations.
+        using (var db = new GatewayDatabase(new SingleTenantContext(), path)) { }
+        // Read it back with full sharing rather than clearing the global connection pool.
+        byte[] bytes;
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        {
+            bytes = new byte[fs.Length];
+            fs.ReadExactly(bytes);
+        }
+        try { Directory.Delete(dir, recursive: true); } catch { /* best effort; the bytes are already held */ }
+        return bytes;
+    }
+
     /// <summary>Open the shared database with the given tenant (defaults to the local single tenant).</summary>
     public GatewayDatabase Open(ITenantContext? tenant = null)
     {
         Directory.CreateDirectory(_dir);
+        // Seed from the migrated template on FIRST open only. A second Open() over the same path is a test
+        // deliberately simulating a Gateway restart, and must find the database it just wrote - not a fresh
+        // one - so the copy is conditional on the file not already existing.
+        if (!File.Exists(DbPath))
+        {
+            File.WriteAllBytes(DbPath, MigratedTemplate.Value);
+        }
         var db = new GatewayDatabase(tenant ?? new SingleTenantContext(), DbPath);
         _opened.Add(db);
         return db;


### PR DESCRIPTION
## I was wrong about the cause, and the correction is the useful part

I reported these suites as sleep-bound. They are not. The unlocked Gateway suite contains **19 sleep calls totalling one second**; Core.Tests has 68 totalling 24. Neither explains minutes.

That reading came from measuring CPU on the test host process alone and finding it near idle. Child processes don't appear in that number, and neither does time spent waiting on a database. *Low CPU* was read as *sleeping* when it meant *waiting on work happening somewhere I wasn't looking*.

## Where the time actually went

Measured per class:

| class | tests | time | per test |
|---|---|---|---|
| `SessionOrderingTests` (pure) | 118 | 53 ms | **0.45 ms** |
| `SnoozeRegistryTests` (database) | 31 | 11 s | **355 ms** |

A database-backed test cost ~800× a pure one, and well over half the suite is database-backed. Constructing a `GatewayDatabase` over an empty file applies the **entire migration set** — the same schema rebuilt from scratch, once per test, hundreds of times a run.

## The fix

The harness migrates **once** per process, holds the result as bytes, and writes those bytes per test. Behaviour-preserving rather than a shortcut: the template comes from the same constructor over the same migration set, every test still opens the real schema through the real code path, and EF's own "no pending migrations" branch then skips the work. Only the repetition goes.

Held as bytes rather than copied from a path deliberately — the first attempt used `File.Copy` plus `ClearAllPools()`, which is process-global and pulled other running tests' connections out from under them.

## Result

**2762 tests: 2 minutes → under one.** Back in the default gate, which now runs **3392 tests in ~80 seconds** end to end including the build.

## Known, not fixed here

One or two database tests still fail per run, never the same ones, all passing in isolation — a rate unchanged by this commit and present before it. The cause is now *located*: `GatewayDatabase.Dispose` calls `SqliteConnection.ClearAllPools()`, which is process-global. One database in a running Gateway makes that harmless, which is why it went unnoticed; hundreds disposing concurrently under test means every disposal reaches across every other live database.

A narrowing to `ClearPool` for this database's own connection string is **not** in this PR: it broke six `DeviceKeyAtRest` tests deterministically, so it was reverted rather than defended. Doing it correctly needs to establish how `Microsoft.Data.Sqlite` keys its pools — a separate piece of work with a production file in it.