### PR TITLE
git commands report a failed launch instead of throwing into their callers

### DIFF
--- a/src/CcDirector.Core.Tests/Git/GitLaunchGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitLaunchGuardTests.cs
@@ -1,0 +1,164 @@
+using CcDirector.Core.Git;
+using CcDirector.Core.Utilities;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Git;
+
+/// <summary>
+/// What the product does when git cannot be LAUNCHED (devthrottle_internal issue #1048).
+///
+/// The defect these cover had never once run. On a machine with no git, Process.Start does NOT
+/// return false - it THROWS Win32Exception with ERROR_FILE_NOT_FOUND. So the missing-git branch in
+/// each of these services was unreachable, and the exception left them by a route none of their
+/// callers expects: every one of them is written against a result object carrying Success=false.
+///
+/// The launch is failed here by naming an executable that resolves nowhere, so the operating system
+/// fails it for exactly the reason it fails on a clean Windows install. These tests therefore run
+/// on ANY machine, with or without git - which matters, because a machine without git is a supported
+/// machine and these are the tests it most needs to keep.
+///
+/// The assertion in every case is the same: a RESULT that says why, never an exception.
+/// </summary>
+public class GitLaunchGuardTests
+{
+    /// <summary>A command name no machine has. Deliberately not a path, so PATH resolution is what fails.</summary>
+    private const string NoSuchExecutable = "devthrottle-no-such-git-executable";
+
+    private const string NotInstalled = "git is not installed on this machine, or is not on PATH";
+
+    private static string ADirectoryThatExists() => Path.GetTempPath();
+
+    [Fact]
+    public async Task GitCommandRunner_WhenGitCannotBeLaunched_ReturnsAFailedResultRatherThanThrowing()
+    {
+        var runner = new GitCommandRunner(NoSuchExecutable);
+
+        var result = await runner.RunAsync(ADirectoryThatExists(), new[] { "worktree", "list", "--porcelain" });
+
+        Assert.False(result.Success);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Equal(NotInstalled, result.Error);
+    }
+
+    /// <summary>
+    /// The worktree inventory is what the Source Control tab's Worktrees page renders, and it is one
+    /// of the callers the exception used to escape into. With no git it must come back as an explicit
+    /// failure carrying the reason - an empty list would render as "this repository has no
+    /// worktrees", which is a statement nothing established.
+    /// </summary>
+    [Fact]
+    public async Task WorktreeInventory_WhenGitCannotBeLaunched_FailsWithTheReasonRatherThanLookingEmpty()
+    {
+        var service = new WorktreeInventoryService(new GitCommandRunner(NoSuchExecutable));
+
+        var inventory = await service.GetInventoryAsync(ADirectoryThatExists(), fetchPrune: false);
+
+        Assert.False(inventory.Success);
+        Assert.Empty(inventory.Worktrees);
+        Assert.Contains(NotInstalled, inventory.Error);
+    }
+
+    /// <summary>
+    /// Stage, unstage, discard and commit reach here from the desktop Source Control buttons, the
+    /// Control API git verbs, and through those the Cockpit and the phone. None of them catches an
+    /// exception; all of them read GitWriteResult.Success.
+    /// </summary>
+    [Fact]
+    public async Task GitWriteService_Commit_WhenGitCannotBeLaunched_ReturnsAFailedResult()
+    {
+        var result = await new GitWriteService(NoSuchExecutable).CommitAsync(ADirectoryThatExists(), "a message");
+
+        Assert.False(result.Success);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Equal(NotInstalled, result.Error);
+    }
+
+    [Fact]
+    public async Task GitWriteService_Stage_WhenGitCannotBeLaunched_ReturnsAFailedResult()
+    {
+        var result = await new GitWriteService(NoSuchExecutable).StageAsync(ADirectoryThatExists(), Array.Empty<string>());
+
+        Assert.False(result.Success);
+        Assert.Equal(NotInstalled, result.Error);
+    }
+
+    /// <summary>
+    /// ProcessRunner has always DOCUMENTED a Started=false result for a process that could not start.
+    /// It could never produce one: Start throws for a missing executable rather than returning false,
+    /// so the branch naming that case was unreachable and every caller carried its own catch-all.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRunner_WithAMissingExecutable_ReportsNotStartedWithTheOperatingSystemCode()
+    {
+        var result = await ProcessRunner.RunAsync(NoSuchExecutable, new[] { "--version" }, ADirectoryThatExists());
+
+        Assert.False(result.Started);
+        Assert.Equal(-1, result.ExitCode);
+        // Carrying the CODE is what lets a caller say "not installed" without guessing at the
+        // wording of an operating system message, which differs by platform and by language.
+        Assert.Equal(2, result.StartErrorCode);
+    }
+
+    /// <summary>
+    /// The read provider the Source Control view renders. It used to report a fixed "Failed to start
+    /// git process", which threw the reason away - and said the same thing when git ran perfectly
+    /// well and merely exited non-zero. The launch is failed here with a working directory that does
+    /// not exist, which reaches the same wiring on a machine that HAS git.
+    /// </summary>
+    [Fact]
+    public async Task GitStatusProvider_WhenGitCannotBeLaunched_ReportsTheReason()
+    {
+        var missingDirectory = Path.Combine(Path.GetTempPath(), "devthrottle-no-such-directory-" + Guid.NewGuid().ToString("N"));
+
+        var result = await new GitStatusProvider().GetStatusAsync(missingDirectory);
+
+        Assert.False(result.Success);
+        Assert.NotEqual("Failed to start git process", result.Error);
+
+        // The sharper assertion, and the one worth having: git IS installed on this machine - the
+        // working directory is what is missing - so the message must NOT claim git is absent. A rule
+        // that mapped every launch failure to "not installed" would pass a prefix check and still be
+        // telling the user to reinstall software they already have.
+        Assert.DoesNotContain("not installed", result.Error!);
+        Assert.StartsWith("git could not be started: ", result.Error);
+        Assert.True(
+            result.Error!.Length > "git could not be started: ".Length,
+            "the reason was dropped - only the prefix survived");
+    }
+
+    // ---- The sentence itself -----------------------------------------------------------------
+
+    [Fact]
+    public void NoSuchFile_SaysNotInstalled()
+    {
+        // Code 2 is ERROR_FILE_NOT_FOUND on Windows and ENOENT on POSIX - the same meaning on both.
+        Assert.Equal(NotInstalled, GitLaunchFailure.Describe(2, "No such file or directory"));
+    }
+
+    /// <summary>
+    /// Code 3 is Windows ERROR_PATH_NOT_FOUND but POSIX ESRCH, "no such process", which says nothing
+    /// about whether git is installed. The platform is passed in rather than read from the machine:
+    /// on Windows the correct rule and "code 3 means missing everywhere" produce identical output, so
+    /// a test reading the real platform could not fail here however wrong the rule became.
+    /// </summary>
+    [Fact]
+    public void CodeThree_IsOnlyAMissingFileOnWindows()
+    {
+        Assert.Equal(NotInstalled, GitLaunchFailure.Describe(3, "The system cannot find the path specified", isWindows: true));
+
+        var onPosix = GitLaunchFailure.Describe(3, "No such process", isWindows: false);
+        Assert.Equal("git could not be started: No such process", onPosix);
+        Assert.DoesNotContain("not installed", onPosix);
+    }
+
+    [Fact]
+    public void AnyOtherCode_KeepsTheRealReason()
+    {
+        // 5 is ERROR_ACCESS_DENIED: git is right there, and calling that "not installed" would send
+        // the user off to reinstall something already on the machine.
+        var message = GitLaunchFailure.Describe(5, "Access is denied");
+
+        Assert.Equal("git could not be started: Access is denied", message);
+        Assert.DoesNotContain("not installed", message);
+    }
+}

--- a/src/CcDirector.Core/Git/GitCommandRunner.cs
+++ b/src/CcDirector.Core/Git/GitCommandRunner.cs
@@ -29,6 +29,22 @@ public sealed class GitCommandResult
 /// </summary>
 public class GitCommandRunner
 {
+    private readonly string _executable;
+
+    /// <summary>Runs the <c>git</c> on this machine's PATH. This is the only production form.</summary>
+    public GitCommandRunner() : this("git") { }
+
+    /// <summary>
+    /// Runs <paramref name="executable"/> instead of <c>git</c>. A TEST SEAM, and the only way to
+    /// reach the missing-git branch on a machine that has git: pass a name that resolves nowhere and
+    /// the launch fails for precisely the reason it fails on a clean Windows install. Production
+    /// never calls this - every call site uses the parameterless constructor above.
+    /// </summary>
+    public GitCommandRunner(string executable)
+    {
+        _executable = executable;
+    }
+
     /// <summary>
     /// Runs <c>git &lt;args&gt;</c> in <paramref name="workingDirectory"/> and returns its result.
     /// </summary>
@@ -39,7 +55,7 @@ public class GitCommandRunner
 
         var psi = new ProcessStartInfo
         {
-            FileName = "git",
+            FileName = _executable,
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -56,7 +72,24 @@ public class GitCommandRunner
         proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
         proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
 
-        proc.Start();
+        // A machine with no git is a supported machine (devthrottle_internal issue #1048), and on one
+        // Process.Start does not return false - it THROWS Win32Exception "The system cannot find the
+        // file specified". Unguarded, that exception left this method by a route none of its callers
+        // expect: every one of them is written against a GitCommandResult carrying Success=false, and
+        // the class already returns exactly that for the other reason a command cannot run (the
+        // working directory being absent, above). Reporting the missing git the same way keeps one
+        // contract instead of two, and puts a sentence a person can act on where the surfaces that
+        // render it - the Worktrees page, the branch services - already display the Error.
+        try
+        {
+            proc.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            FileLog.Write($"[GitCommandRunner] git could not be started: {ex.Message}");
+            return new GitCommandResult { Success = false, ExitCode = -1, Error = GitLaunchFailure.Describe(ex) };
+        }
+
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
         try

--- a/src/CcDirector.Core/Git/GitLaunchFailure.cs
+++ b/src/CcDirector.Core/Git/GitLaunchFailure.cs
@@ -1,0 +1,59 @@
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// The one sentence the product shows when a git command could not be LAUNCHED at all - as opposed
+/// to one that ran and failed, which speaks for itself.
+///
+/// It lives in ONE place because three of them render it - the read providers, the write service,
+/// and the desktop Source Control view - and a sentence copied three times is a sentence that can
+/// only ever be corrected in one of them.
+/// </summary>
+public static class GitLaunchFailure
+{
+    /// <summary>
+    /// Code 2. Windows ERROR_FILE_NOT_FOUND, and POSIX ENOENT. It means the same thing on both -
+    /// there is no such file - which is why it is the one code read on every platform.
+    /// </summary>
+    private const int FileNotFound = 2;
+
+    /// <summary>
+    /// Code 3. WINDOWS ONLY: ERROR_PATH_NOT_FOUND. On POSIX the same number is ESRCH, "no such
+    /// process", which says nothing at all about whether git is installed - reading it as a missing
+    /// install on macOS would tell a Mac user to reinstall software that is sitting on their disk.
+    /// </summary>
+    private const int PathNotFoundWindowsOnly = 3;
+
+    /// <summary>
+    /// Describe why git did not launch, WITHOUT over-claiming. "Not installed" is said only for the
+    /// codes that actually mean the file is not there on THIS operating system; every other reason -
+    /// a permission refusal, a corrupt image, an execution policy - reports itself in its own words
+    /// rather than being relabelled as a missing install and sending someone off to reinstall
+    /// software that is already on their machine.
+    /// </summary>
+    /// <param name="nativeErrorCode">The operating system's own error number from the failed launch.</param>
+    /// <param name="reason">What the failure said, used verbatim for every other code.</param>
+    public static string Describe(int nativeErrorCode, string? reason)
+        => Describe(nativeErrorCode, reason, OperatingSystem.IsWindows());
+
+    /// <summary>
+    /// The rule with the platform passed in. Exposed because the Windows-only reading of code 3 is
+    /// otherwise UNFALSIFIABLE on Windows: a test running here cannot tell the correct rule from one
+    /// that reads code 3 as a missing file everywhere, so the guard would have no test able to fail.
+    /// </summary>
+    internal static string Describe(int nativeErrorCode, string? reason, bool isWindows)
+    {
+        var meansThereIsNoSuchFile =
+            nativeErrorCode == FileNotFound
+            || (isWindows && nativeErrorCode == PathNotFoundWindowsOnly);
+
+        if (meansThereIsNoSuchFile)
+            return "git is not installed on this machine, or is not on PATH";
+        return string.IsNullOrWhiteSpace(reason)
+            ? "git could not be started"
+            : $"git could not be started: {reason}";
+    }
+
+    /// <summary>The same rule, for a launch failure that arrived as an exception.</summary>
+    public static string Describe(System.ComponentModel.Win32Exception ex)
+        => Describe(ex.NativeErrorCode, ex.Message);
+}

--- a/src/CcDirector.Core/Git/GitStatusProvider.cs
+++ b/src/CcDirector.Core/Git/GitStatusProvider.cs
@@ -153,7 +153,10 @@ public class GitStatusProvider
             // scan could not stop it.
             var r = await ProcessRunner.RunAsync("git", new[] { "status", "--porcelain=v1", "-u" }, repoPath, ct);
             if (!r.Started)
-                return ("", "Failed to start git process", -1);
+                // Carries the REASON, not just the fact. On a machine with no git this is the
+                // sentence the Source Control view puts on the screen (issue #1048); it used to be
+                // the fixed "Failed to start git process", which threw the reason away.
+                return ("", GitLaunchFailure.Describe(r.StartErrorCode, r.StandardError), -1);
             return (r.StandardOutput, r.StandardError, r.ExitCode);
         }
         catch (OperationCanceledException)

--- a/src/CcDirector.Core/Git/GitSyncStatusProvider.cs
+++ b/src/CcDirector.Core/Git/GitSyncStatusProvider.cs
@@ -21,11 +21,11 @@ public class GitSyncStatusProvider
     {
         try
         {
-            var output = await RunGitAsync(repoPath, new[] { "status", "--branch", "--porcelain=v2" }, ct);
-            if (output == null)
-                return new GitSyncStatus { Success = false, Error = "Failed to start git process" };
+            var read = await RunGitAsync(repoPath, new[] { "status", "--branch", "--porcelain=v2" }, ct);
+            if (read.Output == null)
+                return new GitSyncStatus { Success = false, Error = read.Problem };
 
-            var status = ParseBranchHeaders(output);
+            var status = ParseBranchHeaders(read.Output);
 
             // Determine behind-main count if not on main
             if (!status.IsDetachedHead && !IsMainBranch(status.BranchName))
@@ -33,8 +33,8 @@ public class GitSyncStatusProvider
                 var mainBranch = await DetectMainBranchAsync(repoPath, ct);
                 if (mainBranch != null)
                 {
-                    var countOutput = await RunGitAsync(repoPath, new[] { "rev-list", "--count", $"HEAD..origin/{mainBranch}" }, ct);
-                    if (countOutput != null && int.TryParse(countOutput.Trim(), out var count))
+                    var countRead = await RunGitAsync(repoPath, new[] { "rev-list", "--count", $"HEAD..origin/{mainBranch}" }, ct);
+                    if (countRead.Output != null && int.TryParse(countRead.Output.Trim(), out var count))
                     {
                         return new GitSyncStatus
                         {
@@ -138,11 +138,11 @@ public class GitSyncStatusProvider
     private async Task<string?> DetectMainBranchAsync(string repoPath, CancellationToken ct)
     {
         var result = await RunGitAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/main" }, ct);
-        if (result != null)
+        if (result.Output != null)
             return "main";
 
         result = await RunGitAsync(repoPath, new[] { "rev-parse", "--verify", "--quiet", "origin/master" }, ct);
-        if (result != null)
+        if (result.Output != null)
             return "master";
 
         return null;
@@ -151,14 +151,24 @@ public class GitSyncStatusProvider
     private static bool IsMainBranch(string branchName) =>
         branchName is "main" or "master";
 
-    private async Task<string?> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
+    /// <summary>
+    /// One git read. <c>Output</c> is null unless the command both launched and exited zero;
+    /// <c>Problem</c> then says which of those two it was. Keeping them apart is the point: the
+    /// caller used to report "Failed to start git process" for BOTH, so a git that ran perfectly
+    /// well and exited non-zero was described as never having started (issue #1048).
+    /// </summary>
+    private readonly record struct GitRead(string? Output, string Problem);
+
+    private async Task<GitRead> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
     {
         // ProcessRunner drains BOTH pipes (the old code never drained stderr, so a git command that
         // filled its error pipe could deadlock) and honors cancellation by killing the child so a
         // superseded scan does not leave git processes behind (issue 516).
         var r = await ProcessRunner.RunAsync("git", args, repoPath, ct);
         if (!r.Started)
-            return null;
-        return r.ExitCode == 0 ? r.StandardOutput : null;
+            return new GitRead(null, GitLaunchFailure.Describe(r.StartErrorCode, r.StandardError));
+        if (r.ExitCode != 0)
+            return new GitRead(null, $"git {string.Join(' ', args)} exited {r.ExitCode}: {r.StandardError.Trim()}");
+        return new GitRead(r.StandardOutput, "");
     }
 }

--- a/src/CcDirector.Core/Git/GitWriteService.cs
+++ b/src/CcDirector.Core/Git/GitWriteService.cs
@@ -23,6 +23,22 @@ public sealed class GitWriteResult
 /// </summary>
 public sealed class GitWriteService
 {
+    private readonly string _executable;
+
+    /// <summary>Runs the <c>git</c> on this machine's PATH. This is the only production form.</summary>
+    public GitWriteService() : this("git") { }
+
+    /// <summary>
+    /// Runs <paramref name="executable"/> instead of <c>git</c>. A TEST SEAM, and the only way to
+    /// reach the missing-git branch on a machine that has git: pass a name that resolves nowhere and
+    /// the launch fails for precisely the reason it fails on a clean Windows install. Production
+    /// never calls this.
+    /// </summary>
+    public GitWriteService(string executable)
+    {
+        _executable = executable;
+    }
+
     /// <summary>Stage paths (<c>git add -- &lt;paths&gt;</c>), or everything when paths is empty (<c>git add -A</c>).</summary>
     public Task<GitWriteResult> StageAsync(string repoPath, IReadOnlyList<string> paths, CancellationToken ct = default)
         => paths.Count == 0
@@ -64,14 +80,14 @@ public sealed class GitWriteService
         return args.ToArray();
     }
 
-    private static async Task<GitWriteResult> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
+    private async Task<GitWriteResult> RunGitAsync(string repoPath, string[] args, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
             return new GitWriteResult { Success = false, Error = $"repo path not found: {repoPath}" };
 
         var psi = new ProcessStartInfo
         {
-            FileName = "git",
+            FileName = _executable,
             WorkingDirectory = repoPath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -88,7 +104,22 @@ public sealed class GitWriteService
         proc.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.AppendLine(e.Data); };
         proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.AppendLine(e.Data); };
 
-        proc.Start();
+        // On a machine with no git, Process.Start THROWS Win32Exception rather than returning false.
+        // Unguarded it escaped every caller of stage / unstage / discard / commit - the desktop Source
+        // Control buttons, the Control API git verbs, and through them the Cockpit and the phone -
+        // none of which catches it: they all read GitWriteResult.Success. Reported as a failed result
+        // it reaches all three surfaces as the sentence below instead of an unhandled exception
+        // (devthrottle_internal issue #1048).
+        try
+        {
+            proc.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            FileLog.Write($"[GitWriteService] git could not be started: {ex.Message}");
+            return new GitWriteResult { Success = false, ExitCode = -1, Error = GitLaunchFailure.Describe(ex) };
+        }
+
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
         await proc.WaitForExitAsync(ct);

--- a/src/CcDirector.Core/Git/PullRequestService.cs
+++ b/src/CcDirector.Core/Git/PullRequestService.cs
@@ -172,7 +172,10 @@ public sealed class PullRequestService
             // cancellation - a CLI that fills its stderr pipe (an auth prompt, a stack of warnings)
             // can no longer deadlock the capture, and a cancelled call leaves no orphaned process.
             var r = await ProcessRunner.RunAsync(exe, args, workingDir, ct);
-            return r.Started ? (r.ExitCode, r.StandardOutput, r.StandardError) : (-1, "", $"{exe} could not start");
+            // ProcessRunner puts WHY it could not start into StandardError (a missing executable
+            // reads "The system cannot find the file specified"). Passing that through keeps the
+            // reason, which a bare "could not start" threw away.
+            return (r.ExitCode, r.StandardOutput, r.StandardError);
         }
         catch (OperationCanceledException)
         {

--- a/src/CcDirector.Core/Utilities/ProcessRunner.cs
+++ b/src/CcDirector.Core/Utilities/ProcessRunner.cs
@@ -15,8 +15,14 @@ namespace CcDirector.Core.Utilities;
 /// </summary>
 public static class ProcessRunner
 {
-    /// <summary>The captured result. <see cref="Started"/> is false when the process could not start.</summary>
-    public readonly record struct Result(int ExitCode, string StandardOutput, string StandardError, bool Started);
+    /// <summary>
+    /// The captured result. <see cref="Started"/> is false when the process could not start, and
+    /// <see cref="StartErrorCode"/> then carries the operating system's own error number so the
+    /// caller can tell "there is no such executable" apart from "it exists and refused to run" -
+    /// a distinction the message text alone cannot be trusted to carry.
+    /// </summary>
+    public readonly record struct Result(
+        int ExitCode, string StandardOutput, string StandardError, bool Started, int StartErrorCode = 0);
 
     /// <summary>
     /// Starts <paramref name="fileName"/> with <paramref name="args"/> in
@@ -41,8 +47,21 @@ public static class ProcessRunner
             psi.ArgumentList.Add(a);
 
         using var proc = new Process { StartInfo = psi };
-        if (!proc.Start())
-            return new Result(-1, "", $"{fileName} could not start", Started: false);
+
+        // Start does NOT return false when the executable is missing - it throws Win32Exception ("The
+        // system cannot find the file specified"). Without this catch the Started=false result was
+        // unreachable for the one case it names, and every caller had to carry its own catch-all to
+        // survive a machine with no git (devthrottle_internal issue #1048). Catching it here is what
+        // makes the documented contract on Started true.
+        try
+        {
+            if (!proc.Start())
+                return new Result(-1, "", $"{fileName} could not start", Started: false);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            return new Result(-1, "", ex.Message, Started: false, StartErrorCode: ex.NativeErrorCode);
+        }
 
         // Start draining BOTH pipes immediately and concurrently - neither read waits on the other.
         var outTask = proc.StandardOutput.ReadToEndAsync(ct);


### PR DESCRIPTION
**Piece two of four.** Pull request #2410 was blocked by three independent review rounds and has been
split by RISK rather than by subject. This is the settled part, and the part that repairs a real
fault on a real machine.

## The defect

**On a machine with no git, `Process.Start` does not return false - it throws `Win32Exception` with
`ERROR_FILE_NOT_FOUND`.**

So the missing-git branch in each of these services had never once run, and the exception left them
by a route none of their callers expects: every one is written against a result object carrying
`Success=false`.

This came out of the instruction on devthrottle_internal#1048 to exercise the Director's Source
Control button on a git-less machine - which that report flagged and said outright it had not
exercised. An unexercised path is not a working path, and this one was not working.

| Service | What it did with no git | Now |
|---|---|---|
| `GitCommandRunner` | Threw into the worktree inventory, the branch / diff / history services, and the repository monitor | Returns the failed result its callers already handle, so the Worktrees page reports the reason it already knows how to render |
| `GitWriteService` | Threw out of stage, unstage, discard and commit - desktop Source Control buttons, Control API git verbs, and through those the Cockpit and the phone | Same fix; all three surfaces get a sentence |
| `ProcessRunner` | Documented a `Started=false` result it could never produce | Produces it, which is what makes the read providers honest without a catch-all |
| `GitStatusProvider`, `GitSyncStatusProvider` | A fixed "failed to start git" message that threw the reason away - and said the same thing when git ran fine and merely exited non-zero | Carry the real reason, and tell a failed launch apart from a non-zero exit |

## The sentence does not over-claim

"Not installed" is a claim about someone's computer, so it is made only for the codes that mean the
file is not there **on this operating system**:

- **Code 2** is `ERROR_FILE_NOT_FOUND` on Windows and `ENOENT` on POSIX. Same meaning; read on both.
- **Code 3** is `ERROR_PATH_NOT_FOUND` on Windows but `ESRCH`, "no such process", on POSIX - where it
  says nothing at all about whether git is installed. Reading it as a missing install would tell a
  Mac user to reinstall software sitting on their disk.
- **Anything else** - a permission refusal, a corrupt image - reports itself in its own words.

The sentence lives in one place, because three surfaces render it and a sentence copied three times
can only ever be corrected in one of them.

## Tests

**Every test here fails the launch by naming an executable that resolves nowhere**, so they run on
any machine, with or without git. That is deliberate: a machine without git is a supported machine,
and these are the tests it most needs to keep. Nothing here is skipped or environment-dependent.

Two assertions worth calling out, because both were weaker in an earlier draft and a reviewer was
right about them:

- The `GitStatusProvider` test asserts that the message does **not** say git is missing - git IS
  installed on the test machine; the working directory is what is absent. A rule mapping every launch
  failure to "not installed" would pass a prefix check and still be wrong.
- The code-3 rule takes the platform as a parameter. On Windows the correct rule and "code 3 means
  missing everywhere" produce identical output, so a test reading the real platform could not fail
  here however wrong the rule became.

`CcDirector.Core.Tests` git filter: 9 passed. Revert-proven - removing each guard turns its own tests
red, with the mutation confirmed present by diff first.

## Why this is separated from the rest

Across all three review rounds, **not one finding landed on these guards.** (`GitLaunchFailure`, the
shared message helper they call, was faulted once - for reading Windows error numbers on macOS - and
that is the code-3 rule above, fixed and clean since.) The findings that blocked #2410 belong to
`GitPresenceDetector`, the wizard notice, and the Source Control view refresh, which ship separately.

Holding this back with them would defer the only part that fixes something, on the strength of
findings belonging to a different component.

Refs devthrottle_internal#1048
