### PR TITLE
release: v1.9.8 - mission attach announced, rail and logging fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.7</Version>
+    <Version>1.9.8</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.8.md
+++ b/docs/public/release-notes/v1.9.8.md
@@ -1,0 +1,33 @@
+# DevThrottle v1.9.8
+
+## Announcing something v1.9.7 shipped quietly: move any session in and out of any mission
+
+The v1.9.7 release included this and its notes never said so, so it is announced here. A session no longer has to be born into a mission. You can now attach any running session to a mission, move it between missions, or detach it entirely - from the command line, with no restart and no respawn:
+
+- `cc-devthrottle mission attach <session> <mission>` attaches a session, or moves it if it already belongs to another mission, and tells you which mission it left.
+- `cc-devthrottle mission attach <session> <mission> --with-children` also brings along every session the target controls, all the way down, naming each one it moves.
+- `cc-devthrottle mission detach <session>` returns a session to belonging to no mission, which is the ordinary state.
+
+The session's workflow seat moves with it, so a session shown under one mission is never quietly governed by the conduct of the one it left. A seat you chose yourself at spawn is preserved - it was never the mission's to take. One honest limit: a running agent keeps the instructions it was handed at birth, so after a move the command tells you exactly how to ask the session to fetch its current conduct.
+
+Sessions spawned by a controlling session now also inherit that session's mission by default, so a team stays a team without anyone remembering a flag.
+
+## What you will notice
+
+**On a brand-new Windows machine, the setup wizard no longer appears frozen on first launch.** Windows showed its firewall security prompt directly on top of the wizard's first button, where it silently swallowed every click aimed at it - no error, the product simply looked broken in its first minute of use. DevThrottle no longer does the thing that made Windows ask: it now checks candidate ports on the machine's internal address only, so the firewall prompt does not appear at all.
+
+**The Browser profiles entry in the Director's side rail is one clickable row again.** It used to unfold into a list of every profile with its own Start link, taking a third of the visible rail. It is now a single row showing the profile count and a green dot when at least one is running; clicking it opens the Browsers settings screen, where all the actions already lived.
+
+## Reliability
+
+**A logging fault can no longer take down the work that was being logged.** Stopping and restarting the application's log writer left it in a state where every later log line threw an error into whichever operation happened to be logging - so one defect surfaced as several unrelated, unreproducible failures. The writer is now replaced rather than revived, and a log call that cannot be accepted is dropped and counted instead of thrown. This one fault was behind most of the sporadic test failures seen on the local gate.
+
+## For people running the source
+
+Two test-suite fixes make the local gate more trustworthy: a backoff test now measures the code's behaviour rather than the machine's load at that moment, and a test that takes the machine-wide gateway lock is kept out of the parallel run, where it could stall the whole run indefinitely.
+
+## Known and not fixed here
+
+- The Director's large-object heap still grows on a long-running instance; retained terminal cells and user-interface objects accumulate on a Director left running for days.
+- A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
+- Four repository views still show a failed git read as an empty result rather than saying the read failed.


### PR DESCRIPTION
Bumps the product version to 1.9.8 and adds docs/public/release-notes/v1.9.8.md.

The release carries main as of 0592b5407: the Browser profiles rail row fix (#2441), the
FileLog robustness fix (#2443), and two test-suite fixes (#2442, #2444). The notes also
announce the mission attach and detach feature (#2399), which shipped in v1.9.7 with no
mention in that release's notes.

The owner approved the notes text verbatim. The full release gate (test-local -Parked
-Configuration Release plus both installer test projects) runs on merged main at the exact
commit before the tag is pushed, per the release run-book.