### PR TITLE
fix(onboarding): the hosted gateway card reads as included to a trial user

### DIFF
--- a/docs/install/install-prompt.md
+++ b/docs/install/install-prompt.md
@@ -77,7 +77,8 @@ Director-only; it cannot host a self-hosted gateway.
    turns on voice, and sends you the morning report. DevThrottle will ask you on its second setup
    screen, and "Not now" is a real answer you can change later in Settings.
 
-     * Hosted gateway (recommended) - we run it. Sign in and this machine is enrolled. Part of Pro:
+     * Hosted gateway (recommended) - we run it. Sign in and this machine is enrolled. Included with
+       Pro, and with the free 14-day Pro trial that new accounts get when they first connect:
        https://devthrottle.com/pricing
      * Self-hosted gateway - run it on your own machine and join it. Windows only. Advanced setups.
      * Not now - local-only on this machine.

--- a/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
+++ b/src/CcDirector.Avalonia/FirstRunWizardDialog.axaml
@@ -595,7 +595,7 @@
 
                         <RadioButton x:Name="GatewayHostedCard" GroupName="GatewayChoice"
                                      Classes="gatewayCard emphasized" IsChecked="True"
-                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled. Your agents run on your machines; fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work."
+                                     AutomationProperties.Name="Hosted gateway, recommended. We run it for you - sign in and this machine is enrolled. Your agents run on your machines; fleet metadata and conversation history are stored on the hosted gateway so remote history and supervision work. Included with Pro, and with the free 14-day Pro trial that new accounts get when they first connect here. No credit card."
                                      IsCheckedChanged="GatewayCard_IsCheckedChanged">
                             <StackPanel Spacing="6">
                                 <StackPanel Orientation="Horizontal" Spacing="10">
@@ -623,9 +623,19 @@
                                      general fact about new accounts, NOT as a promise to this user: it
                                      is granted only on an account's first arrival at the hosted gateway
                                      and never twice, so "you get 14 days" would be false for someone
-                                     coming back. -->
+                                     coming back.
+
+                                     WHY THE INCLUSION COMES FIRST (issue #1243). Leading with the plan
+                                     name still read as exclusion to the very person the trial covers:
+                                     someone who signed up minutes ago for fourteen free days of Pro is
+                                     told, on the card they are one click from taking, that it is "part
+                                     of" a thing they have not bought. The trial is REAL and is granted
+                                     at exactly this step, so the sentence now names both ways in - the
+                                     paid plan and the trial - and the reader finds themselves in one of
+                                     them. It still promises this user nothing: "new accounts", not
+                                     "you", because a returning account is granted no second trial. -->
                                 <TextBlock TextWrapping="Wrap" FontSize="12.5" Foreground="#8A909A"
-                                           Text="Part of Pro. New accounts get 14 days free, no credit card." />
+                                           Text="Included with Pro - and with the free 14-day Pro trial that new accounts get when they first connect here. No credit card." />
                             </StackPanel>
                         </RadioButton>
 


### PR DESCRIPTION
Part one of devthrottle_internal issue 1243, "the 14-day Pro trial is invisible after signup". Copy only, no behaviour change, and it ships on its own without waiting for the rest.

## The problem

The trial is not missing. It is granted at enrolment, written to the gateway `account_trials` ledger, and read for the entitlement decision. A live row exists in the production database right now: one trial granted at 03:42 UTC on 3 August, running fourteen days to 17 August. We grant something valuable and never tell the person, and a promise kept silently is indistinguishable from a promise broken.

The setup wizard's hosted gateway card is the one place in the whole first-run experience that nearly mentions it, and it read as an exclusion:

> Part of Pro. New accounts get 14 days free, no credit card.

Both sentences are true. But leading with the plan name tells the one person the trial actually covers that this is part of something they have not bought - on the card they are one click from taking, at the exact step where the trial is granted.

## The change

> Included with Pro - and with the free 14-day Pro trial that new accounts get when they first connect here. No credit card.

It names both ways in, the paid plan and the trial, so the reader finds themselves in one of them.

It still promises this reader nothing. "New accounts", not "you" - because `TrialRegistry.GrantIfFirstArrival` grants a trial only on an account's first arrival at the hosted gateway and never twice, so "you get 14 days" would be false for someone coming back. That constraint is why the earlier wording existed; it is preserved.

Two smaller things in the same commit, both called out rather than slipped in:

- **The card's accessibility name was missing this sentence.** It mirrors the card's other two body sentences and not the third, so a screen reader heard everything except the plan and the trial. Added.
- **`docs/install/install-prompt.md` carried the same "Part of Pro" sentence** two steps earlier in the same signup journey, with the same misread. Reworded to match. This is one surface wider than the issue's wording, and deliberate - fixing the wizard while the installer still says the old thing is half a fix.

## What is verified

- `dotnet build src/CcDirector.Avalonia` succeeds, 0 warnings, 0 errors. Avalonia compiles XAML at build time, so this proves the markup parses and the attribute is well-formed - it is the real check for a text change in `.axaml`, not a formality.
- No test asserts this string; searched the source tree for both "Part of Pro" and `GatewayHostedCard`. The only code hits on the card are the three selection-handling lines in the code-behind, which this does not touch.
- The full .NET suite was deliberately not run for a copy change.

## What is NOT verified, stated plainly

- **No screenshot of the running wizard.** The change is a literal string in a `TextBlock` that already renders; the build proves it compiles, not that it looks right at that width. Two lines instead of one at 12.5pt in a wrapping block inside a scrolling card - I expect that to be fine and have not seen it.
- **`docs/public/getting-started/04-setup-wizard-walkthrough.md` is left alone**, and it is stale in a way this makes slightly worse. Its caption says the card is 'priced as "Part of Pro" with no figure'. That was already wrong before this change - the card has mentioned the trial since issue 1044 - and the screenshot beside it, `assets/setup-02-gateway.png`, shows the old card. Correcting the caption without a fresh screenshot would put the prose and the image in disagreement, and the house rule is to check screen prose against a committed accessibility dump rather than against the XAML. It needs a re-shot screen, which is its own job.

## What this does NOT fix

Parts two through four of the issue: there is still no read path for trial state anywhere in the product. No endpoint returns it, so no screen can show it - a search of the whole product for `TrialEndsAt`, `DaysLeft` and `trialActive` finds nothing. This pull request makes the one existing mention honest. It does not tell anyone how many days they have left. That is the read endpoint, the website surfaces, and the three-valued state, coming separately.
