### PR TITLE
A session is a commitment - spawning one means owning its completion

### DIFF
--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -117,6 +117,12 @@ prompts, or on the wrong model.
    "Do you want to proceed?" prompt or run on the wrong model/window.
 3. **Use `--prompt`** for the session's first task (dispatched once the agent is ready). For a long
    instruction, write it to a file and make `--prompt` a short "read and follow <path>" pointer.
+4. **Know what will close it before you open it.** A session is a commitment as much as a resource:
+   whoever spawns it owns driving it to completion. Decide at spawn time where its output has to end
+   up - merged into YOUR worktree if it shares yours, or on `origin/main` if it has its own - and put
+   that in the brief. A session whose exit conditions were never stated does not acquire them later;
+   it just stays open. See **Closing a session** below, which applies to the sessions you started as
+   much as to yourself.
 
 ```
 # Create a properly-named, autonomous-ready session
@@ -152,7 +158,7 @@ An unregistered name fails loudly, and a name matching two Directors fails listi
 falls back to another Director - if you get one of those errors, run `director list` and pick, rather
 than dropping the flag and spawning wherever.
 
-## Closing a session (including closing yourself)
+## Closing a session - yours and the ones you started
 
 A session can close itself. When an agent has finished its work and nothing is waiting on the
 user, it should reap its own session rather than leaving an idle entry in Mission Control.
@@ -171,6 +177,27 @@ To reap a DIFFERENT session, pass its id or name: `cc-devthrottle session done <
 
 Do not self-close while something still needs the user (a pending decision, an approval, an
 unanswered question). Reap only when the queue is truly empty.
+
+**Closing the sessions YOU spawned is your job, not theirs.** A child session that has finished its
+work and gone idle is not done - it is unfinished work sitting where nobody is looking. As its parent
+you drive it to all four conditions:
+
+1. **reviewed** by a session OTHER than the one that wrote it;
+2. **output safe** - merged into your worktree if it shares yours, otherwise on `origin/main`,
+   because a worktree of its own will be deleted and anything left in it dies with it;
+3. **worktree removed**, if it had its own;
+4. **session reaped**, with `cc-devthrottle session done <target>`.
+
+**The failure this prevents.** A definition of "done" that means only "the pull request merged"
+leaves a branch, a worktree and a live session behind EVERY time. Those accumulate faster than
+anything removes them, and the cost stays invisible until somebody counts. One coordinator running
+this fleet finished many tasks that way and left 27 worktrees, 7 open pull requests and branches four
+days old - not through any single bad decision, but because nothing in the definition of done
+required cleanup.
+
+**Note that `session done` reaches a session that is not answering.** It flags the target through the
+Director and does not depend on fleet messaging, which can fail. If a session you started has stopped
+responding, you can still close it.
 
 ## Who the user is
 

--- a/src/CcDirector.Gateway/Skills/Content/fleet-comms.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/fleet-comms.skill.md
@@ -44,6 +44,43 @@ no name displays as the bare folder name and is impossible to tell apart. Lead w
 `implement #799`); spawn warns when you give neither. A blank name, or a name equal to the bare
 repository folder name, is rejected - pass something meaningful or a purpose.
 
+### Spawning is a commitment, not a resource request
+
+**When you spawn a session, it is YOUR worker and you own finishing it.** You do not hand it a
+task and walk away. From the moment it exists it is your job to drive it to completion as quickly
+as possible, and to get its work somewhere safe.
+
+**A session is not complete when its work is written. It is complete when ALL of these are true:**
+
+1. its code has been reviewed by a session OTHER than the one that wrote it;
+2. its output is SAFE (see the two destinations below);
+3. its worktree is gone, if it had its own;
+4. the session itself is dead (`cc-devthrottle session done <target>`).
+
+Any one of those missing means it is still open, still yours, and still costing something.
+
+**"Safe" means one of two different things, and you choose which at spawn time:**
+
+- **The child works in YOUR worktree.** Its output is safe once merged into your tree and you
+  carry it forward. You are now responsible for that code.
+- **The child has its OWN worktree.** Its output is safe ONLY on `origin/main`. That worktree
+  will be deleted, and anything left in it - uncommitted changes, a branch never pushed, a patch
+  on disk - dies with it.
+
+Know which one you took on before you spawn; the obligation is different.
+
+**Three questions you must be able to answer for every session you started:**
+
+- when did it start?
+- how long has it been open?
+- what specifically has to happen to close it?
+
+If you cannot answer the third, the session has no exit and will not acquire one by itself.
+
+**This is not a limit on how many sessions you may run.** A hundred sessions is fine if every one
+is being driven to done. Three is a mess if none of them are. What matters is closing, not
+counting - so drive one thing all the way to dead-and-deleted before you pick up the next.
+
 ### If rename, done, or "message send all" answers "HTTP 404 from the Director"
 
 The command is right and the code is right. The Director you are talking to is too old.


### PR DESCRIPTION
Both shipped skills told an agent how to START a session and nothing about how to FINISH one.

So "done" came to mean "the pull request merged" - which leaves a branch, a worktree and a live session behind every single time. Those accumulate faster than anything removes them, and the cost stays invisible until somebody counts. One coordinator running this fleet over 2-3 August finished many tasks exactly that way and left **27 worktrees, 7 open pull requests, and branches four days old**. Not one bad decision anywhere in it - nothing in the definition of done required cleanup, so cleanup did not happen.

## fleet-comms

New section immediately after the spawn commands, because that is the paragraph an agent reads at the moment it is about to create a session.

**A session is complete when ALL four are true:** reviewed by a session other than the one that wrote it; output safe; worktree gone if it had its own; session dead.

**"Safe" is two different things and the parent chooses which at spawn time.** A child working in the parent's worktree is safe once merged into that tree. A child with its OWN worktree is safe only on `origin/main` - that worktree gets deleted, and uncommitted changes, an unpushed branch, or a patch on disk die with it.

**Deliberately not a cap.** A hundred sessions is fine if every one is driven to done; three is a mess if none are. What matters is closing, not counting.

Plus the three questions a parent must be able to answer for anything it started: when did it start, how long has it been open, and what specifically closes it. If you cannot answer the third, the session has no exit and will not acquire one.

## dev-throttle

A fourth point where sessions are created - *know what will close it before you open it*, and put that in the brief, because a session whose exit conditions were never stated does not acquire them later.

The closing section is retitled and extended to cover the sessions you started, not only yourself, and notes that `session done` reaches a session that has stopped answering because it goes through the Director rather than fleet messaging.

## Note

No vendor or product name appears in either edit. An earlier draft said reviews are "usually by a Codex session"; these skills ship to users who will not have it, so it now says what actually matters - reviewed by a session other than the one that wrote it.