### PR TITLE
A git-launch guard test that can fail for the right reason on any machine

### DIFF
--- a/src/CcDirector.Core.Tests/Git/GitLaunchGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Git/GitLaunchGuardTests.cs
@@ -12,10 +12,16 @@ namespace CcDirector.Core.Tests.Git;
 /// each of these services was unreachable, and the exception left them by a route none of their
 /// callers expects: every one of them is written against a result object carrying Success=false.
 ///
-/// The launch is failed here by naming an executable that resolves nowhere, so the operating system
-/// fails it for exactly the reason it fails on a clean Windows install. These tests therefore run
-/// on ANY machine, with or without git - which matters, because a machine without git is a supported
-/// machine and these are the tests it most needs to keep.
+/// EVERY test here fails the launch by naming an executable that resolves nowhere, so the operating
+/// system fails it for exactly the reason it fails on a clean Windows install. These tests therefore
+/// run identically on ANY machine, with or without git - which matters, because a machine without
+/// git is a supported machine and these are the tests it most needs to keep.
+///
+/// That sentence was claimed once before and was FALSE: one test failed the launch with a missing
+/// working directory instead, so its result depended on whether the host had git, and it reddened a
+/// build on a git-less machine. The claim is now verified by a control rather than asserted - the
+/// suite is run a second time with git removed from PATH, and must give the identical result with
+/// nothing skipped. If you add a test here, run that control before you believe this paragraph.
 ///
 /// The assertion in every case is the same: a RESULT that says why, never an exception.
 /// </summary>
@@ -102,28 +108,41 @@ public class GitLaunchGuardTests
     /// <summary>
     /// The read provider the Source Control view renders. It used to report a fixed "Failed to start
     /// git process", which threw the reason away - and said the same thing when git ran perfectly
-    /// well and merely exited non-zero. The launch is failed here with a working directory that does
-    /// not exist, which reaches the same wiring on a machine that HAS git.
+    /// well and merely exited non-zero.
+    ///
+    /// THIS TEST USED TO DEPEND ON THE HOST HAVING GIT, which is the one thing it must not do. It
+    /// failed the launch with a missing working DIRECTORY, so what came back depended on which
+    /// failure the operating system hit first: with git installed, "the directory name is invalid";
+    /// without it, "no such file" - which the rule correctly describes as git not being installed,
+    /// and the assertion that the message must NOT say "not installed" then failed. It reddened a
+    /// build on exactly the machine this whole change exists to support. It now uses the same seam
+    /// as every other test here, so the failure is always the same one, everywhere.
+    ///
+    /// The assertion it used to carry - that a launch failure which is NOT a missing file keeps its
+    /// own words rather than being relabelled "not installed" - has not been lost. It is proved
+    /// directly and deterministically by AnyOtherCode_KeepsTheRealReason below, which is where a
+    /// rule about error codes belongs anyway.
     /// </summary>
     [Fact]
     public async Task GitStatusProvider_WhenGitCannotBeLaunched_ReportsTheReason()
     {
-        var missingDirectory = Path.Combine(Path.GetTempPath(), "devthrottle-no-such-directory-" + Guid.NewGuid().ToString("N"));
+        // A directory of its own, not the shared temp root: GitStatusProvider keeps a STATIC cache
+        // keyed by path, so a sibling test reading the same folder within the cache window could
+        // hand this one a cached success instead of the launch failure it is here to observe.
+        var ownDirectory = Path.Combine(Path.GetTempPath(), "devthrottle-status-launch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(ownDirectory);
+        try
+        {
+            var result = await new GitStatusProvider(NoSuchExecutable).GetStatusAsync(ownDirectory);
 
-        var result = await new GitStatusProvider().GetStatusAsync(missingDirectory);
-
-        Assert.False(result.Success);
-        Assert.NotEqual("Failed to start git process", result.Error);
-
-        // The sharper assertion, and the one worth having: git IS installed on this machine - the
-        // working directory is what is missing - so the message must NOT claim git is absent. A rule
-        // that mapped every launch failure to "not installed" would pass a prefix check and still be
-        // telling the user to reinstall software they already have.
-        Assert.DoesNotContain("not installed", result.Error!);
-        Assert.StartsWith("git could not be started: ", result.Error);
-        Assert.True(
-            result.Error!.Length > "git could not be started: ".Length,
-            "the reason was dropped - only the prefix survived");
+            Assert.False(result.Success);
+            Assert.NotEqual("Failed to start git process", result.Error);
+            Assert.Equal(NotInstalled, result.Error);
+        }
+        finally
+        {
+            try { Directory.Delete(ownDirectory, recursive: true); } catch { /* disposable temp folder */ }
+        }
     }
 
     // ---- The sentence itself -----------------------------------------------------------------

--- a/src/CcDirector.Core/Git/GitStatusProvider.cs
+++ b/src/CcDirector.Core/Git/GitStatusProvider.cs
@@ -30,6 +30,23 @@ public readonly record struct GitCountResult(bool Success, int Count);
 
 public class GitStatusProvider
 {
+    private readonly string _executable;
+
+    /// <summary>Runs the <c>git</c> on this machine's PATH. This is the only production form.</summary>
+    public GitStatusProvider() : this("git") { }
+
+    /// <summary>
+    /// Runs <paramref name="executable"/> instead of <c>git</c>. A TEST SEAM, matching the one
+    /// <see cref="GitCommandRunner"/> and <see cref="GitWriteService"/> already have, and the only
+    /// way to reach the could-not-launch branch WITHOUT depending on what the host machine has
+    /// installed: pass a name that resolves nowhere and the launch fails for precisely the reason it
+    /// fails on a clean Windows install, identically on every machine. Production never calls this.
+    /// </summary>
+    public GitStatusProvider(string executable)
+    {
+        _executable = executable;
+    }
+
     private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(10);
 
     private readonly record struct CacheEntry(string RawOutput, GitStatusResult Result, DateTime Timestamp);
@@ -143,7 +160,7 @@ public class GitStatusProvider
         return null;
     }
 
-    private static async Task<(string Output, string? Error, int ExitCode)> RunGitStatusAsync(string repoPath, CancellationToken ct)
+    private async Task<(string Output, string? Error, int ExitCode)> RunGitStatusAsync(string repoPath, CancellationToken ct)
     {
         try
         {
@@ -151,7 +168,7 @@ public class GitStatusProvider
             // the child (issue 516): the old code read stdout to end before stderr, so a git process
             // that filled its stderr pipe could deadlock, and it passed no token, so a superseded
             // scan could not stop it.
-            var r = await ProcessRunner.RunAsync("git", new[] { "status", "--porcelain=v1", "-u" }, repoPath, ct);
+            var r = await ProcessRunner.RunAsync(_executable, new[] { "status", "--porcelain=v1", "-u" }, repoPath, ct);
             if (!r.Started)
                 // Carries the REASON, not just the fact. On a machine with no git this is the
                 // sentence the Source Control view puts on the screen (issue #1048); it used to be


### PR DESCRIPTION
A guard test for git-launch failures could not fail for the right reason on a machine that has git installed, and could not run at all on one that does not.

`GitStatusProvider` had the executable name `git` as a literal at its single call site, so a test had no way to force the launch itself to fail. The test compensated by pointing at a directory that does not exist - which makes the *directory* the failed thing on a machine with git, and makes the whole test meaningless on a machine without it. That is backwards for a change whose entire purpose is the no-git machine.

## What changed

- `GitStatusProvider` takes the executable name through a constructor seam. The parameterless constructor delegates to `this("git")` (`GitStatusProvider.cs:33-47`) and the one production call site reads `_executable` instead of the literal (`:171`). **Production behaviour is unchanged.**
- The test injects a command name that cannot resolve, inside a unique directory that *does* exist (`GitLaunchGuardTests.cs:127-140`). The executable launch is therefore the failed operation on every host, with or without git. The unique directory also avoids the provider's path-keyed static cache, and cleanup runs in `finally` (`:142-145`).

Cancellation is still rethrown by `GitStatusProvider` (`:179-182`), unchanged.

## Verification

`dotnet build src/CcDirector.Core/CcDirector.Core.csproj` - succeeded, 0 warnings, 0 errors.

`dotnet test --filter FullyQualifiedName~GitLaunchGuardTests` - **9 passed, 0 failed, 0 skipped**.

## Scope

This is deliberately only the test seam. Separate, larger work exists on the same branch's working tree to make a failed git read distinguishable from an empty result across the repository views - the "four repository views still show a failed git read as an empty result" item in the v1.9.7 known-issues list. That work was reviewed and is **not ready**: the new failure state is discarded by every shipped branch caller, and the untracked-diff path still swallows cancellation. It is being tracked separately rather than smuggled in here.

The two are independent: this touches `GitStatusProvider.cs` and `GitLaunchGuardTests.cs`; that work touches seven different files and uses the pre-existing `GitStatusResult.Success/Error` contract, not this constructor seam.
