### PR TITLE
release: v1.9.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.6</Version>
+    <Version>1.9.7</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.


### PR DESCRIPTION
Version bump and release notes for v1.9.7.

The tag is created only after this merges, so it can never point at a commit that is not on main.

See docs/public/release-notes/v1.9.7.md for what is in this release.