### PR TITLE
Make the test-manager skill findable, and say where to start

### DIFF
--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -1,9 +1,29 @@
 ---
 name: test-manager
-description: Owns this repo's test suites - the enforced two-minute budget, parallelism, which suites are parked, and how to diagnose a slow suite by measurement. Triggers on "/test-manager", "tests are slow", "park a suite", "unpark", "test coverage", "flaky test" - which this skill exists to correct.
+description: Owns this repo's test suites - the two-minute budget, parallelism, what is parked, and diagnosing slowness by measurement. Triggers on "/test-manager", "clean up the tests", "fix the tests", "continue the test work", "tests are slow", "park a suite", "unpark", "test coverage", "flaky test".
 ---
 
 # Test Manager
+
+## START HERE IF YOU WERE ASKED TO CLEAN UP, FIX OR CONTINUE THE TESTS
+
+**Read `HANDOVER.md` in this directory FIRST.** It is beside this file and it carries the live state:
+what is parked, the bad test list in priority order, exactly where the last batch stopped, and the
+traps already hit. This file is the rules; that file is the position on the board. Acting on the rules
+without the position means redoing work that is already done.
+
+Then work the queue in this order - it is ordered by what actually helps, not by what is easiest:
+
+1. **Fix or delete the named bad tests.** They are listed in `HANDOVER.md` and below. Until they are
+   gone the gate goes red at random, which erodes trust in every other result. Do this before adding
+   a single test.
+2. **Then un-park in batches of at most 100 ACTUAL tests**, each checked against the four admission
+   tests below. About 60 files / 496 tests already meet the bar, so there are roughly five easy
+   batches waiting.
+3. **Then the git-fixture work** that would let the rest of `Core.Tests` un-park wholesale.
+
+Do not raise the 120-second ceiling. Do not un-park anything to improve a coverage number. Do not add
+a retry to a failing test.
 
 The owner of this repository's test suites. Three duties, in priority order:
 


### PR DESCRIPTION
Two gaps, found by asking whether a new session could actually pick this up when told to *clean up the tests*. It couldn't, for two boring reasons.

**The triggers didn't match how the work gets asked for.** Only "tests are slow", "park a suite", "unpark", "test coverage" and "flaky test" fired it — so "clean up the tests" might not have loaded the skill at all. Now added: `"clean up the tests"`, `"fix the tests"`, `"continue the test work"`.

**The handover pointer was on line 435 of a 440-line file.** A continuation instruction in the footer is a continuation instruction nobody reads. It's now the first thing after the title, with the queue in priority order:

1. Fix or delete the named bad tests — before adding a single test, because a gate that reds at random erodes trust in every other result.
2. Then un-park in batches of at most 100 **actual** tests (~60 files / 496 tests already meet the bar — roughly five easy batches).
3. Then the git-fixture work that would un-park the rest of `Core.Tests` wholesale.

Plus the three standing "do nots": don't raise the ceiling, don't un-park to improve a coverage number, don't add a retry.

A file of rules without the position on the board just means the next session redoes work that's already done.