### PR TITLE
release: v1.9.11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.10</Version>
+    <Version>1.9.11</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.11.md
+++ b/docs/public/release-notes/v1.9.11.md
@@ -1,0 +1,31 @@
+# DevThrottle v1.9.11
+
+A single change, and it is cosmetic: the Director on Windows now wears the same icon as the Director on a Mac.
+
+## The Windows Director shows the current mark, not the old name
+
+The application was renamed some time ago, and every surface moved to the new mark - a black rounded square with a light "D" and a blue terminal prompt beneath it. Every surface except one. The Windows executable still carried the old icon, the one with two letter Cs standing for a name the product no longer uses.
+
+That icon is what you actually look at. It is in the taskbar, in Alt+Tab, in the window title bar, on the desktop shortcut, and in the file properties of the installer you downloaded. So the one place the old name survived was the place it was seen most, and on a machine running both the Windows and the macOS Director the two looked like different applications.
+
+They now match. The drawing differs from the macOS one in a single deliberate way: the tile fills the square edge to edge, because Windows draws its own shadow around an icon, while the Dock expects the shadow and the margin to be part of the artwork.
+
+The icon file also carries nine sizes where it used to carry four. Windows asks for an icon at sixteen, twenty, twenty-four, thirty-two, forty, forty-eight, sixty-four, one hundred and twenty-eight and two hundred and fifty-six pixels across, depending on where it is drawn and how your display is scaled. With only four sizes present, Windows took the nearest one and stretched it, which is why the old icon looked soft in the taskbar. Each size is now drawn for itself.
+
+The mark and the generator that produces it live in the repository, so the next change to it is an edit to a drawing rather than to a binary file nobody can read.
+
+## Upgrading
+
+Nothing to do beyond the usual update. There is no migration, no new setting, and no change to how the Director, the launcher and the Gateway talk to each other. Windows caches application icons aggressively, so if the taskbar or a pinned shortcut still shows the old mark after updating, it will correct itself once the shortcut is unpinned and pinned again, or after a sign-out.
+
+## Known and not fixed here
+
+Everything listed against v1.9.10 still stands. This release changes an icon and nothing else.
+
+- **The Director still opens a local listener during interactive sign-in**, to receive the callback from your browser. It is loopback-only, lasts as long as the sign-in, and carries nothing an agent can call - but the honest statement is that the Director runs without a listening socket, not that it never opens one.
+- The first-run wizard has not yet been verified on a genuinely clean Windows machine. Unchanged from v1.9.9.
+- The v1.9.9 launcher work has not been run on macOS or Linux.
+- Two places still fall back to a local answer when the Gateway fails - session numbering and the dictation dictionary. Both are filed.
+- The Director's large-object heap still grows on a long-running instance.
+- A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
+- Four repository views still show a failed git read as an empty result rather than saying the read failed.


### PR DESCRIPTION
Version bump and release notes for v1.9.11.

The tag is created only after this merges, so it can never point at a commit that is not on main.

See docs/public/release-notes/v1.9.11.md for what is in this release.