### PR TITLE
The wizard stops telling a clean machine to clone a repository

### DIFF
--- a/src/CcDirector.Avalonia.Tests/WizardCleanMachineWordingTests.cs
+++ b/src/CcDirector.Avalonia.Tests/WizardCleanMachineWordingTests.cs
@@ -1,0 +1,43 @@
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The setup wizard's clean-machine acknowledgement must hold on a machine that cannot clone
+/// (devthrottle_internal issue #1048).
+///
+/// "I don't have code on this machine yet" is shown to exactly the person least likely to have git:
+/// someone on a clean Windows box that has never been set up for development. Telling them to clone
+/// a repository is advice they cannot act on, and the failure is quiet and late - they finish
+/// onboarding, go looking for the code they were told to clone, and meet "git: command not found"
+/// outside the product with nothing connecting it back to anything DevThrottle said.
+///
+/// Making a folder always works and needs nothing installed.
+/// </summary>
+public class WizardCleanMachineWordingTests
+{
+    [AvaloniaFact]
+    public void TheAcknowledgementDoesNotRequireGit()
+    {
+        var wizard = new FirstRunWizardDialog(new AgentOptions());
+
+        var text = wizard.CodeNoneAckText.Text ?? "";
+
+        Assert.Contains("Make a folder", text);
+        Assert.DoesNotContain("When you clone", text);
+    }
+
+    /// <summary>
+    /// Cloning is still offered - the point is that it is no longer the ONLY route. A rewrite that
+    /// removed it entirely would be its own kind of wrong: plenty of readers do have git.
+    /// </summary>
+    [AvaloniaFact]
+    public void BringingARepositoryOntoTheMachineIsStillOffered()
+    {
+        var wizard = new FirstRunWizardDialog(new AgentOptions());
+
+        Assert.Contains("bring a repository onto this machine", wizard.CodeNoneAckText.Text ?? "");
+    }
+}

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -404,9 +404,17 @@
                                 Content="I don't have code on this machine yet"
                                 HorizontalAlignment="Center" Margin="0,4,0,0"
                                 Click="BtnNoCodeYet_Click" />
+                        <!-- DO NOT ADVISE AN ACTION THE READER CANNOT TAKE (devthrottle_internal
+                             issue #1048). This said "when you clone or create your first repository",
+                             which needs git - and it is shown on exactly the machine least likely to
+                             have any: a clean Windows box that has never been set up for development.
+                             Making a folder always works, needs nothing installed, and is precisely
+                             what the clean-machine walk did, with a plain folder holding two files
+                             and no git anywhere. Cloning is still named as the other way in for
+                             anyone who has the tools; it is simply no longer the only route offered. -->
                         <TextBlock x:Name="CodeNoneAckText" Classes="hint" IsVisible="False"
                                    HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="480"
-                                   Text="No problem - nothing here is required. When you clone or create your first repository, add its folder from the Repositories view and DevThrottle picks it up." />
+                                   Text="No problem - nothing here is required. Make a folder for your code, or bring a repository onto this machine, then add that folder from the Repositories view and DevThrottle picks it up." />
                     </StackPanel>
                 </ScrollViewer>
                 <!-- The proof number: how many repositories the added folders will surface. -->


### PR DESCRIPTION
**Piece one of four.** Pull request #2410 was blocked by three independent review rounds and has been
split by RISK rather than by subject. This is the piece with genuinely zero dependencies: it changes
one sentence, nothing reads it but the screen, and no review round has ever faulted it.

## What was wrong

The Code step's clean-machine acknowledgement, behind "I don't have code on this machine yet", said:

> No problem - nothing here is required. **When you clone or create your first repository**, add its
> folder from the Repositories view and DevThrottle picks it up.

That sentence is shown to exactly the person least likely to have git: someone on a clean Windows box
that has never been set up for command-line development. On the clean-machine walk of v1.8.7,
`git available: False`.

The failure is quiet and late. The user finishes onboarding, goes looking for the code they were told
to clone, and meets `git: command not found` outside the product - with nothing connecting that back
to anything DevThrottle told them.

## What it says now

> No problem - nothing here is required. **Make a folder for your code, or bring a repository onto
> this machine**, then add that folder from the Repositories view and DevThrottle picks it up.

Making a folder always works and needs nothing installed. It is also exactly what the clean-machine
walk did: a plain folder with two files in it, no git anywhere, and that is what the run used
successfully. Cloning is still named as the other way in for anyone who has the tools - the point is
that it is no longer the ONLY route offered, not that it is wrong.

## Tests

Two, both able to fail:

- The acknowledgement does not require git - contains "Make a folder", does not contain "When you
  clone".
- Bringing a repository onto the machine is still offered. A rewrite that dropped cloning entirely
  would be its own kind of wrong, since plenty of readers do have git.

Reverting the sentence turns the first red. `CcDirector.Avalonia.Tests`: 348 passed.

## What this piece is NOT

It does not detect git, say anything about whether git is installed, or touch the Code step's other
copy. The git-is-recommended notice needs `GitPresenceDetector` and ships separately, with the
findings that belong to it.

Refs devthrottle_internal#1048
