### PR TITLE
v1.9.9 - the portless release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.8</Version>
+    <Version>1.9.9</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.


### PR DESCRIPTION
Version bump to 1.9.9. Release notes for this version are already on main (docs/public/release-notes/v1.9.9.md), written before the tag.

This is the release carrying the removal of the network port from the Director and the launcher.