### PR TITLE
Show which model each session is running, on every surface that names a session

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -24,6 +24,8 @@ import {
   directorsByMachine,
   groupByDirector,
   machineKeyOf,
+  modelChip,
+  modelKeyOf,
   shortDir,
   type DirectorGroup as FormatDirectorGroup,
 } from "./fleetMapFormat";
@@ -57,7 +59,7 @@ const ReachabilityContext = createContext<DirectorReachability[]>([]);
 // fleet page reads that one store, this map and the Sessions roster always agree on the fleet at the
 // same moment, and a hidden tab makes no roster requests at all.
 
-type Pivot = "machine" | "director" | "repo" | "worktree" | "agent" | "list" | "mission";
+type Pivot = "machine" | "director" | "repo" | "worktree" | "agent" | "model" | "list" | "mission";
 
 const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = [
   { key: "machine", label: "By machine", kindLabel: "Machine" },
@@ -73,6 +75,13 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
   { key: "repo", label: "By repository", kindLabel: "Repository" },
   { key: "worktree", label: "By working tree", kindLabel: "Working tree" },
   { key: "agent", label: "By agent", kindLabel: "Agent" },
+  // "By model" (issue devthrottle_internal#1340): the fleet laid out by the model each session is actually
+  // running, the same way it can be laid out by agent. It sits beside "By agent" because it answers the
+  // question one step down - not "which tool", but "which brain in that tool" - and that is the one the
+  // fleet's cost and quality actually turn on. The lane title is the model id exactly as the agent's own
+  // records spell it; the two absences ("no model yet", "model not reported") keep separate lanes rather
+  // than pooling, because pooling them in the layout would undo the distinction the fold exists to make.
+  { key: "model", label: "By model", kindLabel: "Model" },
   // The flat "Fleet list" pivot (issue #1212) absorbs the retired Fleet page: every session once, as
   // the same node card, no lane grouping (machines are already their own pivot).
   { key: "list", label: "Fleet list", kindLabel: "Session" },
@@ -84,7 +93,7 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
 
 // The pivots that lay the fleet out on the node canvas (root -> lanes). "list" is a flat grid and
 // "mission" is its own board; neither uses the canvas or the title search.
-const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "director", "repo", "worktree", "agent"]);
+const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "director", "repo", "worktree", "agent", "model"]);
 
 // The grouping is sticky per browser: the map opens on whatever the user last chose (rather than a
 // "smart" default that guesses from the fleet shape), so returning to the map lands them exactly where
@@ -100,6 +109,7 @@ function initialPivot(): Pivot {
       saved === "repo" ||
       saved === "worktree" ||
       saved === "agent" ||
+      saved === "model" ||
       saved === "list" ||
       saved === "mission"
     )
@@ -683,6 +693,10 @@ function NodeCard({
   // only thing that could shrink and it was ellipsized to a few characters on every card. Null on the
   // agent pivot, where the lane header already states the agent and a per-card badge only repeats it.
   const agentBadge = agentBadgeText(s, pivot);
+  // Which model this session is running (issue devthrottle_internal#1340), beside the agent because the
+  // two are one identity. Every string is the Gateway's; this card chooses nothing about the wording, and
+  // in particular does not decide what a missing model means.
+  const model = modelChip(s, pivot);
 
   return (
     <article
@@ -714,10 +728,15 @@ function NodeCard({
         </span>
       </div>
 
-      {(showRole || agentBadge !== null || tags.length > 0) && (
+      {(showRole || agentBadge !== null || model !== null || tags.length > 0) && (
         <div className="fmap-card-tags">
           {showRole && <span className={`fmap-role ${sessionRole.toLowerCase()}`}>{sessionRole}</span>}
           {agentBadge !== null && <span className="fmap-agent">{agentBadge}</span>}
+          {model !== null && (
+            <span className={model.absent ? "fmap-model absent" : "fmap-model"} title={model.title}>
+              {model.text}
+            </span>
+          )}
           {tags.map((t) => (
             <span key={t.k} className="fmap-card-tag">
               <span className="fmap-card-tag-k">{t.k}</span>
@@ -769,6 +788,11 @@ function buildLanes(sessions: SessionDto[], pivot: Pivot, directors: DirectorRea
       // On-disk checkout folder - each worktree stands alone, even when it belongs to the same repository.
       const title = repoBasename(s.repoPath);
       return { key: title.toLowerCase(), title };
+    }
+    if (pivot === "model") {
+      // The FULL recorded model id, through the shared key so the lane is named the way the records name
+      // the model and both absences keep their own lanes (see fleetMapFormat.modelKeyOf).
+      return modelKeyOf(s);
     }
     const agent = (s.agent ?? "").trim();
     const title = agent.length === 0 ? "(unknown agent)" : agent;
@@ -934,7 +958,9 @@ function cardTags(s: SessionDto, pivot: Pivot): Array<{ k: string; v: string }> 
     out.push({ k: "repo", v: repoIdentity(s.repoName, s.repoPath) });
     return out;
   }
-  // Lane = agent, or the flat Fleet list (no lane at all); show machine + repository.
+  // Lane = agent or model, or the flat Fleet list (no lane at all); show machine + repository. A model
+  // lane wants the same two coordinates an agent lane does - a lane full of "claude-opus-5" cards says
+  // nothing about WHERE each one is running.
   const out: Array<{ k: string; v: string }> = [];
   if (machine.length > 0) out.push({ k: machine, v: repoIdentity(s.repoName, s.repoPath) });
   return out;

--- a/apps/cockpit/src/fleet/fleetMapFormat.test.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.test.ts
@@ -13,6 +13,8 @@ import {
   directorsByMachine,
   groupByDirector,
   machineKeyOf,
+  modelChip,
+  modelKeyOf,
 } from "./fleetMapFormat";
 
 function session(overrides: Partial<SessionDto> = {}): SessionDto {
@@ -262,5 +264,77 @@ describe("agentBadgeText", () => {
     expect(agentBadgeText(session({ agent: "" }), "machine")).toBe("?");
     expect(agentBadgeText(session({ agent: "   " }), "machine")).toBe("?");
     expect(agentBadgeText(session({ agent: undefined }), "machine")).toBe("?");
+  });
+});
+
+// Issue devthrottle_internal#1340. The card renders the Gateway's model verdict and composes none of it;
+// what these pin is WHEN a chip appears and WHICH lane a card lands in - never the wording, which is the
+// Gateway's and is tested once, in C#, where it is decided.
+describe("modelChip", () => {
+  const reported = session({
+    modelDisplay: { kind: "reported", text: "fable-5", modelId: "claude-fable-5", tooltip: "claude-fable-5" },
+  });
+
+  it("renders the Gateway's words verbatim on every pivot but its own", () => {
+    for (const pivot of ["machine", "repo", "agent", "list"]) {
+      expect(modelChip(reported, pivot)).toEqual({ text: "fable-5", title: "claude-fable-5", absent: false });
+    }
+  });
+
+  it("shows nothing on the model pivot, where the lane header already states it", () => {
+    expect(modelChip(reported, "model")).toBeNull();
+  });
+
+  it("marks either absence as absent, and keeps the two sets of words apart", () => {
+    const notYet = session({
+      modelDisplay: { kind: "notRecordedYet", text: "no model yet", modelId: null, tooltip: "not yet", isAbsent: true },
+    });
+    const never = session({
+      modelDisplay: { kind: "notReported", text: "model not reported", modelId: null, tooltip: "never", isAbsent: true },
+    });
+    expect(modelChip(notYet, "machine")?.absent).toBe(true);
+    expect(modelChip(never, "machine")?.absent).toBe(true);
+    expect(modelChip(notYet, "machine")?.text).not.toBe(modelChip(never, "machine")?.text);
+  });
+
+  it("renders nothing when the Gateway stamped no verdict - a missing VERDICT is not a missing model", () => {
+    expect(modelChip(session(), "machine")).toBeNull();
+    expect(modelChip(session({ modelDisplay: null }), "machine")).toBeNull();
+    expect(modelChip(session({ modelDisplay: { kind: "reported", text: "  " } }), "machine")).toBeNull();
+  });
+});
+
+describe("modelKeyOf", () => {
+  it("names a lane with the FULL recorded id, not the shortened badge text", () => {
+    const s = session({ modelDisplay: { kind: "reported", text: "fable-5", modelId: "claude-fable-5" } });
+    expect(modelKeyOf(s)).toEqual({ key: "claude-fable-5", title: "claude-fable-5" });
+  });
+
+  it("folds two spellings of one model into one lane", () => {
+    const a = session({ modelDisplay: { kind: "reported", text: "opus-5", modelId: "claude-opus-5" } });
+    const b = session({ modelDisplay: { kind: "reported", text: "opus-5", modelId: "Claude-Opus-5" } });
+    expect(modelKeyOf(a).key).toBe(modelKeyOf(b).key);
+  });
+
+  it("gives the two absences SEPARATE lanes - pooling them would undo the distinction", () => {
+    const notYet = session({ modelDisplay: { kind: "notRecordedYet", text: "no model yet", isAbsent: true } });
+    const never = session({ modelDisplay: { kind: "notReported", text: "model not reported", isAbsent: true } });
+    expect(modelKeyOf(notYet).key).not.toBe(modelKeyOf(never).key);
+    expect(modelKeyOf(notYet).title).toBe("no model yet");
+    expect(modelKeyOf(never).title).toBe("model not reported");
+  });
+
+  it("puts an unstamped session in its own lane - 'we were not told' is neither absence", () => {
+    const key = modelKeyOf(session()).key;
+    expect(key).not.toBe(modelKeyOf(session({ modelDisplay: { kind: "notReported", text: "x" } })).key);
+  });
+
+  it("keys an absence so it can never collide with a real model id", () => {
+    // A recorded id is always trimmed and non-empty, so the reserved prefix is enough on its own; nothing
+    // here is trying to influence lane ORDER, which is by session count and then title like every pivot.
+    expect(modelKeyOf(session()).key.startsWith("absent:")).toBe(true);
+    expect(modelKeyOf(session({ modelDisplay: { kind: "notReported", text: "x" } })).key.startsWith("absent:")).toBe(
+      true,
+    );
   });
 });

--- a/apps/cockpit/src/fleet/fleetMapFormat.ts
+++ b/apps/cockpit/src/fleet/fleetMapFormat.ts
@@ -1,5 +1,6 @@
-import type { SessionDto } from "@devthrottle/client-core/api/client";
+﻿import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { type DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
+import { modelChipOf, type ModelChip } from "@devthrottle/client-core/sessions/model";
 
 /**
  * Pure helpers for the Fleet Map's card rendering, kept out of FleetMapView.tsx so they can be unit
@@ -243,4 +244,40 @@ export function agentBadgeText(s: SessionDto, pivot: string): string | null {
   // An unknown agent still renders "?" rather than vanishing: a card with no agent is a fact worth
   // seeing, and a silently absent badge reads as "this card is fine" (issue #1625).
   return agent.length === 0 ? "?" : agent;
+}
+
+/**
+ * The model chip for a card's meta row (issue devthrottle_internal#1340), or null when the card must not
+ * show one.
+ *
+ * The chip's WORDS come from the shared reader (client-core `modelChipOf`), which reads the Gateway's fold
+ * and composes nothing - so this Fleet Map card, the session roster and the desktop rail cannot word one
+ * session three ways. All this function adds is the map's own suppression, the same one the agent badge
+ * has: on the "By model" pivot the lane header already states the model for every card in it, and a
+ * per-card chip would only repeat the lane.
+ */
+export function modelChip(s: SessionDto, pivot: string): ModelChip | null {
+  if (pivot === "model") return null;
+  return modelChipOf(s);
+}
+
+/**
+ * The model identity used by the "By model" pivot: the FULL recorded id, so a lane is named the way the
+ * agent's own records name the model, never the shortened badge form.
+ *
+ * Both absences get their own lane rather than being pooled into one "(no model)" bucket - pooling them
+ * would undo, in the layout, exactly the distinction the fold exists to make. A card whose Gateway stamped
+ * no verdict at all lands in its own third lane, because "we were not told" is not the same as either.
+ */
+export function modelKeyOf(s: SessionDto): { key: string; title: string } {
+  const d = s.modelDisplay;
+  // The two absences and the unstamped case key through a reserved "absent:" prefix so they can never
+  // collide with a real model id. It buys nothing in lane ORDER - lanes sort by session count and then by
+  // title, exactly like every other pivot - and it is not trying to.
+  if (d === null || d === undefined) return { key: "absent:unstamped", title: "Gateway sent no model verdict" };
+  const id = (d.modelId ?? "").trim();
+  if (id.length > 0) return { key: id.toLowerCase(), title: id };
+  // An absent model keeps the fold's own words as the lane title, so the lane states which absence it is.
+  const text = (d.text ?? "").trim();
+  return { key: "absent:" + (d.kind ?? "unknown"), title: text.length === 0 ? "No model" : text };
 }

--- a/apps/cockpit/src/fleet/fleetmap.css
+++ b/apps/cockpit/src/fleet/fleetmap.css
@@ -553,6 +553,38 @@
   font-weight: 600;
 }
 
+/* The model chip (issue devthrottle_internal#1340), riding beside the agent chip it belongs with. Filled
+   and a shade brighter than the agent chip, because the model id is what a reader is scanning for and the
+   agent beside it is the context. NO text-transform: these are recorded ids, and capitalizing
+   "claude-fable-5" would print a name the records do not contain. */
+.fmap-model {
+  flex: 0 0 auto;
+  font-size: 9.5px;
+  letter-spacing: 0.02em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid #3a4668;
+  background: #202a45;
+  color: #c3ccdf;
+  font-weight: 600;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Either absence - "no model yet" or "model not reported". Outlined rather than filled, and lighter, so
+   it reads as a note about the card instead of as a model named "no model yet". The WORDS carry which
+   absence it is; this only sets the weight, and it deliberately does not animate or pulse: one of the two
+   is never going to arrive, and a spinner would promise otherwise. */
+.fmap-model.absent {
+  border-style: dashed;
+  background: transparent;
+  color: var(--text-dim);
+  font-weight: 500;
+  opacity: 0.85;
+}
+
 .fmap-card-tags {
   display: flex;
   flex-wrap: wrap;

--- a/apps/cockpit/src/sessions/SessionDetail.tsx
+++ b/apps/cockpit/src/sessions/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
-import { getQueue, type QueueItem } from "@devthrottle/client-core/api/client";
+import { getQueue, type QueueItem, type SessionDto } from "@devthrottle/client-core/api/client";
+import { modelChipOf } from "@devthrottle/client-core/sessions/model";
 import { TerminalPane } from "../panes/TerminalPane";
 import type { SessionsOutletContext } from "./SessionsView";
 import { SessionActionBar } from "./SessionActionBar";
@@ -112,6 +113,12 @@ export function SessionDetail() {
           >
             Source Control
           </button>
+          {/* Which agent and which MODEL the open session is running (issue devthrottle_internal#1340).
+              The roster says it for every row; this says it for the session actually on screen, so the
+              answer is on the surface you are looking at rather than one click away. Both the words and
+              the tooltip are the Gateway's fold, read through the same shared reader the roster and the
+              Fleet Map use. */}
+          {selected && <SessionModelChip session={selected} />}
           {/* The session menu (issue #1214): Rename, Hold/Resume, Handover info, Close - top right of
               the session header, driving the shared Gateway calls. */}
           {selected && <SessionMenu session={selected} variant="page" onClosed={() => navigate("/sessions")} />}
@@ -179,5 +186,25 @@ export function SessionDetail() {
         </div>
       </aside>
     </div>
+  );
+}
+
+/**
+ * The agent + model chip in the session header (issue devthrottle_internal#1340).
+ *
+ * The agent name comes from the session; every word about the MODEL - including which of the two absences
+ * applies when there is none - is the Gateway's fold, read verbatim through the shared reader. Renders
+ * nothing at all when the Gateway stamped no verdict (an older Gateway), because a placeholder invented
+ * here would be this client ruling in the Gateway's place.
+ */
+function SessionModelChip({ session }: { session: SessionDto }) {
+  const model = modelChipOf(session);
+  if (model === null) return null;
+  const agent = (session.agent ?? "").trim();
+  return (
+    <span className={model.absent ? "session-model absent" : "session-model"} title={model.title}>
+      {agent.length > 0 && <span className="session-model-agent">{agent}</span>}
+      {model.text}
+    </span>
   );
 }

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -20,6 +20,7 @@ import {
   promptDeliveryTitle,
 } from "@devthrottle/client-core/sessions/delivery";
 import { supervisionStats } from "@devthrottle/client-core/sessions/supervision";
+import { modelChipOf } from "@devthrottle/client-core/sessions/model";
 import { machinePortLabel } from "@devthrottle/client-core/fleet/directorEndpoint";
 import { isDataStale } from "@devthrottle/client-core/fleet/directorPresentation";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -323,10 +324,16 @@ function RosterRow({
   // A prompt to this session did not go and nothing has landed since (issue internal#811). The Gateway
   // decides that and writes the words; the card only has to refuse to be quiet about it.
   const undelivered = hasUndeliveredPrompt(session);
-  // The tag row (not-delivered / changes / voice / hold-time / snooze-ended / winding-down / last-seen /
-  // waiting) renders only when it has something to say, so a plain working session stays a compact two
-  // lines (name + state).
+  // Which model this session is actually running (issue devthrottle_internal#1340). The Gateway folds the
+  // words - including which of the two absences applies - and this card renders them; it is read through
+  // the same shared reader the Fleet Map card uses, so the two cannot word one session two ways.
+  const model = modelChipOf(session);
+  // The tag row (model / not-delivered / changes / voice / hold-time / snooze-ended / winding-down /
+  // last-seen / waiting) renders only when it has something to say. It used to say that a plain working
+  // session stays a compact two lines; the model changes that on purpose - it is the fact the fleet's cost
+  // and quality turn on, and it was previously visible nowhere while a session was alive.
   const hasTags =
+    model !== null ||
     undelivered ||
     changes !== null ||
     holdCountdown !== null ||
@@ -376,6 +383,13 @@ function RosterRow({
               {changes !== null && (
                 <span className="roster-tag changes" title={changesTitle(session) ?? undefined}>
                   {changes}
+                </span>
+              )}
+              {/* Which model this session is running. Muted when the Gateway's verdict is one of the two
+                  absences, so an absence never carries the weight of a fact - the words say which. */}
+              {model !== null && (
+                <span className={model.absent ? "roster-tag model absent" : "roster-tag model"} title={model.title}>
+                  {model.text}
                 </span>
               )}
               {session.voiceMode && <span className="roster-tag voice">voice</span>}

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -938,6 +938,31 @@ body {
   color: #f5d060;
 }
 
+/* Which model this session is running (issue devthrottle_internal#1340). NOT uppercased and not
+   letter-spaced: these are recorded model ids, and shouting "CLAUDE-FABLE-5" prints a name the agent's
+   records do not contain. The full id is in the tooltip when the chip is shortened. */
+.roster-tag.model {
+  text-transform: none;
+  letter-spacing: 0;
+  background: #202a45;
+  border-color: #3a4668;
+  color: #c3ccdf;
+  max-width: 20ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Either absence - "no model yet" or "model not reported". Outlined instead of filled, so it reads as a
+   note rather than as a model with that name. The WORDS say which absence it is; nothing here pulses or
+   animates, because one of the two is never going to arrive. */
+.roster-tag.model.absent {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--border);
+  color: var(--text-dim);
+}
+
 /* A prompt to this session was NOT delivered - the user's words never reached the agent (issue
    internal#811). Alarm red, because this is the one chip that reports a LOSS rather than a state. The dot
    is deliberately untouched: the agent is doing exactly what it was doing, having heard nothing, and
@@ -1483,6 +1508,43 @@ body {
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   flex: 0 0 auto;
+}
+
+/* Agent + model for the OPEN session (issue devthrottle_internal#1340), sitting at the right of the tab
+   strip. `margin-left: auto` pushes it away from the tabs; the session menu that follows it keeps its own
+   place at the far right. Aligned to the tab text rather than the strip, so it reads as part of the header
+   and not as a fifth tab. */
+.session-model {
+  margin-left: auto;
+  align-self: center;
+  margin-bottom: 6px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11px;
+  padding: 2px 9px;
+  border-radius: 10px;
+  border: 1px solid #3a4668;
+  background: #202a45;
+  color: #c3ccdf;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* The agent half - context for the model beside it, so it is held back rather than competing with it. */
+.session-model-agent {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+/* Either absence - "no model yet" or "model not reported". Outlined, never filled, and never animated:
+   one of the two absences is never going to resolve, and a spinner would say otherwise. */
+.session-model.absent {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--border);
+  color: var(--text-dim);
+  font-weight: 500;
 }
 
 .session-tab {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -694,7 +694,7 @@ Output columns: number, short id, name, machine, repository, model, status. Your
 The MODEL column is the model that session's agent is actually running, read from the agent's own
 records at every turn-end - so it follows a mid-session model switch. Where there is no model, the
 column says which kind of absence it is rather than leaving the cell blank: `no model yet` for a
-session that has not completed a turn (it is coming), `model not reported` for an agent that cannot
+session with nothing recorded yet (it is read at each turn-end), `model not reported` for an agent that cannot
 report one at all (Gemini, Cursor - it is never coming), and `(unknown)` when the Gateway sent no
 verdict for that row.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -688,7 +688,15 @@ OPTIONS:
   --json  -j  Output raw JSON
 ```
 
-Output columns: short id, name, machine, repository, status. Your own session is marked `(you)`.
+Output columns: number, short id, name, machine, repository, model, status. Your own session is marked
+`(you)`.
+
+The MODEL column is the model that session's agent is actually running, read from the agent's own
+records at every turn-end - so it follows a mid-session model switch. Where there is no model, the
+column says which kind of absence it is rather than leaving the cell blank: `no model yet` for a
+session that has not completed a turn (it is coming), `model not reported` for an agent that cannot
+report one at all (Gemini, Cursor - it is never coming), and `(unknown)` when the Gateway sent no
+verdict for that row.
 
 ### Session Whoami
 

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -21,7 +21,34 @@ export type SessionDto = components["schemas"]["SessionDto"] & {
    *  an older Gateway does not stamp it and a Director-local response leaves it null - see
    *  machineCanBeActedOn, which treats only an explicit false as unreachable. */
   machineReachable?: boolean | null;
+  /** The model this session's agent is running right now, exactly as the agent's own records spell it
+   *  (`claude-fable-5`, `gpt-5.6-sol`). Re-read at every turn-end by the owning Director, so a mid-session
+   *  model switch is reflected. Null when no turn has finished yet or when the agent cannot report a model
+   *  at all - which of those two it is comes from `modelDisplay`, never from guessing here. */
+  currentModel?: string | null;
+  /** The Gateway's folded model verdict (see the C# ModelDisplay): the badge text, the full id, and WHICH
+   *  of the two absences applies when there is no model. Rendered verbatim - a client never works out for
+   *  itself whether a missing model means "not yet" or "never". Null from an older Gateway and in
+   *  Director-local responses. */
+  modelDisplay?: ModelDisplay | null;
 };
+
+/** The Gateway-computed model display verdict (see the C# ModelDisplay), rendered verbatim by the Fleet
+ *  Map, the roster and the session view. Hand-written here for the same reason as `machineReachable`
+ *  above: the committed `schema.ts` predates the field. Delete it when the schema is next regenerated
+ *  properly - the two declarations agree, so it is harmless until then. */
+export interface ModelDisplay {
+  /** `reported` | `notRecordedYet` | `notReported`. A style key, never a decision to re-make. */
+  kind?: string;
+  /** The badge text, verbatim: the shortened model id, or the words for whichever absence this is. */
+  text?: string;
+  /** The full recorded id, for lane headers and tables; null in both absent states. */
+  modelId?: string | null;
+  /** The tooltip, verbatim: the full id, or the sentence saying which absence this is. */
+  tooltip?: string;
+  /** True in both absent states, so a card can mute the chip without branching on `kind`. */
+  isAbsent?: boolean;
+}
 
 // WHY THIS FIELD IS DECLARED HERE AND NOT IN THE GENERATED SCHEMA. `schema.ts` is produced by
 // openapi-typescript from a live Gateway's OpenAPI document, and regenerating it today does not produce a

--- a/packages/client-core/src/sessions/model.test.ts
+++ b/packages/client-core/src/sessions/model.test.ts
@@ -24,7 +24,7 @@ describe("modelChipOf", () => {
       modelDisplay: {
         kind: "notRecordedYet",
         text: "no model yet",
-        tooltip: "No model recorded yet - this session has not completed a turn.",
+        tooltip: "No model recorded yet. It is read from the agent's own records at each turn-end.",
         isAbsent: true,
       },
     });

--- a/packages/client-core/src/sessions/model.test.ts
+++ b/packages/client-core/src/sessions/model.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "../api/client";
+import { modelChipOf } from "./model";
+
+// Issue devthrottle_internal#1340. This reader exists so the Fleet Map card, the session roster and the
+// session header cannot word one session three ways - so what is pinned here is that it composes NOTHING.
+// Every string it returns must be the Gateway's, and the one decision it makes is whether there is a
+// verdict at all.
+
+function session(overrides: Partial<SessionDto> = {}): SessionDto {
+  return { sessionId: "s1", agent: "ClaudeCode", ...overrides } as SessionDto;
+}
+
+describe("modelChipOf", () => {
+  it("returns the Gateway's words verbatim", () => {
+    const s = session({
+      modelDisplay: { kind: "reported", text: "fable-5", modelId: "claude-fable-5", tooltip: "claude-fable-5" },
+    });
+    expect(modelChipOf(s)).toEqual({ text: "fable-5", title: "claude-fable-5", absent: false });
+  });
+
+  it("marks both absences absent while keeping their different words", () => {
+    const notYet = session({
+      modelDisplay: {
+        kind: "notRecordedYet",
+        text: "no model yet",
+        tooltip: "No model recorded yet - this session has not completed a turn.",
+        isAbsent: true,
+      },
+    });
+    const never = session({
+      modelDisplay: {
+        kind: "notReported",
+        text: "model not reported",
+        tooltip: "This agent does not report the model it is running.",
+        isAbsent: true,
+      },
+    });
+    expect(modelChipOf(notYet)?.absent).toBe(true);
+    expect(modelChipOf(never)?.absent).toBe(true);
+    expect(modelChipOf(notYet)?.text).not.toBe(modelChipOf(never)?.text);
+    expect(modelChipOf(notYet)?.title).not.toBe(modelChipOf(never)?.title);
+  });
+
+  it("renders nothing when the Gateway stamped no verdict", () => {
+    // A missing VERDICT is not a missing model. An older Gateway said nothing, and inventing a placeholder
+    // here would be this client ruling in the Gateway's place.
+    expect(modelChipOf(session())).toBeNull();
+    expect(modelChipOf(session({ modelDisplay: null }))).toBeNull();
+  });
+
+  it("renders nothing for a verdict with no words in it", () => {
+    expect(modelChipOf(session({ modelDisplay: { kind: "reported", text: "" } }))).toBeNull();
+    expect(modelChipOf(session({ modelDisplay: { kind: "reported", text: "   " } }))).toBeNull();
+  });
+
+  it("treats a missing isAbsent as a fact, not an absence", () => {
+    // Only an explicit true mutes the chip; an older shape that omits the flag renders as a normal model.
+    expect(modelChipOf(session({ modelDisplay: { kind: "reported", text: "opus-5" } }))?.absent).toBe(false);
+  });
+});

--- a/packages/client-core/src/sessions/model.ts
+++ b/packages/client-core/src/sessions/model.ts
@@ -1,0 +1,41 @@
+import type { SessionDto } from "../api/client";
+
+/**
+ * Reading the Gateway's folded "which model is this session running" verdict (issue
+ * devthrottle_internal#1340) for the surfaces that show it: the Cockpit's Fleet Map cards, its session
+ * roster, and its session view.
+ *
+ * There is deliberately NO wording in this file. Every string a user sees - the badge text, the tooltip,
+ * and above all WHICH of the two absences applies - is computed once on the Gateway (the C#
+ * ModelDisplayFold) and rides on `session.modelDisplay`. This module answers one question only: is there a
+ * verdict to render? That split is the whole point. The absences mean opposite things - "this session has
+ * not finished a turn yet, the model is coming" against "this agent can never report a model" - and a
+ * client that writes its own words for them will eventually write the hopeful one for the hopeless case,
+ * which is the defect the Voice screen already taught us (a "Generate narration now" button that could
+ * never work).
+ */
+
+/** What a surface renders for a session's model: the Gateway's words, its tooltip, and whether to mute. */
+export interface ModelChip {
+  /** The badge text, verbatim from the Gateway. Never assembled here. */
+  text: string;
+  /** The tooltip, verbatim: the full recorded id, or the sentence naming the absence. */
+  title: string;
+  /** True in both absent states, so a surface can outline the chip instead of filling it. STYLING only. */
+  absent: boolean;
+}
+
+/**
+ * The chip for one session, or null when there is nothing to render.
+ *
+ * Null means the GATEWAY STAMPED NOTHING - an older Gateway, or a Director-local response - not "no
+ * model". A missing model is a stamped verdict with words of its own; only a missing VERDICT is silent
+ * here, because inventing a placeholder for it would be this client ruling in the Gateway's place.
+ */
+export function modelChipOf(session: SessionDto): ModelChip | null {
+  const d = session.modelDisplay;
+  if (d === null || d === undefined) return null;
+  const text = (d.text ?? "").trim();
+  if (text.length === 0) return null;
+  return { text, title: (d.tooltip ?? "").trim(), absent: d.isAbsent === true };
+}

--- a/src/CcDirector.Avalonia.Tests/SessionRailModelBadgeTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SessionRailModelBadgeTests.cs
@@ -34,7 +34,7 @@ public sealed class SessionRailModelBadgeTests
 
         Assert.Equal("no model yet", vm.ModelLabel);
         Assert.True(vm.IsModelAbsent);
-        Assert.Contains("has not completed a turn", vm.AgentModelTooltip);
+        Assert.Contains("No model recorded yet", vm.AgentModelTooltip);
     }
 
     [Fact]

--- a/src/CcDirector.Avalonia.Tests/SessionRailModelBadgeTests.cs
+++ b/src/CcDirector.Avalonia.Tests/SessionRailModelBadgeTests.cs
@@ -1,0 +1,120 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The rail's agent badge now carries the MODEL as well (issue devthrottle_internal#1340) - the owner's
+/// chosen shape: one pill reading "Claude Code | fable-5", because the tool and the model it is running are
+/// one identity and the rail has no room for two badges.
+///
+/// What these pin is that the rail RENDERS and does not rule. Every word comes from the shared
+/// <c>ModelDisplayFold</c>, the same function the Gateway stamps for the browser clients, so the desktop
+/// and the Cockpit cannot word one session two ways - and the two absences stay apart on this surface too.
+/// </summary>
+public sealed class SessionRailModelBadgeTests
+{
+    private static Session Bare()
+    {
+        var session = new Session(
+            Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null,
+            new InertBackend(), SessionBackendType.ConPty);
+        session.IsBrandNew = false;
+        return session;
+    }
+
+    [Fact]
+    public void BeforeTheFirstTurn_TheBadgeSaysTheModelHasNotArrived_NotThatThereIsNone()
+    {
+        // A Claude session can report its model, so a blank badge here would be a fact the rail failed to
+        // fetch. The words say it is coming.
+        var vm = new SessionViewModel(Bare());
+
+        Assert.Equal("no model yet", vm.ModelLabel);
+        Assert.True(vm.IsModelAbsent);
+        Assert.Contains("has not completed a turn", vm.AgentModelTooltip);
+    }
+
+    [Fact]
+    public void ARecordedModel_ShowsShortenedOnTheBadgeAndInFullInTheTooltip()
+    {
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+
+        session.SetCurrentModel("claude-fable-5");
+
+        // The badge already says "Claude Code", so the model half does not repeat the vendor.
+        Assert.Equal("fable-5", vm.ModelLabel);
+        Assert.False(vm.IsModelAbsent);
+        // The tooltip carries the agent AND the id exactly as the records spell it - the shortening on the
+        // badge must never be the only spelling a reader can get to.
+        Assert.Contains("Claude Code", vm.AgentModelTooltip);
+        Assert.Contains("claude-fable-5", vm.AgentModelTooltip);
+    }
+
+    [Fact]
+    public void AMidSessionModelSwitch_ReachesTheRail()
+    {
+        // The failure this guards is not a wrong string, it is a stale one: the model is re-read at
+        // turn-end, and a /model switch inside a working session raises none of the events the rail already
+        // listens to. Without its own signal the badge keeps its old value until something unrelated
+        // repaints the row - which reads as deliberate, and so is believed.
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+        session.SetCurrentModel("claude-opus-5");
+        Assert.Equal("opus-5", vm.ModelLabel);
+
+        var raised = 0;
+        session.OnCurrentModelChanged += () => raised++;
+
+        session.SetCurrentModel("claude-fable-5");
+
+        Assert.Equal(1, raised);
+        Assert.Equal("fable-5", vm.ModelLabel);
+    }
+
+    [Fact]
+    public void AFailedRead_LeavesTheLastKnownModelStanding_AndSaysNothingNew()
+    {
+        // A read that could not be taken (torn records, agent restarting) is a missed read, not evidence
+        // the session lost its model. Session.SetCurrentModel already ignores a null; this pins that the
+        // rail therefore keeps the last known answer rather than falling back to "no model yet".
+        var session = Bare();
+        var vm = new SessionViewModel(session);
+        session.SetCurrentModel("claude-opus-5");
+
+        var raised = 0;
+        session.OnCurrentModelChanged += () => raised++;
+        session.SetCurrentModel(null);
+        session.SetCurrentModel("   ");
+
+        Assert.Equal(0, raised);
+        Assert.Equal("opus-5", vm.ModelLabel);
+    }
+
+    /// <summary>An inert backend: the Session needs one, these tests never run a process. A local copy
+    /// because the neighbouring rail tests keep theirs private to that class.</summary>
+    private sealed class InertBackend : ISessionBackend
+    {
+        public int ProcessId => 1234;
+        public string Status => "Inert";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067 // Required by the interface; nothing raises them here.
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -645,17 +645,44 @@
                                                        FontSize="9"
                                                        FontWeight="SemiBold" />
                                         </Border>
-                                        <!-- Agent badge: shows which CLI this session is running -->
+                                        <!-- Agent badge: which CLI this session is running AND which model
+                                             it is running (issue internal#1340) - one badge, because they
+                                             are one identity and the rail has no room for two. The model
+                                             half is the recorded id shortened (the badge already says
+                                             "Claude Code", so a leading "claude-" is dropped); the full id
+                                             is in the tooltip. When there is no model the words say WHICH
+                                             absence it is - "no model yet" for a session that has not
+                                             finished a turn, "model not reported" for an agent that can
+                                             never report one - and never a blank, which would read as a
+                                             fact this rail failed to fetch. Every string here comes from
+                                             ModelDisplayFold, the same fold the Gateway stamps for the
+                                             browser clients; the rail composes none of them. -->
                                         <Border Background="{Binding AgentBadgeBrush}"
                                                 CornerRadius="6"
                                                 Padding="6,1"
                                                 VerticalAlignment="Center"
                                                 Margin="0,0,6,0"
-                                                ToolTip.Tip="Agent running in this session">
-                                            <TextBlock Text="{Binding AgentLabel}"
-                                                       Foreground="White"
-                                                       FontSize="9"
-                                                       FontWeight="SemiBold" />
+                                                ToolTip.Tip="{Binding AgentModelTooltip}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding AgentLabel}"
+                                                           Foreground="White"
+                                                           FontSize="9"
+                                                           FontWeight="SemiBold" />
+                                                <!-- The divider is part of the badge, not a colour of its
+                                                     own: same white, held back so the eye reads two halves
+                                                     of one pill rather than two badges jammed together. -->
+                                                <TextBlock Text="|"
+                                                           Foreground="White"
+                                                           Opacity="0.5"
+                                                           FontSize="9"
+                                                           FontWeight="SemiBold"
+                                                           Margin="4,0" />
+                                                <TextBlock Text="{Binding ModelLabel}"
+                                                           Foreground="White"
+                                                           Opacity="{Binding ModelOpacity}"
+                                                           FontSize="9"
+                                                           FontWeight="Normal" />
+                                            </StackPanel>
                                         </Border>
                                     </StackPanel>
                                     <!-- LINE 3: live state. The changes badge is anchored
@@ -811,6 +838,24 @@
                                Foreground="White"
                                FontSize="16" FontWeight="Bold"
                                VerticalAlignment="Center" />
+                    <!-- Agent + model badge for the SELECTED session (issue internal#1340). The rail says
+                         it for every row; this says it for the one on screen, so the answer to "what is
+                         this session running" is on the screen you are actually looking at. Same fold, same
+                         words, same tooltip as the rail - set in code-behind beside the name, because this
+                         banner is code-driven rather than bound. -->
+                    <Border x:Name="HeaderAgentModelBadge"
+                            Background="#1E40AF"
+                            CornerRadius="4"
+                            Padding="8,3"
+                            Margin="8,0,0,0"
+                            VerticalAlignment="Center"
+                            IsVisible="False">
+                        <TextBlock x:Name="HeaderAgentModelText"
+                                   Text=""
+                                   Foreground="White"
+                                   FontSize="11"
+                                   FontWeight="SemiBold" />
+                    </Border>
                     <!-- Message count badge -->
                     <Border x:Name="HeaderMessageCountBadge"
                             Background="#1E40AF"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3094,6 +3094,14 @@ public partial class MainWindow : Window
             : _activeSession.DisplayName;
         HeaderActivityLabel.Text = _activeSession.ActivityLabel;
 
+        // Issue internal#1340: which agent and which MODEL the selected session is running, in the same
+        // words as the rail badge because both read the one fold. The badge is always shown for a session -
+        // the fold's absent states are sentences ("no model yet" / "model not reported"), not blanks, so
+        // there is no case where hiding it is the honest answer.
+        HeaderAgentModelText.Text = $"{_activeSession.AgentLabel} | {_activeSession.ModelLabel}";
+        ToolTip.SetTip(HeaderAgentModelBadge, _activeSession.AgentModelTooltip);
+        HeaderAgentModelBadge.IsVisible = true;
+
         // GitHub Actions remote sessions get a links row (repo slug + thread + Actions).
         if (session.IsRemote)
         {

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -89,6 +89,11 @@ public class SessionViewModel : INotifyPropertyChanged
         // handler, like the deletion badge, because it is a raw local FACT and not one of the Gateway-fold
         // inputs RaiseFoldProjection re-reads.
         session.OnPromptDeliveryChanged += OnPromptDeliveryChangedVm;
+        // The model this session is running (issue internal#1340). Its own handler for the same reason as
+        // the two above: it is a raw local FACT re-read at turn-end, not one of the Gateway-fold inputs
+        // RaiseFoldProjection re-reads, and a /model switch inside a working session raises none of the
+        // events the rail already hears.
+        session.OnCurrentModelChanged += OnCurrentModelChangedVm;
 
         if (session.PromptQueue != null)
         {
@@ -663,6 +668,52 @@ public class SessionViewModel : INotifyPropertyChanged
 
     public ISolidColorBrush AgentBadgeBrush => BadgeBrushFor(Session.AgentKind);
 
+    // ===== The model, folded into the agent badge (issue internal#1340) =====
+    //
+    // The owner picked the combined badge over a second one beside it: "Claude Code | fable-5" reads as one
+    // identity - which tool, running which model - and costs one badge's worth of the row rather than two,
+    // on a rail that already carries a role glyph, a not-delivered alarm and a winding-down marker.
+    //
+    // The rail RENDERS this; it does not decide it. Both halves come from ModelDisplayFold, the same
+    // function the Gateway stamps onto SessionDto.ModelDisplay for the browser clients, so the desktop and
+    // the Cockpit cannot word the same session two ways. It is folded here from the LOCAL DTO rather than
+    // read from a Gateway stamp because its two inputs are facts this Director owns firsthand (its records
+    // watcher writes the model; its driver declares the capability), so the answer is identical and it
+    // still reads correctly with no Gateway attached - unlike the session COLOUR, which reads Gateway-only
+    // inputs and is deliberately never folded here.
+
+    /// <summary>The model half of the agent badge: the recorded model shortened for the rail
+    /// (<c>fable-5</c>), or the honest words for whichever absence this is.</summary>
+    public string ModelLabel => ModelDisplayFold.For(FoldInput).Text;
+
+    /// <summary>True when there is no recorded model, so the badge can mute the model half rather than
+    /// give an absence the same weight as a fact. STYLING only - the words already say which absence
+    /// it is.</summary>
+    public bool IsModelAbsent => ModelDisplayFold.For(FoldInput).IsAbsent;
+
+    /// <summary>The model half's opacity: full weight for a recorded model, dimmed for either absence, so
+    /// a row with no model reads as quieter without the words changing. Bound directly rather than through
+    /// a bool-to-opacity converter, which is a whole class to say one number.</summary>
+    public double ModelOpacity => IsModelAbsent ? 0.72 : 1.0;
+
+    /// <summary>The badge tooltip: the agent, then the FULL recorded model id (the badge itself shows a
+    /// shortened form), or the sentence explaining the absence. One badge, one tooltip.</summary>
+    public string AgentModelTooltip => $"{AgentLabel} - {ModelDisplayFold.For(FoldInput).Tooltip}";
+
+    /// <summary>The agent's records named a different model - a mid-session <c>/model</c> switch, or the
+    /// first turn finishing and recording one at last. Repaint the badge on the UI thread: the records
+    /// watcher raises this from a background read.</summary>
+    private void OnCurrentModelChangedVm()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            OnPropertyChanged(nameof(ModelLabel));
+            OnPropertyChanged(nameof(IsModelAbsent));
+            OnPropertyChanged(nameof(ModelOpacity));
+            OnPropertyChanged(nameof(AgentModelTooltip));
+        });
+    }
+
     /// <summary>Pure agent-kind -> rail label mapping. Every provider has its own arm; the
     /// default is Claude Code (kind 0). Static so it can be unit-tested without a live
     /// <see cref="Session"/> (issue #517 regression: Cursor must not fall through to "Claude Code").</summary>
@@ -939,6 +990,11 @@ public class SessionViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(CustomColorBrush));
         OnPropertyChanged(nameof(AgentLabel));
         OnPropertyChanged(nameof(AgentBadgeBrush));
+        // The model rides ON the agent badge, so anything that repaints the badge repaints both halves.
+        OnPropertyChanged(nameof(ModelLabel));
+        OnPropertyChanged(nameof(IsModelAbsent));
+            OnPropertyChanged(nameof(ModelOpacity));
+        OnPropertyChanged(nameof(AgentModelTooltip));
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -955,6 +955,18 @@ public sealed class Session : IDisposable
     public string? CurrentModel { get; private set; }
 
     /// <summary>
+    /// Raised when <see cref="CurrentModel"/> changes, so the desktop rail repaints the model badge on a
+    /// mid-session model switch (issue internal#1340). Without it the badge would be right only by luck:
+    /// the model is re-read at turn-end, and the rail is told to re-read on activity/hold/role/number
+    /// changes - none of which a <c>/model</c> switch inside a working session has to raise. That is the
+    /// same shape as the role-stamp defect: a displayed fact with no invalidation path shows its old value
+    /// until something unrelated happens to repaint the row, which reads as deliberate and is worse than
+    /// blank. Same contract as <see cref="OnNumberChanged"/>: report what changed, decide nothing about
+    /// how it looks.
+    /// </summary>
+    public event Action? OnCurrentModelChanged;
+
+    /// <summary>
     /// Record the driver-reported current model (issue #1637). Idempotent per value: only logs on a
     /// change. A null/blank argument is IGNORED rather than clearing: a read that cannot determine
     /// the model (torn file, agent restarting) is a missed read, not evidence the session lost its
@@ -967,6 +979,8 @@ public sealed class Session : IDisposable
             return;
         CurrentModel = normalized;
         FileLog.Write($"[Session] SetCurrentModel: session={Id} model={normalized}");
+        try { OnCurrentModelChanged?.Invoke(); }
+        catch (Exception ex) { FileLog.Write($"[Session] {Id} OnCurrentModelChanged handler threw: {ex.Message}"); }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Contracts/ModelDisplay.cs
+++ b/src/CcDirector.Gateway.Contracts/ModelDisplay.cs
@@ -114,8 +114,15 @@ public static class ModelDisplayFold
                 Kind = "notRecordedYet",
                 Text = NotRecordedYetText,
                 ModelId = null,
-                Tooltip = "No model recorded yet - this session has not completed a turn. "
-                          + "It is read from the agent's own records at every turn-end.",
+                // States the FACT (nothing recorded) and the MECHANISM (records, at turn-end), and stops
+                // there. It used to add "this session has not completed a turn", which was a cause nobody
+                // observed: a null model also means a read that could not be taken - torn records, the
+                // agent restarting, a session restored from a store the driver cannot read yet - and
+                // SessionRecordsWatcher keeps the last known value rather than clearing on those, so the
+                // null is exactly as consistent with a failed read as with a first turn. Naming the wrong
+                // one reads as diagnosis and sends a reader looking in the wrong place.
+                Tooltip = "No model recorded yet. It is read from the agent's own records at each "
+                          + "turn-end, and nothing has been recorded for this session so far.",
                 IsAbsent = true,
             }
             : new ModelDisplay

--- a/src/CcDirector.Gateway.Contracts/ModelDisplay.cs
+++ b/src/CcDirector.Gateway.Contracts/ModelDisplay.cs
@@ -1,0 +1,150 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The FOLDED "which model is this session running" verdict for one session - the finished strings every
+/// surface renders VERBATIM (issue devthrottle_internal#1340).
+///
+/// The fact itself (<see cref="SessionDto.CurrentModel"/>) has been on the wire since issue #815 and was
+/// shown to a human in exactly one place: the Cockpit's History page, for sessions that had already ended.
+/// Putting it on the LIVE surfaces meant four of them - the desktop rail, the Fleet Map card, the Cockpit
+/// roster, and the command line table - and the interesting part is not the model, it is the two ABSENCES,
+/// which mean opposite things and must never read the same:
+///
+///   - the session CAN report its model and simply has not finished a turn yet (it is coming), versus
+///   - the agent cannot report its model at all - Gemini records it nowhere readable, Cursor was never
+///     live-verified - so it is NEVER coming.
+///
+/// Four surfaces each deciding that for themselves is four chances to render a hopeful "loading" for a
+/// value that will never arrive, which is the same defect shape as the Voice screen's impossible
+/// "Generate narration now" button (see <see cref="VoiceDisplay"/>): a client that has to guess renders
+/// something PLAUSIBLE instead of something TRUE. So the rule is folded once, here, and the clients render
+/// the strings.
+///
+/// This lives in the contracts assembly rather than in the Gateway because both callers need it and they
+/// are not the same kind of caller: the Gateway stamps it during the /sessions aggregation for the browser
+/// clients, and the desktop rail folds its OWN locally-mapped <see cref="SessionDto"/> through the same
+/// function. That is not the desktop ruling for itself - the two inputs, <see cref="SessionDto.CurrentModel"/>
+/// and <see cref="SessionDto.DriverCapabilities"/>, are facts the DIRECTOR produces and owns firsthand (the
+/// records watcher writes one, the driver declares the other), so the local answer is the same answer, one
+/// rule, and it still reads correctly with no Gateway attached. Compare the session COLOUR, which the
+/// desktop must never fold locally because that fold reads inputs only the Gateway has.
+/// </summary>
+public sealed class ModelDisplay
+{
+    /// <summary>Machine-readable state key, for the client's style lookup only (never re-ruling):
+    /// <c>reported</c> (the records name a model), <c>notRecordedYet</c> (this session can report one but
+    /// has completed no turn), or <c>notReported</c> (this agent cannot report one at all).</summary>
+    public string Kind { get; set; } = "";
+
+    /// <summary>The badge text, rendered verbatim and never assembled on the client. The recorded id
+    /// shortened for width when a model is known (e.g. <c>fable-5</c>), else the honest words for the
+    /// absence (<c>no model yet</c> / <c>model not reported</c>).</summary>
+    public string Text { get; set; } = "";
+
+    /// <summary>The FULL recorded model id, exactly as the agent's own records spell it
+    /// (e.g. <c>claude-fable-5</c>, <c>gpt-5.6-sol</c>), or null in both absent states. This is what the
+    /// "By model" lane headers and the command line table print - only the badge is shortened.</summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>The tooltip, rendered verbatim: the full id when one is known, else the sentence that says
+    /// WHICH absence this is. Never null - a badge with no explanation is what sent a reader looking for a
+    /// setting that does not exist.</summary>
+    public string Tooltip { get; set; } = "";
+
+    /// <summary>True in both absent states, so a client can style the badge as muted/outlined without
+    /// branching on <see cref="Kind"/>. A convenience for STYLING, never a decision.</summary>
+    public bool IsAbsent { get; set; }
+}
+
+/// <summary>
+/// The ONE fold that turns a session's recorded model plus its driver capabilities into the
+/// <see cref="ModelDisplay"/> every surface renders. Pure and static so it is unit-tested without a
+/// Gateway, a Director, or an Avalonia app.
+/// </summary>
+public static class ModelDisplayFold
+{
+    /// <summary>The capability a driver declares when it can read the model out of the tool's own records
+    /// (<c>IAgentDriver.ReadCurrentModel</c>). Its ABSENCE is the whole difference between "not yet" and
+    /// "never" - the two states this fold exists to keep apart.</summary>
+    public const string ModelReportCapability = "ModelReport";
+
+    /// <summary>Badge text longer than this is truncated. The full id is always in the tooltip, so a
+    /// truncation loses nothing a reader cannot get back by hovering; a badge wide enough for any id
+    /// would squeeze the session name on every row that has a short one.</summary>
+    private const int MaxBadgeLength = 22;
+
+    /// <summary>Words for a session that can report its model and has not finished a turn yet.</summary>
+    private const string NotRecordedYetText = "no model yet";
+
+    /// <summary>Words for an agent that cannot report its model at all.</summary>
+    private const string NotReportedText = "model not reported";
+
+    /// <summary>Fold a session's DTO. Never returns null - every session has a model display, because
+    /// "nothing here" is one of the three answers and a blank badge is not one of them.</summary>
+    public static ModelDisplay For(SessionDto session)
+        => For(session.CurrentModel, session.DriverCapabilities);
+
+    /// <summary>The fold itself, over its two raw inputs, so a test states the case rather than building
+    /// a whole session.</summary>
+    public static ModelDisplay For(string? currentModel, IEnumerable<string>? driverCapabilities)
+    {
+        var model = (currentModel ?? "").Trim();
+        if (model.Length > 0)
+        {
+            return new ModelDisplay
+            {
+                Kind = "reported",
+                Text = ShortenForBadge(model),
+                ModelId = model,
+                Tooltip = model,
+                IsAbsent = false,
+            };
+        }
+
+        // The capability list is what tells the two absences apart, and it is already on the wire - no new
+        // field was needed to carry the difference, only the discipline to READ it. A Director that
+        // predates the driver layer reports no capabilities at all; that reads as "cannot report", which is
+        // the truthful answer for it, since nothing on it will ever produce a model.
+        var canReport = driverCapabilities is not null
+            && driverCapabilities.Any(c => string.Equals(c, ModelReportCapability, StringComparison.OrdinalIgnoreCase));
+
+        return canReport
+            ? new ModelDisplay
+            {
+                Kind = "notRecordedYet",
+                Text = NotRecordedYetText,
+                ModelId = null,
+                Tooltip = "No model recorded yet - this session has not completed a turn. "
+                          + "It is read from the agent's own records at every turn-end.",
+                IsAbsent = true,
+            }
+            : new ModelDisplay
+            {
+                Kind = "notReported",
+                Text = NotReportedText,
+                ModelId = null,
+                Tooltip = "This agent does not report the model it is running, so there is nothing to show. "
+                          + "Nothing is loading and nothing is wrong with this session.",
+                IsAbsent = true,
+            };
+    }
+
+    /// <summary>
+    /// The recorded id shortened to fit a badge that sits beside the agent's name.
+    ///
+    /// One rule and one exception: drop a leading <c>claude-</c>, because the badge it rides on already
+    /// says "Claude Code" and a badge reading "Claude Code | claude-fable-5" spends half its width saying
+    /// the word twice. Every other id is used exactly as the records spell it - <c>gpt-5.6-sol</c> stays
+    /// <c>gpt-5.6-sol</c> - because a prettier short form is a name the records would not recognise, and
+    /// this value's whole worth is that it is what the tool actually wrote down.
+    /// </summary>
+    public static string ShortenForBadge(string modelId)
+    {
+        var id = (modelId ?? "").Trim();
+        const string claudePrefix = "claude-";
+        if (id.StartsWith(claudePrefix, StringComparison.OrdinalIgnoreCase) && id.Length > claudePrefix.Length)
+            id = id.Substring(claudePrefix.Length);
+
+        return id.Length <= MaxBadgeLength ? id : id.Substring(0, MaxBadgeLength - 3) + "...";
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -799,6 +799,16 @@ public sealed class SessionDto
     public string? CurrentModel { get; set; }
 
     /// <summary>
+    /// The FOLDED display verdict for <see cref="CurrentModel"/> (issue devthrottle_internal#1340): the
+    /// finished badge text, the full id for the tooltip, and WHICH of the two absences this is when there
+    /// is no model - computed once by <see cref="ModelDisplayFold"/> and rendered verbatim. Stamped by the
+    /// Gateway aggregator beside <see cref="EffectiveColor"/> and <see cref="StateLabel"/>; null in
+    /// Director-local responses, where the desktop rail folds the same function over the same two local
+    /// facts (see <see cref="ModelDisplay"/> for why that is one rule and not two).
+    /// </summary>
+    public ModelDisplay? ModelDisplay { get; set; }
+
+    /// <summary>
     /// This session's CUMULATIVE token spend (issue #1637), reported by the owning Director from the
     /// agent driver's own records (<c>ReadUsage</c>) and refreshed at every turn-end - the same moment
     /// and the same records read as <see cref="CurrentModel"/>, so the model that produced a turn and the
@@ -887,9 +897,9 @@ public sealed class SessionDto
     /// <c>/sessions</c> aggregation stamps scalar fields (EffectiveColor, DirectorId, MachineName,
     /// voice/transcription overlays, etc.) on the object it serves, so callers must never receive the
     /// cached instance itself or one request would contaminate the cache for later ones. Reference-type
-    /// members the aggregator could mutate in place are re-created here; <see cref="VoiceUnavailable"/>
-    /// and <see cref="VoiceDisplay"/> are only ever replaced wholesale by the aggregator (never mutated),
-    /// so sharing their references is safe.
+    /// members the aggregator could mutate in place are re-created here; <see cref="VoiceUnavailable"/>,
+    /// <see cref="VoiceDisplay"/> and <see cref="ModelDisplay"/> are only ever replaced wholesale by the
+    /// aggregator (never mutated), so sharing their references is safe.
     /// </summary>
     public SessionDto Clone()
     {

--- a/src/CcDirector.Gateway.UnitTests/ModelDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/ModelDisplayFoldTests.cs
@@ -1,0 +1,127 @@
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The one place "which model is this session running" is ruled (issue devthrottle_internal#1340). Four
+/// surfaces render this fold - the desktop rail, the desktop session header, the Cockpit Fleet Map and
+/// roster, and the command line table - and the point of the fold is that none of them decides anything.
+///
+/// The assertion that matters most is that the TWO ABSENCES stay distinguishable. They mean opposite
+/// things: one says a model is coming, the other says one is never coming. Rendered the same, they send a
+/// reader hunting for a setting that does not exist, or waiting for a value that will never arrive.
+/// </summary>
+public sealed class ModelDisplayFoldTests
+{
+    private static readonly string[] CanReport = ["Cancel", "ModelReport", "TokenUsage"];
+    private static readonly string[] CannotReport = ["Cancel", "Interrupt"];
+
+    [Fact]
+    public void RecordedModel_IsReported_WithFullIdInTheTooltip()
+    {
+        var d = ModelDisplayFold.For("claude-fable-5", CanReport);
+        Assert.Equal("reported", d.Kind);
+        Assert.Equal("fable-5", d.Text);
+        Assert.Equal("claude-fable-5", d.ModelId);
+        // The badge is shortened; the tooltip must still carry the id the records actually spell, or the
+        // shortening becomes a claim about a model name nobody wrote down.
+        Assert.Equal("claude-fable-5", d.Tooltip);
+        Assert.False(d.IsAbsent);
+    }
+
+    [Fact]
+    public void NonClaudeModel_IsUsedExactlyAsRecorded()
+    {
+        // Only the "claude-" prefix is dropped, and only because the badge it rides on already says
+        // "Claude Code". Every other id is the records' own spelling, untouched.
+        var d = ModelDisplayFold.For("gpt-5.6-sol", CanReport);
+        Assert.Equal("gpt-5.6-sol", d.Text);
+        Assert.Equal("gpt-5.6-sol", d.ModelId);
+    }
+
+    [Fact]
+    public void CanReportButNothingRecorded_SaysTheModelHasNotArrivedYet()
+    {
+        var d = ModelDisplayFold.For(null, CanReport);
+        Assert.Equal("notRecordedYet", d.Kind);
+        Assert.Equal("no model yet", d.Text);
+        Assert.Null(d.ModelId);
+        Assert.True(d.IsAbsent);
+        Assert.Contains("has not completed a turn", d.Tooltip);
+    }
+
+    [Fact]
+    public void CannotReport_SaysTheAgentWillNeverReportOne()
+    {
+        var d = ModelDisplayFold.For(null, CannotReport);
+        Assert.Equal("notReported", d.Kind);
+        Assert.Equal("model not reported", d.Text);
+        Assert.Null(d.ModelId);
+        Assert.True(d.IsAbsent);
+        Assert.Contains("does not report", d.Tooltip);
+    }
+
+    [Fact]
+    public void TheTwoAbsencesNeverRenderTheSame()
+    {
+        // The whole issue in one assertion. Both are "no model", and a surface that showed one string for
+        // both would tell a Gemini user to keep waiting for a value that is never coming.
+        var notYet = ModelDisplayFold.For(null, CanReport);
+        var never = ModelDisplayFold.For(null, CannotReport);
+        Assert.NotEqual(notYet.Kind, never.Kind);
+        Assert.NotEqual(notYet.Text, never.Text);
+        Assert.NotEqual(notYet.Tooltip, never.Tooltip);
+    }
+
+    [Fact]
+    public void NoCapabilitiesAtAll_ReadsAsCannotReport()
+    {
+        // A Director that predates the driver layer reports no capabilities. Nothing on it will ever
+        // produce a model, so "cannot report" is the truthful answer - not a hopeful "any moment now".
+        Assert.Equal("notReported", ModelDisplayFold.For(null, null).Kind);
+        Assert.Equal("notReported", ModelDisplayFold.For(null, []).Kind);
+    }
+
+    [Fact]
+    public void BlankModel_IsTreatedAsNoModel_NotAsAModelCalledNothing()
+    {
+        Assert.True(ModelDisplayFold.For("   ", CanReport).IsAbsent);
+        Assert.True(ModelDisplayFold.For("", CanReport).IsAbsent);
+    }
+
+    [Fact]
+    public void CapabilityMatchIsCaseInsensitive()
+    {
+        Assert.Equal("notRecordedYet", ModelDisplayFold.For(null, ["modelreport"]).Kind);
+    }
+
+    [Fact]
+    public void OverlongModelId_IsTruncatedForTheBadgeAndWholeInTheTooltip()
+    {
+        var id = "some-vendor-model-with-a-very-long-name-v3";
+        var d = ModelDisplayFold.For(id, CanReport);
+        Assert.True(d.Text.Length <= 22, $"badge text was {d.Text.Length} characters: {d.Text}");
+        Assert.EndsWith("...", d.Text);
+        Assert.Equal(id, d.ModelId);
+        Assert.Equal(id, d.Tooltip);
+    }
+
+    [Fact]
+    public void ClaudePrefixAloneIsNeverStrippedToNothing()
+    {
+        // Defensive: an id that IS the prefix would otherwise shorten to an empty badge, which is the one
+        // thing this fold promises never to render.
+        Assert.Equal("claude-", ModelDisplayFold.ShortenForBadge("claude-"));
+    }
+
+    [Fact]
+    public void FoldingASessionReadsTheSessionsOwnTwoFields()
+    {
+        var s = new SessionDto { CurrentModel = "claude-opus-5" };
+        s.DriverCapabilities.Add("ModelReport");
+        var d = ModelDisplayFold.For(s);
+        Assert.Equal("opus-5", d.Text);
+        Assert.Equal("claude-opus-5", d.ModelId);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/ModelDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/ModelDisplayFoldTests.cs
@@ -48,7 +48,12 @@ public sealed class ModelDisplayFoldTests
         Assert.Equal("no model yet", d.Text);
         Assert.Null(d.ModelId);
         Assert.True(d.IsAbsent);
-        Assert.Contains("has not completed a turn", d.Tooltip);
+        // The tooltip states the FACT and the MECHANISM. It must NOT name a cause: a null model is as
+        // consistent with a read that could not be taken as with a first turn that has not landed, and
+        // picking one reads as diagnosis (caught in review of pull request 2449).
+        Assert.Contains("No model recorded yet", d.Tooltip);
+        Assert.Contains("turn-end", d.Tooltip);
+        Assert.DoesNotContain("has not completed a turn", d.Tooltip);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -3938,6 +3938,12 @@ internal static class GatewayEndpoints
                               "docs/new_architecture/session-state.html.");
             s.EffectiveColorHex = SessionColorPalette.HexFor(effectiveColor);
             s.StateLabel = SessionOrdering.StateLabel(s);
+            // Which model this session is running, folded to finished words (issue internal#1340). The raw
+            // CurrentModel keeps riding beside it for the statistics dimension; this is the DISPLAY, and it
+            // is folded here so no client has to work out for itself whether a missing model means "the
+            // first turn has not finished yet" or "this agent can never report one" - two absences that mean
+            // opposite things and that four clients would have rendered four ways.
+            s.ModelDisplay = ModelDisplayFold.For(s);
             // The words for a prompt that did not go (issue internal#811), folded here beside the colour and
             // the label so every client renders one sentence it did not compose. Null on a session that has
             // not lost anything, which is almost all of them.

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -85,6 +85,36 @@ def _repo_name(repo: str) -> str:
     return repo.replace("\\", "/").rstrip("/").split("/")[-1] if repo else "-"
 
 
+def _model_text(s: Dict[str, Any]) -> str:
+    """The MODEL column (issue devthrottle_internal#1340): which model this session is actually running.
+
+    It exists because an agent driving the fleet had to parse the JSON to learn the one fact that
+    drives both cost and quality, while a human reading the same table could not learn it at all.
+
+    RENDER, NEVER RULE. The Gateway folds this - the full recorded id when there is one, and the words
+    for WHICH of the two absences applies when there is not ("no model yet" for a session that has not
+    finished a turn, "model not reported" for an agent that can never report one). This prints the id
+    in full rather than the fold's shortened badge text, because a table has the width a rail does not
+    and a truncated id is not a name anything else will match.
+
+    A row with no folded verdict at all is a Gateway too old to have stamped one. Then, and only then,
+    the raw recorded model stands in - and when there is no model either, the cell reads "(unknown)":
+    deliberately NOT one of the fold's two sentences, because this is a third case. We were told
+    nothing, which is not the same as being told there is no model YET or that there never will be.
+    An empty cell would have quietly claimed the second of those.
+    """
+    display = s.get("modelDisplay", s.get("ModelDisplay"))
+    if isinstance(display, dict):
+        model_id = (display.get("modelId") or display.get("ModelId") or "").strip()
+        if model_id:
+            return model_id
+        text = (display.get("text") or display.get("Text") or "").strip()
+        if text:
+            return text
+    raw = (director.field(s, "currentModel", "CurrentModel") or "").strip()
+    return raw if raw else "(unknown)"
+
+
 def _get_fleet() -> Tuple[List[Dict[str, Any]], Optional[bool], Optional[str], Optional[str]]:
     """The fleet roster and BOTH folded cautions, with this tool's error posture (issue #1051).
 
@@ -219,6 +249,12 @@ def list_sessions(json_output: bool) -> None:
     table.add_column("NAME")
     table.add_column("MACHINE")
     table.add_column("REPOSITORY")
+    # Issue devthrottle_internal#1340. ONE new column, not two: an AGENT column beside it was tried and
+    # cost more than it gave. Rich lays this table out at 80 columns when stdout is a pipe (which is how
+    # every agent reads it), and the eighth column pushed STATUS far enough to elide "Exited (crashed)" -
+    # trading a fact nobody could read anywhere for one already implied by the model id and available in
+    # --json. The model is the fact that was invisible; it gets the width.
+    table.add_column("MODEL")
     table.add_column("STATUS")
 
     me = director.session_id()
@@ -241,7 +277,15 @@ def list_sessions(json_output: bool) -> None:
         if s.get("crashed", s.get("Crashed")) is True:
             status = f"{status} (crashed)"
         marker = " (you)" if me and sid.lower() == me.lower() else ""
-        table.add_row(number_text, director.short_id(sid) + marker, name, machine, _repo_name(repo), status)
+        table.add_row(
+            number_text,
+            director.short_id(sid) + marker,
+            name,
+            machine,
+            _repo_name(repo),
+            _model_text(s),
+            status,
+        )
 
     console.print(table)
     # Issue #1051: printed AFTER the table, so the rows the reader can trust come first and the

--- a/tools/cc-devthrottle/tests/test_session_list_model.py
+++ b/tools/cc-devthrottle/tests/test_session_list_model.py
@@ -1,0 +1,132 @@
+"""Tests for the MODEL column of `cc-devthrottle session list` (issue devthrottle_internal#1340).
+
+The column exists because an agent driving this fleet had to parse `--json` to learn which model a session
+was running, and a human reading the same table could not learn it at all - while it is the single fact
+that drives both the cost and the quality of every session on the list.
+
+What these pin is not "a model appears". It is that the table RENDERS the Gateway's fold and never rules:
+the full recorded id when there is one, and two DIFFERENT sentences for the two absences, which mean
+opposite things ("the first turn has not finished" against "this agent can never report one"). Printed the
+same, they would leave a reader waiting for a value that is never coming.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import session_ops  # noqa: E402
+
+SID = "7a1b2c3d-0000-0000-0000-000000000001"
+
+
+@pytest.fixture
+def serve_fleet(monkeypatch):
+    """Serve a chosen fleet roster from the Director, without any real HTTP.
+
+    The console is widened for the duration: with stdout a pipe, Rich lays the table out at 80 columns and
+    elides cells, so a narrow console would make these tests assert on terminal width rather than on what
+    the column contains.
+    """
+
+    def serve(sessions):
+        monkeypatch.delenv("CC_SESSION_ID", raising=False)
+        monkeypatch.setattr(session_ops.director, "get_json", lambda path: sessions)
+        monkeypatch.setattr(session_ops, "console", Console(width=200))
+
+    return serve
+
+
+def _row(**extra):
+    row = {
+        "sessionId": SID,
+        "name": "a session",
+        "machineName": "SOREN",
+        "repoPath": r"D:\ReposFred\devthrottle",
+        "agent": "ClaudeCode",
+        "activityState": "Working",
+    }
+    row.update(extra)
+    return row
+
+
+def _listing(capsys):
+    session_ops.list_sessions(json_output=False)
+    return capsys.readouterr().out
+
+
+def test_recorded_model_prints_the_full_id_not_the_shortened_badge(serve_fleet, capsys):
+    # The rail shortens "claude-fable-5" to "fable-5" because a rail is narrow. A table is not, and a
+    # truncated id is not a name anything else will match - so the column prints what the records spell.
+    serve_fleet([_row(modelDisplay={"kind": "reported", "text": "fable-5", "modelId": "claude-fable-5"})])
+
+    out = _listing(capsys)
+
+    assert "claude-fable-5" in out
+    assert "MODEL" in out
+
+
+def test_not_recorded_yet_says_so_in_the_gateways_words(serve_fleet, capsys):
+    # No model id, but a verdict: this session CAN report one and simply has not finished a turn.
+    serve_fleet([_row(modelDisplay={"kind": "notRecordedYet", "text": "no model yet", "modelId": None})])
+
+    assert "no model yet" in _listing(capsys)
+
+
+def test_the_two_absences_do_not_print_the_same_string(serve_fleet, capsys):
+    # The whole issue in one test.
+    serve_fleet([_row(modelDisplay={"kind": "notReported", "text": "model not reported", "modelId": None})])
+    never = _listing(capsys)
+
+    serve_fleet([_row(modelDisplay={"kind": "notRecordedYet", "text": "no model yet", "modelId": None})])
+    not_yet = _listing(capsys)
+
+    assert "model not reported" in never
+    assert "no model yet" in not_yet
+    assert never != not_yet
+
+
+def test_unfolded_row_falls_back_to_the_raw_recorded_model(serve_fleet, capsys):
+    # A Gateway too old to stamp the fold still puts the raw model on the wire. Printing it is not ruling -
+    # it is the same fact, unfolded.
+    serve_fleet([_row(currentModel="gpt-5.6-sol")])
+
+    assert "gpt-5.6-sol" in _listing(capsys)
+
+
+def test_no_model_and_no_fold_reads_as_unknown_not_as_either_absence(serve_fleet, capsys):
+    # A third case, and it must not borrow the fold's words: an old Gateway told us nothing, which is not
+    # the same as being told there is no model yet, nor that there never will be one. An empty cell would
+    # have quietly claimed one of those.
+    serve_fleet([_row()])
+
+    out = _listing(capsys)
+    assert "(unknown)" in out
+    assert "no model yet" not in out
+
+
+def test_a_crashed_status_still_fits_beside_the_new_column(serve_fleet, capsys):
+    # The cost of a new column is paid by the ones already there. Rich lays this table out at 80 columns
+    # when stdout is a pipe, and a second new column pushed STATUS far enough to elide "(crashed)" - a fact
+    # issue #1019 exists to keep readable. This pins the budget rather than trusting it.
+    serve_fleet(
+        [
+            _row(
+                activityState="Exited",
+                crashed=True,
+                modelDisplay={"kind": "reported", "text": "opus-5", "modelId": "claude-opus-5"},
+            )
+        ]
+    )
+    session_ops.list_sessions(json_output=False)
+    wide = capsys.readouterr().out
+    assert "crashed" in wide
+
+    # And at the real 80-column width an agent actually reads it at.
+    session_ops.console = Console(width=80)
+    session_ops.list_sessions(json_output=False)
+    assert "crashed" in capsys.readouterr().out


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1340.

## What this shows, and where

The model a session is actually running was already on the wire and was visible to a human in exactly one place: the Cockpit's History page, for sessions that had already ended. While a session was alive, nothing on any screen said which model was doing the work.

It now appears in six places:

- **Director session rail** - folded into the agent badge: `Claude Code | fable-5`
- **Director selected-session header** - the same badge beside the session name
- **Cockpit Fleet Map card** - a chip on the meta row, beside the agent chip
- **Cockpit Fleet Map** - a new **By model** pivot, so the fleet lays out by model the way it lays out by agent
- **Cockpit session roster row**, and **the open session's header**
- **`cc-devthrottle session list`** - a MODEL column

## The design decision worth reading

The issue said a client could read `driverCapabilities` and work out the two absences for itself, and that no new field was needed. This does not do that.

The interesting part is not the model, it is the two absences, and they mean opposite things:

- the session **can** report its model and has not finished a turn - it is coming;
- the agent **cannot** report one at all (Gemini records it nowhere readable, Cursor was never live-verified) - it is never coming.

Five surfaces each deciding that for themselves is five chances to render the hopeful wording for the hopeless case, which is the same defect shape as the Voice screen's "Generate narration now" button that could never succeed. So `ModelDisplayFold` rules it once and every surface renders the finished words.

The Gateway stamps the verdict onto `SessionDto.ModelDisplay` beside `EffectiveColor`, for the browser clients. The **desktop** calls the same pure function over its own locally-mapped session. That is not the rail ruling for itself: both inputs - the recorded model and the driver's capability list - are facts the Director produces firsthand, so the answer is identical and the badge still reads correctly with no Gateway attached. Contrast the session colour, which reads Gateway-only inputs and is deliberately never folded on the desktop.

## Two smaller calls

**The rail folds the model INTO the agent badge** rather than adding a second one (owner's choice between three mocked options). They are one identity, and the rail already carries a role glyph, a not-delivered alarm and a winding-down marker.

**`Session.OnCurrentModelChanged` is new.** The model is re-read at turn-end, and a mid-session `/model` switch raises none of the events the rail already listens to. Without its own signal the badge would keep its old value until something unrelated repainted the row - which reads as deliberate, and is therefore believed. Same class as the role-stamp defect.

**The command line gets one new column, not two.** An AGENT column beside it was built and removed: Rich lays that table out at 80 columns when stdout is a pipe, which is how every agent reads it, and the eighth column pushed STATUS far enough to elide `Exited (crashed)` - the fact issue #1019 exists to keep readable. A test now pins that budget.

## Tests

- `ModelDisplayFoldTests` - 11 cases, including that the two absences never share a string, and that a shortened badge always keeps the full id in the tooltip
- `SessionRailModelBadgeTests` - 4 desktop cases: the pre-first-turn wording, the shortened badge with the full id in the tooltip, a mid-session switch reaching the rail, and a failed read leaving the last known model standing
- `fleetMapFormat.test.ts` - +10: when the chip appears, and the model pivot's lane keys (both absences keep separate lanes; an unstamped session gets a third)
- `model.test.ts` - 5 cases on the shared reader, all of them that it composes nothing
- `test_session_list_model.py` - 6 cases, including the 80-column budget

## Gate

- `.\scripts\test-local.ps1`: **green**, 9 projects, 4,014 tests.
- Web: typecheck clean across all three workspaces; client-core 877 and cockpit 267 green. The two new test files were run individually to prove they execute rather than inferring it from a total.
- Python: green.
- `-Parked`: `Core.Tests` green (4,202). `Gateway.Tests` reported **one** failure - `HostedMissionPartitionWiringTests.An_unattributed_mission_is_quarantined_on_hosted_and_stays_on_disk`, a `POST /missions` answering 500. See below.

## About that one Gateway failure

I could not clear it, and I am not claiming it is unrelated on the strength of a hunch.

What is known: this change touches the `/sessions` fold and adds a DTO property, and goes nowhere near mission creation. Of the Gateway.Tests results kept on this machine, nine runs across six unrelated worktrees have failed this suite, each with a different set of tests and no repeats - including two other mission-family failures in worktrees whose changes had nothing to do with missions. That is the known instability of this host-bound suite.

What is NOT known: a re-run of that one class on this branch never executed. It waited 632 seconds for the suite's machine-wide lock, held by another worktree, and was killed before it ran a single test. So the evidence is a pattern, not a verdict on this diff. Anyone re-running that class when the lock is free will settle it in seconds.
