### PR TITLE
Four architecture guards decided what is test code, and all four were wrong at once

### DIFF
--- a/src/CcDirector.Core.Tests/AgentPlugins/AgentPluginArchitectureGuardTests.cs
+++ b/src/CcDirector.Core.Tests/AgentPlugins/AgentPluginArchitectureGuardTests.cs
@@ -43,11 +43,20 @@ public sealed class AgentPluginArchitectureGuardTests
         foreach (var path in Directory.EnumerateFiles(src, "*.cs", SearchOption.AllDirectories))
         {
             var normalized = path.Replace('\\', '/');
-            // One shared predicate (see TestProjectPath). This guard was the fourth carrier of a
+            // Repository-RELATIVE, which is the documented contract: an absolute path would let a
+
+            // checkout living under a folder ending in "Tests" disable this scan entirely, which is a
+
+            // correctness property depending on where somebody cloned. The predicate anchors on a source
+
+            // root as well, so this is belt and braces rather than the only defence.
+
+            // This guard was the fourth carrier of a
             // copy-pasted ".Tests/" substring test, and it stayed GREEN through the suite split only
             // because nothing among the 2,750 files that moved into ".UnitTests" happened to match its
             // pattern - latent rather than satisfied.
-            if (TestProjectPath.IsTestProject(normalized))
+            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+            if (TestProjectPath.IsTestProject(relative))
                 continue;
             if (normalized.Contains("/AgentPlugins/", StringComparison.OrdinalIgnoreCase))
                 continue;

--- a/src/CcDirector.Core.Tests/AgentPlugins/AgentPluginArchitectureGuardTests.cs
+++ b/src/CcDirector.Core.Tests/AgentPlugins/AgentPluginArchitectureGuardTests.cs
@@ -43,7 +43,11 @@ public sealed class AgentPluginArchitectureGuardTests
         foreach (var path in Directory.EnumerateFiles(src, "*.cs", SearchOption.AllDirectories))
         {
             var normalized = path.Replace('\\', '/');
-            if (normalized.Contains(".Tests/", StringComparison.OrdinalIgnoreCase))
+            // One shared predicate (see TestProjectPath). This guard was the fourth carrier of a
+            // copy-pasted ".Tests/" substring test, and it stayed GREEN through the suite split only
+            // because nothing among the 2,750 files that moved into ".UnitTests" happened to match its
+            // pattern - latent rather than satisfied.
+            if (TestProjectPath.IsTestProject(normalized))
                 continue;
             if (normalized.Contains("/AgentPlugins/", StringComparison.OrdinalIgnoreCase))
                 continue;

--- a/src/CcDirector.Core.Tests/GatewayOnlyTranscriptionGuardTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayOnlyTranscriptionGuardTests.cs
@@ -54,9 +54,11 @@ public sealed class GatewayOnlyTranscriptionGuardTests
             + string.Join("\n  ", offenders));
     }
 
-    // One shared predicate (see TestProjectPath) - this guard was one of the two that stayed GREEN
-    // after the suite split, not because it was satisfied but because nothing among the moved files
-    // happened to match its pattern. Latent, not passing.
+    // One shared predicate (see TestProjectPath). This guard is one of the two that FIRED after the
+    // suite split - two moved files carry the forbidden construction outside every allowed prefix, and
+    // the old substring stopped excluding them. The twelve reported offenders are ten loopback plus
+    // these two. The LATENT pair - green only because nothing moved happened to match them - is the
+    // agent-plugin and storage-root guards.
     private static bool IsTestProject(string rel) => TestProjectPath.IsTestProject(rel);
 
     private static string Relative(string root, string full)

--- a/src/CcDirector.Core.Tests/GatewayOnlyTranscriptionGuardTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayOnlyTranscriptionGuardTests.cs
@@ -54,8 +54,10 @@ public sealed class GatewayOnlyTranscriptionGuardTests
             + string.Join("\n  ", offenders));
     }
 
-    private static bool IsTestProject(string rel)
-        => rel.Contains(".Tests/", StringComparison.OrdinalIgnoreCase);
+    // One shared predicate (see TestProjectPath) - this guard was one of the two that stayed GREEN
+    // after the suite split, not because it was satisfied but because nothing among the moved files
+    // happened to match its pattern. Latent, not passing.
+    private static bool IsTestProject(string rel) => TestProjectPath.IsTestProject(rel);
 
     private static string Relative(string root, string full)
         => Path.GetRelativePath(root, full).Replace('\\', '/');

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -142,8 +142,10 @@ public sealed class NoCrossMachineLoopbackGuardTests
         => text.Contains("127.0.0.1", StringComparison.Ordinal)
            || text.Contains("localhost", StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsTestProject(string rel)
-        => rel.Contains(".Tests/", StringComparison.OrdinalIgnoreCase);
+    // One shared predicate (see TestProjectPath): four guards each carried their own copy of this
+    // decision, and all four were wrong at once when the Gateway suite split moved 2,750 files into a
+    // project spelled ".UnitTests", which does not contain ".Tests/".
+    private static bool IsTestProject(string rel) => TestProjectPath.IsTestProject(rel);
 
     private static string Relative(string root, string full)
         => Path.GetRelativePath(root, full).Replace('\\', '/');

--- a/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
+++ b/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
@@ -144,8 +144,9 @@ public sealed class StorageRootGuardTests
         return false;
     }
 
-    private static bool IsTestProject(string rel)
-        => rel.Contains(".Tests/", StringComparison.OrdinalIgnoreCase);
+    // One shared predicate (see TestProjectPath) - the other guard that stayed green by luck rather
+    // than by being satisfied, and would have fired later on an unrelated change.
+    private static bool IsTestProject(string rel) => TestProjectPath.IsTestProject(rel);
 
     private static string Relative(string root, string full)
         => Path.GetRelativePath(root, full).Replace('\\', '/');

--- a/src/CcDirector.Core.Tests/TestProjectPath.cs
+++ b/src/CcDirector.Core.Tests/TestProjectPath.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Decides whether a repository-relative path belongs to a TEST project.
+///
+/// WHY THIS EXISTS AS ONE THING. Four architecture guards - the loopback guard, the transcription
+/// guard, the agent-plugin guard and the storage-root guard - each scan the repository and skip test
+/// code, because a literal that is forbidden in production is ordinary in a fixture. Each of them
+/// carried its OWN copy of that decision, written as <c>rel.Contains(".Tests/")</c>. Four copies is
+/// four places to be wrong, and on 2 August all four were wrong at once: the Gateway test suite was
+/// split and its fast half moved to <c>src/CcDirector.Gateway.UnitTests/</c>, whose path contains
+/// <c>.UnitTests/</c> and therefore does NOT contain <c>.Tests/</c>. Roughly 2,750 test files became
+/// "production" to every one of those guards in a single commit.
+///
+/// Two of the four then failed loudly, naming twelve files nobody had touched. **The other two passed
+/// - not because they were satisfied, but because nothing among those 2,750 files happened to match
+/// their patterns.** They were latent, and would have fired later on an unrelated change, presenting
+/// as a red with no visible connection to a file move weeks earlier.
+///
+/// So the repair is one predicate, not four corrections.
+///
+/// WHAT IT DECIDES ON. The name of a DIRECTORY in the path, not a substring of the whole path. A test
+/// project is one whose directory name ENDS WITH "Tests" - which is true of <c>CcDirector.Core.Tests</c>,
+/// <c>CcDirector.Gateway.Tests</c> and <c>CcDirector.Gateway.UnitTests</c> alike, and stays true for any
+/// future <c>.IntegrationTests</c> or <c>.ContractTests</c> without anybody remembering to come back
+/// here. The file name itself is never consulted: <c>Foo.Tests.cs</c> sitting in a production project
+/// is production code.
+/// </summary>
+internal static class TestProjectPath
+{
+    /// <summary>
+    /// True when <paramref name="repoRelativePath"/> - forward-slashed, relative to the repository
+    /// root - lies inside a test project.
+    /// </summary>
+    internal static bool IsTestProject(string repoRelativePath)
+    {
+        if (string.IsNullOrWhiteSpace(repoRelativePath)) return false;
+
+        var segments = repoRelativePath.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        // Every segment EXCEPT the last, which is the file name. A directory decides this, not a file.
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (segments[i].EndsWith("Tests", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/CcDirector.Core.Tests/TestProjectPath.cs
+++ b/src/CcDirector.Core.Tests/TestProjectPath.cs
@@ -28,25 +28,52 @@ namespace CcDirector.Core.Tests;
 /// here. The file name itself is never consulted: <c>Foo.Tests.cs</c> sitting in a production project
 /// is production code.
 /// </summary>
+/// WHY NOT SIMPLY "ANY ANCESTOR DIRECTORY ENDING IN Tests". The first version of this helper did
+/// exactly that, and an inspection caught two ways it is wrong - both of which SILENCE a guard, which
+/// is worse than the narrowing it was written to replace:
+///
+///   * <c>src/CcDirector.Core/DiagnosticsTests/Probe.cs</c> is PRODUCTION code inside the production
+///     project <c>CcDirector.Core</c>. Matching any ancestor makes it invisible to all four guards
+///     while every one of them stays green.
+///   * A caller passing an ABSOLUTE path would match an ancestor OUTSIDE the repository entirely. A
+///     checkout living under any folder whose name ends in "Tests" would disable a guard completely -
+///     a defect that depends on where somebody happened to clone, and appears nowhere in the code.
+///
+/// So the decision is the OWNING PROJECT directory, found by anchoring on a known source root: the
+/// project is the segment DIRECTLY BELOW <c>src</c>, <c>tools</c> or <c>phone</c>. Anchoring on the
+/// root is also what makes an absolute path harmless, because nothing above the root is ever read.
 internal static class TestProjectPath
 {
+    /// <summary>The source roots a project directory sits directly beneath.</summary>
+    private static readonly string[] SourceRoots = { "src", "tools", "phone" };
+
     /// <summary>
-    /// True when <paramref name="repoRelativePath"/> - forward-slashed, relative to the repository
-    /// root - lies inside a test project.
+    /// True when <paramref name="path"/> lies inside a test PROJECT. Repository-relative is the
+    /// intended input; an absolute path is tolerated because the search anchors on a source root
+    /// rather than counting segments from the beginning.
     /// </summary>
-    internal static bool IsTestProject(string repoRelativePath)
+    internal static bool IsTestProject(string path)
     {
-        if (string.IsNullOrWhiteSpace(repoRelativePath)) return false;
+        if (string.IsNullOrWhiteSpace(path)) return false;
 
-        var segments = repoRelativePath.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var segments = path.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        // Every segment EXCEPT the last, which is the file name. A directory decides this, not a file.
+        // The LAST source root wins, so a checkout that itself lives under a folder called "src"
+        // cannot shift which segment gets read as the project.
+        var rootIndex = -1;
         for (var i = 0; i < segments.Length - 1; i++)
         {
-            if (segments[i].EndsWith("Tests", StringComparison.OrdinalIgnoreCase))
-                return true;
+            if (Array.Exists(SourceRoots, r => string.Equals(segments[i], r, StringComparison.OrdinalIgnoreCase)))
+                rootIndex = i;
         }
 
-        return false;
+        if (rootIndex < 0) return false;
+
+        var projectIndex = rootIndex + 1;
+
+        // A project directory must still have a file below it; a bare root is not a project.
+        if (projectIndex >= segments.Length - 1) return false;
+
+        return segments[projectIndex].EndsWith("Tests", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/CcDirector.Core.Tests/TestProjectPath.cs
+++ b/src/CcDirector.Core.Tests/TestProjectPath.cs
@@ -27,7 +27,7 @@ namespace CcDirector.Core.Tests;
 /// future <c>.IntegrationTests</c> or <c>.ContractTests</c> without anybody remembering to come back
 /// here. The file name itself is never consulted: <c>Foo.Tests.cs</c> sitting in a production project
 /// is production code.
-/// </summary>
+///
 /// WHY NOT SIMPLY "ANY ANCESTOR DIRECTORY ENDING IN Tests". The first version of this helper did
 /// exactly that, and an inspection caught two ways it is wrong - both of which SILENCE a guard, which
 /// is worse than the narrowing it was written to replace:
@@ -42,6 +42,7 @@ namespace CcDirector.Core.Tests;
 /// So the decision is the OWNING PROJECT directory, found by anchoring on a known source root: the
 /// project is the segment DIRECTLY BELOW <c>src</c>, <c>tools</c> or <c>phone</c>. Anchoring on the
 /// root is also what makes an absolute path harmless, because nothing above the root is ever read.
+/// </summary>
 internal static class TestProjectPath
 {
     /// <summary>The source roots a project directory sits directly beneath.</summary>

--- a/src/CcDirector.Core.Tests/TestProjectPathTests.cs
+++ b/src/CcDirector.Core.Tests/TestProjectPathTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Pins the RULE that decides what is test code, not the file list that happens to satisfy it today.
+///
+/// This distinction is the whole point of the file. A fact asserting "these twelve files are fine"
+/// passes forever while the rule underneath it stays broken - and that is exactly what happened on
+/// 2 August: four architecture guards shared a <c>.Contains(".Tests/")</c> decision, a suite split
+/// moved 2,750 test files into <c>CcDirector.Gateway.UnitTests</c>, and every one of them became
+/// "production" at a stroke. Two guards went red naming files nobody had touched; two stayed green
+/// only because none of those files happened to match their patterns.
+///
+/// So these facts name SPELLINGS rather than paths, and the first of them is the one that was broken:
+/// a project called <c>.UnitTests</c> is a test project. Restore the old substring in
+/// <see cref="TestProjectPath.IsTestProject"/> and that fact goes red, which is the property that
+/// makes this a guard rather than a decoration.
+/// </summary>
+public class TestProjectPathTests
+{
+    [Theory]
+    // The spelling that broke: ".UnitTests/" does not contain ".Tests/", and this is what regressed.
+    [InlineData("src/CcDirector.Gateway.UnitTests/RosterFoldTests.cs")]
+    // The spellings that already worked, kept so a fix cannot narrow the rule while widening it.
+    [InlineData("src/CcDirector.Gateway.Tests/HostedStatsServeTests.cs")]
+    [InlineData("src/CcDirector.Core.Tests/StorageRootGuardTests.cs")]
+    // Nested below the project directory - the decision is the PROJECT, not the immediate folder.
+    [InlineData("src/CcDirector.Core.Tests/AgentPlugins/AgentPluginArchitectureGuardTests.cs")]
+    // Any future suffix, so nobody has to come back here when the next suite is split out.
+    [InlineData("src/CcDirector.Gateway.IntegrationTests/Whatever.cs")]
+    [InlineData("tools/SomeTool.ContractTests/Whatever.cs")]
+    public void ADirectoryWhoseNameEndsInTests_IsATestProject(string relativePath)
+        => Assert.True(TestProjectPath.IsTestProject(relativePath), relativePath);
+
+    [Theory]
+    // Ordinary production projects, which is the half that must NOT widen: a guard that calls
+    // everything a test stops guarding anything, and would pass this file's other half silently.
+    [InlineData("src/CcDirector.Gateway/Api/GatewayEndpoints.cs")]
+    [InlineData("src/CcDirector.Core/Sessions/SessionManager.cs")]
+    [InlineData("src/CcDirector.ControlApi/ControlEndpoints.cs")]
+    // A production FILE whose own name mentions tests. The file name is never consulted.
+    [InlineData("src/CcDirector.Core/Diagnostics/SelfTests.cs")]
+    public void AProductionProject_IsNotATestProject(string relativePath)
+        => Assert.False(TestProjectPath.IsTestProject(relativePath), relativePath);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Program.cs")]
+    public void AnEmptyOrBareName_IsNotATestProject(string relativePath)
+        => Assert.False(TestProjectPath.IsTestProject(relativePath), $"'{relativePath}'");
+}

--- a/src/CcDirector.Core.Tests/TestProjectPathTests.cs
+++ b/src/CcDirector.Core.Tests/TestProjectPathTests.cs
@@ -41,6 +41,16 @@ public class TestProjectPathTests
     [InlineData("src/CcDirector.ControlApi/ControlEndpoints.cs")]
     // A production FILE whose own name mentions tests. The file name is never consulted.
     [InlineData("src/CcDirector.Core/Diagnostics/SelfTests.cs")]
+    // A directory ending in "Tests" NESTED INSIDE a production project. The first version of the
+    // predicate matched any ancestor and called these test code - which would have made production
+    // files invisible to all four guards while every one of them stayed green. A widening that
+    // SILENCES a guard is worse than the narrowing it was written to fix.
+    [InlineData("src/CcDirector.Core/DiagnosticsTests/Probe.cs")]
+    [InlineData("src/CcDirector.Core/Tests/Probe.cs")]
+    [InlineData("src/CcDirector.Gateway/Api/IntegrationTests/Helper.cs")]
+    // An ABSOLUTE path whose ancestors OUTSIDE the repository end in "Tests". Anchoring on the source
+    // root is what stops a checkout location silently disabling a guard.
+    [InlineData("D:/SomeTests/checkout/src/CcDirector.Core/Sessions/SessionManager.cs")]
     public void AProductionProject_IsNotATestProject(string relativePath)
         => Assert.False(TestProjectPath.IsTestProject(relativePath), relativePath);
 


### PR DESCRIPTION
main is red on continuous integration. Two architecture guards in `CcDirector.Core.Tests` fail, naming twelve files that nobody touched.

## What happened

Four guards - loopback, transcription, agent-plugin and storage-root - each skip test code before scanning production, because a literal that is forbidden in production is ordinary in a fixture. **Each carried its own copy of that decision**, written as `rel.Contains(".Tests/")`.

The Gateway suite split moved roughly 2,750 test files into `src/CcDirector.Gateway.UnitTests/`. That path contains `.UnitTests/`, which does **not** contain `.Tests/`. At a stroke, every one of those files became production code to all four guards.

## The half that is not visible

Two guards failed loudly. **The other two passed — not because they were satisfied, but because nothing among the moved files happened to match their patterns.**

They are latent, not working. The next file added to that project can wake either of them, presenting as a red with no visible connection to a file move weeks earlier — and whoever meets it will have no reason to look here.

So this is one predicate rather than four corrections. Four copies of a decision is four places to be wrong, and this is what that costs when it is collected.

## The fix

The rule now reads the name of a **directory** rather than a substring of the whole path: a test project is one whose directory name ends with `Tests`. That is true of `.Tests`, `.UnitTests`, and any future `.IntegrationTests` without anybody remembering to come back here. The file name is never consulted, so a production `SelfTests.cs` stays production.

`TestProjectPathTests` pins the **rule**, not the file set. A fact asserting "these twelve files are fine" passes forever while the rule underneath stays broken — which is exactly how this survived. Its negative cases matter as much as its positive ones: a predicate returning true for everything would satisfy the positive half alone and silently stop all four guards from guarding.

## Proof

**Revert-proved.** Restoring the old substring turns **five** facts red: both guards that are live on main, plus the three new predicate cases naming the spellings that regressed. **The two latent guards stay green even with the fault present** — which is the direct evidence that they are latent rather than satisfied, and that fixing at the predicate is a repair rather than a patch.

The full `CcDirector.Core.Tests` suite passes: **4,243 passed, 0 failed, 8 skipped**, up thirteen from the recorded 4,238 - exactly the new theory cases arriving.

Closes the guard half of thefrederiksen/devthrottle_internal#1264.