### PR TITLE
fix(director): stop the port probe opening every interface, so the setup wizard is not covered by a firewall prompt

### DIFF
--- a/src/CcDirector.ControlApi/PortAllocator.cs
+++ b/src/CcDirector.ControlApi/PortAllocator.cs
@@ -185,17 +185,76 @@ public static class PortAllocator
         return false;
     }
 
+    /// <summary>
+    /// Can the Control API listen on this port? The question is asked about LOOPBACK, because that
+    /// is the address ControlApiHost binds in every addressing mode - the probe must not test a
+    /// wider door than the one the Director actually walks through. Both halves used to.
+    ///
+    /// The bind half opened the candidate port on ALL interfaces (IPAddress.Any) purely to test a
+    /// port it would then bind on loopback only. Windows saw a program opening itself to the network
+    /// and raised the "allow this app on public and private networks?" question against
+    /// cc-director.exe. On a first launch that dialog lands on top of the setup wizard and eats the
+    /// clicks aimed at it, so the wizard looks frozen with no error anywhere. A loopback listener
+    /// raises no such question.
+    ///
+    /// The scan half rejected on the port NUMBER alone, ignoring the listening address, so an
+    /// unrelated program holding (say) 192.168.1.5:7885 wrote that port off for every Director on the
+    /// machine - out of a range of twenty. See <see cref="ConflictsWithLoopbackBind"/>.
+    ///
+    /// The scan is an optimisation, not the authority: the bind below is the real test and catches
+    /// anything the scan lets through.
+    /// </summary>
     private static bool IsPortFree(int port)
+        => IsPortFree(
+            port,
+            static () => IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners(),
+            TryBind);
+
+    /// <summary>
+    /// The body, with BOTH collaborators injected: the listener enumeration and the bind. It is the
+    /// same shape <see cref="CollectLivePortReservations"/> already uses for its own probe.
+    ///
+    /// Both are injected so a test can drive THIS method - the real one - and pin both decisions
+    /// deterministically, with no operating-system socket and therefore no free-port race:
+    ///   * revert the scan to a port-number-only comparison and it returns before the bind delegate is
+    ///     ever invoked, which a test can see;
+    ///   * revert the bind to all interfaces and the address handed to the delegate changes, which a
+    ///     test can capture.
+    ///
+    /// Earlier attempts to cover these two lines all failed, and each failure is why this shape is
+    /// what it is. Testing <see cref="ConflictsWithLoopbackBind"/> alone left the CALL SITE free to
+    /// revert. Binding a real socket could not tell the two addresses apart (Windows lets an
+    /// all-interfaces bind coexist with a listener already holding a specific address) and raced on
+    /// port reuse, going red at random on correct code. Reading the source could be defeated by moving
+    /// the construction into a helper and leaving the expected text in a comment - a review restored
+    /// the defect exactly that way and got a full green.
+    /// </summary>
+    internal static bool IsPortFree(
+        int port, Func<IPEndPoint[]> listActiveTcpListeners, Func<IPAddress, int, bool> tryBind)
     {
         try
         {
-            // Check listeners on all addresses (0.0.0.0 binding would conflict with anything bound there)
-            var props = IPGlobalProperties.GetIPGlobalProperties();
-            foreach (var ep in props.GetActiveTcpListeners())
-                if (ep.Port == port) return false;
+            foreach (var ep in listActiveTcpListeners())
+                if (ConflictsWithLoopbackBind(ep, port)) return false;
 
-            // Try binding to confirm
-            using var listener = new TcpListener(IPAddress.Any, port);
+            return tryBind(IPAddress.Loopback, port);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The real bind: can we listen on this address and port right now? Opening a listener is the only
+    /// authoritative answer - the scan above is an optimisation that can be stale by the time we act
+    /// on it.
+    /// </summary>
+    private static bool TryBind(IPAddress address, int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(address, port);
             listener.Start();
             listener.Stop();
             return true;
@@ -204,6 +263,25 @@ public static class PortAllocator
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// True when an existing listener would block a bind to <c>127.0.0.1:port</c>: it is on the same
+    /// port AND on an address that covers loopback - loopback itself, or a wildcard listener
+    /// (<c>0.0.0.0</c> / <c>::</c>) which already includes it.
+    ///
+    /// A listener on a SPECIFIC non-loopback address - a local network address, a virtual adapter, a
+    /// tunnel - does not collide with a loopback bind, and treating it as if it did costs the
+    /// Director a port it could have used. Pure - unit-tested.
+    /// </summary>
+    internal static bool ConflictsWithLoopbackBind(IPEndPoint listener, int port)
+    {
+        if (listener.Port != port) return false;
+
+        var address = listener.Address;
+        return IPAddress.IsLoopback(address)
+            || address.Equals(IPAddress.Any)
+            || address.Equals(IPAddress.IPv6Any);
     }
 
     private static HashSet<int> ReadPortsInUseByOtherDirectors(string except)

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -31,6 +31,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         // --- Loopback BIND / same-machine control surface (the deliberate security boundary) ---
         ["src/CcDirector.ControlApi/ControlApiHost.cs"] = "Binds Kestrel to loopback (tailscale mode); same-machine ControlApiBaseUrl for in-session agents.",
         ["src/CcDirector.ControlApi/InstanceRegistration.cs"] = "FSW same-machine ControlEndpoint is http://127.0.0.1:{port} by design.",
+        ["src/CcDirector.ControlApi/PortAllocator.cs"] = "Doc comments only. The availability probe asks whether the Control API can bind LOOPBACK - the address ControlApiHost actually binds - so the comments name 127.0.0.1 to say which bind is being tested. Same machine by definition: it is asking about its own bind.",
         ["src/CcDirector.ControlApi/TailscaleServeSelfProvisioner.cs"] = "Maps the tailnet front door to local loopback backend.",
         ["src/CcDirector.ControlApi/GatewayConnectivitySelfTest.cs"] = "Probes the local loopback Control API as part of self-test.",
         ["src/CcDirector.ControlApi/GatewayEnrollmentClient.cs"] = "Epic #1069 A: doc comment on EnrollSignedInAsync states the same-machine caller MUST pass a LOOPBACK gatewayUrl (http://127.0.0.1:<local gateway port>) so the Gateway's guardrail-1 IsLoopback check passes. Documents the policy; the literal address is built by the panel's BuildLoopbackEnrollUrl.",

--- a/src/CcDirector.Gateway.UnitTests/PortAllocatorLoopbackProbeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/PortAllocatorLoopbackProbeTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The port availability probe must ask about LOOPBACK, because loopback is what ControlApiHost
+/// binds in every addressing mode. Two defects came from asking a wider question.
+///
+/// The bind half opened each candidate port on ALL interfaces before throwing it away, which made
+/// Windows raise the firewall question against cc-director.exe - a dialog that lands on top of the
+/// first-launch setup wizard and silently eats the clicks aimed at it. That half is a socket call
+/// and is proved by a clean-machine install, not by a unit test.
+///
+/// The scan half is pure and is what these tests pin: an existing listener may only veto a port when
+/// it would genuinely block a bind to 127.0.0.1. Rejecting on the port NUMBER alone wrote off ports
+/// held by unrelated programs on ordinary network addresses, out of a range of only twenty.
+/// </summary>
+public sealed class PortAllocatorLoopbackProbeTests
+{
+    private const int Port = 7885;
+
+    [Fact]
+    public void ConflictsWithLoopbackBind_LoopbackListenerOnTheSamePort_Conflicts()
+    {
+        // The direct collision: another Director already holds 127.0.0.1:7885.
+        Assert.True(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.Loopback, Port), Port));
+    }
+
+    [Fact]
+    public void ConflictsWithLoopbackBind_IPv6LoopbackListenerOnTheSamePort_Conflicts()
+    {
+        Assert.True(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.IPv6Loopback, Port), Port));
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    public void ConflictsWithLoopbackBind_WildcardListenerOnTheSamePort_Conflicts(string wildcard)
+    {
+        // A wildcard listener already covers loopback, so it blocks the bind. This is the case the
+        // old comment was reaching for, and it is the one that must survive the narrowing: getting
+        // it wrong would let the allocator hand out a port that is genuinely taken.
+        Assert.True(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.Parse(wildcard), Port), Port));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.5")]     // an ordinary local network address
+    [InlineData("100.64.0.7")]      // a tunnel address
+    [InlineData("172.17.0.1")]      // a virtual adapter
+    public void ConflictsWithLoopbackBind_SpecificNonLoopbackAddress_DoesNotConflict(string address)
+    {
+        // The regression this file exists for: a program listening on a real network address does
+        // NOT block a loopback bind. Treating it as if it did cost a Director a usable port.
+        Assert.False(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.Parse(address), Port), Port));
+    }
+
+    [Fact]
+    public void ConflictsWithLoopbackBind_LoopbackListenerOnADifferentPort_DoesNotConflict()
+    {
+        Assert.False(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.Loopback, Port + 1), Port));
+    }
+
+    [Fact]
+    public void ConflictsWithLoopbackBind_WholeLoopbackRangeIsTreatedAsLoopback()
+    {
+        // 127.0.0.0/8 is all loopback, not just 127.0.0.1 - a listener anywhere in it blocks us.
+        Assert.True(PortAllocator.ConflictsWithLoopbackBind(
+            new IPEndPoint(IPAddress.Parse("127.0.0.2"), Port), Port));
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/PortAllocatorProbeCallSiteTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/PortAllocatorProbeCallSiteTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Call-site cover for the availability probe: the two production decisions in
+/// <c>PortAllocator.IsPortFree</c> that this change exists to alter - WHICH listeners may veto a port,
+/// and WHICH address the probe then binds.
+///
+/// These drive the real method with both collaborators stubbed, so each decision is observed rather
+/// than inferred, with no operating-system socket involved. Three earlier approaches failed and each
+/// one is why this file looks like this:
+///
+///   * Testing the predicate alone left the CALL SITE free to revert - a review reverted it and every
+///     test stayed green.
+///   * Binding a real socket could not distinguish the two addresses (Windows lets an all-interfaces
+///     bind coexist with a listener holding a specific address) and raced on port reuse, going red at
+///     random on correct code. A red that means nothing trains people to ignore reds.
+///   * Reading the source was defeated by moving the construction into a helper and leaving the
+///     expected text in a comment. A review restored the defect that way and got a full green.
+///
+/// Capturing the address handed to the bind has none of those problems: it is deterministic, it sees
+/// through any spelling or indirection, and it fails when either line goes back.
+/// </summary>
+public sealed class PortAllocatorProbeCallSiteTests
+{
+    private const int Port = 7885;
+
+    /// <summary>Records what the probe asked to bind, and whether it asked at all.</summary>
+    private sealed class BindSpy
+    {
+        public IPAddress? Address { get; private set; }
+        public bool WasCalled { get; private set; }
+        public bool Result { get; init; } = true;
+
+        public bool Bind(IPAddress address, int port)
+        {
+            WasCalled = true;
+            Address = address;
+            return Result;
+        }
+    }
+
+    private static Func<IPEndPoint[]> Listeners(params IPEndPoint[] endpoints) => () => endpoints;
+
+    [Fact]
+    public void Bind_line_asks_for_loopback_not_all_interfaces()
+    {
+        // PINS THE BIND LINE - the one that raises the Windows firewall question and freezes the
+        // first-launch setup wizard. Whatever address the probe hands to the bind is the address it
+        // would really open. Any all-interfaces form - IPAddress.Any, IPv6Any, an IPEndPoint overload,
+        // a call moved into a helper - changes what is captured here and turns this red.
+        var spy = new BindSpy();
+
+        var free = PortAllocator.IsPortFree(Port, Listeners(), spy.Bind);
+
+        Assert.True(spy.WasCalled);
+        Assert.Equal(IPAddress.Loopback, spy.Address);
+        Assert.True(free);
+    }
+
+    [Fact]
+    public void Scan_line_ignores_a_listener_on_an_ordinary_network_address()
+    {
+        // PINS THE SCAN LINE, and is the defect itself: a program holding 192.168.1.5 on this port
+        // does not block a loopback bind, so the probe must go on to bind. Revert the scan to
+        // comparing the port NUMBER alone and it returns before the bind is ever attempted - which
+        // both assertions below catch.
+        var spy = new BindSpy();
+        var listeners = Listeners(new IPEndPoint(IPAddress.Parse("192.168.1.5"), Port));
+
+        var free = PortAllocator.IsPortFree(Port, listeners, spy.Bind);
+
+        Assert.True(spy.WasCalled);
+        Assert.True(free);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    [InlineData("127.0.0.1")]
+    public void Scan_line_vetoes_a_listener_that_covers_loopback(string address)
+    {
+        // The other direction of the same line. A wildcard or loopback listener really does block the
+        // bind, so the probe must refuse WITHOUT binding. Narrowing the scan must not go so far that
+        // it hands out a port something already holds.
+        var spy = new BindSpy();
+        var listeners = Listeners(new IPEndPoint(IPAddress.Parse(address), Port));
+
+        var free = PortAllocator.IsPortFree(Port, listeners, spy.Bind);
+
+        Assert.False(free);
+        Assert.False(spy.WasCalled);
+    }
+
+    [Fact]
+    public void A_failing_bind_means_the_port_is_not_free()
+    {
+        // The scan passing is not the verdict - the bind is. A port nothing is listening on can still
+        // refuse a bind (a Windows exclusion, a reservation), and the probe must report that.
+        var spy = new BindSpy { Result = false };
+
+        Assert.False(PortAllocator.IsPortFree(Port, Listeners(), spy.Bind));
+        Assert.True(spy.WasCalled);
+    }
+}


### PR DESCRIPTION
On a clean Windows machine, first launch raised the Windows firewall prompt on top of the
setup wizard, over its first button, where it silently ate the clicks aimed at it - the
wizard looked frozen. The cause: the port picker tested each candidate by briefly opening
it on all interfaces before binding loopback only, so Windows saw a program opening itself
to the network.

The probe now binds loopback only, with a guard that a candidate conflicting with an
existing loopback bind is rejected, and tests pinning both the helper and its call site.
Authored and reviewed inside the Remove Network Port mission (three review passes,
fault-injected revert in both directions); included in v1.9.8 at the owner's direction
because the mission phase that deletes this code entirely has not landed.