### PR TITLE
Director rail: Browser profiles is a single clickable row, not an expandable list

### DIFF
--- a/src/CcDirector.Avalonia.Tests/BrowsersRailRenderTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BrowsersRailRenderTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CcDirector.Avalonia.Controls;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The pinned "Browser profiles" rail entry is ONE clickable row that navigates, exactly like the
+/// pinned Repositories entry - never an expandable list, and never a place to start a browser.
+///
+/// It used to unfold into one two-line row per profile, each with its own Start link: a third of the
+/// rail spent on a list, and a control panel in a navigation strip. These drive the REAL control in a
+/// headless window, because the defect was a rendered one - a fold test cannot see how many rows and
+/// buttons reach the screen.
+/// </summary>
+public class BrowsersRailRenderTests
+{
+    private static (BrowsersRailGroup Rail, Window Window) Show()
+    {
+        var rail = new BrowsersRailGroup();
+        var window = new Window { Content = rail, Width = 260, Height = 400 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (rail, window);
+    }
+
+    [AvaloniaFact]
+    public void TheRail_RendersExactlyOneClickableRow_AndNoList()
+    {
+        var (rail, _) = Show();
+
+        // One button: the row itself. Two would mean an action link is back in the rail (Start / Sign
+        // in / Attach / +), which is what moved to the settings screen.
+        Assert.Single(rail.GetVisualDescendants().OfType<Button>());
+
+        // No list control at all: there is no per-profile row to render, expanded or collapsed.
+        Assert.Empty(rail.GetVisualDescendants().OfType<ItemsControl>());
+    }
+
+    [AvaloniaFact]
+    public void ClickingTheRow_AsksToManage_AndNeverExpands()
+    {
+        var (rail, _) = Show();
+        var row = rail.GetVisualDescendants().OfType<Button>().Single();
+
+        var manageRequests = 0;
+        rail.ManageRequested += (_, _) => manageRequests++;
+
+        row.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, manageRequests);
+        Assert.Single(rail.GetVisualDescendants().OfType<Button>());
+
+        // Clicked again it asks again - it does not toggle between "open settings" and "unfold here".
+        row.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, manageRequests);
+        Assert.Single(rail.GetVisualDescendants().OfType<Button>());
+    }
+
+    [AvaloniaFact]
+    public void TheRailIsTheRow_WithNothingStackedUnderIt()
+    {
+        // The complaint that started this was space, but measured height is the wrong check for it: the
+        // old group's profile rows arrived asynchronously, so it too measured one row high the instant
+        // it was shown, and a height assertion PASSES on the broken control. What is structurally true
+        // instead is that this rail IS a row - not a header with a body panel stacked beneath it, which
+        // is where the space went.
+        var (rail, _) = Show();
+
+        Assert.IsType<Button>(rail.Content);
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml
@@ -2,125 +2,43 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="CcDirector.Avalonia.Controls.BrowsersRailGroup">
 
-    <!-- The pinned Browsers group in the left rail (Browsers feature, slice 2). Sits directly above
-         the pinned Repositories entry and follows its visual language: the same button chrome for the
-         header, the same 12px semibold row names. Every row renders the Core fold
-         (AutomationBrowserView) verbatim - dot color, subtitle, and which single action to offer are
-         all decided in CcDirector.Core.Browsers.AutomationBrowserViewFold, never here (rule 7). -->
+    <!-- The pinned "Browser profiles" entry in the left rail. ONE row, exactly like the pinned
+         Repositories entry below it: clickable, never expandable. The rail is a navigation strip, so
+         this row navigates - to Settings > Browsers, where a profile is started, signed in and
+         attached. It carries two facts and no controls: how many profiles exist, and a dot when any
+         of them is up. Both are the Core fold (AutomationBrowserViewFold.FoldRail) rendered verbatim,
+         never decided here (rule 7).
 
-    <UserControl.Styles>
-        <Style Selector="Button.railRow">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Padding" Value="10,5" />
-            <Setter Property="CornerRadius" Value="4" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="Cursor" Value="Hand" />
-        </Style>
-        <Style Selector="Button.railRow:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#2A2A2A" />
-        </Style>
-        <!-- The per-row action link (Start / Sign in / Attach): quiet text, no button chrome. -->
-        <Style Selector="Button.rowAction">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Padding" Value="6,2" />
-            <Setter Property="CornerRadius" Value="3" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="FontSize" Value="11" />
-            <Setter Property="FontWeight" Value="SemiBold" />
-        </Style>
-        <Style Selector="Button.rowAction:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#3C3C3C" />
-        </Style>
-    </UserControl.Styles>
+         It used to unfold into one two-line row per profile, each with its own Start link. That spent
+         a third of the rail on a list, and the Start links implied a human must launch a browser
+         before an agent can use it - agents bring their own up through Browser Harness. -->
 
-    <StackPanel>
-        <!-- Group header: same chrome as the pinned Repositories button below it. Click = expand/
-             collapse; the + on the right opens Settings > Browsers to add one. -->
-        <Button x:Name="HeaderButton"
-                Click="HeaderButton_Click"
-                Background="#2A2A2A" BorderBrush="#3C3C3C" BorderThickness="1"
-                Margin="8,4,8,0" Padding="10,8" CornerRadius="4"
-                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Cursor="Hand"
-                ToolTip.Tip="Real, signed-in browsers your agents can drive through Browser Harness">
-            <DockPanel LastChildFill="True">
-                <!-- Right side of the header: setup nudge OR count, then add, then the chevron. -->
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-                    <TextBlock x:Name="SetupLabel" Text="Setup" Foreground="#F0B848"
-                               FontSize="10" FontWeight="SemiBold" VerticalAlignment="Center"
-                               IsVisible="False"
-                               ToolTip.Tip="Browser Harness is not installed yet - click to set it up" />
-                    <Border x:Name="CountBadge" Background="#3C3C3C" CornerRadius="8" Padding="6,1"
-                            VerticalAlignment="Center" IsVisible="False">
-                        <TextBlock x:Name="CountText" Text="0" Foreground="#CCCCCC"
-                                   FontSize="9" FontWeight="SemiBold" />
-                    </Border>
-                    <Button x:Name="AddButton" Classes="rowAction" Content="+"
-                            Foreground="#CCCCCC" FontSize="13" Padding="5,0"
-                            Click="AddButton_Click"
-                            ToolTip.Tip="Add a browser profile" />
-                    <Path x:Name="Chevron" Fill="#888888" VerticalAlignment="Center"
-                          Data="M 0,0 L 4,4 L 8,0" Stretch="None" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                    <TextBlock Text="[B]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
-                               FontSize="12" VerticalAlignment="Center" />
-                    <TextBlock Text="Browser profiles" Foreground="#CCCCCC" FontSize="12"
-                               FontWeight="SemiBold" VerticalAlignment="Center" />
-                </StackPanel>
-            </DockPanel>
-        </Button>
-
-        <!-- The expanded body. -->
-        <StackPanel x:Name="BodyPanel" Margin="8,2,8,0">
-
-            <!-- One row per browser. Everything shown is the Core fold, verbatim. -->
-            <ItemsControl x:Name="RowsList">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Button Classes="railRow" Tag="{Binding Id}" Click="Row_Click"
-                                Opacity="{Binding RowOpacity}"
-                                ToolTip.Tip="{Binding RowToolTip}">
-                            <Grid ColumnDefinitions="Auto,*,Auto" VerticalAlignment="Center">
-                                <Ellipse Grid.Column="0" Width="8" Height="8" Margin="2,0,9,0"
-                                         VerticalAlignment="Center" Fill="{Binding DotBrush}" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                    <TextBlock Text="{Binding Name}" Foreground="#CCCCCC"
-                                               FontSize="12" FontWeight="SemiBold"
-                                               TextTrimming="CharacterEllipsis" />
-                                    <TextBlock Text="{Binding Subtitle}" Foreground="#888888"
-                                               FontSize="10" TextTrimming="CharacterEllipsis" />
-                                </StackPanel>
-                                <Button Grid.Column="2" Classes="rowAction"
-                                        Content="{Binding ActionLabel}"
-                                        Foreground="{Binding ActionForeground}"
-                                        IsVisible="{Binding ActionVisible}"
-                                        Tag="{Binding Id}" Click="RowAction_Click"
-                                        ToolTip.Tip="{Binding ActionToolTip}" />
-                            </Grid>
-                        </Button>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-
-            <!-- Shown when Browser Harness is missing: the feature advertises itself with the
-                 discovered-but-dimmed rows above and this inline install link. -->
-            <Button x:Name="InstallLink" Classes="railRow" IsVisible="False"
-                    Click="InstallLink_Click"
-                    ToolTip.Tip="Set up browser control in Settings - DevThrottle installs Browser Harness for you">
-                <TextBlock Text="Install Browser Harness" Foreground="#4A9EFF"
-                           FontSize="11" FontWeight="SemiBold" />
-            </Button>
-
-            <!-- Shown when the harness is installed but no browser exists yet. -->
-            <Button x:Name="AddFirstLink" Classes="railRow" IsVisible="False"
-                    Click="AddButton_Click"
-                    ToolTip.Tip="Create your first drivable browser in Settings">
-                <TextBlock Text="Add a browser..." Foreground="#4A9EFF"
-                           FontSize="11" FontWeight="SemiBold" />
-            </Button>
-        </StackPanel>
-    </StackPanel>
+    <Button x:Name="HeaderButton"
+            Click="HeaderButton_Click"
+            Background="#2A2A2A" BorderBrush="#3C3C3C" BorderThickness="1"
+            Margin="8,4,8,0" Padding="10,8" CornerRadius="4"
+            HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Cursor="Hand">
+        <DockPanel LastChildFill="True">
+            <!-- Right side: the setup nudge when the harness is missing, otherwise the running dot
+                 and the profile count. -->
+            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <TextBlock x:Name="SetupLabel" Text="Setup" Foreground="#F0B848"
+                           FontSize="10" FontWeight="SemiBold" VerticalAlignment="Center"
+                           IsVisible="False" />
+                <Ellipse x:Name="RunningDot" Width="8" Height="8"
+                         VerticalAlignment="Center" IsVisible="False" />
+                <Border x:Name="CountBadge" Background="#3C3C3C" CornerRadius="8" Padding="6,1"
+                        VerticalAlignment="Center" IsVisible="False">
+                    <TextBlock x:Name="CountText" Text="0" Foreground="#CCCCCC"
+                               FontSize="9" FontWeight="SemiBold" />
+                </Border>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Text="[B]" Foreground="#4A9EFF" FontFamily="Cascadia Mono, Consolas"
+                           FontSize="12" VerticalAlignment="Center" />
+                <TextBlock Text="Browser profiles" Foreground="#CCCCCC" FontSize="12"
+                           FontWeight="SemiBold" VerticalAlignment="Center" />
+            </StackPanel>
+        </DockPanel>
+    </Button>
 </UserControl>

--- a/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/BrowsersRailGroup.axaml.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Media;
 using Avalonia.Threading;
 using CcDirector.Core.Browsers;
 using CcDirector.Core.Utilities;
@@ -12,29 +11,33 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Avalonia.Controls;
 
 /// <summary>
-/// The pinned "Browsers" group in the left rail: one row per drivable automation browser, each with a
-/// status dot and the single next action (Start / Sign in / Attach). Rows render the Core fold
-/// (<see cref="AutomationBrowserViewFold"/>) verbatim - this control decides layout, never meaning.
-/// When Browser Harness is not installed the group stays visible but dimmed, with an inline install
-/// link, so the feature advertises itself instead of hiding (mockup state 2).
+/// The pinned "Browser profiles" entry in the left rail: ONE clickable row that opens Settings &gt;
+/// Browsers, showing the profile count and a dot when any profile is up. Everything it shows is the
+/// Core fold (<see cref="AutomationBrowserViewFold.FoldRail"/>) rendered verbatim - this control
+/// decides layout, never meaning.
+///
+/// It is deliberately not expandable and offers no per-profile action. The rail is a navigation strip:
+/// Repositories holds seventeen things in one row, and a browsers group that unfolded into four
+/// two-line rows with their own Start links was both a third of the rail and a control panel in the
+/// wrong place. Starting, signing in and attaching live on the Browsers settings screen, which has the
+/// room to report them honestly - and in normal use an agent brings a profile up itself through Browser
+/// Harness, so nobody needs to press Start first.
+///
+/// When Browser Harness is not installed the row stays visible and wears a Setup nudge, so the feature
+/// advertises itself instead of hiding; clicking it lands on the settings screen, where the install runs.
 /// </summary>
 public partial class BrowsersRailGroup : UserControl
 {
-    /// <summary>Raised when the user wants the management surface (Settings > Browsers): the header
-    /// +, a click on a row, or the "Add a browser..." empty-state link.</summary>
+    /// <summary>Raised when the user clicks the row: open the management surface (Settings &gt; Browsers).</summary>
     public event EventHandler? ManageRequested;
 
-    /// <summary>Raised with a short user-facing message (action feedback or a failure) for the host
-    /// window's notification strip.</summary>
+    /// <summary>Raised with a short user-facing message (a failure) for the host window's notification
+    /// strip.</summary>
     public event EventHandler<string>? Notified;
-
-    private static readonly IBrush AccentBrush = Brush.Parse("#4A9EFF");
-    private static readonly IBrush AmberBrush = Brush.Parse("#F0B848");
 
     private readonly DispatcherTimer _refreshTimer;
     private IReadOnlyList<AutomationBrowserView> _views = Array.Empty<AutomationBrowserView>();
     private bool _harnessInstalled;
-    private bool _expanded = true;
     private bool _refreshing;
 
     /// <summary>Bumped by every refresh. A status probe carries the generation it started under and
@@ -46,7 +49,7 @@ public partial class BrowsersRailGroup : UserControl
         InitializeComponent();
 
         // Status is a live port probe, so it can drift (the user closes a browser window by hand);
-        // a slow background re-poll keeps the dots honest without hammering the ports.
+        // a slow background re-poll keeps the running dot honest without hammering the ports.
         _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(30) };
         _refreshTimer.Tick += (_, _) => _ = RefreshAsync();
 
@@ -59,12 +62,12 @@ public partial class BrowsersRailGroup : UserControl
     }
 
     /// <summary>
-    /// Re-read the registry and repaint the group, then find out which browsers are running.
+    /// Re-read the registry and repaint the row, then find out which browsers are running.
     ///
-    /// The rows come from local files and paint immediately; each browser's running/stopped answer
-    /// costs a probe of its debug port and arrives after, on its own. Rows already on screen keep their
-    /// last known status while the fresh probe runs - this method is also driven by a timer, and
-    /// blinking every row to "Checking..." on each tick would read as instability.
+    /// The count comes from local files and paints immediately; each browser's running/stopped answer
+    /// costs a probe of its debug port and arrives after, on its own. The row keeps its last known
+    /// running dot while the fresh probe runs - this method is also driven by a timer, and dropping the
+    /// dot on every tick would read as instability.
     ///
     /// Safe to call from anywhere; overlapping calls collapse into one.
     /// </summary>
@@ -104,8 +107,7 @@ public partial class BrowsersRailGroup : UserControl
 
     /// <summary>
     /// Probe every listed browser CONCURRENTLY and repaint as each answer arrives. Results from a
-    /// superseded refresh are dropped: by then the rows they would update belong to a list that no
-    /// longer exists.
+    /// superseded refresh are dropped: by then they would be updating a list that no longer exists.
     /// </summary>
     private async Task ProbeStatusesAsync(int generation)
     {
@@ -121,8 +123,8 @@ public partial class BrowsersRailGroup : UserControl
             }
             catch (Exception ex)
             {
-                // One browser that cannot be probed leaves its own row on its last known status and
-                // takes nothing else down with it.
+                // One browser that cannot be probed stays on its last known status and takes nothing
+                // else down with it.
                 FileLog.Write($"[BrowsersRailGroup] ProbeStatusesAsync: id={pending.Id} failed (non-fatal): {ex.Message}");
                 return;
             }
@@ -135,139 +137,25 @@ public partial class BrowsersRailGroup : UserControl
 
     private void Render(IReadOnlyList<AutomationBrowserView> views, bool harnessInstalled)
     {
-        CountBadge.IsVisible = harnessInstalled && views.Count > 0;
-        CountText.Text = views.Count.ToString();
-        SetupLabel.IsVisible = !harnessInstalled;
-        InstallLink.IsVisible = _expanded && !harnessInstalled;
-        AddFirstLink.IsVisible = _expanded && harnessInstalled && views.Count == 0;
-        BodyPanel.IsVisible = _expanded;
-        Chevron.Data = Geometry.Parse(_expanded ? "M 0,0 L 4,4 L 8,0" : "M 0,0 L 4,4 L 0,8");
+        var rail = AutomationBrowserViewFold.FoldRail(views, harnessInstalled);
 
-        RowsList.ItemsSource = views.Select(v => new BrowserRailRow
-        {
-            Id = v.Id,
-            Name = v.Name,
-            Subtitle = v.Subtitle,
-            DotBrush = StatusPalette.BrushFor(v.DotColor),
-            // Dimmed advertising rows when the harness is missing: discoverable, not operable.
-            RowOpacity = harnessInstalled ? 1.0 : 0.45,
-            // No action while the status is still unknown: every action here depends on whether the
-            // browser is running, and the fold gives an empty label for exactly that reason.
-            ActionVisible = harnessInstalled && v.Status != AutomationBrowserStatus.Checking,
-            ActionLabel = v.ActionLabel,
-            ActionForeground = v.Status == AutomationBrowserStatus.NeedsSignIn ? AmberBrush : AccentBrush,
-            ActionToolTip = v.Status switch
-            {
-                AutomationBrowserStatus.Stopped => "Start this profile",
-                AutomationBrowserStatus.NeedsSignIn => "Open the sign-in page for the one-time hand sign-in",
-                _ => "Copy the command that points an agent's Browser Harness at this profile",
-            },
-            RowToolTip = $"{v.Subtitle} ({v.StatusLabel}). Click to manage in Settings.",
-        }).ToList();
-    }
-
-    // ---- header ----
-
-    private void HeaderButton_Click(object? sender, RoutedEventArgs e)
-    {
-        _expanded = !_expanded;
-        FileLog.Write($"[BrowsersRailGroup] HeaderButton_Click: expanded={_expanded}");
-        Render(_views, _harnessInstalled);
-    }
-
-    private void AddButton_Click(object? sender, RoutedEventArgs e)
-    {
-        FileLog.Write("[BrowsersRailGroup] AddButton_Click");
-        ManageRequested?.Invoke(this, EventArgs.Empty);
+        SetupLabel.IsVisible = rail.ShowSetup;
+        CountBadge.IsVisible = rail.ShowCount;
+        CountText.Text = rail.CountText;
+        RunningDot.IsVisible = rail.RunningDotColor is not null;
+        if (rail.RunningDotColor is not null)
+            RunningDot.Fill = StatusPalette.BrushFor(rail.RunningDotColor);
+        ToolTip.SetTip(HeaderButton, rail.ToolTip);
     }
 
     /// <summary>
-    /// Open the Browsers settings, where the install runs (issue #1012). The rail is a narrow strip with
-    /// no room to report a multi-step install honestly - progress, and a failure with its reason and the
-    /// manual page - so it hands over to the screen that has. It no longer opens a GitHub page: the
-    /// product installs the harness itself now.
+    /// The whole interaction: open the Browsers settings. That screen manages the profiles AND runs the
+    /// harness install (issue #1012) - the rail is a narrow strip with no room to report a multi-step
+    /// install honestly, so it hands over to the screen that has.
     /// </summary>
-    private void InstallLink_Click(object? sender, RoutedEventArgs e)
+    private void HeaderButton_Click(object? sender, RoutedEventArgs e)
     {
-        FileLog.Write("[BrowsersRailGroup] InstallLink_Click -> manage");
+        FileLog.Write("[BrowsersRailGroup] HeaderButton_Click -> manage");
         ManageRequested?.Invoke(this, EventArgs.Empty);
-    }
-
-    // ---- rows ----
-
-    private void Row_Click(object? sender, RoutedEventArgs e)
-    {
-        FileLog.Write("[BrowsersRailGroup] Row_Click -> manage");
-        ManageRequested?.Invoke(this, EventArgs.Empty);
-    }
-
-    private async void RowAction_Click(object? sender, RoutedEventArgs e)
-    {
-        // Stop the click from also triggering the row's own click (which navigates to Settings).
-        e.Handled = true;
-
-        var id = (sender as Button)?.Tag as string;
-        var view = _views.FirstOrDefault(v => v.Id == id);
-        if (view is null) return;
-
-        try
-        {
-            FileLog.Write($"[BrowsersRailGroup] RowAction_Click: id={view.Id}, status={view.Status}");
-            switch (view.Status)
-            {
-                case AutomationBrowserStatus.Stopped:
-                    Notified?.Invoke(this, $"Starting \"{view.Name}\"...");
-                    await Task.Run(() => AutomationBrowserService.LaunchAsync(view.Id));
-                    Notified?.Invoke(this, $"\"{view.Name}\" is up.");
-                    break;
-
-                case AutomationBrowserStatus.NeedsSignIn:
-                    await RunSignInFlowAsync(view);
-                    break;
-
-                case AutomationBrowserStatus.Ready:
-                    var top = TopLevel.GetTopLevel(this);
-                    if (top?.Clipboard is null)
-                        throw new InvalidOperationException("The clipboard is not available.");
-                    await top.Clipboard.SetTextAsync(view.AttachCommand);
-                    Notified?.Invoke(this, $"Attach command for \"{view.Name}\" copied to the clipboard.");
-                    break;
-            }
-
-            await RefreshAsync();
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[BrowsersRailGroup] RowAction_Click FAILED: id={id}, {ex.Message}");
-            Notified?.Invoke(this, ex.Message);
-        }
-    }
-
-    /// <summary>The one-time human sign-in, via the shared <see cref="BrowserSignInFlow"/> so the rail
-    /// and the Settings tab run the identical flow and wording.</summary>
-    private async Task RunSignInFlowAsync(AutomationBrowserView view)
-    {
-        var owner = TopLevel.GetTopLevel(this) as Window;
-        if (owner is null)
-            throw new InvalidOperationException("No owner window for the sign-in confirmation dialog.");
-
-        Notified?.Invoke(this, $"Opening the sign-in page in \"{view.Name}\"...");
-        if (await BrowserSignInFlow.RunAsync(owner, view))
-            Notified?.Invoke(this, $"\"{view.Name}\" is signed in and ready to drive.");
-    }
-
-    /// <summary>One rendered rail row: the fold's strings plus the brushes this surface maps them to.</summary>
-    public sealed class BrowserRailRow
-    {
-        public string Id { get; init; } = "";
-        public string Name { get; init; } = "";
-        public string Subtitle { get; init; } = "";
-        public IBrush DotBrush { get; init; } = Brushes.Gray;
-        public double RowOpacity { get; init; } = 1.0;
-        public bool ActionVisible { get; init; }
-        public string ActionLabel { get; init; } = "";
-        public IBrush ActionForeground { get; init; } = Brushes.White;
-        public string ActionToolTip { get; init; } = "";
-        public string RowToolTip { get; init; } = "";
     }
 }

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -393,11 +393,11 @@
                     </DockPanel>
                 </Button>
 
-                <!-- Pinned Browsers group (Browsers feature, slice 2): the drivable, signed-in-once
-                     automation browsers on this machine, one row each with a status dot and the single
-                     next action. Sits directly above the pinned Repositories entry. All content is the
-                     Core fold rendered verbatim; the control raises ManageRequested to open
-                     Settings > Browsers. -->
+                <!-- Pinned Browser profiles entry: ONE clickable row, exactly like the pinned
+                     Repositories entry below it - the profile count and a dot when any is running,
+                     no list and no per-profile action. All content is the Core fold rendered
+                     verbatim; the control raises ManageRequested to open Settings > Browsers, where
+                     starting, signing in and attaching live. -->
                 <controls:BrowsersRailGroup x:Name="BrowsersRail" DockPanel.Dock="Bottom" />
 
                 <!-- Session list -->

--- a/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/AutomationBrowserViewFoldTests.cs
@@ -172,4 +172,134 @@ public sealed class AutomationBrowserViewFoldTests
     {
         Assert.Throws<ArgumentNullException>(() => AutomationBrowserViewFold.Fold(null!, AutomationBrowserStatus.Ready, account: null));
     }
+
+    // ---- The pinned rail row ----------------------------------------------------------------------
+    //
+    // One clickable row in the left rail, never a list: it carries the profile count and a dot when any
+    // profile is up, and nothing else. These prove the two facts it states are true.
+
+    private static AutomationBrowserView View(string id, AutomationBrowserStatus status) =>
+        AutomationBrowserViewFold.Fold(
+            new AutomationBrowser(
+                Id: id,
+                Name: id,
+                Kind: BrowserKind.Chrome,
+                UserDataDir: $@"C:\data\browsers\{id}",
+                Port: 9310,
+                CreatedUtc: new DateTime(2026, 7, 23, 12, 0, 0, DateTimeKind.Utc),
+                LastSignedInUtc: null),
+            status,
+            account: null);
+
+    [Fact]
+    public void FoldRail_CountsProfilesAndSaysHowManyAreRunning()
+    {
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[]
+            {
+                View("a", AutomationBrowserStatus.Ready),
+                View("b", AutomationBrowserStatus.Stopped),
+                View("c", AutomationBrowserStatus.NeedsSignIn),
+                View("d", AutomationBrowserStatus.Stopped),
+            },
+            harnessInstalled: true);
+
+        Assert.True(rail.ShowCount);
+        Assert.Equal("4", rail.CountText);
+        // Running means the debug port answered. A browser that is up but never signed in is running.
+        Assert.Equal("4 browser profiles, 2 running. Click to manage them in Settings.", rail.ToolTip);
+        Assert.Equal("green", rail.RunningDotColor);
+        Assert.False(rail.ShowSetup);
+    }
+
+    [Fact]
+    public void FoldRail_NoneRunning_SaysSoAndShowsNoDot()
+    {
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[] { View("a", AutomationBrowserStatus.Stopped), View("b", AutomationBrowserStatus.Stopped) },
+            harnessInstalled: true);
+
+        Assert.Equal("2 browser profiles, none running. Click to manage them in Settings.", rail.ToolTip);
+        Assert.Null(rail.RunningDotColor);
+        Assert.Equal("2", rail.CountText);
+    }
+
+    [Fact]
+    public void FoldRail_OneProfile_ReadsSingular()
+    {
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[] { View("a", AutomationBrowserStatus.Ready) },
+            harnessInstalled: true);
+
+        Assert.Equal("1 browser profile, 1 running. Click to manage them in Settings.", rail.ToolTip);
+    }
+
+    [Fact]
+    public void FoldRail_WhileAnyProfileIsStillBeingProbed_SaysNothingAboutRunning()
+    {
+        // The row repaints on a timer, so "none running" stated during the probe window would be a
+        // falsehood shown repeatedly. Unknown is said by not saying it - the count is still true.
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[] { View("a", AutomationBrowserStatus.Checking), View("b", AutomationBrowserStatus.Stopped) },
+            harnessInstalled: true);
+
+        Assert.Equal("2 browser profiles. Click to manage them in Settings.", rail.ToolTip);
+        Assert.Null(rail.RunningDotColor);
+    }
+
+    [Fact]
+    public void FoldRail_ProbedProfileRunningWhileAnotherIsStillChecking_StillShowsTheDot()
+    {
+        // The dot is an existence claim ("at least one is up"), which a single probed Ready already
+        // settles - unlike the running COUNT, which the unprobed profile could still change.
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[] { View("a", AutomationBrowserStatus.Ready), View("b", AutomationBrowserStatus.Checking) },
+            harnessInstalled: true);
+
+        Assert.Equal("green", rail.RunningDotColor);
+        Assert.Equal("2 browser profiles. Click to manage them in Settings.", rail.ToolTip);
+    }
+
+    [Fact]
+    public void FoldRail_HarnessNotInstalled_WearsTheSetupNudgeAndNoCount()
+    {
+        // The row must stay visible and say what is missing: the feature advertises itself rather than
+        // hiding, and clicking it lands on the screen where the install runs.
+        var rail = AutomationBrowserViewFold.FoldRail(
+            new[] { View("a", AutomationBrowserStatus.Stopped) },
+            harnessInstalled: false);
+
+        Assert.True(rail.ShowSetup);
+        Assert.False(rail.ShowCount);
+        Assert.Null(rail.RunningDotColor);
+        Assert.Contains("not set up yet", rail.ToolTip);
+    }
+
+    [Fact]
+    public void FoldRail_NoProfilesYet_InvitesTheFirstOne()
+    {
+        var rail = AutomationBrowserViewFold.FoldRail(Array.Empty<AutomationBrowserView>(), harnessInstalled: true);
+
+        Assert.False(rail.ShowSetup);
+        Assert.False(rail.ShowCount);
+        Assert.Null(rail.RunningDotColor);
+        Assert.Equal("No browser profiles yet. Click to add one your agents can drive.", rail.ToolTip);
+    }
+
+    [Fact]
+    public void FoldRail_DotColorIsAPaletteNameTheDesktopKnows()
+    {
+        // The surface maps this name to a brush; an unknown name renders the magenta BROKEN sentinel.
+        var rail = AutomationBrowserViewFold.FoldRail(new[] { View("a", AutomationBrowserStatus.Ready) }, harnessInstalled: true);
+
+        Assert.Equal(DotColorOf(AutomationBrowserStatus.Ready), rail.RunningDotColor);
+    }
+
+    private static string DotColorOf(AutomationBrowserStatus status) => AutomationBrowserViewFold.DotColor(status);
+
+    [Fact]
+    public void FoldRail_NullList_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => AutomationBrowserViewFold.FoldRail(null!, harnessInstalled: true));
+    }
 }

--- a/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
+++ b/src/CcDirector.Core/Browsers/AutomationBrowserViewFold.cs
@@ -45,6 +45,28 @@ public sealed record AutomationBrowserView(
     DateTime? LastSignedInUtc);
 
 /// <summary>
+/// The whole content of the pinned "Browser profiles" row in the Director's left rail. The rail is a
+/// navigation strip, not a control panel: the row shows how many profiles exist and whether any are up,
+/// and clicking it opens Settings > Browsers, where starting, signing in and attaching live. Folded here
+/// with everything else so the row cannot come to disagree with the screen it opens.
+/// </summary>
+/// <param name="ShowSetup">True when browser-harness is not installed: the row wears a setup nudge
+/// instead of a count, so the feature still advertises itself rather than going silent.</param>
+/// <param name="ShowCount">True when there is a count worth showing (harness installed, at least one
+/// profile registered).</param>
+/// <param name="CountText">The number of registered profiles, as text.</param>
+/// <param name="RunningDotColor">The dot's colour NAME from the one shared palette when at least one
+/// profile is running - the single piece of live status the row carries - or null when none is, which
+/// is how a surface knows to show no dot at all.</param>
+/// <param name="ToolTip">The row's full sentence, including the running count when it is known.</param>
+public sealed record AutomationBrowsersRailView(
+    bool ShowSetup,
+    bool ShowCount,
+    string CountText,
+    string? RunningDotColor,
+    string ToolTip);
+
+/// <summary>
 /// Folds an <see cref="AutomationBrowser"/> into its <see cref="AutomationBrowserView"/>, and answers
 /// whether browser-harness (the tool that actually drives these browsers) is installed on this machine.
 /// The mapping itself is pure and unit-tested (<see cref="Fold"/>); the async entry points add the two
@@ -232,6 +254,51 @@ public static class AutomationBrowserViewFold
             AutomationBrowserStatus.Checking => $"{kind} - checking...",
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown automation browser status"),
         };
+    }
+
+    /// <summary>
+    /// Fold the whole list down to the single pinned rail row (see <see cref="AutomationBrowsersRailView"/>).
+    ///
+    /// The running count deliberately goes UNSAID while any profile is still being probed. A row that
+    /// reads "none running" for the second before the probes land, and then flips to "2 running", is
+    /// stating something false rather than stating nothing - and this row repaints on a timer, so it
+    /// would do it repeatedly. Running means the debug port answered, whether or not the browser has
+    /// been signed in yet.
+    /// </summary>
+    public static AutomationBrowsersRailView FoldRail(IReadOnlyList<AutomationBrowserView> views, bool harnessInstalled)
+    {
+        if (views is null) throw new ArgumentNullException(nameof(views));
+
+        if (!harnessInstalled)
+            return new AutomationBrowsersRailView(
+                ShowSetup: true,
+                ShowCount: false,
+                CountText: "",
+                RunningDotColor: null,
+                ToolTip: "Browser control is not set up yet. Click to install Browser Harness and set up a signed-in browser.");
+
+        if (views.Count == 0)
+            return new AutomationBrowsersRailView(
+                ShowSetup: false,
+                ShowCount: false,
+                CountText: "",
+                RunningDotColor: null,
+                ToolTip: "No browser profiles yet. Click to add one your agents can drive.");
+
+        var stillChecking = views.Any(v => v.Status == AutomationBrowserStatus.Checking);
+        var running = views.Count(v => v.Status is AutomationBrowserStatus.Ready or AutomationBrowserStatus.NeedsSignIn);
+        var profiles = views.Count == 1 ? "1 browser profile" : $"{views.Count} browser profiles";
+        var runningClause = stillChecking ? "" : running == 0 ? ", none running" : $", {running} running";
+
+        return new AutomationBrowsersRailView(
+            ShowSetup: false,
+            ShowCount: true,
+            CountText: views.Count.ToString(),
+            // Green is the palette's "up and usable"; there is no second colour here on purpose. A
+            // browser that is running but not signed in is still running, and the row has no room to
+            // say more than that - the screen it opens does.
+            RunningDotColor: running > 0 ? "green" : null,
+            ToolTip: $"{profiles}{runningClause}. Click to manage them in Settings.");
     }
 
     /// <summary>The complete attach one-liner an agent runs. Built on the slug id (never the free-text


### PR DESCRIPTION
Browser profiles was the only pinned rail entry that unfolded into a list: four profiles at two lines
each with their own Start link, about a third of the visible rail, directly above a Repositories entry
that holds seventeen things in one row. The rail is a navigation strip; that entry had become a control
panel. The Start links also implied a human must launch a browser before an agent can use one, which is
not how it works - an agent brings its own up through Browser Harness.

## What changes

The rail entry is now one clickable row that opens Settings > Browsers. No chevron, no expand, no `+`,
no per-profile rows, and no Start / Sign in / Attach in the rail. Nothing is lost - all three actions
already live on the Browsers settings screen, which has room to report a launch or a sign-in honestly.

The row keeps the two facts worth having at a glance: the profile count, and a green dot when at least
one profile is up. The full sentence is in the tooltip - "4 browser profiles, 2 running. Click to manage
them in Settings."

While any profile is still being probed the row says nothing about how many are running, rather than
reading "none running" and then correcting itself. It repaints on a timer, so a wrong answer would be
shown repeatedly.

When Browser Harness is not installed the row still wears its amber Setup nudge and lands on the screen
where the install runs, so the feature keeps advertising itself instead of going quiet.

The count, the dot colour and the wording are all decided in `AutomationBrowserViewFold.FoldRail`, like
the rest of this feature, so the row cannot drift from the screen it opens.

## Proof

The real control was rendered headlessly and looked at, above a stand-in Repositories row:

- live state on the build machine (four profiles, none running, so no dot): matches the Repositories
  row's height and chrome, badge reading 4
- with the running state forced, the green dot renders immediately left of the count (that forcing was
  a throwaway local edit, reverted)

Three headless render tests drive the actual control: one clickable row and no list, clicking asks to
manage and never unfolds, and the rail IS the row rather than a header with a body stacked under it.
**All three fail against the previous control**, so they catch the defect they claim to.

Nine fold tests cover the count, the running clause, the singular case, the probe window, the setup
state and the empty state.

Full local runs: `CcDirector.Avalonia.Tests` 356 passed; `CcDirector.Core.Tests` 4197 passed, 8 skipped,
0 failed.

Closes https://github.com/thefrederiksen/devthrottle_internal/issues/1315
