### PR TITLE
Main is red: the per-account model tests still send ids the setters now refuse

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
+using CcDirector.Core.Configuration;
 using CcDirector.Gateway.Tenancy;
 using Xunit;
 
@@ -122,9 +123,13 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
         ("PUT", "gateway/daily-report",             "{\"cadence\":\"off\"}"),
         ("GET", "gateway/injected-text",            null),
         ("PUT", "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words for one account only\"}"),
-        ("PUT", "gateway/ai/wingman-model",         "{\"model\":\"m-think\"}"),
-        ("PUT", "gateway/ai/wingman-fast-model",    "{\"model\":\"m-fast\"}"),
-        ("PUT", "gateway/ai/car-mode-model",        "{\"model\":\"m-car\"}"),
+        // Issue #1360: these three setters REFUSE any id that is not a devthrottle/ included
+        // model, and that refusal is the feature - so the ids here must be real included ones.
+        // Taken from the product constants rather than written out, so a rename moves the test
+        // with it instead of leaving another stale literal behind.
+        ("PUT", "gateway/ai/wingman-model",         "{\"model\":\"" + TranscriptionEndpointResolver.DevThrottleWingmanModel + "\"}"),
+        ("PUT", "gateway/ai/wingman-fast-model",    "{\"model\":\"" + TranscriptionEndpointResolver.DevThrottleWingmanFastModel + "\"}"),
+        ("PUT", "gateway/ai/car-mode-model",        "{\"model\":\"" + TranscriptionEndpointResolver.DevThrottleWingmanModel + "\"}"),
         ("PUT", "gateway/ai/car-mode-end-phrase",   "{\"phrase\":\"alpha out\"}"),
         ("PUT", "gateway/ai/tts-model",             "{\"model\":\"m-speech\"}"),
     };
@@ -235,11 +240,16 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
     [Fact]
     public async Task Wingman_model_written_by_one_tenant_is_invisible_to_another_on_hosted()
     {
-        (await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/ai/wingman-model", "{\"model\":\"alpha-only-model\"}"))
+        // A real included id (issue #1360 - the setter refuses anything else), and deliberately NOT the
+        // default one: tenant B is left on the default, so a value equal to it would make the isolation
+        // assertion below pass no matter how leaky the store was.
+        const string alphaModel = TranscriptionEndpointResolver.DevThrottleWingmanFastModel;
+
+        (await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/ai/wingman-model", "{\"model\":\"" + alphaModel + "\"}"))
             .EnsureSuccessStatusCode();
 
-        Assert.Equal("alpha-only-model", await ReadString(_httpA, "gateway/ai-provider", "wingmanModel"));
-        Assert.NotEqual("alpha-only-model", await ReadString(_httpB, "gateway/ai-provider", "wingmanModel"));
+        Assert.Equal(alphaModel, await ReadString(_httpA, "gateway/ai-provider", "wingmanModel"));
+        Assert.NotEqual(alphaModel, await ReadString(_httpB, "gateway/ai-provider", "wingmanModel"));
     }
 
     /// <summary>ISOLATED - the Car Mode end phrase, written through AiModelsEndpoint, read via the snapshot.</summary>


### PR DESCRIPTION
Main has been red since issue #1360 landed (`ca777121e`). Continuous integration has failed on the last three runs on `main` - including the commit **v1.9.11 was released from**.

Four failures, all in `HostedPerAccountSettingsServeTests`:

```
Every_per_account_route_serves_an_enrolled_tenant_on_hosted(PUT gateway/ai/wingman-model      {"model":"m-think"})
Every_per_account_route_serves_an_enrolled_tenant_on_hosted(PUT gateway/ai/wingman-fast-model {"model":"m-fast"})
Every_per_account_route_serves_an_enrolled_tenant_on_hosted(PUT gateway/ai/car-mode-model     {"model":"m-car"})
Wingman_model_written_by_one_tenant_is_invisible_to_another_on_hosted
```

Each expects `OK` and gets `BadRequest`.

## The setters are right. The tests are stale.

#1360 added `RejectNonIncludedModel` to the five per-account model setters: a per-account or tenant model override must be a `devthrottle/` included model id, and anything else is refused. **That refusal is the feature**, confirmed against the mission's design ruling - so nothing in `AiModelsEndpoint` is touched here.

What is stale is the test data. It still sends `m-think`, `m-fast`, `m-car` and `alpha-only-model`, so it now receives exactly the 400 the design calls for and reads it as a failure.

The tests therefore adopt the real included ids, taken from the **product constants** (`TranscriptionEndpointResolver.DevThrottleWingmanModel`, `DevThrottleWingmanFastModel`) rather than written out again. A literal is what went stale in the first place; referencing the constant means a rename moves the test with it.

The tenant-isolation test deliberately uses the NON-default included id: tenant B is left on the default, so writing a value equal to it would let that assertion pass no matter how leaky the per-tenant store was.

## Why nothing caught it

The mission's builders and all eight review rounds ran **focused** suites, because a solution-wide `dotnet test` was unrunnable on the machine at the time - Docker and Postgres were down (evidence on #1365). `HostedPerAccountSettingsServeTests` sat outside every focused set, so nothing that ran locally ever executed it.

## Why this is worth its own pull request

Beyond the red badge: **the hosted Gateway deploy workflow refuses to deploy any commit whose checks have FAILED.** While `main` is red the Gateway cannot be deployed at all, which blocks the outage work queued behind it.

Kept deliberately separate from the Gateway-refusal pull request so the red-main incident stays traceable on its own.

## Verification

Before, on unmodified `origin/main` - confirmed by checking out `origin/main` directly rather than inferring:

```
Failed!  - Failed: 4, Passed: 44, Skipped: 0, Total: 48
```

After:

```
Passed!  - Failed: 0, Passed: 48, Skipped: 0, Total: 48
```

Refs #1360
