### PR TITLE
Included AI: the product runs on included model ids and shows no cost to members (#1360)

### DIFF
--- a/apps/cockpit/src/assistant/AssistantView.tsx
+++ b/apps/cockpit/src/assistant/AssistantView.tsx
@@ -105,7 +105,7 @@ export function AssistantView() {
     <div className="asst-page">
       <PageHeader
         title="Assistant"
-        subtitle="Ask about your whole fleet - sessions, machines, credits, schedules. Not tied to any session."
+        subtitle="Ask about your whole fleet - sessions, machines, schedules. Not tied to any session."
         actions={entries.length > 0 ? <ModeToggle mode={mode} setMode={setMode} /> : undefined}
       />
 
@@ -127,7 +127,6 @@ export function AssistantView() {
             <ul>
               <li>"How many sessions do I have open, and is anything stuck?"</li>
               <li>"Which sessions have been open too long?"</li>
-              <li>"How are we doing on credits?"</li>
               <li>"Which machines are online?"</li>
               <li>"What runs automatically tonight?"</li>
             </ul>

--- a/apps/mobile/src/components/CreditsNotice.tsx
+++ b/apps/mobile/src/components/CreditsNotice.tsx
@@ -33,9 +33,11 @@ export function CreditsNotice(): React.ReactElement | null {
       <div className="banner banner-info banner-action">
         <span>{info.text}</span>
         <span className="credits-notice-actions">
-          {info.ctaUrl !== null && info.ctaUrl !== "" && (
+          {/* The button renders only when the Gateway sent BOTH a destination and a label - the client
+              never invents a call-to-action, and never defaults to a credits one (issue #1360). */}
+          {info.ctaUrl !== null && info.ctaUrl !== "" && info.ctaLabel !== "" && (
             <a className="banner-btn" href={info.ctaUrl} target="_blank" rel="noopener noreferrer">
-              {info.ctaLabel || "Add credits"}
+              {info.ctaLabel}
             </a>
           )}
           <button className="banner-btn credits-notice-dismiss" onClick={() => setInfo(null)}>

--- a/apps/mobile/src/pages/Assistant.tsx
+++ b/apps/mobile/src/pages/Assistant.tsx
@@ -139,7 +139,6 @@ export function Assistant() {
             <ul>
               <li>"How many sessions do I have open?"</li>
               <li>"Which have been open too long?"</li>
-              <li>"How are we doing on credits?"</li>
               <li>"Which machines are online?"</li>
             </ul>
             <p>It can also message, snooze, start, or close sessions - closing always asks first.</p>

--- a/docs/missions/included-ai-2026-08-05/surfaces.md
+++ b/docs/missions/included-ai-2026-08-05/surfaces.md
@@ -1,0 +1,221 @@
+# Surface inventory - every place a non-admin member can see cost, credits, balance, or a top-up control
+
+Mission: Included AI (issue #1360), phase 2 work item. Swept 5 August 2026 by the
+phase-2 Manager against the product repo at commit c9564222f (worktree cut from
+origin/main) and the website source in the mission worktree
+`devthrottle_internal-wt-included-ai/website`.
+
+Method: swept by KIND of surface, not by memory - the known trap here is one
+mechanism feeding many surfaces. For each surface: what it shows, the file paths,
+and whether administrators keep it. "Admin" means the member's `role` array on the
+cloud `members` table includes `admin` (the same ruling the phase-1 inclusion
+module uses).
+
+The single most important finding is at the top: almost every product-repo cost
+surface is fed by ONE of two mechanisms - the shared 402 "needs credit" state
+machine, and the account credit-balance proxy. Hide the mechanism and every
+surface downstream of it goes quiet; hide surfaces one by one and one will be
+missed.
+
+---
+
+## Kind 1 - the shared "hosted AI needs credit" state machine (ONE mechanism, MANY surfaces)
+
+The single source of the out-of-credits user experience. Every voice, wingman,
+dictation, and text-to-speech surface in the whole product renders what this
+machinery decides.
+
+The mechanism (product repo):
+
+- `src/CcDirector.Core/HostedAi/HostedAiState.cs` - the states. `NeedsCredits`
+  and `CapReached` are the two money states.
+- `src/CcDirector.Core/HostedAi/HostedAiMessages.cs` - the ONE copy source.
+  `NeedsCredits` = "Voice needs credit. Add $5 to turn on transcription, voice
+  mode, and Wingman - enough to last most of a month." with call-to-action
+  "Add credits" opening the Billing page. `CapReached` = "You've hit your monthly
+  spending limit. Raise it in Billing to keep going." with "Open Billing".
+- `HostedAiUrls.Billing` (same directory) - the top-up deep link every
+  call-to-action opens.
+- `src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs` - maps a 402 body's
+  `code` to a state: `insufficient_credits` -> NeedsCredits,
+  `monthly_limit_reached` -> CapReached, and EVERY OTHER OR UNKNOWN CODE ->
+  NeedsCredits. This default is a trap for this mission: the phase-1 proxy now
+  answers `subscription_required` and `fair_use_limit_reached`, and today's
+  mapper would show BOTH as "Voice needs credit. Add $5" - a credits message,
+  with a top-up button, to exactly the people the owner ruled must never see one.
+- `src/CcDirector.Core/HostedAi/HostedAiReadiness.cs` - the PRE-FLIGHT gate:
+  balance at or below zero -> NeedsCredits, which blocks recording surfaces
+  before any server call. After phase 1 an entitled member with a zero balance
+  is served by the cloud, so this client-side balance gate now blocks people the
+  server would serve - it fails the mission's own acceptance test (a fresh
+  zero-balance trial account completes a dictation round-trip).
+- `src/CcDirector.Core/HostedAi/DirectorHostedAiReadiness.cs` - the desktop
+  variant of the same gate (reads the balance through the Gateway).
+- `src/CcDirector.Core/HostedAi/HostedAiPayload.cs`, `HostedAiMessage.cs`,
+  `HostedAiMessages.cs` - the shared 402 wire body `{ error, state, text,
+  ctaLabel, ctaAction, ctaUrl }`.
+- `src/CcDirector.Gateway/HostedAi/HostedAiHttp.cs` - stamps the state onto
+  `SessionDto.VoiceUnavailable` and serves the 402 body.
+- `src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs` - folds the state into
+  the voice screen verdict: badge "Voice needs credit", message, and which
+  actions are offered.
+- `src/CcDirector.Gateway/CarMode/CarModeChat.cs` - a money 402 inside Car Mode
+  raises the same shared message (spoken and shown).
+
+The renderers (every one shows the mechanism's output verbatim):
+
+| Surface | Files | What a non-admin sees today |
+|---|---|---|
+| Mobile app root banner | `apps/mobile/src/components/CreditsNotice.tsx`, mounted in `apps/mobile/src/main.tsx`; emitter in `packages/client-core/src/api/client.ts` (`CreditsError`, `creditsErrorFrom`, `onCreditsNeeded`, plus fallback copy "Voice needs credit. Add credits to turn it on." and default label "Add credits") | Banner with the credits message and an "Add credits" button deep-linking to Billing |
+| Cockpit inline errors | `packages/client-core/src/api/client.ts` (`gatewayErrorMessage` returns the CreditsError message); no app-root banner in the cockpit | The credits sentence inline wherever the error is shown |
+| Voice screen (mobile and cockpit) | `packages/client-core/src/voice/voiceRowState.ts`, `useVoiceMode.ts`; fed by `SessionDto.VoiceUnavailable` | "Voice needs credit" badge, message, call-to-action |
+| Director desktop dialogs | `src/CcDirector.Avalonia/HostedAiUnavailableDialog.axaml(.cs)`, `HostedAi/DesktopHostedAiGate.cs`, `HostedAi/DesktopHostedAiCta.cs` (opens the Billing page), `Voice/SpeakDialog.axaml.cs`, `Voice/DesktopTtsPlayer.cs` | Modal "add credits" dialog before and during dictation, wingman, and read-aloud |
+| Android native app | `phone/CcDirectorClient/Voice/HostedAiUnavailable.cs` (parser plus its OWN hardcoded defaults: "Voice needs credit. Add credits to turn it on.", "Add credits"), `Voice/DirectorVoiceClient.cs`, `TalkPage.xaml.cs` | The same message with an "Add credits" prompt opening Billing |
+| Car Mode (spoken) | `src/CcDirector.Gateway/CarMode/CarModeChat.cs` | The credits message spoken out loud |
+
+Admins keep it? The mechanism must stop producing CREDIT messages for included
+services for EVERYONE - after this mission a 402 on an included service is never
+"add credits" (it is "subscribe" or "fair-use limit reached", both no-numbers).
+The direct-API credits path still 402s with today's wording (design C4), but that
+error goes to API callers, not through this state machine's voice surfaces.
+
+## Kind 2 - the account credit-balance proxy and its readers
+
+The mechanism:
+
+- `src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs` - `GET /account/credits`
+  on the Gateway: proxies the cloud balance with the Gateway's stored account
+  token. Serves `balanceMicros` and `lastDebitMicros`.
+- `src/CcDirector.Gateway.Contracts/AccountCreditsDto.cs` - the wire body.
+- `src/CcDirector.Core/Account/AccountCreditsClient.cs` - the cloud read
+  (`GET /api/v1/account/credits`, JWT-authed).
+- `src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs` - the Director's
+  read of the Gateway proxy.
+
+The readers:
+
+| Surface | Files | What a non-admin sees today |
+|---|---|---|
+| Car Mode voice tools `get_credits` and `get_spend` | `src/CcDirector.Gateway/CarMode/CarModeBrain.cs` (tool definitions and prompt text about credits), `LoopbackCarModeFleet.cs`, `CarModeModels.cs` (`CarModeCredits`); spend side: `src/CcDirector.Gateway/Governance/AccountHostedAiSpendStore.cs`, `HostedAiSpendSweep.cs`, `Data/Entities/AccountHostedAiSpendEntity.cs` | Asks "how are we doing on credits" and the assistant SPEAKS the dollar balance, the last action's cost, and trailing hosted-AI spend |
+| Fleet Assistant (cockpit and mobile) | same brain tooling via `src/CcDirector.Gateway/Api/FleetBrainEndpoint.cs`; suggestion copy in `apps/cockpit/src/assistant/AssistantView.tsx` ("How are we doing on credits?") and `apps/mobile/src/pages/Assistant.tsx` (same line) | Typed answer with dollar amounts; the UI itself suggests asking about credits |
+| Desktop pre-flight balance read | `src/CcDirector.Avalonia/HostedAi/DesktopHostedAiGate.cs` (2-second credit read before dictation), `MainWindow.axaml.cs` (comment at the Speak entry) | Not a display by itself, but it is what turns a zero balance into the blocking "add credits" dialog (Kind 1) |
+| Cockpit / mobile settings | NONE found: `apps/cockpit/src/account/AccountView.tsx` shows no balance; `/account/credits` appears in `packages/client-core/src/api/schema.ts` only, with no caller | Nothing today - the React rebuild dropped the balance display; the endpoint remains live for any client |
+
+Admins keep it? Recommendation (question Q1 below): the product has NO signal
+for the member's admin role today, so these cannot be admin-gated in the product
+repo without new design. Since credits now exist only for direct API callers,
+the recommendation is that in-product balance reads and voice tools go away for
+everyone, and money questions live on the website (Billing for API users, the
+admin pages for administrators).
+
+## Kind 3 - cost and credit WORDING on settings, health, and onboarding surfaces
+
+| Surface | Files | What it says | Keep? |
+|---|---|---|---|
+| AI settings tab (cockpit and phone, shared) | `packages/client-core/src/settings/AiTab.tsx` line 206 | "Hosted models on your DevThrottle account. Billed to your account credits." | HIDE/REWORD for everyone - the sentence is now FALSE (included AI is part of the subscription, not billed to credits) |
+| Transcription health report reasons | `apps/cockpit/src/transcription/TranscriptionHealthView.tsx` ("out_of_credits" -> "ran out of credits"); classification from the Gateway (`src/CcDirector.Gateway/Supervision/TerminatingFaultClassifier.cs`, `SessionFault.cs`, transcription pipeline files) | Health rows can name "ran out of credits" as a failure reason | Reason stays truthful for the direct-API path; after inclusion an included call can no longer fail this way. New refusal codes need their own truthful reasons (see Q3) |
+| Assistant example prompts | `apps/cockpit/src/assistant/AssistantView.tsx` (subtitle "...credits, schedules" and example "How are we doing on credits?"), `apps/mobile/src/pages/Assistant.tsx` | The UI invites a credits question | Follows the Q1 ruling: if the credits tool goes, the example copy goes with it |
+| First-run wizard | `src/CcDirector.Avalonia/FirstRunWizardDialog.axaml` (lines about the trial) | "No credit card." | KEEP - reassurance that there is NO cost, not a cost display |
+
+## Kind 4 - the wingman and cleanup model identities (the alias switch and the picker, design C3)
+
+Not cost displays, but the money-bearing model routing this phase changes -
+listed so the hiding and the switch land as one review.
+
+- `src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs` -
+  `TranscriptionEndpointResolver` constants: `DevThrottleWingmanModel`
+  ("zai-org/GLM-5.2" -> `devthrottle/wingman`), `DevThrottleWingmanFastModel`
+  ("Qwen/Qwen2.5-72B-Instruct" -> `devthrottle/wingman-fast`),
+  `DevThrottleDictationCleanupModel` ("o4-mini" -> `devthrottle/dictation-cleanup`).
+- `src/CcDirector.Core/Configuration/WingmanModelConfig.cs` - resolution honors
+  ANY saved `brain_model` / `brain_model_fast` string verbatim (except the old
+  Claude aliases). A saved CATALOG id would keep billing credits after the
+  switch, which ruling 1 forbids - resolution must fall forward to the
+  devthrottle ids for anything that is not one of them.
+- `src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs` - the hosted
+  per-tenant wingman model overrides (same must-not-honor-catalog-ids rule).
+- `src/CcDirector.Core/Dictation/CleanupOrchestrator.cs` (`DefaultModel`) and
+  `src/CcDirector.Core/Configuration/AgentOptions.cs` (`DictationCleanupModel`)
+  - the dictation-cleanup call sites; session naming rides the fast wingman
+  resolution.
+- The picker: `src/CcDirector.Gateway/Api/AiModelsEndpoint.cs`
+  (`GET /gateway/ai/models?kind=chat` relays the DevThrottle catalog) feeding
+  the "Thinking model" and "Fast model" dropdowns in
+  `packages/client-core/src/settings/AiTab.tsx`. Per design C3 the wingman
+  pickers must stop offering catalog models; the Gateway (which owns every
+  ruling) must serve only the wingman ids for the chat kind. The speech-model
+  picker is unaffected (text-to-speech is included in its entirety).
+
+## Kind 5 - emails
+
+- Product repo: NONE. The Gateway sends no member-facing email today (the
+  transcription suggestion email block carries no money content; the
+  DevThrottle-to-self email channel is a planned capability, not shipped).
+- Website repo: no member-facing credit email found. `api/_lib/email.js` and
+  `api/_lib/notify.js` carry no credit or balance content. `api/daily-report.js`
+  and `api/morning-report.js` DO carry top-up reconciliation and the outstanding
+  credit-liability figure, but they are the OWNER's operational reports -
+  admin-kept by construction. Stripe's own checkout receipts are Stripe's and
+  out of scope (pricing and Stripe untouched by this mission).
+
+## Kind 6 - website repo surfaces (inventory only - the hiding waits for the phase-1 merge and is NOT phase 2's product-repo work)
+
+Member-facing, non-admin members must stop seeing these:
+
+| Surface | Files | What it shows |
+|---|---|---|
+| Account page credits chip | `website/src/pages/Account.jsx` (reads `/account/credits?limit=1`, renders a "Credits $x.xx" chip linking to Billing when the balance is positive) | Balance in dollars plus a Billing link |
+| Billing page credit machinery | `website/src/pages/Billing.jsx` | The balance, top-up presets ($5 minimum), automatic top-up card with threshold and amount, monthly spending cap, card-on-file, the credit ledger ("Credit added by DevThrottle", signed amounts), low-balance notes |
+| Usage page | `website/src/pages/Usage.jsx` | "Rate-card charges, all services - paid from your credits" chart and totals, plus the "Credit balance & top-up ->" link. The COGS reveal on this page is ALREADY admin-only - that part is kept |
+| Auth context / dashboard chrome | `website/src/contexts/AuthContext.jsx` and any shared chrome that carries the credits chip | Wherever the chip mechanism is shared |
+
+Public, signed-out marketing and documentation pages that NAME credits or prices
+(`website/src/pages/Models.jsx` rate card, `Pricing.jsx`, `Landing.jsx`,
+`Signup.jsx`, `Transcription.jsx`, `Terms.jsx`, `Privacy.jsx`, the docs under
+`website/src/content/docs/` - account/billing, account/usage, the api pages -
+and `docsSearchIndex.json` which is generated from them): these document the
+credits product that STILL EXISTS for direct API callers, and they are visible
+to the signed-out public, not "a normal user inside the product". Recommendation:
+KEEP, flagged for the Architect's website phase to confirm scope.
+
+Admin surfaces that keep everything: `website/src/pages/AdminUsage.jsx`,
+`website/src/pages/Admin.jsx`, `website/src/components/admin/MemberRow.jsx`,
+`MembersGrid.jsx`, `MemberDrawer.jsx`, `website/api/v1/admin.js`,
+`website/api/_lib/admin-usage.js`, `api/report.js`, `api/daily-report.js`,
+`api/morning-report.js`.
+
+## Considered and excluded, with reasons
+
+- Claude token usage displays (`src/CcDirector.Core/Claude/ClaudeUsageService.cs`
+  and its consumers): the member's OWN Anthropic plan usage, not DevThrottle
+  cost. Not a credits surface.
+- Session and workflow token counters in the cockpit: agent token counts, not
+  dollars. Not a credits surface.
+- `InsufficientCreditsException` (`src/CcDirector.Core/Transcription/`): plumbing
+  that FEEDS Kind 1, not a surface; its user-visible output is inventoried there.
+- The catalog 402 wording for direct API callers ("top up" message): kept
+  by design C4, byte-for-byte, owner-flagged in the final report.
+
+## Questions for the Architect (asked 5 August; building the unambiguous parts meanwhile)
+
+- Q1 (admin signal): the product repo has NO way to know the member's admin role
+  today - no endpoint the Gateway or clients read carries `role`. So the
+  in-product credit surfaces (Kind 2: the `/account/credits` proxy, the Car Mode
+  and Assistant credit and spend voice tools) cannot be admin-gated without new
+  design. RECOMMENDATION: remove or disable them in-product for everyone -
+  credits are now a direct-API-caller concern managed on the website - and let
+  admins use the website's admin pages. Alternative: the cloud
+  `/api/v1/account/credits` learns to answer "hidden" for non-admins after the
+  phase-1 merge, and the Gateway proxies that verdict verbatim.
+- Q2 (pre-flight balance gate): `HostedAiReadiness` blocks recording when the
+  balance is at or below zero. After inclusion this blocks entitled zero-balance
+  members the server would serve, failing the acceptance test's dictation
+  round-trip. RECOMMENDATION: retire the balance consultation (pre-flight always
+  Ready in DevThrottle mode; the runtime 402 stays the authoritative gate, as
+  the class's own contract already states).
+- Q3 (new 402 codes): `HostedAiErrorMapper` maps unknown codes to NeedsCredits,
+  so `subscription_required` and `fair_use_limit_reached` would render as "Add
+  $5" with a top-up button. RECOMMENDATION: two new states with no-numbers,
+  no-cost copy (subscription wording per design C5 pointing at
+  devthrottle.com/pricing; fair-use wording per the design's plain message), and
+  the Android parser's hardcoded credit defaults updated the same way.

--- a/docs/missions/included-ai-2026-08-05/surfaces.md
+++ b/docs/missions/included-ai-2026-08-05/surfaces.md
@@ -196,7 +196,7 @@ Admin surfaces that keep everything: `website/src/pages/AdminUsage.jsx`,
 - The catalog 402 wording for direct API callers ("top up" message): kept
   by design C4, byte-for-byte, owner-flagged in the final report.
 
-## Questions for the Architect (asked 5 August; building the unambiguous parts meanwhile)
+## Questions for the Architect (asked 5 August; ANSWERED same day - the rulings are recorded verbatim below each question)
 
 - Q1 (admin signal): the product repo has NO way to know the member's admin role
   today - no endpoint the Gateway or clients read carries `role`. So the
@@ -207,15 +207,52 @@ Admin surfaces that keep everything: `website/src/pages/AdminUsage.jsx`,
   admins use the website's admin pages. Alternative: the cloud
   `/api/v1/account/credits` learns to answer "hidden" for non-admins after the
   phase-1 merge, and the Gateway proxies that verdict verbatim.
+
+  RULING (Architect, 5 August 2026, verbatim): "Q1 APPROVED-REMOVE - kill every
+  in-product credit reader and the Car Mode/Assistant credits+spend voice tools
+  and their suggestion copy for EVERYONE (credits are a website concern; admins
+  use the website admin pages), but KEEP the Gateway /account/credits wire
+  endpoint alive for old-client compatibility - surfaces die, the wire stays."
 - Q2 (pre-flight balance gate): `HostedAiReadiness` blocks recording when the
   balance is at or below zero. After inclusion this blocks entitled zero-balance
   members the server would serve, failing the acceptance test's dictation
   round-trip. RECOMMENDATION: retire the balance consultation (pre-flight always
   Ready in DevThrottle mode; the runtime 402 stays the authoritative gate, as
   the class's own contract already states).
+
+  RULING (Architect, 5 August 2026, verbatim): "Q2 APPROVED - retire the
+  client-side balance pre-flight entirely (always Ready in DevThrottle mode);
+  the runtime 402 is the only gate."
 - Q3 (new 402 codes): `HostedAiErrorMapper` maps unknown codes to NeedsCredits,
   so `subscription_required` and `fair_use_limit_reached` would render as "Add
   $5" with a top-up button. RECOMMENDATION: two new states with no-numbers,
   no-cost copy (subscription wording per design C5 pointing at
   devthrottle.com/pricing; fair-use wording per the design's plain message), and
   the Android parser's hardcoded credit defaults updated the same way.
+
+  RULING (Architect, 5 August 2026, verbatim): "Q3 APPROVED-PLUS - two new
+  states subscription_required (wording per design C5, points at
+  devthrottle.com/pricing, no checkout promise) and fair_use_limit_reached
+  (plain, resets next month), no numbers no cost in either; update the Android
+  parser's hardcoded defaults identically; AND change the mapper's unknown-code
+  default from NeedsCredits to a neutral no-money 'hosted AI unavailable' state
+  - an unknown code must never claim credits."
+
+Further rulings from the same reply, recorded verbatim:
+
+- "Kind-4 approach endorsed (fall-forward to devthrottle ids for any
+  non-devthrottle saved model; Gateway serves only wingman ids for chat kind;
+  speech picker untouched)."
+- "Kind-6 KEEP confirmed for public signed-out marketing/docs pages - ruling 2
+  governs the signed-in product experience; flagged for the owner's report."
+
+Manager note on scope, applied under the Kind-4 endorsement: the Car Mode model
+setting (`CarModeModelConfig`, per-tenant `TenantSettingsResolver.CarModeModel`)
+defaults to the fast wingman constant and its saved value is honored verbatim,
+so the same fall-forward guard is applied there - a Car Mode pointed at a
+catalog id would bill credits on an internal feature, which ruling 1 forbids.
+Also discovered during the build: dictation cleanup is DETERMINISTIC in-process
+code today (`CleanupOrchestrator` - no language model call at all; the model
+string is a log label only), so the `devthrottle/dictation-cleanup` id switch
+affects the constant, the log label, and the `AgentOptions` default - there is
+no live cleanup traffic to re-route.

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -317,22 +317,23 @@ async function readFailureDetail(res: Response): Promise<GatewayFailureDetail> {
 
 // The shared "hosted AI is unavailable" body every money endpoint returns on HTTP 402 (issue #939/#941;
 // consumed by mobile in #942): the single-source message + call-to-action. `text` is the message to show;
-// `ctaUrl` deep-links to Billing.
+// `ctaUrl` deep-links to the call-to-action page when there is one.
 export interface HostedAiUnavailable {
-  state: string;      // "NeedsCredits" | "CapReached" | "NeedsKey"
+  state: string;      // "NeedsCredits" | "CapReached" | "NeedsKey" | "SubscriptionRequired" | "FairUseLimitReached" | "Unavailable"
   text: string;
   ctaLabel: string;
-  ctaAction: string;  // "OpenBilling" | "OpenSettings"
+  ctaAction: string;  // "OpenBilling" | "OpenSettings" | "OpenPricing" | "None"
   ctaUrl: string | null;
 }
 
-// A 402 from a hosted-AI call (out of credits / cap / no key). Its `message` IS the shared text, so any
-// surface that already shows `err.message` displays the correct copy by construction; `info` carries the
-// call-to-action for the app-level notice (issue #942).
+// A 402 from a hosted-AI call. Its `message` IS the shared text, so any surface that already shows
+// `err.message` displays the correct copy by construction; `info` carries the call-to-action for the
+// app-level notice (issue #942). The fallback for a body with no text is NEUTRAL (issue #1360): a 402
+// we cannot read must never claim the account is out of credits.
 export class CreditsError extends GatewayError {
   readonly info: HostedAiUnavailable;
   constructor(info: HostedAiUnavailable) {
-    super(402, info.text || info.state || "Voice needs credit.");
+    super(402, info.text || "This AI feature is not available for your account right now.");
     this.name = "CreditsError";
     this.info = info;
   }
@@ -348,16 +349,18 @@ export function onCreditsNeeded(fn: CreditsListener): () => void {
   return () => { creditsListeners.delete(fn); };
 }
 
-// Build a CreditsError from an already-parsed 402 body and notify the app-level notice. Defaults keep the
-// message correct even if a field is missing. Call from the `!res.ok` branch of any hosted-AI call when
-// `res.status === 402` (the body is already the shared shape from the Gateway).
+// Build a CreditsError from an already-parsed 402 body and notify the app-level notice. Call from the
+// `!res.ok` branch of any hosted-AI call when `res.status === 402` (the body is already the shared
+// shape from the Gateway). The defaults for missing fields are NEUTRAL (issue #1360): a 402 whose body
+// cannot be read is an unknown money-shaped refusal, and it must never claim the account is out of
+// credits or offer a top-up button - the owner ruled a normal member sees no cost anywhere.
 export function creditsErrorFrom(body: unknown): CreditsError {
   const b = (body ?? {}) as Partial<HostedAiUnavailable> & { error?: string };
   const info: HostedAiUnavailable = {
-    state: b.state ?? "NeedsCredits",
-    text: b.text ?? b.error ?? "Voice needs credit. Add credits to turn it on.",
-    ctaLabel: b.ctaLabel ?? "Add credits",
-    ctaAction: b.ctaAction ?? "OpenBilling",
+    state: b.state ?? "Unavailable",
+    text: b.text ?? b.error ?? "This AI feature is not available for your account right now.",
+    ctaLabel: b.ctaLabel ?? "",
+    ctaAction: b.ctaAction ?? "None",
     ctaUrl: b.ctaUrl ?? null,
   };
   for (const fn of creditsListeners) { try { fn(info); } catch { /* a listener must never break the throw */ } }

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1846,7 +1846,9 @@ export type PermanentDictationReason = "audio-too-large" | "unsupported-format";
  *    until the user explicitly retries it; nothing was injected.
  *  - otherwise (`terminal` false, `permanent` falsey): nothing final happened; the copy is KEPT and the
  *    driver retries. `error` carries the honest "held, will keep trying" reason and `outOfCredits` flags
- *    the out-of-credits case so the driver can throttle and the app can show the Add-credits notice. */
+ *    any money-shaped 402 (credits, subscription, fair use, unknown) so the driver throttles its retry
+ *    loop - a fast retry fixes none of them. The app-level notice and the held copy both come from the
+ *    Gateway's MAPPED state (issue #1360), never from a hardcoded credits sentence. */
 export interface DictationSubmitResult {
   terminal: boolean;
   submitted: boolean;
@@ -1895,9 +1897,22 @@ export interface DictationUploadArgs {
 export const DICTATION_HELD_NO_CONNECTION_MESSAGE =
   "No connection - your recording is saved and will keep trying.";
 
-/** The held line when transcription credits ran out: kept, and it sends once credits are available. */
+/** The held line when transcription credits ran out: kept, and it sends once credits are available.
+ *  This wording is reachable ONLY from the direct-API `insufficient_credits` state (the Gateway maps
+ *  that 402 code to state "NeedsCredits") - see dictationHeld402Message. */
 export const DICTATION_HELD_CREDITS_MESSAGE =
   "Out of transcription credits - your recording is saved and will send when credits are added.";
+
+/** The held line for a 402 whose mapped state is NOT the credits one: the Gateway's own mapped copy
+ *  (subscription required, fair-use limit, or the neutral unknown-code sentence), followed by the
+ *  honest saved-on-device clause. The Gateway owns the verdict and its wording (rule 7 - the client is
+ *  dumb); this client must never replace a subscription/fair-use/unknown refusal with credits wording
+ *  the owner ruled a normal member never sees (issue #1360). */
+export function dictationHeld402Message(info: HostedAiUnavailable): string {
+  if (info.state === "NeedsCredits") return DICTATION_HELD_CREDITS_MESSAGE;
+  const text = info.text.trim().replace(/\.$/, "");
+  return `${text}. Your recording is saved on this device.`;
+}
 
 export async function uploadDictationToSession(
   args: DictationUploadArgs,
@@ -2039,10 +2054,13 @@ export async function uploadDictationToSession(
     }
 
     if (comp.status === 402) {
-      // Out of transcription credits: fire the app-level Add-credits notice, then keep the audio held so
-      // it sends once credits return. A plain fast retry will not fix it, so the driver throttles this.
-      creditsErrorFrom(await comp.json().catch(() => ({})));
-      return held(DICTATION_HELD_CREDITS_MESSAGE, true);
+      // A money-shaped refusal. The body carries the Gateway's MAPPED state and copy (issue #1360):
+      // creditsErrorFrom parses it and fires the app-level notice, and the held strip renders the SAME
+      // mapped copy - the credits wording only for the direct-API insufficient_credits state, never for
+      // a subscription/fair-use/unknown refusal. The audio stays held either way; a plain fast retry
+      // will not fix any of these, so the driver throttles this.
+      const err = creditsErrorFrom(await comp.json().catch(() => ({})));
+      return held(dictationHeld402Message(err.info), true);
     }
 
     const body = (await comp.json().catch(() => ({}))) as {

--- a/packages/client-core/src/api/dictation402Copy.test.ts
+++ b/packages/client-core/src/api/dictation402Copy.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DICTATION_HELD_CREDITS_MESSAGE,
+  dictationHeld402Message,
+  uploadDictationToSession,
+  type DictationUploadArgs,
+  type HostedAiUnavailable,
+} from "./client";
+
+// Durable dictation 402 copy (issue #1360, inspection round). The Gateway maps every 402 code into the
+// shared hosted-AI state and composes the copy; this client must RENDER that mapped copy, never replace
+// it with hardcoded add-credits wording. Before this fix, every 402 - subscription required, fair-use
+// limit, unknown code - was shown as "Out of transcription credits ...", which is exactly the credit
+// wording the owner ruled a normal member never sees. Put the hardcoded DICTATION_HELD_CREDITS_MESSAGE
+// return back in the 402 branch and these go red.
+
+const UPLOAD_ID = "33333333-3333-3333-3333-333333333333";
+
+const SUBSCRIPTION_TEXT =
+  "Included AI features come with DevThrottle Pro. This account's trial or plan isn't active - see the plans at devthrottle.com/pricing.";
+const FAIR_USE_TEXT =
+  "This month's fair-use limit for included AI features has been reached. It resets at the start of next month.";
+const CREDITS_TEXT =
+  "Voice needs credit. Add $5 to turn on transcription, voice mode, and Wingman - enough to last most of a month.";
+
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function baseArgs(): DictationUploadArgs {
+  return {
+    sessionId: "11111111-1111-1111-1111-111111111111",
+    uploadId: UPLOAD_ID,
+    audio: new Blob(["hello"], { type: "audio/webm" }),
+    before: "",
+    after: "",
+    prefix: "",
+    baselineBufferBytes: 0,
+    resumed: true,
+  };
+}
+
+// Register succeeds, then complete answers 402 with the given (already Gateway-mapped) body.
+function mock402(body: unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID });
+      if (url.includes("/complete")) return fakeResponse(402, body);
+      throw new Error("unexpected fetch: " + url);
+    }),
+  );
+}
+
+describe("durable dictation renders the MAPPED 402 state's copy", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("subscription_required shows the subscription copy, not credits wording", async () => {
+    mock402({ state: "SubscriptionRequired", text: SUBSCRIPTION_TEXT, ctaLabel: "View plans", ctaAction: "OpenPricing", ctaUrl: "https://devthrottle.com/pricing" });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.outOfCredits).toBe(true); // the driver still throttles the retry loop
+    expect(result.error).toContain("DevThrottle Pro");
+    expect(result.error).toContain("Your recording is saved on this device.");
+    expect(result.error!.toLowerCase()).not.toContain("credit");
+  });
+
+  it("fair_use_limit_reached shows the fair-use copy, not credits wording", async () => {
+    mock402({ state: "FairUseLimitReached", text: FAIR_USE_TEXT, ctaLabel: "", ctaAction: "None", ctaUrl: null });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.error).toContain("fair-use limit");
+    expect(result.error).toContain("Your recording is saved on this device.");
+    expect(result.error!.toLowerCase()).not.toContain("credit");
+  });
+
+  it("an unreadable 402 body shows the neutral copy, never a credits claim", async () => {
+    mock402({});
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.error).toContain("This AI feature is not available for your account right now.");
+    expect(result.error).toContain("Your recording is saved on this device.");
+    expect(result.error!.toLowerCase()).not.toContain("credit");
+  });
+
+  it("the direct-API insufficient_credits state keeps the existing held-credits line", async () => {
+    mock402({ state: "NeedsCredits", text: CREDITS_TEXT, ctaLabel: "Add credits", ctaAction: "OpenBilling", ctaUrl: "https://devthrottle.com/account" });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.outOfCredits).toBe(true);
+    expect(result.error).toBe(DICTATION_HELD_CREDITS_MESSAGE);
+  });
+});
+
+describe("dictationHeld402Message", () => {
+  it("appends the saved-on-device clause without doubling the full stop", () => {
+    const info: HostedAiUnavailable = { state: "FairUseLimitReached", text: FAIR_USE_TEXT, ctaLabel: "", ctaAction: "None", ctaUrl: null };
+    const message = dictationHeld402Message(info);
+    expect(message).toBe(FAIR_USE_TEXT + " Your recording is saved on this device.");
+    expect(message).not.toContain("..");
+  });
+});

--- a/packages/client-core/src/settings/AiTab.tsx
+++ b/packages/client-core/src/settings/AiTab.tsx
@@ -212,7 +212,7 @@ export function AiTab({ accountHref }: AiTabProps) {
       {!catalogAvailable && (
         <p className="settings-hint settings-hint-inline">
           Model browsing and testing aren&apos;t available on the hosted Gateway yet. Your saved models are
-          shown below; per-account model selection arrives with account-scoped billing.
+          shown below; per-account model selection is coming to the hosted Gateway.
         </p>
       )}
 

--- a/packages/client-core/src/settings/AiTab.tsx
+++ b/packages/client-core/src/settings/AiTab.tsx
@@ -203,7 +203,8 @@ export function AiTab({ accountHref }: AiTabProps) {
             <span className="settings-provider-badge">Hosted</span>
           </span>
           <span className="settings-provider-desc">
-            Hosted models on your DevThrottle account. Billed to your account credits.
+            Hosted models on your DevThrottle account. Included with your account - transcription,
+            the wingman, and voice.
           </span>
         </div>
       </div>

--- a/phone/CcDirectorClient/Voice/HostedAiUnavailable.cs
+++ b/phone/CcDirectorClient/Voice/HostedAiUnavailable.cs
@@ -30,16 +30,18 @@ public sealed class HostedAiUnavailableException : Exception
 
     /// <summary>
     /// When <paramref name="status"/> is 402, parse the shared body into a typed exception; otherwise
-    /// null (the caller keeps its existing error). Defaults keep the message sensible if a field is
-    /// missing or the body is not the shared shape.
+    /// null (the caller keeps its existing error). The defaults for a body that is missing fields are
+    /// NEUTRAL (issue #1360): a 402 whose body cannot be read is an unknown money-shaped refusal, and
+    /// it must never claim the account is out of credits - the owner ruled a normal member sees no
+    /// cost, no credits, and no top-up prompt anywhere.
     /// </summary>
     public static HostedAiUnavailableException? TryFrom(int status, string body)
     {
         if (status != 402) return null;
 
-        var state = "NeedsCredits";
-        var text = "Voice needs credit. Add credits to turn it on.";
-        var ctaLabel = "Add credits";
+        var state = "Unavailable";
+        var text = "This AI feature is not available for your account right now.";
+        var ctaLabel = "";
         string? ctaUrl = null;
         try
         {
@@ -58,7 +60,7 @@ public sealed class HostedAiUnavailableException : Exception
         }
         catch (JsonException)
         {
-            // A non-JSON 402 body still means out of credits; keep the sensible defaults.
+            // A non-JSON 402 body is an unknown money-shaped refusal; keep the neutral defaults.
         }
         return new HostedAiUnavailableException(state, text, ctaLabel, ctaUrl);
     }

--- a/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiCta.cs
+++ b/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiCta.cs
@@ -31,6 +31,7 @@ public static class DesktopHostedAiCta
         var url = action switch
         {
             HostedAiCtaAction.OpenBilling => HostedAiUrls.Billing,
+            HostedAiCtaAction.OpenPricing => HostedAiUrls.Pricing,
             HostedAiCtaAction.OpenSettings => await ResolveCockpitUrlAsync(ct).ConfigureAwait(false),
             _ => null,
         };

--- a/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiGate.cs
+++ b/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiGate.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using CcDirector.Core.Account;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.HostedAi;
 using CcDirector.Core.Transcription;
@@ -30,21 +28,18 @@ public static class DesktopHostedAiGate
     internal static Func<CancellationToken, Task<HostedAiState>>? CheckOverrideForTests;
 
     /// <summary>
-    /// Resolve the current hosted-AI state for the configured mode: reads the mode locally, the
-    /// bring-your-own key through the shared resolver, and the balance over HTTP from the Gateway. A
-    /// fresh resolver + client are built per call so the answer reflects the live state (adding $5 or a
-    /// key is picked up on the next check, no restart).
+    /// Resolve the current hosted-AI state for the configured mode. Since the Included AI mission
+    /// (issue #1360) this makes NO network call: the balance pre-flight is retired (a zero balance says
+    /// nothing about whether the server will serve an included call), so the check reads the mode
+    /// locally and answers Ready - the runtime 402, reported through the same shared dialog, is the
+    /// only gate.
     /// </summary>
     public static Task<HostedAiState> CheckAsync(CancellationToken ct = default)
     {
         var testOverride = CheckOverrideForTests;
         if (testOverride is not null) return testOverride(ct);
 
-        // A short timeout keeps the pre-flight from stalling the UI: a slow/unknown balance falls open to
-        // Ready (the runtime 402 stays the authoritative gate), so the feature is never blocked on a slow
-        // read - only on a definitive out-of-credits / no-key answer, which returns fast.
-        var credits = new GatewayAccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(2) });
-        var readiness = DirectorHostedAiReadiness.Create(new HostedAiKeyResolver(), credits);
+        var readiness = DirectorHostedAiReadiness.Create(new HostedAiKeyResolver());
         return readiness.CheckAsync(ct);
     }
 

--- a/src/CcDirector.Avalonia/Voice/DesktopTtsPlayer.cs
+++ b/src/CcDirector.Avalonia/Voice/DesktopTtsPlayer.cs
@@ -137,10 +137,14 @@ public sealed class DesktopTtsPlayer : IDisposable
         return true;
     }
 
-    /// <summary>True when a failed generation's status is one of the out-of-credits / cap codes a 402
-    /// carries (issue #940), so the shared add-credits state should be surfaced.</summary>
+    /// <summary>True when a failed generation's status is one of the machine codes a 402 carries
+    /// (issue #940; the two Included AI codes added by issue #1360), so the shared hosted-AI
+    /// unavailable state should be surfaced with the right copy for the actual condition.</summary>
     private static bool IsOutOfCreditsStatus(string? status) =>
-        status == HostedAiErrorMapper.InsufficientCreditsCode || status == HostedAiErrorMapper.MonthlyLimitReachedCode;
+        status == HostedAiErrorMapper.InsufficientCreditsCode
+        || status == HostedAiErrorMapper.MonthlyLimitReachedCode
+        || status == HostedAiErrorMapper.SubscriptionRequiredCode
+        || status == HostedAiErrorMapper.FairUseLimitReachedCode;
 
     /// <summary>Stop any in-progress playback immediately.</summary>
     public void Stop()

--- a/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
@@ -26,7 +26,7 @@ public sealed class CarModeModelConfigTests
         {
             // The env var is a per-install debug switch; an INCLUDED id is honored.
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, "devthrottle/wingman");
-            Assert.Equal("devthrottle/wingman", CarModeModelConfig.Resolve());
+            Assert.Equal("devthrottle/wingman", CarModeModelConfig.Resolve().Value);
         }
         finally
         {
@@ -52,8 +52,8 @@ public sealed class CarModeModelConfigTests
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, catalogId);
             // A non-included env value is treated as "not chosen": resolution falls forward to the
             // saved-setting-or-default leg, exactly as a non-included saved value does.
-            Assert.Equal(CarModeModelConfig.Get(), CarModeModelConfig.Resolve());
-            Assert.NotEqual(catalogId, CarModeModelConfig.Resolve());
+            Assert.Equal(CarModeModelConfig.Get(), CarModeModelConfig.Resolve().Value);
+            Assert.NotEqual(catalogId, CarModeModelConfig.Resolve().Value);
         }
         finally
         {
@@ -70,7 +70,7 @@ public sealed class CarModeModelConfigTests
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, null);
             // With no env override the effective model is exactly the persisted user setting (Get()),
             // which is the included fast default when nothing is saved. Never empty.
-            var resolved = CarModeModelConfig.Resolve();
+            var resolved = CarModeModelConfig.Resolve().Value;
             Assert.Equal(CarModeModelConfig.Get(), resolved);
             Assert.False(string.IsNullOrWhiteSpace(resolved));
         }

--- a/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
@@ -24,9 +24,36 @@ public sealed class CarModeModelConfigTests
         var original = Environment.GetEnvironmentVariable(CarModeModelConfig.EnvVar);
         try
         {
-            // The env var is a per-install debug switch and is deliberately honored verbatim.
+            // The env var is a per-install debug switch; an INCLUDED id is honored.
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, "devthrottle/wingman");
             Assert.Equal("devthrottle/wingman", CarModeModelConfig.Resolve());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, original);
+        }
+    }
+
+    /// <summary>
+    /// The environment-override revert-proof for the Included AI rule (issue #1360, inspection round):
+    /// Car Mode's model rides the DevThrottle deployment credential, so a catalog id set through
+    /// CC_CARMODE_MODEL would bill credits on an internal feature. Put the honor-any-nonblank-env read
+    /// back and this goes red.
+    /// </summary>
+    [Theory]
+    [InlineData("Qwen/Qwen2.5-72B-Instruct")]
+    [InlineData("zai-org/GLM-5.2")]
+    [InlineData("kimi-k2")]
+    public void Resolve_EnvOverrideCatalogId_FallsForwardToTheSavedSettingOrDefault(string catalogId)
+    {
+        var original = Environment.GetEnvironmentVariable(CarModeModelConfig.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, catalogId);
+            // A non-included env value is treated as "not chosen": resolution falls forward to the
+            // saved-setting-or-default leg, exactly as a non-included saved value does.
+            Assert.Equal(CarModeModelConfig.Get(), CarModeModelConfig.Resolve());
+            Assert.NotEqual(catalogId, CarModeModelConfig.Resolve());
         }
         finally
         {

--- a/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
@@ -6,14 +6,15 @@ namespace CcDirector.Core.Tests;
 /// <summary>
 /// Car Mode runs its OWN model (a fast tier + tool_choice=required), separate from the Wingman. These
 /// pin the resolution precedence the Architect settled: the CC_CARMODE_MODEL env override wins, then the
-/// user's saved setting, then the Qwen2.5-72B default.
+/// user's saved setting (honored only when it is a DevThrottle internal included id - issue #1360), then
+/// the included fast wingman default.
 /// </summary>
 public sealed class CarModeModelConfigTests
 {
     [Fact]
-    public void Default_IsTheFastQwenTier()
+    public void Default_IsTheIncludedFastWingmanId()
     {
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", CarModeModelConfig.Default);
+        Assert.Equal("devthrottle/wingman-fast", CarModeModelConfig.Default);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleWingmanFastModel, CarModeModelConfig.Default);
     }
 
@@ -23,8 +24,9 @@ public sealed class CarModeModelConfigTests
         var original = Environment.GetEnvironmentVariable(CarModeModelConfig.EnvVar);
         try
         {
-            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, "zai-org/GLM-5.2");
-            Assert.Equal("zai-org/GLM-5.2", CarModeModelConfig.Resolve());
+            // The env var is a per-install debug switch and is deliberately honored verbatim.
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, "devthrottle/wingman");
+            Assert.Equal("devthrottle/wingman", CarModeModelConfig.Resolve());
         }
         finally
         {
@@ -40,7 +42,7 @@ public sealed class CarModeModelConfigTests
         {
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, null);
             // With no env override the effective model is exactly the persisted user setting (Get()),
-            // which is the Qwen default when nothing is saved. Never empty.
+            // which is the included fast default when nothing is saved. Never empty.
             var resolved = CarModeModelConfig.Resolve();
             Assert.Equal(CarModeModelConfig.Get(), resolved);
             Assert.False(string.IsNullOrWhiteSpace(resolved));
@@ -49,5 +51,47 @@ public sealed class CarModeModelConfigTests
         {
             Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, original);
         }
+    }
+}
+
+/// <summary>
+/// The saved-setting half of the Car Mode resolution, against a private storage root. The catalog-id
+/// case is the Car Mode revert-proof for the Included AI rule (issue #1360): put the old
+/// honor-any-saved-string read back and it goes red.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class CarModeModelConfigSavedSettingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public CarModeModelConfigSavedSettingTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-carmodel-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Theory]
+    [InlineData("zai-org/GLM-5.2")]
+    [InlineData("Qwen/Qwen2.5-72B-Instruct")]
+    [InlineData("kimi-k2")]
+    public void Get_SavedCatalogId_FallsForwardToIncludedDefault(string catalogId)
+    {
+        CarModeModelConfig.Set(catalogId);
+        Assert.Equal(CarModeModelConfig.Default, CarModeModelConfig.Get());
+    }
+
+    [Fact]
+    public void Get_SavedIncludedId_IsHonored()
+    {
+        CarModeModelConfig.Set("devthrottle/wingman");
+        Assert.Equal("devthrottle/wingman", CarModeModelConfig.Get());
     }
 }

--- a/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
@@ -46,18 +46,22 @@ public sealed class IncludedModelIdTests
             producers);
     }
 
-    [Fact]
-    public void AReflectionForgedInstance_ThrowsAtFirstUseOfValue()
+    [Theory]
+    [InlineData("Qwen/Qwen2.5-72B-Instruct")]
+    [InlineData("  devthrottle/wingman  ")]
+    public void AReflectionForgedInstance_ThrowsAtFirstUseOfValue(string forgedValue)
     {
         // Phase-2 inspection round 3 invoked the private constructor through reflection with the
         // catalog id both earlier bypasses carried, and the transports trusted the forged instance.
         // The Value getter now validates on every read, so a forged instance throws at its first
         // use and can never reach a transport. This is the round-3 inspection's construction made
-        // a permanent test.
+        // a permanent test. The round-4 inspection forged a whitespace-padded included id and the
+        // then-lenient getter accepted it; the getter now demands the prefix verbatim on the stored
+        // string, and the mint trims, so a padded value proves a forge and throws too.
         var constructor = Assert.Single(
             typeof(IncludedModelId).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance));
 
-        var forged = (IncludedModelId)constructor.Invoke(new object[] { "Qwen/Qwen2.5-72B-Instruct" });
+        var forged = (IncludedModelId)constructor.Invoke(new object[] { forgedValue });
 
         var thrown = Assert.Throws<InvalidOperationException>(() => forged.Value);
         Assert.Contains("outside the mint", thrown.Message, StringComparison.Ordinal);
@@ -78,6 +82,10 @@ public sealed class IncludedModelIdTests
         Assert.NotNull(minted);
         Assert.Equal("devthrottle/wingman", minted!.Value);
         Assert.Equal(IncludedModelId.Wingman, minted);
+
+        // The mint normalizes: a padded candidate stores the trimmed id, so no legitimate
+        // instance can carry whitespace and the strict getter never throws on a minted value.
+        Assert.Equal("devthrottle/wingman", IncludedModelId.TryMint("  devthrottle/wingman  ")!.Value);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
@@ -47,6 +47,23 @@ public sealed class IncludedModelIdTests
     }
 
     [Fact]
+    public void AReflectionForgedInstance_ThrowsAtFirstUseOfValue()
+    {
+        // Phase-2 inspection round 3 invoked the private constructor through reflection with the
+        // catalog id both earlier bypasses carried, and the transports trusted the forged instance.
+        // The Value getter now validates on every read, so a forged instance throws at its first
+        // use and can never reach a transport. This is the round-3 inspection's construction made
+        // a permanent test.
+        var constructor = Assert.Single(
+            typeof(IncludedModelId).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance));
+
+        var forged = (IncludedModelId)constructor.Invoke(new object[] { "Qwen/Qwen2.5-72B-Instruct" });
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => forged.Value);
+        Assert.Contains("outside the mint", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TryMint_RefusesACatalogId_AndMintsAnIncludedId()
     {
         // The exact catalog id both inspection bypasses carried must not mint.

--- a/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/IncludedModelIdTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Configuration;
+
+/// <summary>
+/// <see cref="IncludedModelId"/> is the structural guard of the Included AI mission (issue #1360):
+/// the ONLY way a chat model id reaches a request authenticated by the DevThrottle deployment
+/// credential is as this type, and the only way to obtain the type is the mint on the class itself.
+/// These tests pin the producer surface with reflection - so a new public way to conjure an instance
+/// goes red here instead of waiting for an inspection - and prove the mint's two behaviours: refuse
+/// (null) for the callers that answer 400, and fall forward to the included default for the
+/// resolution legs.
+/// </summary>
+public sealed class IncludedModelIdTests
+{
+    [Fact]
+    public void TheMintIsTheOnlyProducer_NoPublicConstructor_AndAPinnedStaticSurface()
+    {
+        // Phase-2 inspection round 2 bypassed the earlier runtime guards by construction. The fix is
+        // that construction itself is impossible: no constructor is visible outside the class, and
+        // the public static members able to produce an instance are exactly the pinned set below -
+        // the two mint methods plus the three known included ids. Add a producer and this fails.
+        var type = typeof(IncludedModelId);
+
+        Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.All(
+            type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance),
+            c => Assert.True(c.IsPrivate, $"constructor {c} must be private - the mint is the only producer"));
+
+        var producers = type
+            .GetMembers(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m switch
+            {
+                MethodInfo method => method.ReturnType == type && !method.IsSpecialName,
+                PropertyInfo property => property.PropertyType == type,
+                _ => false,
+            })
+            .Select(m => m.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            new[] { "DictationCleanup", "MintOrFallForward", "TryMint", "Wingman", "WingmanFast" },
+            producers);
+    }
+
+    [Fact]
+    public void TryMint_RefusesACatalogId_AndMintsAnIncludedId()
+    {
+        // The exact catalog id both inspection bypasses carried must not mint.
+        Assert.Null(IncludedModelId.TryMint("Qwen/Qwen2.5-72B-Instruct"));
+        Assert.Null(IncludedModelId.TryMint("glm-5.2"));
+        Assert.Null(IncludedModelId.TryMint("opus"));
+        Assert.Null(IncludedModelId.TryMint(null));
+        Assert.Null(IncludedModelId.TryMint(""));
+        Assert.Null(IncludedModelId.TryMint("   "));
+
+        var minted = IncludedModelId.TryMint("devthrottle/wingman");
+        Assert.NotNull(minted);
+        Assert.Equal("devthrottle/wingman", minted!.Value);
+        Assert.Equal(IncludedModelId.Wingman, minted);
+    }
+
+    [Fact]
+    public void MintOrFallForward_FallsForwardToTheIncludedDefault_ForACatalogId()
+    {
+        // The fall-forward rule every resolution leg (saved setting, tenant override, environment
+        // override) now runs through: a catalog id degrades to the included default instead of
+        // billing credits on an internal feature.
+        Assert.Equal(IncludedModelId.WingmanFast,
+            IncludedModelId.MintOrFallForward("Qwen/Qwen2.5-72B-Instruct", IncludedModelId.WingmanFast));
+        Assert.Equal(IncludedModelId.Wingman,
+            IncludedModelId.MintOrFallForward(null, IncludedModelId.Wingman));
+
+        // An included candidate is honored, never swapped for the default.
+        Assert.Equal("devthrottle/wingman",
+            IncludedModelId.MintOrFallForward("devthrottle/wingman", IncludedModelId.WingmanFast).Value);
+    }
+
+    [Fact]
+    public void TheKnownStatics_CarryTheIncludedConstants()
+    {
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleWingmanModel, IncludedModelId.Wingman.Value);
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleWingmanFastModel, IncludedModelId.WingmanFast.Value);
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleDictationCleanupModel, IncludedModelId.DictationCleanup.Value);
+        Assert.True(TranscriptionEndpointResolver.IsDevThrottleIncludedModel(IncludedModelId.Wingman.Value));
+        Assert.True(TranscriptionEndpointResolver.IsDevThrottleIncludedModel(IncludedModelId.WingmanFast.Value));
+        Assert.True(TranscriptionEndpointResolver.IsDevThrottleIncludedModel(IncludedModelId.DictationCleanup.Value));
+    }
+
+    [Fact]
+    public void EqualityIsByValue()
+    {
+        Assert.Equal(IncludedModelId.TryMint("devthrottle/wingman"), IncludedModelId.TryMint("devthrottle/wingman"));
+        Assert.NotEqual(IncludedModelId.Wingman, IncludedModelId.WingmanFast);
+        Assert.Equal(IncludedModelId.Wingman.GetHashCode(), IncludedModelId.TryMint("devthrottle/wingman")!.GetHashCode());
+        Assert.Equal("devthrottle/wingman", IncludedModelId.Wingman.ToString());
+    }
+}

--- a/src/CcDirector.Core.Tests/Configuration/ProviderRoutingTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/ProviderRoutingTests.cs
@@ -11,13 +11,19 @@ namespace CcDirector.Core.Tests.Configuration;
 /// </summary>
 public sealed class ProviderRoutingTests
 {
+    // The wingman, fast wingman, and dictation-cleanup ids are the DEVTHROTTLE INTERNAL included ids
+    // (issue #1360, Included AI): the hosted proxy meters them as included services and never bills
+    // credits. These pins are the revert-proof for the alias switch - point a constant back at a
+    // catalog id (the pre-mission "zai-org/GLM-5.2" / "Qwen/Qwen2.5-72B-Instruct" / "o4-mini") and
+    // they go red, because a catalog id bills credits on an internal feature.
+
     [Fact]
-    public void ResolveWingman_DevThrottle_UsesProxyBaseAndGlmModel()
+    public void ResolveWingman_DevThrottle_UsesProxyBaseAndIncludedWingmanId()
     {
         var ep = TranscriptionEndpointResolver.ResolveWingman(TranscriptionMode.DevThrottle);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleBaseUrl, ep.BaseUrl);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleKeyName, ep.KeyName);
-        Assert.Equal("zai-org/GLM-5.2", ep.Model);
+        Assert.Equal("devthrottle/wingman", ep.Model);
     }
 
     [Fact]
@@ -26,16 +32,16 @@ public sealed class ProviderRoutingTests
         var ep = TranscriptionEndpointResolver.ResolveWingman(TranscriptionMode.Byo);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleBaseUrl, ep.BaseUrl);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleKeyName, ep.KeyName);
-        Assert.Equal("zai-org/GLM-5.2", ep.Model);
+        Assert.Equal("devthrottle/wingman", ep.Model);
     }
 
     [Fact]
-    public void ResolveWingmanFast_DevThrottle_UsesProxyBaseAndFastModel()
+    public void ResolveWingmanFast_DevThrottle_UsesProxyBaseAndIncludedFastId()
     {
         var ep = TranscriptionEndpointResolver.ResolveWingmanFast(TranscriptionMode.DevThrottle);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleBaseUrl, ep.BaseUrl);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleKeyName, ep.KeyName);
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", ep.Model);
+        Assert.Equal("devthrottle/wingman-fast", ep.Model);
     }
 
     [Fact]
@@ -44,14 +50,29 @@ public sealed class ProviderRoutingTests
         var ep = TranscriptionEndpointResolver.ResolveWingmanFast(TranscriptionMode.Byo);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleBaseUrl, ep.BaseUrl);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleKeyName, ep.KeyName);
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", ep.Model);
+        Assert.Equal("devthrottle/wingman-fast", ep.Model);
     }
 
     [Fact]
-    public void DictationCleanup_DefaultsToOpenAiStabilityModel()
+    public void DictationCleanup_DefaultsToIncludedCleanupId()
     {
-        Assert.Equal("o4-mini", TranscriptionEndpointResolver.DevThrottleDictationCleanupModel);
+        Assert.Equal("devthrottle/dictation-cleanup", TranscriptionEndpointResolver.DevThrottleDictationCleanupModel);
         Assert.Equal(TranscriptionEndpointResolver.DevThrottleDictationCleanupModel, CleanupOrchestrator.DefaultModel);
+    }
+
+    [Theory]
+    [InlineData("devthrottle/wingman", true)]
+    [InlineData("devthrottle/wingman-fast", true)]
+    [InlineData("devthrottle/dictation-cleanup", true)]
+    [InlineData("zai-org/GLM-5.2", false)]
+    [InlineData("Qwen/Qwen2.5-72B-Instruct", false)]
+    [InlineData("o4-mini", false)]
+    [InlineData("kimi-k2", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsDevThrottleIncludedModel_AcceptsOnlyTheInternalPrefix(string? model, bool expected)
+    {
+        Assert.Equal(expected, TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
@@ -4,9 +4,12 @@ using Xunit;
 namespace CcDirector.Core.Tests.Configuration;
 
 /// <summary>
-/// <see cref="WingmanModelConfig"/> resolves the hosted wingman chat model: a real saved id is honored;
-/// an unset or stale Claude-alias value falls forward to the DevThrottle default so the wingman never
-/// calls the proxy with a model it cannot run.
+/// <see cref="WingmanModelConfig"/> resolves the hosted wingman chat model. Since the Included AI
+/// mission (issue #1360) the wingman runs ONLY on DevThrottle internal included ids
+/// (devthrottle/wingman, devthrottle/wingman-fast): a saved internal id is honored; everything else -
+/// unset, a legacy Claude alias, or a CATALOG model id (which would bill credits on an internal
+/// feature) - falls forward to the included default. The catalog-id tests here are the revert-proof
+/// for that rule: put the old honor-any-saved-string resolution back and they go red.
 /// </summary>
 [Collection("CcStorageRoot")]
 public sealed class WingmanModelConfigTests : IDisposable
@@ -28,69 +31,95 @@ public sealed class WingmanModelConfigTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_Unset_UsesProviderDefault()
+    public void Resolve_Unset_UsesIncludedDefault()
     {
-        Assert.Equal("zai-org/GLM-5.2", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
-        Assert.Equal("zai-org/GLM-5.2", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
     }
 
     [Theory]
     [InlineData("opus")]
     [InlineData("sonnet")]
     [InlineData("haiku")]
-    public void Resolve_StaleClaudeAlias_FallsForwardToProviderDefault(string alias)
+    public void Resolve_StaleClaudeAlias_FallsForwardToIncludedDefault(string alias)
     {
         WingmanModelConfig.Set(alias);   // a legacy warm-brain value the hosted proxy cannot run
-        Assert.Equal("zai-org/GLM-5.2", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+    }
+
+    /// <summary>
+    /// REVERT-PROOF for the Included AI inclusion rule (issue #1360): a saved CATALOG model id must
+    /// NOT be honored - a wingman pointed at a catalog id bills credits, which the ruling forbids for
+    /// an internal feature. The old defaults saved by earlier releases are exactly such ids.
+    /// </summary>
+    [Theory]
+    [InlineData("kimi-k2")]
+    [InlineData("zai-org/GLM-5.2")]
+    [InlineData("Qwen/Qwen2.5-72B-Instruct")]
+    public void Resolve_SavedCatalogId_FallsForwardToIncludedDefault(string catalogId)
+    {
+        WingmanModelConfig.Set(catalogId);
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
     }
 
     [Fact]
-    public void Resolve_RealHostedModel_IsHonored()
+    public void Resolve_SavedIncludedId_IsHonored()
     {
-        WingmanModelConfig.Set("kimi-k2");
-        Assert.Equal("kimi-k2", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
-        Assert.Equal("kimi-k2", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
+        WingmanModelConfig.Set("devthrottle/wingman-fast");
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
     }
 
     [Fact]
     public void Set_PersistsToBrainModelKey()
     {
-        WingmanModelConfig.Set("zai-org/GLM-5.2");
-        Assert.Equal("zai-org/GLM-5.2", CcDirectorConfigService.ReadRaw()["brain_model"]!.GetValue<string>());
+        WingmanModelConfig.Set("devthrottle/wingman");
+        Assert.Equal("devthrottle/wingman", CcDirectorConfigService.ReadRaw()["brain_model"]!.GetValue<string>());
     }
 
     [Fact]
-    public void ResolveFast_Unset_UsesProviderFastDefault()
+    public void ResolveFast_Unset_UsesIncludedFastDefault()
     {
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.ResolveFast(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.Byo));
     }
 
     [Fact]
-    public void ResolveFast_StaleClaudeAlias_FallsForwardToProviderFastDefault()
+    public void ResolveFast_StaleClaudeAlias_FallsForwardToIncludedFastDefault()
     {
         WingmanModelConfig.SetFast("opus");
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+    }
+
+    /// <summary>Fast-role half of the same revert-proof: a saved catalog id on brain_model_fast is not
+    /// honored either.</summary>
+    [Fact]
+    public void ResolveFast_SavedCatalogId_FallsForwardToIncludedFastDefault()
+    {
+        WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
     }
 
     [Fact]
     public void SetFast_PersistsToSeparateKey_AndDoesNotTouchThinking()
     {
-        WingmanModelConfig.Set("zai-org/GLM-5.2");
-        WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
+        WingmanModelConfig.Set("devthrottle/wingman");
+        WingmanModelConfig.SetFast("devthrottle/wingman-fast");
 
         var raw = CcDirectorConfigService.ReadRaw();
-        Assert.Equal("zai-org/GLM-5.2", raw["brain_model"]!.GetValue<string>());
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", raw["brain_model_fast"]!.GetValue<string>());
+        Assert.Equal("devthrottle/wingman", raw["brain_model"]!.GetValue<string>());
+        Assert.Equal("devthrottle/wingman-fast", raw["brain_model_fast"]!.GetValue<string>());
     }
 
     [Fact]
     public void Resolve_ByRole_DispatchesToThinkingOrFast()
     {
-        WingmanModelConfig.Set("zai-org/GLM-5.2");
-        WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
+        // Cross-saved on purpose so the assert can tell the roles apart: each role must read its OWN key.
+        WingmanModelConfig.Set("devthrottle/wingman-fast");
+        WingmanModelConfig.SetFast("devthrottle/wingman");
 
-        Assert.Equal("zai-org/GLM-5.2", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Thinking));
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Fast));
     }
 }

--- a/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
@@ -33,8 +33,8 @@ public sealed class WingmanModelConfigTests : IDisposable
     [Fact]
     public void Resolve_Unset_UsesIncludedDefault()
     {
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle).Value);
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo).Value);
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public sealed class WingmanModelConfigTests : IDisposable
     public void Resolve_StaleClaudeAlias_FallsForwardToIncludedDefault(string alias)
     {
         WingmanModelConfig.Set(alias);   // a legacy warm-brain value the hosted proxy cannot run
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle).Value);
     }
 
     /// <summary>
@@ -59,16 +59,16 @@ public sealed class WingmanModelConfigTests : IDisposable
     public void Resolve_SavedCatalogId_FallsForwardToIncludedDefault(string catalogId)
     {
         WingmanModelConfig.Set(catalogId);
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle).Value);
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.Byo).Value);
     }
 
     [Fact]
     public void Resolve_SavedIncludedId_IsHonored()
     {
         WingmanModelConfig.Set("devthrottle/wingman-fast");
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle));
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle).Value);
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.Byo).Value);
     }
 
     [Fact]
@@ -81,15 +81,15 @@ public sealed class WingmanModelConfigTests : IDisposable
     [Fact]
     public void ResolveFast_Unset_UsesIncludedFastDefault()
     {
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.Byo));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle).Value);
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.Byo).Value);
     }
 
     [Fact]
     public void ResolveFast_StaleClaudeAlias_FallsForwardToIncludedFastDefault()
     {
         WingmanModelConfig.SetFast("opus");
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle).Value);
     }
 
     /// <summary>Fast-role half of the same revert-proof: a saved catalog id on brain_model_fast is not
@@ -98,7 +98,7 @@ public sealed class WingmanModelConfigTests : IDisposable
     public void ResolveFast_SavedCatalogId_FallsForwardToIncludedFastDefault()
     {
         WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle).Value);
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public sealed class WingmanModelConfigTests : IDisposable
         WingmanModelConfig.Set("devthrottle/wingman-fast");
         WingmanModelConfig.SetFast("devthrottle/wingman");
 
-        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Thinking));
-        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Thinking).Value);
+        Assert.Equal("devthrottle/wingman", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Fast).Value);
     }
 }

--- a/src/CcDirector.Core.Tests/HostedAi/DirectorHostedAiReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/DirectorHostedAiReadinessTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 namespace CcDirector.Core.Tests.HostedAi;
 
 /// <summary>
-/// Issue #940 (epic #937): the Director/desktop readiness helper. It gathers the mode locally and the
-/// balance over HTTP, then defers to the shared
-/// <see cref="HostedAiReadiness"/> - so the desktop resolves the identical state the Gateway does. These
-/// prove it consults only the input the mode needs and maps each combination correctly, including the
-/// add-credits-without-restart flow.
+/// Issue #940 (epic #937), rewritten by the Included AI mission (issue #1360): the Director/desktop
+/// readiness helper defers to the shared <see cref="HostedAiReadiness"/>, which no longer consults
+/// the balance - so the desktop makes NO pre-dictation credit read and always resolves Ready in
+/// DevThrottle mode. The runtime 402 is the only gate. The never-fetches tests are the desktop half
+/// of the Q2 revert-proof.
 /// </summary>
 public sealed class DirectorHostedAiReadinessTests
 {
@@ -25,55 +25,41 @@ public sealed class DirectorHostedAiReadinessTests
             _ => { onBalanceFetch?.Invoke(); return Task.FromResult(balanceMicros); });
 
     [Fact]
-    public async Task LegacyByo_NoKey_UsesDevThrottleBalanceAndReadyWhenUnknown()
+    public async Task LegacyByo_Ready()
         => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.Byo, key: null).CheckAsync());
-
-    [Fact]
-    public async Task LegacyByo_WithKey_Ready()
-        => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.Byo, key: "sk-abc").CheckAsync());
-
-    [Fact]
-    public async Task LegacyByo_FetchesBalance()
-    {
-        var balanceFetched = false;
-        await Build(TranscriptionMode.Byo, key: "sk-abc", onBalanceFetch: () => balanceFetched = true).CheckAsync();
-        Assert.True(balanceFetched);
-    }
 
     [Theory]
     [InlineData(0L)]
     [InlineData(-1L)]
-    public async Task DevThrottle_EmptyBalance_NeedsCredits(long balance)
-        => Assert.Equal(HostedAiState.NeedsCredits, await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync());
+    public async Task DevThrottle_ZeroBalance_StillReady(long balance)
+        // Included AI revert-proof (issue #1360): the old gate answered NeedsCredits here and blocked
+        // the zero-balance entitled member the mission's acceptance test serves.
+        => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync());
 
     [Fact]
     public async Task DevThrottle_PositiveBalance_Ready()
         => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.DevThrottle, balanceMicros: 5_000_000).CheckAsync());
 
     [Fact]
-    public async Task DevThrottle_UnknownBalance_DoesNotBlock_Ready()
+    public async Task DevThrottle_UnknownBalance_Ready()
         => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.DevThrottle, balanceMicros: null).CheckAsync());
 
     [Fact]
-    public async Task DevThrottle_DoesNotFetchKey()
+    public async Task NeverFetchesKeyOrBalance()
     {
+        // No credit read and no key read on any check (issue #1360): the balance was the desktop's
+        // 2-second pre-dictation HTTP fetch, now gone entirely.
         var keyFetched = false;
-        await Build(TranscriptionMode.DevThrottle, balanceMicros: 5_000_000, onKeyFetch: () => keyFetched = true).CheckAsync();
+        var balanceFetched = false;
+        await Build(TranscriptionMode.DevThrottle,
+            onKeyFetch: () => keyFetched = true,
+            onBalanceFetch: () => balanceFetched = true).CheckAsync();
+        await Build(TranscriptionMode.Byo,
+            onKeyFetch: () => keyFetched = true,
+            onBalanceFetch: () => balanceFetched = true).CheckAsync();
+
         Assert.False(keyFetched);
-    }
-
-    [Fact]
-    public async Task DevThrottle_AddCredits_UnlocksWithoutRestart()
-    {
-        long balance = 0;
-        var check = new DirectorHostedAiReadiness(
-            () => TranscriptionMode.DevThrottle,
-            _ => Task.FromResult<string?>(null),
-            _ => Task.FromResult<long?>(balance));
-
-        Assert.Equal(HostedAiState.NeedsCredits, await check.CheckAsync());
-        balance = 5_000_000; // user adds $5
-        Assert.Equal(HostedAiState.Ready, await check.CheckAsync());
+        Assert.False(balanceFetched);
     }
 
     [Fact]
@@ -82,5 +68,12 @@ public sealed class DirectorHostedAiReadinessTests
         Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(null!, _ => Task.FromResult<string?>(null), _ => Task.FromResult<long?>(0)));
         Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(() => TranscriptionMode.Byo, null!, _ => Task.FromResult<long?>(0)));
         Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(() => TranscriptionMode.Byo, _ => Task.FromResult<string?>(null), null!));
+    }
+
+    [Fact]
+    public async Task Create_WiresTheModeAndAnswersReady()
+    {
+        var readiness = DirectorHostedAiReadiness.Create(new HostedAiKeyResolver(), () => TranscriptionMode.DevThrottle);
+        Assert.Equal(HostedAiState.Ready, await readiness.CheckAsync());
     }
 }

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiErrorMapperTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiErrorMapperTests.cs
@@ -4,10 +4,12 @@ using Xunit;
 namespace CcDirector.Core.Tests.HostedAi;
 
 /// <summary>
-/// Issue #938 (epic #937): the runtime 402 mapper. It must branch on the machine-readable
-/// <c>code</c> (never the shared <c>type</c>): <c>insufficient_credits</c> -> NeedsCredits,
-/// <c>monthly_limit_reached</c> -> CapReached, and any other 402 -> NeedsCredits (the common case).
-/// The code parse reads both the nested and flat OpenAI-compatible shapes and defaults safely.
+/// Issue #938 (epic #937), extended by the Included AI mission (issue #1360): the runtime 402 mapper.
+/// It must branch on the machine-readable <c>code</c> (never the shared <c>type</c>). The four known
+/// codes map to their states; ANY other code - including an absent one - maps to the NEUTRAL
+/// <see cref="HostedAiState.Unavailable"/>. The unknown-code tests are the Q3 revert-proof: put the
+/// old NeedsCredits default back and they go red, because an unknown 402 would again show an
+/// add-credits prompt to members the owner ruled must never see a cost.
 /// </summary>
 public sealed class HostedAiErrorMapperTests
 {
@@ -16,9 +18,15 @@ public sealed class HostedAiErrorMapperTests
     [InlineData("monthly_limit_reached", HostedAiState.CapReached)]
     [InlineData("MONTHLY_LIMIT_REACHED", HostedAiState.CapReached)]
     [InlineData("  monthly_limit_reached  ", HostedAiState.CapReached)]
-    [InlineData("some_other_code", HostedAiState.NeedsCredits)]
-    [InlineData("", HostedAiState.NeedsCredits)]
-    [InlineData(null, HostedAiState.NeedsCredits)]
+    [InlineData("subscription_required", HostedAiState.SubscriptionRequired)]
+    [InlineData("SUBSCRIPTION_REQUIRED", HostedAiState.SubscriptionRequired)]
+    [InlineData("fair_use_limit_reached", HostedAiState.FairUseLimitReached)]
+    [InlineData("  fair_use_limit_reached  ", HostedAiState.FairUseLimitReached)]
+    // The Q3 revert-proof rows: an unknown or absent code must NEVER claim "out of credits".
+    [InlineData("some_other_code", HostedAiState.Unavailable)]
+    [InlineData("unknown", HostedAiState.Unavailable)]
+    [InlineData("", HostedAiState.Unavailable)]
+    [InlineData(null, HostedAiState.Unavailable)]
     public void MapCode_BranchesOnCode(string? code, HostedAiState expected)
         => Assert.Equal(expected, HostedAiErrorMapper.MapCode(code));
 
@@ -41,8 +49,10 @@ public sealed class HostedAiErrorMapperTests
     [InlineData("   ")]
     [InlineData("not json at all")]
     [InlineData("{ \"error\": { \"type\": \"insufficient_quota\" } }")] // no code field
-    public void ParseErrorCode_MissingOrUnparseable_DefaultsToInsufficientCredits(string body)
-        => Assert.Equal(HostedAiErrorMapper.InsufficientCreditsCode, HostedAiErrorMapper.ParseErrorCode(body));
+    public void ParseErrorCode_MissingOrUnparseable_IsUnknown_NeverAssumedOutOfCredits(string body)
+        // Q3 revert-proof (issue #1360): the old default was insufficient_credits, which turned every
+        // unreadable 402 into an add-credits prompt.
+        => Assert.Equal(HostedAiErrorMapper.UnknownCode, HostedAiErrorMapper.ParseErrorCode(body));
 
     [Fact]
     public void Map402_NestedMonthlyLimit_CapReached()
@@ -58,10 +68,17 @@ public sealed class HostedAiErrorMapperTests
         Assert.Equal(HostedAiState.NeedsCredits, HostedAiErrorMapper.Map402(body));
     }
 
+    [Theory]
+    [InlineData("{ \"error\": { \"code\": \"subscription_required\" } }", HostedAiState.SubscriptionRequired)]
+    [InlineData("{ \"error\": { \"code\": \"fair_use_limit_reached\" } }", HostedAiState.FairUseLimitReached)]
+    public void Map402_IncludedAiCodes_MapToTheirStates(string body, HostedAiState expected)
+        => Assert.Equal(expected, HostedAiErrorMapper.Map402(body));
+
     [Fact]
-    public void Map402_NonJsonBody_NeedsCredits()
+    public void Map402_NonJsonBody_IsNeutralUnavailable()
     {
-        // A non-JSON 402 body still means out of credits (the transcription path's proven behavior).
-        Assert.Equal(HostedAiState.NeedsCredits, HostedAiErrorMapper.Map402("Payment Required"));
+        // A non-JSON 402 body is a money-shaped refusal with no readable reason. It must be reported
+        // neutrally - never as "out of credits" (issue #1360).
+        Assert.Equal(HostedAiState.Unavailable, HostedAiErrorMapper.Map402("Payment Required"));
     }
 }

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
@@ -69,9 +69,61 @@ public sealed class HostedAiMessagesTests
         Assert.Null(m.CtaUrl); // Settings is surface-local, not a web address
     }
 
+    [Fact]
+    public void SubscriptionRequired_PointsAtPricing_NamesNoCostAndNoCredits()
+    {
+        // Issue #1360: no live entitlement. The copy points at the PRICING page (design C5: no
+        // checkout to promise), and must carry NO credit words, NO numbers, and NO top-up prompt -
+        // the owner ruled a normal member sees no cost anywhere.
+        var m = HostedAiMessages.For(HostedAiState.SubscriptionRequired);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("View plans", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.OpenPricing, m.CtaAction);
+        Assert.NotNull(m.CtaUrl);
+        Assert.EndsWith("/pricing", m.CtaUrl);
+        Assert.DoesNotContain("credit", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("balance", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("top up", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch("[0-9$]", m.Text);
+        Assert.True(HostedAiCopyRules.IsClean(m.Text));
+    }
+
+    [Fact]
+    public void FairUseLimitReached_PlainResetsNextMonth_NoNumbersNoCostNoCta()
+    {
+        // Issue #1360, owner verbatim "They should never know this": the fair-use cap is invisible,
+        // so the copy carries no numbers, no dollars, no credit words, and offers no call-to-action.
+        var m = HostedAiMessages.For(HostedAiState.FairUseLimitReached);
+        Assert.NotEmpty(m.Text);
+        Assert.Contains("resets", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.None, m.CtaAction);
+        Assert.Null(m.CtaUrl);
+        Assert.DoesNotContain("credit", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch("[0-9$%]", m.Text);
+        Assert.True(HostedAiCopyRules.IsClean(m.Text));
+    }
+
+    [Fact]
+    public void Unavailable_IsNeutral_NamesNoMoneyAndOffersNoCta()
+    {
+        // Issue #1360: the unknown-code state. Neutral by design - it must never claim credits.
+        var m = HostedAiMessages.For(HostedAiState.Unavailable);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.None, m.CtaAction);
+        Assert.Null(m.CtaUrl);
+        Assert.DoesNotContain("credit", m.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch("[0-9$]", m.Text);
+        Assert.True(HostedAiCopyRules.IsClean(m.Text));
+    }
+
     [Theory]
     [InlineData(HostedAiState.NeedsCredits)]
     [InlineData(HostedAiState.CapReached)]
+    [InlineData(HostedAiState.SubscriptionRequired)]
+    [InlineData(HostedAiState.FairUseLimitReached)]
+    [InlineData(HostedAiState.Unavailable)]
     public void HostedCopy_PassesForbiddenLanguageRules(HostedAiState state)
     {
         var m = HostedAiMessages.For(state);

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiPayloadTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiPayloadTests.cs
@@ -16,6 +16,9 @@ public sealed class HostedAiPayloadTests
     [InlineData(HostedAiState.NeedsCredits, "NeedsCredits", "OpenBilling")]
     [InlineData(HostedAiState.CapReached, "CapReached", "OpenBilling")]
     [InlineData(HostedAiState.NeedsKey, "NeedsKey", "OpenSettings")]
+    [InlineData(HostedAiState.SubscriptionRequired, "SubscriptionRequired", "OpenPricing")]
+    [InlineData(HostedAiState.FairUseLimitReached, "FairUseLimitReached", "None")]
+    [InlineData(HostedAiState.Unavailable, "Unavailable", "None")]
     public void For_CarriesSharedCopy_AndErrorMirrorsText(HostedAiState state, string expectedState, string expectedAction)
     {
         var p = HostedAiPayload.For(state);
@@ -50,6 +53,9 @@ public sealed class HostedAiPayloadTests
     {
         Assert.Equal("CapReached", HostedAiPayload.FromBody("{\"error\":{\"code\":\"monthly_limit_reached\"}}").State);
         Assert.Equal("NeedsCredits", HostedAiPayload.FromBody("{\"error\":{\"code\":\"insufficient_credits\"}}").State);
-        Assert.Equal("NeedsCredits", HostedAiPayload.FromBody("not json").State); // default
+        Assert.Equal("SubscriptionRequired", HostedAiPayload.FromBody("{\"error\":{\"code\":\"subscription_required\"}}").State);
+        Assert.Equal("FairUseLimitReached", HostedAiPayload.FromBody("{\"error\":{\"code\":\"fair_use_limit_reached\"}}").State);
+        // An unreadable body is UNKNOWN and must stay neutral - never "out of credits" (issue #1360).
+        Assert.Equal("Unavailable", HostedAiPayload.FromBody("not json").State);
     }
 }

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiReadinessTests.cs
@@ -5,11 +5,13 @@ using Xunit;
 namespace CcDirector.Core.Tests.HostedAi;
 
 /// <summary>
-/// Issue #938 (epic #937): the shared pre-flight readiness check. Every (mode, balance)
-/// combination must resolve to the one correct <see cref="HostedAiState"/>, an unknown balance must
-/// NOT block, and - the criterion the whole gate exists for - adding $5 must flip a check from
-/// <see cref="HostedAiState.NeedsCredits"/> to <see cref="HostedAiState.Ready"/> with no restart,
-/// proving the balance is re-read fresh on every call (no cache).
+/// Issue #938 (epic #937), rewritten by the Included AI mission (issue #1360): the shared pre-flight
+/// readiness check no longer consults the account balance AT ALL. The internal AI features are
+/// included with an entitled account and never billed to credits, so a zero balance says nothing
+/// about whether the server will serve the call - a client-side balance gate would block exactly the
+/// members the mission exists to serve. The zero-balance-still-Ready and never-reads-the-balance
+/// tests are the REVERT-PROOF: put the old balance gate back and they go red with the mission's
+/// reported symptom (a zero-balance entitled member blocked before recording).
 /// </summary>
 public sealed class HostedAiReadinessTests
 {
@@ -21,50 +23,24 @@ public sealed class HostedAiReadinessTests
             _ => Task.FromResult(balanceMicros));
 
     [Fact]
-    public async Task LegacyByo_NoKey_UsesDevThrottleBalanceAndReadyWhenUnknown()
+    public async Task LegacyByo_Ready()
     {
         var state = await Build(TranscriptionMode.Byo, key: null).CheckAsync();
         Assert.Equal(HostedAiState.Ready, state);
     }
 
     [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task LegacyByo_BlankKey_UsesDevThrottleBalanceAndReadyWhenUnknown(string key)
-    {
-        var state = await Build(TranscriptionMode.Byo, key: key).CheckAsync();
-        Assert.Equal(HostedAiState.Ready, state);
-    }
-
-    [Fact]
-    public async Task LegacyByo_WithKey_Ready()
-    {
-        var state = await Build(TranscriptionMode.Byo, key: "sk-abc123").CheckAsync();
-        Assert.Equal(HostedAiState.Ready, state);
-    }
-
-    [Fact]
-    public async Task LegacyByo_ReadsBalance()
-    {
-        var balanceRead = false;
-        var check = new HostedAiReadiness(
-            () => TranscriptionMode.Byo,
-            _ => "sk-abc123",
-            _ => { balanceRead = true; return Task.FromResult<long?>(0); });
-
-        await check.CheckAsync();
-
-        Assert.True(balanceRead);
-    }
-
-    [Theory]
     [InlineData(0L)]
     [InlineData(-1L)]
     [InlineData(-500_000L)]
-    public async Task DevThrottle_EmptyOrNegativeBalance_NeedsCredits(long balance)
+    public async Task DevThrottle_ZeroOrNegativeBalance_StillReady(long balance)
     {
+        // The Included AI revert-proof (issue #1360): a zero-balance ENTITLED member is served by the
+        // cloud, so the pre-flight must not block them. The old gate answered NeedsCredits here - the
+        // exact defect the mission fixes (the acceptance test is a zero-balance trial account
+        // completing a dictation round-trip).
         var state = await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync();
-        Assert.Equal(HostedAiState.NeedsCredits, state);
+        Assert.Equal(HostedAiState.Ready, state);
     }
 
     [Theory]
@@ -77,47 +53,28 @@ public sealed class HostedAiReadinessTests
     }
 
     [Fact]
-    public async Task DevThrottle_UnknownBalance_DoesNotBlock_Ready()
+    public async Task DevThrottle_UnknownBalance_Ready()
     {
-        // Signed out or the cloud is unreachable -> balance null -> the pre-flight check must not block;
-        // the runtime 402 is the authoritative gate and reports the identical state.
         var state = await Build(TranscriptionMode.DevThrottle, balanceMicros: null).CheckAsync();
         Assert.Equal(HostedAiState.Ready, state);
     }
 
     [Fact]
-    public async Task DevThrottle_AddCredits_UnlocksWithoutRestart()
+    public async Task BalanceProvider_IsNeverInvoked()
     {
-        // The balance the check reads changes underneath the SAME instance (a $5 top-up). Because the
-        // balance is re-read fresh each call, the very next check flips NeedsCredits -> Ready with no
-        // restart and no new object - the epic's headline acceptance criterion.
-        long balance = 0;
-        var check = new HostedAiReadiness(
-            () => TranscriptionMode.DevThrottle,
-            _ => null,
-            _ => Task.FromResult<long?>(balance));
-
-        Assert.Equal(HostedAiState.NeedsCredits, await check.CheckAsync());
-
-        balance = 5_000_000; // user adds $5
-
-        Assert.Equal(HostedAiState.Ready, await check.CheckAsync());
-    }
-
-    [Fact]
-    public async Task DevThrottle_ReadsBalanceFreshEveryCall()
-    {
+        // The check must not even READ the balance (issue #1360): the read was the desktop's
+        // pre-dictation credit fetch, and the balance is a cost fact a normal member's product
+        // experience must not depend on. Reverting the readiness change re-invokes this delegate.
         var reads = 0;
         var check = new HostedAiReadiness(
             () => TranscriptionMode.DevThrottle,
             _ => null,
-            _ => { reads++; return Task.FromResult<long?>(5_000_000); });
+            _ => { reads++; return Task.FromResult<long?>(0); });
 
         await check.CheckAsync();
         await check.CheckAsync();
-        await check.CheckAsync();
 
-        Assert.Equal(3, reads); // no caching between calls
+        Assert.Equal(0, reads);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Claude/BriefBuilder.cs
+++ b/src/CcDirector.Core/Claude/BriefBuilder.cs
@@ -65,9 +65,11 @@ public sealed class BriefBuilder : IDisposable
     /// <summary>
     /// Create a condenser, or null when no DevThrottle account key is available. A null condenser is the
     /// EXPLICIT degrade path: the brief endpoint still serves the raw extraction and reports
-    /// <c>Condenser = "unavailable"</c> - visible, never silent.
+    /// <c>Condenser = "unavailable"</c> - visible, never silent. The model is the PROVEN included type
+    /// (issue #1360) - this class presents the DevThrottle deployment credential, so a raw string
+    /// cannot be accepted here; null means the default fast tier.
     /// </summary>
-    public static BriefBuilder? TryCreate(string model = DefaultModel, HttpClient? httpClient = null)
+    public static BriefBuilder? TryCreate(IncludedModelId? model = null, HttpClient? httpClient = null)
     {
         var key = Environment.GetEnvironmentVariable(TranscriptionEndpointResolver.DevThrottleKeyName);
         if (string.IsNullOrWhiteSpace(key))
@@ -75,7 +77,7 @@ public sealed class BriefBuilder : IDisposable
             FileLog.Write("[BriefBuilder] TryCreate: DEVTHROTTLE_API_KEY not set; condenser unavailable");
             return null;
         }
-        return new BriefBuilder(key.Trim(), string.IsNullOrWhiteSpace(model) ? DefaultModel : model, httpClient);
+        return new BriefBuilder(key.Trim(), (model ?? IncludedModelId.WingmanFast).Value, httpClient);
     }
 
     // ====================================================================

--- a/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
@@ -10,7 +10,8 @@ namespace CcDirector.Core.Configuration;
 /// separate from any Wingman model, surfaced on the AI Settings screen.
 ///
 /// Resolution precedence (settled with the Architect):
-///   1. the <c>CC_CARMODE_MODEL</c> environment variable (a per-install override / debug switch) - wins;
+///   1. the <c>CC_CARMODE_MODEL</c> environment variable (a per-install override / debug switch) - wins,
+///      honored only when it is a DevThrottle internal included id (issue #1360);
 ///   2. the user's saved setting (config.json <c>car_mode_model</c>) - what the AI Settings dropdown
 ///      writes - honored only when it is a DevThrottle internal included id (issue #1360);
 ///   3. the default, <see cref="Default"/> (the fast wingman id), the fast tier proven cleanest under
@@ -53,12 +54,21 @@ public static class CarModeModelConfig
     /// The EFFECTIVE Car Mode model the brain runs, applying the full precedence: the
     /// <see cref="EnvVar"/> environment override wins, then the user's saved setting, then
     /// <see cref="Default"/>. Read at call time so a settings change (or an env change on restart) is
-    /// honoured on the next turn.
+    /// honoured on the next turn. The environment override is subject to the SAME included-id rule as
+    /// the saved setting (issue #1360): Car Mode is an internal included feature and its model is sent
+    /// with the DevThrottle deployment credential, so a catalog id here would bill credits no matter
+    /// which knob it arrived through. A non-included environment value falls forward exactly as a
+    /// non-included saved value does.
     /// </summary>
     public static string Resolve()
     {
         var env = Environment.GetEnvironmentVariable(EnvVar);
-        if (!string.IsNullOrWhiteSpace(env)) return env.Trim();
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            var model = env.Trim();
+            if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
+                return model;
+        }
         return Get();
     }
 

--- a/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
@@ -11,9 +11,11 @@ namespace CcDirector.Core.Configuration;
 ///
 /// Resolution precedence (settled with the Architect):
 ///   1. the <c>CC_CARMODE_MODEL</c> environment variable (a per-install override / debug switch) - wins;
-///   2. the user's saved setting (config.json <c>car_mode_model</c>) - what the AI Settings dropdown writes;
-///   3. the default, <see cref="Default"/> (Qwen2.5-72B), the fast tier proven cleanest under the guardrail.
-/// GLM-5.2 remains a selectable option in the dropdown (slower but a strong tool-caller).
+///   2. the user's saved setting (config.json <c>car_mode_model</c>) - what the AI Settings dropdown
+///      writes - honored only when it is a DevThrottle internal included id (issue #1360);
+///   3. the default, <see cref="Default"/> (the fast wingman id), the fast tier proven cleanest under
+///      the guardrail. The thinking wingman id remains a selectable option in the dropdown (slower but
+///      a strong tool-caller).
 /// </summary>
 public static class CarModeModelConfig
 {
@@ -38,7 +40,11 @@ public static class CarModeModelConfig
         if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
         {
             var model = v.GetValue<string>().Trim();
-            if (model.Length > 0) return model;
+            // Car Mode is an internal included feature (issue #1360): only a DevThrottle internal id
+            // is honored. A catalog id saved by an older release would bill credits, so it falls
+            // forward to the included default.
+            if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
+                return model;
         }
         return Default;
     }

--- a/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
@@ -58,18 +58,14 @@ public static class CarModeModelConfig
     /// the saved setting (issue #1360): Car Mode is an internal included feature and its model is sent
     /// with the DevThrottle deployment credential, so a catalog id here would bill credits no matter
     /// which knob it arrived through. A non-included environment value falls forward exactly as a
-    /// non-included saved value does.
+    /// non-included saved value does. Returns the PROVEN type, so what this resolves can be handed
+    /// straight to the deployment credential.
     /// </summary>
-    public static string Resolve()
+    public static IncludedModelId Resolve()
     {
         var env = Environment.GetEnvironmentVariable(EnvVar);
-        if (!string.IsNullOrWhiteSpace(env))
-        {
-            var model = env.Trim();
-            if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
-                return model;
-        }
-        return Get();
+        return IncludedModelId.TryMint(env)
+               ?? IncludedModelId.MintOrFallForward(Get(), IncludedModelId.WingmanFast);
     }
 
     /// <summary>Persist the chosen Car Mode model to config.json (merge-patch).</summary>

--- a/src/CcDirector.Core/Configuration/IncludedModelId.cs
+++ b/src/CcDirector.Core/Configuration/IncludedModelId.cs
@@ -1,0 +1,74 @@
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// A chat model id PROVEN to be one of DevThrottle's internal included-service ids (issue #1360,
+/// Included AI). This type is the class-wide guard on the meeting point of a chat model id and the
+/// DevThrottle deployment credential, made structural: every constructor and resolver tuple that puts
+/// a chat model on a request authenticated by the deployment credential takes THIS type, not a raw
+/// string, so an unvalidated string cannot reach the wire from any call site - present or future.
+///
+/// The two earlier runtime guards this replaces were both bypassed by construction in the phase-2
+/// inspection: a base-URL string-equality check was defeated by the equivalent
+/// <c>https://devthrottle.com:443/api/v1</c> spelling, and the Car Mode transports publicly accepted
+/// raw resolver tuples around their guarded default resolver. A type cannot be spelled around: the
+/// only way to obtain an instance is the mint on this class, and the mint validates.
+///
+/// THE ONLY MINT PATH IS HERE. The constructor is private; <see cref="TryMint"/> is the single
+/// validation gate, <see cref="MintOrFallForward"/> is the fall-forward resolution every settings leg
+/// uses (a catalog id saved by an older release degrades to the included default instead of billing
+/// credits), and the three named statics are the known included ids pre-minted from their constants.
+/// A reflection test pins this producer surface so a new public way to conjure an instance fails the
+/// build's tests, not an inspection.
+///
+/// Deliberately NOT used by BYO/self-configured provider paths that present the MEMBER's own key -
+/// those legitimately run catalog models on the member's own account and keep raw strings.
+/// </summary>
+public sealed class IncludedModelId : IEquatable<IncludedModelId>
+{
+    /// <summary>The proven included model id, trimmed. Always carries the
+    /// <see cref="TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix"/>.</summary>
+    public string Value { get; }
+
+    private IncludedModelId(string value) => Value = value;
+
+    /// <summary>The wingman thinking tier (<see cref="TranscriptionEndpointResolver.DevThrottleWingmanModel"/>).</summary>
+    public static IncludedModelId Wingman { get; } = new(TranscriptionEndpointResolver.DevThrottleWingmanModel);
+
+    /// <summary>The wingman fast tier (<see cref="TranscriptionEndpointResolver.DevThrottleWingmanFastModel"/>).</summary>
+    public static IncludedModelId WingmanFast { get; } = new(TranscriptionEndpointResolver.DevThrottleWingmanFastModel);
+
+    /// <summary>The dictation-cleanup id (<see cref="TranscriptionEndpointResolver.DevThrottleDictationCleanupModel"/>).</summary>
+    public static IncludedModelId DictationCleanup { get; } = new(TranscriptionEndpointResolver.DevThrottleDictationCleanupModel);
+
+    /// <summary>
+    /// The single validation gate: mints <paramref name="candidate"/> when it is a DevThrottle internal
+    /// included id, else null. Callers that must REFUSE a non-included id (the settings write endpoints,
+    /// test-chat) branch on the null; callers that must FALL FORWARD use
+    /// <see cref="MintOrFallForward"/> instead.
+    /// </summary>
+    public static IncludedModelId? TryMint(string? candidate)
+        => TranscriptionEndpointResolver.IsDevThrottleIncludedModel(candidate)
+            ? new IncludedModelId(candidate!.Trim())
+            : null;
+
+    /// <summary>
+    /// The fall-forward resolution rule (issue #1360): <paramref name="candidate"/> when it is an
+    /// included id, else <paramref name="fallForward"/>. A catalog id - saved by an older release,
+    /// set in an environment override, or stored as a tenant override - degrades to the included
+    /// default instead of billing credits on an internal feature.
+    /// </summary>
+    public static IncludedModelId MintOrFallForward(string? candidate, IncludedModelId fallForward)
+    {
+        ArgumentNullException.ThrowIfNull(fallForward);
+        return TryMint(candidate) ?? fallForward;
+    }
+
+    public bool Equals(IncludedModelId? other)
+        => other is not null && string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => Equals(obj as IncludedModelId);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value);
+
+    public override string ToString() => Value;
+}

--- a/src/CcDirector.Core/Configuration/IncludedModelId.cs
+++ b/src/CcDirector.Core/Configuration/IncludedModelId.cs
@@ -11,7 +11,11 @@ namespace CcDirector.Core.Configuration;
 /// inspection: a base-URL string-equality check was defeated by the equivalent
 /// <c>https://devthrottle.com:443/api/v1</c> spelling, and the Car Mode transports publicly accepted
 /// raw resolver tuples around their guarded default resolver. A type cannot be spelled around: the
-/// only way to obtain an instance is the mint on this class, and the mint validates.
+/// mint on this class is the only producer of USABLE instances. An instance forged by invoking the
+/// private constructor through reflection (phase-2 inspection round 3) carries an unvalidated value
+/// and throws at its first use of <see cref="Value"/>, so it can never reach a transport. Deliberate
+/// reflection beyond that is outside the threat model: code already running in this process with
+/// reflection rights could read the deployment credential directly.
 ///
 /// THE ONLY MINT PATH IS HERE. The constructor is private; <see cref="TryMint"/> is the single
 /// validation gate, <see cref="MintOrFallForward"/> is the fall-forward resolution every settings leg
@@ -25,11 +29,32 @@ namespace CcDirector.Core.Configuration;
 /// </summary>
 public sealed class IncludedModelId : IEquatable<IncludedModelId>
 {
-    /// <summary>The proven included model id, trimmed. Always carries the
-    /// <see cref="TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix"/>.</summary>
-    public string Value { get; }
+    private readonly string _value;
 
-    private IncludedModelId(string value) => Value = value;
+    /// <summary>The proven included model id, trimmed. Always carries the
+    /// <see cref="TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix"/> - the getter
+    /// validates that on every read, so a forged instance (private constructor invoked through
+    /// reflection, bypassing the mint) throws here at first use instead of reaching a transport.
+    /// Every legitimate instance comes from the mint, which only stores prefixed values, so no
+    /// legitimate read can throw.</summary>
+    public string Value
+    {
+        get
+        {
+            if (!TranscriptionEndpointResolver.IsDevThrottleIncludedModel(_value))
+            {
+                throw new InvalidOperationException(
+                    $"Forged {nameof(IncludedModelId)}: the stored value does not carry the " +
+                    $"'{TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix}' prefix, so this " +
+                    "instance was constructed outside the mint (for example by invoking the private " +
+                    "constructor through reflection). The mint is the only producer of usable instances.");
+            }
+
+            return _value;
+        }
+    }
+
+    private IncludedModelId(string value) => _value = value;
 
     /// <summary>The wingman thinking tier (<see cref="TranscriptionEndpointResolver.DevThrottleWingmanModel"/>).</summary>
     public static IncludedModelId Wingman { get; } = new(TranscriptionEndpointResolver.DevThrottleWingmanModel);

--- a/src/CcDirector.Core/Configuration/IncludedModelId.cs
+++ b/src/CcDirector.Core/Configuration/IncludedModelId.cs
@@ -10,12 +10,16 @@ namespace CcDirector.Core.Configuration;
 /// The two earlier runtime guards this replaces were both bypassed by construction in the phase-2
 /// inspection: a base-URL string-equality check was defeated by the equivalent
 /// <c>https://devthrottle.com:443/api/v1</c> spelling, and the Car Mode transports publicly accepted
-/// raw resolver tuples around their guarded default resolver. A type cannot be spelled around: the
-/// mint on this class is the only producer of USABLE instances. An instance forged by invoking the
-/// private constructor through reflection (phase-2 inspection round 3) carries an unvalidated value
-/// and throws at its first use of <see cref="Value"/>, so it can never reach a transport. Deliberate
-/// reflection beyond that is outside the threat model: code already running in this process with
-/// reflection rights could read the deployment credential directly.
+/// raw resolver tuples around their guarded default resolver. A type cannot be spelled around: in
+/// ordinary (non-reflective) code the mint on this class is the only producer of instances, and it
+/// normalizes (trims) its input before validating and storing. The exact enforced invariant is on
+/// <see cref="Value"/>: no instance whose stored value is not a devthrottle/-prefixed id (verbatim,
+/// ordinal) is usable. So an instance forged by invoking the private constructor through reflection
+/// (phase-2 inspection rounds 3 and 4) throws at its first use of <see cref="Value"/> unless the
+/// forged value already names an included id verbatim - the harmless case, because this guard's job
+/// is credential/model separation, not provenance. Deliberate reflection beyond that is outside the
+/// threat model: code already running in this process with reflection rights could read the
+/// deployment credential directly.
 ///
 /// THE ONLY MINT PATH IS HERE. The constructor is private; <see cref="TryMint"/> is the single
 /// validation gate, <see cref="MintOrFallForward"/> is the fall-forward resolution every settings leg
@@ -31,17 +35,22 @@ public sealed class IncludedModelId : IEquatable<IncludedModelId>
 {
     private readonly string _value;
 
-    /// <summary>The proven included model id, trimmed. Always carries the
-    /// <see cref="TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix"/> - the getter
-    /// validates that on every read, so a forged instance (private constructor invoked through
-    /// reflection, bypassing the mint) throws here at first use instead of reaching a transport.
-    /// Every legitimate instance comes from the mint, which only stores prefixed values, so no
-    /// legitimate read can throw.</summary>
+    /// <summary>The proven included model id. The getter enforces the exact invariant on every
+    /// read: the STORED string must carry the
+    /// <see cref="TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix"/> verbatim
+    /// (ordinal, no trimming or other normalization at read time), else it throws. The mint trims
+    /// its input before validating and storing, so no legitimate instance can carry whitespace and
+    /// no legitimate read can throw. A forged instance (private constructor invoked through
+    /// reflection, bypassing the mint) is therefore usable only if it already stores a
+    /// devthrottle/-prefixed id verbatim - the harmless case, because this guard exists to keep
+    /// non-included model ids off the deployment credential, not to prove provenance.</summary>
     public string Value
     {
         get
         {
-            if (!TranscriptionEndpointResolver.IsDevThrottleIncludedModel(_value))
+            if (_value is null
+                || !_value.StartsWith(
+                    TranscriptionEndpointResolver.DevThrottleIncludedModelPrefix, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     $"Forged {nameof(IncludedModelId)}: the stored value does not carry the " +
@@ -72,9 +81,12 @@ public sealed class IncludedModelId : IEquatable<IncludedModelId>
     /// <see cref="MintOrFallForward"/> instead.
     /// </summary>
     public static IncludedModelId? TryMint(string? candidate)
-        => TranscriptionEndpointResolver.IsDevThrottleIncludedModel(candidate)
-            ? new IncludedModelId(candidate!.Trim())
+    {
+        var normalized = candidate?.Trim();
+        return TranscriptionEndpointResolver.IsDevThrottleIncludedModel(normalized)
+            ? new IncludedModelId(normalized!)
             : null;
+    }
 
     /// <summary>
     /// The fall-forward resolution rule (issue #1360): <paramref name="candidate"/> when it is an

--- a/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
+++ b/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
@@ -97,16 +97,37 @@ public static class TranscriptionEndpointResolver
     public const string DevThrottleModel = "gpt-4o-transcribe";
 
     /// <summary>
-    /// The dictation dictionary-cleanup model. Kept separate from the general Wingman fast model so
-    /// transcription cleanup can use the OpenAI stability route without moving unrelated chat traffic.
+    /// The dictation dictionary-cleanup model id. Kept separate from the general Wingman fast model so
+    /// dictation-flavored calls stay distinguishable from wingman chat. This is a DevThrottle-served
+    /// internal id (issue #1360): the hosted proxy maps it to its upstream and meters it as an included
+    /// service instead of billing credits. Catalog model ids bill credits on every path.
     /// </summary>
-    public const string DevThrottleDictationCleanupModel = "o4-mini";
+    public const string DevThrottleDictationCleanupModel = "devthrottle/dictation-cleanup";
 
-    /// <summary>The default DevThrottle thinking model.</summary>
-    public const string DevThrottleWingmanModel = "zai-org/GLM-5.2";
+    /// <summary>
+    /// The DevThrottle thinking model id. An internal DevThrottle-served id (issue #1360), not a catalog
+    /// model: the hosted proxy maps it to its upstream and meters it as the included wingman service,
+    /// never billing credits. A catalog id here would bill credits, which the Included AI ruling forbids
+    /// for an internal feature.
+    /// </summary>
+    public const string DevThrottleWingmanModel = "devthrottle/wingman";
 
-    /// <summary>The default DevThrottle fast model.</summary>
-    public const string DevThrottleWingmanFastModel = "Qwen/Qwen2.5-72B-Instruct";
+    /// <summary>The DevThrottle fast model id. Same contract as <see cref="DevThrottleWingmanModel"/>:
+    /// an internal DevThrottle-served id, metered as included wingman usage, never billed to credits.</summary>
+    public const string DevThrottleWingmanFastModel = "devthrottle/wingman-fast";
+
+    /// <summary>
+    /// The id prefix that marks a model as one of DevThrottle's internal included-service ids
+    /// (issue #1360). A saved wingman or Car Mode model that does NOT carry this prefix is a catalog
+    /// model - it would bill credits, so resolution falls forward to the included default instead of
+    /// honoring it.
+    /// </summary>
+    public const string DevThrottleIncludedModelPrefix = "devthrottle/";
+
+    /// <summary>True when <paramref name="model"/> is one of DevThrottle's internal included-service
+    /// ids (carries the <see cref="DevThrottleIncludedModelPrefix"/>).</summary>
+    public static bool IsDevThrottleIncludedModel(string? model)
+        => model is not null && model.TrimStart().StartsWith(DevThrottleIncludedModelPrefix, StringComparison.Ordinal);
 
     /// <summary>The default DevThrottle text-to-speech model.</summary>
     public const string DevThrottleTtsModel = "hexgrad/Kokoro-82M";

--- a/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
@@ -25,22 +25,24 @@ public static class WingmanModelConfig
     public const string FastConfigKey = "brain_model_fast";
 
     /// <summary>
-    /// The hosted wingman model for <paramref name="mode"/>: the saved brain_model when it is a real
-    /// hosted model id, else the provider default (<see cref="TranscriptionEndpointResolver.ResolveWingman"/>).
+    /// The hosted wingman model for <paramref name="mode"/>: the saved brain_model when it is a
+    /// DevThrottle internal included id, else the included default (<see cref="IncludedModelId.Wingman"/>,
+    /// the same id <see cref="TranscriptionEndpointResolver.ResolveWingman"/> names). Returns the
+    /// PROVEN type, so what this resolves can be handed straight to the deployment credential.
     /// </summary>
-    public static string Resolve(TranscriptionMode mode) =>
-        ResolveKey(ConfigKey, () => TranscriptionEndpointResolver.ResolveWingman(mode).Model);
+    public static IncludedModelId Resolve(TranscriptionMode mode) =>
+        ResolveKey(ConfigKey, IncludedModelId.Wingman);
 
     /// <summary>
     /// The hosted fast wingman model for <paramref name="mode"/>: the saved brain_model_fast when it
-    /// is a real hosted model id, else the provider default
-    /// (<see cref="TranscriptionEndpointResolver.ResolveWingmanFast"/>).
+    /// is a DevThrottle internal included id, else the included default
+    /// (<see cref="IncludedModelId.WingmanFast"/>).
     /// </summary>
-    public static string ResolveFast(TranscriptionMode mode) =>
-        ResolveKey(FastConfigKey, () => TranscriptionEndpointResolver.ResolveWingmanFast(mode).Model);
+    public static IncludedModelId ResolveFast(TranscriptionMode mode) =>
+        ResolveKey(FastConfigKey, IncludedModelId.WingmanFast);
 
     /// <summary>Resolve the model for the requested wingman role.</summary>
-    public static string Resolve(TranscriptionMode mode, WingmanModelRole role) => role switch
+    public static IncludedModelId Resolve(TranscriptionMode mode, WingmanModelRole role) => role switch
     {
         WingmanModelRole.Thinking => Resolve(mode),
         WingmanModelRole.Fast => ResolveFast(mode),
@@ -59,19 +61,17 @@ public static class WingmanModelConfig
         CcDirectorConfigService.MergePatch(new JsonObject { [FastConfigKey] = model.Trim() });
     }
 
-    private static string ResolveKey(string configKey, Func<string> providerDefault)
+    private static IncludedModelId ResolveKey(string configKey, IncludedModelId includedDefault)
     {
         var node = CcDirectorConfigService.ReadRaw()[configKey];
         if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
         {
-            var model = v.GetValue<string>().Trim();
             // Only a DevThrottle internal included id is honored (issue #1360): anything else - a
             // catalog id, a legacy Claude alias, an old default - would bill credits or fail on the
-            // proxy, so it falls forward to the included default.
-            if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
-                return model;
+            // proxy, so the mint falls forward to the included default.
+            return IncludedModelId.MintOrFallForward(v.GetValue<string>(), includedDefault);
         }
-        return providerDefault();
+        return includedDefault;
     }
 }
 

--- a/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
@@ -5,15 +5,16 @@ namespace CcDirector.Core.Configuration;
 
 /// <summary>
 /// The chat model the hosted wingman runs on through DevThrottle. The wingman is a stateless
-/// provider-compatible chat call, so the model must be one DevThrottle serves. The user can pick any
-/// model from the live catalog (the AI tab's "Wingman model" dropdown); the choice is stored in the
-/// existing config.json "brain_model" key.
+/// provider-compatible chat call, so the model must be one DevThrottle serves. The choice is stored in
+/// the existing config.json "brain_model" key.
 ///
-/// Resolution rule (why this exists rather than reading brain_model directly): brain_model historically
-/// defaulted to a Claude tier alias ("opus"/"sonnet"/"haiku") for the old warm claude.exe brain, which
-/// the hosted proxy does NOT serve. So a stale or unset brain_model must fall forward to the provider's
-/// default hosted model (glm-5.2 / gpt-5.5), never a Claude alias - otherwise the wingman would call the
-/// proxy with a model it cannot run. A real hosted model id the user saved is honored as-is.
+/// Resolution rule (issue #1360, Included AI): the wingman is an INCLUDED service - it runs on
+/// DevThrottle's internal model ids (<c>devthrottle/wingman</c>, <c>devthrottle/wingman-fast</c>),
+/// which the hosted proxy meters and never bills to credits. A saved model that is NOT one of the
+/// internal ids - a catalog id picked in an older release, or the legacy Claude tier aliases
+/// ("opus"/"sonnet"/"haiku") from the old warm claude.exe brain - would bill credits (or not run at
+/// all), so it is treated as "not chosen" and resolution falls forward to the included default.
+/// Only a DevThrottle internal id is honored as saved.
 /// </summary>
 public static class WingmanModelConfig
 {
@@ -22,11 +23,6 @@ public static class WingmanModelConfig
 
     /// <summary>The config.json key the fast wingman model is stored under.</summary>
     public const string FastConfigKey = "brain_model_fast";
-
-    /// <summary>Claude tier aliases that predate the hosted wingman and cannot run on the proxy; treated
-    /// as "not chosen" so they fall forward to the provider default.</summary>
-    private static readonly HashSet<string> ClaudeAliases =
-        new(StringComparer.OrdinalIgnoreCase) { "opus", "sonnet", "haiku" };
 
     /// <summary>
     /// The hosted wingman model for <paramref name="mode"/>: the saved brain_model when it is a real
@@ -69,7 +65,10 @@ public static class WingmanModelConfig
         if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
         {
             var model = v.GetValue<string>().Trim();
-            if (model.Length > 0 && !ClaudeAliases.Contains(model))
+            // Only a DevThrottle internal included id is honored (issue #1360): anything else - a
+            // catalog id, a legacy Claude alias, an old default - would bill credits or fail on the
+            // proxy, so it falls forward to the included default.
+            if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
                 return model;
         }
         return providerDefault();

--- a/src/CcDirector.Core/HostedAi/DirectorHostedAiReadiness.cs
+++ b/src/CcDirector.Core/HostedAi/DirectorHostedAiReadiness.cs
@@ -4,26 +4,23 @@ using CcDirector.Core.Configuration;
 namespace CcDirector.Core.HostedAi;
 
 /// <summary>
-/// The Director/desktop-side hosted-AI readiness check (issue #940, epic #937). The desktop app runs
-/// transcription and text-to-speech in-process, so - unlike the Gateway - it must gather the readiness
-/// inputs itself: the mode from local config and the account balance over HTTP from the Gateway (the
-/// account token is Gateway-only, so the balance cannot be read locally).
+/// The Director/desktop-side hosted-AI readiness check (issue #940, epic #937).
 ///
-/// It does NOT re-implement the decision - it gathers the three inputs (async: the key and balance are
-/// I/O) and feeds them to the one shared, unit-tested <see cref="HostedAiReadiness"/>, so the desktop
-/// resolves the identical <see cref="HostedAiState"/> the Gateway does. An unknown balance (signed out /
-/// Gateway unreachable) does NOT block - the runtime 402 stays the authoritative gate - matching the
-/// foundation's contract.
+/// SINCE THE INCLUDED AI MISSION (issue #1360) this performs NO balance read - it defers to the shared
+/// <see cref="HostedAiReadiness"/>, which always answers Ready in DevThrottle mode. The internal AI
+/// features are included with an entitled account and never billed to credits, so a client-side
+/// balance gate would block exactly the members the server would serve; the runtime 402 is the only
+/// gate. This also removed the desktop's pre-dictation credit read over HTTP (and the last in-product
+/// consumer of the balance for a decision), per the Architect's phase-2 rulings Q1/Q2.
 /// </summary>
 public sealed class DirectorHostedAiReadiness
 {
     private readonly Func<TranscriptionMode> _modeProvider;
-    private readonly Func<CancellationToken, Task<long?>> _balanceMicrosProvider;
 
     /// <param name="modeProvider">Supplies the current mode (local config, read fresh per check).</param>
     /// <param name="byoKeyProvider">Legacy constructor parameter retained for compatibility; ignored.</param>
-    /// <param name="balanceMicrosProvider">Reads the account balance in micro-dollars over HTTP, null when
-    /// unknown (signed out / unreachable - do not block). Only consulted in DevThrottle mode.</param>
+    /// <param name="balanceMicrosProvider">Legacy constructor parameter retained for compatibility;
+    /// NEVER invoked (issue #1360 retired the client-side balance gate).</param>
     public DirectorHostedAiReadiness(
         Func<TranscriptionMode> modeProvider,
         Func<CancellationToken, Task<string?>> byoKeyProvider,
@@ -31,39 +28,34 @@ public sealed class DirectorHostedAiReadiness
     {
         _modeProvider = modeProvider ?? throw new ArgumentNullException(nameof(modeProvider));
         _ = byoKeyProvider ?? throw new ArgumentNullException(nameof(byoKeyProvider));
-        _balanceMicrosProvider = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
+        _ = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
     }
 
     /// <summary>
-    /// Wire the real desktop plumbing: the mode from <see cref="TranscriptionModeConfig"/>, the key from
-    /// the balance from <see cref="GatewayAccountCreditsClient"/> against the configured Gateway.
+    /// Wire the real desktop plumbing: the mode from <see cref="TranscriptionModeConfig"/>. No credits
+    /// client and no Gateway call - the balance is not consulted (issue #1360).
     /// </summary>
     public static DirectorHostedAiReadiness Create(
         HostedAiKeyResolver keyResolver,
-        GatewayAccountCreditsClient creditsClient,
-        Func<GatewayConfig>? gatewayProvider = null,
         Func<TranscriptionMode>? modeProvider = null)
     {
         if (keyResolver is null) throw new ArgumentNullException(nameof(keyResolver));
-        if (creditsClient is null) throw new ArgumentNullException(nameof(creditsClient));
-        var gateway = gatewayProvider ?? GatewayConfig.Load;
 
         return new DirectorHostedAiReadiness(
             modeProvider ?? TranscriptionModeConfig.Get,
             _ => Task.FromResult<string?>(null),
-            async ct => (await creditsClient.GetCreditsAsync(gateway(), ct)).BalanceMicros);
+            _ => Task.FromResult<long?>(null));
     }
 
     /// <summary>
-    /// Resolve whether hosted AI can run for the configured mode right now. Gathers the mode and
-    /// current account balance, then defers the decision to the shared <see cref="HostedAiReadiness"/>.
+    /// Resolve whether hosted AI can run for the configured mode right now. Defers the decision to the
+    /// shared <see cref="HostedAiReadiness"/> (always Ready in DevThrottle mode - the runtime 402 rules).
     /// </summary>
     public async Task<HostedAiState> CheckAsync(CancellationToken ct = default)
     {
         var mode = _modeProvider();
-        var balance = await _balanceMicrosProvider(ct).ConfigureAwait(false);
 
-        var readiness = new HostedAiReadiness(() => mode, _ => null, _ => Task.FromResult(balance));
+        var readiness = new HostedAiReadiness(() => mode, _ => null, _ => Task.FromResult<long?>(null));
         return await readiness.CheckAsync(ct).ConfigureAwait(false);
     }
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs
@@ -9,57 +9,80 @@ namespace CcDirector.Core.HostedAi;
 /// (<see cref="HostedAiReadiness"/>), never "transcription failed: ...402..." or a silent nothing.
 ///
 /// Branch on the machine-readable <c>code</c>, NOT the <c>type</c>: the website proxy returns the same
-/// <c>type</c> (<c>insufficient_quota</c>) for both conditions, so only the <c>code</c> distinguishes an
-/// empty balance from a hit monthly cap (server contract in epic #937):
+/// <c>type</c> (<c>insufficient_quota</c>) for more than one condition, so only the <c>code</c> tells
+/// them apart (server contract in epic #937; the two Included AI codes added by issue #1360):
 /// <list type="bullet">
 /// <item><c>insufficient_credits</c> -> <see cref="HostedAiState.NeedsCredits"/></item>
 /// <item><c>monthly_limit_reached</c> -> <see cref="HostedAiState.CapReached"/></item>
+/// <item><c>subscription_required</c> -> <see cref="HostedAiState.SubscriptionRequired"/></item>
+/// <item><c>fair_use_limit_reached</c> -> <see cref="HostedAiState.FairUseLimitReached"/></item>
+/// <item>anything else -> <see cref="HostedAiState.Unavailable"/> - an UNKNOWN code must never claim
+/// the account is out of credits (issue #1360; the old default was NeedsCredits, which would show an
+/// "add credits" prompt to members the owner ruled must never see a cost)</item>
 /// </list>
 /// </summary>
 public static class HostedAiErrorMapper
 {
-    /// <summary>The proxy code for an empty account balance.</summary>
+    /// <summary>The proxy code for an empty account balance (the direct-API credits path).</summary>
     public const string InsufficientCreditsCode = "insufficient_credits";
 
-    /// <summary>The proxy code for a reached monthly spending limit.</summary>
+    /// <summary>The proxy code for a reached monthly spending limit (the credits spend cap).</summary>
     public const string MonthlyLimitReachedCode = "monthly_limit_reached";
 
+    /// <summary>The proxy code for a member with no live entitlement on an included service (issue #1360).</summary>
+    public const string SubscriptionRequiredCode = "subscription_required";
+
+    /// <summary>The proxy code for a used-up monthly fair-use allowance on the included services (issue #1360).</summary>
+    public const string FairUseLimitReachedCode = "fair_use_limit_reached";
+
     /// <summary>
-    /// Map a 402 error <paramref name="code"/> to a state. <c>monthly_limit_reached</c> is the cap;
-    /// every other value (including <c>insufficient_credits</c>, an unknown code, or null) maps to
-    /// <see cref="HostedAiState.NeedsCredits"/>, because this is only ever consulted for a 402 and an
-    /// empty balance is the common case (matching the existing transcription behavior).
+    /// Map a 402 error <paramref name="code"/> to a state. The four known codes map to their states;
+    /// everything else - an unknown code, or null when the body carried none at all - maps to the
+    /// NEUTRAL <see cref="HostedAiState.Unavailable"/>. A null/absent code is genuinely unknown, and
+    /// guessing "out of credits" on it would put a top-up prompt in front of members who must never
+    /// see one; the direct-API credits path always names its code, so nothing is lost by not guessing.
     /// </summary>
     public static HostedAiState MapCode(string? code) => (code?.Trim().ToLowerInvariant()) switch
     {
+        InsufficientCreditsCode => HostedAiState.NeedsCredits,
         MonthlyLimitReachedCode => HostedAiState.CapReached,
-        _ => HostedAiState.NeedsCredits,
+        SubscriptionRequiredCode => HostedAiState.SubscriptionRequired,
+        FairUseLimitReachedCode => HostedAiState.FairUseLimitReached,
+        _ => HostedAiState.Unavailable,
     };
+
+    /// <summary>The sentinel for a 402 body that carried NO machine code (or was not JSON). Maps to the
+    /// neutral <see cref="HostedAiState.Unavailable"/> - never assumed to mean "out of credits"
+    /// (issue #1360: the old default was <see cref="InsufficientCreditsCode"/>, which put an add-credits
+    /// prompt in front of members who must never see a cost).</summary>
+    public const string UnknownCode = "unknown";
 
     /// <summary>
     /// Best-effort read of the machine-readable error code from a provider-compatible 402 body
     /// (<c>{ "error": { "code": "insufficient_credits" } }</c> or a flat <c>{ "code": ... }</c>).
-    /// Defaults to <see cref="InsufficientCreditsCode"/> when the body carries no code, since the caller
-    /// only reaches here on a 402. This is the single shared parse the transcription pipeline also uses.
+    /// Returns <see cref="UnknownCode"/> when the body carries no code - a genuinely unknown condition,
+    /// deliberately NOT collapsed into "out of credits" (issue #1360). This is the single shared parse
+    /// the transcription pipeline also uses.
     /// </summary>
     public static string ParseErrorCode(string? body)
     {
-        if (string.IsNullOrWhiteSpace(body)) return InsufficientCreditsCode;
+        if (string.IsNullOrWhiteSpace(body)) return UnknownCode;
         try
         {
             using var doc = JsonDocument.Parse(body);
             var root = doc.RootElement;
             if (root.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.Object
                 && err.TryGetProperty("code", out var nested) && nested.ValueKind == JsonValueKind.String)
-                return nested.GetString() ?? InsufficientCreditsCode;
+                return nested.GetString() ?? UnknownCode;
             if (root.TryGetProperty("code", out var flat) && flat.ValueKind == JsonValueKind.String)
-                return flat.GetString() ?? InsufficientCreditsCode;
+                return flat.GetString() ?? UnknownCode;
         }
         catch (JsonException)
         {
-            // A non-JSON 402 body still means out of credits; fall through to the default code.
+            // A non-JSON 402 body is a money-shaped refusal with no readable reason: unknown, never
+            // assumed to be out of credits.
         }
-        return InsufficientCreditsCode;
+        return UnknownCode;
     }
 
     /// <summary>Parse the code out of a 402 body and map it to a state in one call.</summary>

--- a/src/CcDirector.Core/HostedAi/HostedAiMessage.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessage.cs
@@ -19,6 +19,11 @@ public enum HostedAiCtaAction
 
     /// <summary>Open the local Settings AI tab so the user can finish DevThrottle AI setup.</summary>
     OpenSettings = 2,
+
+    /// <summary>Open the public DevThrottle pricing page (issue #1360:
+    /// <see cref="HostedAiState.SubscriptionRequired"/>). Deliberately the PRICING page and not a
+    /// checkout - design C5: production has no purchasable checkout, so the copy must not promise one.</summary>
+    OpenPricing = 3,
 }
 
 /// <summary>
@@ -48,6 +53,9 @@ public static class HostedAiUrls
     /// <summary>The onboarding page for a brand-new account.</summary>
     public const string GetStartedPath = "/account/get-started";
 
+    /// <summary>The public pricing page (issue #1360: the subscription-required call-to-action).</summary>
+    public const string PricingPath = "/pricing";
+
     /// <summary>The website base (env override, else the production default), without a trailing slash.</summary>
     public static string WebsiteBase()
     {
@@ -59,4 +67,7 @@ public static class HostedAiUrls
 
     /// <summary>The absolute onboarding URL.</summary>
     public static string GetStarted => WebsiteBase() + GetStartedPath;
+
+    /// <summary>The absolute pricing URL for the subscription-required call-to-action.</summary>
+    public static string Pricing => WebsiteBase() + PricingPath;
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
@@ -60,6 +60,33 @@ public static class HostedAiMessages
             HostedAiCtaAction.None,
             null),
 
+        // No live entitlement (issue #1360). Points at the PRICING page, never a checkout (design C5:
+        // production has none to promise), and NEVER mentions credits, balances, or a top-up - the
+        // owner ruled a normal member sees no cost anywhere. No numbers.
+        HostedAiState.SubscriptionRequired => new HostedAiMessage(
+            "Included AI features come with DevThrottle Pro. This account's trial or plan isn't active - see the plans at devthrottle.com/pricing.",
+            "View plans",
+            HostedAiCtaAction.OpenPricing,
+            HostedAiUrls.Pricing),
+
+        // The monthly fair-use allowance is used up (issue #1360). NO numbers, NO cost, NO
+        // call-to-action: the cap is deliberately invisible ("They should never know this" - the
+        // owner) and nothing the member can click lifts a month-long condition.
+        HostedAiState.FairUseLimitReached => new HostedAiMessage(
+            "This month's fair-use limit for included AI features has been reached. It resets at the start of next month.",
+            "",
+            HostedAiCtaAction.None,
+            null),
+
+        // A 402 whose machine code this build does not recognize (issue #1360). Deliberately neutral:
+        // an unknown code must never claim the account is out of credits, so this names no money and
+        // offers no call-to-action.
+        HostedAiState.Unavailable => new HostedAiMessage(
+            "This AI feature is not available for your account right now.",
+            "",
+            HostedAiCtaAction.None,
+            null),
+
         _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown hosted-AI state"),
     };
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiReadiness.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiReadiness.cs
@@ -4,31 +4,30 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.HostedAi;
 
 /// <summary>
-/// The shared pre-flight "can this user use hosted AI right now?" check (issue #938, epic #937). Hung
-/// on the existing centralized routing path (<see cref="TranscriptionMode"/> +
-/// <see cref="TranscriptionEndpointResolver"/>), it returns ONE typed <see cref="HostedAiState"/> that
-/// every voice/Wingman/TTS surface consults before it lets the user record or fires a hosted call - so
-/// a feature with no way to pay is marked unavailable up front with the consistent message
-/// (<see cref="HostedAiMessages.For"/>), instead of failing badly after the user has already spoken.
+/// The shared pre-flight "can this user use hosted AI right now?" check (issue #938, epic #937).
 ///
-/// Pure of I/O plumbing: the mode and account balance read are injected as delegates, so this class is
-/// fully unit-testable and the Gateway owns the wiring
-/// (<c>GatewayHostedAi.CreateReadiness</c>). The balance delegate is invoked FRESH on every
-/// <see cref="CheckAsync"/> (this class holds no cache), so adding $5 unlocks the feature on the next
-/// check with no restart - the acceptance criterion the whole gate exists for.
+/// SINCE THE INCLUDED AI MISSION (issue #1360) this check ALWAYS answers
+/// <see cref="HostedAiState.Ready"/> in DevThrottle mode and performs NO balance read. It used to
+/// block recording when the account balance was at or below zero - but the internal AI features
+/// (transcription, voice, wingman, text-to-speech) are now INCLUDED with an entitled account and
+/// never billed to credits, so a zero balance says nothing about whether the server will serve the
+/// call. A client-side balance gate would have blocked exactly the members the mission exists to
+/// serve (the acceptance test is a ZERO-balance trial account completing a dictation round-trip).
+/// The runtime 402, mapped by <see cref="HostedAiErrorMapper"/>, is the ONLY gate - the Architect's
+/// ruling on the phase-2 question Q2, recorded in the mission record's surfaces.md.
+///
+/// The class and its call sites are kept (rather than deleted) so every surface still funnels through
+/// one pre-flight seam - the next condition that genuinely CAN be known up front has a home.
 /// </summary>
 public sealed class HostedAiReadiness
 {
     private readonly Func<TranscriptionMode> _modeProvider;
-    private readonly Func<CancellationToken, Task<long?>> _balanceMicrosProvider;
 
     /// <param name="modeProvider">Supplies the current transcription/provider mode, read fresh per check
     /// so a mode change takes effect with no restart.</param>
     /// <param name="keyProvider">Legacy constructor parameter retained for compatibility; ignored.</param>
-    /// <param name="balanceMicrosProvider">Reads the signed-in account's balance in micro-dollars, fresh
-    /// per check. Returns null when the balance is UNKNOWN (signed out or the cloud is unreachable): the
-    /// pre-flight check must not block on an unknown balance - the authoritative gate is the runtime 402
-    /// (<see cref="HostedAiErrorMapper"/>), which reports the identical state.</param>
+    /// <param name="balanceMicrosProvider">Legacy constructor parameter retained for compatibility;
+    /// NEVER invoked (issue #1360 retired the client-side balance gate - see the class summary).</param>
     public HostedAiReadiness(
         Func<TranscriptionMode> modeProvider,
         Func<string, string?> keyProvider,
@@ -36,25 +35,17 @@ public sealed class HostedAiReadiness
     {
         _modeProvider = modeProvider ?? throw new ArgumentNullException(nameof(modeProvider));
         _ = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
-        _balanceMicrosProvider = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
+        _ = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
     }
 
     /// <summary>
-    /// Decide whether hosted AI can run for the configured mode right now:
-    /// <list type="bullet">
-    /// <item>DevThrottle hosted -> <see cref="HostedAiState.NeedsCredits"/> when the balance is a known
-    /// value at or below zero, else <see cref="HostedAiState.Ready"/> (including when the balance is
-    /// unknown - see <c>balanceMicrosProvider</c>). The monthly-cap state is generally only known at
-    /// runtime from the 402, so it is not decided here.</item>
-    /// </list>
+    /// Always <see cref="HostedAiState.Ready"/> in DevThrottle mode: the included features are gated by
+    /// the server's runtime 402, never by a client-side balance read (issue #1360 - see the class summary).
     /// </summary>
-    public async Task<HostedAiState> CheckAsync(CancellationToken ct = default)
+    public Task<HostedAiState> CheckAsync(CancellationToken ct = default)
     {
         _ = _modeProvider();
-
-        var balance = await _balanceMicrosProvider(ct);
-        var result = balance is long b && b <= 0 ? HostedAiState.NeedsCredits : HostedAiState.Ready;
-        FileLog.Write($"[HostedAiReadiness] CheckAsync: mode=devthrottle, balanceMicros={(balance is null ? "unknown" : balance.ToString())} -> {result}");
-        return result;
+        FileLog.Write("[HostedAiReadiness] CheckAsync: mode=devthrottle -> Ready (no pre-flight balance gate; the runtime 402 rules)");
+        return Task.FromResult(HostedAiState.Ready);
     }
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiState.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiState.cs
@@ -64,4 +64,30 @@ public enum HostedAiState
     /// outage panel.
     /// </summary>
     Retrying = 5,
+
+    /// <summary>
+    /// The account has no live entitlement for the included AI features (issue #1360, proxy 402 code
+    /// <c>subscription_required</c>): no active trial and no active plan. This is NOT a credits
+    /// condition - the copy points at the pricing page and never mentions credits, balances, or a
+    /// top-up, because the owner ruled that a normal member sees no cost anywhere in the product.
+    /// </summary>
+    SubscriptionRequired = 6,
+
+    /// <summary>
+    /// The account's monthly fair-use allowance for the included AI features is used up (issue #1360,
+    /// proxy 402 code <c>fair_use_limit_reached</c>). It resets at the start of next month. The copy
+    /// carries NO numbers and NO cost - the fair-use cap is deliberately invisible ("They should never
+    /// know this" - the owner) - and no call-to-action, because there is nothing the member can click
+    /// to lift a month-long condition.
+    /// </summary>
+    FairUseLimitReached = 7,
+
+    /// <summary>
+    /// A money-shaped refusal (HTTP 402) whose machine code this build does not recognize. Deliberately
+    /// NEUTRAL: an unknown code must never claim the account is out of credits (issue #1360 - the old
+    /// mapper defaulted unknowns to <see cref="NeedsCredits"/>, which would have shown "add credits" to
+    /// members the owner ruled must never see a cost). Says the feature is unavailable, offers no
+    /// call-to-action, names no money.
+    /// </summary>
+    Unavailable = 8,
 }

--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -66,7 +66,7 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
         // Issue #2017: the model now persists to the per-tenant store, not config.json. Read it back directly
         // from the resolver for the self-host local tenant (an independent store re-read), then confirm the
         // snapshot reflects it too.
-        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking).Value);
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
         Assert.Equal("devthrottle/wingman-fast", (string?)snap!["wingmanModel"]);
     }
@@ -78,7 +78,7 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
         resp.EnsureSuccessStatusCode();
         Assert.Equal("devthrottle/wingman", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
 
-        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast).Value);
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
         Assert.Equal("devthrottle/wingman", (string?)snap!["wingmanFastModel"]);
     }
@@ -97,9 +97,9 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
 
         // And nothing was stored: the resolver still answers the included defaults.
         var mode = TranscriptionModeConfig.Get();
-        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
-        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Fast));
-        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.CarModeModel(TenantId.Local));
+        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking).Value);
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Fast).Value);
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.CarModeModel(TenantId.Local).Value);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -57,28 +57,49 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Put_wingman_model_persists_and_snapshot_reflects_it()
     {
-        var resp = await _http.PutAsJsonAsync("gateway/ai/wingman-model", new { model = "kimi-k2" });
+        // The FAST id on the THINKING role: an included id (the setter honors nothing else since issue
+        // #1360) that differs from the role's default, so the re-read proves a write, not a no-op.
+        var resp = await _http.PutAsJsonAsync("gateway/ai/wingman-model", new { model = "devthrottle/wingman-fast" });
         resp.EnsureSuccessStatusCode();
-        Assert.Equal("kimi-k2", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
+        Assert.Equal("devthrottle/wingman-fast", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
 
         // Issue #2017: the model now persists to the per-tenant store, not config.json. Read it back directly
         // from the resolver for the self-host local tenant (an independent store re-read), then confirm the
         // snapshot reflects it too.
-        Assert.Equal("kimi-k2", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking));
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
-        Assert.Equal("kimi-k2", (string?)snap!["wingmanModel"]);
+        Assert.Equal("devthrottle/wingman-fast", (string?)snap!["wingmanModel"]);
     }
 
     [Fact]
     public async Task Put_wingman_fast_model_persists_and_snapshot_reflects_it()
     {
-        var resp = await _http.PutAsJsonAsync("gateway/ai/wingman-fast-model", new { model = "qwen-fast" });
+        var resp = await _http.PutAsJsonAsync("gateway/ai/wingman-fast-model", new { model = "devthrottle/wingman" });
         resp.EnsureSuccessStatusCode();
-        Assert.Equal("qwen-fast", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
+        Assert.Equal("devthrottle/wingman", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
 
-        Assert.Equal("qwen-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast));
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
-        Assert.Equal("qwen-fast", (string?)snap!["wingmanFastModel"]);
+        Assert.Equal("devthrottle/wingman", (string?)snap!["wingmanFastModel"]);
+    }
+
+    [Theory]
+    [InlineData("gateway/ai/wingman-model")]
+    [InlineData("gateway/ai/wingman-fast-model")]
+    [InlineData("gateway/ai/car-mode-model")]
+    public async Task Put_model_setters_refuse_catalog_ids(string route)
+    {
+        // Included AI revert-proof (issue #1360): the wingman and Car Mode are internal included
+        // features, and a catalog id would bill credits - the setter must refuse it loudly, never
+        // store it. Put the old accept-anything setter back and this goes red.
+        var resp = await _http.PutAsJsonAsync(route, new { model = "kimi-k2" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+
+        // And nothing was stored: the resolver still answers the included defaults.
+        var mode = TranscriptionModeConfig.Get();
+        Assert.Equal("devthrottle/wingman", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.TenantSettingsResolver.CarModeModel(TenantId.Local));
     }
 
     [Fact]
@@ -97,16 +118,31 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     public async Task Snapshot_defaults_wingman_and_tts_model()
     {
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
-        Assert.Equal("zai-org/GLM-5.2", (string?)snap!["wingmanModel"]);   // provider default when unset
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", (string?)snap["wingmanFastModel"]);
+        Assert.Equal("devthrottle/wingman", (string?)snap!["wingmanModel"]);   // included default when unset
+        Assert.Equal("devthrottle/wingman-fast", (string?)snap["wingmanFastModel"]);
         Assert.Equal("hexgrad/Kokoro-82M", (string?)snap["ttsModel"]);
     }
 
     [Fact]
-    public async Task Get_models_without_key_reports_not_signed_in()
+    public async Task Get_chat_models_serves_only_the_included_wingman_ids_and_never_the_catalog()
     {
-        // No DevThrottle key stored -> the catalog cannot be fetched; a clear 503, never a crash/empty.
+        // Included AI revert-proof (issue #1360, design C3): the chat kind feeds the wingman pickers,
+        // which must never offer catalog models. NO provider key is stored in this rig, so this list
+        // arriving at all also proves no upstream catalog call is involved - put the old
+        // relay-the-catalog branch back and this answers 503 instead.
         var resp = await _http.GetAsync("gateway/ai/models?kind=chat");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        var ids = (body!["models"] as JsonArray)!.Select(m => (string?)m!["id"]).ToList();
+        Assert.Equal(new[] { "devthrottle/wingman", "devthrottle/wingman-fast" }, ids);
+    }
+
+    [Fact]
+    public async Task Get_speech_models_without_key_reports_not_signed_in()
+    {
+        // The SPEECH kind still reads the live catalog: no DevThrottle key stored -> the catalog cannot
+        // be fetched; a clear 503, never a crash/empty.
+        var resp = await _http.GetAsync("gateway/ai/models?kind=speech");
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
 

--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -147,6 +147,22 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Post_test_chat_refuses_catalog_ids_before_touching_the_credential()
+    {
+        // Included AI revert-proof (issue #1360, inspection round): test-chat sends the requested
+        // model with the deployment credential, so it must refuse a non-included id exactly as the
+        // model setters do. The refusal comes BEFORE the credential is resolved: in this key-less rig
+        // a catalog id answers 400, while an included id gets past the guard to the key check and
+        // answers 503 (not signed in). Put the old accept-any-nonblank-model round trip back and the
+        // catalog id answers 503 too - red.
+        var catalog = await _http.PostAsJsonAsync("gateway/ai/test-chat", new { model = "kimi-k2" });
+        Assert.Equal(HttpStatusCode.BadRequest, catalog.StatusCode);
+
+        var included = await _http.PostAsJsonAsync("gateway/ai/test-chat", new { model = "devthrottle/wingman" });
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, included.StatusCode);
+    }
+
+    [Fact]
     public async Task Put_wingman_model_rejects_blank_and_non_object()
     {
         Assert.Equal(HttpStatusCode.BadRequest,

--- a/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
@@ -97,7 +97,7 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
             _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
         Assert.Equal(WingmanModelConfig.Resolve(mode, WingmanModelRole.Fast),
             _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Fast));
-        Assert.NotEqual("sentinel-think", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
+        Assert.NotEqual("sentinel-think", _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking).Value);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
@@ -55,13 +55,13 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Get_ai_provider_defaults_to_devthrottle_with_glm()
+    public async Task Get_ai_provider_defaults_to_devthrottle_with_included_wingman_ids()
     {
         var obj = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
         Assert.NotNull(obj);
         Assert.Equal("devthrottle", (string?)obj!["provider"]);
-        Assert.Equal("zai-org/GLM-5.2", (string?)obj["wingmanModel"]);
-        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", (string?)obj["wingmanFastModel"]);
+        Assert.Equal("devthrottle/wingman", (string?)obj["wingmanModel"]);
+        Assert.Equal("devthrottle/wingman-fast", (string?)obj["wingmanFastModel"]);
         Assert.Equal("gpt-4o-transcribe", (string?)obj["transcriptionModel"]);
         Assert.Equal("af_bella", (string?)obj["ttsVoice"]);   // DevThrottle (Kokoro) default voice
         var voices = obj["voices"] as JsonArray;

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -296,9 +296,9 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         "daily-report" => ReportCadences.Name(_gateway.TenantSettingsResolver.DailyReportCadence(TenantId.Local)),
         "transcription-mode" => TranscriptionModeConfig.Get().ToConfigString(),
         "tts-voice" => _gateway.TenantSettingsResolver.TtsVoice(TenantId.Local, TranscriptionModeConfig.Get()),
-        "wingman-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking),
-        "wingman-fast-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast),
-        "car-mode-model" => _gateway.TenantSettingsResolver.CarModeModel(TenantId.Local),
+        "wingman-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking).Value,
+        "wingman-fast-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Fast).Value,
+        "car-mode-model" => _gateway.TenantSettingsResolver.CarModeModel(TenantId.Local).Value,
         "car-mode-end-phrase" => _gateway.TenantSettingsResolver.CarModeEndPhrase(TenantId.Local),
         "tts-model" => _gateway.TenantSettingsResolver.TtsModel(TenantId.Local, TranscriptionModeConfig.Get()),
         _ => throw new ArgumentOutOfRangeException(nameof(key), key, "no read-back written for this setting"),
@@ -410,7 +410,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         const string Sentinel = "devthrottle/sentinel-model-no-reset-would-return";
         var mode = TranscriptionModeConfig.Get();
         _gateway.TenantSettingsResolver.SetWingmanModel(TenantId.Local, WingmanModelRole.Thinking, Sentinel, DateTime.UtcNow);
-        Assert.Equal(Sentinel, _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
+        Assert.Equal(Sentinel, _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking).Value);
 
         var response = await OwnerSettingsRoutes.SendAsync(_http, "PUT", "gateway/ai-provider",
             "{\"provider\":\"devthrottle\"}");
@@ -420,7 +420,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal("devthrottle", document.RootElement.GetProperty("provider").GetString());
 
-        var afterwards = _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking);
+        var afterwards = _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking).Value;
         Assert.NotEqual(Sentinel, afterwards);
         Assert.False(string.IsNullOrWhiteSpace(afterwards));
     }

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -264,9 +264,12 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 // transcription-mode is NOT here - it needs a seeded starting value to be distinguishable
                 // from a no-op, so it has its own test below.
                 data.Add(hosted, "PUT", "gateway/tts-voice", "{\"voice\":\"shimmer\"}", "tts-voice", "shimmer");
-                data.Add(hosted, "PUT", "gateway/ai/wingman-model", "{\"model\":\"hosted-wingman\"}", "wingman-model", "hosted-wingman");
-                data.Add(hosted, "PUT", "gateway/ai/wingman-fast-model", "{\"model\":\"hosted-fast\"}", "wingman-fast-model", "hosted-fast");
-                data.Add(hosted, "PUT", "gateway/ai/car-mode-model", "{\"model\":\"hosted-car\"}", "car-mode-model", "hosted-car");
+                // Model values are DevThrottle internal included ids (issue #1360: the resolver honors
+                // nothing else), each chosen OPPOSITE to its role's default so the re-read still proves
+                // a write rather than a no-op.
+                data.Add(hosted, "PUT", "gateway/ai/wingman-model", "{\"model\":\"devthrottle/wingman-fast\"}", "wingman-model", "devthrottle/wingman-fast");
+                data.Add(hosted, "PUT", "gateway/ai/wingman-fast-model", "{\"model\":\"devthrottle/wingman\"}", "wingman-fast-model", "devthrottle/wingman");
+                data.Add(hosted, "PUT", "gateway/ai/car-mode-model", "{\"model\":\"devthrottle/wingman\"}", "car-mode-model", "devthrottle/wingman");
                 data.Add(hosted, "PUT", "gateway/ai/car-mode-end-phrase", "{\"phrase\":\"finished here\"}", "car-mode-end-phrase", "finished here");
                 data.Add(hosted, "PUT", "gateway/ai/tts-model", "{\"model\":\"hosted-speech\"}", "tts-model", "hosted-speech");
             }
@@ -401,8 +404,10 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
 
         // A value the reset cannot possibly produce, so "unchanged" and "reset" cannot be confused. The reset
         // now clears the TENANT's override (issue #2017), so the before-state is seeded as a tenant override -
-        // exactly what the AI tab writes - not a global config value.
-        const string Sentinel = "sentinel-model-no-provider-would-return";
+        // exactly what the AI tab writes - not a global config value. The sentinel carries the devthrottle/
+        // prefix because since issue #1360 the resolver honors only DevThrottle internal included ids - an
+        // unprefixed sentinel would fall forward to the default and could not seed a before-state at all.
+        const string Sentinel = "devthrottle/sentinel-model-no-reset-would-return";
         var mode = TranscriptionModeConfig.Get();
         _gateway.TenantSettingsResolver.SetWingmanModel(TenantId.Local, WingmanModelRole.Thinking, Sentinel, DateTime.UtcNow);
         Assert.Equal(Sentinel, _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, mode, WingmanModelRole.Thinking));
@@ -427,11 +432,13 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
             var data = new TheoryData<string?, string, string, string, int, string>();
             foreach (var hosted in new string?[] { null, "0" })
             {
-                // The catalog and test-chat routes both resolve the provider credential out of the key
-                // vault first. With no credential stored they answer 503 with this exact sentence - a
-                // handler-unique receipt that costs no network round-trip. (Issue #2022 removed the
-                // brain-config receipt route along with the endpoint.)
-                data.Add(hosted, "GET", "gateway/ai/models", "",
+                // The SPEECH catalog and test-chat routes both resolve the provider credential out of
+                // the key vault first. With no credential stored they answer 503 with this exact
+                // sentence - a handler-unique receipt that costs no network round-trip. (Issue #2022
+                // removed the brain-config receipt route along with the endpoint; issue #1360 made the
+                // CHAT kind a fixed local list that needs no credential, so the receipt row pins the
+                // speech kind explicitly.)
+                data.Add(hosted, "GET", "gateway/ai/models?kind=speech", "",
                     503, "not signed in to DevThrottle - sign in on the Account tab");
                 data.Add(hosted, "POST", "gateway/ai/test-chat", "{\"model\":\"some-model\"}",
                     503, "not signed in to DevThrottle - sign in on the Account tab");

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -437,10 +437,12 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 // sentence - a handler-unique receipt that costs no network round-trip. (Issue #2022
                 // removed the brain-config receipt route along with the endpoint; issue #1360 made the
                 // CHAT kind a fixed local list that needs no credential, so the receipt row pins the
-                // speech kind explicitly.)
+                // speech kind explicitly. The test-chat row sends an INCLUDED id because the handler now
+                // refuses a non-included id with a 400 BEFORE resolving the credential - the refusal is
+                // pinned by AiModelsEndpointTests; this row pins the credential receipt.)
                 data.Add(hosted, "GET", "gateway/ai/models?kind=speech", "",
                     503, "not signed in to DevThrottle - sign in on the Account tab");
-                data.Add(hosted, "POST", "gateway/ai/test-chat", "{\"model\":\"some-model\"}",
+                data.Add(hosted, "POST", "gateway/ai/test-chat", "{\"model\":\"devthrottle/wingman\"}",
                     503, "not signed in to DevThrottle - sign in on the Account tab");
             }
             return data;

--- a/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
@@ -151,10 +151,10 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
         var mode = TranscriptionModeConfig.Get();
 
         Assert.Equal(
-            WingmanModelConfig.Resolve(mode, WingmanModelRole.Thinking),
+            WingmanModelConfig.Resolve(mode, WingmanModelRole.Thinking).Value,
             _gateway.ResolveWingmanModel(TenantId.Local, WingmanModelRole.Thinking));
         Assert.Equal(
-            WingmanModelConfig.Resolve(mode, WingmanModelRole.Fast),
+            WingmanModelConfig.Resolve(mode, WingmanModelRole.Fast).Value,
             _gateway.ResolveWingmanModel(TenantId.Local, WingmanModelRole.Fast));
     }
 

--- a/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
@@ -60,16 +60,30 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
     [Fact]
     public void WingmanModel_TwoTenantsAndBothRoles_SelectOnlyTheirOwnRuntimeValues()
     {
-        _gateway.TenantSettingsResolver.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "tenant-a-thinking", Now);
-        _gateway.TenantSettingsResolver.SetWingmanModel(TenantA, WingmanModelRole.Fast, "tenant-a-fast", Now);
-        _gateway.TenantSettingsResolver.SetWingmanModel(TenantB, WingmanModelRole.Thinking, "tenant-b-thinking", Now);
-        _gateway.TenantSettingsResolver.SetWingmanModel(TenantB, WingmanModelRole.Fast, "tenant-b-fast", Now);
+        // Overrides must be DevThrottle internal included ids (issue #1360) or resolution falls
+        // forward to the default - so the four distinct values are crossed role assignments of the
+        // two included ids, which still proves each (tenant, role) cell reads only its own value.
+        _gateway.TenantSettingsResolver.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "devthrottle/wingman", Now);
+        _gateway.TenantSettingsResolver.SetWingmanModel(TenantA, WingmanModelRole.Fast, "devthrottle/wingman-fast", Now);
+        _gateway.TenantSettingsResolver.SetWingmanModel(TenantB, WingmanModelRole.Thinking, "devthrottle/wingman-fast", Now);
+        _gateway.TenantSettingsResolver.SetWingmanModel(TenantB, WingmanModelRole.Fast, "devthrottle/wingman", Now);
 
-        Assert.Equal("tenant-a-thinking", _gateway.ResolveWingmanModel(TenantA, WingmanModelRole.Thinking));
-        Assert.Equal("tenant-a-fast", _gateway.ResolveWingmanModel(TenantA, WingmanModelRole.Fast));
-        Assert.Equal("tenant-b-thinking", _gateway.ResolveWingmanModel(TenantB, WingmanModelRole.Thinking));
-        Assert.Equal("tenant-b-fast", _gateway.ResolveWingmanModel(TenantB, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman", _gateway.ResolveWingmanModel(TenantA, WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.ResolveWingmanModel(TenantA, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", _gateway.ResolveWingmanModel(TenantB, WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman", _gateway.ResolveWingmanModel(TenantB, WingmanModelRole.Fast));
         Assert.Throws<ArgumentException>(() => _gateway.ResolveWingmanModel(default, WingmanModelRole.Thinking));
+    }
+
+    [Fact]
+    public void WingmanModel_CatalogIdOverride_FallsForwardToTheIncludedDefault()
+    {
+        // The Included AI revert-proof on the per-tenant path (issue #1360): a catalog-id override
+        // saved by an older release must NOT reach the proxy - it would bill credits on an internal
+        // feature. Put the old honor-any-override read back and this goes red.
+        _gateway.TenantSettingsResolver.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "zai-org/GLM-5.2", Now);
+
+        Assert.Equal("devthrottle/wingman", _gateway.ResolveWingmanModel(TenantA, WingmanModelRole.Thinking));
     }
 
     [Fact]
@@ -110,8 +124,10 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
     {
         using var data = new GatewayDbTestHarness();
         var settings = new TenantSettingsResolver(new TenantSettingsStore(data.Open()));
-        settings.SetCarModeModel(TenantA, "car-a", Now);
-        settings.SetCarModeModel(TenantB, "car-b", Now);
+        // Distinct per-tenant values drawn from the DevThrottle internal included ids (issue #1360) -
+        // a non-devthrottle override falls forward to the default and could not tell the tenants apart.
+        settings.SetCarModeModel(TenantA, "devthrottle/wingman", Now);
+        settings.SetCarModeModel(TenantB, "devthrottle/wingman-fast", Now);
 
         var handler = new RecordingCarModeHandler();
         var chat = new HostedCarModeChat(
@@ -123,8 +139,8 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
         await chat.CompleteAsync(TenantB, "[]", "[]", CancellationToken.None);
 
         Assert.Collection(handler.Requests,
-            request => Assert.Equal("car-a", JsonDocument.Parse(request).RootElement.GetProperty("model").GetString()),
-            request => Assert.Equal("car-b", JsonDocument.Parse(request).RootElement.GetProperty("model").GetString()));
+            request => Assert.Equal("devthrottle/wingman", JsonDocument.Parse(request).RootElement.GetProperty("model").GetString()),
+            request => Assert.Equal("devthrottle/wingman-fast", JsonDocument.Parse(request).RootElement.GetProperty("model").GetString()));
         await Assert.ThrowsAsync<ArgumentException>(() =>
             chat.CompleteAsync(default, "[]", "[]", CancellationToken.None));
     }

--- a/src/CcDirector.Gateway.UnitTests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CarModeBrainTests.cs
@@ -96,28 +96,15 @@ public sealed class CarModeBrainTests
             return Task.CompletedTask;
         }
 
-        // Fleet-overview read tools (the cockpit Assistant build).
-        public int CreditsCalls;
-        public CarModeCredits CreditsResult { get; set; } = new(false, null, null);
+        // Fleet-overview read tools (the cockpit Assistant build). The credits and spend tools were
+        // removed by the Included AI mission (issue #1360, ruling Q1).
         public IReadOnlyList<CarModeMachineInfo> Machines { get; set; } = new List<CarModeMachineInfo>();
         public IReadOnlyList<CarModeScheduleInfo> Schedules { get; set; } = new List<CarModeScheduleInfo>();
-        public List<int> SpendDays { get; } = new();
-        public CarModeSpendSummary SpendResult { get; set; } = new(0, 0, DateTime.UtcNow, DateTime.UtcNow);
 
-        public Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
-        {
-            CreditsCalls++;
-            return Task.FromResult(CreditsResult);
-        }
         public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
             => Task.FromResult(Machines);
         public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct)
             => Task.FromResult(Schedules);
-        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
-        {
-            SpendDays.Add(days);
-            return Task.FromResult(SpendResult);
-        }
     }
 
     private static CarModeToolCall Call(string name, string args = "{}") => new("call_1", name, args);
@@ -1017,35 +1004,47 @@ public sealed class CarModeBrainTests
     // ---- Fleet-overview read tools (the cockpit Assistant build) ----
 
     [Fact]
-    public async Task RunTurn_GetCredits_SignedIn_ReturnsDollarsToTheModel()
+    public async Task RunTurn_GetCredits_IsGone_TheBrainAnswersUnknownTool()
     {
-        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(true, 12_340_000, 5_600) };
+        // Included AI revert-proof (issue #1360, ruling Q1): the credits tool must not exist. A model
+        // that still calls it gets the unknown-tool error, and no fleet read happens. Restoring the
+        // tool turns this into a real credits read and goes red.
+        var fleet = new FakeFleet();
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
-            Speak("You have about twelve dollars and thirty four cents left."));
+            Speak("Account questions are handled on the DevThrottle website."));
         var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
 
-        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how are we doing on credits", CancellationToken.None);
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "how are we doing on credits", CancellationToken.None);
 
-        Assert.Equal(1, fleet.CreditsCalls);
-        Assert.Contains("twelve dollars", result.Spoken);
-        // The tool result the model saw carries real dollars, converted from micro-dollars.
-        Assert.Contains("12.34", chat.SeenMessages[1]);
+        Assert.Contains("Unknown tool", chat.SeenMessages[1]);
     }
 
     [Fact]
-    public async Task RunTurn_GetCredits_SignedOut_TellsTheModelThereIsNoBalance()
+    public async Task RunTurn_GetSpend_IsGone_TheBrainAnswersUnknownTool()
     {
-        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(false, null, null) };
+        // The spend half of the same removal (issue #1360, ruling Q1).
+        var fleet = new FakeFleet();
         var chat = new ScriptedChat(
-            new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
-            Speak("The Gateway is not signed in, so there is no balance to read."));
+            new CarModeAssistantTurn(null, new[] { Call("get_spend") }),
+            Speak("Account questions are handled on the DevThrottle website."));
         var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
 
-        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None);
+        await brain.RunTurnAsync(TenantId.Local, "device-a", "what have we spent", CancellationToken.None);
 
-        Assert.Contains("not signed in", chat.SeenMessages[1]);
-        Assert.Contains("no balance", result.Spoken);
+        Assert.Contains("Unknown tool", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public void ToolCatalog_CarriesNoCreditsOrSpendTool_AndPromptDoesNotOfferThem()
+    {
+        // The model can only call what the catalog offers, so the catalog itself must not name the
+        // removed money tools - and the system prompt must not advertise them either.
+        Assert.DoesNotContain("get_credits", CarModeBrain.ToolCatalogJsonForTests);
+        Assert.DoesNotContain("get_spend", CarModeBrain.ToolCatalogJsonForTests);
+        var prompt = CarModeBrain.BuildSystemPrompt(SpokenLanguages.English);
+        Assert.DoesNotContain("get_credits", prompt);
+        Assert.DoesNotContain("get_spend", prompt);
     }
 
     [Fact]
@@ -1097,67 +1096,8 @@ public sealed class CarModeBrainTests
         Assert.Contains("Nightly hygiene", result.Spoken);
     }
 
-    [Fact]
-    public async Task RunTurn_GetSpend_DefaultsToSevenDays_AndConvertsDollars()
-    {
-        var fleet = new FakeFleet { SpendResult = new CarModeSpendSummary(2_500_000, 41, DateTime.UtcNow.AddDays(-7), DateTime.UtcNow) };
-        var chat = new ScriptedChat(
-            new CarModeAssistantTurn(null, new[] { Call("get_spend") }),
-            Speak("About two and a half dollars this week."));
-        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
-
-        await brain.RunTurnAsync(TenantId.Local, "device-a", "what have we spent", CancellationToken.None);
-
-        Assert.Equal(new[] { 7 }, fleet.SpendDays);
-        Assert.Contains("2.5", chat.SeenMessages[1]);
-    }
-
-    [Fact]
-    public async Task RunTurn_GetSpend_InvalidDays_IsAToolError_NotASilentSevenDayAnswer()
-    {
-        // Codex review finding 6: an explicitly supplied but invalid window must come back to the model
-        // as a tool error it can correct - never silently become the seven-day default, which would
-        // answer a question the owner did not ask.
-        var fleet = new FakeFleet();
-        var chat = new ScriptedChat(
-            new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"three weeks\"}") }),
-            Speak("How many days did you mean?"));
-        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
-
-        await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for three weeks", CancellationToken.None);
-
-        Assert.Empty(fleet.SpendDays);                     // the fleet was never asked
-        Assert.Contains("days must be a whole number", chat.SeenMessages[1]);
-    }
-
-    [Fact]
-    public async Task RunTurn_GetCredits_SignedInWithNoBalance_FailsLoud_NeverZeroDollars()
-    {
-        // Codex review finding 6: a signed-in credits read with no balance is a malformed payload. The
-        // fleet contract is to throw before the brain ever sees it; if a (fake or future) fleet hands the
-        // brain that shape anyway, the brain itself must fail loud - zero dollars is the classic
-        // plausible fabricated number and must be impossible to produce.
-        var fleet = new FakeFleet { CreditsResult = new CarModeCredits(true, null, null) };
-        var chat = new ScriptedChat(new CarModeAssistantTurn(null, new[] { Call("get_credits") }));
-        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
-
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => brain.RunTurnAsync(TenantId.Local, "device-a", "credits", CancellationToken.None));
-    }
-
-    [Fact]
-    public async Task RunTurn_GetSpend_HonorsTheDaysArgument()
-    {
-        var fleet = new FakeFleet { SpendResult = new CarModeSpendSummary(0, 0, DateTime.UtcNow.AddDays(-30), DateTime.UtcNow) };
-        var chat = new ScriptedChat(
-            new CarModeAssistantTurn(null, new[] { Call("get_spend", "{\"days\":\"30\"}") }),
-            Speak("Nothing in the last thirty days."));
-        var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
-
-        await brain.RunTurnAsync(TenantId.Local, "device-a", "spend for the month", CancellationToken.None);
-
-        Assert.Equal(new[] { 30 }, fleet.SpendDays);
-    }
+    // The get_spend default-window, invalid-days, and malformed-payload tests went with the tools
+    // themselves (issue #1360, ruling Q1) - there is no spend or credits read left to exercise.
 
     // ---- The one surface: the Assistant ----
 
@@ -1235,26 +1175,27 @@ public sealed class CarModeBrainTests
     [Fact]
     public async Task RunTurn_UnavailableTool_IsRelayedAsAToolError_NotATurnFailure()
     {
-        // A knowingly-unavailable tool (per-tenant credits on hosted, issue #2129) must reach the model
-        // as a tool error it can say in plain words - the turn succeeds, and the message carries the fact.
-        var fleet = new UnavailableCreditsFleet();
+        // A knowingly-unavailable tool (issue #2129) must reach the model as a tool error it can say in
+        // plain words - the turn succeeds, and the message carries the fact. (The original vehicle was
+        // the credits tool; that tool is gone (issue #1360), so the machines read carries the shape.)
+        var fleet = new UnavailableMachinesFleet();
         var chat = new ScriptedChat(
-            new CarModeAssistantTurn(null, new[] { Call("get_credits") }),
-            Speak("Credits are not available on the hosted Gateway yet."));
+            new CarModeAssistantTurn(null, new[] { Call("list_machines") }),
+            Speak("The machine list is not available here yet."));
         var brain = new CarModeBrain(chat, _ => fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => SpokenLanguages.English, _ => { });
 
-        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "how are my credits", CancellationToken.None);
+        var result = await brain.RunTurnAsync(TenantId.Local, "device-a", "which machines are online", CancellationToken.None);
 
         Assert.Contains("not available", result.Spoken);
-        Assert.Contains("not available per account on the hosted Gateway yet", chat.SeenMessages[1]);
+        Assert.Contains("not available on this deployment yet", chat.SeenMessages[1]);
     }
 
-    /// <summary>A fleet whose credits read is knowingly unavailable (the hosted refusal shape).</summary>
-    private sealed class UnavailableCreditsFleet : FakeFleet2
+    /// <summary>A fleet whose machines read is knowingly unavailable (the hosted refusal shape).</summary>
+    private sealed class UnavailableMachinesFleet : FakeFleet2
     {
-        public override Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
+        public override Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
             => throw new CarModeToolUnavailableException(
-                "The credit balance is not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
+                "The machine list is not available on this deployment yet. Sessions and schedules all still work.");
     }
 
     /// <summary>An overridable fake fleet for one-off shapes (FakeFleet's members are not virtual).</summary>
@@ -1274,13 +1215,9 @@ public sealed class CarModeBrainTests
             => Task.FromResult(new CarModeExplain("", false));
         public Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct) => Task.CompletedTask;
         public Task SnoozeSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
-        public virtual Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
-            => Task.FromResult(new CarModeCredits(false, null, null));
-        public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
+        public virtual Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
             => Task.FromResult<IReadOnlyList<CarModeMachineInfo>>(new List<CarModeMachineInfo>());
         public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct)
             => Task.FromResult<IReadOnlyList<CarModeScheduleInfo>>(new List<CarModeScheduleInfo>());
-        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
-            => Task.FromResult(new CarModeSpendSummary(0, 0, DateTime.UtcNow, DateTime.UtcNow));
     }
 }

--- a/src/CcDirector.Gateway.UnitTests/CarModeWarmupTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CarModeWarmupTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.CarMode;
 using Xunit;
@@ -31,7 +32,7 @@ public sealed class CarModeWarmupTests
     {
         var handler = new RecordingHandler();
         var warmup = new CarModeWarmup(
-            _ => ("https://api.test/v1", "test-model", "dt_live_key"),
+            _ => ("https://api.test/v1", IncludedModelId.WingmanFast, "dt_live_key"),
             _ => ("https://api.test/v1", "af_bella", "tts-model", "dt_live_key"),
             new HttpClient(handler), _ => { });
 
@@ -46,7 +47,7 @@ public sealed class CarModeWarmupTests
     {
         var handler = new RecordingHandler();
         var warmup = new CarModeWarmup(
-            _ => ("https://api.test/v1", "test-model", ""),          // no model key
+            _ => ("https://api.test/v1", IncludedModelId.WingmanFast, ""),          // no model key
             _ => ("https://api.test/v1", "af_bella", "tts-model", "dt_live_key"),
             new HttpClient(handler), _ => { });
 
@@ -61,7 +62,7 @@ public sealed class CarModeWarmupTests
     {
         var handler = new RecordingHandler { Responder = _ => throw new HttpRequestException("upstream down") };
         var warmup = new CarModeWarmup(
-            _ => ("https://api.test/v1", "m", "k"),
+            _ => ("https://api.test/v1", IncludedModelId.WingmanFast, "k"),
             _ => ("https://api.test/v1", "v", "tm", "k"),
             new HttpClient(handler), _ => { });
 

--- a/src/CcDirector.Gateway.UnitTests/HostedInferenceBrainTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedInferenceBrainTests.cs
@@ -35,11 +35,31 @@ public sealed class HostedInferenceBrainTests
         JsonSerializer.Serialize(new { choices = new[] { new { message = new { role = "assistant", content } } } });
 
     [Fact]
+    public void Ctor_DevThrottleBase_RefusesCatalogModelIds()
+    {
+        // Included AI revert-proof (issue #1360, inspection round): this class is where a chat model id
+        // meets the DevThrottle deployment credential, so on the DevThrottle base only the internal
+        // included ids may be constructed - a catalog id would bill credits on an internal feature.
+        // Remove the constructor guard and this goes red.
+        using var http = new HttpClient(new StubHandler(HttpStatusCode.OK, OkBody("x")));
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { }));
+        Assert.Contains("included model id", ex.Message);
+
+        // A trailing slash or different casing of the same base is the same base.
+        Assert.Throws<ArgumentException>(() =>
+            new HostedInferenceBrain("https://DevThrottle.com/api/v1/", "dt_live_abc", "Qwen/Qwen2.5-72B-Instruct", http, _ => { }));
+
+        // Any other base stays a generic provider-compatible client: no included-id rule applies.
+        _ = new HostedInferenceBrain("https://api.openai.com/v1", "sk-abc", "gpt-5.5", http, _ => { });
+    }
+
+    [Fact]
     public async Task AskAsync_PostsChatCompletions_WithModelBearerAndUserMessage()
     {
         var stub = new StubHandler(HttpStatusCode.OK, OkBody("the spoken summary"));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         var result = await brain.AskAsync("translate this");
 
@@ -51,7 +71,7 @@ public sealed class HostedInferenceBrainTests
         Assert.Equal("dt_live_abc", stub.LastRequest.Headers.Authorization.Parameter);
 
         using var doc = JsonDocument.Parse(stub.LastRequestBody!);
-        Assert.Equal("glm-5.2", doc.RootElement.GetProperty("model").GetString());
+        Assert.Equal("devthrottle/wingman", doc.RootElement.GetProperty("model").GetString());
         var messages = doc.RootElement.GetProperty("messages");
         Assert.Equal(1, messages.GetArrayLength());
         Assert.Equal("user", messages[0].GetProperty("role").GetString());
@@ -63,7 +83,7 @@ public sealed class HostedInferenceBrainTests
     {
         var stub = new StubHandler(HttpStatusCode.OK, OkBody("x"));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "", "devthrottle/wingman", http, _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Null(stub.LastRequest);   // no-fallback: never called the model without a credential
@@ -76,7 +96,7 @@ public sealed class HostedInferenceBrainTests
         // string - so it matches every other surface by construction.
         var stub = new StubHandler(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Contains(Core.HostedAi.HostedAiMessages.For(Core.HostedAi.HostedAiState.NeedsCredits).Text, ex.Message);
@@ -89,7 +109,7 @@ public sealed class HostedInferenceBrainTests
         // from the out-of-credits copy.
         var stub = new StubHandler(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"monthly_limit_reached\"}}");
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Contains(Core.HostedAi.HostedAiMessages.For(Core.HostedAi.HostedAiState.CapReached).Text, ex.Message);
@@ -119,7 +139,7 @@ public sealed class HostedInferenceBrainTests
         // Retry-After hint, so the caller can back off for exactly that long instead of guessing.
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", TimeSpan.FromSeconds(12));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         Assert.Equal(TimeSpan.FromSeconds(12), ex.RetryAfter);
@@ -133,7 +153,7 @@ public sealed class HostedInferenceBrainTests
         // its own exponential backoff.
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", retryAfter: null);
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         Assert.Null(ex.RetryAfter);
@@ -146,7 +166,7 @@ public sealed class HostedInferenceBrainTests
         // failure keeps catching a 429 unchanged (issue #1324).
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{}", retryAfter: null);
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
 
         await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         var caught = await Record.ExceptionAsync(() => brain.AskAsync("hi"));
@@ -177,7 +197,7 @@ public sealed class HostedInferenceBrainTests
         // the voice path maps to Retrying. A tiny injected deadline proves the bound without a real wait.
         var handler = new HangingHandler();
         using var http = new HttpClient(handler);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { },
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { },
             callTimeout: TimeSpan.FromMilliseconds(100));
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -196,7 +216,7 @@ public sealed class HostedInferenceBrainTests
         // voice path would wrongly turn into a Retrying banner.
         var handler = new HangingHandler();
         using var http = new HttpClient(handler);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { },
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { },
             callTimeout: TimeSpan.FromMinutes(5));   // deadline far away, so only the caller-cancel can fire
 
         using var cts = new CancellationTokenSource();

--- a/src/CcDirector.Gateway.UnitTests/HostedInferenceBrainTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedInferenceBrainTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using CcDirector.Core.Configuration;
 using CcDirector.Gateway.Wingman;
 using Xunit;
 
@@ -34,32 +35,19 @@ public sealed class HostedInferenceBrainTests
     private static string OkBody(string content) =>
         JsonSerializer.Serialize(new { choices = new[] { new { message = new { role = "assistant", content } } } });
 
-    [Fact]
-    public void Ctor_DevThrottleBase_RefusesCatalogModelIds()
-    {
-        // Included AI revert-proof (issue #1360, inspection round): this class is where a chat model id
-        // meets the DevThrottle deployment credential, so on the DevThrottle base only the internal
-        // included ids may be constructed - a catalog id would bill credits on an internal feature.
-        // Remove the constructor guard and this goes red.
-        using var http = new HttpClient(new StubHandler(HttpStatusCode.OK, OkBody("x")));
-        var ex = Assert.Throws<ArgumentException>(() =>
-            new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { }));
-        Assert.Contains("included model id", ex.Message);
-
-        // A trailing slash or different casing of the same base is the same base.
-        Assert.Throws<ArgumentException>(() =>
-            new HostedInferenceBrain("https://DevThrottle.com/api/v1/", "dt_live_abc", "Qwen/Qwen2.5-72B-Instruct", http, _ => { }));
-
-        // Any other base stays a generic provider-compatible client: no included-id rule applies.
-        _ = new HostedInferenceBrain("https://api.openai.com/v1", "sk-abc", "gpt-5.5", http, _ => { });
-    }
+    // Included AI (issue #1360): this class is where a chat model id meets the DevThrottle deployment
+    // credential. The earlier constructor guard compared the base URL for string equality and was
+    // bypassed by construction in the phase-2 inspection (https://devthrottle.com:443/api/v1 is the
+    // same endpoint but not the same string). The guard is now the IncludedModelId TYPE on the
+    // constructor - a catalog id string no longer compiles here - pinned by
+    // IncludedModelTypeSurfaceTests, with the mint's own behaviour proven in IncludedModelIdTests.
 
     [Fact]
     public async Task AskAsync_PostsChatCompletions_WithModelBearerAndUserMessage()
     {
         var stub = new StubHandler(HttpStatusCode.OK, OkBody("the spoken summary"));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         var result = await brain.AskAsync("translate this");
 
@@ -83,7 +71,7 @@ public sealed class HostedInferenceBrainTests
     {
         var stub = new StubHandler(HttpStatusCode.OK, OkBody("x"));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "", IncludedModelId.Wingman, http, _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Null(stub.LastRequest);   // no-fallback: never called the model without a credential
@@ -96,7 +84,7 @@ public sealed class HostedInferenceBrainTests
         // string - so it matches every other surface by construction.
         var stub = new StubHandler(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"insufficient_credits\"}}");
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Contains(Core.HostedAi.HostedAiMessages.For(Core.HostedAi.HostedAiState.NeedsCredits).Text, ex.Message);
@@ -109,7 +97,7 @@ public sealed class HostedInferenceBrainTests
         // from the out-of-credits copy.
         var stub = new StubHandler(HttpStatusCode.PaymentRequired, "{\"error\":{\"code\":\"monthly_limit_reached\"}}");
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
         Assert.Contains(Core.HostedAi.HostedAiMessages.For(Core.HostedAi.HostedAiState.CapReached).Text, ex.Message);
@@ -139,7 +127,7 @@ public sealed class HostedInferenceBrainTests
         // Retry-After hint, so the caller can back off for exactly that long instead of guessing.
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", TimeSpan.FromSeconds(12));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         Assert.Equal(TimeSpan.FromSeconds(12), ex.RetryAfter);
@@ -153,7 +141,7 @@ public sealed class HostedInferenceBrainTests
         // its own exponential backoff.
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", retryAfter: null);
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         Assert.Null(ex.RetryAfter);
@@ -166,7 +154,7 @@ public sealed class HostedInferenceBrainTests
         // failure keeps catching a 429 unchanged (issue #1324).
         var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{}", retryAfter: null);
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
         var caught = await Record.ExceptionAsync(() => brain.AskAsync("hi"));
@@ -197,7 +185,7 @@ public sealed class HostedInferenceBrainTests
         // the voice path maps to Retrying. A tiny injected deadline proves the bound without a real wait.
         var handler = new HangingHandler();
         using var http = new HttpClient(handler);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { },
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { },
             callTimeout: TimeSpan.FromMilliseconds(100));
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -216,7 +204,7 @@ public sealed class HostedInferenceBrainTests
         // voice path would wrongly turn into a Retrying banner.
         var handler = new HangingHandler();
         using var http = new HttpClient(handler);
-        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "devthrottle/wingman", http, _ => { },
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { },
             callTimeout: TimeSpan.FromMinutes(5));   // deadline far away, so only the caller-cancel can fire
 
         using var cts = new CancellationTokenSource();
@@ -231,7 +219,7 @@ public sealed class HostedInferenceBrainTests
     {
         var stub = new StubHandler(HttpStatusCode.OK, OkBody(""));
         using var http = new HttpClient(stub);
-        var brain = new HostedInferenceBrain("https://api.openai.com/v1", "sk-abc", "gpt-5.5", http, _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, http, _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.AskAsync("hi"));
     }
@@ -247,7 +235,7 @@ public sealed class HostedInferenceBrainTests
     [Fact]
     public async Task ClearAndRestart_AreNoOps()
     {
-        var brain = new HostedInferenceBrain("https://api.openai.com/v1", "sk-abc", "gpt-5.5", new HttpClient(new StubHandler(HttpStatusCode.OK, OkBody("x"))), _ => { });
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", IncludedModelId.Wingman, new HttpClient(new StubHandler(HttpStatusCode.OK, OkBody("x"))), _ => { });
         await brain.ClearAsync();     // must not throw
         await brain.RestartAsync();   // must not throw
         Assert.Null(brain.SessionId);

--- a/src/CcDirector.Gateway.UnitTests/IncludedModelTypeSurfaceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/IncludedModelTypeSurfaceTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.CarMode;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The phase-2 inspection (round 2) bypassed the previous runtime guards by CONSTRUCTION, two ways:
+/// <see cref="HostedInferenceBrain"/> accepted a catalog id when the base URL was spelled
+/// <c>https://devthrottle.com:443/api/v1</c> (same endpoint, defeats string equality), and
+/// <see cref="HostedCarModeChat"/> / <see cref="CarModeWarmup"/> publicly accepted raw resolver
+/// tuples around their guarded default resolver. These tests are those two constructions converted
+/// into permanent evidence: every public seam that puts a chat model on a request authenticated by
+/// the deployment credential is typed <see cref="IncludedModelId"/>, so the bypasses are no longer
+/// expressible with a raw catalog string. Weaken any signature back to a raw string and this goes red.
+/// </summary>
+public sealed class IncludedModelTypeSurfaceTests
+{
+    [Fact]
+    public void HostedInferenceBrain_Constructor_TakesTheProvenType_NeverARawModelString()
+    {
+        var ctors = typeof(HostedInferenceBrain).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotEmpty(ctors);
+        Assert.All(ctors, c =>
+        {
+            var model = c.GetParameters().SingleOrDefault(p => p.Name == "model");
+            Assert.NotNull(model);
+            Assert.Equal(typeof(IncludedModelId), model!.ParameterType);
+        });
+    }
+
+    [Fact]
+    public void CarModeTransports_ResolverTuples_CarryTheProvenType_NeverARawModelString()
+    {
+        // The model resolver a caller can hand HostedCarModeChat or CarModeWarmup must produce
+        // IncludedModelId - the raw (BaseUrl, string Model, Key) tuple of the round-2 bypass does not
+        // compile any more. Checked on the constructor signatures, where the bypass was constructed.
+        var typedResolver = typeof(Func<TenantId, (string BaseUrl, IncludedModelId Model, string Key)>);
+
+        var chatCtor = Assert.Single(typeof(HostedCarModeChat).GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Equal(typedResolver, chatCtor.GetParameters()[0].ParameterType);
+
+        var warmupCtor = Assert.Single(typeof(CarModeWarmup).GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Equal(typedResolver, warmupCtor.GetParameters()[0].ParameterType);
+
+        // And the default resolver produces the same typed tuple, so wiring stays one seam.
+        var defaultResolver = typeof(HostedCarModeChat).GetMethod(nameof(HostedCarModeChat.DefaultResolver));
+        Assert.NotNull(defaultResolver);
+        Assert.Equal(typedResolver, defaultResolver!.ReturnType);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/Speech/SpokenLanguageContractTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Speech/SpokenLanguageContractTests.cs
@@ -720,9 +720,7 @@ public sealed class SpokenLanguageContractTests
         public Task SwitchVoiceModeAsync(string sessionId, bool on, CancellationToken ct) => throw Unused();
         public Task SnoozeSessionAsync(string sessionId, CancellationToken ct) => throw Unused();
         public Task DeleteSessionAsync(string sessionId, CancellationToken ct) => throw Unused();
-        public Task<CarModeCredits> GetCreditsAsync(CancellationToken ct) => throw Unused();
         public Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct) => throw Unused();
         public Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct) => throw Unused();
-        public Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct) => throw Unused();
     }
 }

--- a/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
@@ -22,15 +22,21 @@ public sealed class TenantSettingsResolverTests
     private static TenantSettingsResolver NewResolver(GatewayDbTestHarness h)
         => new(new TenantSettingsStore(h.Open()));
 
+    // Override values in these tests are DevThrottle internal included ids: since the Included AI
+    // mission (issue #1360) a non-devthrottle override is not honored - it would bill credits on an
+    // internal feature - so resolution falls forward to the operator default. The wingman "thinking"
+    // override is deliberately set to the FAST id (and vice versa) where two distinct values are
+    // needed, which still proves the cells are stored separately.
+
     [Fact]
     public void CarModeModel_OverrideSet_ReturnsOverride()
     {
         using var h = new GatewayDbTestHarness();
         var r = NewResolver(h);
 
-        r.SetCarModeModel(TenantA, "a-custom-model", Now);
+        r.SetCarModeModel(TenantA, "devthrottle/wingman", Now);
 
-        Assert.Equal("a-custom-model", r.CarModeModel(TenantA));
+        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA));
     }
 
     [Fact]
@@ -43,17 +49,31 @@ public sealed class TenantSettingsResolverTests
     }
 
     [Fact]
+    public void CarModeModel_CatalogIdOverride_FallsForwardToOperatorGlobalDefault()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        // The Included AI revert-proof (issue #1360): a catalog-id Car Mode override saved by an older
+        // release must not reach the proxy - it would bill credits on an internal feature.
+        r.SetCarModeModel(TenantA, "zai-org/GLM-5.2", Now);
+
+        Assert.Equal(CarModeModelConfig.Resolve(), r.CarModeModel(TenantA));
+    }
+
+    [Fact]
     public void OneTenantsOverride_DoesNotLeakToAnother_WhoGetsTheGlobalDefault()
     {
         using var h = new GatewayDbTestHarness();
         var r = NewResolver(h);
 
-        r.SetCarModeModel(TenantA, "a-custom-model", Now);
+        // The thinking id: distinct from the fast-id operator default, so a leak is visible.
+        r.SetCarModeModel(TenantA, "devthrottle/wingman", Now);
 
         // Tenant B never set an override: it must get the OPERATOR global default, never tenant A's value.
-        Assert.Equal("a-custom-model", r.CarModeModel(TenantA));
+        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA));
         Assert.Equal(CarModeModelConfig.Resolve(), r.CarModeModel(TenantB));
-        Assert.NotEqual("a-custom-model", r.CarModeModel(TenantB));
+        Assert.NotEqual("devthrottle/wingman", r.CarModeModel(TenantB));
     }
 
     [Fact]
@@ -62,11 +82,25 @@ public sealed class TenantSettingsResolverTests
         using var h = new GatewayDbTestHarness();
         var r = NewResolver(h);
 
-        r.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "thinker", Now);
-        r.SetWingmanModel(TenantA, WingmanModelRole.Fast, "sprinter", Now);
+        // Crossed on purpose: each role must read its OWN stored cell.
+        r.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "devthrottle/wingman-fast", Now);
+        r.SetWingmanModel(TenantA, WingmanModelRole.Fast, "devthrottle/wingman", Now);
 
-        Assert.Equal("thinker", r.WingmanModel(TenantA, Mode, WingmanModelRole.Thinking));
-        Assert.Equal("sprinter", r.WingmanModel(TenantA, Mode, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", r.WingmanModel(TenantA, Mode, WingmanModelRole.Thinking));
+        Assert.Equal("devthrottle/wingman", r.WingmanModel(TenantA, Mode, WingmanModelRole.Fast));
+    }
+
+    [Fact]
+    public void WingmanModel_CatalogIdOverride_FallsForwardToIncludedDefault()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        // The Included AI revert-proof on the per-tenant wingman path (issue #1360).
+        r.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "Qwen/Qwen2.5-72B-Instruct", Now);
+
+        Assert.Equal(WingmanModelConfig.Resolve(Mode, WingmanModelRole.Thinking),
+            r.WingmanModel(TenantA, Mode, WingmanModelRole.Thinking));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
@@ -36,7 +36,7 @@ public sealed class TenantSettingsResolverTests
 
         r.SetCarModeModel(TenantA, "devthrottle/wingman", Now);
 
-        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA));
+        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA).Value);
     }
 
     [Fact]
@@ -71,9 +71,9 @@ public sealed class TenantSettingsResolverTests
         r.SetCarModeModel(TenantA, "devthrottle/wingman", Now);
 
         // Tenant B never set an override: it must get the OPERATOR global default, never tenant A's value.
-        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA));
+        Assert.Equal("devthrottle/wingman", r.CarModeModel(TenantA).Value);
         Assert.Equal(CarModeModelConfig.Resolve(), r.CarModeModel(TenantB));
-        Assert.NotEqual("devthrottle/wingman", r.CarModeModel(TenantB));
+        Assert.NotEqual("devthrottle/wingman", r.CarModeModel(TenantB).Value);
     }
 
     [Fact]
@@ -86,8 +86,8 @@ public sealed class TenantSettingsResolverTests
         r.SetWingmanModel(TenantA, WingmanModelRole.Thinking, "devthrottle/wingman-fast", Now);
         r.SetWingmanModel(TenantA, WingmanModelRole.Fast, "devthrottle/wingman", Now);
 
-        Assert.Equal("devthrottle/wingman-fast", r.WingmanModel(TenantA, Mode, WingmanModelRole.Thinking));
-        Assert.Equal("devthrottle/wingman", r.WingmanModel(TenantA, Mode, WingmanModelRole.Fast));
+        Assert.Equal("devthrottle/wingman-fast", r.WingmanModel(TenantA, Mode, WingmanModelRole.Thinking).Value);
+        Assert.Equal("devthrottle/wingman", r.WingmanModel(TenantA, Mode, WingmanModelRole.Fast).Value);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
@@ -75,13 +75,30 @@ public sealed class VoiceDisplayFoldTests
     [InlineData(HostedAiState.NeedsCredits)]
     [InlineData(HostedAiState.CapReached)]
     [InlineData(HostedAiState.NeedsKey)]
+    [InlineData(HostedAiState.SubscriptionRequired)]
+    [InlineData(HostedAiState.FairUseLimitReached)]
+    [InlineData(HostedAiState.Unavailable)]
     public void Blocked_CarriesTheSharedCallToAction_NoGenerateButton(HostedAiState state)
     {
         var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false, unavailable: state, nothingToNarrate: false);
         Assert.Equal("blocked", d.Kind);
-        Assert.NotNull(d.Reason);                 // the add-credit / raise-cap / finish-setup CTA rides here
+        Assert.NotNull(d.Reason);                 // the shared CTA (where one exists) rides here
         Assert.Equal(HostedAiMessages.For(state).Text, d.Message);
         Assert.False(d.CanGenerate);              // a generate button would hit the same wall
+    }
+
+    [Theory]
+    [InlineData(HostedAiState.SubscriptionRequired, "Not included with this account")]
+    [InlineData(HostedAiState.FairUseLimitReached, "Monthly fair-use limit reached")]
+    [InlineData(HostedAiState.Unavailable, "Voice unavailable")]
+    public void IncludedAiRefusals_HaveNoCostWordsInTheirLabelsOrCopy(HostedAiState state, string expectedLabel)
+    {
+        // Issue #1360: the two Included AI refusals and the neutral unknown state must never put credit
+        // or money words on the voice screen.
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false, unavailable: state, nothingToNarrate: false);
+        Assert.Equal(expectedLabel, d.Label);
+        Assert.DoesNotContain("credit", d.Label, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("credit", d.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -14,10 +14,15 @@ using Microsoft.AspNetCore.Routing;
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
-/// The AI model catalog + test surface for the Settings AI tab. It lets the page populate the wingman
-/// and speech model dropdowns from DevThrottle's live catalog (not a hardcoded list), test a
-/// chat model with one round-trip, and persist the chosen wingman/speech model. The browser never sees
+/// The AI model catalog + test surface for the Settings AI tab. It populates the model dropdowns, tests a
+/// chat model with one round-trip, and persists the chosen wingman/speech model. The browser never sees
 /// the credential - the Gateway resolves it from the vault and presents it to DevThrottle.
+///
+/// SINCE THE INCLUDED AI MISSION (issue #1360, design C3) the CHAT kind serves a FIXED list of
+/// DevThrottle's internal included wingman ids and never the catalog: the wingman and Car Mode are
+/// internal included features, and a catalog model there would bill credits. The speech kind still reads
+/// the live catalog (text-to-speech is included in its entirety, so every speech model is safe to offer).
+/// The wingman/Car Mode model setters refuse a non-included id with a 400 for the same reason.
 ///
 ///   GET  /gateway/ai/models?kind=chat|speech -> { models:[ {id, description, voices[], defaultVoice} ] }
 ///   POST /gateway/ai/test-chat  { model }    -> { ok, reply, seconds } | { error }
@@ -118,6 +123,15 @@ internal static class AiModelsEndpoint
         app.MapGet("/gateway/ai/models", async (string? kind, CancellationToken ct) =>
         {
             var k = string.Equals(kind, "speech", StringComparison.OrdinalIgnoreCase) ? "speech" : "chat";
+
+            // The CHAT kind feeds the wingman (and Car Mode) model pickers, and since the Included AI
+            // mission (issue #1360, design consequence C3) those pickers offer ONLY DevThrottle's
+            // internal included ids - never the catalog. A wingman pointed at a catalog id would bill
+            // credits, which the ruling forbids for an internal feature. The list is fixed and local:
+            // no upstream call, no provider credential spent, nothing for a catalog outage to break.
+            if (k == "chat")
+                return Results.Json(new { models = IncludedChatModels() });
+
             var mode = TranscriptionModeConfig.Get();
             var ep = TranscriptionEndpointResolver.ResolveTts(mode);   // base URL + key name (same per provider)
             var key = vault.Get(ep.KeyName);
@@ -188,6 +202,7 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 var model = body.Model.Trim();
+                if (RejectNonIncludedModel(model, "wingman model") is { } refusal) return refusal;
                 resolver.SetWingmanModel(t.Value, WingmanModelRole.Thinking, model, DateTime.UtcNow);
                 FileLog.Write($"[AiModelsEndpoint] wingman thinking model set: {model} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { model });
@@ -205,6 +220,7 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 var model = body.Model.Trim();
+                if (RejectNonIncludedModel(model, "wingman fast model") is { } refusal) return refusal;
                 resolver.SetWingmanModel(t.Value, WingmanModelRole.Fast, model, DateTime.UtcNow);
                 FileLog.Write($"[AiModelsEndpoint] wingman fast model set: {model} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { model });
@@ -222,6 +238,7 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 var model = body.Model.Trim();
+                if (RejectNonIncludedModel(model, "Car Mode model") is { } refusal) return refusal;
                 resolver.SetCarModeModel(t.Value, model, DateTime.UtcNow);
                 FileLog.Write($"[AiModelsEndpoint] car mode model set: {model} for tenant={t.Value.ToLogString()}");
                 return Results.Json(new { model });
@@ -268,6 +285,36 @@ internal static class AiModelsEndpoint
 
     private static string ProviderKeyMissingMessage(TranscriptionMode mode) =>
         "not signed in to DevThrottle - sign in on the Account tab";
+
+    /// <summary>
+    /// The fixed chat-kind picker list (issue #1360, design C3): DevThrottle's internal included
+    /// wingman ids and nothing else. Catalog models are deliberately absent - they bill credits.
+    /// </summary>
+    private static List<ModelDto> IncludedChatModels() => new()
+    {
+        new ModelDto(TranscriptionEndpointResolver.DevThrottleWingmanModel,
+            "DevThrottle wingman - the thinking tier, included with your account", new List<string>(), null),
+        new ModelDto(TranscriptionEndpointResolver.DevThrottleWingmanFastModel,
+            "DevThrottle wingman fast - the low-latency tier, included with your account", new List<string>(), null),
+    };
+
+    /// <summary>
+    /// The 400 a model setter answers when the value is not a DevThrottle internal included id
+    /// (issue #1360). The wingman and Car Mode are internal features: a catalog id here would bill
+    /// credits, so the write is refused loudly instead of being stored and silently ignored at
+    /// resolution time.
+    /// </summary>
+    private static IResult? RejectNonIncludedModel(string model, string settingName)
+    {
+        if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model)) return null;
+        FileLog.Write($"[AiModelsEndpoint] {settingName} REFUSED non-included model '{model}'");
+        return Results.BadRequest(new
+        {
+            error = $"'{model}' is not a DevThrottle included model id. The {settingName} must be one of the " +
+                    $"devthrottle/ ids (for example {TranscriptionEndpointResolver.DevThrottleWingmanModel} or " +
+                    $"{TranscriptionEndpointResolver.DevThrottleWingmanFastModel}).",
+        });
+    }
 
     /// <summary>
     /// List DevThrottle models for a kind. DevThrottle uses GET /models?type=chat|speech; speech

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -22,7 +22,9 @@ namespace CcDirector.Gateway.Api;
 /// DevThrottle's internal included wingman ids and never the catalog: the wingman and Car Mode are
 /// internal included features, and a catalog model there would bill credits. The speech kind still reads
 /// the live catalog (text-to-speech is included in its entirety, so every speech model is safe to offer).
-/// The wingman/Car Mode model setters refuse a non-included id with a 400 for the same reason.
+/// The wingman/Car Mode model setters refuse a non-included id with a 400 for the same reason, and so
+/// does test-chat: it sends the requested model with the deployment credential, so an arbitrary id
+/// there would bill credits just as a saved one would.
 ///
 ///   GET  /gateway/ai/models?kind=chat|speech -> { models:[ {id, description, voices[], defaultVoice} ] }
 ///   POST /gateway/ai/test-chat  { model }    -> { ok, reply, seconds } | { error }
@@ -160,6 +162,14 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
 
+                // The SAME non-included-id rejection the model setters apply (issue #1360, inspection
+                // round). This route sends the requested model with the deployment credential, so an
+                // arbitrary model id here - a stale picker, a hand-written request - would run a catalog
+                // model on the deployment key and bill the exact credits this mission eliminates. The
+                // picker only offers included ids, so a legitimate caller never sees this refusal.
+                var model = body.Model.Trim();
+                if (RejectNonIncludedModel(model, "test-chat model") is { } refusal) return refusal;
+
                 var mode = TranscriptionModeConfig.Get();
                 var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
                 var key = vault.Get(ep.KeyName);
@@ -169,7 +179,7 @@ internal static class AiModelsEndpoint
 
                 // One real round-trip to the chosen model - the same path the wingman uses - so the user
                 // can prove a newly-picked model actually responds before relying on it.
-                var brain = new HostedInferenceBrain(ep.BaseUrl, key!, body.Model.Trim(), log: FileLog.Write);
+                var brain = new HostedInferenceBrain(ep.BaseUrl, key!, model, log: FileLog.Write);
                 var ask = await brain.AskAsync("Reply with exactly the single word: pong. Output nothing else.", ctx.RequestAborted);
                 return Results.Json(new { ok = true, reply = ask.Text.Trim(), seconds = Math.Round(ask.ReplySeconds, 1) });
             }

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -162,13 +162,15 @@ internal static class AiModelsEndpoint
                 if (body is null || string.IsNullOrWhiteSpace(body.Model))
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
 
-                // The SAME non-included-id rejection the model setters apply (issue #1360, inspection
-                // round). This route sends the requested model with the deployment credential, so an
-                // arbitrary model id here - a stale picker, a hand-written request - would run a catalog
-                // model on the deployment key and bill the exact credits this mission eliminates. The
-                // picker only offers included ids, so a legitimate caller never sees this refusal.
+                // The SAME non-included-id refusal the model setters apply (issue #1360). This route
+                // sends the requested model with the deployment credential, so an arbitrary model id
+                // here - a stale picker, a hand-written request - would run a catalog model on the
+                // deployment key and bill the exact credits this mission eliminates. The mint is the
+                // gate: the brain's constructor only accepts the minted type, so a raw string cannot
+                // reach the wire even if this refusal were edited away.
                 var model = body.Model.Trim();
-                if (RejectNonIncludedModel(model, "test-chat model") is { } refusal) return refusal;
+                var minted = IncludedModelId.TryMint(model);
+                if (minted is null) return NonIncludedModelRefusal(model, "test-chat model");
 
                 var mode = TranscriptionModeConfig.Get();
                 var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
@@ -179,7 +181,7 @@ internal static class AiModelsEndpoint
 
                 // One real round-trip to the chosen model - the same path the wingman uses - so the user
                 // can prove a newly-picked model actually responds before relying on it.
-                var brain = new HostedInferenceBrain(ep.BaseUrl, key!, model, log: FileLog.Write);
+                var brain = new HostedInferenceBrain(ep.BaseUrl, key!, minted, log: FileLog.Write);
                 var ask = await brain.AskAsync("Reply with exactly the single word: pong. Output nothing else.", ctx.RequestAborted);
                 return Results.Json(new { ok = true, reply = ask.Text.Trim(), seconds = Math.Round(ask.ReplySeconds, 1) });
             }
@@ -312,11 +314,15 @@ internal static class AiModelsEndpoint
     /// The 400 a model setter answers when the value is not a DevThrottle internal included id
     /// (issue #1360). The wingman and Car Mode are internal features: a catalog id here would bill
     /// credits, so the write is refused loudly instead of being stored and silently ignored at
-    /// resolution time.
+    /// resolution time. Validation is the <see cref="IncludedModelId"/> mint - the same single gate
+    /// every wire path is typed against - never a second local check that could drift from it.
     /// </summary>
     private static IResult? RejectNonIncludedModel(string model, string settingName)
+        => IncludedModelId.TryMint(model) is null ? NonIncludedModelRefusal(model, settingName) : null;
+
+    /// <summary>The refusal payload for a non-included model id, shared by the setters and test-chat.</summary>
+    private static IResult NonIncludedModelRefusal(string model, string settingName)
     {
-        if (TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model)) return null;
         FileLog.Write($"[AiModelsEndpoint] {settingName} REFUSED non-included model '{model}'");
         return Results.BadRequest(new
         {

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -702,10 +702,10 @@ internal static class SettingsEndpoints
             provider = "devthrottle",
             // The per-tenant model/voice choices (issue #2017), each the tenant's override else the operator
             // default, so models picked on the AI tab round-trip across a reload for THIS tenant.
-            wingmanModel = resolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Thinking),
-            wingmanFastModel = resolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Fast),
+            wingmanModel = resolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Thinking).Value,
+            wingmanFastModel = resolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Fast).Value,
             // Car Mode runs its OWN model, separate from the Wingman (a fast tier + tool_choice=required).
-            carModeModel = resolver.CarModeModel(tenant),
+            carModeModel = resolver.CarModeModel(tenant).Value,
             // Car Mode's hands-free sign-off phrase, per tenant. Default "over and out".
             carModeEndPhrase = resolver.CarModeEndPhrase(tenant),
             // transcriptionModel + voices are provider-level facts (one hosted option), not per-tenant.

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -434,23 +434,8 @@ public sealed class CarModeBrain
                     Action: null,
                     ArmedConfirmation: true);
             }
-            case "get_credits":
-            {
-                var credits = await timer.TimeFleetAsync(() => fleet.GetCreditsAsync(ct));
-                if (!credits.SignedIn)
-                    return Result(new { signedIn = false, message = "The Gateway is not signed in to a DevThrottle account, so there is no balance to read." });
-                // The fleet guarantees a signed-in read carries a balance (it throws on a malformed
-                // payload); this throw is the same guarantee restated here so a fake fleet in a test -
-                // or a future second implementation - can never turn "no number" into zero dollars.
-                var balanceMicros = credits.BalanceMicros
-                    ?? throw new InvalidOperationException("get_credits: signed in but no balanceMicros - the fleet must fail loud on a malformed credits payload, never hand the brain a null balance.");
-                return Result(new
-                {
-                    signedIn = true,
-                    balanceDollars = Math.Round(balanceMicros / 1_000_000.0, 2),
-                    lastActionCostDollars = credits.LastDebitMicros is { } debit ? Math.Round(debit / 1_000_000.0, 4) : (double?)null,
-                });
-            }
+            // The get_credits and get_spend tools were removed by the Included AI mission (issue #1360,
+            // ruling Q1): the Assistant and Car Mode no longer speak balances, costs, or spend totals.
             case "list_machines":
             {
                 var machines = await timer.TimeFleetAsync(() => fleet.ListMachinesAsync(ct));
@@ -474,25 +459,6 @@ public sealed class CarModeBrain
                         s.Name, s.Enabled, s.Schedule, s.Machine, action = s.ActionSummary,
                         s.NextRunUtc, s.LastFiredUtc, s.LastStatus,
                     }),
-                });
-            }
-            case "get_spend":
-            {
-                // Codex review finding 6: seven days is the default for an OMITTED argument only. An
-                // explicitly supplied but invalid days value goes back to the model as a tool error it can
-                // correct - silently substituting 7 would answer a question the owner did not ask.
-                var daysText = ReadStringArg(call.ArgumentsJson, "days");
-                int days;
-                if (string.IsNullOrWhiteSpace(daysText))
-                    days = 7;
-                else if (!int.TryParse(daysText, out days) || days < 1 || days > 90)
-                    return Result(new { error = "days must be a whole number from 1 to 90, or omitted for the default 7." });
-                var spend = await timer.TimeFleetAsync(() => fleet.GetSpendAsync(days, ct));
-                return Result(new
-                {
-                    days,
-                    totalDollars = Math.Round(spend.TotalMicros / 1_000_000.0, 2),
-                    hostedActionCount = spend.DebitCount,
                 });
             }
             default:
@@ -631,12 +597,13 @@ public sealed class CarModeBrain
         + "- When a question is ABOUT THE FLEET - how many sessions there are, which need you, what a session "
         + "is doing, the latest one, or an action on a session - use the tools to get REAL facts first. Never "
         + "guess a count, a name, or a state.\n"
-        + "- Account and infrastructure questions have their own read tools: get_credits for the credit "
-        + "balance, get_spend for recent hosted AI spending, list_machines for which machines are online, and "
-        + "list_schedules for the scheduled jobs. Use them the same way - never guess a balance, a dollar "
-        + "figure, or a schedule. Sessions in list_sessions carry ageHours (how long open) and idleMinutes "
-        + "(how long since output), so \"open too long\" and \"is anything stuck\" are answered from those "
-        + "real numbers.\n"
+        + "- Infrastructure questions have their own read tools: list_machines for which machines are online, "
+        + "and list_schedules for the scheduled jobs. Use them the same way - never guess a machine list or a "
+        + "schedule. Questions about credits, balances, cost, or spending are NOT answerable here - there is "
+        + "no tool for them; say plainly that account and billing questions are handled on the DevThrottle "
+        + "website, and never guess or invent a dollar figure. Sessions in list_sessions carry ageHours (how "
+        + "long open) and idleMinutes (how long since output), so \"open too long\" and \"is anything stuck\" "
+        + "are answered from those real numbers.\n"
         + "- When the owner asks for HELP or how this works - \"help\", \"what can you do\", \"what can you "
         + "help me with\", \"how does this work\", \"how do I talk to you\" - call get_help and nothing else. "
         + "It speaks a fixed guided explanation; do NOT write your own and do NOT read the fleet for it.\n"
@@ -721,6 +688,10 @@ public sealed class CarModeBrain
         + "- Include concrete numbers (counts, hours, dollars) when you have them from the tools.\n"
         + "- Every answer goes through speak_answer, an action means calling its tool, and a destructive action "
         + "needs the owner's confirmation.";
+
+    /// <summary>Test window onto the tool catalog, so a guard can prove a removed tool (the Included AI
+    /// money tools, issue #1360) is really absent from what the model is offered.</summary>
+    internal static string ToolCatalogJsonForTests => ToolCatalogJson;
 
     // The tool catalog. Standard chat-completions function tools: reads, ordinary acts, and the
     // destructive delete (which the loop holds for a spoken confirmation - the model just requests it).
@@ -861,28 +832,6 @@ public sealed class CarModeBrain
               "name": "get_help",
               "description": "Explain to the owner what the Assistant can do and how to talk to it. Call this - and NOTHING else - when the owner asks for help or how this works: \"help\", \"what can you do\", \"what can you help me with\", \"how does this work\", \"how do I talk to you\". It speaks a fixed guided explanation of the two ways to talk to the Assistant; you do not write the words and you do not read the fleet for it.",
               "parameters": { "type": "object", "properties": {}, "required": [] }
-            }
-          },
-          {
-            "type": "function",
-            "function": {
-              "name": "get_credits",
-              "description": "Read the account's current credit balance in dollars, and what the last hosted action cost. Use for questions about credits, balance, subscription money, or \"are we running low\". Never guess a balance.",
-              "parameters": { "type": "object", "properties": {}, "required": [] }
-            }
-          },
-          {
-            "type": "function",
-            "function": {
-              "name": "get_spend",
-              "description": "Read the total hosted AI spend in dollars over the trailing window, and how many hosted actions it covers. Use for \"what have we spent\", \"how fast are we burning credits\", or pace questions. Defaults to the last 7 days.",
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "days": { "type": "string", "description": "The trailing window in days, 1 to 90. Omit for 7." }
-                },
-                "required": []
-              }
             }
           },
           {

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -154,7 +154,19 @@ public sealed class HostedCarModeChat : ICarModeChat
             // Same base URL + vault key as the wingman endpoint; only the model differs for Car Mode.
             var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
             var key = vaultGet(ep.KeyName) ?? "";
-            return (ep.BaseUrl, tenantSettings.CarModeModel(tenant), key);
+            var model = tenantSettings.CarModeModel(tenant);
+            // Car Mode calls chat completions directly (not through HostedInferenceBrain), so this
+            // resolver is where its model id meets the deployment credential. The resolution above is
+            // already guarded (issue #1360: tenant override, saved setting, and environment override all
+            // fall forward on a non-included id), so this throw is unreachable today - it exists so a
+            // future edit to any resolution leg cannot route a catalog id onto the deployment key and
+            // bill credits on an internal feature. Loud by design (no-fallback rule).
+            if (!TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
+                throw new InvalidOperationException(
+                    $"'{model}' is not a DevThrottle internal included model id. Car Mode is an internal " +
+                    "included feature (issue #1360) and runs only the devthrottle/ ids on the deployment " +
+                    "credential; fix the resolution that produced this value.");
+            return (ep.BaseUrl, model, key);
         };
     }
 }

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -47,15 +47,18 @@ public sealed class HostedCarModeChat : ICarModeChat
 {
     private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromMinutes(2) };
 
-    private readonly Func<TenantId, (string BaseUrl, string Model, string Key)> _resolve;
+    private readonly Func<TenantId, (string BaseUrl, IncludedModelId Model, string Key)> _resolve;
     private readonly HttpClient _http;
     private readonly Action<string> _log;
 
     /// <param name="resolve">Resolves the base URL, model, and credential for the current settings, read
-    ///  fresh each call.</param>
+    ///  fresh each call. The model is the PROVEN included type (issue #1360): this transport presents
+    ///  the DevThrottle deployment credential, so a raw string cannot be accepted here - the phase-2
+    ///  inspection bypassed the earlier resolver-internal check by supplying a raw tuple directly to
+    ///  this constructor, and the type is what makes that construction inexpressible.</param>
     /// <param name="http">HTTP client (tests inject a stub handler); a shared 2-minute client when null.</param>
     /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
-    public HostedCarModeChat(Func<TenantId, (string BaseUrl, string Model, string Key)> resolve, HttpClient? http = null, Action<string>? log = null)
+    public HostedCarModeChat(Func<TenantId, (string BaseUrl, IncludedModelId Model, string Key)> resolve, HttpClient? http = null, Action<string>? log = null)
     {
         _resolve = resolve ?? throw new ArgumentNullException(nameof(resolve));
         _http = http ?? SharedHttp;
@@ -76,7 +79,7 @@ public sealed class HostedCarModeChat : ICarModeChat
         // call every turn is what makes a fast model choose tools RELIABLY instead of hallucinating an
         // action it never took. Conversational turns still work because the tool catalog carries an
         // explicit speak_answer tool the model calls to say anything - so "required" never traps it.
-        var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":{messagesJson},\"tools\":{toolsJson},\"tool_choice\":\"required\",\"stream\":false}}";
+        var body = $"{{\"model\":{JsonSerializer.Serialize(model.Value)},\"messages\":{messagesJson},\"tools\":{toolsJson},\"tool_choice\":\"required\",\"stream\":false}}";
 
         var url = baseUrl.TrimEnd('/') + "/chat/completions";
         using var req = new HttpRequestMessage(HttpMethod.Post, url);
@@ -142,7 +145,7 @@ public sealed class HostedCarModeChat : ICarModeChat
     /// <see cref="CompleteAsync"/> and the brain's tool catalog), which is what makes a fast model choose
     /// tools reliably.
     /// </summary>
-    public static Func<TenantId, (string BaseUrl, string Model, string Key)> DefaultResolver(
+    public static Func<TenantId, (string BaseUrl, IncludedModelId Model, string Key)> DefaultResolver(
         Func<string, string?> vaultGet,
         TenantSettingsResolver tenantSettings)
     {
@@ -154,19 +157,10 @@ public sealed class HostedCarModeChat : ICarModeChat
             // Same base URL + vault key as the wingman endpoint; only the model differs for Car Mode.
             var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
             var key = vaultGet(ep.KeyName) ?? "";
-            var model = tenantSettings.CarModeModel(tenant);
-            // Car Mode calls chat completions directly (not through HostedInferenceBrain), so this
-            // resolver is where its model id meets the deployment credential. The resolution above is
-            // already guarded (issue #1360: tenant override, saved setting, and environment override all
-            // fall forward on a non-included id), so this throw is unreachable today - it exists so a
-            // future edit to any resolution leg cannot route a catalog id onto the deployment key and
-            // bill credits on an internal feature. Loud by design (no-fallback rule).
-            if (!TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
-                throw new InvalidOperationException(
-                    $"'{model}' is not a DevThrottle internal included model id. Car Mode is an internal " +
-                    "included feature (issue #1360) and runs only the devthrottle/ ids on the deployment " +
-                    "credential; fix the resolution that produced this value.");
-            return (ep.BaseUrl, model, key);
+            // CarModeModel returns the PROVEN included type (issue #1360): every resolution leg -
+            // tenant override, saved setting, environment override - falls forward on a non-included
+            // id inside the IncludedModelId mint, so no runtime check is needed or possible here.
+            return (ep.BaseUrl, tenantSettings.CarModeModel(tenant), key);
         };
     }
 }

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -70,10 +70,8 @@ public sealed record CarModeSessionInfo
     public int IdleMinutes { get; init; }
 }
 
-/// <summary>The account credit balance for the get_credits read tool, from GET /account/credits. SignedIn
-/// false means the Gateway holds no account credential - there IS no balance, and the brain says so rather
-/// than inventing a zero (the endpoint never fabricates a balance and neither does the tool).</summary>
-public sealed record CarModeCredits(bool SignedIn, long? BalanceMicros, long? LastDebitMicros);
+// The CarModeCredits and CarModeSpendSummary records were removed with the get_credits and get_spend
+// tools (issue #1360, Included AI ruling Q1): no in-product surface reads a balance or a spend total.
 
 /// <summary>One machine running Directors, for the list_machines read tool: the machine name the owner says
 /// out loud, how recently the Gateway heard from it, and how many fleet sessions it is running now.</summary>
@@ -104,15 +102,10 @@ public sealed record CarModeScheduleInfo
     public string? LastStatus { get; init; }
 }
 
-/// <summary>The hosted AI spend total over a trailing window, for the get_spend read tool, from
-/// GET /gateway/governance/hosted-ai-spend/summary.</summary>
-public sealed record CarModeSpendSummary(long TotalMicros, int DebitCount, DateTime SinceUtc, DateTime UntilUtc);
-
 /// <summary>
-/// A fleet tool that is KNOWINGLY unavailable on this deployment (issue #2129: per-tenant credits and
-/// spend are not served on the hosted Gateway yet). Distinct from a genuine failure on purpose: the brain
-/// converts this into a tool-error result the model RELAYS in plain words ("credits are not available
-/// here yet"), instead of failing the whole turn - the owner hears the truth, not an error page.
+/// A fleet tool that is KNOWINGLY unavailable on this deployment (issue #2129). Distinct from a genuine
+/// failure on purpose: the brain converts this into a tool-error result the model RELAYS in plain words,
+/// instead of failing the whole turn - the owner hears the truth, not an error page.
 /// </summary>
 public sealed class CarModeToolUnavailableException : Exception
 {

--- a/src/CcDirector.Gateway/CarMode/CarModeWarmup.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeWarmup.cs
@@ -23,7 +23,7 @@ public sealed class CarModeWarmup
 {
     private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromSeconds(20) };
 
-    private readonly Func<TenantId, (string BaseUrl, string Model, string Key)> _model;
+    private readonly Func<TenantId, (string BaseUrl, Core.Configuration.IncludedModelId Model, string Key)> _model;
     private readonly Func<TenantId, (string BaseUrl, string Voice, string Model, string Key)> _tts;
     private readonly HttpClient _http;
     private readonly Action<string> _log;
@@ -31,8 +31,13 @@ public sealed class CarModeWarmup
     // 0 = idle, 1 = a warmup is in flight. Collapses an overlapping Start + keep-warm tick.
     private int _inFlight;
 
+    // The chat model resolver carries the PROVEN included type (issue #1360): the warmup presents the
+    // DevThrottle deployment credential, and the phase-2 inspection showed a raw tuple handed to this
+    // constructor bypassed every resolver-internal check - the type makes that construction
+    // inexpressible. The text-to-speech resolver keeps plain strings: speech is included in its
+    // entirety, so no id there can bill credits.
     public CarModeWarmup(
-        Func<TenantId, (string BaseUrl, string Model, string Key)> modelResolver,
+        Func<TenantId, (string BaseUrl, Core.Configuration.IncludedModelId Model, string Key)> modelResolver,
         Func<TenantId, (string BaseUrl, string Voice, string Model, string Key)> ttsResolver,
         HttpClient? http = null,
         Action<string>? log = null)
@@ -77,7 +82,7 @@ public sealed class CarModeWarmup
                 _log("[CarModeWarmup] model warm skipped: no key configured");
                 return;
             }
-            var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":[{{\"role\":\"user\",\"content\":\"ping\"}}],\"max_tokens\":1,\"stream\":false}}";
+            var body = $"{{\"model\":{JsonSerializer.Serialize(model.Value)},\"messages\":[{{\"role\":\"user\",\"content\":\"ping\"}}],\"max_tokens\":1,\"stream\":false}}";
             var url = baseUrl.TrimEnd('/') + "/chat/completions";
             using var req = new HttpRequestMessage(HttpMethod.Post, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);

--- a/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
@@ -58,10 +58,9 @@ public interface ICarModeFleet
     ///  you" on its own when the timer fires (Snooze Length mission). Addressed by session id.</summary>
     Task SnoozeSessionAsync(string sessionId, CancellationToken ct);
 
-    /// <summary>The account credit balance, exactly what the Settings account section shows
-    ///  (GET /account/credits). SignedIn false means there is no account credential and no balance -
-    ///  the brain says so plainly rather than inventing a number.</summary>
-    Task<CarModeCredits> GetCreditsAsync(CancellationToken ct);
+    // The credit-balance and spend read tools were REMOVED by the Included AI mission (issue #1360,
+    // Architect ruling Q1): credits are a website concern for direct API callers, and no in-product
+    // surface - spoken or shown - reads a balance or a spend total anymore.
 
     /// <summary>The machines running Directors right now (GET /directors grouped by machine), each with how
     ///  recently the Gateway heard from it and how many roster sessions it carries. Answers "which machines
@@ -71,8 +70,4 @@ public interface ICarModeFleet
     /// <summary>The scheduled jobs (GET /cron/jobs) as compact speakable views: name, on/off, when, where,
     ///  and what each fire does, plus the next due time and the last outcome.</summary>
     Task<IReadOnlyList<CarModeScheduleInfo>> ListSchedulesAsync(CancellationToken ct);
-
-    /// <summary>The hosted AI spend total over the trailing <paramref name="days"/> days
-    ///  (GET /gateway/governance/hosted-ai-spend/summary). Real ledger dollars, never an estimate.</summary>
-    Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct);
 }

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -201,28 +201,9 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         _log($"[CarModeFleet] snoozed session {sessionId}");
     }
 
-    public async Task<CarModeCredits> GetCreditsAsync(CancellationToken ct)
-    {
-        // Issue #2129: /account/credits reads the MACHINE's one stored account credential, which has no
-        // per-tenant meaning on the hosted Gateway (absent by design there; were it present, every tenant
-        // would be shown the same account's balance). Refuse with a relayable fact instead of either lie.
-        if (GatewayHostedMode.IsHosted)
-            throw new CarModeToolUnavailableException(
-                "The credit balance is not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
-        // The SAME token-free proxy the Settings account section reads (GET /account/credits). A signed-out
-        // Gateway answers signedIn=false explicitly; a cloud failure is a non-success status and throws loud.
-        var root = await GetJsonObjectAsync("/account/credits", ct);
-        var signedIn = root.TryGetProperty("signedIn", out var si) && si.ValueKind == JsonValueKind.True;
-        var balance = GetInt64OrNull(root, "balanceMicros");
-        var lastDebit = GetInt64OrNull(root, "lastDebitMicros");
-        // Codex review finding 6: a signed-in response with no balance is a MALFORMED payload, and turning
-        // it into a zero-dollar answer is exactly the plausible fabricated number the no-fallback rule
-        // exists to prevent. Fail loud; the turn reports a specific contract failure instead.
-        if (signedIn && balance is null)
-            throw new InvalidOperationException("The /account/credits response said signedIn but carried no balanceMicros - malformed payload.");
-        _log($"[CarModeFleet] credits: signedIn={signedIn}");
-        return new CarModeCredits(signedIn, balance, lastDebit);
-    }
+    // GetCreditsAsync was removed by the Included AI mission (issue #1360, ruling Q1): no in-product
+    // surface reads the credit balance anymore. The Gateway's GET /account/credits wire endpoint
+    // itself stays alive for old-client compatibility.
 
     public async Task<IReadOnlyList<CarModeMachineInfo>> ListMachinesAsync(CancellationToken ct)
     {
@@ -295,32 +276,9 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         return schedules;
     }
 
-    public async Task<CarModeSpendSummary> GetSpendAsync(int days, CancellationToken ct)
-    {
-        // Issue #2129: the governance spend store is process-wide, so on the hosted Gateway its total would
-        // AGGREGATE every tenant's spending - an aggregate no single tenant may see (partition when
-        // attributable, deny when aggregate). Refuse with a relayable fact until a per-tenant read exists.
-        if (GatewayHostedMode.IsHosted)
-            throw new CarModeToolUnavailableException(
-                "Spending totals are not available per account on the hosted Gateway yet. Sessions, machines, and schedules all still work.");
-        if (days <= 0) throw new ArgumentOutOfRangeException(nameof(days), "The spend window must be at least one day.");
-        var until = DateTime.UtcNow;
-        var since = until.AddDays(-days);
-        var root = await GetJsonObjectAsync(
-            $"/gateway/governance/hosted-ai-spend/summary?since={Uri.EscapeDataString(since.ToString("o"))}&until={Uri.EscapeDataString(until.ToString("o"))}", ct);
-        // A summary with no total is a malformed response, not a zero - zero dollars is exactly the kind of
-        // plausible fabricated number that ships unnoticed, so it fails loud instead.
-        var total = GetInt64OrNull(root, "totalMicros")
-            ?? throw new InvalidOperationException("The hosted-AI spend summary came back without a totalMicros field.");
-        var summary = new CarModeSpendSummary(
-            total,
-            (int)(GetInt64OrNull(root, "debitCount")
-                ?? throw new InvalidOperationException("The hosted-AI spend summary came back without a debitCount field.")),
-            GetDateTimeOrNull(root, "sinceUtc") ?? since,
-            GetDateTimeOrNull(root, "untilUtc") ?? until);
-        _log($"[CarModeFleet] spend over {days}d -> {summary.DebitCount} debits");
-        return summary;
-    }
+    // GetSpendAsync was removed by the Included AI mission (issue #1360, ruling Q1): no in-product
+    // surface reads a spend total anymore. The governance spend store and sweep keep RECORDING -
+    // recording is not showing - and the admin surfaces on the website keep everything.
 
     /// <summary>Read THIS Gateway's aggregated roster, reusing a read taken within the last
     ///  <see cref="RosterCacheTtl"/> so one turn's several roster reads (and back-to-back turns) collapse to

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1408,7 +1408,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 var model = _tenantSettingsResolver.WingmanModel(tenant, mode, Core.Configuration.WingmanModelRole.Thinking);
                 CcDirector.AgentBrain.IAgentBrain brain = new Wingman.HostedInferenceBrain(
                     ep.BaseUrl, key, model, log: FileLog.Write, callTimeout: TimeSpan.FromMinutes(3));
-                return Task.FromResult((brain, model));
+                return Task.FromResult((brain, model.Value));
             });
         // The daily-email block composer. It folds the tenant's "Suggestions in my daily email" choice,
         // whether there is anything pending, and the once-per-batch cadence into ONE verdict, so whatever
@@ -2064,7 +2064,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// honored on the next turn without a Gateway restart.
     /// </summary>
     internal string ResolveWingmanModel(TenantId tenant, Core.Configuration.WingmanModelRole role)
-        => _tenantSettingsResolver.WingmanModel(tenant, Core.Configuration.TranscriptionModeConfig.Get(), role);
+        => _tenantSettingsResolver.WingmanModel(tenant, Core.Configuration.TranscriptionModeConfig.Get(), role).Value;
 
     private Task<CcDirector.AgentBrain.IAgentBrain> WingmanBrainAsync(TenantId tenant, Core.Configuration.WingmanModelRole role, CancellationToken ct)
     {

--- a/src/CcDirector.Gateway/HostedAi/GatewayHostedAi.cs
+++ b/src/CcDirector.Gateway/HostedAi/GatewayHostedAi.cs
@@ -8,22 +8,20 @@ namespace CcDirector.Gateway.HostedAi;
 
 /// <summary>
 /// Wires the shared, delegate-injected <see cref="HostedAiReadiness"/> check (Core, issue #938) to the
-/// Gateway's real resources: the key vault, the account credential
-/// (<see cref="DevThrottleAccountService"/>), and the credits client (<see cref="AccountCreditsClient"/>).
-/// The Gateway is the only place that holds the account token and the vault, so the wiring lives here
-/// while the decision logic stays pure in Core. This is the factory the per-platform sub-issues
-/// (#939-#943) call to obtain a ready-to-use check.
+/// Gateway's resources. Since the Included AI mission (issue #1360) the check consults NO account
+/// balance - the included features are gated by the runtime 402 only - so the wiring is just the vault
+/// key reader and the mode; the account and credits parameters are kept so call sites compile
+/// unchanged, and are no longer used.
 /// </summary>
 public static class GatewayHostedAi
 {
     /// <summary>
-    /// Build a <see cref="HostedAiReadiness"/> that reads the DevThrottle account balance through
-    /// <paramref name="credits"/> using the token <paramref name="account"/> holds.
+    /// Build the pre-flight <see cref="HostedAiReadiness"/>. No balance read is wired (issue #1360
+    /// retired the client-side balance gate; the runtime 402 rules).
     /// </summary>
     /// <param name="vault">The Gateway key vault.</param>
-    /// <param name="account">The Gateway-hosted account credential service, or null on a host without one
-    /// (then the balance is always unknown and DevThrottle mode reports Ready - the runtime 402 gates it).</param>
-    /// <param name="credits">The cloud credits client (the injectable cloud-egress seam).</param>
+    /// <param name="account">Retained for call-site compatibility; no longer read.</param>
+    /// <param name="credits">Retained for call-site compatibility; no longer called.</param>
     /// <param name="modeProvider">Supplies the current transcription mode; defaults to
     /// <see cref="TranscriptionModeConfig.Get"/> so a Cockpit mode change takes effect with no restart.</param>
     public static HostedAiReadiness CreateReadiness(
@@ -38,36 +36,6 @@ public static class GatewayHostedAi
         return new HostedAiReadiness(
             modeProvider ?? TranscriptionModeConfig.Get,
             name => vault.Get(name),
-            ct => ReadBalanceMicrosAsync(account, credits, ct));
-    }
-
-    /// <summary>
-    /// Read the account balance in micro-dollars for the pre-flight check, or null when it is UNKNOWN.
-    /// Signed out (no token) is unknown; a cloud failure is an expected external condition mapped to
-    /// unknown here at the egress boundary - the pre-flight check must never block on a balance it could
-    /// not read (the runtime 402 remains the authoritative, identically-reported gate). The raw token is
-    /// never logged (DT-05).
-    /// </summary>
-    private static async Task<long?> ReadBalanceMicrosAsync(
-        DevThrottleAccountService? account, AccountCreditsClient credits, CancellationToken ct)
-    {
-        var token = account?.GetAccessTokenForForwarding();
-        if (string.IsNullOrEmpty(token))
-        {
-            FileLog.Write("[GatewayHostedAi] ReadBalanceMicros: no account credential -> balance unknown");
-            return null;
-        }
-
-        try
-        {
-            var result = await credits.GetCreditsAsync(token, ct).ConfigureAwait(false);
-            FileLog.Write($"[GatewayHostedAi] ReadBalanceMicros: balanceMicros={result.BalanceMicros}");
-            return result.BalanceMicros;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayHostedAi] ReadBalanceMicros FAILED (balance unknown, not blocking): {ex.Message}");
-            return null;
-        }
+            _ => Task.FromResult<long?>(null));
     }
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -36,7 +36,12 @@ public sealed class TenantSettingsResolver
 
     // ---- reads: tenant override, else operator global default -------------------------------------------
 
-    /// <summary>The tenant's wingman model for a role, or the operator global default when unset.</summary>
+    /// <summary>
+    /// The tenant's wingman model for a role, or the operator global default when unset. Only a
+    /// DevThrottle internal included id is honored from the override (issue #1360, Included AI): a
+    /// tenant override saved as a catalog id in an older release would bill credits on an internal
+    /// feature, so it falls forward to the included default exactly as the config.json path does.
+    /// </summary>
     public string WingmanModel(TenantId tenant, TranscriptionMode mode, WingmanModelRole role)
     {
         var key = role switch
@@ -45,7 +50,10 @@ public sealed class TenantSettingsResolver
             WingmanModelRole.Fast => TenantSettingKeys.WingmanFastModel,
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unknown wingman model role"),
         };
-        return NonEmptyOverride(tenant, key) ?? WingmanModelConfig.Resolve(mode, role);
+        var saved = NonEmptyOverride(tenant, key);
+        if (saved is not null && TranscriptionEndpointResolver.IsDevThrottleIncludedModel(saved))
+            return saved;
+        return WingmanModelConfig.Resolve(mode, role);
     }
 
     /// <summary>
@@ -156,9 +164,18 @@ public sealed class TenantSettingsResolver
     public string TtsModel(TenantId tenant, TranscriptionMode mode)
         => NonEmptyOverride(tenant, TenantSettingKeys.TtsModel) ?? TtsModelConfig.Resolve(mode);
 
-    /// <summary>The tenant's Car Mode model, or the operator global default when unset.</summary>
+    /// <summary>
+    /// The tenant's Car Mode model, or the operator global default when unset. Car Mode is an internal
+    /// feature, so the same included-id rule as <see cref="WingmanModel"/> applies (issue #1360): a
+    /// catalog-id override falls forward to the included default instead of billing credits.
+    /// </summary>
     public string CarModeModel(TenantId tenant)
-        => NonEmptyOverride(tenant, TenantSettingKeys.CarModeModel) ?? CarModeModelConfig.Resolve();
+    {
+        var saved = NonEmptyOverride(tenant, TenantSettingKeys.CarModeModel);
+        if (saved is not null && TranscriptionEndpointResolver.IsDevThrottleIncludedModel(saved))
+            return saved;
+        return CarModeModelConfig.Resolve();
+    }
 
     /// <summary>The tenant's Car Mode end phrase, or the operator global default when unset.</summary>
     public string CarModeEndPhrase(TenantId tenant)

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -40,9 +40,11 @@ public sealed class TenantSettingsResolver
     /// The tenant's wingman model for a role, or the operator global default when unset. Only a
     /// DevThrottle internal included id is honored from the override (issue #1360, Included AI): a
     /// tenant override saved as a catalog id in an older release would bill credits on an internal
-    /// feature, so it falls forward to the included default exactly as the config.json path does.
+    /// feature, so the mint falls forward to the included default exactly as the config.json path
+    /// does. Returns the PROVEN <see cref="IncludedModelId"/>, so what this resolves can be handed
+    /// straight to the deployment credential.
     /// </summary>
-    public string WingmanModel(TenantId tenant, TranscriptionMode mode, WingmanModelRole role)
+    public IncludedModelId WingmanModel(TenantId tenant, TranscriptionMode mode, WingmanModelRole role)
     {
         var key = role switch
         {
@@ -50,10 +52,8 @@ public sealed class TenantSettingsResolver
             WingmanModelRole.Fast => TenantSettingKeys.WingmanFastModel,
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unknown wingman model role"),
         };
-        var saved = NonEmptyOverride(tenant, key);
-        if (saved is not null && TranscriptionEndpointResolver.IsDevThrottleIncludedModel(saved))
-            return saved;
-        return WingmanModelConfig.Resolve(mode, role);
+        return IncludedModelId.MintOrFallForward(
+            NonEmptyOverride(tenant, key), WingmanModelConfig.Resolve(mode, role));
     }
 
     /// <summary>
@@ -167,15 +167,12 @@ public sealed class TenantSettingsResolver
     /// <summary>
     /// The tenant's Car Mode model, or the operator global default when unset. Car Mode is an internal
     /// feature, so the same included-id rule as <see cref="WingmanModel"/> applies (issue #1360): a
-    /// catalog-id override falls forward to the included default instead of billing credits.
+    /// catalog-id override falls forward to the included default instead of billing credits. Returns
+    /// the PROVEN <see cref="IncludedModelId"/>.
     /// </summary>
-    public string CarModeModel(TenantId tenant)
-    {
-        var saved = NonEmptyOverride(tenant, TenantSettingKeys.CarModeModel);
-        if (saved is not null && TranscriptionEndpointResolver.IsDevThrottleIncludedModel(saved))
-            return saved;
-        return CarModeModelConfig.Resolve();
-    }
+    public IncludedModelId CarModeModel(TenantId tenant)
+        => IncludedModelId.MintOrFallForward(
+            NonEmptyOverride(tenant, TenantSettingKeys.CarModeModel), CarModeModelConfig.Resolve());
 
     /// <summary>The tenant's Car Mode end phrase, or the operator global default when unset.</summary>
     public string CarModeEndPhrase(TenantId tenant)

--- a/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
+++ b/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
@@ -63,36 +63,26 @@ public sealed class HostedInferenceBrain : IAgentBrain
 
     /// <param name="baseUrl">The provider-compatible <c>/v1</c> base URL.</param>
     /// <param name="apiKey">The credential to present as the Bearer token. Must be non-empty.</param>
-    /// <param name="model">The chat model id.</param>
+    /// <param name="model">The chat model id, as the PROVEN included type (issue #1360). This class is
+    /// only ever constructed with the DevThrottle deployment credential, so the model must be an
+    /// internal included id - a catalog id would bill credits on an internal feature. The guard is the
+    /// TYPE, not a check in this constructor: an earlier base-URL string-equality check here was
+    /// bypassed by construction with the equivalent <c>https://devthrottle.com:443/api/v1</c> spelling
+    /// (phase-2 inspection round 2), so this constructor no longer tries to recognize the endpoint -
+    /// it simply cannot be handed an unvalidated string. The only mint path is
+    /// <see cref="Core.Configuration.IncludedModelId"/>.</param>
     /// <param name="http">HTTP client (tests inject a stub over a fake handler); a shared client when null.</param>
     /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
     /// <param name="callTimeout">Per-call deadline (tests pass a tiny value to prove the fast-fail without
     /// a real wait); <see cref="DefaultCallTimeout"/> when null.</param>
-    public HostedInferenceBrain(string baseUrl, string apiKey, string model, HttpClient? http = null, Action<string>? log = null, TimeSpan? callTimeout = null)
+    public HostedInferenceBrain(string baseUrl, string apiKey, Core.Configuration.IncludedModelId model, HttpClient? http = null, Action<string>? log = null, TimeSpan? callTimeout = null)
     {
         if (string.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("baseUrl is required", nameof(baseUrl));
-        if (string.IsNullOrWhiteSpace(model)) throw new ArgumentException("model is required", nameof(model));
-        // THE meeting point of a chat model id and the DevThrottle deployment credential (issue #1360,
-        // inspection round). Every guarded resolution (WingmanModelConfig, CarModeModelConfig, the
-        // tenant settings resolver, the test-chat refusal) already ensures only an internal included id
-        // gets here, so on the DevThrottle base this throw is unreachable today - it exists so a FUTURE
-        // call site cannot hand a catalog id to the deployment key and bill credits on an internal
-        // feature. Loud by design (no-fallback rule): a silent model swap here would hide the caller's
-        // bug. Other base URLs are untouched - this class is a generic provider-compatible client.
-        if (string.Equals(baseUrl.Trim().TrimEnd('/'), Core.Configuration.TranscriptionEndpointResolver.DevThrottleBaseUrl, StringComparison.OrdinalIgnoreCase)
-            && !Core.Configuration.TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
-        {
-            throw new ArgumentException(
-                $"'{model.Trim()}' is not a DevThrottle internal included model id. Chat calls on the " +
-                "DevThrottle deployment credential run only the devthrottle/ ids (issue #1360) - a " +
-                "catalog id here would bill credits on an internal feature. Resolve the model through " +
-                "WingmanModelConfig / CarModeModelConfig / TenantSettingsResolver instead of passing a " +
-                "raw string.", nameof(model));
-        }
+        ArgumentNullException.ThrowIfNull(model);
         _http = http ?? SharedHttp;
         _chatUrl = baseUrl.TrimEnd('/') + "/chat/completions";
         _apiKey = apiKey ?? "";
-        _model = model.Trim();
+        _model = model.Value;
         _callTimeout = callTimeout ?? DefaultCallTimeout;
         _log = log ?? FileLog.Write;
     }

--- a/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
+++ b/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
@@ -72,6 +72,23 @@ public sealed class HostedInferenceBrain : IAgentBrain
     {
         if (string.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("baseUrl is required", nameof(baseUrl));
         if (string.IsNullOrWhiteSpace(model)) throw new ArgumentException("model is required", nameof(model));
+        // THE meeting point of a chat model id and the DevThrottle deployment credential (issue #1360,
+        // inspection round). Every guarded resolution (WingmanModelConfig, CarModeModelConfig, the
+        // tenant settings resolver, the test-chat refusal) already ensures only an internal included id
+        // gets here, so on the DevThrottle base this throw is unreachable today - it exists so a FUTURE
+        // call site cannot hand a catalog id to the deployment key and bill credits on an internal
+        // feature. Loud by design (no-fallback rule): a silent model swap here would hide the caller's
+        // bug. Other base URLs are untouched - this class is a generic provider-compatible client.
+        if (string.Equals(baseUrl.Trim().TrimEnd('/'), Core.Configuration.TranscriptionEndpointResolver.DevThrottleBaseUrl, StringComparison.OrdinalIgnoreCase)
+            && !Core.Configuration.TranscriptionEndpointResolver.IsDevThrottleIncludedModel(model))
+        {
+            throw new ArgumentException(
+                $"'{model.Trim()}' is not a DevThrottle internal included model id. Chat calls on the " +
+                "DevThrottle deployment credential run only the devthrottle/ ids (issue #1360) - a " +
+                "catalog id here would bill credits on an internal feature. Resolve the model through " +
+                "WingmanModelConfig / CarModeModelConfig / TenantSettingsResolver instead of passing a " +
+                "raw string.", nameof(model));
+        }
         _http = http ?? SharedHttp;
         _chatUrl = baseUrl.TrimEnd('/') + "/chat/completions";
         _apiKey = apiKey ?? "";

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -109,7 +109,11 @@ public static class VoiceDisplayFold
             case HostedAiState.NeedsCredits:
             case HostedAiState.CapReached:
             case HostedAiState.NeedsKey:
-                // Carries the shared call-to-action (add credit / raise the cap / finish setup). The CTA
+            case HostedAiState.SubscriptionRequired:
+            case HostedAiState.FairUseLimitReached:
+            case HostedAiState.Unavailable:
+                // Carries the shared call-to-action where one exists (add credit / raise the cap /
+                // finish setup / view plans - the fair-use and unknown states have none). The CTA
                 // IS a real action, so it rides in Reason; a generate button is still wrong (it would hit
                 // the same wall), so CanGenerate stays false.
                 return new VoiceDisplay
@@ -154,6 +158,9 @@ public static class VoiceDisplayFold
         HostedAiState.NeedsCredits => "Voice needs credit",
         HostedAiState.CapReached => "Monthly limit reached",
         HostedAiState.NeedsKey => "Finish setup",
+        // The two Included AI refusals (issue #1360): no cost words, no numbers.
+        HostedAiState.SubscriptionRequired => "Not included with this account",
+        HostedAiState.FairUseLimitReached => "Monthly fair-use limit reached",
         _ => "Voice unavailable",
     };
 }


### PR DESCRIPTION
Product-repo half of the Included AI mission (devthrottle_internal #1360): the internal AI features run on DevThrottle's included model ids and the product shows no cost, credits, or top-up to members.

What changes:
- The wingman (thinking and fast), session naming, dictation cleanup, and Car Mode call the included ids (devthrottle/wingman, devthrottle/wingman-fast, devthrottle/dictation-cleanup). A saved or overridden model naming anything else falls forward to the included default - enforced structurally: IncludedModelId is the only way a chat model reaches the deployment credential, minted centrally, with a permanent reflection-forge test proving a forged or padded instance throws at first use.
- The wingman model pickers offer only the included ids; the speech picker is unchanged.
- The shared hosted-AI state machine gains subscription-required and fair-use states with plain no-numbers copy on every renderer (mobile banner, cockpit, voice screens, desktop dialogs, the Android parser's defaults, Car Mode spoken, and the durable dictation status strip); an unknown 402 code now renders a neutral no-money state, never a credits demand.
- In-product credit surfaces are gone for everyone: the balance readers, the Car Mode/Assistant credits and spend voice tools and their suggestion copy, the client-side zero-balance pre-flight gate. GET /account/credits stays on the wire for old clients.
- No pricing, Stripe, checkout, or trial machinery touched.

Conduct: mission workflow, record in devthrottle_internal docs/missions/included-ai-2026-08-05/. Independently inspected by five Codex seats across five rounds - round 1 (4 findings: two catalog-id bypass routes, a hardcoded 402 renderer, a billing sentence), rounds 2-4 driving the guard from heuristic to type-level to reflection-proof (each round's bypass constructions now permanent tests), round 5 PASS with zero findings. Focused suites green throughout; the solution-wide dotnet test limitation on this machine is recorded in the inspections.