### PR TITLE
Reconcile the v1.9.11 release notes and bring the tag's commit onto main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.10</Version>
+    <Version>1.9.11</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v1.9.11.md
+++ b/docs/public/release-notes/v1.9.11.md
@@ -1,0 +1,32 @@
+# DevThrottle v1.9.11
+
+## Your plan now includes the AI features - no credits needed
+
+Dictation, spoken replies, session naming, and the Wingman are included with
+DevThrottle Pro and with the free 14-day trial. The app no longer asks you to
+add credits for any of them:
+
+- Dictation and voice work on a brand-new account from the first minute. There
+  is no balance to top up and no "add credits" dialog before you can record.
+- The Wingman, session naming, and dictation cleanup now run on DevThrottle's
+  included models. The model settings offer exactly those models, so a saved
+  setting can never route your included features onto paid API models.
+- If your trial has ended and you have no subscription, the app now says so
+  plainly and points you to devthrottle.com/pricing - it no longer asks you to
+  buy credits for features that credits do not buy.
+- Prepaid credits remain what they always were: optional, and only for calling
+  the DevThrottle model APIs directly with your own API key. Nothing about
+  that path changed.
+
+## The phone recorder lasts all day
+
+- Recording no longer stops at a default time cap, keeps capturing while you
+  navigate between screens, and shows a recording indicator on every screen.
+- The recorder holds a wake lock and asks Android to exempt it from battery
+  Doze, so long recordings are not silently killed in your pocket.
+- If a recording ever has to be cut short, it is cut short loudly - you are
+  told, instead of discovering a truncated file later.
+
+## Small fixes
+
+- The Windows Director icon now matches the macOS mark.


### PR DESCRIPTION
The v1.9.11 cut collided with a pre-pushed release/v1.9.11 branch: PR 2465 merged the icon-only notes to main while the pushed tag v1.9.11 (3daed31) carries the version bump plus the full notes. This PR reconciles the notes file to describe everything v1.9.11 actually ships - the included AI features, the all-day phone recorder, the icon change, and the known-issues carry-over - and, merged as a MERGE COMMIT (not squash), brings the tag's commit into main's history so the tag is an ancestor of main, per the repo's own release invariant (the v1.9.2 lesson). The tag's tree and main's tree then differ only by this richer notes file.