### PR TITLE
The mobile recorder records all day: no default cap, capture survives navigation, an indicator on every screen

### DIFF
--- a/apps/mobile/src/components/RecordingBanner.tsx
+++ b/apps/mobile/src/components/RecordingBanner.tsx
@@ -36,7 +36,12 @@ export function RecordingBanner() {
   const [clock, setClock] = useState("00:00:00");
 
   const capturing = session.phase === "recording" || session.phase === "paused" || session.phase === "stopping";
-  const shown = capturing && location.pathname !== "/recorder";
+  // A capture that DIED (microphone suspended) must be announced everywhere too, not just on the
+  // Recorder page - otherwise the red bar silently vanishes and the user in another screen assumes
+  // it is still recording. The error state shows until dismissed on the Recorder page.
+  const lost = !capturing && session.error !== null;
+  const onRecorderPage = location.pathname === "/recorder" || location.pathname.startsWith("/recorder/");
+  const shown = (capturing || lost) && !onRecorderPage;
 
   useEffect(() => {
     const root = document.documentElement;
@@ -58,13 +63,23 @@ export function RecordingBanner() {
 
   // The live clock is the banner's proof of life - a frozen number would be a lying indicator.
   useEffect(() => {
-    if (!shown) return;
+    if (!shown || !capturing) return;
     setClock(formatClock(recordingSession.elapsedMs()));
     const t = setInterval(() => setClock(formatClock(recordingSession.elapsedMs())), 500);
     return () => clearInterval(t);
-  }, [shown]);
+  }, [shown, capturing]);
 
   if (!shown) return null;
+
+  // Three truthful states: live (pulsing red + clock), saving (still red, the final segment may be
+  // flushing), lost (amber, the capture stopped - tap for the details and the saved audio).
+  const label = lost
+    ? "Recording stopped - tap for details"
+    : session.phase === "paused"
+      ? `Recording paused ${clock}`
+      : session.phase === "stopping"
+        ? "Saving recording..."
+        : `Recording ${clock}`;
 
   return (
     <button
@@ -72,12 +87,13 @@ export function RecordingBanner() {
       className="recbanner"
       ref={barRef}
       onClick={() => void navigate("/recorder")}
-      aria-label={`Recording in progress, ${clock}. Open the recorder.`}
+      aria-label={`${label}. Open the recorder.`}
     >
-      <span className={`recbanner-dot${session.phase === "paused" ? " recbanner-dot-paused" : ""}`} aria-hidden="true" />
-      <span className="recbanner-text">
-        {session.phase === "paused" ? "Recording paused" : "Recording"} {clock}
-      </span>
+      <span
+        className={`recbanner-dot${session.phase === "paused" || lost ? " recbanner-dot-paused" : ""}`}
+        aria-hidden="true"
+      />
+      <span className="recbanner-text">{label}</span>
       <span className="recbanner-open">Open</span>
     </button>
   );

--- a/apps/mobile/src/components/RecordingBanner.tsx
+++ b/apps/mobile/src/components/RecordingBanner.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { recordingSession, useRecordingSession } from "@devthrottle/client-core/recorder/recordingSession";
+
+// THE RECORDING BANNER (recorder-unlimited-capture mission). While a recording is live, this bar is
+// on EVERY screen of the app: the capture session lives above the router precisely so navigating
+// away from the Recorder page cannot stop it, and a capture that survives navigation needs an
+// indicator that survives navigation with it. A glance at the top of the screen answers "is it
+// still recording?" - the mission's third ask - with the live elapsed clock as proof it is not a
+// stale banner. Tapping it lands on the Recorder page, where Stop is.
+//
+// On the Recorder page itself it renders nothing: that page's status card already shows the same
+// state larger, and doubling it would burn a strip of a small screen to say one thing twice.
+//
+// IT PUBLISHES ITS OWN MEASURED HEIGHT AS --recbanner-h, exactly like the voice-mode banner
+// publishes --voicemode-h and for the same reason: the pinned screens (.terminal-screen,
+// .assistant-screen) are fixed out of the document flow and offset themselves by --topbars-h, the
+// sum of every top bar. A bar that does not add its height to that sum paints OVER those screens'
+// own headers (shipped and reported for the voice-mode banner on 2026-07-25 - "there's a black
+// space at the top" was the over-correction; losing the header was the original sin). Zero when
+// not shown, so nothing about any screen changes when no recording is running.
+function formatClock(ms: number): string {
+  const totalS = Math.floor(ms / 1000);
+  const h = Math.floor(totalS / 3600);
+  const m = Math.floor((totalS % 3600) / 60);
+  const s = totalS % 60;
+  const two = (n: number) => String(n).padStart(2, "0");
+  return `${two(h)}:${two(m)}:${two(s)}`;
+}
+
+export function RecordingBanner() {
+  const session = useRecordingSession();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const barRef = useRef<HTMLButtonElement | null>(null);
+  const [clock, setClock] = useState("00:00:00");
+
+  const capturing = session.phase === "recording" || session.phase === "paused" || session.phase === "stopping";
+  const shown = capturing && location.pathname !== "/recorder";
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!shown) {
+      root.style.setProperty("--recbanner-h", "0px");
+      return;
+    }
+    const el = barRef.current;
+    if (el === null) return;
+    const apply = () => root.style.setProperty("--recbanner-h", `${Math.round(el.getBoundingClientRect().height)}px`);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty("--recbanner-h", "0px");
+    };
+  }, [shown]);
+
+  // The live clock is the banner's proof of life - a frozen number would be a lying indicator.
+  useEffect(() => {
+    if (!shown) return;
+    setClock(formatClock(recordingSession.elapsedMs()));
+    const t = setInterval(() => setClock(formatClock(recordingSession.elapsedMs())), 500);
+    return () => clearInterval(t);
+  }, [shown]);
+
+  if (!shown) return null;
+
+  return (
+    <button
+      type="button"
+      className="recbanner"
+      ref={barRef}
+      onClick={() => void navigate("/recorder")}
+      aria-label={`Recording in progress, ${clock}. Open the recorder.`}
+    >
+      <span className={`recbanner-dot${session.phase === "paused" ? " recbanner-dot-paused" : ""}`} aria-hidden="true" />
+      <span className="recbanner-text">
+        {session.phase === "paused" ? "Recording paused" : "Recording"} {clock}
+      </span>
+      <span className="recbanner-open">Open</span>
+    </button>
+  );
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -23,6 +23,8 @@ import { installGlobalErrorReporting } from "@devthrottle/client-core/errors/rep
 import { CreditsNotice } from "./components/CreditsNotice";
 import { ConnectionBanner } from "./components/ConnectionBanner";
 import { VoiceModeBanner } from "./components/VoiceModeBanner";
+import { RecordingBanner } from "./components/RecordingBanner";
+import { recordingSession } from "@devthrottle/client-core/recorder/recordingSession";
 import { useVisibleViewportHeight } from "./hooks/useVisibleViewportHeight";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { useKeepWarm } from "@devthrottle/client-core/net/useKeepWarm";
@@ -80,6 +82,11 @@ function GatedLayout() {
           to catch, not a way out. Here it is on the session screen auto-speak just dropped you into. It
           renders nothing at all when voice mode is off. */}
       <VoiceModeBanner />
+      {/* The recording banner is mounted here for the same reason as the voice-mode banner: a live
+          recording survives navigation (the session lives above the router), so its indicator must
+          be on every screen too. Renders nothing while no recording is running, and nothing on the
+          Recorder page itself. */}
+      <RecordingBanner />
       <Outlet />
     </>
   );
@@ -118,6 +125,13 @@ if ("serviceWorker" in navigator && navigator.serviceWorker.controller !== null)
   let reloadingForNewWorker = false;
   navigator.serviceWorker.addEventListener("controllerchange", () => {
     if (reloadingForNewWorker) return;
+    // NEVER reload over a live recording (recorder-unlimited-capture mission): a deploy landing
+    // mid-capture would kill the microphone and truncate the recording to force an update the user
+    // never asked for. The stale shell keeps running; the new build takes over on the next open.
+    if (recordingSession.isCapturing()) {
+      console.log("[mobile] a new service worker took control - reload deferred, a recording is live");
+      return;
+    }
     reloadingForNewWorker = true;
     console.log("[mobile] a new service worker took control - reloading to run the latest build");
     window.location.reload();

--- a/apps/mobile/src/pages/Recorder.tsx
+++ b/apps/mobile/src/pages/Recorder.tsx
@@ -7,17 +7,17 @@ import {
   listRecordings,
   recordingStoreAvailable,
   recoverInterrupted,
-  saveChunk,
   saveRecording,
   type LocalRecording,
 } from "@devthrottle/client-core/recorder/recordingStore";
-import { SegmentRecorder, MAX_RECORDING_MS } from "@devthrottle/client-core/recorder/segmentRecorder";
+import {
+  recordingSession,
+  useRecordingSession,
+} from "@devthrottle/client-core/recorder/recordingSession";
 import {
   driveRecordingUpload,
   resumePendingRecordingUploads,
-  sha256Hex,
 } from "@devthrottle/client-core/recorder/ingestUpload";
-import { getInstallId } from "@devthrottle/client-core/auth/deviceKey";
 import {
   getRecordings,
   getTranscript,
@@ -71,12 +71,6 @@ function formatWhen(iso: string): string {
   return isNaN(d.getTime()) ? iso : d.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
 }
 
-function defaultTitle(): string {
-  return `Recording ${new Date().toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}`;
-}
-
-type Phase = "idle" | "starting" | "recording" | "paused" | "stopping";
-
 /** One library row: a local (not yet delivered) recording OR a server-side one, never both - the
  *  local copy is deleted exactly when the server acknowledges it holds everything. */
 interface LibraryRow {
@@ -107,30 +101,29 @@ function Cross() {
 export function Recorder() {
   const storeOk = recordingStoreAvailable();
 
-  const [phase, setPhase] = useState<Phase>("idle");
+  // The capture lifecycle lives in the app-level recording session, NOT in this page: leaving this
+  // page must not stop the recording (recorder-unlimited-capture mission). This page renders the
+  // session's state and drives its controls; the live numbers are polled on a display tick.
+  const session = useRecordingSession();
+  const { phase, title, error } = session;
+  const activeNotes = session.notes;
+
   const [elapsedMs, setElapsedMs] = useState(0);
   const [segmentCount, setSegmentCount] = useState(0);
   const [level, setLevel] = useState(0);
-  const [title, setTitle] = useState("");
   const [noteText, setNoteText] = useState("");
-  const [activeNotes, setActiveNotes] = useState<{ tMs: number; text: string }[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [autoStopped, setAutoStopped] = useState(false);
 
   const [localRecordings, setLocalRecordings] = useState<LocalRecording[]>([]);
   const [serverRecordings, setServerRecordings] = useState<RecordingListItem[]>([]);
   const [serverError, setServerError] = useState<string | null>(null);
 
   const [playingId, setPlayingId] = useState<string | null>(null);
+  const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [transcriptFor, setTranscriptFor] = useState<{ id: string; text: string } | null>(null);
   const [confirmDiscard, setConfirmDiscard] = useState<string | null>(null);
 
-  const recorderRef = useRef<SegmentRecorder | null>(null);
-  const activeRef = useRef<LocalRecording | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const playTokenRef = useRef(0);
-  const titleRef = useRef("");
-  titleRef.current = title;
 
   const refreshLocal = useCallback(async () => {
     setLocalRecordings(await listRecordings());
@@ -152,7 +145,9 @@ export function Recorder() {
   useEffect(() => {
     const controller = new AbortController();
     void (async () => {
-      await recoverInterrupted();
+      // The LIVE capture (if any) is excluded from recovery: the session survives navigation, so a
+      // "recording" row may be the healthy capture running right now, not an orphan.
+      await recoverInterrupted(recordingSession.getState().recordingId ?? undefined);
       await refreshLocal();
       await refreshServer(controller.signal);
       void resumePendingRecordingUploads(() => void refreshLocal()).then(() => {
@@ -173,195 +168,54 @@ export function Recorder() {
       controller.abort();
       clearInterval(poll);
       window.removeEventListener("online", onOnline);
-      // Leaving the screen mid-capture stops cleanly: every finalized segment is already durable,
-      // and stop() finalizes the open one before releasing the microphone.
-      const rec = recorderRef.current;
-      if (rec !== null) void rec.stop();
+      // Leaving the screen does NOT touch the capture - the session lives above the router and
+      // recording continues (the global recording banner keeps it visible). Only playback stops.
       const audio = audioRef.current;
       if (audio !== null) audio.pause();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Re-read the library whenever the session finalized, queued, or progressed an upload.
+  useEffect(() => {
+    void refreshLocal();
+    void refreshServer();
+  }, [session.libraryVersion, refreshLocal, refreshServer]);
+
   // The live tick: timer, level meter, segment count - only while capturing.
   useEffect(() => {
     if (phase !== "recording" && phase !== "paused") return;
     const t = setInterval(() => {
-      const rec = recorderRef.current;
-      if (rec === null) return;
-      setElapsedMs(rec.elapsedMs);
-      setSegmentCount(rec.segmentCount);
-      setLevel(rec.level());
+      setElapsedMs(recordingSession.elapsedMs());
+      setSegmentCount(recordingSession.segmentCount());
+      setLevel(recordingSession.level());
     }, TICK_MS);
     return () => clearInterval(t);
   }, [phase]);
 
-  const finalizeActive = useCallback(
-    async (recovered: boolean) => {
-      const rec = activeRef.current;
-      if (rec === null) return;
-      let queuedId: string | null = null;
-      const fresh = await getRecording(rec.recordingId);
-      if (fresh !== null) {
-        if (fresh.segments === 0) {
-          // Nothing was captured (stopped within the first second) - an empty recording can never
-          // pass the server's completeness gate, so it is removed rather than shown as sendable.
-          await deleteRecording(fresh.recordingId);
-        } else {
-          // Stop finalizes AND queues the upload - no Send step (the Android recorder's "uploaded
-          // automatically" bar, issue devthrottle_internal#966).
-          fresh.state = "queued";
-          fresh.endedAt = new Date().toISOString();
-          fresh.title = titleRef.current.trim() || fresh.title;
-          if (recovered) fresh.recovered = true;
-          await saveRecording(fresh);
-          queuedId = fresh.recordingId;
-        }
-      }
-      activeRef.current = null;
-      recorderRef.current = null;
-      setPhase("idle");
+  // Reset the displayed numbers when the capture ends (the tick above stops running).
+  useEffect(() => {
+    if (phase === "idle") {
       setElapsedMs(0);
       setSegmentCount(0);
       setLevel(0);
-      setActiveNotes([]);
-      setTitle("");
-      await refreshLocal();
-      if (queuedId !== null) {
-        void driveRecordingUpload(queuedId, () => void refreshLocal()).then(() => {
-          void refreshLocal();
-          void refreshServer();
-        });
-      }
-    },
-    [refreshLocal, refreshServer],
-  );
-
-  const startRecording = useCallback(async () => {
-    if (!storeOk) return;
-    setError(null);
-    setAutoStopped(false);
-    setPhase("starting");
-    const recordingId = crypto.randomUUID();
-    const rec: LocalRecording = {
-      recordingId,
-      title: titleRef.current.trim() || defaultTitle(),
-      deviceId: getInstallId(),
-      startedAt: new Date().toISOString(),
-      endedAt: null,
-      codec: "webm-opus",
-      sampleRateHz: 48000,
-      channels: 1,
-      state: "recording",
-      completed: false,
-      segments: 0,
-      durationMs: 0,
-      notes: [],
-      createdAt: Date.now(),
-    };
-    try {
-      // The durable shell exists BEFORE the microphone opens - from here on, every finalized
-      // segment lands in IndexedDB the moment the recorder rotates past it.
-      await saveRecording(rec);
-      activeRef.current = rec;
-      setTitle(rec.title);
-      setActiveNotes([]);
-
-      const recorder = new SegmentRecorder({
-        onSegment: async (seg) => {
-          const sha = await sha256Hex(seg.blob);
-          await saveChunk({
-            recordingId,
-            index: seg.index,
-            blob: seg.blob,
-            startMs: seg.startMs,
-            durationMs: seg.durationMs,
-            bytes: seg.blob.size,
-            sha256: sha,
-            uploaded: false,
-          });
-          const fresh = await getRecording(recordingId);
-          if (fresh !== null) {
-            fresh.segments = Math.max(fresh.segments, seg.index + 1);
-            fresh.durationMs += seg.durationMs;
-            fresh.title = titleRef.current.trim() || fresh.title;
-            await saveRecording(fresh);
-          }
-        },
-        onError: (message) => {
-          setError(`Recording stopped: ${message}`);
-          void finalizeActive(false);
-        },
-        onAutoStop: () => {
-          setAutoStopped(true);
-          void finalizeActive(false);
-        },
-      });
-      recorderRef.current = recorder;
-      await recorder.start();
-      // Now that the browser has chosen the container, stamp the real codec + sample rate.
-      rec.codec = recorder.codecLabel;
-      rec.sampleRateHz = recorder.sampleRateHz;
-      await saveRecording(rec);
-      setPhase("recording");
-    } catch (err) {
-      recorderRef.current?.dispose();
-      recorderRef.current = null;
-      activeRef.current = null;
-      await deleteRecording(recordingId);
-      setError(err instanceof Error ? err.message : String(err));
-      setPhase("idle");
-    }
-  }, [storeOk, finalizeActive]);
-
-  const pauseResume = useCallback(async () => {
-    const recorder = recorderRef.current;
-    if (recorder === null) return;
-    if (phase === "recording") {
-      await recorder.pause();
-      setPhase("paused");
-    } else if (phase === "paused") {
-      try {
-        await recorder.resume();
-        setPhase("recording");
-      } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
-      }
     }
   }, [phase]);
 
-  const stopRecording = useCallback(async () => {
-    const recorder = recorderRef.current;
-    if (recorder === null) return;
-    setPhase("stopping");
-    await recorder.stop();
-    await finalizeActive(false);
-  }, [finalizeActive]);
+  // Capture controls are thin wrappers over the app-level session, which owns the whole lifecycle
+  // (durable shell, segment persistence, finalize-and-queue-upload, truncation surfacing).
+  const startRecording = useCallback(() => recordingSession.start(), []);
+  const pauseResume = useCallback(
+    () => (phase === "paused" ? recordingSession.resume() : recordingSession.pause()),
+    [phase],
+  );
+  const stopRecording = useCallback(() => recordingSession.stop(), []);
+  const persistTitle = useCallback(() => recordingSession.persistTitle(), []);
 
   const addNote = useCallback(async () => {
-    const text = noteText.trim();
-    const recorder = recorderRef.current;
-    const active = activeRef.current;
-    if (text === "" || recorder === null || active === null) return;
-    const note = { tMs: Math.round(recorder.elapsedMs), text };
-    const fresh = await getRecording(active.recordingId);
-    if (fresh !== null) {
-      fresh.notes = [...fresh.notes, note];
-      await saveRecording(fresh);
-      setActiveNotes(fresh.notes);
-    }
+    await recordingSession.addNote(noteText);
     setNoteText("");
   }, [noteText]);
-
-  const persistTitle = useCallback(async () => {
-    const active = activeRef.current;
-    if (active === null) return;
-    const fresh = await getRecording(active.recordingId);
-    if (fresh !== null) {
-      fresh.title = titleRef.current.trim() || fresh.title;
-      await saveRecording(fresh);
-    }
-  }, []);
 
   // Manual retry for a PARKED (saved-and-retryable) row only - the happy path uploads by itself.
   const retryUpload = useCallback(
@@ -372,12 +226,11 @@ export function Recorder() {
       rec.lastError = undefined;
       await saveRecording(rec);
       await refreshLocal();
-      void driveRecordingUpload(recordingId, () => void refreshLocal()).then(() => {
-        void refreshLocal();
-        void refreshServer();
+      void driveRecordingUpload(recordingId, () => recordingSession.notifyLibraryChanged()).then(() => {
+        recordingSession.notifyLibraryChanged();
       });
     },
-    [refreshLocal, refreshServer],
+    [refreshLocal],
   );
 
   const discardRecording = useCallback(
@@ -440,7 +293,7 @@ export function Recorder() {
           cleanup();
           if (playTokenRef.current === token) {
             setPlayingId(null);
-            setError("Playback failed - this segment could not be decoded.");
+            setPlaybackError("Playback failed - this segment could not be decoded.");
           }
         };
         void audio.play().catch(() => {
@@ -478,7 +331,6 @@ export function Recorder() {
   ].sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
 
   const recording = phase === "recording" || phase === "paused";
-  const remainingMs = Math.max(0, MAX_RECORDING_MS - elapsedMs);
 
   return (
     <div className="screen">
@@ -502,9 +354,9 @@ export function Recorder() {
         </div>
       )}
 
-      {autoStopped && (
-        <div className="banner rec-banner-info" role="status">
-          Recording reached the 30 minute limit and was stopped. Everything captured is saved below.
+      {playbackError !== null && (
+        <div className="banner banner-error" role="alert">
+          {playbackError}
         </div>
       )}
 
@@ -520,7 +372,6 @@ export function Recorder() {
         </div>
         <div className="rec-segments">
           {segmentCount} segment{segmentCount === 1 ? "" : "s"} captured
-          {recording && remainingMs < 5 * 60_000 && ` - ${formatDuration(remainingMs)} left`}
         </div>
         <div className="rec-level" aria-hidden="true">
           <div className="rec-level-fill" style={{ width: `${Math.round(level * 100)}%` }} />
@@ -532,10 +383,19 @@ export function Recorder() {
         type="text"
         placeholder="Title (optional, edit anytime until you stop)"
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => recordingSession.setTitle(e.target.value)}
         onBlur={() => void persistTitle()}
         disabled={phase === "stopping"}
       />
+
+      {recording && (
+        <div className="rec-section-hint">
+          There is no time limit - recording continues while you use the rest of the app, and the
+          red bar up top shows it is live. Keep the screen on: if the phone locks or the browser
+          suspends the page, the microphone is cut - the recording then stops, saves everything
+          captured, and says here that it was cut short.
+        </div>
+      )}
 
       {!recording ? (
         <button
@@ -653,6 +513,11 @@ export function Recorder() {
               {l !== undefined && l.state === "retry" && (
                 <div className="rec-row-err">
                   {l.lastError ?? "Send failed - the recording is saved on this phone and will be retried."}
+                </div>
+              )}
+              {l?.interrupted !== undefined && (
+                <div className="rec-row-err">
+                  Cut short: {l.interrupted}
                 </div>
               )}
               {transcribeFailed && (

--- a/apps/mobile/src/pages/Recorder.tsx
+++ b/apps/mobile/src/pages/Recorder.tsx
@@ -226,9 +226,10 @@ export function Recorder() {
       rec.lastError = undefined;
       await saveRecording(rec);
       await refreshLocal();
-      void driveRecordingUpload(recordingId, () => recordingSession.notifyLibraryChanged()).then(() => {
-        recordingSession.notifyLibraryChanged();
-      });
+      void driveRecordingUpload(recordingId, () => recordingSession.notifyLibraryChanged()).then(
+        () => recordingSession.notifyLibraryChanged(),
+        () => recordingSession.notifyLibraryChanged(),
+      );
     },
     [refreshLocal],
   );
@@ -256,6 +257,7 @@ export function Recorder() {
   const playRecording = useCallback(
     async (row: LibraryRow) => {
       stopPlayback();
+      setPlaybackError(null);
       const token = ++playTokenRef.current;
       const audio = audioRef.current ?? new Audio();
       audioRef.current = audio;
@@ -359,7 +361,10 @@ export function Recorder() {
 
       {playbackError !== null && (
         <div className="banner banner-error" role="alert">
-          {playbackError}
+          {playbackError}{" "}
+          <button type="button" className="rec-row-btn" onClick={() => setPlaybackError(null)}>
+            Dismiss
+          </button>
         </div>
       )}
 

--- a/apps/mobile/src/pages/Recorder.tsx
+++ b/apps/mobile/src/pages/Recorder.tsx
@@ -350,7 +350,10 @@ export function Recorder() {
 
       {error !== null && (
         <div className="banner banner-error" role="alert">
-          {error}
+          {error}{" "}
+          <button type="button" className="rec-row-btn" onClick={() => recordingSession.clearError()}>
+            Dismiss
+          </button>
         </div>
       )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -21,7 +21,7 @@
      whichever bar it did not account for. The screens that are pinned out of the document flow
      (.terminal-screen) cannot be pushed down by anything rendered above them, so they
      read this directly; the screens in normal flow are pushed by body's padding-top below. */
-  --topbars-h: calc(var(--connbanner-h, 0px) + var(--voicemode-h, 0px));
+  --topbars-h: calc(var(--connbanner-h, 0px) + var(--voicemode-h, 0px) + var(--recbanner-h, 0px));
 }
 
 * {
@@ -2502,6 +2502,74 @@ a.banner-btn {
 .voicemode-off:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+/* The recording banner (recorder-unlimited-capture mission): on every screen while a recording is
+   live, exactly as the voice-mode banner is on every screen while the fleet narrates. The whole bar
+   is one button - its job is "glance, and tap to get back to Stop". Parks below the other two bars
+   and publishes --recbanner-h into --topbars-h so the pinned screens give up its height too. */
+.recbanner {
+  position: sticky;
+  top: calc(var(--connbanner-h, 0px) + var(--voicemode-h, 0px));
+  z-index: 6;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 9px 14px;
+  border: none;
+  border-bottom: 1px solid #7f2d33;
+  background: #331116;
+  color: #fadfe1;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.recbanner-dot {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e5484d;
+  animation: recbanner-pulse 1.6s ease-in-out infinite;
+}
+
+/* Paused is amber and still - a pulsing red dot over a paused capture would claim audio is being
+   captured when none is. The indicator must tell the truth at a glance. */
+.recbanner-dot-paused {
+  background: #e8b339;
+  animation: none;
+}
+
+@keyframes recbanner-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.recbanner-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.recbanner-open {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: #7f2d33;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
 }
 
 /* The standing statement of what this tab does to the fleet: every session on the Gateway is a voice

--- a/packages/client-core/src/recorder/recordingSession.ts
+++ b/packages/client-core/src/recorder/recordingSession.ts
@@ -30,6 +30,7 @@ import { SegmentRecorder } from "./segmentRecorder";
 import {
   deleteRecording,
   getRecording,
+  listChunks,
   recordingStoreAvailable,
   saveChunk,
   saveRecording,
@@ -103,25 +104,64 @@ function owns(recordingId: string): boolean {
   return active !== null && active.recordingId === recordingId;
 }
 
-/** Finalize the active capture into the automatic upload path. Runs at most once per capture.
- *  interruptedReason is null for a user stop; for a system stop it is recorded on the row AND as a
- *  timestamped note, which rides the complete call into the transcript - so the truncation stays
- *  visible after the delivered local row is deleted. */
-async function finalizeActive(interruptedReason: string | null): Promise<void> {
-  const rec = active;
-  if (rec === null || finalized === rec.recordingId) return;
-  finalized = rec.recordingId;
+// The lease heartbeat: touch the header's updatedAt every minute in EVERY non-idle phase, so
+// another tab's recovery never mistakes a paused capture (no segment rotations) or a long start
+// (permission prompt left open) for an orphan. Segment writes also refresh it; this covers the
+// quiet phases.
+let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+function startHeartbeat(recordingId: string): void {
+  stopHeartbeat();
+  heartbeat = setInterval(() => {
+    if (!owns(recordingId)) {
+      stopHeartbeat();
+      return;
+    }
+    void chainHeaderWrite(async () => {
+      if (!owns(recordingId) || finalized === recordingId) return;
+      const fresh = await getRecording(recordingId);
+      if (fresh === null || fresh.state !== "recording") return;
+      fresh.updatedAt = Date.now();
+      await saveRecording(fresh);
+    }).catch(() => {
+      /* a missed heartbeat is recovered by the next one; recovery needs three minutes of silence */
+    });
+  }, 60_000);
+}
+
+function stopHeartbeat(): void {
+  if (heartbeat !== null) {
+    clearInterval(heartbeat);
+    heartbeat = null;
+  }
+}
+
+/** Finalize ONE SPECIFIC capture into the automatic upload path. Keyed to the recording id and run
+ *  at most once per capture: a stale continuation from an earlier capture can never finalize a
+ *  newer one. The header is reconciled from the chunks actually on disk, so a transient header
+ *  write failure during capture can neither make a real recording look empty (and get deleted) nor
+ *  under-count its segments. interruptedReason is null for a user stop; for a system stop it is
+ *  recorded on the row AND as a timestamped note, which rides the complete call into the
+ *  transcript - so the truncation stays visible after the delivered local row is deleted. */
+async function finalizeActive(recordingId: string, interruptedReason: string | null): Promise<void> {
+  if (!owns(recordingId) || finalized === recordingId) return;
+  finalized = recordingId;
+  stopHeartbeat();
   let queuedId: string | null = null;
   try {
     await chainHeaderWrite(async () => {
-      const fresh = await getRecording(rec.recordingId);
+      const fresh = await getRecording(recordingId);
       if (fresh === null) return;
-      if (fresh.segments === 0) {
+      // Reconcile from disk, not from the header's own counters: the chunks are the truth.
+      const chunks = await listChunks(recordingId);
+      if (chunks.length === 0) {
         // Nothing was captured (stopped within the first second) - an empty recording can never
         // pass the server's completeness gate, so it is removed rather than shown as sendable.
-        await deleteRecording(fresh.recordingId);
+        await deleteRecording(recordingId);
         return;
       }
+      fresh.segments = chunks.reduce((max, c) => Math.max(max, c.index + 1), 0);
+      fresh.durationMs = chunks.reduce((sum, c) => sum + c.durationMs, 0);
       // Stop finalizes AND queues the upload - no Send step (the Android recorder's "uploaded
       // automatically" bar, issue devthrottle_internal#966).
       fresh.state = "queued";
@@ -142,8 +182,10 @@ async function finalizeActive(interruptedReason: string | null): Promise<void> {
     // and recovery will pick the row up on the next open; what must NOT happen is a lying UI.
     emit({ error: `The recording could not be finalized: ${err instanceof Error ? err.message : String(err)}` });
   } finally {
-    active = null;
-    recorder = null;
+    if (owns(recordingId)) {
+      active = null;
+      recorder = null;
+    }
     emit({ phase: "idle", recordingId: null, title: "", notes: [] });
     bumpLibrary();
   }
@@ -156,14 +198,15 @@ async function finalizeActive(interruptedReason: string | null): Promise<void> {
   }
 }
 
-/** The capture died under us (persist failure or the system suspending the microphone). Surface it
- *  and finalize what exists - the recording keeps everything captured and says it was cut short.
- *  The phase flips to "stopping" IMMEDIATELY so the banner never pulses "Recording" over a dead
- *  microphone, and so a user Stop pressed during this finalize is a harmless no-op. */
-function handleCaptureLoss(message: string): void {
-  if (active === null || finalized === active.recordingId) return;
+/** The capture died under us (persist failure or the system suspending the microphone). Keyed to
+ *  the recorder INSTANCE that reported it, so a late error from an already-replaced capture is
+ *  ignored. Surfaces the loss and finalizes what exists - the recording keeps everything captured
+ *  and says it was cut short. The phase flips to "stopping" IMMEDIATELY so the banner never pulses
+ *  "Recording" over a dead microphone, and a user Stop pressed during this finalize is a no-op. */
+function handleCaptureLoss(from: SegmentRecorder, recordingId: string, message: string): void {
+  if (recorder !== from || !owns(recordingId) || finalized === recordingId) return;
   emit({ phase: "stopping", error: `Recording stopped: ${message}` });
-  void finalizeActive(message).catch(() => {
+  void finalizeActive(recordingId, message).catch(() => {
     // finalizeActive contains its own failure handling; this guard only prevents an unhandled
     // rejection from a double-failure.
   });
@@ -256,42 +299,55 @@ export const recordingSession = {
           });
         },
         onError: (message) => {
-          handleCaptureLoss(message);
+          handleCaptureLoss(r, recordingId, message);
         },
       });
       recorder = r;
+      startHeartbeat(recordingId);
       await r.start();
-      // The microphone can die during the await above (handleCaptureLoss finalizes and clears the
-      // session). A stale continuation must not resurrect the row or claim to be recording.
-      if (!owns(recordingId) || recorder !== r) return;
+      // The microphone can die during the await above (handleCaptureLoss flips the phase and
+      // finalizes). A stale continuation must not resurrect the row or claim to be recording, so
+      // every guard is re-checked after every await - including the phase and the finalize marker.
+      const stillStarting = () =>
+        owns(recordingId) && recorder === r && finalized !== recordingId && state.phase === "starting";
+      if (!stillStarting()) return;
       // Now that the browser has chosen the container, stamp the real codec + sample rate.
       await chainHeaderWrite(async () => {
+        if (!owns(recordingId) || finalized === recordingId) return;
         const fresh = await getRecording(recordingId);
         if (fresh === null) return;
         fresh.codec = r.codecLabel;
         fresh.sampleRateHz = r.sampleRateHz;
         await saveRecording(fresh);
       });
-      if (!owns(recordingId) || recorder !== r) return;
+      if (!stillStarting()) return;
       emit({ phase: "recording" });
     } catch (err) {
       // Only unwind a capture this continuation still owns - a concurrent loss handler may have
       // already salvaged and finalized it, and deleting the row out from under that would lose it.
-      if (owns(recordingId) || active === null) {
+      const owned = owns(recordingId);
+      if (owned) {
         recorder?.dispose();
         recorder = null;
         active = null;
+        stopHeartbeat();
         try {
           if (finalized !== recordingId) await deleteRecording(recordingId);
         } catch {
           /* the row stays; recovery on next open cleans an empty shell */
         }
       }
-      emit({
-        phase: "idle",
-        recordingId: null,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      // Do not clobber the state of a capture this continuation no longer owns; the finalizer that
+      // took over already emitted the truthful state. Surface the start error either way.
+      if (owned || state.recordingId === recordingId || state.recordingId === null) {
+        emit({
+          phase: "idle",
+          recordingId: null,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      } else {
+        emit({ error: err instanceof Error ? err.message : String(err) });
+      }
     }
   },
 
@@ -300,9 +356,15 @@ export const recordingSession = {
     const r = recorder;
     if (r === null || state.phase !== "recording") return;
     const id = state.recordingId;
-    await r.pause();
-    // A stop or loss that landed during the await owns the phase now.
-    if (recorder === r && id !== null && owns(id) && state.phase === "recording") emit({ phase: "paused" });
+    try {
+      await r.pause();
+      // A stop or loss that landed during the await owns the phase now.
+      if (recorder === r && id !== null && owns(id) && state.phase === "recording") emit({ phase: "paused" });
+    } catch (err) {
+      if (recorder === r && id !== null && owns(id)) {
+        emit({ error: err instanceof Error ? err.message : String(err) });
+      }
+    }
   },
 
   /** Resume a paused capture. A failed microphone reopen surfaces as error; capture stays paused. */
@@ -314,7 +376,10 @@ export const recordingSession = {
       await r.resume();
       if (recorder === r && id !== null && owns(id) && state.phase === "paused") emit({ phase: "recording" });
     } catch (err) {
-      emit({ error: err instanceof Error ? err.message : String(err) });
+      // A late rejection from a capture that already ended must not raise a false alarm.
+      if (recorder === r && id !== null && owns(id)) {
+        emit({ error: err instanceof Error ? err.message : String(err) });
+      }
     }
   },
 
@@ -322,14 +387,22 @@ export const recordingSession = {
    *  is already in flight is a no-op (that finalize owns the ending). */
   async stop(): Promise<void> {
     const r = recorder;
-    if (r === null || (state.phase !== "recording" && state.phase !== "paused")) return;
+    const id = state.recordingId;
+    if (r === null || id === null || (state.phase !== "recording" && state.phase !== "paused")) return;
     emit({ phase: "stopping" });
+    let flushFailure: string | null = null;
     try {
       await r.stop();
-    } catch {
-      // The recorder is already dead; finalize still queues everything that reached disk.
+    } catch (err) {
+      // The final flush failed: everything already rotated to disk still uploads, but this must
+      // not present as a clean stop - the tail of the audio may be missing.
+      flushFailure =
+        "the final part of the recording could not be saved (" +
+        (err instanceof Error ? err.message : String(err)) +
+        ")";
+      emit({ error: `Recording stopped: ${flushFailure}` });
     }
-    await finalizeActive(null);
+    await finalizeActive(id, flushFailure);
   },
 
   /** Update the working title (editable until stop). Persisted via persistTitle / at finalize. */

--- a/packages/client-core/src/recorder/recordingSession.ts
+++ b/packages/client-core/src/recorder/recordingSession.ts
@@ -1,0 +1,293 @@
+// The app-level recording session (recorder-unlimited-capture mission). Exactly one capture can be
+// live per app instance, and it must SURVIVE IN-APP NAVIGATION: the SegmentRecorder used to be
+// constructed inside the Recorder PAGE component, so leaving the page - to check a session, use
+// voice mode, anything - unmounted the page and stopped the recording. During an all-day conference
+// that is fatal. The session lives here, at module scope, above the router: the Recorder page and
+// the global recording indicator both subscribe to it, and navigation neither creates nor destroys
+// it.
+//
+// Everything the capture lifecycle needs is owned here - the SegmentRecorder, the active
+// LocalRecording header, the title as edited so far, the notes, and the finalize-and-queue-upload
+// step. Pages read a snapshot via useRecordingSession() (useSyncExternalStore) and poll the live
+// numbers (elapsed, level, segment count) on their own display ticks, exactly as the page previously
+// polled its local recorder.
+//
+// What a PWA honestly cannot promise: capture through a locked screen. The app holds a screen wake
+// lock while foregrounded (useScreenWakeLock), which keeps the screen - and therefore capture -
+// alive; but if the phone does lock or the browser suspends the page, the microphone track ends,
+// the SegmentRecorder salvages and stops, and the recording is finalized here with `interrupted`
+// set so the library says plainly it was cut short. Truncation is surfaced, never hidden.
+
+import { useSyncExternalStore } from "react";
+import { SegmentRecorder } from "./segmentRecorder";
+import {
+  deleteRecording,
+  getRecording,
+  recordingStoreAvailable,
+  saveChunk,
+  saveRecording,
+  type LocalNote,
+  type LocalRecording,
+} from "./recordingStore";
+import { driveRecordingUpload, sha256Hex } from "./ingestUpload";
+import { getInstallId } from "../auth/deviceKey";
+
+export type RecordingPhase = "idle" | "starting" | "recording" | "paused" | "stopping";
+
+export interface RecordingSessionState {
+  phase: RecordingPhase;
+  /** The live capture's recording id; null when idle. */
+  recordingId: string | null;
+  /** The title as edited so far (editable until stop; the value at stop wins). */
+  title: string;
+  /** Notes typed during the live capture, in the order they were added. */
+  notes: LocalNote[];
+  /** A capture failure or system stop, in plain English. Cleared when the next capture starts. */
+  error: string | null;
+  /** Bumped whenever the local recording library changed (finalized, queued, upload progressed) so
+   *  list screens know to re-read it without owning the lifecycle. */
+  libraryVersion: number;
+}
+
+let recorder: SegmentRecorder | null = null;
+let active: LocalRecording | null = null;
+let state: RecordingSessionState = {
+  phase: "idle",
+  recordingId: null,
+  title: "",
+  notes: [],
+  error: null,
+  libraryVersion: 0,
+};
+const listeners = new Set<() => void>();
+
+function emit(patch: Partial<RecordingSessionState>): void {
+  state = { ...state, ...patch };
+  for (const l of listeners) l();
+}
+
+function bumpLibrary(): void {
+  emit({ libraryVersion: state.libraryVersion + 1 });
+}
+
+function defaultTitle(): string {
+  return `Recording ${new Date().toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}`;
+}
+
+/** Finalize the active capture into the automatic upload path. interruptedReason is null for a
+ *  user stop; for a system stop it is recorded on the row so a cut-off recording says so. */
+async function finalizeActive(interruptedReason: string | null): Promise<void> {
+  const rec = active;
+  if (rec === null) return;
+  let queuedId: string | null = null;
+  const fresh = await getRecording(rec.recordingId);
+  if (fresh !== null) {
+    if (fresh.segments === 0) {
+      // Nothing was captured (stopped within the first second) - an empty recording can never pass
+      // the server's completeness gate, so it is removed rather than shown as sendable.
+      await deleteRecording(fresh.recordingId);
+    } else {
+      // Stop finalizes AND queues the upload - no Send step (the Android recorder's "uploaded
+      // automatically" bar, issue devthrottle_internal#966).
+      fresh.state = "queued";
+      fresh.endedAt = new Date().toISOString();
+      fresh.title = state.title.trim() || fresh.title;
+      if (interruptedReason !== null) fresh.interrupted = interruptedReason;
+      await saveRecording(fresh);
+      queuedId = fresh.recordingId;
+    }
+  }
+  active = null;
+  recorder = null;
+  emit({ phase: "idle", recordingId: null, title: "", notes: [] });
+  bumpLibrary();
+  if (queuedId !== null) {
+    void driveRecordingUpload(queuedId, () => bumpLibrary()).then(() => bumpLibrary());
+  }
+}
+
+/** The capture died under us (persist failure or the system suspending the microphone). Surface it
+ *  and finalize what exists - the recording keeps everything captured and says it was cut short. */
+async function handleCaptureLoss(message: string): Promise<void> {
+  emit({ error: `Recording stopped: ${message}` });
+  await finalizeActive(message);
+}
+
+export const recordingSession = {
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getState(): RecordingSessionState {
+    return state;
+  },
+
+  // Live display numbers - polled by UI ticks, deliberately not part of the snapshot (they change
+  // every frame and would make every subscriber re-render continuously).
+  elapsedMs(): number {
+    return recorder?.elapsedMs ?? 0;
+  },
+  segmentCount(): number {
+    return recorder?.segmentCount ?? 0;
+  },
+  level(): number {
+    return recorder?.level() ?? 0;
+  },
+  isCapturing(): boolean {
+    return state.phase === "recording" || state.phase === "paused";
+  },
+
+  /** Begin a new capture. No-op unless idle. Unlimited by design - no maxDurationMs is passed. */
+  async start(): Promise<void> {
+    if (state.phase !== "idle") return;
+    if (!recordingStoreAvailable()) {
+      emit({ error: "This browser cannot store recordings durably (no IndexedDB)." });
+      return;
+    }
+    emit({ error: null, phase: "starting" });
+    const recordingId = crypto.randomUUID();
+    const rec: LocalRecording = {
+      recordingId,
+      title: state.title.trim() || defaultTitle(),
+      deviceId: getInstallId(),
+      startedAt: new Date().toISOString(),
+      endedAt: null,
+      codec: "webm-opus",
+      sampleRateHz: 48000,
+      channels: 1,
+      state: "recording",
+      completed: false,
+      segments: 0,
+      durationMs: 0,
+      notes: [],
+      createdAt: Date.now(),
+    };
+    try {
+      // The durable shell exists BEFORE the microphone opens - from here on, every finalized
+      // segment lands in IndexedDB the moment the recorder rotates past it.
+      await saveRecording(rec);
+      active = rec;
+      emit({ recordingId, title: rec.title, notes: [] });
+
+      const r = new SegmentRecorder({
+        onSegment: async (seg) => {
+          const sha = await sha256Hex(seg.blob);
+          await saveChunk({
+            recordingId,
+            index: seg.index,
+            blob: seg.blob,
+            startMs: seg.startMs,
+            durationMs: seg.durationMs,
+            bytes: seg.blob.size,
+            sha256: sha,
+            uploaded: false,
+          });
+          const fresh = await getRecording(recordingId);
+          if (fresh !== null) {
+            fresh.segments = Math.max(fresh.segments, seg.index + 1);
+            fresh.durationMs += seg.durationMs;
+            fresh.title = state.title.trim() || fresh.title;
+            await saveRecording(fresh);
+          }
+        },
+        onError: (message) => {
+          void handleCaptureLoss(message);
+        },
+      });
+      recorder = r;
+      await r.start();
+      // Now that the browser has chosen the container, stamp the real codec + sample rate.
+      rec.codec = r.codecLabel;
+      rec.sampleRateHz = r.sampleRateHz;
+      await saveRecording(rec);
+      emit({ phase: "recording" });
+    } catch (err) {
+      recorder?.dispose();
+      recorder = null;
+      active = null;
+      await deleteRecording(recordingId);
+      emit({
+        phase: "idle",
+        recordingId: null,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+
+  /** Pause capture (finalizes the open segment and releases the microphone - the honest signal). */
+  async pause(): Promise<void> {
+    const r = recorder;
+    if (r === null || state.phase !== "recording") return;
+    await r.pause();
+    emit({ phase: "paused" });
+  },
+
+  /** Resume a paused capture. A failed microphone reopen surfaces as error; capture stays paused. */
+  async resume(): Promise<void> {
+    const r = recorder;
+    if (r === null || state.phase !== "paused") return;
+    try {
+      await r.resume();
+      emit({ phase: "recording" });
+    } catch (err) {
+      emit({ error: err instanceof Error ? err.message : String(err) });
+    }
+  },
+
+  /** Stop and finalize: the recording is queued for automatic upload. */
+  async stop(): Promise<void> {
+    const r = recorder;
+    if (r === null || (state.phase !== "recording" && state.phase !== "paused")) return;
+    emit({ phase: "stopping" });
+    await r.stop();
+    await finalizeActive(null);
+  },
+
+  /** Update the working title (editable until stop). Persisted via persistTitle / at finalize. */
+  setTitle(title: string): void {
+    emit({ title });
+  },
+
+  /** Write the working title through to the durable header row (e.g. on input blur). */
+  async persistTitle(): Promise<void> {
+    const rec = active;
+    if (rec === null) return;
+    const fresh = await getRecording(rec.recordingId);
+    if (fresh !== null) {
+      fresh.title = state.title.trim() || fresh.title;
+      await saveRecording(fresh);
+    }
+  },
+
+  /** Attach a timestamped note to the live capture. Persisted immediately. */
+  async addNote(text: string): Promise<void> {
+    const trimmed = text.trim();
+    const r = recorder;
+    const rec = active;
+    if (trimmed === "" || r === null || rec === null) return;
+    const note: LocalNote = { tMs: Math.round(r.elapsedMs), text: trimmed };
+    const fresh = await getRecording(rec.recordingId);
+    if (fresh !== null) {
+      fresh.notes = [...fresh.notes, note];
+      await saveRecording(fresh);
+      emit({ notes: fresh.notes });
+    }
+  },
+
+  /** Clear a surfaced capture error (the library row keeps its own interrupted marker). */
+  clearError(): void {
+    emit({ error: null });
+  },
+
+  /** List screens call this after their own store writes (retry, discard) so every other
+   *  subscriber re-reads the library too. */
+  notifyLibraryChanged(): void {
+    bumpLibrary();
+  },
+};
+
+/** React subscription to the session snapshot. Live numbers (elapsed, level, segment count) are
+ *  polled from recordingSession on a display tick instead - see the snapshot's field docs. */
+export function useRecordingSession(): RecordingSessionState {
+  return useSyncExternalStore(recordingSession.subscribe, recordingSession.getState, recordingSession.getState);
+}

--- a/packages/client-core/src/recorder/recordingSession.ts
+++ b/packages/client-core/src/recorder/recordingSession.ts
@@ -182,11 +182,17 @@ async function finalizeActive(recordingId: string, interruptedReason: string | n
     // and recovery will pick the row up on the next open; what must NOT happen is a lying UI.
     emit({ error: `The recording could not be finalized: ${err instanceof Error ? err.message : String(err)}` });
   } finally {
-    if (owns(recordingId)) {
+    // Only reset session state this finalizer still owns: a new capture may have legitimately
+    // begun (start() refuses while non-idle, but a stale catch could have force-idled the phase),
+    // and its state must never be clobbered by an older capture's finalizer.
+    const owned = owns(recordingId);
+    if (owned) {
       active = null;
       recorder = null;
     }
-    emit({ phase: "idle", recordingId: null, title: "", notes: [] });
+    if (owned || state.recordingId === recordingId) {
+      emit({ phase: "idle", recordingId: null, title: "", notes: [] });
+    }
     bumpLibrary();
   }
   if (queuedId !== null) {
@@ -248,6 +254,8 @@ export const recordingSession = {
     }
     emit({ error: null, phase: "starting" });
     const recordingId = crypto.randomUUID();
+    let r: SegmentRecorder | null = null;
+    let registered = false;
     const rec: LocalRecording = {
       recordingId,
       title: state.title.trim() || defaultTitle(),
@@ -270,10 +278,11 @@ export const recordingSession = {
       // segment lands in IndexedDB the moment the recorder rotates past it.
       await saveRecording(rec);
       active = rec;
+      registered = true;
       finalized = null;
       emit({ recordingId, title: rec.title, notes: [] });
 
-      const r = new SegmentRecorder({
+      const rr = new SegmentRecorder({
         onSegment: async (seg) => {
           const sha = await sha256Hex(seg.blob);
           await saveChunk({
@@ -299,55 +308,59 @@ export const recordingSession = {
           });
         },
         onError: (message) => {
-          handleCaptureLoss(r, recordingId, message);
+          handleCaptureLoss(rr, recordingId, message);
         },
       });
-      recorder = r;
+      r = rr;
+      recorder = rr;
       startHeartbeat(recordingId);
-      await r.start();
+      await rr.start();
       // The microphone can die during the await above (handleCaptureLoss flips the phase and
       // finalizes). A stale continuation must not resurrect the row or claim to be recording, so
       // every guard is re-checked after every await - including the phase and the finalize marker.
       const stillStarting = () =>
-        owns(recordingId) && recorder === r && finalized !== recordingId && state.phase === "starting";
+        owns(recordingId) && recorder === rr && finalized !== recordingId && state.phase === "starting";
       if (!stillStarting()) return;
       // Now that the browser has chosen the container, stamp the real codec + sample rate.
       await chainHeaderWrite(async () => {
         if (!owns(recordingId) || finalized === recordingId) return;
         const fresh = await getRecording(recordingId);
         if (fresh === null) return;
-        fresh.codec = r.codecLabel;
-        fresh.sampleRateHz = r.sampleRateHz;
+        fresh.codec = rr.codecLabel;
+        fresh.sampleRateHz = rr.sampleRateHz;
         await saveRecording(fresh);
       });
       if (!stillStarting()) return;
       emit({ phase: "recording" });
     } catch (err) {
-      // Only unwind a capture this continuation still owns - a concurrent loss handler may have
-      // already salvaged and finalized it, and deleting the row out from under that would lose it.
-      const owned = owns(recordingId);
-      if (owned) {
-        recorder?.dispose();
-        recorder = null;
-        active = null;
-        stopHeartbeat();
-        try {
-          if (finalized !== recordingId) await deleteRecording(recordingId);
-        } catch {
-          /* the row stays; recovery on next open cleans an empty shell */
-        }
+      const msg = err instanceof Error ? err.message : String(err);
+      // Failed before the session held anything: nothing to unwind, just report honestly.
+      if (!registered) {
+        emit({ phase: "idle", recordingId: null, error: msg });
+        return;
       }
-      // Do not clobber the state of a capture this continuation no longer owns; the finalizer that
-      // took over already emitted the truthful state. Surface the start error either way.
-      if (owned || state.recordingId === recordingId || state.recordingId === null) {
-        emit({
-          phase: "idle",
-          recordingId: null,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      } else {
-        emit({ error: err instanceof Error ? err.message : String(err) });
+      // Unwind ONLY a capture this continuation provably still owns, with no loss-finalizer in
+      // flight. Anything else is a stale failure: the finalizer that took over already emitted the
+      // truthful state, and touching the session here could clobber a newer capture (the reviewer's
+      // A-fails-while-B-starts race).
+      // Read the phase through the getter: the guard at the top of start() narrowed state.phase to
+      // "idle" in the compiler's eyes, and emit() reassignments do not reset that narrowing here.
+      const stillMine =
+        owns(recordingId) &&
+        recorder === r &&
+        finalized !== recordingId &&
+        recordingSession.getState().phase === "starting";
+      if (!stillMine) return;
+      r?.dispose();
+      recorder = null;
+      active = null;
+      stopHeartbeat();
+      try {
+        await deleteRecording(recordingId);
+      } catch {
+        /* the row stays; recovery on next open cleans an empty shell */
       }
+      emit({ phase: "idle", recordingId: null, error: msg });
     }
   },
 

--- a/packages/client-core/src/recorder/recordingSession.ts
+++ b/packages/client-core/src/recorder/recordingSession.ts
@@ -6,17 +6,24 @@
 // the global recording indicator both subscribe to it, and navigation neither creates nor destroys
 // it.
 //
-// Everything the capture lifecycle needs is owned here - the SegmentRecorder, the active
-// LocalRecording header, the title as edited so far, the notes, and the finalize-and-queue-upload
-// step. Pages read a snapshot via useRecordingSession() (useSyncExternalStore) and poll the live
-// numbers (elapsed, level, segment count) on their own display ticks, exactly as the page previously
-// polled its local recorder.
+// Concurrency discipline (the reviewer's findings, all applied):
+//   - Every mutation of the durable header row goes through ONE serialized queue (headerChain), so
+//     a title blur racing a stop, or a note racing a rotation, cannot overwrite each other's
+//     read-modify-write.
+//   - Finalization is keyed to the capture's recordingId and runs at most once per capture: a Stop
+//     pressed while a microphone-loss finalize is in flight is a no-op, and a stale continuation
+//     from an already-finalized capture can neither emit "recording" nor resurrect deleted rows.
+//   - Failure paths land in a truthful state: a storage failure during stop still releases the
+//     recorder, still surfaces the error, and never leaves the banner claiming a live capture.
 //
 // What a PWA honestly cannot promise: capture through a locked screen. The app holds a screen wake
 // lock while foregrounded (useScreenWakeLock), which keeps the screen - and therefore capture -
 // alive; but if the phone does lock or the browser suspends the page, the microphone track ends,
-// the SegmentRecorder salvages and stops, and the recording is finalized here with `interrupted`
-// set so the library says plainly it was cut short. Truncation is surfaced, never hidden.
+// the SegmentRecorder salvages and stops, and the recording is finalized here as cut short. The
+// reason is written BOTH on the local row (`interrupted`) and as a timestamped NOTE on the
+// recording itself - notes ride the complete call to the Gateway and into the transcript, so the
+// truncation stays visible even after the local row is delivered and deleted. Truncation is
+// surfaced, never hidden.
 
 import { useSyncExternalStore } from "react";
 import { SegmentRecorder } from "./segmentRecorder";
@@ -42,7 +49,8 @@ export interface RecordingSessionState {
   title: string;
   /** Notes typed during the live capture, in the order they were added. */
   notes: LocalNote[];
-  /** A capture failure or system stop, in plain English. Cleared when the next capture starts. */
+  /** A capture failure or system stop, in plain English. Sticks until dismissed or the next
+   *  capture starts, so a loss that happened on another screen is still seen. */
   error: string | null;
   /** Bumped whenever the local recording library changed (finalized, queued, upload progressed) so
    *  list screens know to re-read it without owning the lifecycle. */
@@ -51,6 +59,8 @@ export interface RecordingSessionState {
 
 let recorder: SegmentRecorder | null = null;
 let active: LocalRecording | null = null;
+/** The recordingId whose finalize has begun - each capture finalizes at most once. */
+let finalized: string | null = null;
 let state: RecordingSessionState = {
   phase: "idle",
   recordingId: null,
@@ -74,43 +84,89 @@ function defaultTitle(): string {
   return `Recording ${new Date().toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}`;
 }
 
-/** Finalize the active capture into the automatic upload path. interruptedReason is null for a
- *  user stop; for a system stop it is recorded on the row so a cut-off recording says so. */
+// ONE serialized queue for every durable-header mutation (title, notes, per-segment counters,
+// finalize). Read-modify-write on the same IndexedDB row from concurrent async paths is how a late
+// title save used to be able to erase a stop's endedAt. The chain survives a failed step; the
+// failure surfaces to that step's caller only.
+let headerChain: Promise<void> = Promise.resolve();
+function chainHeaderWrite<T>(work: () => Promise<T>): Promise<T> {
+  const next = headerChain.then(work);
+  headerChain = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+/** True while this capture (by id) is still the live one - stale continuations must not write. */
+function owns(recordingId: string): boolean {
+  return active !== null && active.recordingId === recordingId;
+}
+
+/** Finalize the active capture into the automatic upload path. Runs at most once per capture.
+ *  interruptedReason is null for a user stop; for a system stop it is recorded on the row AND as a
+ *  timestamped note, which rides the complete call into the transcript - so the truncation stays
+ *  visible after the delivered local row is deleted. */
 async function finalizeActive(interruptedReason: string | null): Promise<void> {
   const rec = active;
-  if (rec === null) return;
+  if (rec === null || finalized === rec.recordingId) return;
+  finalized = rec.recordingId;
   let queuedId: string | null = null;
-  const fresh = await getRecording(rec.recordingId);
-  if (fresh !== null) {
-    if (fresh.segments === 0) {
-      // Nothing was captured (stopped within the first second) - an empty recording can never pass
-      // the server's completeness gate, so it is removed rather than shown as sendable.
-      await deleteRecording(fresh.recordingId);
-    } else {
+  try {
+    await chainHeaderWrite(async () => {
+      const fresh = await getRecording(rec.recordingId);
+      if (fresh === null) return;
+      if (fresh.segments === 0) {
+        // Nothing was captured (stopped within the first second) - an empty recording can never
+        // pass the server's completeness gate, so it is removed rather than shown as sendable.
+        await deleteRecording(fresh.recordingId);
+        return;
+      }
       // Stop finalizes AND queues the upload - no Send step (the Android recorder's "uploaded
       // automatically" bar, issue devthrottle_internal#966).
       fresh.state = "queued";
       fresh.endedAt = new Date().toISOString();
       fresh.title = state.title.trim() || fresh.title;
-      if (interruptedReason !== null) fresh.interrupted = interruptedReason;
+      if (interruptedReason !== null) {
+        fresh.interrupted = interruptedReason;
+        fresh.notes = [
+          ...fresh.notes,
+          { tMs: fresh.durationMs, text: `[capture] Recording was cut short here: ${interruptedReason}` },
+        ];
+      }
       await saveRecording(fresh);
       queuedId = fresh.recordingId;
-    }
+    });
+  } catch (err) {
+    // The header write failed (storage trouble). The audio segments already on disk are untouched
+    // and recovery will pick the row up on the next open; what must NOT happen is a lying UI.
+    emit({ error: `The recording could not be finalized: ${err instanceof Error ? err.message : String(err)}` });
+  } finally {
+    active = null;
+    recorder = null;
+    emit({ phase: "idle", recordingId: null, title: "", notes: [] });
+    bumpLibrary();
   }
-  active = null;
-  recorder = null;
-  emit({ phase: "idle", recordingId: null, title: "", notes: [] });
-  bumpLibrary();
   if (queuedId !== null) {
-    void driveRecordingUpload(queuedId, () => bumpLibrary()).then(() => bumpLibrary());
+    const id = queuedId;
+    void driveRecordingUpload(id, () => bumpLibrary()).then(
+      () => bumpLibrary(),
+      () => bumpLibrary(),
+    );
   }
 }
 
 /** The capture died under us (persist failure or the system suspending the microphone). Surface it
- *  and finalize what exists - the recording keeps everything captured and says it was cut short. */
-async function handleCaptureLoss(message: string): Promise<void> {
-  emit({ error: `Recording stopped: ${message}` });
-  await finalizeActive(message);
+ *  and finalize what exists - the recording keeps everything captured and says it was cut short.
+ *  The phase flips to "stopping" IMMEDIATELY so the banner never pulses "Recording" over a dead
+ *  microphone, and so a user Stop pressed during this finalize is a harmless no-op. */
+function handleCaptureLoss(message: string): void {
+  if (active === null || finalized === active.recordingId) return;
+  emit({ phase: "stopping", error: `Recording stopped: ${message}` });
+  void finalizeActive(message).catch(() => {
+    // finalizeActive contains its own failure handling; this guard only prevents an unhandled
+    // rejection from a double-failure.
+  });
 }
 
 export const recordingSession = {
@@ -133,8 +189,11 @@ export const recordingSession = {
   level(): number {
     return recorder?.level() ?? 0;
   },
+  /** True whenever a capture exists in ANY non-idle phase - including starting (the durable shell
+   *  may exist) and stopping (the final segment may still be flushing to disk). The service-worker
+   *  update reload checks this: reloading during a stop is exactly the truncation it must avoid. */
   isCapturing(): boolean {
-    return state.phase === "recording" || state.phase === "paused";
+    return state.phase !== "idle";
   },
 
   /** Begin a new capture. No-op unless idle. Unlimited by design - no maxDurationMs is passed. */
@@ -161,12 +220,14 @@ export const recordingSession = {
       durationMs: 0,
       notes: [],
       createdAt: Date.now(),
+      updatedAt: Date.now(),
     };
     try {
       // The durable shell exists BEFORE the microphone opens - from here on, every finalized
       // segment lands in IndexedDB the moment the recorder rotates past it.
       await saveRecording(rec);
       active = rec;
+      finalized = null;
       emit({ recordingId, title: rec.title, notes: [] });
 
       const r = new SegmentRecorder({
@@ -182,30 +243,50 @@ export const recordingSession = {
             sha256: sha,
             uploaded: false,
           });
-          const fresh = await getRecording(recordingId);
-          if (fresh !== null) {
+          await chainHeaderWrite(async () => {
+            const fresh = await getRecording(recordingId);
+            if (fresh === null) return;
             fresh.segments = Math.max(fresh.segments, seg.index + 1);
             fresh.durationMs += seg.durationMs;
             fresh.title = state.title.trim() || fresh.title;
+            // The heartbeat: recovery (this tab or ANOTHER tab of the same origin) treats a
+            // recently-touched "recording" row as live, never as an orphan to seize.
+            fresh.updatedAt = Date.now();
             await saveRecording(fresh);
-          }
+          });
         },
         onError: (message) => {
-          void handleCaptureLoss(message);
+          handleCaptureLoss(message);
         },
       });
       recorder = r;
       await r.start();
+      // The microphone can die during the await above (handleCaptureLoss finalizes and clears the
+      // session). A stale continuation must not resurrect the row or claim to be recording.
+      if (!owns(recordingId) || recorder !== r) return;
       // Now that the browser has chosen the container, stamp the real codec + sample rate.
-      rec.codec = r.codecLabel;
-      rec.sampleRateHz = r.sampleRateHz;
-      await saveRecording(rec);
+      await chainHeaderWrite(async () => {
+        const fresh = await getRecording(recordingId);
+        if (fresh === null) return;
+        fresh.codec = r.codecLabel;
+        fresh.sampleRateHz = r.sampleRateHz;
+        await saveRecording(fresh);
+      });
+      if (!owns(recordingId) || recorder !== r) return;
       emit({ phase: "recording" });
     } catch (err) {
-      recorder?.dispose();
-      recorder = null;
-      active = null;
-      await deleteRecording(recordingId);
+      // Only unwind a capture this continuation still owns - a concurrent loss handler may have
+      // already salvaged and finalized it, and deleting the row out from under that would lose it.
+      if (owns(recordingId) || active === null) {
+        recorder?.dispose();
+        recorder = null;
+        active = null;
+        try {
+          if (finalized !== recordingId) await deleteRecording(recordingId);
+        } catch {
+          /* the row stays; recovery on next open cleans an empty shell */
+        }
+      }
       emit({
         phase: "idle",
         recordingId: null,
@@ -218,28 +299,36 @@ export const recordingSession = {
   async pause(): Promise<void> {
     const r = recorder;
     if (r === null || state.phase !== "recording") return;
+    const id = state.recordingId;
     await r.pause();
-    emit({ phase: "paused" });
+    // A stop or loss that landed during the await owns the phase now.
+    if (recorder === r && id !== null && owns(id) && state.phase === "recording") emit({ phase: "paused" });
   },
 
   /** Resume a paused capture. A failed microphone reopen surfaces as error; capture stays paused. */
   async resume(): Promise<void> {
     const r = recorder;
     if (r === null || state.phase !== "paused") return;
+    const id = state.recordingId;
     try {
       await r.resume();
-      emit({ phase: "recording" });
+      if (recorder === r && id !== null && owns(id) && state.phase === "paused") emit({ phase: "recording" });
     } catch (err) {
       emit({ error: err instanceof Error ? err.message : String(err) });
     }
   },
 
-  /** Stop and finalize: the recording is queued for automatic upload. */
+  /** Stop and finalize: the recording is queued for automatic upload. A stop while a loss-finalize
+   *  is already in flight is a no-op (that finalize owns the ending). */
   async stop(): Promise<void> {
     const r = recorder;
     if (r === null || (state.phase !== "recording" && state.phase !== "paused")) return;
     emit({ phase: "stopping" });
-    await r.stop();
+    try {
+      await r.stop();
+    } catch {
+      // The recorder is already dead; finalize still queues everything that reached disk.
+    }
     await finalizeActive(null);
   },
 
@@ -252,11 +341,14 @@ export const recordingSession = {
   async persistTitle(): Promise<void> {
     const rec = active;
     if (rec === null) return;
-    const fresh = await getRecording(rec.recordingId);
-    if (fresh !== null) {
+    const id = rec.recordingId;
+    await chainHeaderWrite(async () => {
+      if (finalized === id) return; // the stop already wrote the final title
+      const fresh = await getRecording(id);
+      if (fresh === null || fresh.state !== "recording") return;
       fresh.title = state.title.trim() || fresh.title;
       await saveRecording(fresh);
-    }
+    });
   },
 
   /** Attach a timestamped note to the live capture. Persisted immediately. */
@@ -265,16 +357,18 @@ export const recordingSession = {
     const r = recorder;
     const rec = active;
     if (trimmed === "" || r === null || rec === null) return;
+    const id = rec.recordingId;
     const note: LocalNote = { tMs: Math.round(r.elapsedMs), text: trimmed };
-    const fresh = await getRecording(rec.recordingId);
-    if (fresh !== null) {
+    await chainHeaderWrite(async () => {
+      const fresh = await getRecording(id);
+      if (fresh === null) return;
       fresh.notes = [...fresh.notes, note];
       await saveRecording(fresh);
-      emit({ notes: fresh.notes });
-    }
+      if (owns(id)) emit({ notes: fresh.notes });
+    });
   },
 
-  /** Clear a surfaced capture error (the library row keeps its own interrupted marker). */
+  /** Dismiss a surfaced capture error (the library row keeps its own interrupted marker). */
   clearError(): void {
     emit({ error: null });
   },

--- a/packages/client-core/src/recorder/recordingStore.ts
+++ b/packages/client-core/src/recorder/recordingStore.ts
@@ -83,6 +83,11 @@ export interface LocalRecording {
   notes: LocalNote[];
   /** Epoch milliseconds the recording was created (list ordering). */
   createdAt: number;
+  /** Epoch milliseconds of the last header write while capturing - the live capture's HEARTBEAT.
+   *  Recovery treats a recently-touched "recording" row as live (possibly in another tab of this
+   *  origin) rather than as an orphan to seize. Optional: rows from older builds lack it and are
+   *  recovered as before. */
+  updatedAt?: number;
   /** Set when this recording was recovered after an interrupted capture (the app closed while
    *  recording), so the library row can say so honestly. */
   recovered?: boolean;
@@ -239,9 +244,16 @@ export async function deleteRecording(recordingId: string): Promise<void> {
  *
  * The capture that is LIVE right now must be excluded: the recording session survives navigation
  * (it lives above the router), so a "recording" row is no longer proof of a dead capture - it may be
- * the one currently running. Pass its id as excludeRecordingId; recovering it would tear the audio
- * out from under a healthy capture.
+ * the one currently running. Two guards, because IndexedDB is origin-wide while the session
+ * singleton is per tab:
+ *   - excludeRecordingId skips THIS tab's live capture;
+ *   - the updatedAt heartbeat skips a capture live in ANOTHER tab - its segment rotation touches
+ *     the header every minute, so a "recording" row with a fresh heartbeat is running somewhere,
+ *     and seizing it would start uploading a recording that is still being written.
+ * A genuinely dead capture stops heartbeating and is recovered once the heartbeat is stale.
  */
+const RECOVERY_HEARTBEAT_STALE_MS = 3 * 60_000;
+
 export async function recoverInterrupted(excludeRecordingId?: string): Promise<LocalRecording[]> {
   if (!hasIndexedDb()) return [];
   const all = await listRecordings();
@@ -249,6 +261,7 @@ export async function recoverInterrupted(excludeRecordingId?: string): Promise<L
   for (const rec of all) {
     if (rec.state !== "recording") continue;
     if (rec.recordingId === excludeRecordingId) continue;
+    if (rec.updatedAt !== undefined && Date.now() - rec.updatedAt < RECOVERY_HEARTBEAT_STALE_MS) continue;
     const chunks = await listChunks(rec.recordingId);
     if (chunks.length === 0) {
       await deleteRecording(rec.recordingId);

--- a/packages/client-core/src/recorder/recordingStore.ts
+++ b/packages/client-core/src/recorder/recordingStore.ts
@@ -86,6 +86,11 @@ export interface LocalRecording {
   /** Set when this recording was recovered after an interrupted capture (the app closed while
    *  recording), so the library row can say so honestly. */
   recovered?: boolean;
+  /** Set when capture was stopped by the SYSTEM rather than the user (the microphone was suspended
+   *  by a screen lock, another app, or the browser pausing the page). Holds the plain-English
+   *  reason. The library row says so - a cut-off recording must never look complete
+   *  (recorder-unlimited-capture mission). */
+  interrupted?: string;
   /** The last upload failure, in plain English, so the saved-and-retryable row can say why. */
   lastError?: string;
   /** Determinate progress for the upload pass in flight, persisted on the record itself so the
@@ -231,13 +236,19 @@ export async function deleteRecording(recordingId: string): Promise<void> {
  * the audio is never stranded just because the app died - and the row says it was recovered. An
  * empty shell (no segments captured) is deleted - the server's completeness gate refuses a zero-segment
  * recording, so there is nothing it could ever become. Returns the recovered recordings.
+ *
+ * The capture that is LIVE right now must be excluded: the recording session survives navigation
+ * (it lives above the router), so a "recording" row is no longer proof of a dead capture - it may be
+ * the one currently running. Pass its id as excludeRecordingId; recovering it would tear the audio
+ * out from under a healthy capture.
  */
-export async function recoverInterrupted(): Promise<LocalRecording[]> {
+export async function recoverInterrupted(excludeRecordingId?: string): Promise<LocalRecording[]> {
   if (!hasIndexedDb()) return [];
   const all = await listRecordings();
   const recovered: LocalRecording[] = [];
   for (const rec of all) {
     if (rec.state !== "recording") continue;
+    if (rec.recordingId === excludeRecordingId) continue;
     const chunks = await listChunks(rec.recordingId);
     if (chunks.length === 0) {
       await deleteRecording(rec.recordingId);

--- a/packages/client-core/src/recorder/segmentRecorder.test.ts
+++ b/packages/client-core/src/recorder/segmentRecorder.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 // contract with the server - CodecToExt maps these labels by substring, so a wrong label would make
 // the server store segments under the wrong extension and content type.
 
-import { codecLabelFor, MAX_RECORDING_MS, SEGMENT_MS } from "./segmentRecorder";
+import { codecLabelFor, SEGMENT_MS } from "./segmentRecorder";
 
 describe("codecLabelFor", () => {
   it("maps every MediaRecorder container to a label the server's CodecToExt resolves correctly", () => {
@@ -21,8 +21,7 @@ describe("codecLabelFor", () => {
 });
 
 describe("capture constants", () => {
-  it("rotates one-minute segments (the Android recorder's interval) and caps at thirty minutes", () => {
+  it("rotates one-minute segments (the Android recorder's interval)", () => {
     expect(SEGMENT_MS).toBe(60_000);
-    expect(MAX_RECORDING_MS).toBe(30 * 60_000);
   });
 });

--- a/packages/client-core/src/recorder/segmentRecorder.ts
+++ b/packages/client-core/src/recorder/segmentRecorder.ts
@@ -65,16 +65,15 @@ export interface SegmentRecorderOptions {
   onSegment: (segment: FinalizedSegment) => Promise<void>;
   /** A segment could not be persisted or the recorder failed mid-capture. The capture is stopped. */
   onError: (message: string) => void;
-  /** Total capture reached the cap and the recorder stopped itself. */
+  /** Total capture reached the opt-in cap and the recorder stopped itself. */
   onAutoStop?: () => void;
-  /** Auto-stop cap on total captured (non-paused) time. Default 30 minutes. */
+  /** OPT-IN auto-stop cap on total captured (non-paused) time. There is deliberately NO default:
+   *  recording is unlimited (recorder-unlimited-capture mission - a 30-minute default cap silently
+   *  truncated a conference talk). A caller that wants a bound passes one explicitly. */
   maxDurationMs?: number;
   /** Rotation interval override for tests. Default SEGMENT_MS. */
   segmentMs?: number;
 }
-
-/** Default cap: 30 minutes of captured audio (the issue's stated maximum). */
-export const MAX_RECORDING_MS = 30 * 60_000;
 
 export class SegmentRecorder {
   private readonly opts: SegmentRecorderOptions;
@@ -223,6 +222,14 @@ export class SegmentRecorder {
       if (timer !== undefined) clearTimeout(timer);
     }
 
+    // The system can close the microphone under us - screen lock, another app claiming it, the
+    // browser suspending the page. A track's "ended" event fires ONLY for such external causes
+    // (never for our own track.stop()), so this is the honest signal that capture died. Salvage
+    // what the recorder flushed and stop loudly: a capture that dies must never look complete.
+    for (const track of this.stream.getTracks()) {
+      track.addEventListener("ended", () => this.onTrackEnded());
+    }
+
     // Live level meter on the captured stream (display only).
     const AudioCtor =
       window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
@@ -259,8 +266,8 @@ export class SegmentRecorder {
         await this.finalizeSegment();
         // finalizeSegment stops the capture itself when the segment could not be persisted.
         if (this.stopped || this.failed) return;
-        const cap = this.opts.maxDurationMs ?? MAX_RECORDING_MS;
-        if (this.elapsedBeforeSegment >= cap) {
+        const cap = this.opts.maxDurationMs;
+        if (cap !== undefined && this.elapsedBeforeSegment >= cap) {
           // The cap is enforced here, at a segment boundary, so the capped recording is made of
           // exactly the finalized segments already persisted - nothing is truncated or lost.
           this.stopped = true;
@@ -271,6 +278,23 @@ export class SegmentRecorder {
         this.startSegment();
       });
     }, segmentMs);
+  }
+
+  private onTrackEnded(): void {
+    void this.enqueue(async () => {
+      // A pause released the stream on purpose; a stop already finished. Only a LIVE capture whose
+      // track died externally is a loss to report.
+      if (this.stopped || this.paused || this.failed) return;
+      this.failed = true;
+      this.stopped = true;
+      this.clearRotateTimer();
+      await this.finalizeSegment();
+      this.releaseStream();
+      this.opts.onError(
+        "the phone suspended the microphone (screen lock, another app took it, or the browser " +
+          "paused the page). Everything captured up to that point is saved.",
+      );
+    });
   }
 
   private clearRotateTimer(): void {


### PR DESCRIPTION
## Why

Mission: recorder captures all day, never auto-stops (mission/recorder-unlimited-capture.md, corrected 2026-08-05). The owner's 30-minute conference trial stopped itself mid-sentence: the PWA segment recorder's DEFAULT cap (`MAX_RECORDING_MS`, 30 minutes) fired at a segment boundary - exactly 30 one-minute segments - and the truncated recording presented as complete. (Pull request 2461 fixed the native MAUI recorder on the same evidence; that app is not the one in use. This one is.)

## What changed (web only: packages/client-core, apps/mobile)

- **No recording limit.** `maxDurationMs` is strictly opt-in with no default, and no caller passes one. Recording runs until the user stops it.
- **Capture survives in-app navigation.** The lifecycle moves out of the Recorder page component (where leaving the page unmounted the recorder and killed the capture) into an app-level recording session (`client-core/recorder/recordingSession.ts`) above the router. The page and the new banner are subscribers. Recovery of interrupted recordings excludes the live capture by id, and a header heartbeat (refreshed every minute in every non-idle phase) stops another tab of the same origin from seizing a paused or starting capture as an orphan.
- **A persistent recording indicator.** A red bar with a live elapsed clock on every screen while recording (hidden on the Recorder page, which shows the same state larger). Publishes its measured height into `--topbars-h` exactly like the voice-mode banner so pinned screens are never painted over. Shows "Saving recording..." during stop, and an amber "Recording stopped - tap for details" on every screen after a capture loss, until dismissed.
- **Honest limits, no silent truncation.** A PWA cannot promise capture through a locked screen. The app already holds a screen wake lock while foregrounded; if the system still suspends the microphone, the track's `ended` event fires, the recorder salvages what was flushed, and the recording is finalized as cut short - the reason goes on the local row AND as a timestamped note that rides the complete call into the Gateway transcript, so the marker survives delivery deleting the local row. A service-worker update taking control mid-capture defers its reload instead of killing the recording.

## Review

Reviewed by Codex (gpt-5.6-sol) over four rounds, run inline. Rounds one to three found real concurrency defects - unserialized finalization, stale-continuation resurrection, header read-modify-write races, a lying UI on storage failure, the non-durable interrupted marker, reload-guard gaps, and an ownership race between a failing start and a loss finalizer - all fixed in the follow-up commits. Round four verdict: MERGE.

Deliberate deferrals, agreed with the reviewer as non-blocking: a microphone mute/stall watchdog (track `ended` covers the dominant loss modes), mounting the banner outside the auth-gated layout (recording requires an enrolled device), and dedicated concurrency test files for the session (follow-up).

## Gate

This change is entirely web-side; the .NET gate does not build any of these files. The web gate is green: `npm run typecheck` across all three workspaces, client-core 877/877 tests, cockpit 267/267 tests, and a clean mobile production build. The known lint environment issue (missing rule definitions, pre-existing, hits untouched files) is unrelated.

## Proof still owed (tracked in the mission)

Deploying the built bundle to the owner's Gateway (`wwwroot/mobile`, no restart needed) and a real 90-minute foreground recording from the owner's phone, uploaded and transcribed end to end.
