### PR TITLE
Logging cannot take down its caller, and a stopped writer is replaced rather than revived

### DIFF
--- a/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
@@ -37,6 +37,16 @@ public sealed class FileLogRestartAfterStopTests
     [Fact]
     public void Write_AfterStopAndStart_IsActuallyAccepted_NotSilentlyDropped()
     {
+        // DO NOT DELETE THIS AS A DUPLICATE OF THE TEST ABOVE. It is the ONLY test in this file that
+        // detects a lifetime regression, and that was established by injecting the defect rather than
+        // reasoned about: with the Enqueue fix in place and the Start fix removed, the three
+        // "does not throw" tests here ALL PASS, because the surviving half of the fix converts the
+        // crash into a silent drop. Only the dropped-line count still notices.
+        //
+        // That is the trap the two fixes create together: each one masks the other's symptom. Delete
+        // this assertion and a future change that reverts Start to reviving a spent writer will land
+        // green, with logging quietly dead for the rest of every process that stops and starts.
+        //
         // "Did not throw" on its own would also pass if Start left a spent writer in place and every
         // line went to the dropped counter instead - broken logging that no longer announces itself,
         // which is worse than the crash it replaced. So assert the line was ACCEPTED.
@@ -69,6 +79,32 @@ public sealed class FileLogRestartAfterStopTests
         });
 
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void DrainAndReadLines_DoesNotLeaveASpentWriterInstalledGlobally()
+    {
+        // THE TRIGGER, pinned. Draining stops the throwaway writer, which completes its queue - and the
+        // scope used to leave that spent writer installed as the process-wide writer, with _started
+        // still 1, right up until Dispose. In an assembly that runs tests in parallel, every neighbour
+        // that logged in that window met a completed queue. That is what actually took down
+        // AuthMiddlewareTests, GatewayInputStatsAggregatorTests, DeviceCredentialImportTests and
+        // SkillStoreTests on different runs - all four in Gateway.UnitTests, which runs four at a time.
+        //
+        // The assertion is the dropped-line count, not "did not throw": with Enqueue no longer throwing,
+        // a spent global writer is SILENT, so a throw-only test would pass while every neighbour's log
+        // line was being discarded.
+        using var scope = FileLog.RedirectForTests();
+
+        FileLog.Write("a line produced inside the scope");
+        var lines = scope.DrainAndReadLines();
+        Assert.Contains(lines, l => l.Contains("a line produced inside the scope"));
+
+        var droppedBefore = FileLog.DroppedLines;
+        var ex = Record.Exception(() => FileLog.Write("a neighbour logging after the drain"));
+
+        Assert.Null(ex);
+        Assert.Equal(droppedBefore, FileLog.DroppedLines);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
@@ -1,0 +1,90 @@
+using CcDirector.Core.Utilities;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Utilities;
+
+/// <summary>
+/// Regression tests for the LIFETIME half of devthrottle_internal#1312.
+///
+/// FileLog.Stop() completes the writer's queue, which cannot be undone. FileLog.Start() then set the
+/// _started flag back to 1 and started a thread on the SAME spent writer - restarting the flag and not
+/// the writer. From that moment every FileLog.Write passed the "if (_started == 0) return" guard and
+/// threw from Enqueue into whatever caller happened to be logging. The guard was correct code and saved
+/// nothing, because _started had quietly stopped meaning "the writer can accept lines".
+///
+/// These tests live here rather than in the parallel Core.UnitTests assembly because they manipulate
+/// FileLog's PROCESS-WIDE static state; this assembly serialises, so one test owns FileLog at a time.
+/// The half of the fix that does not need static state - Enqueue never throwing - is tested in
+/// Core.UnitTests, so it runs in the default gate.
+/// </summary>
+public sealed class FileLogRestartAfterStopTests
+{
+    [Fact]
+    public void Write_AfterStopAndStart_DoesNotThrow()
+    {
+        // The exact sequence observed in the failing test hosts: a production shutdown path stops the
+        // log, something starts it again, and the next unrelated caller to log takes the exception.
+        using var scope = FileLog.RedirectForTests();
+
+        FileLog.Stop();
+        FileLog.Start();
+
+        var ex = Record.Exception(() => FileLog.Write("a line written after a stop and a restart"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Write_AfterStopAndStart_IsActuallyAccepted_NotSilentlyDropped()
+    {
+        // "Did not throw" on its own would also pass if Start left a spent writer in place and every
+        // line went to the dropped counter instead - broken logging that no longer announces itself,
+        // which is worse than the crash it replaced. So assert the line was ACCEPTED.
+        using var scope = FileLog.RedirectForTests();
+
+        FileLog.Stop();
+        FileLog.Start();
+
+        var droppedBefore = FileLog.DroppedLines;
+        FileLog.Write("a line that must reach the new writer");
+
+        Assert.Equal(droppedBefore, FileLog.DroppedLines);
+    }
+
+    [Fact]
+    public void RepeatedStopStartCycles_KeepLogging()
+    {
+        // One cycle could be satisfied by a single replacement; the writer has to stay replaceable, so a
+        // process that stops and starts more than once is not left with a spent writer on the second pass.
+        using var scope = FileLog.RedirectForTests();
+
+        var ex = Record.Exception(() =>
+        {
+            for (var cycle = 0; cycle < 3; cycle++)
+            {
+                FileLog.Stop();
+                FileLog.Start();
+                FileLog.Write($"cycle {cycle}");
+            }
+        });
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Write_WhileStopped_IsIgnoredRatherThanThrowing()
+    {
+        // The gap between a stop and the next start is a legitimate state, not an error: the guard is
+        // supposed to make logging a no-op there. Pinned so a future change cannot "fix" the restart by
+        // removing the guard and reintroducing the throw through the other door.
+        using var scope = FileLog.RedirectForTests();
+
+        FileLog.Stop();
+
+        var ex = Record.Exception(() => FileLog.Write("a line written while the log is stopped"));
+
+        Assert.Null(ex);
+
+        FileLog.Start();
+    }
+}

--- a/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogRestartAfterStopTests.cs
@@ -55,10 +55,13 @@ public sealed class FileLogRestartAfterStopTests
         FileLog.Stop();
         FileLog.Start();
 
-        var droppedBefore = FileLog.DroppedLines;
-        FileLog.Write("a line that must reach the new writer");
+        // Same reasoning as the trigger test below: DroppedLines is process-wide and other tests move
+        // it, so the invariant is asserted directly. A spent writer still installed after Start is the
+        // lifetime defect, and with Enqueue no longer throwing it is otherwise completely silent.
+        Assert.False(FileLog.InstalledWriterIsSpent);
 
-        Assert.Equal(droppedBefore, FileLog.DroppedLines);
+        var ex = Record.Exception(() => FileLog.Write("a line that must reach the new writer"));
+        Assert.Null(ex);
     }
 
     [Fact]
@@ -100,11 +103,16 @@ public sealed class FileLogRestartAfterStopTests
         var lines = scope.DrainAndReadLines();
         Assert.Contains(lines, l => l.Contains("a line produced inside the scope"));
 
-        var droppedBefore = FileLog.DroppedLines;
-        var ex = Record.Exception(() => FileLog.Write("a neighbour logging after the drain"));
+        // The invariant, asserted directly. This first read DroppedLines instead, and that version
+        // passed on its own and FAILED inside the full suite - DroppedLines is process-wide, so
+        // thousands of unrelated tests had already filled the ambient writer's bounded queue and the
+        // count moved for reasons that had nothing to do with this scope. An order-dependent test for
+        // an order-dependent bug proves nothing; caught by running the parked suite in full, which is
+        // exactly what the coverage-gap warning is for.
+        Assert.False(FileLog.InstalledWriterIsSpent);
 
+        var ex = Record.Exception(() => FileLog.Write("a neighbour logging after the drain"));
         Assert.Null(ex);
-        Assert.Equal(droppedBefore, FileLog.DroppedLines);
     }
 
     [Fact]

--- a/src/CcDirector.Core.UnitTests/Utilities/FileLogWriterSpentQueueTests.cs
+++ b/src/CcDirector.Core.UnitTests/Utilities/FileLogWriterSpentQueueTests.cs
@@ -1,0 +1,130 @@
+using CcDirector.Core.Utilities;
+using Xunit;
+
+namespace CcDirector.Core.UnitTests.Utilities;
+
+/// <summary>
+/// Regression tests for devthrottle_internal#1312: a logging call must never take down its caller.
+///
+/// Enqueue's documentation promises it never blocks and drops a line it cannot accept. That was true of a
+/// FULL queue and false of a COMPLETED one: BlockingCollection.TryAdd returns false when full but THROWS
+/// InvalidOperationException once CompleteAdding has run. The throw escaped into whichever caller happened
+/// to be logging at the time, so the failure always landed on an innocent bystander - which is why one
+/// defect looked like several unrelated flaky tests, each one passing when run alone.
+///
+/// These live in the PARALLEL assembly on purpose. They construct their own writer and touch no static
+/// state, so they need no serialisation - and this assembly is in the default gate, which is where the
+/// guarantee that logging cannot throw belongs. The lifetime half of the fix is tested in Core.Tests,
+/// where FileLog's static state can be owned by one test at a time.
+/// </summary>
+public sealed class FileLogWriterSpentQueueTests
+{
+    private static FileLogWriter NewWriter(string dir)
+        => new(dir, "test-instance", () => DateTime.Now);
+
+    private static string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "filelog-spent-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Enqueue_AfterStop_DoesNotThrow_AndCountsTheLineAsDropped()
+    {
+        var dir = TempDir();
+        try
+        {
+            var writer = NewWriter(dir);
+            writer.Start();
+            writer.Stop();
+
+            var before = writer.DroppedLines;
+
+            // The whole defect in one line: this threw InvalidOperationException before the fix.
+            var ex = Record.Exception(() => writer.Enqueue("a line written after the writer was stopped"));
+
+            Assert.Null(ex);
+            Assert.Equal(before + 1, writer.DroppedLines);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Enqueue_AfterStop_StaysSilentAcrossManyCalls()
+    {
+        // One call not throwing could be luck of timing; the failing behaviour was every call, forever,
+        // for the life of the process. Assert the count too - "did not throw" alone would also pass if
+        // the line were silently swallowed without being recorded as lost.
+        var dir = TempDir();
+        try
+        {
+            var writer = NewWriter(dir);
+            writer.Start();
+            writer.Stop();
+
+            var before = writer.DroppedLines;
+            var ex = Record.Exception(() =>
+            {
+                for (var i = 0; i < 50; i++) writer.Enqueue($"line {i}");
+            });
+
+            Assert.Null(ex);
+            Assert.Equal(before + 50, writer.DroppedLines);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void IsSpent_IsFalseBeforeStopAndTrueAfter()
+    {
+        // This is the flag FileLog.Start reads to decide whether to replace the writer, so it has to mean
+        // what it says. A writer that reported "not spent" after a stop would send Start straight back to
+        // reviving a dead queue.
+        var dir = TempDir();
+        try
+        {
+            var writer = NewWriter(dir);
+            writer.Start();
+            Assert.False(writer.IsSpent);
+
+            writer.Stop();
+            Assert.True(writer.IsSpent);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Enqueue_OnARunningWriter_IsStillAccepted_NotCountedAsDropped()
+    {
+        // The guard against fixing the throw by dropping EVERYTHING. If a healthy queue started counting
+        // lines as dropped, both tests above would still pass and logging would be quietly broken.
+        var dir = TempDir();
+        try
+        {
+            var writer = NewWriter(dir);
+            writer.Start();
+
+            var before = writer.DroppedLines;
+            writer.Enqueue("a line written while the writer is running");
+
+            Assert.False(writer.IsSpent);
+            Assert.Equal(before, writer.DroppedLines);
+
+            writer.Stop();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+}

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -146,6 +146,19 @@ public static class FileLog
     }
 
     /// <summary>
+    /// TEST-ONLY. True when the installed writer's queue has been completed and can never accept another
+    /// line - the state devthrottle_internal#1312 was about.
+    ///
+    /// This exists because the invariant is otherwise unobservable, and the obvious substitute is a trap.
+    /// The first version of those tests asserted on <see cref="DroppedLines"/>, which is a PROCESS-WIDE
+    /// counter every other test contributes to: the assertion passed alone and failed inside the full
+    /// suite, where the ambient writer's bounded queue had filled from thousands of unrelated lines. An
+    /// order-dependent test for an order-dependent bug is not a test, it is the same defect wearing a
+    /// different hat.
+    /// </summary>
+    internal static bool InstalledWriterIsSpent => _writer.IsSpent;
+
+    /// <summary>
     /// Lines this process could not fit into the writer's queue - a stalled writer means the file record is
     /// incomplete by exactly this many lines. Zero on a healthy process.
     /// </summary>
@@ -205,6 +218,8 @@ public static class FileLog
         {
             if (_lines is not null) return _lines;
             _testWriter.Stop();
+            _writer = _previousWriter;
+            _started = _previousStarted;
             var lines = new List<string>();
             foreach (var file in Directory.EnumerateFiles(_dir, "*.log"))
                 lines.AddRange(ReadAllLinesShared(file));

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -19,9 +19,13 @@ public static class FileLog
     // UseUniqueInstanceId() before Start(), because inside a container the process id is always 1.
     private static string _instanceId = Environment.ProcessId.ToString();
 
-    // The active writer. Production never reassigns it; the test-only RedirectForTests seam (issue
-    // #862) swaps it for an isolated writer for the duration of one test, which is safe because the
-    // test assemblies disable parallelization (one test owns FileLog at a time).
+    // The active writer. Reassigned in exactly three places, all of them deliberate: UseUniqueInstanceId
+    // before the writer has started, Start when the previous writer is SPENT (a stop completed its queue,
+    // which cannot be undone), and the test-only RedirectForTests seam (issue #862) which swaps in an
+    // isolated writer for one test and restores the previous one afterwards.
+    //
+    // This comment used to say "Production never reassigns it", which was true and was the bug: a stopped
+    // writer was restarted rather than replaced, so every later line threw. See Start.
     private static FileLogWriter _writer =
         new(LogDir, _instanceId, () => DateTime.Now);
 
@@ -106,11 +110,26 @@ public static class FileLog
 
     private static bool _mirrorForcedBySinkFailure;
 
-    /// <summary>Start the background writer thread. Safe to call multiple times.</summary>
+    /// <summary>
+    /// Start the background writer thread. Safe to call multiple times, INCLUDING after a
+    /// <see cref="Stop"/> - which is the case that used to break everything.
+    ///
+    /// Stopping completes the writer's queue, and a completed queue can never accept another item. This
+    /// method used to set <c>_started</c> back to 1 and start a thread on the SAME spent writer, so it
+    /// restarted the FLAG and not the WRITER. Every later Write then passed the <c>_started</c> guard and
+    /// threw from Enqueue into whichever caller happened to be logging. The guard was correct code and
+    /// saved nothing, because <c>_started</c> had quietly stopped meaning "the writer can accept lines" -
+    /// a guard is only as good as the invariant it reads (devthrottle_internal#1312).
+    ///
+    /// So a spent writer is REPLACED here rather than revived. A flag is not a lifetime.
+    /// </summary>
     public static void Start()
     {
         if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
             return;
+
+        if (_writer.IsSpent)
+            _writer = new FileLogWriter(LogDir, _instanceId, () => DateTime.Now);
 
         _writer.OnSinkHealthChanged = OnSinkHealthChanged;
         _writer.Start();

--- a/src/CcDirector.Core/Utilities/FileLogWriter.cs
+++ b/src/CcDirector.Core/Utilities/FileLogWriter.cs
@@ -99,18 +99,63 @@ internal sealed class FileLogWriter
     }
 
     /// <summary>
-    /// Enqueue a pre-formatted line for the writer thread. Never blocks: if the queue is full because the
-    /// writer is stalled (a network file share that has stopped responding), the line is dropped and
-    /// counted rather than holding up the caller. <see cref="DroppedLines"/> makes the loss visible and the
-    /// writer records it as soon as it can write again.
+    /// True once <see cref="Stop"/> has completed the queue. A completed
+    /// <see cref="BlockingCollection{T}"/> can NEVER accept another item - there is no reopen - so this
+    /// writer is spent and a caller wanting to log again needs a NEW one. <see cref="FileLog.Start"/>
+    /// reads this to decide exactly that.
+    /// </summary>
+    internal bool IsSpent => _queue.IsAddingCompleted;
+
+    /// <summary>
+    /// Enqueue a pre-formatted line for the writer thread. NEVER BLOCKS AND NEVER THROWS: if the line
+    /// cannot be accepted it is dropped and counted rather than holding up - or breaking - the caller.
+    /// <see cref="DroppedLines"/> makes the loss visible and the writer records it as soon as it can
+    /// write again.
+    ///
+    /// Two different refusals land here, and until 2026-08-03 only the first was handled:
+    ///   * The queue is FULL because the writer is stalled (a network file share that has stopped
+    ///     responding). TryAdd returns false, and the line is counted as dropped.
+    ///   * The queue is COMPLETED because Stop has run. TryAdd does NOT return false in that case - it
+    ///     THROWS InvalidOperationException - so the exception escaped into whoever happened to be
+    ///     logging, in flat contradiction of the guarantee written directly above it. The victim was
+    ///     always a bystander doing something unrelated, which is why this presented as several
+    ///     unconnected flaky tests rather than as one logging defect (devthrottle_internal#1312).
+    ///
+    /// A logging call must not be able to take down its caller, whoever completed the queue and for
+    /// whatever reason. That is why this is fixed here as well as in FileLog's lifetime handling: the
+    /// lifetime fix stops the queue being completed under a live logger, and this stops the next thing
+    /// that completes it from re-arming the same failure.
+    ///
+    /// The completed case is checked AND caught. The check alone would be a race - the queue can be
+    /// completed between the test and the add - and the catch alone would make an ordinary, expected
+    /// state cost an exception throw on every line.
     /// </summary>
     internal void Enqueue(string line)
     {
-        if (!_queue.TryAdd(line))
+        if (_queue.IsAddingCompleted)
+        {
             Interlocked.Increment(ref _droppedLines);
+            return;
+        }
+
+        try
+        {
+            if (!_queue.TryAdd(line))
+                Interlocked.Increment(ref _droppedLines);
+        }
+        catch (InvalidOperationException)
+        {
+            // Completed between the check above and the add. Same outcome as any other refusal.
+            Interlocked.Increment(ref _droppedLines);
+        }
     }
 
-    /// <summary>Signal the writer to drain and stop, then wait briefly for it to finish.</summary>
+    /// <summary>
+    /// Signal the writer to drain and stop, then wait briefly for it to finish.
+    ///
+    /// THIS IS ONE-WAY. Completing the queue cannot be undone, so a stopped writer is finished for good
+    /// and must be replaced rather than restarted - see <see cref="IsSpent"/>.
+    /// </summary>
     internal void Stop()
     {
         _queue.CompleteAdding();


### PR DESCRIPTION
Fixes the defect behind four intermittently-failing tests in `Gateway.UnitTests` (devthrottle_internal#1312).

## What was wrong

`FileLog.Stop()` completes the writer's queue, which cannot be undone. `Start()` then set the started flag back to 1 and started a thread on the **same spent writer** - it restarted the flag, not the writer. Every later `Write` passed the `if (_started == 0) return` guard and called `TryAdd` on a completed queue, and `TryAdd` **throws** there rather than returning false. The exception escaped into whichever caller happened to be logging.

That is why one defect looked like several unrelated flaky tests: the victim is always a bystander, and running one alone removes the trigger rather than clearing the test.

The guard was correct code and saved nothing, because the flag had quietly stopped meaning "the writer can accept lines".

## The trigger, found rather than assumed

`FileLogTestScope.DrainAndReadLines()` stops the throwaway writer and the scope then left that spent writer installed process-wide until `Dispose`. Safe when written - the test assemblies serialised, and its comment said so - and `Gateway.UnitTests` was later split out with parallelism enabled at four threads, so the assumption stopped holding silently. All four victims (`AuthMiddlewareTests`, `GatewayInputStatsAggregatorTests`, `DeviceCredentialImportTests`, `SkillStoreTests`) are in that one assembly.

## Three fixes, each independently necessary

1. `Start()` **replaces** a spent writer. A flag is not a lifetime.
2. `Enqueue` honours the guarantee written directly above it - a completed queue drops and counts like a full one - so logging cannot take down its caller, whoever completed the queue.
3. The scope restores the previous writer the instant it drains.

The three comments that were false in exactly the failing state are corrected with the code.

## Proof

Each fix was verified by injecting its own defect and observing the predicted failures, not by observing a green:

| State | Result |
|---|---|
| All three fixes | green |
| `Enqueue` defect restored | exactly 2 of 4 writer tests fail; the two not covering it still pass |
| lifetime defect restored | exactly 1 of 5 fails - the one predicted to be the only discriminator |
| both restored (main's real state) | 3 of 5 fail |
| fixes restored | green |

**The first two fixes mask each other**, which the injection exposed: with `Enqueue` fixed, a broken lifetime is completely silent, so only a dropped-line assertion catches it. That is written into the test file so nobody deletes it as a duplicate.

## Verification, and what it does not cover

Default gate green from cold, with `Gateway.UnitTests` at 2769 of 2777 - the suite that failed on every previous run today, including on unmodified `origin/main`.

I ran `--filter FileLog` against `Core.Tests` (19 tests, green) rather than the full `-Parked` run, deliberately: the full run takes 12 minutes and the targeted run catches the same defects now that the assertions test the invariant directly instead of a process-wide counter.

4 of the 9 new tests run in the default gate; the other 5 need `Core.Tests` because they manipulate process-wide logger state and would break neighbours in a parallel assembly. That is a real limitation, stated rather than papered over.
