### PR TITLE
release: v1.9.10 - the Handovers list is ordered by date

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.9</Version>
+    <Version>1.9.10</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.10.md
+++ b/docs/public/release-notes/v1.9.10.md
@@ -1,0 +1,25 @@
+# DevThrottle v1.9.10
+
+A single fix: the Handovers list in the New Session dialog now shows your newest handover first.
+
+## Your most recent handover is at the top of the list, where you expect it
+
+The Handovers tab ordered documents by their filename rather than by their date. Handovers written by the product itself are named for what they are - a session move, a rebuild manifest - while the ones you write are named for the day and minute they were written. Sorting those names as text floated every name beginning with a letter above every name beginning with a date.
+
+The result was a list that looked sorted but was not. A handover written minutes ago sat thirteenth of a hundred and forty-three, below a dozen machine-written files, and the date shown against each row ran out of order the whole way down - so the one column you would use to find your document was the one column you could not trust. The list is now ordered by that same visible date, newest first, which is how the Cockpit has always shown it.
+
+Reading the list is also no longer done on the interface thread, so opening the tab with a few hundred handovers no longer briefly holds up the window.
+
+## Upgrading
+
+Nothing to do beyond the usual update. This release changes one dialog. It carries no migration, no new setting, and no change to how the Director, the launcher and the Gateway talk to each other.
+
+## Known and not fixed here
+
+- **The Director still opens a local listener during interactive sign-in**, to receive the callback from your browser. It is loopback-only, lasts as long as the sign-in, and carries nothing an agent can call - but the honest statement is that the Director runs without a listening socket, not that it never opens one.
+- The first-run wizard has not yet been verified on a genuinely clean Windows machine. Unchanged from v1.9.9.
+- The v1.9.9 launcher work has not been run on macOS or Linux.
+- Two places still fall back to a local answer when the Gateway fails - session numbering and the dictation dictionary. Both are filed.
+- The Director's large-object heap still grows on a long-running instance.
+- A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
+- Four repository views still show a failed git read as an empty result rather than saying the read failed.


### PR DESCRIPTION
Bumps `Directory.Build.props` to 1.9.10 and adds `docs/public/release-notes/v1.9.10.md`, which the release workflow publishes verbatim (it fails without it).

## What v1.9.10 carries

Two commits since v1.9.9:

- **#2452 - Handovers tab lists newest first.** The one user-visible fix. The list ordered by filename, so machine-written names beginning with a letter floated above every dated handover and the visible date column ran out of order. Now ordered by that same displayed date, and the frontmatter read moved off the interface thread.
- **#2411 - the deploy skill is the only path.** Documentation and agent instructions only; no user-visible effect, so it is not in the notes body.

## Accuracy gate

Verified against `origin/main`, not against the description: `HandoverViewModel.LoadOrdered` orders by `FileDate` descending and is called inside `Task.Run`. Shipped and on by default, no flag.

## Release gate

Not yet run. It runs on **merged main at the exact commit to be tagged**, after this merges - all three commands, since the two installer projects are not in the solution:

```
.\scripts\test-local.ps1 -Parked -Configuration Release
dotnet test tools/cc-director-setup.Tests/ -c Release
dotnet test tools/cc-director-setup-engine.Tests/ -c Release
```

The tag is pushed only once that is green.