### PR TITLE
The gate is a local run and a review, never a wait on continuous integration

### DIFF
--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -157,13 +157,16 @@ commit (Step 4), drive it home:
    rule carried that exception list and it is deliberately gone: every exception was an invitation
    to pay the fifty minutes again.
 
-   Do NOT justify this by telling yourself the job runs the same tests you just ran. IT DOES NOT,
-   and the difference is the whole reason the gaps above are written down: the .NET job runs the
-   two parked suites and the two installer projects, none of which any local invocation touches.
-   The reason not to wait is that a verdict arriving fifty minutes after everyone has moved on
-   does not get read, so it buys nothing while costing a day - and the coverage it holds is worth
-   having on purpose, by running it locally when your change touches it, rather than by accident,
-   an hour late.
+   Do NOT justify this by telling yourself the job runs the same tests you just ran. It does not
+   run the same tests as your DEFAULT local run, which omits the two parked suites and never
+   touches the two installer projects. That coverage is reachable locally and on purpose -
+   `-Parked` for the suites, and the two explicit `dotnet test tools/cc-director-setup*.Tests`
+   commands - which is what the release gate uses.
+
+   The reason not to wait is not that the job is redundant. It is that a verdict arriving fifty
+   minutes after everyone has moved on does not get read, so it buys nothing while costing a day.
+   Where its coverage matters, run that coverage yourself, deliberately, instead of receiving it
+   late by accident.
 
    If you want to see the fast checks in passing, look once and move on - do not watch them:
 

--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -145,31 +145,45 @@ commit (Step 4), drive it home:
 
 2. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
 
-3. DO NOT WAIT FOR THE .NET CI JOB. "Build & Test (.NET)" takes roughly FIFTY MINUTES and is the
-   same suite you just ran locally on a far stronger machine. Waiting on it is the single largest
-   source of dead time in this repository, and it is why local is now the gate.
+3. NEVER WAIT FOR A CONTINUOUS INTEGRATION RESULT. Not for "Build & Test (.NET)", which takes
+   roughly FIFTY MINUTES and is the same suite you just ran locally on a far stronger machine,
+   and not for any other check. There is no exception - not a release, not a change to the build
+   or to continuous integration itself, not a cross-platform change. The old rule carried that
+   exception list and it is deliberately gone: every exception was an invitation to pay the fifty
+   minutes again.
 
-   The other three checks - "Build & Test (web)", "Tool contracts (Python)", "Inventory drift" -
-   each finish in about a minute and cover things the local .NET run does NOT. Wait for those:
+   If you want to see the fast checks in passing, look once and move on - do not watch them:
 
        gh pr checks <number>
 
-   If any of those three fail, fix and push a NEW commit (never amend, never --no-verify).
+   If something fails, fix it and push a NEW commit (never amend, never --no-verify).
 
-4. Merge with squash once the local run is green and the three fast checks pass:
+4. GET A REVIEW FROM A DIFFERENT AGENT FAMILY BEFORE MERGING. The author is the last to see the
+   defect, so the reviewer must not be the writer. Codex is the default reviewer, and it runs as
+   a real tracked session - never backgrounded, never hidden:
+
+       cc-devthrottle session spawn <repo> --agent Codex --prompt "<what to review>" --name "review: <what it is>"
+
+   This review replaces the wait, it does not sit alongside it. Waiting bought a second opinion
+   from a machine that runs the same tests; a reviewer reads the change itself, which is the part
+   the tests cannot do.
+
+5. Merge with squash once the local run is green and the review is clean:
    gh pr merge <number> --squash --delete-branch.
    (delete_branch_on_merge is ON, but --delete-branch is explicit and harmless.)
 
-   The .NET job keeps running after the merge as a backstop. If it goes red on main, fix it
-   forward immediately - that is the trade for not waiting on it.
+   Continuous integration keeps running after the merge as a backstop. If it goes red on main,
+   FIX IT FORWARD IMMEDIATELY. That is the whole trade, and it only works if the red is actually
+   chased - a red left standing turns the backstop into noise and then nobody looks at it at all.
 
-   WAIT FOR THE .NET JOB ANYWAY when the change is genuinely risky: a release commit, a change to
-   the build or CI itself, anything cross-platform, or anything you could not test locally. Those
-   are the cases the fifty minutes is actually worth paying for.
-4. Park the checkout back on main:
+   Note what the local gate does NOT cover: test-local.ps1 runs the .NET suites only - no web
+   tests, no Python tests. If you touched the browser shells or the Python toolbelt, the answer
+   is in the "Build & Test (web)" and "Tool contracts (Python)" jobs, and fixing forward means
+   watching for those rather than walking away.
+6. Park the checkout back on main:
    git checkout main && git pull
    If you worked in a worktree, remove it: git worktree remove ../<repo>-wt-<short-desc>.
-5. Verify the resting state: git status --short is empty, git branch --show-current is main,
+7. Verify the resting state: git status --short is empty, git branch --show-current is main,
    and the feature branch is gone (git branch --list <type>/<short-desc> prints nothing).
 
 STEP 8: Report completion

--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -135,11 +135,17 @@ commit (Step 4), drive it home:
 
        .\scripts\test-local.ps1
 
-   It builds once and runs every test project, starting them together so the six that do not
-   serialize finish while the Gateway suite queues for its machine-wide lock. Use -Fast to skip
-   the Gateway suite when the change provably does not touch it, and say so in the pull request.
    Do NOT hand-roll a dotnet test invocation - the script is the one place the whole fleet gets
    faster when the suite improves.
+
+   KNOW WHAT THE DEFAULT RUN DOES NOT COVER. It runs the suites that fit the two-minute budget,
+   roughly 3400 tests. It does NOT run the two parked suites - Gateway.Tests (host-bound, takes a
+   machine-wide lock) and Core.Tests - which need -Parked. It runs NO web tests and NO Python
+   tests. And -Fast is a NO-OP retained for old callers; the default is already the fast run, so
+   passing it gates nothing and must never be cited as though it did.
+
+   If your change touches a parked suite, the browser shells or the Python toolbelt, run that
+   coverage yourself. A green default run is not evidence about code it never executed.
 
    If it is not green, fix it before opening a pull request. A red local run is a red change.
 
@@ -176,10 +182,9 @@ commit (Step 4), drive it home:
    FIX IT FORWARD IMMEDIATELY. That is the whole trade, and it only works if the red is actually
    chased - a red left standing turns the backstop into noise and then nobody looks at it at all.
 
-   Note what the local gate does NOT cover: test-local.ps1 runs the .NET suites only - no web
-   tests, no Python tests. If you touched the browser shells or the Python toolbelt, the answer
-   is in the "Build & Test (web)" and "Tool contracts (Python)" jobs, and fixing forward means
-   watching for those rather than walking away.
+   Chasing a red is not waiting for a green: nothing is held open pending a check, but the web
+   and Python jobs are the only place those tests run at all. If you touched the browser shells
+   or the Python toolbelt, merge without waiting and then go back and read that result.
 6. Park the checkout back on main:
    git checkout main && git pull
    If you worked in a worktree, remove it: git worktree remove ../<repo>-wt-<short-desc>.
@@ -192,7 +197,8 @@ Tell the user:
 - Pull request number and merge commit on main
 - Number of files changed
 - That the branch was deleted and the checkout is parked back on main, clean
-- Any exception (e.g. left open because checks are still running) WITH the reason
+- Any exception WITH the reason. "Checks are still running" is NOT one - nothing is ever left
+  open waiting for a check.
 
 ## Handling bypass requests
 

--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -152,11 +152,18 @@ commit (Step 4), drive it home:
 2. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
 
 3. NEVER WAIT FOR A CONTINUOUS INTEGRATION RESULT. Not for "Build & Test (.NET)", which takes
-   roughly FIFTY MINUTES and is the same suite you just ran locally on a far stronger machine,
-   and not for any other check. There is no exception - not a release, not a change to the build
-   or to continuous integration itself, not a cross-platform change. The old rule carried that
-   exception list and it is deliberately gone: every exception was an invitation to pay the fifty
-   minutes again.
+   roughly FIFTY MINUTES, and not for any other check. There is no exception - not a release, not
+   a change to the build or to continuous integration itself, not a cross-platform change. The old
+   rule carried that exception list and it is deliberately gone: every exception was an invitation
+   to pay the fifty minutes again.
+
+   Do NOT justify this by telling yourself the job runs the same tests you just ran. IT DOES NOT,
+   and the difference is the whole reason the gaps above are written down: the .NET job runs the
+   two parked suites and the two installer projects, none of which any local invocation touches.
+   The reason not to wait is that a verdict arriving fifty minutes after everyone has moved on
+   does not get read, so it buys nothing while costing a day - and the coverage it holds is worth
+   having on purpose, by running it locally when your change touches it, rather than by accident,
+   an hour late.
 
    If you want to see the fast checks in passing, look once and move on - do not watch them:
 
@@ -170,9 +177,10 @@ commit (Step 4), drive it home:
 
        cc-devthrottle session spawn <repo> --agent Codex --prompt "<what to review>" --name "review: <what it is>"
 
-   This review replaces the wait, it does not sit alongside it. Waiting bought a second opinion
-   from a machine that runs the same tests; a reviewer reads the change itself, which is the part
-   the tests cannot do.
+   This review replaces the wait, it does not sit alongside it. Waiting bought a slow re-run of
+   mostly the same tests plus some coverage you are better off running deliberately; a reviewer
+   reads the change itself, which is the part no test run can do - including whether the change
+   says something untrue about the code it describes.
 
 5. Merge with squash once the local run is green and the review is clean:
    gh pr merge <number> --squash --delete-branch.

--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -30,7 +30,11 @@ version numbers, release notes, tags, or the mailing list.
 - **It will only ship green main.** The run refuses, in seconds and before it
   touches anything, if it was started against any ref other than `refs/heads/main`,
   or if the commit being shipped has a check that failed or has not finished. If it
-  refuses for a pending check, wait for continuous integration and start it again.
+  refuses for a pending check, wait for continuous integration and start it again. This is the one
+  wait the no-waiting rule (CLAUDE.md 5a) does not cover, and it is not our policy: 5a governs
+  whether a MERGE is held open, while this is the deploy workflow's own refusal to push unverified
+  code to a live service. Since every merge to main now gets its own run that cannot be evicted,
+  that check will actually finish - before, it could be cancelled and then never go green at all.
 - **It does not set up any infrastructure.** The Azure resource group, container
   registry, database connection, and storage are already provisioned and persist
   across deploys. This deploy only: rebuild the image, point the live service at

--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -62,7 +62,11 @@ git rev-list --count <last-tag>..origin/main    # how many commits shipped
 - Confirm the release is cut from `origin/main`, and that your local branch is not
   behind it. The code you are documenting lives on `origin/main`; your working
   branch may not have it.
-- Confirm the mainline is green in continuous integration before going further.
+- Run the RELEASE gate locally and let it finish: `.\scripts\test-local.ps1 -Parked`. This is the
+  one run that includes the two parked suites (`Gateway.Tests`, `Core.Tests`), which the ordinary
+  gate skips. It replaces the old instruction to wait for a green continuous integration run.
+  It is not optional here: the release workflow runs ZERO tests, and a pushed tag cannot be
+  un-pushed, so a release is the one place "fix it forward" is not available.
 
 ### Step 2: Decide the version number
 
@@ -198,7 +202,9 @@ pull request. That is how v1.1.0 shipped (pull request #1489).
    The workflow publishes that file verbatim and FAILS if it is missing, so a tag
    pushed without it burns a whole build and cannot be un-pushed.
 2. Open a pull request that bumps `Directory.Build.props` to the new version, titled
-   `release: v<version> - <one-line summary>`. Merge it once it is green.
+   `release: v<version> - <one-line summary>`. Merge it once the local `-Parked` run from Step 1
+   is green and the review is clean - not on a continuous integration result, which is never
+   waited for.
 3. Create the tag `v<version>` on `main` at the merged bump commit and push it. That
    is the last manual act. Monitor the Actions run.
 

--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -63,8 +63,10 @@ git rev-list --count <last-tag>..origin/main    # how many commits shipped
   behind it. The code you are documenting lives on `origin/main`; your working
   branch may not have it.
 - Know that a release is gated by a LOCAL run, not by continuous integration, and that the run
-  which counts happens later - on the version-bump head immediately before the merge and tag (see
-  "Cut the release"). It is `.\scripts\test-local.ps1 -Parked -Configuration Release` PLUS the two
+  which counts happens later - on MERGED `main`, at the exact commit about to be tagged, after the
+  version-bump pull request has landed (see "Cut the release"). A run against the pull-request head
+  does not count: the squash merge produces a different commit.
+  It is `.\scripts\test-local.ps1 -Parked -Configuration Release` PLUS the two
   installer test projects the script cannot reach, and it is the one release-blocking wait, because
   the release workflow runs ZERO tests and a pushed tag cannot be un-pushed. A release is the
   single place "fix it forward" is unavailable.

--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -64,9 +64,10 @@ git rev-list --count <last-tag>..origin/main    # how many commits shipped
   branch may not have it.
 - Know that a release is gated by a LOCAL run, not by continuous integration, and that the run
   which counts happens later - on the version-bump head immediately before the merge and tag (see
-  "Cut the release"). It is `.\scripts\test-local.ps1 -Parked -Configuration Release`, and it is
-  the one release-blocking wait, because the release workflow runs ZERO tests and a pushed tag
-  cannot be un-pushed. A release is the single place "fix it forward" is unavailable.
+  "Cut the release"). It is `.\scripts\test-local.ps1 -Parked -Configuration Release` PLUS the two
+  installer test projects the script cannot reach, and it is the one release-blocking wait, because
+  the release workflow runs ZERO tests and a pushed tag cannot be un-pushed. A release is the
+  single place "fix it forward" is unavailable.
 - You may run it now as an early warning, but an early run is NOT the gate: everything committed
   after it - notes, the version bump, other people's merges - is untested by it.
 
@@ -205,23 +206,33 @@ pull request. That is how v1.1.0 shipped (pull request #1489).
    pushed without it burns a whole build and cannot be un-pushed.
 2. Open a pull request that bumps `Directory.Build.props` to the new version, titled
    `release: v<version> - <one-line summary>`.
-3. **Run the release gate on the commit you are actually about to ship**, with the branch rebased
-   on current `origin/main`, immediately before you merge:
+3. Merge the bump pull request once its ordinary local gate is green and the review is clean -
+   never on a continuous integration result, which is never waited for.
+4. **Run the release gate on MERGED MAIN, immediately before you tag.** Not on the pull request
+   head: a squash merge produces a different commit, and `main` can move underneath you during a
+   run that takes tens of minutes. Park the checkout on the exact commit you are about to tag,
+   and run all three of these:
 
+       git checkout main && git pull
        .\scripts\test-local.ps1 -Parked -Configuration Release
+       dotnet test tools/cc-director-setup.Tests/ -c Release
+       dotnet test tools/cc-director-setup-engine.Tests/ -c Release
 
-   Two things about that command are deliberate and neither is optional:
+   Every part of that is deliberate:
    - `-Parked` adds `Gateway.Tests` and `Core.Tests`, which the ordinary gate skips.
    - `-Configuration Release` matches what is shipped. The script defaults to **Debug**, while
      the continuous integration job this replaced ran `-c Release`. Releasing on a Debug-only
      run would quietly test a different build from the one users download.
+   - **The two installer projects are NOT optional and NOT covered by the script.** They are not
+     in `cc-director.sln`, so `test-local.ps1` never touches them - it runs nine projects, all
+     under `src\`. The continuous integration job ran them separately, and the release publishes
+     `cc-director-setup.exe`, so leaving them out ships the first thing a new user sees with no
+     test behind it at all. Folding them into `-Parked` is the follow-up that removes this
+     footgun; until then, run them by hand.
 
-   A gate run earlier in this procedure does NOT count. Notes commits, the version bump and any
-   merges that landed meanwhile all sit between it and the tag, so it is a verdict about a commit
-   nobody is shipping. This is the one release-blocking wait, and it is local.
-4. Merge once that run is green and the review is clean - never on a continuous integration
-   result, which is never waited for.
-5. Create the tag `v<version>` on `main` at the merged bump commit and push it. That
+   If anything here is red, fix it forward on `main` and run the gate again. Do not tag until it
+   is green: this is the one release-blocking wait, and it is local.
+5. Create the tag `v<version>` on `main` at the gated commit and push it. That
    is the last manual act. Monitor the Actions run.
 
 **Do NOT create or publish a GitHub release by hand, and do NOT paste the notes into

--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -62,11 +62,13 @@ git rev-list --count <last-tag>..origin/main    # how many commits shipped
 - Confirm the release is cut from `origin/main`, and that your local branch is not
   behind it. The code you are documenting lives on `origin/main`; your working
   branch may not have it.
-- Run the RELEASE gate locally and let it finish: `.\scripts\test-local.ps1 -Parked`. This is the
-  one run that includes the two parked suites (`Gateway.Tests`, `Core.Tests`), which the ordinary
-  gate skips. It replaces the old instruction to wait for a green continuous integration run.
-  It is not optional here: the release workflow runs ZERO tests, and a pushed tag cannot be
-  un-pushed, so a release is the one place "fix it forward" is not available.
+- Know that a release is gated by a LOCAL run, not by continuous integration, and that the run
+  which counts happens later - on the version-bump head immediately before the merge and tag (see
+  "Cut the release"). It is `.\scripts\test-local.ps1 -Parked -Configuration Release`, and it is
+  the one release-blocking wait, because the release workflow runs ZERO tests and a pushed tag
+  cannot be un-pushed. A release is the single place "fix it forward" is unavailable.
+- You may run it now as an early warning, but an early run is NOT the gate: everything committed
+  after it - notes, the version bump, other people's merges - is untested by it.
 
 ### Step 2: Decide the version number
 
@@ -202,10 +204,24 @@ pull request. That is how v1.1.0 shipped (pull request #1489).
    The workflow publishes that file verbatim and FAILS if it is missing, so a tag
    pushed without it burns a whole build and cannot be un-pushed.
 2. Open a pull request that bumps `Directory.Build.props` to the new version, titled
-   `release: v<version> - <one-line summary>`. Merge it once the local `-Parked` run from Step 1
-   is green and the review is clean - not on a continuous integration result, which is never
-   waited for.
-3. Create the tag `v<version>` on `main` at the merged bump commit and push it. That
+   `release: v<version> - <one-line summary>`.
+3. **Run the release gate on the commit you are actually about to ship**, with the branch rebased
+   on current `origin/main`, immediately before you merge:
+
+       .\scripts\test-local.ps1 -Parked -Configuration Release
+
+   Two things about that command are deliberate and neither is optional:
+   - `-Parked` adds `Gateway.Tests` and `Core.Tests`, which the ordinary gate skips.
+   - `-Configuration Release` matches what is shipped. The script defaults to **Debug**, while
+     the continuous integration job this replaced ran `-c Release`. Releasing on a Debug-only
+     run would quietly test a different build from the one users download.
+
+   A gate run earlier in this procedure does NOT count. Notes commits, the version bump and any
+   merges that landed meanwhile all sit between it and the tag, so it is a verdict about a commit
+   nobody is shipping. This is the one release-blocking wait, and it is local.
+4. Merge once that run is green and the review is clean - never on a continuous integration
+   result, which is never waited for.
+5. Create the tag `v<version>` on `main` at the merged bump commit and push it. That
    is the last manual act. Monitor the Actions run.
 
 **Do NOT create or publish a GitHub release by hand, and do NOT paste the notes into

--- a/.claude/skills/test-manager/HANDOVER.md
+++ b/.claude/skills/test-manager/HANDOVER.md
@@ -31,8 +31,11 @@ un-park anything to raise a coverage number.
    and a skipped gate has a true coverage of zero. A batch that would blow the 120-second ceiling does
    not go in, however good the tests are.
 5. **Local is the gate, and nothing ever waits on continuous integration.** Not for a release
-   either - a release runs the local `-Parked` gate instead. Continuous integration is a
-   post-merge backstop that is never watched and never left red: a red is driven to green at once.
+   either - a release runs the local `-Parked -Configuration Release` gate instead, on the commit
+   being shipped. Continuous integration is a post-merge backstop that is never WAITED on and
+   never left red: a red is driven to green at once. Reading a result after the merge is chasing,
+   not waiting, and it is required for the web and Python jobs - they are the only place those
+   tests run at all.
 
 ## The queue, in the order I would do it
 

--- a/.claude/skills/test-manager/HANDOVER.md
+++ b/.claude/skills/test-manager/HANDOVER.md
@@ -31,8 +31,9 @@ un-park anything to raise a coverage number.
    and a skipped gate has a true coverage of zero. A batch that would blow the 120-second ceiling does
    not go in, however good the tests are.
 5. **Local is the gate, and nothing ever waits on continuous integration.** Not for a release
-   either - a release runs the local `-Parked -Configuration Release` gate instead, on the commit
-   being shipped. Continuous integration is a post-merge backstop that is never WAITED on and
+   either - a release runs the local `-Parked -Configuration Release` gate instead, plus the two
+   installer test projects the script cannot reach, on merged main at the commit being tagged.
+   Continuous integration is a post-merge backstop that is never WAITED on and
    never left red: a red is driven to green at once. Reading a result after the merge is chasing,
    not waiting, and it is required for the web and Python jobs - they are the only place those
    tests run at all.

--- a/.claude/skills/test-manager/HANDOVER.md
+++ b/.claude/skills/test-manager/HANDOVER.md
@@ -30,8 +30,9 @@ un-park anything to raise a coverage number.
 4. **Speed beats coverage.** A fast gate runs on every change; a slow comprehensive one gets skipped,
    and a skipped gate has a true coverage of zero. A batch that would blow the 120-second ceiling does
    not go in, however good the tests are.
-5. **Local is the gate.** CI is for releases, explicit requests, and its own failures - and a red CI is
-   driven to green, never left standing.
+5. **Local is the gate, and nothing ever waits on continuous integration.** Not for a release
+   either - a release runs the local `-Parked` gate instead. Continuous integration is a
+   post-merge backstop that is never watched and never left red: a red is driven to green at once.
 
 ## The queue, in the order I would do it
 

--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -129,21 +129,22 @@ split - a new project that silently inherited it would look like a win and be th
 **Prove parallelism by measurement, not by intent.** Wall clock must be far below the summed test
 durations. If they are close, the tests are running one at a time whatever the configuration says.
 
-## LOCAL IS THE GATE. CI IS FOR RELEASES AND FOR ITS OWN FAILURES
+## LOCAL IS THE GATE. NOTHING EVER WAITS ON CONTINUOUS INTEGRATION
 
-Run `.\scripts	est-local.ps1`. This machine is far stronger than a CI runner and gives the answer in
-about a minute; the .NET job on CI takes roughly fifty. **Do not wait on CI to merge ordinary work.**
+Run `.\scripts	est-local.ps1`. This machine is far stronger than a runner and gives the answer in
+about a minute; the .NET job takes roughly fifty. **Never wait on continuous integration to merge -
+no exceptions, releases included.** The gate is the local run plus a review by a different agent
+family (Codex by default), and then the change merges.
 
-CI is run in exactly these cases:
+The exception list this section used to carry - releases, changes to the build, cross-platform work -
+is gone deliberately. Every exception was an invitation to pay the fifty minutes again, and the
+answer it bought was one the local run had already given.
 
-| When | Why |
-|------|-----|
-| Cutting a release | The one time the full matrix is worth fifty minutes. |
-| Explicitly asked for | Somebody wants it, or it has been a while and drift is suspected. |
-| **CI itself went red** | Then it is re-run and driven to green - a red CI is never left standing. |
-
-A red CI is not a background condition to be worked around. Fix it forward immediately, re-run, and
-confirm it clears. That is the trade for not waiting on it the rest of the time.
+Continuous integration still runs after the merge, as a backstop. It is never watched and never
+waited for, and it is never left red: **a red is fixed forward immediately, re-run, and confirmed
+clear.** That is the whole trade. A red left standing turns the backstop into noise, and a backstop
+nobody reads is not a backstop - which is exactly how two architecture guards stayed red on main for
+a morning without anybody being told.
 
 ## Deciding what to run: ALWAYS ask the selector, never guess
 
@@ -441,8 +442,9 @@ Answer with what is NOT running, not with a number of tests. The honest summary 
 - **Running by default:** ~3400 tests, ~80 seconds.
 - **Not running by default:** the host-bound Gateway suite (endpoints, tenancy, boundaries) and all
   of `Core.Tests`. Both run under `-Parked`.
-- **CI** still runs everything after a merge as a backstop; it takes about fifty minutes and does not
-  block anyone.
+- **Continuous integration** still runs everything after a merge as a backstop; it takes about fifty
+  minutes, blocks nobody, and is never waited for. When it reddens it is fixed forward at once - an
+  unchased red is how this backstop stops being one.
 
 If a change touches the Gateway's host-bound surface, or anything Core covers, say so and run
 `-Parked` before merging. The budget buys speed on ordinary changes; it is not a licence to skip

--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -131,7 +131,7 @@ durations. If they are close, the tests are running one at a time whatever the c
 
 ## LOCAL IS THE GATE. NOTHING EVER WAITS ON CONTINUOUS INTEGRATION
 
-Run `.\scripts	est-local.ps1`. This machine is far stronger than a runner and gives the answer in
+Run `.\scripts\test-local.ps1`. This machine is far stronger than a runner and gives the answer in
 about a minute; the .NET job takes roughly fifty. **Never wait on continuous integration to merge -
 no exceptions, releases included.** The gate is the local run plus a review by a different agent
 family (Codex by default), and then the change merges.
@@ -140,11 +140,19 @@ The exception list this section used to carry - releases, changes to the build, 
 is gone deliberately. Every exception was an invitation to pay the fifty minutes again, and the
 answer it bought was one the local run had already given.
 
-Continuous integration still runs after the merge, as a backstop. It is never watched and never
-waited for, and it is never left red: **a red is fixed forward immediately, re-run, and confirmed
-clear.** That is the whole trade. A red left standing turns the backstop into noise, and a backstop
-nobody reads is not a backstop - which is exactly how two architecture guards stayed red on main for
-a morning without anybody being told.
+A release still needs the coverage the default run skips, and gets it LOCALLY: run
+`.\scripts\test-local.ps1 -Parked` and let it finish before cutting one. That is not a softened
+version of the old rule - it is a local gate, not a wait on a runner. It matters because the
+release workflow runs ZERO tests and a pushed tag cannot be un-pushed, so a release is the single
+place where fixing forward is not available.
+
+Continuous integration still runs after the merge, as a backstop. It is never **waited on** - no
+merge is ever held open for it - and it is never left red: **a red is fixed forward immediately,
+re-run, and confirmed clear.** Reading a result after the fact is chasing, not waiting, and it is
+required: the web and Python jobs are the only place those tests run at all, so a change touching
+the browser shells or the Python toolbelt must go back and read them. A red left standing turns the
+backstop into noise, and a backstop nobody reads is not a backstop - which is exactly how two
+architecture guards stayed red on main for a morning without anybody being told.
 
 ## Deciding what to run: ALWAYS ask the selector, never guess
 

--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -36,7 +36,8 @@ The owner of this repository's test suites. Three duties, in priority order:
 | Action | Command |
 |--------|---------|
 | Run the gate (this is THE gate) | `.\scripts\test-local.ps1` |
-| Run the gate plus parked suites (before a release) | `.\scripts\test-local.ps1 -Parked` |
+| Run the gate plus parked suites | `.\scripts\test-local.ps1 -Parked` |
+| THE RELEASE GATE - on the commit being shipped | `.\scripts\test-local.ps1 -Parked -Configuration Release` |
 | Run only the locked Gateway suite | `.\scripts\test-local.ps1 -Gateway` |
 | Filter within a run | `.\scripts\test-local.ps1 -Filter "FullyQualifiedName~Snooze"` |
 

--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -37,7 +37,7 @@ The owner of this repository's test suites. Three duties, in priority order:
 |--------|---------|
 | Run the gate (this is THE gate) | `.\scripts\test-local.ps1` |
 | Run the gate plus parked suites | `.\scripts\test-local.ps1 -Parked` |
-| THE RELEASE GATE - on the commit being shipped | `.\scripts\test-local.ps1 -Parked -Configuration Release` |
+| THE RELEASE GATE - on merged main, at the commit being tagged | `.\scripts\test-local.ps1 -Parked -Configuration Release` **plus** the two `tools/cc-director-setup*.Tests` projects - see the release gate section; the script alone is NOT the whole gate |
 | Run only the locked Gateway suite | `.\scripts\test-local.ps1 -Gateway` |
 | Filter within a run | `.\scripts\test-local.ps1 -Filter "FullyQualifiedName~Snooze"` |
 
@@ -141,11 +141,20 @@ The exception list this section used to carry - releases, changes to the build, 
 is gone deliberately. Every exception was an invitation to pay the fifty minutes again, and the
 answer it bought was one the local run had already given.
 
-A release still needs the coverage the default run skips, and gets it LOCALLY: run
-`.\scripts\test-local.ps1 -Parked -Configuration Release` on the exact commit being shipped, and
-let it finish. `-Parked` adds the two skipped suites; `-Configuration Release` matches what users
-download, because this script defaults to Debug while the continuous integration job it replaced
-ran Release. An earlier run does not count - whatever was committed after it is untested by it.
+A release still needs the coverage the default run skips, and gets it LOCALLY, on merged `main` at
+the exact commit about to be tagged:
+
+    .\scripts\test-local.ps1 -Parked -Configuration Release
+    dotnet test tools/cc-director-setup.Tests/ -c Release
+    dotnet test tools/cc-director-setup-engine.Tests/ -c Release
+
+`-Parked` adds the two skipped suites. `-Configuration Release` matches what users download,
+because this script defaults to Debug while the continuous integration job it replaced ran Release.
+The two installer projects are outside `cc-director.sln` and this script therefore never runs them,
+while the release ships `cc-director-setup.exe` - folding them into `-Parked` is the follow-up that
+removes the footgun. An earlier run does not count, and neither does a run against a pull-request
+head rather than the squashed commit that gets tagged.
+
 That is not a softened version of the old rule - it is a local gate, not a wait on a runner. It
 matters because the release workflow runs ZERO tests and a pushed tag cannot be un-pushed, so a
 release is the single place where fixing forward is not available.

--- a/.claude/skills/test-manager/skill.md
+++ b/.claude/skills/test-manager/skill.md
@@ -141,10 +141,13 @@ is gone deliberately. Every exception was an invitation to pay the fifty minutes
 answer it bought was one the local run had already given.
 
 A release still needs the coverage the default run skips, and gets it LOCALLY: run
-`.\scripts\test-local.ps1 -Parked` and let it finish before cutting one. That is not a softened
-version of the old rule - it is a local gate, not a wait on a runner. It matters because the
-release workflow runs ZERO tests and a pushed tag cannot be un-pushed, so a release is the single
-place where fixing forward is not available.
+`.\scripts\test-local.ps1 -Parked -Configuration Release` on the exact commit being shipped, and
+let it finish. `-Parked` adds the two skipped suites; `-Configuration Release` matches what users
+download, because this script defaults to Debug while the continuous integration job it replaced
+ran Release. An earlier run does not count - whatever was committed after it is untested by it.
+That is not a softened version of the old rule - it is a local gate, not a wait on a runner. It
+matters because the release workflow runs ZERO tests and a pushed tag cannot be un-pushed, so a
+release is the single place where fixing forward is not available.
 
 Continuous integration still runs after the merge, as a backstop. It is never **waited on** - no
 merge is ever held open for it - and it is never left red: **a red is fixed forward immediately,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,9 +252,13 @@ walking away from it. Merge without waiting; come back for the answer.
 **Releasing is the one place the missing coverage bites, and it cannot be fixed forward.** The
 release workflow runs ZERO tests - it builds and publishes artifacts - and a pushed tag cannot be
 un-pushed. So a defect that the default gate never looked at ships, and "fix it forward" is not
-available to a release that is already out. **Before a release, run `.\scripts\test-local.ps1
--Parked` and let it finish.** That is the release gate, it is local, and it replaces the old
-instruction to wait for a green continuous integration run - it does not reintroduce it.
+available to a release that is already out. **Before a release, on the exact commit being
+shipped, run `.\scripts\test-local.ps1 -Parked -Configuration Release` and let it finish.**
+`-Parked` adds the two skipped suites; `-Configuration Release` matches what users download,
+because the script defaults to Debug while the continuous integration job it replaced ran Release.
+An earlier run does not count - the version bump and anything else merged since is untested by it.
+That is the release gate, it is local, and it replaces the old instruction to wait for a green
+continuous integration run rather than reintroducing it.
 
 If the Gateway suite says it is WAITING on a lock held by another run, that is not a hang - it is
 one run at a time by design, and it prints its holder every 30 seconds. See issue #1156 for why that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,22 @@ cross-platform change. That exception list is gone deliberately. Waiting fifty m
 answer you already have locally was the single largest source of dead time in this repository
 (issue #1156), and every exception written into the rule was an invitation to pay it again.
 
-1. **Run the local gate.** Use the script, not a hand-rolled `dotnet test`: it builds once and
-   starts every test project together, so the six that do not serialize finish while the Gateway
-   suite queues for its machine-wide lock. It is also the ONE place the whole fleet gets faster
-   when the suite improves - a convention each caller re-implements cannot be improved centrally.
-   `-Fast` skips the Gateway suite for a change that provably does not touch it; say so in the
-   pull request if you rely on it. A red local run is a red change - fix it before going further.
+1. **Run the local gate.** Use the script, not a hand-rolled `dotnet test` - it is the ONE place
+   the whole fleet gets faster when the suite improves, and a convention each caller
+   re-implements cannot be improved centrally. A red local run is a red change; fix it before
+   going further.
+
+   Know exactly what the default run covers, because it is not everything:
+   - It runs every suite that fits the two-minute budget, roughly 3,400 tests.
+   - **Two suites are PARKED and do NOT run by default** - `Gateway.Tests` (host-bound, takes a
+     machine-wide lock) and `Core.Tests` (far outside the budget). Run them with `-Parked`.
+   - `-Fast` is a **no-op**, retained only for callers that still pass it. The default is the
+     fast run. Do not claim a change was gated by `-Fast`; it means nothing.
+   - It runs **no web tests and no Python tests** at all.
+
+   So a regression inside a parked suite, the browser shells, or the Python toolbelt can reach
+   main with a green local run. If your change touches any of those, run `-Parked` or the
+   relevant suite yourself - do not let "the gate was green" stand in for coverage it never had.
 2. **Get the change reviewed by a different agent family.** The author is the last to see the
    defect, so the reviewer must not be the writer. Codex is the default reviewer, and it runs as
    a real tracked session, never backgrounded and never hidden:
@@ -234,11 +244,17 @@ answer you already have locally was the single largest source of dead time in th
 trade, and it only works if the red is actually chased: a red that is left standing turns the
 backstop into noise, and then nobody looks at it at all. Chase it the moment you see it.
 
-**Know what the local gate does NOT cover.** `test-local.ps1` runs the .NET suites only - it runs
-no web tests and no Python tests. Those live only in the "Build & Test (web)" and "Tool contracts
-(Python)" jobs, which finish in about a minute each. You are not required to wait for them, but if
-you touched the browser shells or the Python toolbelt, that is where the answer is, and fixing it
-forward means watching for it rather than walking away.
+**Chasing a red is not the same as waiting for a green.** Nothing is ever held open pending a
+check. But the web and Python jobs are the ONLY place those tests run at all, so if you touched
+the browser shells or the Python toolbelt, go and read that result after merging rather than
+walking away from it. Merge without waiting; come back for the answer.
+
+**Releasing is the one place the missing coverage bites, and it cannot be fixed forward.** The
+release workflow runs ZERO tests - it builds and publishes artifacts - and a pushed tag cannot be
+un-pushed. So a defect that the default gate never looked at ships, and "fix it forward" is not
+available to a release that is already out. **Before a release, run `.\scripts\test-local.ps1
+-Parked` and let it finish.** That is the release gate, it is local, and it replaces the old
+instruction to wait for a green continuous integration run - it does not reintroduce it.
 
 If the Gateway suite says it is WAITING on a lock held by another run, that is not a hang - it is
 one run at a time by design, and it prints its holder every 30 seconds. See issue #1156 for why that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,13 +252,23 @@ walking away from it. Merge without waiting; come back for the answer.
 **Releasing is the one place the missing coverage bites, and it cannot be fixed forward.** The
 release workflow runs ZERO tests - it builds and publishes artifacts - and a pushed tag cannot be
 un-pushed. So a defect that the default gate never looked at ships, and "fix it forward" is not
-available to a release that is already out. **Before a release, on the exact commit being
-shipped, run `.\scripts\test-local.ps1 -Parked -Configuration Release` and let it finish.**
-`-Parked` adds the two skipped suites; `-Configuration Release` matches what users download,
+available to a release that is already out. **The release gate runs on merged `main` at the exact
+commit about to be tagged, and it is three commands, not one:**
+
+    .\scripts\test-local.ps1 -Parked -Configuration Release
+    dotnet test tools/cc-director-setup.Tests/ -c Release
+    dotnet test tools/cc-director-setup-engine.Tests/ -c Release
+
+`-Parked` adds the two skipped suites. `-Configuration Release` matches what users download,
 because the script defaults to Debug while the continuous integration job it replaced ran Release.
-An earlier run does not count - the version bump and anything else merged since is untested by it.
-That is the release gate, it is local, and it replaces the old instruction to wait for a green
-continuous integration run rather than reintroducing it.
+The two installer projects are **not in `cc-director.sln`**, so `test-local.ps1` never runs them -
+it runs nine projects, all under `src\` - and the release publishes `cc-director-setup.exe`, so
+omitting them ships the installer with nothing behind it.
+
+An earlier run does not count: the version bump and anything merged since is untested by it, and a
+run against a pull-request head is not a run against the squashed commit that gets tagged. This is
+the release gate, it is local, and it replaces the old instruction to wait for a green continuous
+integration run rather than reintroducing it.
 
 If the Gateway suite says it is WAITING on a lock held by another run, that is not a hang - it is
 one run at a time by design, and it prints its holder every 30 seconds. See issue #1156 for why that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,26 +205,40 @@ Do NOT put try-catch in helper methods or service methods.
 - Use Arrange-Act-Assert pattern
 - Name tests: `MethodName_Scenario_ExpectedResult`
 
-### 5a. RUN THE TESTS LOCALLY - GITHUB IS NOT THE GATE
+### 5a. LOCAL RUN, THEN A REVIEW, THEN MERGE - NEVER WAIT FOR CONTINUOUS INTEGRATION
 
-**Run `.\scripts\test-local.ps1` before you open a pull request. That run is the gate.**
+**The gate is two things, both of which happen here: `.\scripts\test-local.ps1` goes green, and a
+reviewer from a different agent family reads the change. Then merge. Nothing waits on GitHub.**
 
-Do NOT run `gh pr checks --watch` on "Build & Test (.NET)" and wait for it. That job takes about
-FIFTY MINUTES and runs the same tests you can run here, on a machine with 24 logical cores and 64 GB.
-Waiting on it was the single largest source of dead time in this repository (issue #1156).
+There is no longer any case in which you hold a merge open waiting for a continuous integration
+result - not a release, not a change to the build or to continuous integration itself, not a
+cross-platform change. That exception list is gone deliberately. Waiting fifty minutes for an
+answer you already have locally was the single largest source of dead time in this repository
+(issue #1156), and every exception written into the rule was an invitation to pay it again.
 
-- **Use the script, not a hand-rolled `dotnet test`.** It builds once and starts every test project
-  together, so the six that do not serialize finish while the Gateway suite queues for its
-  machine-wide lock. It is also the ONE place the whole fleet gets faster when the suite improves -
-  a convention each caller re-implements cannot be improved centrally.
-- `-Fast` skips the Gateway suite for a change that provably does not touch it. Say so in the pull
-  request if you rely on it.
-- **Do wait for the three fast checks** - "Build & Test (web)", "Tool contracts (Python)",
-  "Inventory drift". They take about a minute each and cover things the local .NET run does not.
-- The .NET job still runs after the merge as a backstop. If it reddens on main, fix it forward
-  immediately. That is the trade for not waiting on it.
-- **Do wait for the .NET job anyway** when the change is genuinely risky: a release commit, a change
-  to the build or to CI itself, anything cross-platform, or anything you could not test locally.
+1. **Run the local gate.** Use the script, not a hand-rolled `dotnet test`: it builds once and
+   starts every test project together, so the six that do not serialize finish while the Gateway
+   suite queues for its machine-wide lock. It is also the ONE place the whole fleet gets faster
+   when the suite improves - a convention each caller re-implements cannot be improved centrally.
+   `-Fast` skips the Gateway suite for a change that provably does not touch it; say so in the
+   pull request if you rely on it. A red local run is a red change - fix it before going further.
+2. **Get the change reviewed by a different agent family.** The author is the last to see the
+   defect, so the reviewer must not be the writer. Codex is the default reviewer, and it runs as
+   a real tracked session, never backgrounded and never hidden:
+
+       cc-devthrottle session spawn <repo> --agent Codex --prompt "<what to review>" --name "review: <what it is>"
+
+3. **Merge.** `gh pr merge <number> --squash --delete-branch`, then park the checkout back on main.
+
+**When continuous integration goes red afterwards, fix it forward immediately.** That is the whole
+trade, and it only works if the red is actually chased: a red that is left standing turns the
+backstop into noise, and then nobody looks at it at all. Chase it the moment you see it.
+
+**Know what the local gate does NOT cover.** `test-local.ps1` runs the .NET suites only - it runs
+no web tests and no Python tests. Those live only in the "Build & Test (web)" and "Tool contracts
+(Python)" jobs, which finish in about a minute each. You are not required to wait for them, but if
+you touched the browser shells or the Python toolbelt, that is where the answer is, and fixing it
+forward means watching for it rather than walking away.
 
 If the Gateway suite says it is WAITING on a lock held by another run, that is not a hang - it is
 one run at a time by design, and it prints its holder every 30 seconds. See issue #1156 for why that

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,6 +12,28 @@ Pre-release tags: append `-rc1`, `-rc2`, etc. for release candidates. Pre-releas
 
 ## Release Process
 
+> The authoritative run-book is the `release-manager` skill
+> (`.claude/skills/release-manager/SKILL.md`). This page is the short form; where the two differ,
+> the skill wins.
+
+### 0. The release gate - MANDATORY, and local
+
+Run this on the exact commit you are about to tag, with the branch rebased on current
+`origin/main`, and let it finish:
+
+```powershell
+.\scripts\test-local.ps1 -Parked -Configuration Release
+```
+
+Both switches matter. `-Parked` adds `Gateway.Tests` and `Core.Tests`, which the ordinary gate
+skips, and `-Configuration Release` matches what is actually shipped - the script defaults to
+Debug. A run from earlier in the process does not count: anything committed after it, including
+the version bump, is untested by it.
+
+Nothing waits on continuous integration here or anywhere else (CLAUDE.md 5a). This local run is
+the gate instead, and unlike an ordinary change a release cannot be fixed forward - the release
+workflow runs no tests, and a pushed tag cannot be un-pushed.
+
 ### 1. Bump Version
 
 Update the `<Version>` tag in both csproj files:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,29 +16,39 @@ Pre-release tags: append `-rc1`, `-rc2`, etc. for release candidates. Pre-releas
 > (`.claude/skills/release-manager/SKILL.md`). This page is the short form; where the two differ,
 > the skill wins.
 
-The release gate runs AFTER the version bump is committed and BEFORE the tag - see step 3 below.
-Running it any earlier is pointless: the bump itself would be untested by it.
+The release gate runs on MERGED `main`, after the version bump has landed and before the tag - see
+step 3. Running it any earlier is pointless: the bump itself would be untested by it, and a run
+against a pull-request head is not a run against the squashed commit that gets tagged.
 
-### 1. Bump Version
+### 1. Bump the version
 
-Update the `<Version>` tag in both csproj files:
+The version lives in ONE place - `<Version>` in `Directory.Build.props` at the repository root.
+Every project derives its assembly versions from it, and no project may declare its own.
 
-- `src/CcDirector.Wpf/CcDirector.Wpf.csproj`
-- `tools/cc-director-setup/cc-director-setup.csproj`
+(The two csproj files this page used to name, `src/CcDirector.Wpf/CcDirector.Wpf.csproj` and
+`tools/cc-director-setup/cc-director-setup.csproj`, no longer exist. Editing "both csproj files"
+has been impossible for some time.)
 
-Also update `VersionText` in `tools/cc-director-setup/MainWindow.xaml` if the displayed version differs.
+### 2. Land it on main through a pull request
 
-### 2. Commit
+`main` is protected and cannot be pushed to directly, so the bump reaches it the same way every
+other change does: a pull request titled `release: v<version> - <one-line summary>`, merged once
+its ordinary local gate is green and the review is clean. Stage the file you changed by name -
+never `git add -A`, which sweeps up whatever else is in a shared checkout.
 
 ```bash
-git add -A
-git commit -m "chore: bump version to vX.Y.Z"
+git add Directory.Build.props
+git commit -m "release: vX.Y.Z - <one-line summary>"
 ```
+
+Note also that `docs/public/release-notes/v<version>.md` must already be merged to `main` before
+you tag: the workflow publishes it verbatim and FAILS without it, burning a build on a tag that
+cannot be un-pushed.
 
 ### 3. The release gate - MANDATORY, and local
 
-On the exact commit you are about to tag - the bump already committed, nothing else pending -
-run all of this and let it finish:
+On MERGED `main`, at the exact commit you are about to tag - park the checkout there first with
+`git checkout main && git pull` - run all of this and let it finish:
 
 ```powershell
 .\scripts\test-local.ps1 -Parked -Configuration Release
@@ -56,22 +66,19 @@ the gate instead, and unlike an ordinary change a release cannot be fixed forwar
 workflow runs no tests, and a pushed tag cannot be un-pushed. If it is red, fix it forward and
 run the gate again before tagging.
 
-### 4. Tag
+### 4. Tag the gated commit and push the tag
 
 ```bash
 git tag vX.Y.Z
-```
-
-Tags without `-` in the suffix (e.g., `v1.2.0`) become the "Latest" release on GitHub. Tags with `-rc` (e.g., `v1.2.0-rc1`) become pre-releases.
-
-### 5. Push
-
-```bash
-git push origin main
 git push origin vX.Y.Z
 ```
 
-### 6. Wait for the release build to produce the artifacts
+Only the TAG is pushed. `main` already carries the bump - it arrived through the merged pull
+request in step 2 - and cannot be pushed to directly in any case.
+
+Tags without `-` in the suffix (e.g., `v1.2.0`) become the "Latest" release on GitHub. Tags with `-rc` (e.g., `v1.2.0-rc1`) become pre-releases.
+
+### 5. Wait for the release build to produce the artifacts
 
 This is the ONE wait that remains, and it is not a test gate - it is the build that produces the
 downloadable files, so there is nothing to release until it finishes. The rule against waiting on
@@ -84,7 +91,7 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) will:
 3. Build all cc-tools as zip archives
 4. Create a GitHub Release with all artifacts attached
 
-### 7. Verify
+### 6. Verify
 
 1. Go to the [Releases page](https://github.com/thefrederiksen/devthrottle/releases)
 2. Confirm the new release is marked "Latest" (if not a pre-release)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,23 +16,8 @@ Pre-release tags: append `-rc1`, `-rc2`, etc. for release candidates. Pre-releas
 > (`.claude/skills/release-manager/SKILL.md`). This page is the short form; where the two differ,
 > the skill wins.
 
-### 0. The release gate - MANDATORY, and local
-
-Run this on the exact commit you are about to tag, with the branch rebased on current
-`origin/main`, and let it finish:
-
-```powershell
-.\scripts\test-local.ps1 -Parked -Configuration Release
-```
-
-Both switches matter. `-Parked` adds `Gateway.Tests` and `Core.Tests`, which the ordinary gate
-skips, and `-Configuration Release` matches what is actually shipped - the script defaults to
-Debug. A run from earlier in the process does not count: anything committed after it, including
-the version bump, is untested by it.
-
-Nothing waits on continuous integration here or anywhere else (CLAUDE.md 5a). This local run is
-the gate instead, and unlike an ordinary change a release cannot be fixed forward - the release
-workflow runs no tests, and a pushed tag cannot be un-pushed.
+The release gate runs AFTER the version bump is committed and BEFORE the tag - see step 3 below.
+Running it any earlier is pointless: the bump itself would be untested by it.
 
 ### 1. Bump Version
 
@@ -50,7 +35,28 @@ git add -A
 git commit -m "chore: bump version to vX.Y.Z"
 ```
 
-### 3. Tag
+### 3. The release gate - MANDATORY, and local
+
+On the exact commit you are about to tag - the bump already committed, nothing else pending -
+run all of this and let it finish:
+
+```powershell
+.\scripts\test-local.ps1 -Parked -Configuration Release
+dotnet test tools/cc-director-setup.Tests/ -c Release
+dotnet test tools/cc-director-setup-engine.Tests/ -c Release
+```
+
+`-Parked` adds `Gateway.Tests` and `Core.Tests`, which the ordinary gate skips.
+`-Configuration Release` matches what is actually shipped; the script defaults to Debug.
+The two installer projects are not in `cc-director.sln`, so `test-local.ps1` never runs them -
+and this release publishes `cc-director-setup.exe`, so skipping them ships the installer untested.
+
+Nothing waits on continuous integration here or anywhere else (CLAUDE.md 5a). This local run is
+the gate instead, and unlike an ordinary change a release cannot be fixed forward - the release
+workflow runs no tests, and a pushed tag cannot be un-pushed. If it is red, fix it forward and
+run the gate again before tagging.
+
+### 4. Tag
 
 ```bash
 git tag vX.Y.Z
@@ -58,14 +64,14 @@ git tag vX.Y.Z
 
 Tags without `-` in the suffix (e.g., `v1.2.0`) become the "Latest" release on GitHub. Tags with `-rc` (e.g., `v1.2.0-rc1`) become pre-releases.
 
-### 4. Push
+### 5. Push
 
 ```bash
 git push origin main
 git push origin vX.Y.Z
 ```
 
-### 5. Wait for the release build to produce the artifacts
+### 6. Wait for the release build to produce the artifacts
 
 This is the ONE wait that remains, and it is not a test gate - it is the build that produces the
 downloadable files, so there is nothing to release until it finishes. The rule against waiting on
@@ -78,7 +84,7 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) will:
 3. Build all cc-tools as zip archives
 4. Create a GitHub Release with all artifacts attached
 
-### 6. Verify
+### 7. Verify
 
 1. Go to the [Releases page](https://github.com/thefrederiksen/devthrottle/releases)
 2. Confirm the new release is marked "Latest" (if not a pre-release)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,7 +43,11 @@ git push origin main
 git push origin vX.Y.Z
 ```
 
-### 5. Wait for CI
+### 5. Wait for the release build to produce the artifacts
+
+This is the ONE wait that remains, and it is not a test gate - it is the build that produces the
+downloadable files, so there is nothing to release until it finishes. The rule against waiting on
+continuous integration (CLAUDE.md 5a) is about the test job gating a merge; it does not apply here.
 
 The GitHub Actions workflow (`.github/workflows/release.yml`) will:
 


### PR DESCRIPTION
## What changes

The merge rule had become "local is the gate, **except** when it isn't". The exception list - a release commit, a change to the build or to continuous integration itself, anything cross-platform, anything not testable locally - sent you straight back to a fifty-minute wait for an answer the local run had already produced. That list is removed rather than trimmed, because every entry on it was an invitation to pay the cost again.

The gate is now two things, both local:

1. `.\scripts\test-local.ps1` goes green.
2. A reviewer from a **different agent family** reads the change - Codex by default, run as a tracked session, never backgrounded.

Then it merges. Nothing waits on GitHub.

## Never waiting is not the same as never reading

Continuous integration remains a post-merge backstop. No merge is ever held open for it, and **a red is fixed forward immediately** - that is the whole trade, and it only holds if the red is actually chased. An unchased red turns the backstop into noise: that is precisely how two architecture guards stayed red on main for a morning today without anybody being told.

Reading a result after the fact is chasing, not waiting, and for some changes it is required - see the coverage gaps below.

## What the local gate does NOT cover - now stated everywhere, not implied

This is the part that made the original version of this change unsafe, and it is why the documents are blunt about it now:

- **Two suites are parked.** `Gateway.Tests` and `Core.Tests` do not run by default; they need `-Parked`.
- **`-Fast` is a no-op**, retained only for old callers. Two documents claimed it skipped the Gateway suite. It gates nothing and must never be cited as though it did.
- **No web tests and no Python tests run locally at all.** They exist only in the "Build & Test (web)" and "Tool contracts (Python)" jobs, so a change touching the browser shells or the Python toolbelt must go and read those after merging.
- **The two installer test projects are not reachable from the script.** `test-local.ps1` runs nine projects, all under `src\`; `tools/cc-director-setup.Tests` and `tools/cc-director-setup-engine.Tests` are not in `cc-director.sln` and no local invocation touches them - while `release.yml` publishes `cc-director-setup.exe`.

## Releases: the one place fixing forward is unavailable

The release workflow runs **zero** tests and a pushed tag cannot be un-pushed. Combined with the gaps above, dropping the wait would have let a release ship without the parked suites or the installer ever being run.

So the release gate is local, and it is three commands, on **merged main at the exact commit about to be tagged** - not on a pull-request head, which the squash merge turns into a different commit:

```powershell
.\scripts\test-local.ps1 -Parked -Configuration Release
dotnet test tools/cc-director-setup.Tests/ -c Release
dotnet test tools/cc-director-setup-engine.Tests/ -c Release
```

`-Configuration Release` is not decoration: the script defaults to **Debug**, while the continuous integration job this replaces ran `-c Release`. Without it the release would be gated on a different build from the one users download.

## Follow-up, deliberately not smuggled in here

Folding the two installer projects into `-Parked` is the real fix, so the release gate is one command again. That is a change to the script and wants its own verification, so it is not in a documentation pull request.

## Files (7)

- `CLAUDE.md` - rule 5a rewritten.
- `.claude/skills/commit/skill.md` - the commit flow, and "checks are still running" removed as a reason to leave a pull request open.
- `.claude/skills/test-manager/skill.md` - the gate section, the quick-reference table, the honest-summary bullet, and a literal tab that had eaten part of the script path in a command people are told to run.
- `.claude/skills/test-manager/HANDOVER.md` - rule 5.
- `.claude/skills/release-manager/SKILL.md` - the release gate, moved to merged main and given all three commands.
- `.claude/skills/deploy-hosted-gateway/SKILL.md` - marks its pending-check wait as the deploy workflow's own refusal to ship unverified code to a live service, not an exception to this rule.
- `docs/releasing.md` - was not safe to follow: it named two csproj files that no longer exist, used `git add -A` in a shared checkout, and pushed a local bump commit straight to a protected branch. Now bumps `Directory.Build.props`, lands it through a pull request, gates merged main, and pushes only the tag.

Documentation only; no code paths touched.

## Review

Reviewed independently across four rounds. It found twelve defects, including three false statements in the first draft of this change - that the default run covers every test project, that `-Fast` skips the Gateway suite, and a release gate pinned to a commit nobody ships.
