### PR TITLE
The phone recorder captures all day: wake lock, Doze exemption, and truncation that is never silent

### DIFF
--- a/phone/CcRecorder/CcRecorder.csproj
+++ b/phone/CcRecorder/CcRecorder.csproj
@@ -34,8 +34,8 @@
 		<ApplicationId>com.ccdirector.recorder</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+		<ApplicationDisplayVersion>1.1</ApplicationDisplayVersion>
+		<ApplicationVersion>2</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>None</WindowsPackageType>

--- a/phone/CcRecorder/MainPage.xaml.cs
+++ b/phone/CcRecorder/MainPage.xaml.cs
@@ -117,6 +117,15 @@ public partial class MainPage : ContentPage
             await _recorder.StartAsync(TitleEntry.Text ?? "");
             _uiTimer.Start();
             RefreshUi();
+#if ANDROID
+            // Doze ignores wake locks from apps that are not on the battery
+            // optimization exemption list, so all-day capture needs BOTH the
+            // service's wake lock and this exemption. Shows the system consent
+            // dialog once; silently does nothing when already granted. Fired
+            // after StartAsync so the recording is already running regardless
+            // of what the user does with the dialog.
+            RequestIgnoreBatteryOptimizationsIfNeeded();
+#endif
         }
         catch (Exception ex)
         {
@@ -156,6 +165,7 @@ public partial class MainPage : ContentPage
         var options = new List<string> { isPlaying ? "Stop playing" : "Play recording" };
         if (!string.IsNullOrWhiteSpace(row.Transcript)) options.Add("Read transcript");
         if (row.State is "Queued" or "Retry") options.Add("Upload now");
+        if (row.Interrupted) options.Add("Why was it interrupted?");
         if (!string.IsNullOrWhiteSpace(row.UploadError)) options.Add("Why did upload fail?");
         if (!string.IsNullOrWhiteSpace(row.TranscriptError)) options.Add("Why did transcription fail?");
 
@@ -166,6 +176,11 @@ public partial class MainPage : ContentPage
             case "Stop playing": _recorder.StopPlayback(); break;
             case "Read transcript": await DisplayAlert(row.Title, row.Transcript, "Close"); break;
             case "Upload now": await ProcessQueueAsync(); break;
+            case "Why was it interrupted?":
+                await DisplayAlert("Recording interrupted",
+                    (row.CaptureError ?? "The recording was cut off before it was stopped.")
+                    + " Everything captured up to that point was kept and uploaded.", "OK");
+                break;
             case "Why did upload fail?": await DisplayAlert("Upload error", row.UploadError ?? "", "OK"); break;
             case "Why did transcription fail?": await DisplayAlert("Transcription error", row.TranscriptError ?? "", "OK"); break;
         }
@@ -254,10 +269,32 @@ public partial class MainPage : ContentPage
                 return new LibraryRow(
                     r.RecordingId, r.Title, BuildSubtitle(r, r.RecordingId == playingId),
                     r.Transcript, r.State, r.UploadError, r.TranscriptError, progress, working,
-                    uploadStroke, transStroke, !transFailed, transFailed);
+                    uploadStroke, transStroke, !transFailed, transFailed,
+                    r.Interrupted, r.CaptureError);
             })
             .ToList();
     }
+
+#if ANDROID
+    // One-tap system dialog asking to exempt the app from battery optimization.
+    // Required for unlimited recording: Doze ignores wake locks from non-exempt
+    // apps, so without this the capture CPU is suspended about half an hour
+    // after the screen turns off. No-op once granted.
+    private static void RequestIgnoreBatteryOptimizationsIfNeeded()
+    {
+        var ctx = global::Android.App.Application.Context;
+        var pkg = ctx.PackageName;
+        if (string.IsNullOrEmpty(pkg)) return;
+        var pm = (global::Android.OS.PowerManager?)ctx.GetSystemService(
+            global::Android.Content.Context.PowerService);
+        if (pm is null || pm.IsIgnoringBatteryOptimizations(pkg)) return;
+        var intent = new global::Android.Content.Intent(
+            global::Android.Provider.Settings.ActionRequestIgnoreBatteryOptimizations,
+            global::Android.Net.Uri.Parse("package:" + pkg));
+        intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
+        ctx.StartActivity(intent);
+    }
+#endif
 
     private static string BuildSubtitle(RecordingSummary r, bool playing)
     {
@@ -283,11 +320,15 @@ public partial class MainPage : ContentPage
             _ => r.State,
         };
         var prefix = playing ? "Playing now  -  " : "";
-        return $"{prefix}{dur}  -  {stateText}  -  tap to play";
+        // A cut-off recording must never read as a complete one: say so before
+        // anything else in the row.
+        var interrupted = r.Interrupted ? "INTERRUPTED  -  " : "";
+        return $"{prefix}{interrupted}{dur}  -  {stateText}  -  tap to play";
     }
 
     private sealed record LibraryRow(
         string RecordingId, string Title, string Subtitle, string? Transcript,
         string State, string? UploadError, string? TranscriptError, double Progress, bool IsUploading,
-        Brush UploadStroke, Brush TransCheckStroke, bool TransShowCheck, bool TransShowX);
+        Brush UploadStroke, Brush TransCheckStroke, bool TransShowCheck, bool TransShowX,
+        bool Interrupted, string? CaptureError);
 }

--- a/phone/CcRecorder/MainPage.xaml.cs
+++ b/phone/CcRecorder/MainPage.xaml.cs
@@ -121,10 +121,11 @@ public partial class MainPage : ContentPage
             // Doze ignores wake locks from apps that are not on the battery
             // optimization exemption list, so all-day capture needs BOTH the
             // service's wake lock and this exemption. Shows the system consent
-            // dialog once; silently does nothing when already granted. Fired
-            // after StartAsync so the recording is already running regardless
-            // of what the user does with the dialog.
-            RequestIgnoreBatteryOptimizationsIfNeeded();
+            // dialog; does nothing once granted. Fired after StartAsync so the
+            // recording is already running regardless of what the user does
+            // with the dialog, and it handles its own errors so a refusal to
+            // show the dialog can never read as a recording-start failure.
+            await RequestIgnoreBatteryOptimizationsIfNeededAsync();
 #endif
         }
         catch (Exception ex)
@@ -179,7 +180,8 @@ public partial class MainPage : ContentPage
             case "Why was it interrupted?":
                 await DisplayAlert("Recording interrupted",
                     (row.CaptureError ?? "The recording was cut off before it was stopped.")
-                    + " Everything captured up to that point was kept and uploaded.", "OK");
+                    + " Everything that could be saved up to that point was kept and uploaded;"
+                    + " up to the final minute may be missing.", "OK");
                 break;
             case "Why did upload fail?": await DisplayAlert("Upload error", row.UploadError ?? "", "OK"); break;
             case "Why did transcription fail?": await DisplayAlert("Transcription error", row.TranscriptError ?? "", "OK"); break;
@@ -279,20 +281,35 @@ public partial class MainPage : ContentPage
     // One-tap system dialog asking to exempt the app from battery optimization.
     // Required for unlimited recording: Doze ignores wake locks from non-exempt
     // apps, so without this the capture CPU is suspended about half an hour
-    // after the screen turns off. No-op once granted.
-    private static void RequestIgnoreBatteryOptimizationsIfNeeded()
+    // after the screen turns off. No-op once granted; asked again on every
+    // record start until it is. Deliberately never blocks recording - a denied
+    // exemption still records, and a recording that later gets cut off is
+    // marked INTERRUPTED rather than hidden.
+    private async Task RequestIgnoreBatteryOptimizationsIfNeededAsync()
     {
-        var ctx = global::Android.App.Application.Context;
-        var pkg = ctx.PackageName;
-        if (string.IsNullOrEmpty(pkg)) return;
-        var pm = (global::Android.OS.PowerManager?)ctx.GetSystemService(
-            global::Android.Content.Context.PowerService);
-        if (pm is null || pm.IsIgnoringBatteryOptimizations(pkg)) return;
-        var intent = new global::Android.Content.Intent(
-            global::Android.Provider.Settings.ActionRequestIgnoreBatteryOptimizations,
-            global::Android.Net.Uri.Parse("package:" + pkg));
-        intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
-        ctx.StartActivity(intent);
+        try
+        {
+            var ctx = global::Android.App.Application.Context;
+            var pkg = ctx.PackageName;
+            if (string.IsNullOrEmpty(pkg)) return;
+            var pm = (global::Android.OS.PowerManager?)ctx.GetSystemService(
+                global::Android.Content.Context.PowerService);
+            if (pm is null || pm.IsIgnoringBatteryOptimizations(pkg)) return;
+            var intent = new global::Android.Content.Intent(
+                global::Android.Provider.Settings.ActionRequestIgnoreBatteryOptimizations,
+                global::Android.Net.Uri.Parse("package:" + pkg));
+            intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
+            ctx.StartActivity(intent);
+        }
+        catch (Exception ex)
+        {
+            // The recording is already running; tell the user exactly how to
+            // grant the exemption by hand instead of failing the start.
+            await DisplayAlert("Battery optimization",
+                "Android refused to show the exemption dialog (" + ex.Message + "). "
+                + "Recording continues, but for all-day capture please set it manually: "
+                + "Settings > Apps > CC Recorder > Battery > Unrestricted.", "OK");
+        }
     }
 #endif
 

--- a/phone/CcRecorder/MainPage.xaml.cs
+++ b/phone/CcRecorder/MainPage.xaml.cs
@@ -180,7 +180,7 @@ public partial class MainPage : ContentPage
             case "Why was it interrupted?":
                 await DisplayAlert("Recording interrupted",
                     (row.CaptureError ?? "The recording was cut off before it was stopped.")
-                    + " Everything that could be saved was kept and uploaded;"
+                    + " Everything that could be saved was kept and queued for upload;"
                     + " the tail of the audio may be missing.", "OK");
                 break;
             case "Why did upload fail?": await DisplayAlert("Upload error", row.UploadError ?? "", "OK"); break;

--- a/phone/CcRecorder/MainPage.xaml.cs
+++ b/phone/CcRecorder/MainPage.xaml.cs
@@ -180,8 +180,8 @@ public partial class MainPage : ContentPage
             case "Why was it interrupted?":
                 await DisplayAlert("Recording interrupted",
                     (row.CaptureError ?? "The recording was cut off before it was stopped.")
-                    + " Everything that could be saved up to that point was kept and uploaded;"
-                    + " up to the final minute may be missing.", "OK");
+                    + " Everything that could be saved was kept and uploaded;"
+                    + " the tail of the audio may be missing.", "OK");
                 break;
             case "Why did upload fail?": await DisplayAlert("Upload error", row.UploadError ?? "", "OK"); break;
             case "Why did transcription fail?": await DisplayAlert("Transcription error", row.TranscriptError ?? "", "OK"); break;

--- a/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
+++ b/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
@@ -150,16 +150,18 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             catch
             {
                 // Start failed partway. Undo everything - including a recorder
-                // that already began capturing - so the app is honestly idle
-                // (not stuck showing "Recording"), and rethrow so the UI
-                // reports the real error.
+                // that already began capturing and a manifest already written -
+                // so the app is honestly idle (not stuck showing "Recording")
+                // and no half-born recording lingers on disk to be "recovered"
+                // later. Rethrow so the UI reports the real error.
+                _rollTimer?.Dispose();
+                _rollTimer = null;
                 IsRecording = false;
                 CaptureLive = false;
-                if (_recorder is not null)
-                {
-                    try { _recorder.Reset(); _recorder.Release(); } catch { /* never fully started */ }
-                    _recorder = null;
-                }
+                ReleaseRecorderQuietly();
+                try { if (Directory.Exists(_recordingDir)) Directory.Delete(_recordingDir, recursive: true); }
+                catch { /* at most milliseconds of audio from a start that already failed */ }
+                _manifest = null;
                 StopForegroundService();
                 throw;
             }
@@ -204,7 +206,9 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             _rollTimer = null;
             try
             {
-                if (_paused) { _recorder?.Resume(); _paused = false; } // so FinalizeSegment can stop cleanly
+                // Stop() is legal from the paused state, so a failed Resume must
+                // not fail the stop - it only exists so the file ends cleanly.
+                if (_paused) { try { _recorder?.Resume(); } catch { } _paused = false; }
                 FinalizeSegment();
                 if (_manifest is not null)
                 {
@@ -216,9 +220,10 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             catch (Exception ex)
             {
                 // A failed finalize must not leave the app stuck "recording"
-                // with the wake lock held. Keep every segment already on disk,
-                // say plainly that the tail may be missing, and still queue the
-                // recording for upload.
+                // with the wake lock held or the microphone owned. Keep every
+                // segment already on disk, say plainly that the tail may be
+                // missing, and still queue the recording for upload.
+                ReleaseRecorderQuietly();
                 if (_manifest is not null)
                 {
                     _manifest.EndedAt ??= DateTime.UtcNow.ToString("o");
@@ -521,9 +526,14 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         lock (_gate)
         {
             if (!IsRecording || !ReferenceEquals(_recorder, failed)) return;
+            // Salvage is best-effort and must not decide whether a replacement
+            // is attempted: a recorder that just reported a fatal error may
+            // well refuse to finalize, and that is no reason to give up on the
+            // rest of the recording.
+            try { FinalizeSegment(); }
+            catch { ReleaseRecorderQuietly(); }
             try
             {
-                FinalizeSegment();
                 StartSegment();
                 // The error cost an unknown slice of the current segment. Leave
                 // a timestamped note so the gap is visible in the transcript
@@ -538,7 +548,17 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
                 {
                     // Respect an in-progress pause: the replacement recorder
                     // starts out capturing, so pause it again immediately.
-                    try { _recorder?.Pause(); } catch { /* device may not support; same as Pause() */ }
+                    try { _recorder?.Pause(); }
+                    catch
+                    {
+                        // The replacement will not pause. Reflect reality
+                        // rather than pretending: the recording is running, so
+                        // account the pause that just ended and re-arm the
+                        // roll timer. The UI updates via RaiseChanged below.
+                        _pausedAccum += DateTime.UtcNow - _pauseStartedUtc;
+                        _paused = false;
+                        _rollTimer?.Change(SegmentLength, SegmentLength);
+                    }
                 }
                 else
                 {
@@ -570,14 +590,7 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         // recorder in its own finally. If even salvage fails, release the dead
         // recorder; every earlier segment is already a finalized file.
         try { FinalizeSegment(); }
-        catch
-        {
-            if (_recorder is not null)
-            {
-                try { _recorder.Reset(); _recorder.Release(); } catch { /* already dead */ }
-                _recorder = null;
-            }
-        }
+        catch { ReleaseRecorderQuietly(); }
         IsRecording = false;
         _paused = false;
         CaptureLive = false;
@@ -594,6 +607,19 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         StopForegroundService();
         // If the enqueue fails, the next app open drains the queue instead.
         try { UploadScheduler.EnqueueNow(global::Android.App.Application.Context); } catch { }
+    }
+
+    /// <summary>
+    /// Release the native recorder without letting any step's failure skip the
+    /// next: Reset and Release are attempted independently, and the field is
+    /// always cleared so the microphone is never left owned by a dead handle.
+    /// </summary>
+    private void ReleaseRecorderQuietly()
+    {
+        if (_recorder is null) return;
+        try { _recorder.Reset(); } catch { }
+        try { _recorder.Release(); } catch { }
+        _recorder = null;
     }
 
     private void StartSegment()

--- a/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
+++ b/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
@@ -21,6 +21,14 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
     // transcription API's per-file size limit. See the plan doc.
     private static readonly TimeSpan SegmentLength = TimeSpan.FromMinutes(1);
 
+    /// <summary>
+    /// True while a capture is genuinely running in this process. The sticky
+    /// foreground service checks this on start so that an automatic restart
+    /// after a process death cannot post a "Recording in progress" notification
+    /// with no recording behind it.
+    /// </summary>
+    internal static volatile bool CaptureLive;
+
     private readonly object _gate = new();
     private MediaRecorder? _recorder;
     private System.Threading.Timer? _rollTimer;
@@ -130,9 +138,23 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             _paused = false;
             _pausedAccum = TimeSpan.Zero;
             IsRecording = true;
+            CaptureLive = true;
 
-            StartForegroundService();
-            StartSegment();
+            try
+            {
+                StartForegroundService();
+                StartSegment();
+            }
+            catch
+            {
+                // Capture never began. Undo everything so the app is honestly
+                // idle (not stuck showing "Recording") and rethrow so the UI
+                // reports the real error.
+                IsRecording = false;
+                CaptureLive = false;
+                StopForegroundService();
+                throw;
+            }
             SaveManifest();
 
             _rollTimer = new System.Threading.Timer(_ => RollSegment(), null, SegmentLength, SegmentLength);
@@ -178,6 +200,7 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             if (_paused) { _recorder?.Resume(); _paused = false; } // so FinalizeSegment can stop cleanly
             FinalizeSegment();
             IsRecording = false;
+            CaptureLive = false;
             if (_manifest is not null)
             {
                 _manifest.EndedAt = DateTime.UtcNow.ToString("o");
@@ -273,6 +296,13 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
 
             m.EndedAt = DateTime.UtcNow.ToString("o");
             m.State = "Queued"; // queued for background upload; never deleted until delivered
+            // A recovered recording was CUT OFF, not stopped. Mark it so the
+            // library says so plainly - the original failure mode here was a
+            // truncated recording that looked complete (see the recorder
+            // all-day-capture mission).
+            m.Interrupted = true;
+            m.CaptureError ??= "Recording was cut off before it was stopped "
+                + "(the app was killed or the phone suspended it).";
             WriteManifest(summary.RecordingId, m);
         }
         RaiseChanged();
@@ -434,11 +464,76 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         lock (_gate)
         {
             if (!IsRecording) return;
-            FinalizeSegment();
-            StartSegment();
-            SaveManifest();
+            try
+            {
+                FinalizeSegment();
+                StartSegment();
+                SaveManifest();
+            }
+            catch (Exception ex)
+            {
+                // A roll that cannot start its next segment means capture is
+                // dead. Never let that pass silently: end the recording now,
+                // keep everything captured so far, and mark it interrupted.
+                AbortCapture("Segment rotation failed: " + ex.Message);
+            }
         }
         RaiseChanged();
+    }
+
+    /// <summary>
+    /// A running <see cref="MediaRecorder"/> reported a fatal error. Try to
+    /// survive it by rolling to a fresh recorder instance; if even that fails,
+    /// end the recording cleanly and visibly. Stale callbacks from an instance
+    /// that was already rotated out are ignored.
+    /// </summary>
+    private void OnRecorderError(MediaRecorder failed, string what)
+    {
+        lock (_gate)
+        {
+            if (!IsRecording || !ReferenceEquals(_recorder, failed)) return;
+            try
+            {
+                FinalizeSegment();
+                StartSegment();
+                SaveManifest();
+            }
+            catch (Exception ex)
+            {
+                AbortCapture($"Recorder error ({what}); restart failed: {ex.Message}");
+            }
+        }
+        RaiseChanged();
+    }
+
+    /// <summary>
+    /// Capture died mid-recording and could not be restarted. Ends the
+    /// recording immediately with everything captured so far, marks it
+    /// Interrupted (with the reason) so the library never presents it as
+    /// complete, and queues it for upload. Must be called inside the gate.
+    /// </summary>
+    private void AbortCapture(string reason)
+    {
+        _rollTimer?.Dispose();
+        _rollTimer = null;
+        if (_recorder is not null)
+        {
+            try { _recorder.Reset(); _recorder.Release(); } catch { /* already dead */ }
+            _recorder = null;
+        }
+        IsRecording = false;
+        _paused = false;
+        CaptureLive = false;
+        if (_manifest is not null)
+        {
+            _manifest.EndedAt = DateTime.UtcNow.ToString("o");
+            _manifest.State = "Queued"; // whatever was captured still uploads
+            _manifest.Interrupted = true;
+            _manifest.CaptureError = reason;
+            SaveManifest();
+        }
+        StopForegroundService();
+        UploadScheduler.EnqueueNow(global::Android.App.Application.Context);
     }
 
     private void StartSegment()
@@ -457,6 +552,10 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         rec.SetAudioChannels(1);
         rec.SetAudioEncodingBitRate(64000);
         rec.SetOutputFile(path);
+        // Surface capture failures instead of recording silence: without this,
+        // a MediaRecorder that dies mid-segment is invisible until the
+        // transcript comes back short.
+        rec.Error += (_, e) => OnRecorderError(rec, e.What.ToString());
         rec.Prepare();
         rec.Start();
 
@@ -533,7 +632,8 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
                     m.RecordingId, m.Title, m.StartedAt, m.Chunks.Count,
                     m.Chunks.Sum(c => c.DurationMs), state, m.VaultDocId, m.Transcript,
                     m.UploadError, m.UploadProgress, m.UploadPhase, m.UploadCurrent, m.UploadTotal,
-                    m.TranscriptionState, m.TranscriptError, m.Completed));
+                    m.TranscriptionState, m.TranscriptError, m.Completed,
+                    m.Interrupted, m.CaptureError));
             }
             catch { /* skip unreadable manifest */ }
         }

--- a/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
+++ b/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
@@ -144,20 +144,25 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             {
                 StartForegroundService();
                 StartSegment();
+                SaveManifest();
+                _rollTimer = new System.Threading.Timer(_ => RollSegment(), null, SegmentLength, SegmentLength);
             }
             catch
             {
-                // Capture never began. Undo everything so the app is honestly
-                // idle (not stuck showing "Recording") and rethrow so the UI
+                // Start failed partway. Undo everything - including a recorder
+                // that already began capturing - so the app is honestly idle
+                // (not stuck showing "Recording"), and rethrow so the UI
                 // reports the real error.
                 IsRecording = false;
                 CaptureLive = false;
+                if (_recorder is not null)
+                {
+                    try { _recorder.Reset(); _recorder.Release(); } catch { /* never fully started */ }
+                    _recorder = null;
+                }
                 StopForegroundService();
                 throw;
             }
-            SaveManifest();
-
-            _rollTimer = new System.Threading.Timer(_ => RollSegment(), null, SegmentLength, SegmentLength);
         }
         RaiseChanged();
         return Task.CompletedTask;
@@ -197,17 +202,39 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             if (!IsRecording) return Task.CompletedTask;
             _rollTimer?.Dispose();
             _rollTimer = null;
-            if (_paused) { _recorder?.Resume(); _paused = false; } // so FinalizeSegment can stop cleanly
-            FinalizeSegment();
-            IsRecording = false;
-            CaptureLive = false;
-            if (_manifest is not null)
+            try
             {
-                _manifest.EndedAt = DateTime.UtcNow.ToString("o");
-                _manifest.State = "Queued"; // queued for background upload; never deleted
-                SaveManifest();
+                if (_paused) { _recorder?.Resume(); _paused = false; } // so FinalizeSegment can stop cleanly
+                FinalizeSegment();
+                if (_manifest is not null)
+                {
+                    _manifest.EndedAt = DateTime.UtcNow.ToString("o");
+                    _manifest.State = "Queued"; // queued for background upload; never deleted
+                    SaveManifest();
+                }
             }
-            StopForegroundService();
+            catch (Exception ex)
+            {
+                // A failed finalize must not leave the app stuck "recording"
+                // with the wake lock held. Keep every segment already on disk,
+                // say plainly that the tail may be missing, and still queue the
+                // recording for upload.
+                if (_manifest is not null)
+                {
+                    _manifest.EndedAt ??= DateTime.UtcNow.ToString("o");
+                    _manifest.State = "Queued";
+                    _manifest.Interrupted = true;
+                    _manifest.CaptureError = "Stop failed: " + ex.Message;
+                    try { SaveManifest(); } catch { /* disk write failing is the very error being handled */ }
+                }
+            }
+            finally
+            {
+                IsRecording = false;
+                _paused = false;
+                CaptureLive = false;
+                StopForegroundService();
+            }
         }
         // Hand the queue to WorkManager so it uploads even if the app is
         // swiped closed (and after reboot), constrained to network availability.
@@ -463,7 +490,9 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
     {
         lock (_gate)
         {
-            if (!IsRecording) return;
+            // Pause stops the roll timer, but a tick already in flight can
+            // land after the pause takes hold - never rotate a paused capture.
+            if (!IsRecording || _paused) return;
             try
             {
                 FinalizeSegment();
@@ -496,7 +525,27 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             {
                 FinalizeSegment();
                 StartSegment();
+                // The error cost an unknown slice of the current segment. Leave
+                // a timestamped note so the gap is visible in the transcript
+                // timeline instead of passing as continuous audio.
+                _manifest?.Notes.Add(new NoteInfo
+                {
+                    TMs = (long)(DateTime.UtcNow - _startedUtc).TotalMilliseconds,
+                    Text = $"[capture] Recorder error ({what}); a short audio gap may exist here.",
+                });
                 SaveManifest();
+                if (_paused)
+                {
+                    // Respect an in-progress pause: the replacement recorder
+                    // starts out capturing, so pause it again immediately.
+                    try { _recorder?.Pause(); } catch { /* device may not support; same as Pause() */ }
+                }
+                else
+                {
+                    // The new segment gets a full interval, not the remainder
+                    // of the one the dying recorder was in.
+                    _rollTimer?.Change(SegmentLength, SegmentLength);
+                }
             }
             catch (Exception ex)
             {
@@ -516,10 +565,18 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
     {
         _rollTimer?.Dispose();
         _rollTimer = null;
-        if (_recorder is not null)
+        // Salvage the open segment where the recorder can still finalize it -
+        // FinalizeSegment keeps whatever landed on disk and releases the
+        // recorder in its own finally. If even salvage fails, release the dead
+        // recorder; every earlier segment is already a finalized file.
+        try { FinalizeSegment(); }
+        catch
         {
-            try { _recorder.Reset(); _recorder.Release(); } catch { /* already dead */ }
-            _recorder = null;
+            if (_recorder is not null)
+            {
+                try { _recorder.Reset(); _recorder.Release(); } catch { /* already dead */ }
+                _recorder = null;
+            }
         }
         IsRecording = false;
         _paused = false;
@@ -530,10 +587,13 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             _manifest.State = "Queued"; // whatever was captured still uploads
             _manifest.Interrupted = true;
             _manifest.CaptureError = reason;
-            SaveManifest();
+            // The service and wake lock below must be released even if this
+            // write fails; the manifest on disk then keeps its last good state.
+            try { SaveManifest(); } catch { }
         }
         StopForegroundService();
-        UploadScheduler.EnqueueNow(global::Android.App.Application.Context);
+        // If the enqueue fails, the next app open drains the queue instead.
+        try { UploadScheduler.EnqueueNow(global::Android.App.Application.Context); } catch { }
     }
 
     private void StartSegment()

--- a/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
+++ b/phone/CcRecorder/Platforms/Android/AndroidAudioRecorder.cs
@@ -498,6 +498,11 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             // Pause stops the roll timer, but a tick already in flight can
             // land after the pause takes hold - never rotate a paused capture.
             if (!IsRecording || _paused) return;
+            // Timer.Change cannot recall a callback already queued, so a stale
+            // tick can race a segment that error recovery restarted moments
+            // ago. Rotating a seconds-old segment serves nobody - skip; the
+            // re-armed timer owns the next rotation.
+            if (DateTime.UtcNow - _segmentStartedUtc < TimeSpan.FromSeconds(5)) return;
             try
             {
                 FinalizeSegment();
@@ -535,19 +540,12 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
             try
             {
                 StartSegment();
-                // The error cost an unknown slice of the current segment. Leave
-                // a timestamped note so the gap is visible in the transcript
-                // timeline instead of passing as continuous audio.
-                _manifest?.Notes.Add(new NoteInfo
-                {
-                    TMs = (long)(DateTime.UtcNow - _startedUtc).TotalMilliseconds,
-                    Text = $"[capture] Recorder error ({what}); a short audio gap may exist here.",
-                });
-                SaveManifest();
+                // The replacement recorder starts out capturing, so an
+                // in-progress pause must be re-applied IMMEDIATELY - before
+                // any manifest work - or audio records while the user sees
+                // "Paused".
                 if (_paused)
                 {
-                    // Respect an in-progress pause: the replacement recorder
-                    // starts out capturing, so pause it again immediately.
                     try { _recorder?.Pause(); }
                     catch
                     {
@@ -566,6 +564,15 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
                     // of the one the dying recorder was in.
                     _rollTimer?.Change(SegmentLength, SegmentLength);
                 }
+                // The error cost an unknown slice of the current segment. Leave
+                // a timestamped note so the gap is visible in the transcript
+                // timeline instead of passing as continuous audio.
+                _manifest?.Notes.Add(new NoteInfo
+                {
+                    TMs = (long)(DateTime.UtcNow - _startedUtc).TotalMilliseconds,
+                    Text = $"[capture] Recorder error ({what}); a short audio gap may exist here.",
+                });
+                SaveManifest();
             }
             catch (Exception ex)
             {

--- a/phone/CcRecorder/Platforms/Android/AndroidManifest.xml
+++ b/phone/CcRecorder/Platforms/Android/AndroidManifest.xml
@@ -7,6 +7,13 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<!-- All-day capture: the recording service holds a partial wake lock so the
+	     segment-roll timer keeps firing with the screen off, and the app asks to
+	     be exempted from battery optimization because Doze ignores wake locks
+	     from non-exempt apps. Without BOTH, Android suspends capture about half
+	     an hour after screen-off. -->
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
+	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<!-- Issue #687: re-arm the background upload workers after a device reboot so
 	     pending recordings drain without the user opening the app. -->
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/phone/CcRecorder/Platforms/Android/RecorderForegroundService.cs
+++ b/phone/CcRecorder/Platforms/Android/RecorderForegroundService.cs
@@ -42,6 +42,10 @@ public sealed class RecorderForegroundService : Service
         // interrupted) by the recorder's next upload pass.
         if (!AndroidAudioRecorder.CaptureLive)
         {
+            // Kick the background upload worker so the orphaned recording is
+            // recovered and uploaded now, not on the next app open. If the
+            // enqueue fails the next app open still drains the queue.
+            try { UploadScheduler.EnqueueNow(this); } catch { }
             StopSelf();
             return StartCommandResult.NotSticky;
         }

--- a/phone/CcRecorder/Platforms/Android/RecorderForegroundService.cs
+++ b/phone/CcRecorder/Platforms/Android/RecorderForegroundService.cs
@@ -11,6 +11,16 @@ namespace CcRecorder.Platforms.Android;
 /// not reclaim it when the screen locks or the app is backgrounded. The actual
 /// capture + segment rotation runs in <see cref="AndroidAudioRecorder"/> in the
 /// same process.
+///
+/// The service holds a partial wake lock for the whole recording. Without it,
+/// Doze suspends the app's CPU once the screen has been off for a while (about
+/// half an hour), the segment-roll timer stops firing, and Android then kills
+/// the process - which is exactly how a 30-minute conference recording died at
+/// a clean segment boundary while the speaker kept talking. The wake lock only
+/// counts while the app is on the battery-optimization exemption list (Doze
+/// ignores wake locks otherwise), so <c>MainPage</c> requests that exemption
+/// when recording starts. Recording is unlimited by design: the lock has no
+/// timeout and is released only when the recording is stopped.
 /// </summary>
 [Service(
     Exported = false,
@@ -20,18 +30,45 @@ public sealed class RecorderForegroundService : Service
     public const string ChannelId = "cc_recorder_capture";
     private const int NotificationId = 4801;
 
+    private PowerManager.WakeLock? _wakeLock;
+
     public override IBinder? OnBind(Intent? intent) => null;
 
     public override StartCommandResult OnStartCommand(Intent? intent, StartCommandFlags flags, int startId)
     {
+        // Sticky restart after a process death: there is no live capture, so a
+        // "Recording in progress" notification would be a lie. Stop immediately.
+        // The interrupted recording itself is recovered (and clearly marked as
+        // interrupted) by the recorder's next upload pass.
+        if (!AndroidAudioRecorder.CaptureLive)
+        {
+            StopSelf();
+            return StartCommandResult.NotSticky;
+        }
+
         CreateChannel();
 
-        var notification = new NotificationCompat.Builder(this, ChannelId)
-            .SetContentTitle("CC Recorder")
-            .SetContentText("Recording in progress")
-            .SetSmallIcon(global::Android.Resource.Drawable.PresenceAudioOnline)
-            .SetOngoing(true)
-            .Build();
+        // Tapping the notification opens the app; the chronometer counts up
+        // live so a glance shows capture is still running, not just that a
+        // notification was once posted.
+        var launch = PackageManager?.GetLaunchIntentForPackage(PackageName ?? "");
+        var tapToOpen = launch is null
+            ? null
+            : PendingIntent.GetActivity(this, 0, launch, PendingIntentFlags.Immutable);
+
+        // Statement calls, not a fluent chain: the binding marks each SetX
+        // return as nullable, which turns a chain into a wall of warnings.
+        var builder = new NotificationCompat.Builder(this, ChannelId);
+        builder.SetContentTitle("CC Recorder");
+        builder.SetContentText("Recording in progress");
+        builder.SetSmallIcon(global::Android.Resource.Drawable.PresenceAudioOnline);
+        builder.SetOngoing(true);
+        builder.SetShowWhen(true);
+        builder.SetWhen(Java.Lang.JavaSystem.CurrentTimeMillis());
+        builder.SetUsesChronometer(true);
+        if (tapToOpen is not null) builder.SetContentIntent(tapToOpen);
+        var notification = builder.Build()
+            ?? throw new InvalidOperationException("Recording notification could not be built.");
 
         if (OperatingSystem.IsAndroidVersionAtLeast(29))
             StartForeground(NotificationId, notification,
@@ -39,8 +76,36 @@ public sealed class RecorderForegroundService : Service
         else
             StartForeground(NotificationId, notification);
 
+        AcquireWakeLock();
+
         // Sticky: if the process is killed, Android tries to restart the service.
         return StartCommandResult.Sticky;
+    }
+
+    private void AcquireWakeLock()
+    {
+        if (_wakeLock is not null) return;
+        var pm = (PowerManager?)GetSystemService(PowerService)
+            ?? throw new InvalidOperationException(
+                "PowerManager unavailable; cannot keep the CPU awake for capture.");
+        var wl = pm.NewWakeLock(WakeLockFlags.Partial, "CcRecorder:capture")
+            ?? throw new InvalidOperationException(
+                "Wake lock could not be created; cannot keep the CPU awake for capture.");
+        wl.SetReferenceCounted(false);
+        // No timeout on purpose: the recording has no time limit. Released in
+        // OnDestroy, which runs when the recorder stops this service.
+        wl.Acquire();
+        _wakeLock = wl;
+    }
+
+    public override void OnDestroy()
+    {
+        if (_wakeLock is not null)
+        {
+            if (_wakeLock.IsHeld) _wakeLock.Release();
+            _wakeLock = null;
+        }
+        base.OnDestroy();
     }
 
     private void CreateChannel()

--- a/phone/CcRecorder/Recording/LocalManifest.cs
+++ b/phone/CcRecorder/Recording/LocalManifest.cs
@@ -58,6 +58,14 @@ public sealed class LocalManifest
     public string? VaultDocId { get; set; }
     public string? Transcript { get; set; }
 
+    // TRUNCATION surfacing. True when this recording did NOT end with the user
+    // pressing Stop - the process was killed mid-capture (recovered later), or
+    // the recorder failed and could not be restarted. The library shows this
+    // plainly so a cut-off recording is never presented as a complete one.
+    // CaptureError carries the reason when one is known.
+    public bool Interrupted { get; set; }
+    public string? CaptureError { get; set; }
+
     // True once the server has ACKNOWLEDGED the complete call (HTTP 202): the
     // manifest - including the NOTES - is delivered and server-side transcription
     // is queued. This is the phone's real terminal condition, NOT State=="Uploaded".
@@ -100,4 +108,6 @@ public sealed record RecordingSummary(
     int UploadTotal,
     string? TranscriptionState,
     string? TranscriptError,
-    bool Completed = false);
+    bool Completed = false,
+    bool Interrupted = false,
+    string? CaptureError = null);


### PR DESCRIPTION
## Why

Mission: recorder captures all day, never auto-stops (mission/recorder-unlimited-capture.md). A 30-minute trial recording of the conference talk stopped itself mid-sentence at a clean segment boundary. There is no coded limit anywhere; the stop was environmental: capture held no wake lock and the app is not exempt from battery optimization, so Doze suspended the process about half an hour after screen-off - and the truncated recording then displayed as a complete one.

## What changed (phone/CcRecorder only)

- The recording foreground service now holds a partial wake lock for the whole recording - no timeout, recording is unlimited by design - released when the recording stops.
- Starting a recording asks once for the battery-optimization exemption (Doze ignores wake locks from non-exempt apps, so both halves are required). The prompt is deliberately advisory: recording never refuses to start, and the ask repeats on every start until granted.
- Truncation is never silent. A recording that did not end with the user pressing Stop is marked INTERRUPTED in the library with a tap-for-reason explanation. Recovery of orphaned recordings sets the marker; a mid-run recorder failure that cannot be rolled past ends the recording cleanly with the same marker and salvages the open segment where possible.
- A MediaRecorder error mid-segment rolls to a fresh recorder and leaves a timestamped note in the recording so the gap is visible in the transcript timeline; pause state and the roll timer survive the recovery truthfully.
- No failure path can leave the app stuck "recording", the microphone owned, or the wake lock held: start is transactional (a partway failure fully unwinds, including deleting the half-born recording directory), stop is failure-safe, and abort releases everything even when the manifest write fails.
- The persistent notification shows a live counting chronometer, opens the app when tapped, and a sticky service restart after a process death stops itself and kicks the upload worker instead of claiming to record.

## Review

Reviewed by Codex (gpt-5.6-sol) over four rounds, run inline. Rounds one to three produced eighteen findings; all accepted ones are fixed in the follow-up commits. Two findings were deliberately rejected as design decisions: recording never hard-requires the battery exemption, and there is no service-start acknowledgement handshake (the service starts while the app is in the foreground; a failure there crashes visibly). Round four verdict: MERGE.

## Gate

`.\scripts\test-local.ps1`: 4,238 passed, 8 failed - all eight are `HostedSchemaRefusesAnUnownedRowTests`, which need a local Postgres at 127.0.0.1:55432 that is not running on this machine. This change touches only phone/CcRecorder, which no test suite in the gate builds or runs; the Gateway sources here are identical to origin/main, so those eight fail the same way on the parent. The flagged parked suites (Core.Tests, Gateway.Tests) do not cover the phone project either.

## Proof still owed (tracked in the mission)

The definition of done requires a real 90-minute screen-off recording landing on the Gateway from the owner's device, and the installed build confirmed on the phone. The signed APK (version 1.1, code 2) is built from this branch and is being delivered to the device; the long-run proof happens there.
