### PR TITLE
docs: the v1.9.7 release notes

### DIFF
--- a/docs/public/release-notes/v1.9.7.md
+++ b/docs/public/release-notes/v1.9.7.md
@@ -1,0 +1,41 @@
+# DevThrottle v1.9.7
+
+## What you will notice
+
+**The setup wizard stops sending you somewhere you cannot go.** On a machine with no git installed, it used to end by telling you to clone your first repository. It now says to create a folder, which always works - and a plain folder with your code in it is all DevThrottle ever needed.
+
+**The hosted gateway card says what you actually get.** It named a price and left the fourteen-day trial unsaid, and read as though the hosted option was something you had not paid for. It now names the trial and says there is no credit card.
+
+**Dictation keeps the end of what you said.** Stopping a recording could drop the tail, and the level meter kept moving after the microphone had stopped. Both fixed.
+
+**Git problems explain themselves instead of crashing.** If git is missing or a repository has moved, the commands that use it now report what went wrong. Previously the failure escaped as an unhandled error.
+
+**A Director tells you which one it is,** and can be addressed by name across a fleet. A Director that shuts down cleanly stops being reported as an unreachable machine.
+
+**The full-screen takeover is gone** from both the Director and the phone app.
+
+## Memory
+
+**A finished session releases its handler and its watcher.** They were kept after the session ended, so a long-running Director accumulated dead subscriptions - 146 of them in one measured case - and the memory behind each one. This is the first of the leak fixes; more are being measured and are not in this release.
+
+## Reliability
+
+**A deploy that cannot reach its database no longer takes the site down.** On 2 August a hosted deploy stopped production for 38.5 seconds. The new container failed one database connection, treated it as fatal, and then neither served nor exited - so the platform waited out its full start limit, gave up, and stopped the site, killing the healthy container that had been serving throughout. The database open is now retried for a bounded window, and a container that genuinely cannot open its database exits with a failure code so the platform restarts it instead of waiting on it. Both connection pools are bounded.
+
+Measured on the first deploy carrying this fix: the swap itself served every one of 1,990 sampled requests without a single failure.
+
+**The gateway reads a snooze once per fold** instead of once per session, with a guard against overlapping display sweeps.
+
+## For people running the source
+
+The local test gate now runs in about two minutes. The gateway suite was split, and what cannot fit inside that budget is parked and named rather than silently dropped. Test selection follows the change being made.
+
+## Known and not fixed here
+
+- The Director's large-object heap still grows on a long-running instance. The largest contributor is understood and is not in this release.
+- A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
+- Four repository views still show a failed git read as an empty result - "No changes", "No commits." - rather than saying the read failed.
+
+## Nothing here is a CPU fix
+
+Work was done on this machine to recover processor time, but it was operational rather than a change to the product. No CPU behaviour in DevThrottle is different in this release.

--- a/docs/public/release-notes/v1.9.7.md
+++ b/docs/public/release-notes/v1.9.7.md
@@ -16,6 +16,8 @@
 
 ## Memory
 
+**Dictation no longer leaves a microphone recording after you close the window.** Closing the Speak dialog while it was still starting up left a recorder running that nothing could ever stop or release - it kept capturing audio and holding it in memory for as long as the application ran. One long-running Director was measured holding 12.69 GB this way, 86 percent of everything it had allocated, across 87 abandoned recorders of which nine were still recording. Separately, preparing a recording for transcription used to copy the whole clip three times; it is now written once.
+
 **A finished session releases its handler and its watcher.** They were kept after the session ended, so a long-running Director accumulated dead subscriptions - 146 of them in one measured case - and the memory behind each one. This is the first of the leak fixes; more are being measured and are not in this release.
 
 ## Reliability
@@ -32,7 +34,7 @@ The local test gate now runs in about two minutes. The gateway suite was split, 
 
 ## Known and not fixed here
 
-- The Director's large-object heap still grows on a long-running instance. The largest contributor is understood and is not in this release.
+- The Director's large-object heap still grows on a long-running instance. Its largest single contributor - abandoned dictation recorders - is fixed in this release, but the rest is not: several hundred thousand retained terminal cells and user-interface objects still accumulate on a Director left running for days.
 - A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
 - Four repository views still show a failed git read as an empty result - "No changes", "No commits." - rather than saying the read failed.
 


### PR DESCRIPTION
The v1.9.7 release notes, written during release prep and previously sitting uncommitted in the shared main checkout - where they existed in exactly one working directory and nowhere else.

Three things in them are deliberate and should survive editing:

- **"Nothing here is a CPU fix"** is stated plainly, with the reason. Processor time was recovered on the build machine during this work, but it was operational - killing a runaway vault scan and releasing orphaned MSBuild nodes - not a change to the product. A release note claiming a fix we did not ship is worse than no release note.
- **The Director's large-object heap is listed as still growing.** Its largest single contributor, abandoned dictation recorders, is fixed by #2433 and the entry says so; the several hundred thousand retained terminal cells and user-interface objects behind the remaining 8 percent are not fixed and the entry says that too.
- **The vault catalog scan runaway is listed as diagnosed, not fixed.**

The Memory section carries both memory fixes that actually shipped: the finished-session handler and watcher release (#2401), and the dictation recorder leak (#2433).

The release script reads this file from disk and publishes it verbatim as the GitHub release page, so it needs to be on main and correct before the tag.