### PR TITLE
feat(gateway): GET /account/trial, so a member can be told their trial is running

### DIFF
--- a/src/CcDirector.Gateway.Contracts/AccountTrialDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AccountTrialDto.cs
@@ -1,0 +1,81 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The body of <c>GET /account/trial</c> (issue #1243): whether the calling account's free Pro trial is
+/// running, when it ends, and how many days are left.
+///
+/// WHY THIS CONTRACT EXISTS AT ALL. The trial already worked. It is granted at hosted enrolment, written to
+/// the Gateway's own <c>account_trials</c> ledger, and read for the entitlement decision - and there was no
+/// read path out of it. No endpoint returned trial state, so no screen could show one: a search of the whole
+/// product for a trial end, a day count, or an active flag found nothing. We granted something valuable and
+/// never told the person, and a promise kept silently is indistinguishable from a promise broken.
+///
+/// THE STATE IS NOT A BOOLEAN, AND THERE IS DELIBERATELY NO BOOLEAN ON THIS CONTRACT. A
+/// <c>trialActive: false</c> field would answer "is a trial running?" with "no" in the one case where the
+/// honest answer is "I could not find out" - and every consumer that read the boolean would make that
+/// substitution silently, at every site, forever. The reader is forced to look at <see cref="State"/> and
+/// decide what to do about <see cref="StateUnknown"/> because there is no comfortable field to reach for
+/// instead.
+///
+/// FOUR VALUES, THREE PARTITIONS. <see cref="StateExpired"/> and <see cref="StateNone"/> are separated
+/// because a sentence shown to a member cannot fold them - "your Pro trial ended on 17 August" is false for
+/// someone who never had one. The SAFETY partition is still three, and it is the one that must never be
+/// collapsed: running / known-not-running / unknown.
+///
+/// The Gateway folds <see cref="Message"/> once and the client renders it verbatim (CLAUDE.md rule 7). A
+/// client that composes its own sentence from these fields will, the first time it meets a state it did not
+/// expect, render something plausible instead of something true.
+/// </summary>
+public sealed class AccountTrialDto
+{
+    /// <summary>A free Pro trial is running right now. <see cref="EndsAtUtc"/> and
+    /// <see cref="DaysRemaining"/> are populated.</summary>
+    public const string StateActive = "active";
+
+    /// <summary>This account HAD a trial and its window has closed. It is never extended or re-granted, so
+    /// this is permanent. <see cref="EndsAtUtc"/> is populated and names the day it ended.</summary>
+    public const string StateExpired = "expired";
+
+    /// <summary>The read succeeded and this account was never granted a trial. NOT the same as
+    /// <see cref="StateUnknown"/>, and never to be shown as "expired".</summary>
+    public const string StateNone = "none";
+
+    /// <summary>
+    /// The trial could not be determined - the ledger read failed, no account is bound to the caller, or this
+    /// Gateway is not the one holding the caller's trial. IGNORANCE, NOT ABSENCE. A surface must say so out
+    /// loud; rendering this as "no trial" tells a member with twelve days left that they have nothing.
+    /// </summary>
+    public const string StateUnknown = "unknown";
+
+    /// <summary>
+    /// Which of the four states this account is in - one of <see cref="StateActive"/>,
+    /// <see cref="StateExpired"/>, <see cref="StateNone"/>, <see cref="StateUnknown"/>. Always populated. A
+    /// consumer that does not recognise the value must treat it as <see cref="StateUnknown"/>, never as an
+    /// absence of trial.
+    /// </summary>
+    public string State { get; set; } = StateUnknown;
+
+    /// <summary>
+    /// The finished, user-facing sentence, computed on the Gateway and rendered verbatim. Always populated,
+    /// including on <see cref="StateUnknown"/> - a surface that cannot determine the trial still owes the
+    /// member a sentence, and the client must never compose one from the other fields.
+    /// </summary>
+    public string Message { get; set; } = "";
+
+    /// <summary>When the trial was granted. Populated whenever a trial row was read (active or expired);
+    /// null otherwise. Never fabricated.</summary>
+    public DateTime? StartedAtUtc { get; set; }
+
+    /// <summary>
+    /// When the trial ends, or ended. Populated whenever a trial row was read (active or expired); null
+    /// otherwise - unknown, never a fabricated date.
+    /// </summary>
+    public DateTime? EndsAtUtc { get; set; }
+
+    /// <summary>
+    /// Whole days left, counting a part-day as a day, so the last day of a trial reads "1 day left" rather
+    /// than "0 days left" while access still works. Populated ONLY on <see cref="StateActive"/> and at least
+    /// 1 there; null in every other state. A null is not a zero and must never be rendered as one.
+    /// </summary>
+    public int? DaysRemaining { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/Account/AccountTrialReadTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountTrialReadTests.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Linq;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// The free Pro trial READ (issue #1243) - the path that tells a member their trial is running.
+///
+/// The trial itself was never broken. It is granted at hosted enrolment, stored in <c>account_trials</c>, and
+/// read for the entitlement decision; a live row sat in the production database with fourteen days on it
+/// while every screen stayed silent, because nothing could ask. These tests cover the read that was missing
+/// and, above all, what it says when it CANNOT ANSWER.
+///
+/// THE ONE THAT MATTERS MOST is <see cref="An_UNREADABLE_ledger_is_UNKNOWN_and_is_never_described_as_no_trial"/>.
+/// Collapsing "I could not find out" into "you have no trial" is the failure this whole shape exists to
+/// prevent: it tells a member with twelve days left that they have nothing, and it does it silently, on a
+/// billing page, at the moment they are deciding whether to trust the product. Every other test here is about
+/// saying something TRUE; that one is about refusing to say something comfortable.
+///
+/// Four states, three partitions. Expired and never-granted are split because a SENTENCE cannot fold them -
+/// "your Pro trial ended on 17 August" is false for someone who never had one. The safety partition is still
+/// three: running / known-not-running / unknown, and only the last may never be folded into the others.
+///
+/// Revert-proved, one production line at a time, each mutation confirmed present by diff before the run:
+///  - In <c>TrialRegistry.ReadStatus</c>, return <c>NeverGranted</c> where it returns <c>Expired</c>:
+///    <see cref="An_ended_trial_is_EXPIRED_and_still_names_the_day_it_ended"/> and
+///    <see cref="A_member_whose_trial_ended_is_never_told_they_never_had_one"/> go RED.
+///  - In <c>TrialRegistry.ReadStatus</c>, return <c>NeverGranted</c> where it returns <c>Unreadable</c> - the
+///    exact collapse under proof: <see cref="An_UNREADABLE_ledger_is_UNKNOWN_and_is_never_described_as_no_trial"/>
+///    goes RED.
+///  - In <c>TrialRegistry.ReadStatus</c>, weaken <c>nowUtc &lt; row.ExpiresAtUtc</c> to <c>&lt;=</c>:
+///    <see cref="At_the_exact_expiry_instant_the_trial_has_ENDED_not_one_tick_later"/> goes RED.
+///  - In <c>AccountTrialEndpoint.DaysRemaining</c>, swap <c>Math.Ceiling</c> for <c>Math.Floor</c>:
+///    <see cref="A_part_day_still_counts_as_a_day_so_the_last_day_never_reads_zero"/> goes RED.
+/// </summary>
+public sealed class AccountTrialReadTests : IDisposable
+{
+    private const string Subject = "sub-trial-read";
+
+    /// <summary>A fixed instant, so the fourteen-day window is judged exactly rather than in whichever
+    /// direction the clock happens to be pointing when the suite runs.</summary>
+    private static readonly DateTime Granted = new(2026, 8, 3, 3, 42, 0, DateTimeKind.Utc);
+
+    private readonly GatewayDbTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    // -------------------------------------------------------------------------------------------------
+    // The ledger read: four states kept apart.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_running_trial_is_ACTIVE_and_carries_both_of_its_instants()
+    {
+        // The state the production row is in right now. A surface needs the END to name a date, and the START
+        // is what lets it say how long the trial has been running without inventing one.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, Granted);
+
+        var status = trials.ReadStatus(Subject, Granted.AddDays(2));
+
+        Assert.Equal(TrialStatusKind.Active, status.Kind);
+        Assert.Equal(Granted, status.StartedAtUtc);
+        Assert.Equal(Granted.AddDays(14), status.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void An_ended_trial_is_EXPIRED_and_still_names_the_day_it_ended()
+    {
+        // EXPIRED, not "none". The row is deliberately kept after the window closes - it is what stops a
+        // second trial - so the date it ended is knowledge we hold and can state.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, Granted);
+
+        var status = trials.ReadStatus(Subject, Granted.AddDays(20));
+
+        Assert.Equal(TrialStatusKind.Expired, status.Kind);
+        Assert.Equal(Granted.AddDays(14), status.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void An_account_that_never_had_a_trial_is_NEVER_GRANTED_and_not_expired()
+    {
+        // The control that keeps the split honest in the other direction. A paying member who never took a
+        // trial is in this state, and telling them theirs "ended" would be a plain falsehood.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+
+        var status = trials.ReadStatus("sub-never-had-one", Granted);
+
+        Assert.Equal(TrialStatusKind.NeverGranted, status.Kind);
+        Assert.Null(status.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void At_the_exact_expiry_instant_the_trial_has_ENDED_not_one_tick_later()
+    {
+        // Boundaries are where a policy is decided. This mirrors the assertion the entitlement side already
+        // pins, and it is here as well because the two now share ONE comparison - so if that comparison is
+        // ever weakened, the display and the access decision are wrong together and this catches it.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, Granted);
+
+        var oneTickBefore = trials.ReadStatus(Subject, Granted.AddDays(14).AddTicks(-1));
+        var atExpiry = trials.ReadStatus(Subject, Granted.AddDays(14));
+
+        Assert.Equal(TrialStatusKind.Active, oneTickBefore.Kind);
+        Assert.Equal(TrialStatusKind.Expired, atExpiry.Kind);
+    }
+
+    [Fact]
+    public void The_access_decision_and_the_displayed_state_can_never_disagree()
+    {
+        // Evaluate is now a FOLD over ReadStatus rather than a second read, so there is one row load and one
+        // expiry comparison in the type. This asserts the fold at every state: what the member is told and
+        // what the paywall does are answers to the same read, not two reads that happen to agree today.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, Granted);
+
+        foreach (var moment in new[] { Granted, Granted.AddDays(13), Granted.AddDays(14), Granted.AddDays(99) })
+        {
+            var shown = trials.ReadStatus(Subject, moment);
+            var access = trials.Evaluate(Subject, moment);
+
+            var runningPerDisplay = shown.Kind == TrialStatusKind.Active;
+            var runningPerAccess = access.Outcome == TrialOutcome.Active;
+
+            Assert.True(runningPerDisplay == runningPerAccess,
+                $"at {moment:O} the display says running={runningPerDisplay} and the access decision says " +
+                $"running={runningPerAccess}. These must come from one read - a member told their trial is " +
+                $"live while the paywall refuses them (or the reverse) is the worst outcome of the two paths " +
+                $"drifting.");
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // The description: what a member is actually shown.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void An_active_trial_is_described_with_its_day_count_and_its_end_date()
+    {
+        // The sentence the issue asks for, folded on the Gateway so every surface renders the same one.
+        var status = new TrialStatus(TrialStatusKind.Active, Granted, Granted.AddDays(14));
+
+        var dto = AccountTrialEndpoint.Describe(status, Granted.AddDays(2));
+
+        Assert.Equal(AccountTrialDto.StateActive, dto.State);
+        Assert.Equal(12, dto.DaysRemaining);
+        Assert.Equal(Granted.AddDays(14), dto.EndsAtUtc);
+        Assert.Contains("12 days left", dto.Message, StringComparison.Ordinal);
+        Assert.Contains("17 August 2026", dto.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_last_day_never_reads_zero()
+    {
+        // Pins the FLOOR OF ONE specifically. With hours left, a plain round-down would print "0 days left"
+        // beside access that still works, which reads as an expiry that has not happened - the product
+        // contradicting itself on the last day of the window, precisely the day a member is deciding whether
+        // to pay. This case alone does NOT prove the rounding direction: the clamp rescues a round-down here,
+        // which is why the test below exists and why this one no longer claims to cover it.
+        var status = new TrialStatus(TrialStatusKind.Active, Granted, Granted.AddDays(14));
+
+        var lastHours = AccountTrialEndpoint.Describe(status, Granted.AddDays(13).AddHours(20));
+
+        Assert.Equal(1, lastHours.DaysRemaining);
+        Assert.Contains("1 day left", lastHours.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("1 days left", lastHours.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_part_day_still_counts_as_a_day_so_time_left_is_never_rounded_away()
+    {
+        // THE ROUNDING DIRECTION, pinned where the clamp cannot rescue it: twelve days and six hours remain.
+        // Rounding DOWN reports 12 and quietly deletes a quarter of a day of Pro from what the member is told
+        // they have - always in the direction that under-states what they were promised.
+        //
+        // Added because the first version of this suite did not have it: the round-down mutation passed every
+        // test, so the ceiling was unproven while appearing covered. A revert-proof that fails to redden is
+        // the finding, not the inconvenience.
+        var status = new TrialStatus(TrialStatusKind.Active, Granted, Granted.AddDays(14));
+
+        var partDay = AccountTrialEndpoint.Describe(status, Granted.AddDays(1).AddHours(18));
+
+        Assert.Equal(13, partDay.DaysRemaining);
+        Assert.Contains("13 days left", partDay.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_member_whose_trial_ended_is_never_told_they_never_had_one()
+    {
+        var status = new TrialStatus(TrialStatusKind.Expired, Granted, Granted.AddDays(14));
+
+        var dto = AccountTrialEndpoint.Describe(status, Granted.AddDays(20));
+
+        Assert.Equal(AccountTrialDto.StateExpired, dto.State);
+        Assert.Equal(Granted.AddDays(14), dto.EndsAtUtc);
+        Assert.Contains("ended on 17 August 2026", dto.Message, StringComparison.Ordinal);
+        Assert.Null(dto.DaysRemaining);
+    }
+
+    [Fact]
+    public void A_member_who_never_had_a_trial_is_never_told_theirs_ended()
+    {
+        // The other direction of the same split, and the one a paying member meets.
+        var dto = AccountTrialEndpoint.Describe(new TrialStatus(TrialStatusKind.NeverGranted), Granted);
+
+        Assert.Equal(AccountTrialDto.StateNone, dto.State);
+        Assert.DoesNotContain("ended", dto.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("expired", dto.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(dto.EndsAtUtc);
+        Assert.Null(dto.DaysRemaining);
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // The state this whole shape exists for.
+    // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void An_UNREADABLE_ledger_is_UNKNOWN_and_is_never_described_as_no_trial()
+    {
+        // THE ONE THAT MATTERS. A failed read is ignorance, not absence. Answered as "none" it would tell a
+        // member on day two of their trial that they have nothing - confidently, on a page about what they
+        // are entitled to, with no way for them to tell it was a database error.
+        var dto = AccountTrialEndpoint.Describe(new TrialStatus(TrialStatusKind.Unreadable), Granted);
+
+        Assert.Equal(AccountTrialDto.StateUnknown, dto.State);
+        Assert.NotEqual(AccountTrialDto.StateNone, dto.State);
+        Assert.NotEqual(AccountTrialDto.StateExpired, dto.State);
+
+        // And it must SAY so, not merely be flagged. A surface renders this verbatim, so the correction to
+        // the reader's natural assumption has to be in the sentence itself.
+        Assert.Contains("does not mean you have no trial", dto.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void An_unknown_answer_carries_no_date_and_no_day_count()
+    {
+        // A number beside "we could not tell" invites exactly the reading this state prevents. Absent, never
+        // zero: a zero day count is a statement, and it is one we have no evidence for.
+        var dto = AccountTrialEndpoint.Describe(new TrialStatus(TrialStatusKind.Unreadable), Granted);
+
+        Assert.Null(dto.DaysRemaining);
+        Assert.Null(dto.EndsAtUtc);
+        Assert.Null(dto.StartedAtUtc);
+    }
+
+    [Fact]
+    public void An_active_read_with_no_end_instant_is_answered_UNKNOWN_rather_than_inventing_a_date()
+    {
+        // A contradiction, not a state to render. The alternative to refusing here is printing a date derived
+        // from nothing on a page telling somebody what they are entitled to - and it would look completely
+        // ordinary, which is what makes it worth a test.
+        var dto = AccountTrialEndpoint.Describe(new TrialStatus(TrialStatusKind.Active, Granted), Granted);
+
+        Assert.Equal(AccountTrialDto.StateUnknown, dto.State);
+        Assert.Null(dto.EndsAtUtc);
+        Assert.Null(dto.DaysRemaining);
+    }
+
+    [Fact]
+    public void The_contract_offers_no_boolean_that_could_absorb_the_unknown_state()
+    {
+        // A STRUCTURAL guard, not a behavioural one. Every test above can pass while somebody adds a helpful
+        // `TrialActive` boolean to the contract - and from that moment every consumer has a comfortable field
+        // to read instead of the state, and each one silently answers "is a trial running?" with "no" in the
+        // one case where the honest answer is "I could not find out". The absence of that field is what forces
+        // a reader to look at State and decide what to do about unknown.
+        var offenders = typeof(AccountTrialDto).GetProperties()
+            .Where(p => p.PropertyType == typeof(bool) || p.PropertyType == typeof(bool?))
+            .Select(p => p.Name)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            "AccountTrialDto must expose no boolean: a two-valued field makes the unknown/none choice for " +
+            "every consumer, at every site, silently. Found: " + string.Join(", ", offenders) +
+            ". Read State instead and handle StateUnknown explicitly.");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Account/AccountTrialReadTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountTrialReadTests.cs
@@ -4,6 +4,7 @@ using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.Tests.Data;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests.Account;
@@ -225,6 +226,38 @@ public sealed class AccountTrialReadTests : IDisposable
     // -------------------------------------------------------------------------------------------------
     // The state this whole shape exists for.
     // -------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_LEDGER_THAT_CANNOT_BE_READ_PRODUCES_Unreadable_and_never_never_granted()
+    {
+        // THE GUARD ITSELF, exercised through a REAL failing read rather than a hand-built status.
+        //
+        // This test exists because its absence was caught by a revert-proof that refused to redden. Every
+        // other test here builds a TrialStatus by hand and hands it to Describe, which proves the SENTENCE is
+        // right for an unreadable ledger - and proves nothing at all about whether the registry ever produces
+        // that state. Collapsing Unreadable into NeverGranted in ReadStatus left the whole suite green: the
+        // description was validated, the placement was not.
+        //
+        // Dropping the table is the same failure injection the entitlement side already uses for its Unknown
+        // path. It makes the query genuinely throw, which is the only way to reach the catch under proof.
+        var db = _harness.Open();
+        var trials = new TrialRegistry(db);
+        trials.GrantIfFirstArrival(Subject, alreadyKnownToGateway: false, Granted);
+
+        using (var ctx = db.CreateUnscopedContext())
+            ctx.Database.ExecuteSqlRaw("DROP TABLE account_trials");
+
+        var status = trials.ReadStatus(Subject, Granted.AddDays(2));
+
+        // The account HAS a live trial. If a failed read answered NeverGranted, this member would be told
+        // they have nothing while twelve days of Pro were still running.
+        Assert.Equal(TrialStatusKind.Unreadable, status.Kind);
+        Assert.NotEqual(TrialStatusKind.NeverGranted, status.Kind);
+        Assert.NotEqual(TrialStatusKind.Expired, status.Kind);
+
+        // And the access decision must reach the same conclusion from the same read: retry, never refuse.
+        Assert.Equal(TrialOutcome.Unknown, trials.Evaluate(Subject, Granted.AddDays(2)).Outcome);
+    }
 
     [Fact]
     public void An_UNREADABLE_ledger_is_UNKNOWN_and_is_never_described_as_no_trial()

--- a/src/CcDirector.Gateway.Tests/Account/HostedAccountTrialEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/HostedAccountTrialEndpointTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// <c>GET /account/trial</c> (issue #1243) driven END TO END through a REAL <see cref="GatewayHost"/> over
+/// REAL HTTP, with the REAL auth middleware, the REAL tenant registry and the REAL trial ledger.
+///
+/// WHY END TO END AND NOT ONLY THE FOLD. <see cref="AccountTrialReadTests"/> proves the states in isolation,
+/// and it would keep passing while the route was never mapped, or was mapped where the auth middleware does
+/// not cover it, or resolved the caller from something other than their own device key. The defect being
+/// closed is precisely that NOTHING COULD ASK - so at least one test has to actually ask, over the wire, the
+/// way the website and the app will.
+///
+/// The trial is granted here through <see cref="Tenancy.TrialRegistry.GrantIfFirstArrival"/> - the same call
+/// hosted enrolment makes, and the only place a trial is ever created - so the row these tests read is a
+/// genuine trial row and not a fixture that merely resembles one.
+///
+/// Revert-prove: delete the <c>AccountTrialEndpoint.Map(...)</c> line in <c>GatewayHost</c> and every test
+/// here goes RED with 404 - which is the defect itself, exactly as it stands on main today.
+///
+/// This class sets the process-wide CC_GATEWAY_HOSTED, so it belongs to the hosted-mode collection; the
+/// storage root is isolated per instance for the same reason the sibling hosted classes isolate theirs.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedAccountTrialEndpointTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    // Unique per instance: a subject shared with another class would let whichever ran first decide whether
+    // this one's account had a trial, which is the shape that makes a suite fail only when it runs whole.
+    private readonly string _subjectOnTrial = "sub-on-trial-" + Guid.NewGuid().ToString("N");
+    private readonly string _subjectExpired = "sub-trial-over-" + Guid.NewGuid().ToString("N");
+    private readonly string _subjectNoTrial = "sub-no-trial-" + Guid.NewGuid().ToString("N");
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-trial-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _keyOnTrial = "";
+    private string _keyExpired = "";
+    private string _keyNoTrial = "";
+
+    /// <summary>Authenticated, but bound to no tenant at all - the caller we cannot identify.</summary>
+    private string _keyUnbound = "";
+
+    private string? _priorHosted;
+    private string? _priorRoot;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _instancesDir);
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // Minted through the REAL registry exactly as hosted enrolment does it, so the tenant behind each key
+        // is a genuine row and the subject the trial ledger is keyed by is the one the route will resolve.
+        var onTrial = _gateway.TenantRegistry.MintOrLookupBySubject(_subjectOnTrial, "new@example.com");
+        var expired = _gateway.TenantRegistry.MintOrLookupBySubject(_subjectExpired, "old@example.com");
+        var noTrial = _gateway.TenantRegistry.MintOrLookupBySubject(_subjectNoTrial, "paid@example.com");
+
+        _keyOnTrial = _gateway.Devices.Register("dev-trial", "M1").DeviceKey;
+        _keyExpired = _gateway.Devices.Register("dev-expired", "M2").DeviceKey;
+        _keyNoTrial = _gateway.Devices.Register("dev-none", "M3").DeviceKey;
+        _keyUnbound = _gateway.Devices.Register("dev-unbound", "M4").DeviceKey;
+        _gateway.Devices.SetAccountBinding("dev-trial", _subjectOnTrial, onTrial.Value);
+        _gateway.Devices.SetAccountBinding("dev-expired", _subjectExpired, expired.Value);
+        _gateway.Devices.SetAccountBinding("dev-none", _subjectNoTrial, noTrial.Value);
+
+        // The route is mapped with the REAL clock, so the fixtures are placed relative to real now. One trial
+        // starting now has its full fourteen days; one granted five weeks ago is long over. The third account
+        // is granted nothing at all, which is how a paying member and a pre-rollout account look.
+        var now = DateTime.UtcNow;
+        _gateway.TrialRegistry.GrantIfFirstArrival(_subjectOnTrial, alreadyKnownToGateway: false, now);
+        _gateway.TrialRegistry.GrantIfFirstArrival(_subjectExpired, alreadyKnownToGateway: false, now.AddDays(-35));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    private async Task<HttpResponseMessage> Get(string deviceKey)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, "account/trial");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        return await _http.SendAsync(req);
+    }
+
+    private async Task<JsonElement> TrialFor(string deviceKey)
+    {
+        var resp = await Get(deviceKey);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return JsonDocument.Parse(await resp.Content.ReadAsStringAsync()).RootElement;
+    }
+
+    [Fact]
+    public async Task An_enrolled_member_on_a_running_trial_is_TOLD_SO_with_the_days_left_and_the_end_date()
+    {
+        // The whole issue in one assertion. Before this route existed the product granted this member fourteen
+        // days of Pro and had no way to mention it: a search for a trial end, a day count, or an active flag
+        // across the entire product found nothing. This is the read that was missing.
+        var body = await TrialFor(_keyOnTrial);
+
+        Assert.Equal("active", body.GetProperty("state").GetString());
+        Assert.Equal(14, body.GetProperty("daysRemaining").GetInt32());
+        Assert.NotEqual(JsonValueKind.Null, body.GetProperty("endsAtUtc").ValueKind);
+
+        var message = body.GetProperty("message").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(message));
+        Assert.Contains("14 days left", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_member_whose_trial_is_over_is_told_it_ENDED_and_not_that_they_never_had_one()
+    {
+        var body = await TrialFor(_keyExpired);
+
+        Assert.Equal("expired", body.GetProperty("state").GetString());
+        Assert.NotEqual(JsonValueKind.Null, body.GetProperty("endsAtUtc").ValueKind);
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("daysRemaining").ValueKind);
+    }
+
+    [Fact]
+    public async Task An_account_with_no_trial_gets_NONE_and_is_never_told_a_trial_expired()
+    {
+        // A paying member, or one that predates the trial, is in this state. It is a real answer - the read
+        // succeeded and found nothing - and it must not borrow the expired sentence.
+        var body = await TrialFor(_keyNoTrial);
+
+        Assert.Equal("none", body.GetProperty("state").GetString());
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("endsAtUtc").ValueKind);
+        Assert.DoesNotContain("ended", body.GetProperty("message").GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A_tenant_unbound_key_is_refused_by_the_middleware_and_is_never_told_it_has_no_trial()
+    {
+        // WRITTEN AGAINST WHAT ACTUALLY HAPPENS, after the first version of this test asserted 403 and was
+        // wrong. A key that is authenticated but bound to no tenant never reaches this endpoint at all: the
+        // host-wide auth middleware refuses it with 401 first, the same way it does on /account/status. So the
+        // endpoint's own deny branch is unreachable this way and is proved directly instead, below.
+        //
+        // What still matters here, and is the whole point of asserting a refusal rather than skipping it: a
+        // consumer must not be able to read this refusal as an answer about a trial. It carries no state, no
+        // dates, and nothing resembling "none" - so a page that treats any non-ok response as UNKNOWN (which
+        // is what the website client does) cannot be led into printing "no trial" by this path.
+        var resp = await Get(_keyUnbound);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("\"none\"", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("daysRemaining", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task The_endpoints_own_deny_branch_answers_UNKNOWN_and_never_no_trial()
+    {
+        // The branch the middleware hides from the wire, proved where it lives. A hosted request that reaches
+        // the route with nothing binding it to a tenant is IGNORANCE about who is asking - so it keeps its 403
+        // AND still carries a three-way state, rather than a bare error envelope a consumer would have to
+        // guess about. Answering "none" here would tell somebody with twelve days left that they have nothing.
+        //
+        // Driven through the real fold with a real boundary over the real device registry; only the request is
+        // synthetic, because a request with no authenticated device is exactly the condition under test.
+        var boundary = new CcDirector.Gateway.Tenancy.HostedTenantBoundary(
+            new CcDirector.Core.Tenancy.AsyncLocalTenantContext(), _gateway.Devices);
+        var ctx = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+
+        var (dto, status) = await CcDirector.Gateway.Api.AccountTrialEndpoint.ResolveAsync(
+            ctx, _gateway.TrialRegistry, boundary, _gateway.TenantRegistry, DateTime.UtcNow);
+
+        Assert.Equal(403, status);
+        Assert.Equal(CcDirector.Gateway.Contracts.AccountTrialDto.StateUnknown, dto.State);
+        Assert.NotEqual(CcDirector.Gateway.Contracts.AccountTrialDto.StateNone, dto.State);
+        Assert.False(string.IsNullOrWhiteSpace(dto.Message));
+        Assert.Null(dto.DaysRemaining);
+        Assert.Null(dto.EndsAtUtc);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_refused()
+    {
+        // Control: adding this route must not have opened a hole. The host-wide auth middleware still refuses,
+        // so every branch above is only ever reached by a proven caller.
+        var resp = await _http.GetAsync("account/trial");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_response_carries_no_credential_material()
+    {
+        // Control (DT-05): the caller's identity is resolved FROM the device key, so the risk is echoing it
+        // back. The body is a state, a sentence and two dates - never a key and never the Gateway token.
+        var body = await (await Get(_keyOnTrial)).Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain(_keyOnTrial, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(Token, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(_subjectOnTrial, body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task One_member_can_never_read_another_members_trial()
+    {
+        // The tenant boundary, asserted on a NEW route rather than assumed from the ones beside it. Each key
+        // resolves its OWN account: the member on a live trial and the member whose trial is over must not be
+        // able to see each other's state, and the route takes nothing from the request but the proven key.
+        var onTrial = await TrialFor(_keyOnTrial);
+        var expired = await TrialFor(_keyExpired);
+
+        Assert.Equal("active", onTrial.GetProperty("state").GetString());
+        Assert.Equal("expired", expired.GetProperty("state").GetString());
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountActingCredential.cs
+++ b/src/CcDirector.Gateway/Api/AccountActingCredential.cs
@@ -246,6 +246,18 @@ internal static class AccountOperations
         "Your account is active and your credit balance is unaffected - it simply cannot be read through "
         + "this hosted Gateway. Check it on the DevThrottle website.");
 
+    /// <summary>
+    /// The free Pro trial (issue #1243). Only the DENY and MISWIRED verdicts are ever rendered from this one:
+    /// the trial ledger is the Gateway's OWN table, so a resolved caller needs no forwardable credential and
+    /// the HostedNoGatewayCredential message is never reached. The reassurance still matters on the paths that
+    /// ARE reached, because "we cannot tell you about your trial" is the sentence most likely to be misread as
+    /// "you do not have one".
+    /// </summary>
+    public static readonly AccountOperation Trial = new(
+        "GET /account/trial",
+        "tell you whether a free Pro trial is running",
+        "This does not mean you have no trial - it means this Gateway could not find out.");
+
     public static readonly AccountOperation Logout = new(
         "POST /account/logout",
         "sign your account out",

--- a/src/CcDirector.Gateway/Api/AccountTrialEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountTrialEndpoint.cs
@@ -1,0 +1,229 @@
+using System.Globalization;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The free-Pro-trial read: <c>GET /account/trial</c> (issue #1243). Answers whether the CALLER's trial is
+/// running, when it ends, and how many days are left.
+///
+/// WHY IT DID NOT EXIST. The trial itself was never broken. <see cref="Tenancy.TrialRegistry"/> grants it at
+/// hosted enrolment, the Gateway's own <c>account_trials</c> ledger stores it, and the entitlement decision
+/// reads it - a live row sat in the production database with fourteen days on it while every screen in the
+/// product stayed silent, because nothing could ask. The entire defect was the missing read path: we grant
+/// something valuable and never tell the person, and a promise kept silently is indistinguishable from a
+/// promise broken.
+///
+/// THIS ROUTE NEEDS NO OUTBOUND CREDENTIAL, which is what makes it different from its <c>/account</c>
+/// siblings. The credit balance and the device list live in the cloud and are proxied with the Gateway's
+/// stored account token; the trial ledger is the Gateway's OWN table, read locally. So the caller's identity
+/// is all that is needed, and it comes from exactly where every other hosted identity comes from - the
+/// authenticated device key, resolved once by <see cref="AccountActingCredential"/>, never from anything the
+/// client claims.
+///
+/// EVERY ANSWER CARRIES A THREE-WAY STATE, INCLUDING THE REFUSALS. The deny and the deployment-fault paths
+/// return their proper 403 and 503, and they return the SAME <see cref="AccountTrialDto"/> shape with
+/// <see cref="AccountTrialDto.StateUnknown"/> rather than a bare error envelope. That is a deliberate
+/// divergence from <see cref="AccountCreditsEndpoint"/>: this contract exists so that no consumer can ever
+/// be handed a body without a state, because the one thing a trial surface must never do is decide for
+/// itself what a missing answer means. A page that reads a failure as "no trial" tells a member with twelve
+/// days left that they have nothing.
+///
+/// Security: nothing identifying is logged - not the subject, not the email. Inherits the host-wide Gateway
+/// token middleware like the other <c>/account</c> routes.
+/// </summary>
+internal static class AccountTrialEndpoint
+{
+    /// <summary>Maps <c>GET /account/trial</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    /// <param name="trials">The trial ledger - the Gateway's own table, read locally, never proxied.</param>
+    /// <param name="tenantBoundary">
+    /// The hosted tenant boundary. On hosted it resolves the CALLER's tenant from their authenticated device
+    /// key. Required and non-nullable: a forgotten boundary must be a compile error, never a silent default,
+    /// and on hosted a missing one fails CLOSED rather than dropping to the self-host answer.
+    /// </param>
+    /// <param name="tenants">The tenant registry, read on hosted to turn the caller's tenant into the
+    /// account subject the trial ledger is keyed by.</param>
+    /// <param name="nowUtc">The clock, injected so the day count and the expiry boundary are testable at an
+    /// exact instant. Defaults to the real one.</param>
+    public static void Map(IEndpointRouteBuilder app, Tenancy.TrialRegistry trials,
+        Tenancy.HostedTenantBoundary tenantBoundary, Tenancy.TenantRegistry? tenants = null,
+        Func<DateTime>? nowUtc = null)
+    {
+        if (trials is null) throw new ArgumentNullException(nameof(trials));
+        if (tenantBoundary is null) throw new ArgumentNullException(nameof(tenantBoundary));
+
+        var clock = nowUtc ?? (() => DateTime.UtcNow);
+
+        app.MapGet("/account/trial", async (HttpContext ctx) =>
+        {
+            // Entry point: the delegate is the boundary, so the only try-catch lives here. An unexpected
+            // failure is reported AS an unknown - which is not a fallback hiding a problem but this route's
+            // whole contract, because "I could not find out" is the true answer and it is logged loud.
+            try
+            {
+                var (dto, status) = await ResolveAsync(ctx, trials, tenantBoundary, tenants, clock()).ConfigureAwait(false);
+                FileLog.Write($"[AccountTrialEndpoint] GET /account/trial: state={dto.State}, status={status}");
+                return Results.Json(dto, statusCode: status);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[AccountTrialEndpoint] GET /account/trial FAILED ({ex.GetType().Name}): {ex.Message} - answering UNKNOWN, which must never be rendered as no-trial");
+                return Results.Json(Unknown(
+                    "DevThrottle could not read your trial status just now. This does not mean you have no "
+                    + "trial - try again shortly."),
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The whole decision, folded once and rendered verbatim by the client (CLAUDE.md rule 7). Internal so it
+    /// can be exercised directly at every state without standing a web host up.
+    /// </summary>
+    internal static async Task<(AccountTrialDto Dto, int StatusCode)> ResolveAsync(
+        HttpContext ctx, Tenancy.TrialRegistry trials, Tenancy.HostedTenantBoundary boundary,
+        Tenancy.TenantRegistry? tenants, DateTime now)
+    {
+        // SELF-HOST. The trial is a hosted-account fact: it is granted at hosted enrolment and recorded in the
+        // HOSTED Gateway's ledger. This Gateway's own account_trials table is a different table belonging to a
+        // different deployment, and reading it here would produce a statement that is true about THIS RECORD
+        // and false about the world - the most convincing kind of wrong answer. So it does not read: it says
+        // it cannot tell, which is exactly what is true.
+        if (!GatewayHostedMode.IsHosted)
+        {
+            return (Unknown(
+                "This is a self-hosted DevThrottle Gateway, so it does not hold your account's trial status. "
+                + "A free Pro trial belongs to your DevThrottle account on the hosted Gateway - check it on "
+                + "the DevThrottle website."),
+                StatusCodes.Status200OK);
+        }
+
+        var verdict = await AccountActingCredential
+            .ResolveAsync(AccountOperations.Trial, ctx, account: null, boundary, tenants, ctx.RequestAborted)
+            .ConfigureAwait(false);
+
+        // A deny (nothing bound this request to an account) and a deployment fault both keep their proper
+        // status code AND carry a state, so a consumer parsing the body is never handed a shape it cannot read
+        // a three-way answer out of. Neither is "you have no trial" - we do not know whose trial to look up.
+        if (verdict.State is AccountActingState.HostedNoTenant or AccountActingState.HostedMiswired)
+            return (Unknown(verdict.Message), verdict.StatusCode);
+
+        // The subject is the ledger's key, resolved from the authenticated device key at the one place that
+        // turns a key into an identity. Its absence is ignorance about WHO is asking, so it is an unknown -
+        // never an answer about a trial we never looked for.
+        if (string.IsNullOrWhiteSpace(verdict.AccountSubject))
+        {
+            FileLog.Write("[AccountTrialEndpoint] the caller's tenant resolved but no account subject is mapped to it - answering UNKNOWN");
+            return (Unknown(
+                "DevThrottle could not identify the account behind this request, so it cannot tell you "
+                + "whether a free Pro trial is running. This does not mean you have no trial."),
+                StatusCodes.Status200OK);
+        }
+
+        var status = trials.ReadStatus(verdict.AccountSubject, now);
+        return (Describe(status, now), StatusCodes.Status200OK);
+    }
+
+    /// <summary>
+    /// Turns one ledger read into the finished body. Pure: no clock of its own, no database, no request - so
+    /// every state and both sides of the expiry boundary are pinned by direct tests.
+    /// </summary>
+    internal static AccountTrialDto Describe(Tenancy.TrialStatus status, DateTime now)
+    {
+        if (status is null) throw new ArgumentNullException(nameof(status));
+
+        switch (status.Kind)
+        {
+            case Tenancy.TrialStatusKind.Active:
+            {
+                // Active without an end instant would be a day count with nothing behind it. The registry
+                // always carries the row's expiry on Active, so this is a contradiction rather than a state to
+                // render - and inventing a date on a page about what someone is entitled to is worse than
+                // saying we do not know.
+                if (status.ExpiresAtUtc is not { } expires)
+                {
+                    FileLog.Write("[AccountTrialEndpoint] a trial read said ACTIVE with no expiry instant - answering UNKNOWN rather than naming a date we do not have");
+                    return Unknown(
+                        "DevThrottle could not read when your free Pro trial ends. This does not mean you "
+                        + "have no trial - try again shortly.");
+                }
+
+                var days = DaysRemaining(expires, now);
+                return new AccountTrialDto
+                {
+                    State = AccountTrialDto.StateActive,
+                    StartedAtUtc = status.StartedAtUtc,
+                    EndsAtUtc = expires,
+                    DaysRemaining = days,
+                    Message = $"Your free Pro trial is running - {days} {(days == 1 ? "day" : "days")} left, "
+                              + $"ending {OnDay(expires)}.",
+                };
+            }
+
+            case Tenancy.TrialStatusKind.Expired:
+                return new AccountTrialDto
+                {
+                    State = AccountTrialDto.StateExpired,
+                    StartedAtUtc = status.StartedAtUtc,
+                    EndsAtUtc = status.ExpiresAtUtc,
+                    Message = status.ExpiresAtUtc is { } ended
+                        ? $"Your free Pro trial ended on {OnDay(ended)}."
+                        : "Your free Pro trial has ended.",
+                };
+
+            case Tenancy.TrialStatusKind.NeverGranted:
+                // NOT "your trial expired" - this account never had one, and saying it ended would be false.
+                // Stated as a plain fact rather than a loss, because a paying member is in this state too.
+                return new AccountTrialDto
+                {
+                    State = AccountTrialDto.StateNone,
+                    Message = "No free Pro trial is running on this account.",
+                };
+
+            case Tenancy.TrialStatusKind.Unreadable:
+                return Unknown(
+                    "DevThrottle could not read your trial status just now. This does not mean you have no "
+                    + "trial - try again shortly.");
+
+            default:
+                // An unrecognised state is ignorance by definition. It resolves toward unknown, never toward
+                // the comfortable answer - which is the direction that would quietly tell a member on day two
+                // of their trial that they have nothing.
+                FileLog.Write($"[AccountTrialEndpoint] unrecognised trial status '{status.Kind}' - answering UNKNOWN");
+                return Unknown(
+                    "DevThrottle could not read your trial status just now. This does not mean you have no "
+                    + "trial - try again shortly.");
+        }
+    }
+
+    /// <summary>
+    /// Whole days left, counting a PART day as a day: while a trial is active there is always at least some of
+    /// today left, so the smallest true answer is 1. Rounding down would print "0 days left" beside working
+    /// access on the last day, which reads as an expiry that has not happened.
+    /// </summary>
+    private static int DaysRemaining(DateTime expires, DateTime now)
+    {
+        var left = expires - now;
+        var days = (int)Math.Ceiling(left.TotalDays);
+        return days < 1 ? 1 : days;
+    }
+
+    /// <summary>The end date as a person would say it, invariant so it never varies with server culture.</summary>
+    private static string OnDay(DateTime instant)
+        => instant.ToString("d MMMM yyyy", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The undetermined answer, in one place. It carries no dates and no day count - an unknown that shipped
+    /// a number beside it would invite exactly the reading this state exists to prevent.
+    /// </summary>
+    private static AccountTrialDto Unknown(string message) => new()
+    {
+        State = AccountTrialDto.StateUnknown,
+        Message = message,
+    };
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3051,6 +3051,14 @@ public sealed class GatewayHost : IAsyncDisposable
         AccountCreditsEndpoint.Map(_app, Account, new Core.Account.AccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
             tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
 
+        // The free Pro trial read (issue #1243): GET /account/trial. NOT a proxy - unlike the two routes above
+        // there is no cloud call and no account token, because the trial ledger is this Gateway's own
+        // account_trials table. The trial was already being granted at enrolment and stored here; nothing
+        // could ask about it, so no screen ever said a trial was running. This is that read path. Every
+        // answer, including the denials, carries a three-way state so no surface has to decide for itself
+        // what a missing answer means. Inherits the host-wide token middleware like the other /account routes.
+        AccountTrialEndpoint.Map(_app, TrialRegistry, tenantBoundary: _tenantBoundary, tenants: TenantRegistry);
+
         // "DevThrottle emails me" relay (issue #1318 consumer): POST /account/email. A session or scheduled
         // run passes a subject + body (+ optional attachments); the Gateway injects its own stored account
         // token and forwards to the cloud primitive (POST /api/v1/account/notify-owner, devthrottle_internal

--- a/src/CcDirector.Gateway/Tenancy/TrialRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/TrialRegistry.cs
@@ -28,6 +28,46 @@ public enum TrialOutcome
     Unknown,
 }
 
+/// <summary>
+/// What a trial read established for a surface that DESCRIBES the trial to the member, rather than deciding
+/// entitlement from it. Four values, because the two questions need different resolutions.
+///
+/// <see cref="TrialOutcome"/> has three because that is exactly what an ACCESS decision can act on: grant,
+/// refuse, retry. "Never had a trial" and "the trial ended" both mean refuse, so folding them is correct
+/// there. A SENTENCE shown to a member cannot fold them: "your Pro trial ended on 17 August" told to someone
+/// who never had one is false, and so is "you have no trial" told to someone whose fourteen days finished
+/// yesterday. So this splits the refusal in two and leaves the other two alone.
+///
+/// THE SAFETY PARTITION IS STILL THREE, and it is the one that must never be collapsed: ACTIVE /
+/// KNOWN-NOT-ACTIVE (<see cref="Expired"/> and <see cref="NeverGranted"/>) / <see cref="Unreadable"/>.
+/// Unreadable is ignorance and may never be answered as either of the others - telling a member they have no
+/// trial because a database read failed is telling someone with twelve days left that they have nothing.
+/// </summary>
+public enum TrialStatusKind
+{
+    /// <summary>The read succeeded and a trial is running right now.</summary>
+    Active,
+
+    /// <summary>The read succeeded, a trial WAS granted to this account, and its window has closed. It is
+    /// never extended or re-granted, so this state is permanent.</summary>
+    Expired,
+
+    /// <summary>The read succeeded and this account was never granted a trial at all.</summary>
+    NeverGranted,
+
+    /// <summary>The read FAILED. We do not KNOW - this must never be answered as any of the other three.</summary>
+    Unreadable,
+}
+
+/// <summary>One descriptive trial read: the four-way status and the row's instants when there was a row.</summary>
+/// <param name="Kind">The four-way status. The Unreadable value may never be folded into the others.</param>
+/// <param name="StartedAtUtc">When the trial was granted; present whenever a row was read.</param>
+/// <param name="ExpiresAtUtc">When the trial ends or ended; present whenever a row was read. Unlike
+/// <see cref="TrialDecision.ExpiresAtUtc"/> this is populated on <see cref="TrialStatusKind.Expired"/> too,
+/// because a surface saying "your trial ended" has to name the date. It is NOT an entitlement period end and
+/// nothing clips a lease to it.</param>
+public sealed record TrialStatus(TrialStatusKind Kind, DateTime? StartedAtUtc = null, DateTime? ExpiresAtUtc = null);
+
 /// <summary>The result of one trial read: the three-way outcome and, on <see cref="TrialOutcome.Active"/>,
 /// the exact instant the trial ends.</summary>
 /// <param name="Outcome">The three-way outcome. Never fold the three into two.</param>
@@ -97,12 +137,47 @@ public sealed class TrialRegistry
     /// testable at an exact instant.</param>
     public TrialDecision Evaluate(string accountSubject, DateTime nowUtc)
     {
-        // A blank subject is a caller error, not a failed read. Answering Unknown would invite a retry loop
+        // DELEGATES to the single read rather than performing its own (issue #1243). There is exactly ONE
+        // place that loads the row and ONE expiry comparison in this type, so the access decision and the
+        // sentence shown to the member can never disagree about whether a trial is running - which they could
+        // the moment a second method repeated the boundary rule and one of the two was later edited.
+        var status = ReadStatus(accountSubject, nowUtc);
+
+        return status.Kind switch
+        {
+            // The period end the entitlement decision carries forward, so the hosted access lease clips to it.
+            TrialStatusKind.Active => new TrialDecision(TrialOutcome.Active, status.ExpiresAtUtc),
+
+            // IGNORANCE, NOT ABSENCE. Never a grant and never a refusal - the caller turns this into a retry.
+            TrialStatusKind.Unreadable => new TrialDecision(TrialOutcome.Unknown),
+
+            // Expired and NeverGranted are both KNOWLEDGE that no trial covers this account now, and an access
+            // decision has one answer for both. Only a sentence shown to a member needs them apart.
+            _ => new TrialDecision(TrialOutcome.None),
+        };
+    }
+
+    /// <summary>
+    /// Read what covers this account at <paramref name="nowUtc"/>, keeping "never had one" and "it ended"
+    /// apart (issue #1243). READ-ONLY, like <see cref="Evaluate"/>, and the ONLY place this type loads the
+    /// trial row - <see cref="Evaluate"/> is a fold over this.
+    ///
+    /// This exists because the trial was granted and never mentioned anywhere: no endpoint returned it, so no
+    /// screen could show it, and a promise kept silently is indistinguishable from a promise broken. A surface
+    /// that tells a member about their trial needs to name the date it ends or ended, and needs to say
+    /// "I cannot tell you" out loud when the read fails rather than picking the comfortable answer.
+    /// </summary>
+    /// <param name="accountSubject">The verified account subject. The caller must have validated the token
+    /// this came from; this method does not re-verify it.</param>
+    /// <param name="nowUtc">The moment to judge the trial window against.</param>
+    public TrialStatus ReadStatus(string accountSubject, DateTime nowUtc)
+    {
+        // A blank subject is a caller error, not a failed read. Answering Unreadable would invite a retry loop
         // that can never succeed. There is no trial for nobody.
         if (string.IsNullOrWhiteSpace(accountSubject))
         {
-            FileLog.Write("[TrialRegistry] Evaluate: NO TRIAL - no account subject was supplied");
-            return new TrialDecision(TrialOutcome.None);
+            FileLog.Write("[TrialRegistry] ReadStatus: NO TRIAL - no account subject was supplied");
+            return new TrialStatus(TrialStatusKind.NeverGranted);
         }
 
         var subject = accountSubject.Trim();
@@ -118,23 +193,23 @@ public sealed class TrialRegistry
             // IGNORANCE, NOT ABSENCE. A failed read does not tell us the account has no trial, so it may not
             // deny and it may not grant. Logged loud and by type: a persistent failure here stops every new
             // member from starting a trial and must not be quiet.
-            FileLog.Write($"[TrialRegistry] Evaluate: READ FAILED ({ex.GetType().Name}) - answering UNKNOWN, " +
+            FileLog.Write($"[TrialRegistry] ReadStatus: READ FAILED ({ex.GetType().Name}) - answering UNREADABLE, " +
                           "which must be retried and must NEVER be treated as no-trial or as a live trial");
-            return new TrialDecision(TrialOutcome.Unknown);
+            return new TrialStatus(TrialStatusKind.Unreadable);
         }
 
         if (row is null)
-            return new TrialDecision(TrialOutcome.None);
+            return new TrialStatus(TrialStatusKind.NeverGranted);
 
         // STRICTLY LESS THAN, so the expiry instant itself is already outside the window - at exactly
         // ExpiresAtUtc the trial HAS ended, which is what the field means. An inclusive comparison would grant
         // on an expired trial: one tick, but a tick in the give-it-away direction, and boundaries are where a
         // policy is decided, so this one is pinned by its own test.
         if (nowUtc < row.ExpiresAtUtc)
-            return new TrialDecision(TrialOutcome.Active, row.ExpiresAtUtc);
+            return new TrialStatus(TrialStatusKind.Active, row.StartedAtUtc, row.ExpiresAtUtc);
 
-        FileLog.Write("[TrialRegistry] Evaluate: NO TRIAL - this account's trial has ended (it is never extended or re-granted)");
-        return new TrialDecision(TrialOutcome.None);
+        FileLog.Write("[TrialRegistry] ReadStatus: NO TRIAL - this account's trial has ended (it is never extended or re-granted)");
+        return new TrialStatus(TrialStatusKind.Expired, row.StartedAtUtc, row.ExpiresAtUtc);
     }
 
     /// <summary>


### PR DESCRIPTION
Part two of devthrottle_internal issue #1243, "the 14-day Pro trial is invisible after signup" - the read endpoint. The website half is a separate pull request on `thefrederiksen/devthrottle_internal` (#1253); neither depends on the other. Part one (#2426) is the wizard copy.

## The problem

The trial was never broken. `TrialRegistry` grants it at hosted enrolment, `account_trials` stores it, and the entitlement decision reads it - a live row sits in production right now with fourteen days on it. What did not exist was a **read path out of it**. No endpoint returned trial state, so no screen could show one: searching the whole product for a trial end, a day count, or an active flag found nothing. We grant something valuable and never tell the person, and a promise kept silently is indistinguishable from a promise broken.

## What this adds

**`TrialRegistry.ReadStatus`** - four-way: active / expired / never granted / unreadable. Expired and never-granted are split because a *sentence* cannot fold them - "your Pro trial ended on 17 August" is false for someone who never had one, and a paying member is in exactly that state. `TrialOutcome` keeps its three values untouched, because three is exactly what an *access* decision can act on.

`Evaluate` is now a **fold over `ReadStatus`** rather than a second read. There is one row load and one expiry comparison in the whole type, so the paywall and the sentence shown to the member cannot come to different views of the same row. A test asserts that agreement at four instants.

**`GET /account/trial`** - deliberately **not a proxy**. Unlike `/account/credits` and `/account/devices` there is no cloud call and no account token, because the trial ledger is this Gateway's own table. The caller's identity comes from the authenticated device key, resolved once by `AccountActingCredential`, never from anything the client claims.

## Part four: the unknown is never folded into the comfortable answer

- **Every response carries a three-way state, including the refusals.** The deny (403) and the deployment fault (503) keep their status codes *and* return the `AccountTrialDto` shape with `unknown`, rather than a bare error envelope. That is a deliberate divergence from `AccountCreditsEndpoint`, and the reason is the whole issue: no consumer may ever be handed a body it has to guess about.
- **There is no boolean anywhere on the contract, and a test enforces its absence.** A `trialActive: false` field would answer "is a trial running?" with "no" in the one case where the honest answer is "I could not find out", and every consumer that read it would make that substitution silently, at every site, forever. Without one, a reader must look at `state`.
- **Self-host answers `unknown`, not `none`.** A self-hosted Gateway's own `account_trials` table is a different table belonging to a different deployment. Reading it would produce a statement true about *this record* and false about the world - the most convincing kind of wrong answer.
- An `Active` status with no expiry instant resolves to `unknown` rather than naming a date we do not have.

## What is verified

- **The new tests: 23 passed, 0 failed** (`CcDirector.Gateway.Tests`, filtered to `AccountTrialReadTests` and `HostedAccountTrialEndpointTests`).
- **One of them drives a REAL `GatewayHost` over REAL HTTP** with the real auth middleware, real tenant registry and real trial ledger, with trials granted through `GrantIfFirstArrival` - the same call enrolment makes, and the only place a trial is ever created. The unit tests would all keep passing while the route was never mapped; the defect here is precisely that *nothing could ask*, so something has to actually ask.
- **Four revert-proofs, each mutating the real production line, each confirmed present by diff before the run, each restored after:**

  | Mutation | Result |
  |---|---|
  | `Expired` collapses into `NeverGranted` | RED - 4 tests |
  | **an unreadable ledger collapses into no-trial** | RED - the failure-injection test |
  | expiry boundary `<` weakened to `<=` | RED - the boundary test |
  | `Math.Ceiling` to `Math.Floor` in the day count | RED - 2 tests |

### Two revert-proofs failed to redden first time, and both were real findings

Reporting these because they are the substance of the proof, not incidental.

1. **The most important guard was unproven.** Collapsing `Unreadable` into `NeverGranted` inside `ReadStatus` left the entire suite green. Every test built a `TrialStatus` by hand and handed it to `Describe` - which proves the *sentence* shown for an unreadable ledger is right, and proves nothing about whether the registry ever *produces* that state. The description was validated; the placement was not. Fixed by dropping the table so the query genuinely throws (the same failure injection the entitlement side already uses) and asserting that an account with a **live** trial reads as `Unreadable` rather than never-granted - on both the display read and the access decision. Third commit.

2. **The rounding direction was unproven.** `Math.Floor` passed every test, because the floor-of-one clamp (`days < 1 ? 1 : days`) rescues a round-down at the last-day case the test used. A second test now pins it where the clamp cannot reach - twelve days and six hours left, where rounding down deletes a quarter of a day of Pro from what the member is told they have. The old test keeps its own job and no longer claims coverage it did not have.

### One test was written against an assumption that was wrong

The first version asserted a tenant-unbound device key reaches the endpoint and gets a 403 with an `unknown` body. It does not: the host-wide auth middleware refuses it with **401** first, exactly as on `/account/status`. The test now asserts what actually happens - and still asserts the thing that matters, that the refusal carries nothing a consumer could read as "no trial". The endpoint's own deny branch, which the middleware hides from the wire, is proved directly instead.

## The full local gate

`.\scripts\test-local.ps1` reports **1 failure in `CcDirector.Gateway.UnitTests`** - and it is **pre-existing on main, not from this change**. Proof rather than assertion:

- The failing test is a **different one on each run** (`SnoozeRegistryTests.Clear_removes_the_entry...`, then `WorkListStoreCaseParityTests.StoreNameCollision...`), always with the same exception: `InvalidOperationException: The collection has been marked as complete with regards to additions`, thrown inside `FileLogWriter.Enqueue` during shutdown. Nothing in the stack touches trials.
- Run alone, that suite passes 31/31.
- **A clean worktree checked out at `origin/main` with none of this change fails identically** - 1 failed, 2768 passed, 2777 total, the same numbers as this branch.

Worth a separate issue: one test per full run dies in the shared log writer's shutdown race.

Rebased onto current `origin/main` (8d165f6c0) so the new suite-selection tooling applies.

**One run is still in flight and I will report it rather than assume it.** The gate PARKS `CcDirector.Gateway.Tests` - which is exactly where these new tests live, and where the existing `HostedProTrialTests` and `HostedEntitlementGateTests` live too. Those are the tests most exposed to the `Evaluate` refactor, so `scripts/test-local.ps1 -Parked` is running now (that suite serialises machine-wide and is slow). What is already proven is that the 23 tests in that project pass when the project is run directly. What is NOT yet proven is the rest of that project against this change. I will post the result.

## What is NOT verified, stated plainly

- **Nothing was run against the hosted Gateway or the production database.** Every trial row in these tests is one the test granted through the real registry into a throwaway database. The live row that prompted the issue was not read by anything here.
- **No client consumes this endpoint yet in this pull request.** The website reads its own Supabase-side function (#1253) rather than calling this route, because the `gateway` schema lives in the same Postgres and the website has no device key. So this endpoint's first real consumer is the desktop app, and **that surface is not in this change** - see below.
- **The line in the app after enrolment is NOT done.** That was the third item of the issue's part three and it is the one piece of the four parts I have not shipped. It needs either a desktop call to this route or the trial carried on the enrolment response, plus a way to see the wizard actually render it - and I would be writing a sentence into a screen I had not watched. Flagging it as outstanding rather than shipping it unverified.
