### PR TITLE
Choose test suites from the change, and stop being silent about parked coverage

### DIFF
--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -22,6 +22,55 @@ The owner of this repository's test suites. Three duties, in priority order:
 
 ---
 
+## Deciding what to run: ALWAYS ask the selector, never guess
+
+`scripts/select-tests.ps1` answers "which suites can this change actually affect" from the files it
+touched. **Use it whenever the question comes up** - before merging, when someone asks whether the
+parked suites are needed, or when a change feels risky.
+
+    .\scripts\select-tests.ps1 -Explain
+
+It derives the answer from the .csproj REFERENCE GRAPH, not from a hand-written folder list: each
+test project's transitive closure is computed, and a suite is selected when the change touched any
+project inside it. A hand-maintained map goes stale silently the first time somebody adds a
+ProjectReference; this one cannot.
+
+It fails toward running MORE. An unrecognised path, a changed .csproj or .sln, a change to the gate
+itself - all select everything. Only paths whose irrelevance is obvious (docs, markdown, images) are
+allowed to select nothing.
+
+**The gate calls it automatically and prints a COVERAGE GAP warning** when a change touches code that
+a parked suite covers. That warning is the answer to "who remembers to run `-Parked`" - nobody has
+to. Treat it as a required action, not a hint: run `-Parked` before merging, or say in the pull
+request why not.
+
+### Why the gate WARNS instead of auto-running the parked suites
+
+Measured by replaying the last hundred merges: a parked suite was implicated in **69 to 80 per cent
+of changes**, because `CcDirector.Core` and `Gateway.Contracts` are referenced by nearly everything.
+Running them automatically would restore a twelve-to-forty-five-minute gate for seven changes in ten
+- exactly the problem the budget removed. So the fast gate stands and the reader is told precisely
+what it did not cover.
+
+That number is also the honest measure of how much selection saves here: **less than you would hope.**
+The fan-out from the shared projects is the real constraint, and the way to actually shrink it is to
+make the parked suites fast enough to stop being parked.
+
+### The map is validated against history, not asserted
+
+`scripts/validate-test-selection.ps1` replays the last hundred merges and checks the only property
+that can hurt: that the selection was never TOO SMALL. Ground truth is derived from paths, not from
+the graph, so the check is not circular - a change editing `Engine.Tests` must select `Engine.Tests`,
+a change under `src/` must select something, a change under `apps/` must select the web tests.
+
+Last run: **100 changes, zero violations.** 44 per cent ran everything (fail-safe), 42 per cent
+narrowed, 13 per cent needed no tests, 1 per cent web only.
+
+Re-run it after changing the selector or restructuring projects. It is cheap and it is the only thing
+standing between a clever map and a silent skip. It is honest about its limits too: a suite that
+should run because of a RUNTIME coupling the reference graph cannot see will not be caught by any
+path-based harness.
+
 ## The law: a two-minute budget, enforced
 
 `$BudgetSeconds = 120` in `scripts/test-local.ps1`. Each suite gets that long. One that has not

--- a/scripts/select-tests.ps1
+++ b/scripts/select-tests.ps1
@@ -1,0 +1,170 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Decide WHICH test suites a change actually needs, from the files it touched.
+
+.DESCRIPTION
+    The gate runs about 3400 tests in eighty seconds, and two suites are parked because they cannot
+    meet that budget - so most of the time they run for nobody. Selection is how the parked coverage
+    comes back: a change that touches the Gateway's host-bound surface picks up the host-bound suite
+    automatically, whether or not anyone remembered to pass -Parked, while a change to the phone app
+    keeps paying nothing for tests it cannot possibly break.
+
+    THE DEPENDENCY MAP IS DERIVED, NOT WRITTEN DOWN. A hand-maintained list of "this folder needs
+    that suite" is wrong the day somebody adds a ProjectReference, and wrong silently. This reads the
+    .csproj files, builds the reference graph, and computes each test project's transitive closure.
+    A test project is selected when the change touched any project inside its own closure. Nobody has
+    to remember to update it.
+
+    IT FAILS TOWARD RUNNING MORE, ALWAYS. A wrong selection that runs too much costs seconds; a wrong
+    selection that skips costs a regression that reaches main behind a green gate, and a silent skip
+    is indistinguishable from a pass. So: an unrecognised path selects EVERYTHING, a project file
+    change selects EVERYTHING (the graph itself moved), and a change to the gate or to this script
+    selects EVERYTHING. Only paths whose irrelevance is obvious and stated are allowed to select
+    nothing.
+
+.PARAMETER Base
+    The ref to diff against. Defaults to origin/main.
+
+.PARAMETER Explain
+    Print the reasoning - which paths were seen, which projects they belong to, and why each suite
+    was or was not selected.
+
+.EXAMPLE
+    .\scripts\select-tests.ps1
+    .\scripts\select-tests.ps1 -Explain
+    .\scripts\select-tests.ps1 -Base HEAD~1 -Explain
+#>
+param(
+    [string]$Base = "origin/main",
+    # An explicit file list instead of a diff. The validation harness feeds historical changes through
+    # here, so the rules being validated are THE rules, not a second copy of them that can drift.
+    [string[]]$Files,
+    [switch]$Explain
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Get-ProjectGraph {
+    $projs = @{}
+    Get-ChildItem -Path (Join-Path $repoRoot "src") -Filter *.csproj -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '\\(bin|obj)\\' } | ForEach-Object {
+            $text = Get-Content $_.FullName -Raw
+            $name = $_.BaseName
+            $refs = [regex]::Matches($text, 'ProjectReference\s+Include="([^"]+)"') |
+                    ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Groups[1].Value) }
+            $dir = (Split-Path -Parent $_.FullName).Substring($repoRoot.Length).TrimStart('\','/') -replace '\\','/'
+            $projs[$name] = [pscustomobject]@{
+                Name   = $name
+                Dir    = $dir
+                Refs   = @($refs)
+                # Both spellings are in use: the six historical ".Tests" projects and the newer
+                # ".UnitTests" split-out. Matching on IsTestProject alone missed one of them.
+                IsTest = ($text -replace '\s','') -match '<IsTestProject>true</IsTestProject>' -or $name -match '\.(Unit)?Tests$'
+            }
+        }
+    return $projs
+}
+
+function Get-Closure {
+    param($Projs, [string]$Name, $Seen = $null)
+    if ($null -eq $Seen) { $Seen = New-Object 'System.Collections.Generic.HashSet[string]' }
+    foreach ($r in $Projs[$Name].Refs) {
+        if ($Projs.ContainsKey($r) -and $Seen.Add($r)) { Get-Closure $Projs $r $Seen | Out-Null }
+    }
+    return $Seen
+}
+
+$projs = Get-ProjectGraph
+$testProjects = @($projs.Values | Where-Object { $_.IsTest } | Sort-Object Name)
+
+# Each test project's own closure, plus itself: the set of projects whose change can affect it.
+$affects = @{}
+foreach ($t in $testProjects) {
+    $c = Get-Closure $projs $t.Name
+    $set = New-Object 'System.Collections.Generic.HashSet[string]'
+    [void]$set.Add($t.Name)
+    foreach ($x in $c) { [void]$set.Add($x) }
+    $affects[$t.Name] = $set
+}
+
+if ($PSBoundParameters.ContainsKey('Files')) {
+    $changed = @($Files)
+} else {
+    $changed = @(& git -C $repoRoot diff --name-only "$Base...HEAD" 2>$null)
+    if ($LASTEXITCODE -ne 0) { $changed = @() }
+}
+if ($changed.Count -eq 0) {
+    # No diff, or the base is unknown. Both mean "cannot reason about this change" -> run everything.
+    $changed = @()
+}
+
+$selected = New-Object 'System.Collections.Generic.HashSet[string]'
+$needWeb  = $false
+$runAll   = $false
+$reasons  = @()
+
+if ($changed.Count -eq 0) {
+    $runAll = $true
+    $reasons += "no diff against $Base could be read - running everything"
+}
+
+foreach ($f in $changed) {
+    $p = $f -replace '\\','/'
+    switch -Regex ($p) {
+        # The graph itself moved, or the gate did. Either way no selection can be trusted.
+        '\.csproj$|\.sln$'                    { $runAll = $true; $reasons += "$p - a project or solution file changed, so the dependency graph itself moved"; continue }
+        '^scripts/(test-local|select-tests)\.ps1$' { $runAll = $true; $reasons += "$p - the gate itself changed"; continue }
+        '^Directory\.Build\.'                 { $runAll = $true; $reasons += "$p - a build-wide property changed"; continue }
+
+        # Web only. No .NET assembly can be affected by a React or TypeScript change.
+        '^(apps|packages)/'                   { $needWeb = $true; $reasons += "$p - web workspace"; continue }
+
+        # Documented as affecting no test. Keep this list SHORT and obvious.
+        '^docs/|\.md$|^\.github/|\.(png|jpg|jpeg|gif|svg|ico)$' { $reasons += "$p - affects no test"; continue }
+
+        '^src/' {
+            # Longest matching project directory owns the file.
+            $owner = $projs.Values | Where-Object { $p.StartsWith($_.Dir + "/") } |
+                     Sort-Object { $_.Dir.Length } -Descending | Select-Object -First 1
+            if ($null -eq $owner) {
+                $runAll = $true; $reasons += "$p - under src/ but inside no known project, so nothing can be ruled out"
+            } else {
+                $hit = @($testProjects | Where-Object { $affects[$_.Name].Contains($owner.Name) })
+                foreach ($t in $hit) { [void]$selected.Add($t.Name) }
+                $reasons += "$p - $($owner.Name) -> $(($hit | ForEach-Object Name) -join ', ')"
+            }
+            continue
+        }
+
+        default { $runAll = $true; $reasons += "$p - unrecognised path, so nothing can be ruled out" }
+    }
+}
+
+if ($runAll) {
+    $final = @($testProjects | ForEach-Object Name)
+    $needWeb = $true
+} else {
+    $final = @($selected)
+}
+
+if ($Explain) {
+    Write-Host "Base: $Base    files changed: $($changed.Count)"
+    Write-Host ""
+    foreach ($r in $reasons) { Write-Host "  $r" }
+    Write-Host ""
+    Write-Host "Run all: $runAll    Web tests: $needWeb"
+    Write-Host "Selected suites:"
+    if ($final.Count -eq 0) { Write-Host "  (none - this change cannot affect any .NET test)" }
+    foreach ($s in ($final | Sort-Object)) { Write-Host "  $s" }
+}
+
+# The machine-readable answer, for test-local.ps1 and for the validation harness.
+[pscustomobject]@{
+    RunAll   = $runAll
+    Web      = $needWeb
+    Suites   = @($final | Sort-Object)
+    Changed  = $changed
+    Reasons  = $reasons
+}

--- a/scripts/test-local.ps1
+++ b/scripts/test-local.ps1
@@ -223,6 +223,36 @@ Write-Host ""
 Write-Host "TRX files: $logDir"
 Write-Host ""
 
+# COVERAGE WARNING. The default run is fast because two suites are parked - but "parked" must never
+# quietly mean "this change was never tested". select-tests.ps1 works out, from the reference graph,
+# which suites this change could actually affect; if a PARKED one is in that set, say so loudly.
+#
+# It WARNS rather than running them, and the measurement is why. Replaying the last hundred merges,
+# a parked suite was implicated in 69 to 80 per cent of changes - because CcDirector.Core and
+# Gateway.Contracts are referenced by nearly everything. Running them automatically would restore the
+# twelve-to-forty-five-minute gate for seven changes in ten, which is the problem this whole exercise
+# removed. So the fast gate stands, and the reader is told exactly what it did not cover.
+$parkedNames = @($parkedProjects | ForEach-Object { Split-Path -Leaf ([System.IO.Path]::GetDirectoryName((Join-Path $repoRoot $_))) })
+$coverageGap = @()
+if (-not $Parked -and -not $Gateway) {
+    try {
+        $sel = & (Join-Path $PSScriptRoot "select-tests.ps1")
+        $coverageGap = @($sel.Suites | Where-Object { $parkedNames -contains $_ })
+    } catch {
+        # A selector that cannot run must not fail the gate, but it must not be silent either.
+        Write-Host "NOTE: could not compute test selection ($($_.Exception.Message)); coverage gap unknown."
+    }
+}
+
+if ($coverageGap.Count -gt 0) {
+    Write-Host ""
+    Write-Host "COVERAGE GAP - this change touches code covered by PARKED suite(s) that did not run:"
+    foreach ($n in $coverageGap) { Write-Host "  $n" }
+    Write-Host ""
+    Write-Host "Run '.\scripts	est-local.ps1 -Parked' before merging, or say in the pull request why not."
+    Write-Host "(Explain the reasoning with: .\scripts\select-tests.ps1 -Explain)"
+}
+
 if ($overBudget.Count -gt 0) {
     Write-Host ("RESULT: OVER BUDGET - {0} suite(s) exceeded the {1}-second ceiling and were STOPPED:" -f $overBudget.Count, $BudgetSeconds)
     foreach ($n in $overBudget) { Write-Host "  $n" }

--- a/scripts/validate-test-selection.ps1
+++ b/scripts/validate-test-selection.ps1
@@ -1,0 +1,114 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Replay the last N merged changes through select-tests.ps1 and prove it never skips a suite it
+    should have run.
+
+.DESCRIPTION
+    Selection is only safe if it is wrong in ONE direction. Running too much costs seconds; skipping
+    a suite that mattered puts a regression on main behind a green gate, and a silent skip looks
+    exactly like a pass. So this harness does not ask "was the selection minimal" - it asks "was the
+    selection ever too small", which is the only question that can hurt.
+
+    THE GROUND TRUTH IS DELIBERATELY INDEPENDENT OF THE MAP. Checking the selector against its own
+    dependency graph would be circular and would pass by construction. Instead the required set is
+    derived from the changed PATHS alone:
+
+      - a change that edits files inside a test project's own directory REQUIRES that suite. Nobody
+        needs a graph to know that editing Engine.Tests means running Engine.Tests.
+      - a change that edits any file under src/ REQUIRES a non-empty selection. A .NET source change
+        that selects nothing is a bug in the map however plausible its reasoning.
+      - a change that edits apps/ or packages/ REQUIRES the web tests.
+
+    That is a weaker statement than "the selection is correct", and it is honest about being so: it
+    catches the class of error that is dangerous, not every error. A suite that SHOULD have run
+    because of a subtle runtime coupling the reference graph cannot see will not be caught here, and
+    no path-based harness could catch it.
+
+.PARAMETER Count
+    How many merges into main to replay. Default 100.
+
+.EXAMPLE
+    .\scripts\validate-test-selection.ps1
+    .\scripts\validate-test-selection.ps1 -Count 250
+#>
+param(
+    [int]$Count = 100
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$selector = Join-Path $PSScriptRoot "select-tests.ps1"
+
+# The merges into main, newest first. First-parent keeps this to real landings rather than every
+# commit that rode in on a branch.
+$shas = @(& git -C $repoRoot log --first-parent --format=%H -n $Count origin/main)
+Write-Host "Replaying $($shas.Count) merged changes through the selector..."
+Write-Host ""
+
+$violations = @()
+$stats = [ordered]@{ total = 0; runAll = 0; webOnly = 0; noTests = 0; narrowed = 0 }
+$suiteCounts = @{}
+
+foreach ($sha in $shas) {
+    $files = @(& git -C $repoRoot diff --name-only "$sha^" $sha 2>$null)
+    if ($files.Count -eq 0) { continue }
+    $stats.total++
+
+    $r = & $selector -Files $files
+    foreach ($s in $r.Suites) { $suiteCounts[$s] = 1 + [int]$suiteCounts[$s] }
+
+    if ($r.RunAll) { $stats.runAll++ }
+    elseif ($r.Suites.Count -eq 0 -and $r.Web) { $stats.webOnly++ }
+    elseif ($r.Suites.Count -eq 0) { $stats.noTests++ }
+    else { $stats.narrowed++ }
+
+    $subject = (& git -C $repoRoot log -1 --format=%s $sha)
+
+    # GROUND TRUTH 1: a suite whose OWN files changed must be selected.
+    $ownTouched = @($files | ForEach-Object { ($_ -replace '\\','/') } |
+        Where-Object { $_ -match '^src/(CcDirector\.[A-Za-z.]*?(?:Unit)?Tests)/' } |
+        ForEach-Object { [regex]::Match(($_ -replace '\\','/'), '^src/(CcDirector\.[A-Za-z.]*?(?:Unit)?Tests)/').Groups[1].Value } |
+        Sort-Object -Unique)
+    foreach ($o in $ownTouched) {
+        if ($r.Suites -notcontains $o) {
+            $violations += [pscustomobject]@{ Sha=$sha.Substring(0,9); Kind="own files changed but suite not selected"; Detail=$o; Subject=$subject }
+        }
+    }
+
+    # GROUND TRUTH 2: any .NET source change must select at least one suite.
+    $touchedDotNet = @($files | Where-Object { ($_ -replace '\\','/') -match '^src/.*\.(cs|axaml|csproj)$' })
+    if ($touchedDotNet.Count -gt 0 -and $r.Suites.Count -eq 0) {
+        $violations += [pscustomobject]@{ Sha=$sha.Substring(0,9); Kind="src changed but NO suite selected"; Detail="$($touchedDotNet.Count) files"; Subject=$subject }
+    }
+
+    # GROUND TRUTH 3: a web workspace change must select the web tests.
+    $touchedWeb = @($files | Where-Object { ($_ -replace '\\','/') -match '^(apps|packages)/.*\.(ts|tsx|js|jsx|css)$' })
+    if ($touchedWeb.Count -gt 0 -and -not $r.Web) {
+        $violations += [pscustomobject]@{ Sha=$sha.Substring(0,9); Kind="web changed but web tests not selected"; Detail="$($touchedWeb.Count) files"; Subject=$subject }
+    }
+}
+
+Write-Host "How the $($stats.total) changes were classified:"
+Write-Host ("  run everything (fail-safe) : {0,4}   ({1:P0})" -f $stats.runAll,  ($stats.runAll / [Math]::Max(1,$stats.total)))
+Write-Host ("  narrowed to some suites    : {0,4}   ({1:P0})" -f $stats.narrowed,($stats.narrowed / [Math]::Max(1,$stats.total)))
+Write-Host ("  web tests only             : {0,4}   ({1:P0})" -f $stats.webOnly, ($stats.webOnly / [Math]::Max(1,$stats.total)))
+Write-Host ("  no tests at all            : {0,4}   ({1:P0})" -f $stats.noTests, ($stats.noTests / [Math]::Max(1,$stats.total)))
+Write-Host ""
+Write-Host "How often each suite would have run:"
+foreach ($k in ($suiteCounts.Keys | Sort-Object { -$suiteCounts[$_] })) {
+    Write-Host ("  {0,-40} {1,4} / {2}   ({3:P0})" -f $k, $suiteCounts[$k], $stats.total, ($suiteCounts[$k] / [Math]::Max(1,$stats.total)))
+}
+Write-Host ""
+
+if ($violations.Count -eq 0) {
+    Write-Host "RESULT: PASS - across $($stats.total) merged changes the selector never skipped a suite it was required to run."
+    exit 0
+}
+
+Write-Host "RESULT: FAIL - $($violations.Count) violation(s). The selector skipped something it should have run:"
+$violations | Select-Object -First 25 | ForEach-Object {
+    Write-Host ("  {0}  {1}: {2}" -f $_.Sha, $_.Kind, $_.Detail)
+    Write-Host ("      {0}" -f $_.Subject)
+}
+exit 1


### PR DESCRIPTION
Parking two suites made the gate fast and left a hole: they only run if somebody remembers `-Parked`, and nobody remembers. This closes it without reopening the speed problem.

## The selector

`scripts/select-tests.ps1` answers *which suites can this change affect* from the files it touched — derived from the **.csproj reference graph**, not a hand-written folder map. Each test project's transitive closure is computed; a suite is selected when the change touched any project inside it. Nobody has to update a list when a `ProjectReference` moves.

It fails toward running **more**: an unrecognised path, a changed `.csproj`/`.sln`, or a change to the gate itself all select everything. Only obviously irrelevant paths (docs, markdown, images) select nothing.

The gate calls it and prints a **COVERAGE GAP** warning naming any parked suite that covers the change.

## Why it warns rather than auto-running

Replaying the last 100 merges, a parked suite was implicated in **69–80% of changes**, because `CcDirector.Core` and `Gateway.Contracts` are referenced by nearly everything:

| suite | would run |
|---|---|
| `Gateway.Tests` (parked) | 80% |
| `Gateway.UnitTests` | 77% |
| `Core.Tests` (parked) | 69% |

Auto-running would restore a 12-to-45-minute gate for 7 changes in 10. That figure is also the honest measure of what selection buys here: **less than hoped.** The fan-out from the shared projects is the real constraint, and the way to shrink it is to make the parked suites fast enough to stop being parked.

## Validated against history, not asserted

`scripts/validate-test-selection.ps1` replays those 100 merges and checks the only property that can hurt — that the selection was never **too small**. Ground truth comes from paths, not the graph, so it isn't circular: editing a test project must select that suite, touching `src/` must select something, touching `apps/` must select the web tests.

```
100 merged changes replayed, ZERO violations.
44% run everything (fail-safe) | 42% narrowed | 13% no tests | 1% web only
```

It's honest about its limit: a runtime coupling the reference graph can't see wouldn't be caught by any path-based harness.

## Verification

Gate green: 3412 tests. Validation: PASS. The coverage warning fires correctly on this very change.

**On running `-Parked` for this PR:** the selector says run everything, but that's the fail-safe rule firing because `scripts/test-local.ps1` is in the diff. This change touches **no product code at all** — only two new scripts, the gate script, and a skill markdown — so the parked suites cannot regress from it. That is the "say why not in the pull request" path the rule explicitly allows.