### PR TITLE
A Gateway that refuses a session key now says so - and the test suite stops destroying the voice of the session that runs it

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -35,6 +35,18 @@ public, permanent record. Get them right.
 - **Never claim a design document is a shipped feature.** Step 4 exists because it
   is easy to read an architecture document and write "we added X" when the code
   is not merged, or is merged but turned off by default. Verify against the code.
+- **A release that adds or changes a Gateway hub method deploys the hosted Gateway
+  BEFORE the tag is pushed.** The desktop Director auto-updates; the hosted Gateway
+  does not - it ships only when someone runs the deploy workflow. So a release that
+  teaches the Director to call something the live Gateway has never heard of puts
+  every machine in the fleet on a version the Gateway cannot serve, the moment they
+  update. That is not hypothetical: v1.9.9 made the per-session Gateway key the only
+  door an agent has to the fleet, the hosted Gateway had not been deployed since
+  before `RegisterSessionKey` existed, and every session on every machine had its key
+  refused with 401 until the Gateway was deployed hours later (#2457, #2459).
+  Check with `git diff <last-tag>..origin/main -- src/CcDirector.Gateway/Streaming/`;
+  if anything there changed, deploy first (see the `deploy-hosted-gateway` skill),
+  confirm `/healthz` reports the new commit, and only then cut the tag.
 - **The human publishes the release, never the agent.** Cutting the tag is an
   outward-facing, hard-to-reverse action. Prepare everything; the human clicks
   publish.

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -657,17 +657,41 @@ jobs:
           TARGET="${{ needs.deploy.outputs.short }}"
 
           # Scan the WHOLE timeline, not just a final sample: once production has served TARGET, any later
-          # 200 carrying a different commit is the supersession. A single closing request would miss a
-          # rollback that was itself swapped over again before the watch ended.
-          # Arm only after TARGET has been served 3 times running. A single sample is not enough: the front
-          # door can flap back to the old instance for a moment during the cutover itself, and calling that
-          # "superseded" would cry rollback on every healthy deploy.
-          # A later "none" counts too - an image that reports no commit is not this deploy either, and
-          # treating it as clean would hide exactly the swap this scan exists to catch.
-          other=$(awk -v t="$TARGET" '
+          # SUSTAINED run of 200s carrying a different commit is the supersession. A single closing
+          # request would miss a rollback that was itself swapped over again before the watch ended.
+          # A "none" counts as a different commit - an image that reports no commit is not this deploy
+          # either, and treating it as clean would hide exactly the swap this scan exists to catch.
+          #
+          # BOTH thresholds exist because ONE of them was not enough, and the run that proved it is
+          # 31005677755 (2026-08-05). Arming after 3 consecutive TARGET samples was meant to sit past the
+          # cutover, but the cutover is not a clean edge: for ~2.9 seconds the front door alternated
+          # between the old instance and the new one, so the third consecutive TARGET landed INSIDE the
+          # flap and the very next straggler from the old instance fired the verdict. That deploy was
+          # healthy - production served TARGET solidly for the rest of the record and is serving it now -
+          # and it was reported superseded. The 2026-08-03 run reported the same shape for the same reason.
+          #
+          # This is the expensive direction of wrong. A pipeline that cries rollback on healthy deploys
+          # is a pipeline whose rollback verdict stops being read, and then a real rollback goes by
+          # unnoticed. So the OTHER commit must now also be sustained - it is not enough to appear.
+          #
+          # 10 consecutive is ~1.5s at the observed median sample interval of 0.15s. The measured flap
+          # never produced more than 2 consecutive samples from the old instance; a genuine swap-back
+          # serves the old commit for the whole remainder of the watch (hundreds of samples), so it
+          # clears this bar immediately. The gap between 2 and 10 is the margin, and it is deliberate:
+          # missing a real swap-back by a second costs nothing (the run reports the closing commit too,
+          # in the `serving` check below), while a false alarm costs the verdict's credibility.
+          OTHER_RUN_REQUIRED=10
+          other=$(awk -v t="$TARGET" -v need="$OTHER_RUN_REQUIRED" '
             !armed && $2=="200" && $3==t { run++; if (run >= 3) armed=1; next }
             !armed { run=0; next }
-            armed && $2=="200" && $3!=t { print ($3=="" ? "none" : $3); exit }
+            # Armed. Count only CONSECUTIVE 200s carrying something other than the target; anything
+            # else (a 200 back on the target, an outage sample) breaks the run and resets it.
+            armed && $2=="200" && $3!=t {
+              seen++; last=($3=="" ? "none" : $3)
+              if (seen >= need) { print last; exit }
+              next
+            }
+            armed { seen=0; next }
           ' "$LOG")
           serving=$(printf '%s' "$(curl -s -m 10 "${GATEWAY_URL}/healthz" 2>/dev/null)" | jq -r '.commit // empty' 2>/dev/null || echo "")
           echo "serving_commit_at_end=${serving}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -684,14 +684,23 @@ jobs:
           other=$(awk -v t="$TARGET" -v need="$OTHER_RUN_REQUIRED" '
             !armed && $2=="200" && $3==t { run++; if (run >= 3) armed=1; next }
             !armed { run=0; next }
-            # Armed. Count only CONSECUTIVE 200s carrying something other than the target; anything
-            # else (a 200 back on the target, an outage sample) breaks the run and resets it.
-            armed && $2=="200" && $3!=t {
+            # Armed. Count 200s carrying something other than the target. Only a 200 back ON the
+            # target resets the count - an outage sample does NOT.
+            #
+            # That asymmetry is deliberate and was a review finding. Resetting on any non-200 sounds
+            # equivalent and is not: a genuinely rolled-back instance that is also unhealthy serves the
+            # old commit in runs of 200s separated by 503s, and under a reset-on-anything rule it could
+            # do that for the entire watch without ever reaching the threshold - so the worst kind of
+            # rollback, one that is both wrong AND failing, would be the one we stayed silent about.
+            # The question this scan asks is "has production stopped serving what we deployed", and an
+            # outage is not evidence that it resumed.
+            armed && $2=="200" && $3==t { seen=0; next }
+            armed && $2=="200" {
               seen++; last=($3=="" ? "none" : $3)
               if (seen >= need) { print last; exit }
               next
             }
-            armed { seen=0; next }
+            armed { next }
           ' "$LOG")
           serving=$(printf '%s' "$(curl -s -m 10 "${GATEWAY_URL}/healthz" 2>/dev/null)" | jq -r '.commit // empty' 2>/dev/null || echo "")
           echo "serving_commit_at_end=${serving}" >> "$GITHUB_OUTPUT"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1410,12 +1410,28 @@ public partial class MainWindow : Window
                 credential.Revoke();
             }
         }
+        catch (CcDirector.ControlApi.GatewayRefusedSessionKeyException ex)
+        {
+            // The Gateway is there and refusing us. This is a VERDICT, not an absence of one, and it
+            // has to be its own: no verdict renders as no Sessions row, so this exact failure - every
+            // session in the fleet locked out - used to leave the Home page blank while the log named
+            // the cause every ten seconds (#2457, #2459). It is the one screen that should have said
+            // so, and it said nothing.
+            //
+            // Not the no-Gateway verdict either: that is the benign accepted trade, and dressing a
+            // live refusal in it would be worse than silence.
+            FileLog.Write($"[MainWindow] the Gateway REFUSED this Director's session key: {ex.Message}");
+            _lastFleetToolCheck = new FleetToolCheck(
+                FleetToolVerdict.GatewayRefusedKey, null, OwnToolBinDir(),
+                "The Gateway is connected but refuses this Director's session keys, so every "
+                + "session's command line is answered 401. The Gateway is older than this Director "
+                + "and needs deploying; nothing on this machine can repair it.");
+        }
         catch (Exception ex)
         {
             // Never let a probe failure take the window down, and never let it read as a pass either.
-            // NO VERDICT is the honest outcome here, and it is deliberately NOT the no-Gateway
-            // verdict: a Gateway that refused the probe key throws into this branch, and calling
-            // that "no Gateway" would dress a real refusal up as an expected, benign state.
+            // NO VERDICT is the honest outcome for anything we cannot name - an unexplained failure
+            // must not be handed a confident label just because a label is available.
             FileLog.Write($"[MainWindow] RefreshFleetToolReachabilityAsync FAILED: {ex.Message}");
             _lastFleetToolCheck = null;
         }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1420,12 +1420,14 @@ public partial class MainWindow : Window
             //
             // Not the no-Gateway verdict either: that is the benign accepted trade, and dressing a
             // live refusal in it would be worse than silence.
-            FileLog.Write($"[MainWindow] the Gateway REFUSED this Director's session key: {ex.Message}");
+            FileLog.Write($"[MainWindow] the Gateway did NOT accept this Director's session key: {ex.Message}");
             _lastFleetToolCheck = new FleetToolCheck(
                 FleetToolVerdict.GatewayRefusedKey, null, OwnToolBinDir(),
-                "The Gateway is connected but refuses this Director's session keys, so every "
-                + "session's command line is answered 401. The Gateway is older than this Director "
-                + "and needs deploying; nothing on this machine can repair it.");
+                "The Gateway is connected but did not accept this Director's session key, so every "
+                + "session's command line is answered 401. The most common cause is a Gateway older "
+                + "than this Director, which needs deploying - but the registration only reports that "
+                + "it did not land, not why, so a transport failure looks the same from here. Nothing "
+                + "on this machine can repair either one.");
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -545,26 +545,42 @@ public sealed class ControlApiHost : IAsyncDisposable
     private static void ObserveSessionKeyRegistration(
         GatewayStreamClient stream, SessionKeyRegistration registration, Guid sessionId)
     {
-        _ = Task.Run(async () =>
+        // STARTED HERE, SYNCHRONOUSLY, AND ONLY THEN OBSERVED. The call runs on this thread to its
+        // first await, which is what puts the registration on the tunnel before the agent process is
+        // launched - let alone booted - exactly as the call site promises.
+        //
+        // Task.Run would look equivalent and is NOT. It defers the whole call until the thread pool
+        // gets to it, so a session could present its key before the registration had even begun and be
+        // answered 401, and a short-lived session could be revoked before the queued work started and
+        // then have its dead credential re-registered behind it. Observing a result must not change
+        // WHEN the work happens.
+        var pending = stream.RegisterSessionKeyAsync(registration);
+        _ = ObserveAsync(pending, sessionId);
+
+        // Parameters named apart from the locals above on purpose: a local function parameter that
+        // shadows an enclosing local is a compile error in some scopes, and this is not the place to
+        // find that out.
+        static async Task ObserveAsync(Task<bool> registrationTask, Guid id)
         {
             // A task root is an entry point, so the catch belongs here: there is no caller left to
             // throw to, and an escape would be an unobserved exception rather than a reported one.
             try
             {
-                var registered = await stream.RegisterSessionKeyAsync(registration).ConfigureAwait(false);
+                var registered = await registrationTask.ConfigureAwait(false);
                 if (!registered)
                     FileLog.Write(
-                        $"[ControlApiHost] session {sessionId} was launched with a Gateway key the Gateway did NOT "
-                        + "accept: its fleet commands will answer 401 until a reseed registers it. When this repeats "
-                        + "for EVERY session, the Gateway is older than this Director and needs deploying - the keys "
-                        + "are not the fault.");
+                        $"[ControlApiHost] session {id} was launched with a Gateway key the Gateway did NOT "
+                        + "accept, so its fleet commands will answer 401 until a reseed registers it. The reason is "
+                        + "NOT known here: RegisterSessionKeyAsync returns the same false for a hub-side refusal, a "
+                        + "tunnel that was not connected, and a transport failure. If this repeats for EVERY session, "
+                        + "check whether the Gateway is older than this Director.");
             }
             catch (Exception ex)
             {
                 FileLog.Write(
-                    $"[ControlApiHost] session key registration for {sessionId} FAULTED: {ex.Message}");
+                    $"[ControlApiHost] session key registration for {id} FAULTED: {ex.Message}");
             }
-        });
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -408,7 +408,7 @@ public sealed class ControlApiHost : IAsyncDisposable
             var key = _sessionGatewayKeys.Mint(sessionId);
             var registration = _sessionGatewayKeys.RegistrationFor(sessionId);
             if (registration is not null)
-                _ = _streamClient.RegisterSessionKeyAsync(registration);
+                ObserveSessionKeyRegistration(_streamClient, registration, sessionId);
             return key;
         };
 
@@ -520,6 +520,54 @@ public sealed class ControlApiHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// Send a session key registration WITHOUT waiting for it, but observe how it turns out.
+    ///
+    /// The send is still not awaited by the caller, and must not be: session creation cannot block on
+    /// the network (see the note at the call site). What changed is that the result is no longer
+    /// thrown away. The call site used to read `_ = _streamClient.RegisterSessionKeyAsync(...)`, and
+    /// that discard cost two things.
+    ///
+    /// First, this is the only place that knows WHICH session the key belongs to and that it was
+    /// minted for a real launch rather than for the health probe. The stream client logs its own
+    /// failure, but it logs it as one more transport-level line; the fact that a session was just
+    /// handed a credential the Gateway will refuse belongs here, in the launch path, said in those
+    /// terms.
+    ///
+    /// Second, a discarded task is an UNOBSERVED task. Everything RegisterSessionKeyAsync does today
+    /// is inside its own try, so nothing escapes - but that is a property of the callee that the call
+    /// site was silently depending on, and the day it stops being true the exception disappears into
+    /// the runtime instead of the log.
+    ///
+    /// Issues #2457 and #2459: on 2026-08-05 every registration in the fleet was refused at once
+    /// because the hosted Gateway predated the RegisterSessionKey hub method. The sessions that came
+    /// up in that window went looking for a fault in their own credential, which was fine.
+    /// </summary>
+    private static void ObserveSessionKeyRegistration(
+        GatewayStreamClient stream, SessionKeyRegistration registration, Guid sessionId)
+    {
+        _ = Task.Run(async () =>
+        {
+            // A task root is an entry point, so the catch belongs here: there is no caller left to
+            // throw to, and an escape would be an unobserved exception rather than a reported one.
+            try
+            {
+                var registered = await stream.RegisterSessionKeyAsync(registration).ConfigureAwait(false);
+                if (!registered)
+                    FileLog.Write(
+                        $"[ControlApiHost] session {sessionId} was launched with a Gateway key the Gateway did NOT "
+                        + "accept: its fleet commands will answer 401 until a reseed registers it. When this repeats "
+                        + "for EVERY session, the Gateway is older than this Director and needs deploying - the keys "
+                        + "are not the fault.");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write(
+                    $"[ControlApiHost] session key registration for {sessionId} FAULTED: {ex.Message}");
+            }
+        });
+    }
+
+    /// <summary>
     /// Mint, register, and hand out a short-lived Gateway session key for the desktop's fleet-tool
     /// health probe - the same kind of credential a real session launch stamps, taken through the
     /// same mint-and-register path, so the probe proves exactly what a spawned session would
@@ -530,12 +578,17 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// no tunnel). That is a fact about this machine's connection and the caller renders it as the
     /// mission's accepted no-Gateway trade.
     ///
-    /// A Gateway that is connected and REFUSES the registration THROWS instead, and the difference
-    /// matters more than it looks. Returning null there would report "no Gateway" - a benign,
-    /// expected state - for a Gateway that is right there and rejecting us, which is a real fault
-    /// wearing a harmless label, and precisely the kind of plausible-but-wrong state this mission
-    /// keeps finding. The caller turns the exception into NO VERDICT plus a loud log, never a pass
-    /// and never a false calm.
+    /// A Gateway that is connected and REFUSES the registration throws
+    /// <see cref="GatewayRefusedSessionKeyException"/> instead, and the difference matters more than
+    /// it looks. Returning null there would report "no Gateway" - a benign, expected state - for a
+    /// Gateway that is right there and rejecting us, which is a real fault wearing a harmless label,
+    /// and precisely the kind of plausible-but-wrong state this mission keeps finding.
+    ///
+    /// The caller turns that specific exception into a RED Sessions row naming an out-of-date
+    /// Gateway. It used to turn it into no verdict, which renders as no row at all - so the one
+    /// screen built to surface this failure stayed blank through a fleet-wide outage (#2457, #2459).
+    /// Any OTHER exception is still no verdict, and that is still right: an unexplained failure must
+    /// never be handed a confident label.
     ///
     /// This is not hypothetical. The registration is keyed by session id and the hub does not check
     /// that the id belongs to a live session of the calling Director - the mission's own inspection
@@ -568,7 +621,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         {
             if (_sessionGatewayKeys.Forget(probeId))
                 _streamClient?.RevokeSessionKey(probeId.ToString());
-            throw new InvalidOperationException(
+            throw new GatewayRefusedSessionKeyException(
                 "the Gateway is connected but refused to register the fleet-tool probe key, so the "
                 + "tools cannot be checked - this is a Gateway-side refusal, not a missing Gateway");
         }

--- a/src/CcDirector.ControlApi/GatewayRefusedSessionKeyException.cs
+++ b/src/CcDirector.ControlApi/GatewayRefusedSessionKeyException.cs
@@ -1,0 +1,26 @@
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// The Gateway is connected and REFUSED to register a session key.
+///
+/// This exists so the caller can tell that one state apart from every other way the fleet-tool probe
+/// can fail, and it exists because it could not. <see cref="ControlApiHost.MintFleetToolProbeCredentialAsync"/>
+/// has always thrown for a refusal - deliberately, so it could never be confused with the benign
+/// no-Gateway state - but it threw a plain <see cref="InvalidOperationException"/>, indistinguishable
+/// from a bug in the probe. The desktop's only honest response to "something went wrong, I do not
+/// know what" is NO VERDICT, and no verdict renders as no row at all.
+///
+/// So on 2026-08-05, while every session on every machine was being refused by a Gateway that
+/// predated the session key registry, the Home page - the one screen built to surface exactly this -
+/// showed nothing. The failure was known, logged, and silent. Issues #2457 and #2459.
+///
+/// Catching this specific type is what lets the desktop say "the Gateway refused the key" instead of
+/// shrugging. Anything else still means no verdict, which remains correct: an unexplained failure
+/// must not be dressed up as a diagnosis.
+/// </summary>
+public sealed class GatewayRefusedSessionKeyException : Exception
+{
+    public GatewayRefusedSessionKeyException(string message) : base(message)
+    {
+    }
+}

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -476,6 +476,72 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// The hub methods this Director will actually call on a Gateway, and therefore the ones whose
+    /// absence it should say something about. Kept deliberately SHORT: this is not an inventory of
+    /// the hub, it is the list whose absence has a consequence a person needs to hear about.
+    /// </summary>
+    private static readonly string[] MethodsThisDirectorNeeds =
+    {
+        "RegisterSessionKey", "RevokeSessionKey", "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+    };
+
+    /// <summary>The capability line already reported, so a ten-second reseed does not repeat it forever.</summary>
+    private string _lastCapabilityReport = "";
+
+    /// <summary>
+    /// Say ONCE, plainly, what the Gateway on the other end cannot do.
+    ///
+    /// This is the line that did not exist on 2026-08-05. The hosted Gateway predated
+    /// <c>RegisterSessionKey</c>, so this Director kept minting session keys and sending registrations
+    /// that could never be accepted, and every agent it launched was handed a credential answering 401.
+    /// The only trace was a transport-level "Method does not exist" logged every ten seconds by the
+    /// recovery path - true, but describing one failed call rather than the state of the connection
+    /// (#2457, #2459).
+    ///
+    /// A NULL argument is the important case, not an error: a Gateway built before capabilities were
+    /// reported returns nothing from Hello, and that alone dates it before this work.
+    ///
+    /// It only LOGS. Nothing here refuses to mint a key or short-circuits a call - the recovery paths
+    /// already retry every reseed, and a second mechanism deciding the same question would give two
+    /// answers to it. The fix for an out-of-date Gateway is to deploy it, and the point of this line
+    /// is that someone reading the log can tell that is what is needed.
+    ///
+    /// Reported on CHANGE only. The reseed runs every ten seconds and an unchanged fact repeated
+    /// forever is how a log stops being read.
+    /// </summary>
+    private void ReportGatewayCapabilities(GatewayCapabilities? capabilities)
+    {
+        var report = DescribeGatewayCapabilities(capabilities);
+        if (string.Equals(report, _lastCapabilityReport, StringComparison.Ordinal)) return;
+        _lastCapabilityReport = report;
+        FileLog.Write($"[GatewayStreamClient] {report}");
+    }
+
+    /// <summary>
+    /// The sentence <see cref="ReportGatewayCapabilities"/> writes. Pure and separate from the logging
+    /// so the wording - which is the entire value of this feature - can be tested directly rather than
+    /// inferred from a log file.
+    /// </summary>
+    internal static string DescribeGatewayCapabilities(GatewayCapabilities? capabilities)
+    {
+        if (capabilities is null)
+            return "the Gateway did not report its capabilities, so it was built before capability "
+                + "reporting existed - it is OLDER than this Director. If session keys are being refused, "
+                + "this is why, and deploying the Gateway is the fix.";
+
+        var missing = MethodsThisDirectorNeeds
+            .Where(m => !capabilities.HubMethods.Contains(m, StringComparer.Ordinal))
+            .ToArray();
+        var identity = $"Gateway v{capabilities.Version}"
+            + (capabilities.Commit.Length > 0 ? $" ({capabilities.Commit})" : "");
+        return missing.Length == 0
+            ? $"{identity}: has every hub method this Director needs"
+            : $"{identity} is MISSING the hub method(s) this Director needs: {string.Join(", ", missing)}. "
+              + "Calls to them will fail until the Gateway is deployed; a missing RegisterSessionKey "
+              + "means EVERY session's command line will answer 401.";
+    }
+
     private async Task<ReseedReport> ReseedAsync()
     {
         var conn = _connection;
@@ -490,7 +556,10 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             var seq = Interlocked.Increment(ref _sequence);
 
             var helloStarted = DateTime.UtcNow;
-            await conn.InvokeAsync("Hello", new DirectorStreamHello
+            // Invoked GENERICALLY so the Gateway's answer is read. A Gateway too old to return
+            // capabilities returns nothing, which SignalR gives us as null - and null is the answer
+            // that matters. See ReportGatewayCapabilities.
+            var capabilities = await conn.InvokeAsync<GatewayCapabilities?>("Hello", new DirectorStreamHello
             {
                 DirectorId = _directorId,
                 Version = _version,
@@ -501,6 +570,7 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 DisplayName = ReadDisplayName(),
             });
             awaitGateway += DateTime.UtcNow - helloStarted;
+            ReportGatewayCapabilities(capabilities);
 
             // OUR work, on this machine: assembling the roster. Timed apart from the send because a slow build
             // is a local problem (a starved machine, a lock held too long) and a slow send is the Gateway's -

--- a/src/CcDirector.Core.Tests/Claude/HookScriptRoundTripTests.cs
+++ b/src/CcDirector.Core.Tests/Claude/HookScriptRoundTripTests.cs
@@ -107,6 +107,24 @@ public sealed class HookScriptRoundTripTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        // REMOVE BOTH FIRST, ALWAYS. psi.Environment starts as a copy of THIS process's environment, and
+        // these tests used only to ADD to it - so a case that passes null for either path was not testing
+        // "the variable is not set", it was inheriting whatever the caller had. Run from inside a live
+        // DevThrottle session (which is how the release gate runs), both variables ARE set, and the
+        // hook then did exactly its job against the REAL session.
+        //
+        // That was not merely a false red. `With_no_variables_set_the_hook_is_inert` feeds the hook
+        // {"session_id":"x"}, so the drop landed in the live session's own pointer file and overwrote its
+        // Claude transcript id with the literal "x" - permanently, and persisted. That session could never
+        // resolve its transcript again, so it never narrated another turn: no error, no retry, just a rail
+        // stuck on "Preparing voice" forever. It hit three sessions, one of them while it was running the
+        // v1.9.11 release gate (#2456).
+        //
+        // So the premise is now ESTABLISHED rather than assumed. A test that says "neither variable is
+        // set" must make that true; inheriting the answer is how it came to be false in exactly the
+        // environment that mattered most.
+        psi.Environment.Remove(SessionHookFiles.PreambleFileEnvVar);
+        psi.Environment.Remove(SessionHookFiles.PointerFileEnvVar);
         if (preambleFile is not null) psi.Environment[SessionHookFiles.PreambleFileEnvVar] = preambleFile;
         if (pointerFile is not null) psi.Environment[SessionHookFiles.PointerFileEnvVar] = pointerFile;
 
@@ -205,8 +223,13 @@ public sealed class HookScriptRoundTripTests : IDisposable
 
         foreach (var source in new[] { "clear", "compact" })
         {
-            var id = $"{source}-{Guid.NewGuid()}";
-            var transcript = $"/tmp/{id}.jsonl";
+            // A PLAIN GUID, because that is what Claude actually mints. This used to be
+            // $"{source}-{Guid.NewGuid()}" - readable in a failure message, and a shape the product never
+            // produces. Since #2456 the pointer setter refuses an id that is not a GUID, so an
+            // unrealistic id here would fail against a guard that is behaving correctly. The source label
+            // still distinguishes the two iterations; it just lives in the transcript name now.
+            var id = Guid.NewGuid().ToString();
+            var transcript = $"/tmp/{source}-{id}.jsonl";
             var (exitCode, stdout, _) = RunHook(interpreter, arguments,
                 $$"""{"session_id":"{{id}}","transcript_path":"{{transcript}}","hook_event_name":"SessionStart","source":"{{source}}"}""",
                 preambleFile, pointerFile);

--- a/src/CcDirector.Core.Tests/History/SessionHistoryReaderTests.cs
+++ b/src/CcDirector.Core.Tests/History/SessionHistoryReaderTests.cs
@@ -20,7 +20,7 @@ public sealed class SessionHistoryReaderTests
         });
 
         var session = NewSession(AgentKind.ClaudeCode);
-        session.UpdateClaudeSessionPointer("claude-id", path, "startup"); // sets the live pointer
+        session.UpdateClaudeSessionPointer("aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa", path, "startup"); // sets the live pointer
 
         try
         {

--- a/src/CcDirector.Core.Tests/Home/HomeStatusSessionsRowTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusSessionsRowTests.cs
@@ -137,4 +137,77 @@ public class HomeStatusSessionsRowTests
             Assert.Equal(HomeCheckAction.OpenTools, row!.Action);
         }
     }
+
+    // The Gateway refuses this Director's session keys (#2457, #2459). On 2026-08-05 this exact
+    // state - every session in the fleet locked out by a Gateway older than the Directors talking
+    // to it - produced NO VERDICT, and no verdict renders as no row. The Home page was blank while
+    // the Director's own log named the cause every ten seconds.
+
+    [Fact]
+    public void GatewayRefusedTheKey_IsARedRow_NotSilence()
+    {
+        var status = BuildWith(new FleetToolCheck(
+            FleetToolVerdict.GatewayRefusedKey, null, @"C:\x\bin",
+            "The Gateway is connected but refuses this Director's session keys."));
+
+        var row = SessionsRow(status);
+        Assert.NotNull(row);
+        Assert.Equal(HomeCheckLevel.Bad, row!.Level);
+        Assert.False(status.AllReady);
+    }
+
+    [Fact]
+    public void GatewayRefusedTheKey_TheRowBlamesTheGatewayAndSaysItIsEverySession()
+    {
+        // The user arrives here having been told by an agent that DevThrottle is broken. The row has
+        // to move them off this machine - nothing on it is at fault - and "every session" is what
+        // turns one odd session into a Gateway that needs deploying.
+        var detail = SessionsRow(BuildWith(new FleetToolCheck(
+            FleetToolVerdict.GatewayRefusedKey, null, @"C:\x\bin", "refused")))!.Detail;
+
+        Assert.Contains("Gateway", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("EVERY session", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("out of date", detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GatewayRefusedTheKey_DoesNotRouteToAToolRepair()
+    {
+        // The install is fine. Offering to repair it would spend the user's attempt on a guaranteed
+        // no-op and land them back on the same red row - the shape issue #1045 fixed for the
+        // stale-install case, which must not be reintroduced by a new verdict.
+        var row = SessionsRow(BuildWith(new FleetToolCheck(
+            FleetToolVerdict.GatewayRefusedKey, null, @"C:\x\bin", "refused")));
+
+        Assert.NotEqual(HomeCheckAction.OpenTools, row!.Action);
+        Assert.NotEqual(HomeCheckAction.RepairTools, row.Action);
+        Assert.Equal(HomeCheckAction.OpenSettings, row.Action);
+    }
+
+    [Fact]
+    public void EveryVerdictInTheEnumHasBeenDecided_NoneFallsThroughToSilence()
+    {
+        // The defect this whole row exists to prevent is a real state rendering as nothing. It came
+        // back anyway, through a state that had no verdict rather than no row - so pin the decision
+        // itself: every verdict must have been CONSIDERED here, and the two that legitimately show
+        // no row must be named rather than reached by falling off the end of the switch.
+        //
+        // A verdict added later fails this test until someone decides what it renders. That is the
+        // point: silence must be a choice, never a default.
+        var showNoRowOnPurpose = new[] { FleetToolVerdict.Unchecked, FleetToolVerdict.NoGateway };
+
+        foreach (FleetToolVerdict verdict in Enum.GetValues<FleetToolVerdict>())
+        {
+            var row = SessionsRow(BuildWith(new FleetToolCheck(verdict, null, @"C:\x\bin", "detail")));
+            if (Array.IndexOf(showNoRowOnPurpose, verdict) >= 0)
+            {
+                Assert.Null(row);
+                continue;
+            }
+
+            Assert.True(row is not null,
+                $"{verdict} renders no Sessions row at all. If that is intended, add it to the list "
+                + "above with the reason; if it is not, this is the blank-page defect returning.");
+        }
+    }
 }

--- a/src/CcDirector.Core.Tests/Home/HomeStatusSessionsRowTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusSessionsRowTests.cs
@@ -167,7 +167,23 @@ public class HomeStatusSessionsRowTests
 
         Assert.Contains("Gateway", detail, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("EVERY session", detail, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("out of date", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("older than this Director", detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GatewayRefusedTheKey_OffersTheCauseWithoutAssertingIt()
+    {
+        // The evidence underneath this row is a single false from RegisterSessionKeyAsync, which
+        // returns the same value for a hub-side refusal, an unconnected tunnel and a transport
+        // failure. Stating "the Gateway is out of date" as fact would be a confident diagnosis drawn
+        // from evidence that cannot support it - the very failure mode this row exists to end, which
+        // makes it the worst possible place to reintroduce it.
+        var detail = SessionsRow(BuildWith(new FleetToolCheck(
+            FleetToolVerdict.GatewayRefusedKey, null, @"C:\x\bin", "refused")))!.Detail;
+
+        Assert.Contains("did not accept", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("most often", detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("is out of date", detail, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/SessionClaudePointerTests.cs
+++ b/src/CcDirector.Core.Tests/SessionClaudePointerTests.cs
@@ -6,43 +6,127 @@ using Xunit;
 namespace CcDirector.Core.Tests;
 
 /// <summary>
-/// Verifies Session.UpdateClaudeSessionPointer (the target of the POST /claude-hook endpoint):
-/// it updates the Claude session id and transcript path on a non-blank report, and ignores
-/// blank values so a partial hook payload never clears a good pointer.
+/// Verifies Session.UpdateClaudeSessionPointer (the target of the session-pointer drop): it updates
+/// the Claude session id and transcript path on a well-formed report, ignores blank values so a
+/// partial hook payload never clears a good pointer, and REFUSES an id that is not a session id at
+/// all.
+///
+/// The ids here are GUIDs because real ones are (for example
+/// 57409e62-bd96-42f1-9fd8-77a758658d2c). These tests used to use convenient labels like
+/// "claude-new", which read fine and quietly modelled something the product never produces - and
+/// that is not a cosmetic point, because the shape is now the guard.
 /// </summary>
 public sealed class SessionClaudePointerTests
 {
+    private const string OriginalId = "11111111-1111-4111-8111-111111111111";
+    private const string NewId = "22222222-2222-4222-8222-222222222222";
+
+    private static Session NewSession(string? claudeSessionId = OriginalId) => new(
+        Guid.NewGuid(),
+        repoPath: @"C:\test\repo",
+        workingDirectory: @"C:\test\repo",
+        claudeArgs: null,
+        backend: new NullBackend(),
+        claudeSessionId: claudeSessionId,
+        activityState: ActivityState.Working,
+        createdAt: DateTimeOffset.UtcNow,
+        customName: null,
+        customColor: null);
+
     [Fact]
     public void UpdateClaudeSessionPointer_UpdatesOnNonBlank_IgnoresBlank()
     {
-        using var s = new Session(
-            Guid.NewGuid(),
-            repoPath: @"C:\test\repo",
-            workingDirectory: @"C:\test\repo",
-            claudeArgs: null,
-            backend: new NullBackend(),
-            claudeSessionId: "claude-orig",
-            activityState: ActivityState.Working,
-            createdAt: DateTimeOffset.UtcNow,
-            customName: null,
-            customColor: null);
+        using var s = NewSession();
 
-        Assert.Equal("claude-orig", s.ClaudeSessionId);
+        Assert.Equal(OriginalId, s.ClaudeSessionId);
         Assert.Null(s.ClaudeTranscriptPath);
 
         // A /clear hook reports the new id + transcript file.
-        s.UpdateClaudeSessionPointer("claude-new", @"C:\proj\new.jsonl", "clear");
-        Assert.Equal("claude-new", s.ClaudeSessionId);
+        s.UpdateClaudeSessionPointer(NewId, @"C:\proj\new.jsonl", "clear");
+        Assert.Equal(NewId, s.ClaudeSessionId);
         Assert.Equal(@"C:\proj\new.jsonl", s.ClaudeTranscriptPath);
 
         // A payload missing fields must not wipe the good pointer.
         s.UpdateClaudeSessionPointer(null, null, "startup");
-        Assert.Equal("claude-new", s.ClaudeSessionId);
+        Assert.Equal(NewId, s.ClaudeSessionId);
         Assert.Equal(@"C:\proj\new.jsonl", s.ClaudeTranscriptPath);
 
-        s.UpdateClaudeSessionPointer("   ", "   ", "x");
-        Assert.Equal("claude-new", s.ClaudeSessionId);
+        s.UpdateClaudeSessionPointer("   ", "   ", "resume");
+        Assert.Equal(NewId, s.ClaudeSessionId);
         Assert.Equal(@"C:\proj\new.jsonl", s.ClaudeTranscriptPath);
+    }
+
+    // Issue #2456. A drop carrying the literal id "x" - no event, no source, no transcript - was
+    // accepted over a verified GUID and persisted. The session could no longer resolve its transcript,
+    // so narration found no reply, recorded "nothing to narrate" and returned without generating
+    // anything: the rail sat on "Preparing voice" forever and the session never spoke again. Silent,
+    // permanent, and it hit three sessions - one while running the v1.9.11 release gate.
+
+    [Theory]
+    [InlineData("x")]                                   // the exact value that did the damage
+    [InlineData("claude-new")]                          // a plausible-looking label that is not an id
+    [InlineData("57409e62-bd96-42f1-9fd8")]             // a TRUNCATED guid - the near miss that matters most
+    [InlineData("not a guid at all")]
+    [InlineData("../../other-tenant/voice-audio/x")]    // a path, not an id
+    public void AMalformedId_IsRefused_AndTheGoodOneStands(string malformed)
+    {
+        using var s = NewSession();
+
+        s.UpdateClaudeSessionPointer(malformed, @"C:\proj\new.jsonl", "SessionStart");
+
+        Assert.Equal(OriginalId, s.ClaudeSessionId);
+    }
+
+    [Fact]
+    public void AMalformedId_AlsoRefusesTheTranscriptPathThatCameWithIt()
+    {
+        // The whole drop is suspect, not just its id. Taking the path from a message we have already
+        // judged malformed would half-apply it - and a transcript path pointing somewhere the id does
+        // not agree with is its own silent wrong-transcript bug.
+        using var s = NewSession();
+        s.UpdateClaudeSessionPointer(NewId, @"C:\proj\good.jsonl", "clear");
+
+        s.UpdateClaudeSessionPointer("x", @"C:\proj\attacker.jsonl", "SessionStart");
+
+        Assert.Equal(NewId, s.ClaudeSessionId);
+        Assert.Equal(@"C:\proj\good.jsonl", s.ClaudeTranscriptPath);
+    }
+
+    [Fact]
+    public void AMalformedId_CannotEvenTakeHoldWhenThereIsNoPointerYet()
+    {
+        // The empty case is the one a "keep what you had" guard can accidentally leave open: with
+        // nothing to protect, an accept costs nothing visible today and breaks narration later.
+        using var s = NewSession(claudeSessionId: null);
+
+        s.UpdateClaudeSessionPointer("x", null, "SessionStart");
+
+        Assert.Null(s.ClaudeSessionId);
+    }
+
+    [Fact]
+    public void AWellFormedIdStillReplacesAnEarlierOne()
+    {
+        // The guard must not be so tight that the real thing it exists to allow stops working: Claude
+        // mints a NEW id on /clear and on compaction, and tracking it is the whole point of the drop.
+        using var s = NewSession();
+
+        s.UpdateClaudeSessionPointer(NewId, @"C:\proj\new.jsonl", "compact");
+
+        Assert.Equal(NewId, s.ClaudeSessionId);
+        Assert.Equal(@"C:\proj\new.jsonl", s.ClaudeTranscriptPath);
+    }
+
+    [Fact]
+    public void TheRealWorldRepairValueIsAccepted()
+    {
+        // The exact id used to repair session 114d729f by hand on 2026-08-06, so the shape the guard
+        // accepts is pinned to a value taken from production rather than one invented for the test.
+        using var s = NewSession(claudeSessionId: null);
+
+        s.UpdateClaudeSessionPointer("57409e62-bd96-42f1-9fd8-77a758658d2c", null, "resume");
+
+        Assert.Equal("57409e62-bd96-42f1-9fd8-77a758658d2c", s.ClaudeSessionId);
     }
 
     private sealed class NullBackend : ISessionBackend

--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -97,7 +97,7 @@ public sealed class ConversationIngestorTests : IDisposable
     {
         var path = Path.Combine(_root, $"transcript-{Guid.NewGuid():N}.jsonl");
         File.WriteAllLines(path, jsonlLines);
-        session.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+        session.UpdateClaudeSessionPointer("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb", path, "test");
         return path;
     }
 
@@ -233,7 +233,7 @@ public sealed class ConversationIngestorTests : IDisposable
         var path = WriteTranscript(sessionA, UserLine("shared conversation", ts));
 
         var sessionB = NewSession();
-        sessionB.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+        sessionB.UpdateClaudeSessionPointer("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb", path, "test");
 
         using var ingestor = NewIngestor();
         await ingestor.IngestAsync(sessionA);
@@ -460,7 +460,7 @@ public sealed class ConversationIngestorTests : IDisposable
         var path = WriteTranscript(sessionA, UserLine("one shared conversation", ts));
 
         var sessionB = NewSession();
-        sessionB.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+        sessionB.UpdateClaudeSessionPointer("bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb", path, "test");
 
         using var ingestor = NewIngestor();
         _sink.HoldFirstPush = true;

--- a/src/CcDirector.Core.UnitTests/Sessions/SessionPointerDropTests.cs
+++ b/src/CcDirector.Core.UnitTests/Sessions/SessionPointerDropTests.cs
@@ -58,6 +58,14 @@ public sealed class SessionPointerDropTests : IDisposable
     private string PathFor(Session session)
         => SessionHookFiles.PointerPathFor(session.Id, session.PointerDropToken, _dir);
 
+    // GUIDs, because real Claude session ids are. Since #2456 a drop whose id is not a GUID is
+    // refused whole, so a readable label here would fail against a guard that is working.
+    private const string RotatedId = "cccccccc-7777-4777-8777-cccccccccccc";
+    private const string RotatedAId = "dddddddd-8888-4888-8888-dddddddddddd";
+    private const string RotatedBId = "eeeeeeee-9999-4999-8999-eeeeeeeeeeee";
+    private const string MappedId = "aaaaaaaa-5555-4555-8555-aaaaaaaaaaaa";
+    private const string HijackId = "bbbbbbbb-6666-4666-8666-bbbbbbbbbbbb";
+
     private static string Body(string claudeId, string transcript, string source = "clear")
         => $$"""{"session_id":"{{claudeId}}","transcript_path":"{{transcript}}","hook_event_name":"SessionStart","source":"{{source}}","cwd":"/tmp"}""";
 
@@ -105,7 +113,7 @@ public sealed class SessionPointerDropTests : IDisposable
     public void An_applied_drop_is_removed()
     {
         var session = Adopt();
-        Drop(session, "rotated", "/tmp/rotated.jsonl");
+        Drop(session, RotatedId, "/tmp/rotated.jsonl");
         var path = PathFor(session);
 
         Assert.True(Watcher().Apply(path));
@@ -183,11 +191,11 @@ public sealed class SessionPointerDropTests : IDisposable
 
         // A body that names the OTHER session in every field a body could carry.
         File.WriteAllText(PathFor(mine),
-            $$"""{"session_id":"hijack","transcript_path":"/tmp/hijack.jsonl","sessionId":"{{other.Id}}","cc_session_id":"{{other.Id}}"}""");
+            $$"""{"session_id":"{{HijackId}}","transcript_path":"/tmp/hijack.jsonl","sessionId":"{{other.Id}}","cc_session_id":"{{other.Id}}"}""");
 
         Watcher().Apply(PathFor(mine));
 
-        Assert.Equal("hijack", mine.ClaudeSessionId);
+        Assert.Equal(HijackId, mine.ClaudeSessionId);
         Assert.Equal("the-id-from-launch", other.ClaudeSessionId);
     }
 
@@ -275,8 +283,8 @@ public sealed class SessionPointerDropTests : IDisposable
     {
         var a = Adopt();
         var b = Adopt();
-        Drop(a, "rotated-a", "/tmp/a.jsonl");
-        Drop(b, "rotated-b", "/tmp/b.jsonl");
+        Drop(a, RotatedAId, "/tmp/a.jsonl");
+        Drop(b, RotatedBId, "/tmp/b.jsonl");
         File.WriteAllText(
             SessionHookFiles.PointerPathFor(Guid.NewGuid(), SessionHookFiles.NewDropToken(), _dir),
             Body("rotated-stranger", "/tmp/stranger.jsonl"));
@@ -284,8 +292,8 @@ public sealed class SessionPointerDropTests : IDisposable
 
         Assert.Equal(2, Watcher().Sweep());
 
-        Assert.Equal("rotated-a", a.ClaudeSessionId);
-        Assert.Equal("rotated-b", b.ClaudeSessionId);
+        Assert.Equal(RotatedAId, a.ClaudeSessionId);
+        Assert.Equal(RotatedBId, b.ClaudeSessionId);
 
         // The two that were applied are gone; the two that were not stay put. A sweep that deleted what
         // it could not apply would throw away a drop for a session that is merely still starting up.
@@ -304,11 +312,67 @@ public sealed class SessionPointerDropTests : IDisposable
     {
         var session = Adopt();
         File.WriteAllText(PathFor(session),
-            """{"claudeSessionId":"mapped-id","transcriptPath":"/tmp/mapped.jsonl","hookEvent":"SessionStart","source":"compact"}""");
+            $$"""{"claudeSessionId":"{{MappedId}}","transcriptPath":"/tmp/mapped.jsonl","hookEvent":"SessionStart","source":"compact"}""");
 
         Assert.True(Watcher().Apply(PathFor(session)));
-        Assert.Equal("mapped-id", session.ClaudeSessionId);
+        Assert.Equal(MappedId, session.ClaudeSessionId);
         Assert.Equal("/tmp/mapped.jsonl", session.ClaudeTranscriptPath);
+    }
+
+    // Issue #2456: the drop that destroyed three sessions. A body carrying the literal id "x" - no
+    // event, no source, no transcript - was accepted over a verified GUID and persisted, after which
+    // the session could never resolve its transcript and silently never narrated again.
+
+    [Theory]
+    [InlineData("x")]                        // the exact value from the incident
+    [InlineData("hijack")]
+    [InlineData("mapped-id")]
+    [InlineData("57409e62-bd96-42f1-9fd8")]  // truncated GUID: the near miss
+    public void A_drop_naming_a_non_guid_is_refused_whole(string malformed)
+    {
+        var session = Adopt();
+        Drop(session, malformed, "/tmp/malformed.jsonl");
+
+        Assert.False(Watcher().Apply(PathFor(session)));
+
+        // BOTH writers must have been skipped. Guarding only UpdateClaudeSessionPointer is not enough:
+        // RelinkClaudeSession assigns Session.ClaudeSessionId directly through its internal setter, and
+        // in the original incident it is the line that actually persisted "x". A version of this fix
+        // that guarded only the first passed every other test in this file while leaving the session
+        // corrupted exactly as before.
+        Assert.Equal("the-id-from-launch", session.ClaudeSessionId);
+        Assert.Null(session.ClaudeTranscriptPath);
+    }
+
+    [Fact]
+    public void A_refused_drop_is_deleted_so_the_sweep_does_not_retry_it_forever()
+    {
+        // A malformed body will never become valid. Left in the box, the two-second sweep would
+        // re-read and re-log it for the life of the session.
+        var session = Adopt();
+        Drop(session, "x", "/tmp/malformed.jsonl");
+
+        Assert.False(Watcher().Apply(PathFor(session)));
+
+        Assert.False(File.Exists(PathFor(session)));
+    }
+
+    [Fact]
+    public void A_refused_drop_does_not_break_the_routing_map_for_the_id_it_already_had()
+    {
+        // RelinkClaudeSession removes the OLD mapping before installing the new one, so a refusal that
+        // reached it would unhook a working session from its own transcript even if the assignment
+        // were somehow blocked. Refusing before that call is what keeps the old link intact.
+        var session = Adopt();
+        var good = Guid.NewGuid().ToString();
+        Drop(session, good, "/tmp/good.jsonl");
+        Assert.True(Watcher().Apply(PathFor(session)));
+
+        Drop(session, "x", "/tmp/bad.jsonl");
+        Assert.False(Watcher().Apply(PathFor(session)));
+
+        Assert.Equal(good, session.ClaudeSessionId);
+        Assert.Equal("/tmp/good.jsonl", session.ClaudeTranscriptPath);
     }
 
     /// <summary>
@@ -319,7 +383,7 @@ public sealed class SessionPointerDropTests : IDisposable
     public void Forgetting_a_session_removes_its_drop()
     {
         var session = Adopt();
-        Drop(session, "rotated", "/tmp/rotated.jsonl");
+        Drop(session, RotatedId, "/tmp/rotated.jsonl");
         var path = PathFor(session);
 
         Watcher().Forget(session.Id);

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -175,12 +175,20 @@ public static class HomeStatusBuilder
             //
             // The sentence names the Gateway because the failure the user has in front of them is an
             // agent saying DevThrottle is broken, on a machine where nothing is. It also says EVERY
-            // session, because that is the fact that turns this from "my session is odd" into "the
-            // Gateway needs deploying" - one refused session looks like bad luck, all of them do not.
+            // session, because that is what turns this from "my session is odd" into something to act
+            // on - one refused session looks like bad luck, all of them do not.
+            //
+            // It says the key was NOT ACCEPTED, and offers an out-of-date Gateway as the likely cause
+            // rather than asserting it. The evidence underneath is a single false from
+            // RegisterSessionKeyAsync, which returns the same value for a hub-side refusal, an
+            // unconnected tunnel and a transport failure - so a row that stated "the Gateway is out of
+            // date" would be a confident diagnosis drawn from evidence that cannot tell those apart.
+            // That is the exact failure this whole change exists to stop, and it would be poor to
+            // reintroduce it in the row meant to fix it.
             Setup.FleetToolVerdict.GatewayRefusedKey =>
                 new HomeCheck(SessionsRowTitle, HomeCheckLevel.Bad,
-                    "the Gateway is refusing this Director's session keys, so EVERY session's "
-                    + "command line answers 401 - the Gateway is out of date and needs deploying",
+                    "the Gateway did not accept this Director's session keys, so EVERY session's "
+                    + "command line answers 401 - most often a Gateway older than this Director",
                     HomeCheckAction.OpenSettings),
 
             // No Gateway means no agent tooling - the accepted trade, not a fault in the install.

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -166,6 +166,23 @@ public static class HomeStatusBuilder
                 new HomeCheck(SessionsRowTitle, HomeCheckLevel.Bad,
                     $"the command line cannot reach the fleet: {check.Detail}", HomeCheckAction.OpenTools),
 
+            // The Gateway is connected and refusing the key. RED, and routed to SETTINGS rather than
+            // to Tools: OpenTools would send someone to repair an install that has nothing wrong
+            // with it, which is the same wrong-destination mistake #1045 fixed for the row above.
+            // Settings is where the Gateway this Director is attached to is named, which is the one
+            // thing the user can actually act on from here - a Director cannot deploy a Gateway, and
+            // a row that offers nowhere to go reads as broken.
+            //
+            // The sentence names the Gateway because the failure the user has in front of them is an
+            // agent saying DevThrottle is broken, on a machine where nothing is. It also says EVERY
+            // session, because that is the fact that turns this from "my session is odd" into "the
+            // Gateway needs deploying" - one refused session looks like bad luck, all of them do not.
+            Setup.FleetToolVerdict.GatewayRefusedKey =>
+                new HomeCheck(SessionsRowTitle, HomeCheckLevel.Bad,
+                    "the Gateway is refusing this Director's session keys, so EVERY session's "
+                    + "command line answers 401 - the Gateway is out of date and needs deploying",
+                    HomeCheckAction.OpenSettings),
+
             // No Gateway means no agent tooling - the accepted trade, not a fault in the install.
             // No row, matching what this page has always done for the standalone state: a local-only
             // machine must not carry a standing warning for a configuration it chose, and painting the

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -583,8 +583,41 @@ public sealed class Session : IDisposable
     /// </summary>
     public void UpdateClaudeSessionPointer(string? claudeSessionId, string? transcriptPath, string? source)
     {
+        // A session id must LOOK like one before it is allowed to replace a working one.
+        //
+        // This guard used to be `!IsNullOrWhiteSpace`, and that is the whole of how issue #2456 destroyed
+        // three sessions. A drop arrived carrying the literal one-character id "x" - with no event, no
+        // source and no transcript - and it was accepted over a verified GUID and persisted. The session
+        // could no longer resolve its own transcript, so narration read no reply, recorded "nothing to
+        // narrate", and returned before generating anything. The rail sat on "Preparing voice" forever and
+        // the session never spoke again. Nothing failed loudly; nothing retried; no reason was recorded
+        // anywhere. One of the three took the damage while running the v1.9.11 release gate.
+        //
+        // The writer in that case was a TEST inheriting the caller's environment, and that is fixed at its
+        // own site - but fixing only the messenger would leave this door open to every other writer. Any
+        // non-blank string could overwrite a known-good pointer, and the damage was silent and permanent.
+        // This guard alone would have prevented all three cases with that test unchanged.
+        //
+        // REFUSING is strictly better than accepting here, and the asymmetry is the point: keeping a
+        // slightly stale id costs one turn of narration, while taking a malformed one costs the session
+        // its voice for good, with no error to notice. So a value that does not parse as a GUID is
+        // refused and said out loud, and the previous good value stands.
         if (!string.IsNullOrWhiteSpace(claudeSessionId))
-            ClaudeSessionId = claudeSessionId;
+        {
+            if (Guid.TryParse(claudeSessionId, out _))
+            {
+                ClaudeSessionId = claudeSessionId;
+            }
+            else
+            {
+                FileLog.Write(
+                    $"[Session] UpdateClaudeSessionPointer REFUSED a malformed claude session id for sid={Id}: "
+                    + $"'{claudeSessionId}' is not a GUID (source={source ?? "(none)"}). Keeping "
+                    + $"'{ClaudeSessionId ?? "(none)"}'. A pointer drop carrying a non-GUID id is a bug in "
+                    + "whatever wrote it - see issue #2456.");
+                return;
+            }
+        }
         if (!string.IsNullOrWhiteSpace(transcriptPath))
             ClaudeTranscriptPath = transcriptPath;
         FileLog.Write($"[Session] UpdateClaudeSessionPointer: sid={Id} source={source ?? "(none)"} claudeId={claudeSessionId ?? "(none)"} transcript={transcriptPath ?? "(none)"}");

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -602,6 +602,14 @@ public sealed class Session : IDisposable
         // slightly stale id costs one turn of narration, while taking a malformed one costs the session
         // its voice for good, with no error to notice. So a value that does not parse as a GUID is
         // refused and said out loud, and the previous good value stands.
+        //
+        // WHAT THIS DOES NOT DO, stated plainly because the shape of the check invites the wrong
+        // assumption: it validates SHAPE, not identity. A well-formed GUID naming a transcript that
+        // does not exist is still accepted, and would silence narration in exactly the same way. So
+        // this closes the incident and the whole class of malformed-value writers; it does not close
+        // the class of well-formed-but-wrong ones. Closing that needs the pointer checked against a
+        // transcript that actually exists, which is a larger change and is deliberately not attempted
+        // here.
         if (!string.IsNullOrWhiteSpace(claudeSessionId))
         {
             if (Guid.TryParse(claudeSessionId, out _))

--- a/src/CcDirector.Core/Sessions/SessionPointerWatcher.cs
+++ b/src/CcDirector.Core/Sessions/SessionPointerWatcher.cs
@@ -219,6 +219,34 @@ public sealed class SessionPointerWatcher : IDisposable
             return false;
         }
 
+        // A drop naming an id that is not a session id is REFUSED WHOLE, here, before either writer
+        // below runs. This is the chokepoint and it has to be: the id reaches the session by TWO
+        // routes - UpdateClaudeSessionPointer, and RelinkClaudeSession, which assigns
+        // Session.ClaudeSessionId directly through its internal setter. Guarding only the first leaves
+        // the second to re-apply exactly what was just refused, which is not a hypothetical: it is what
+        // the 2026-08-05 log shows happening, "RelinkClaudeSession: Linked ... to Claude session x"
+        // one line after the pointer update (#2456).
+        //
+        // The cost of accepting one is the whole point. A session whose id no longer resolves to a
+        // transcript cannot be narrated: the voice path reads no reply, records "nothing to narrate"
+        // and returns without generating anything, so the session goes silent for good with no error
+        // raised anywhere. Three sessions were lost that way, one while running a release gate.
+        //
+        // Refused drops are DELETED rather than left. A malformed body will never become valid, so
+        // leaving it would have the two-second sweep retry and re-log it forever. That is unlike the
+        // token-mismatch refusal above, which is left in place deliberately because it is evidence of
+        // a write by something other than that session's own hook.
+        if (!string.IsNullOrWhiteSpace(evt.ClaudeSessionId) && !Guid.TryParse(evt.ClaudeSessionId, out _))
+        {
+            FileLog.Write($"[SessionPointerWatcher] REFUSED the whole drop for {sessionId}: claudeId " +
+                          $"'{evt.ClaudeSessionId}' is not a GUID (event={evt.HookEvent} source={evt.Source}). " +
+                          "A pointer drop carrying a non-GUID id is a bug in whatever wrote it; the session " +
+                          "keeps the pointer it had - see issue #2456.");
+            try { File.Delete(path); }
+            catch (Exception ex) { FileLog.Write($"[SessionPointerWatcher] could not remove refused {path}: {ex.Message}"); }
+            return false;
+        }
+
         FileLog.Write($"[SessionPointerWatcher] drop for {sessionId}: event={evt.HookEvent} source={evt.Source} " +
                       $"claudeId={evt.ClaudeSessionId} transcript={evt.TranscriptPath}");
         session.UpdateClaudeSessionPointer(evt.ClaudeSessionId, evt.TranscriptPath, evt.Source);

--- a/src/CcDirector.Core/Setup/FleetToolReachability.cs
+++ b/src/CcDirector.Core/Setup/FleetToolReachability.cs
@@ -34,6 +34,25 @@ public enum FleetToolVerdict
     /// whose install has nothing wrong with it.
     /// </summary>
     NoGateway,
+
+    /// <summary>
+    /// The Gateway is connected and REFUSED the session key, so the probe never got as far as
+    /// running a tool. Every session on this machine is refused the same way, and so is every
+    /// session on every other machine pointed at that Gateway.
+    ///
+    /// This is a THIRD state, and it had to be, because it belongs to neither of its neighbours.
+    /// It is not <see cref="NoGateway"/> - the Gateway is right there, answering. It is not
+    /// <see cref="CannotReachGateway"/> either, and that distinction is the one that decides
+    /// whether the user is sent somewhere useful: CannotReachGateway means the toolbelt is at
+    /// fault, usually a stale install on PATH, and it offers install and PATH repairs. Those
+    /// repairs cannot fix this. Nothing on this machine can. The Gateway is out of date and the
+    /// remedy is to deploy it.
+    ///
+    /// Before this verdict existed the refusal produced no verdict at all, and no verdict renders
+    /// as no row - which is how a fleet-wide outage sat on the Home page as blank space for five
+    /// hours while the Director's own log named the cause every ten seconds (#2457, #2459).
+    /// </summary>
+    GatewayRefusedKey,
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/GatewayCapabilities.cs
+++ b/src/CcDirector.Gateway.Contracts/GatewayCapabilities.cs
@@ -1,0 +1,55 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// What the Gateway on the other end of the tunnel can do, answered by <c>Hello</c>.
+///
+/// WHY THIS EXISTS. A Director and the Gateway it dials are deployed separately and update on
+/// different days, so the Director routinely talks to a Gateway older than itself. Until now it had
+/// no way to ask, and found out one hub method at a time, by calling one and being told "Method does
+/// not exist" - which is a runtime error carrying no version, no list, and no way to know whether
+/// anything else is missing too.
+///
+/// On 2026-08-05 that cost the whole fleet a morning. The hosted Gateway predated
+/// <c>RegisterSessionKey</c>, so every Director happily minted a session key for every session it
+/// launched, sent a registration that could never be accepted, and handed each agent a credential
+/// the Gateway would refuse. Every agent's command line answered 401. Nothing said "this Gateway is
+/// too old for me" because nothing had ever asked (#2457, #2459).
+///
+/// A NULL ANSWER IS A REAL ANSWER, and it is the reason this is shaped as a return value rather than
+/// a new hub method. SignalR returns default (null) when a client invokes a hub method that returns
+/// nothing, so <c>InvokeAsync&lt;GatewayCapabilities?&gt;("Hello", ...)</c> against a Gateway built
+/// before this type simply yields null - meaning "old enough to predate capability reporting", which
+/// is exactly the diagnosis worth having. It cost the older Gateway nothing and required no
+/// negotiation, no version compare, and no second round trip. A new hub method would have failed in
+/// precisely the way this exists to stop.
+///
+/// It is backward compatible in BOTH directions: an older Director calls the non-generic
+/// <c>InvokeAsync("Hello", ...)</c> and discards the result, which is unchanged behaviour.
+///
+/// WHAT THIS IS NOT. It is not a feature gate. Nothing here decides whether the Director attempts a
+/// call - the recovery paths already retry, and building a second decision on top of them would give
+/// two answers to one question. It is diagnosis: the Director says plainly, once, at the point of
+/// connection, what the Gateway it just reached cannot do.
+/// </summary>
+public sealed class GatewayCapabilities
+{
+    /// <summary>
+    /// The Gateway's build version, so the two halves are comparable in one log line rather than by
+    /// reading two machines' logs side by side.
+    /// </summary>
+    public string Version { get; set; } = "";
+
+    /// <summary>
+    /// The Gateway's short commit, matching the <c>commit</c> field on <c>/healthz</c> - which is how
+    /// a deploy is verified, so the same string identifies the running build from both directions.
+    /// </summary>
+    public string Commit { get; set; } = "";
+
+    /// <summary>
+    /// The hub methods this Gateway actually exposes to a Director. A NAMED LIST rather than a
+    /// version number or a set of booleans, deliberately: the Director's question is never "which
+    /// release is this" but "will the call I am about to make land", and a list answers that for
+    /// methods added after this type was written without needing a new field for each one.
+    /// </summary>
+    public List<string> HubMethods { get; set; } = new();
+}

--- a/src/CcDirector.Gateway.Tests/HelloCapabilityCompatibilityTests.cs
+++ b/src/CcDirector.Gateway.Tests/HelloCapabilityCompatibilityTests.cs
@@ -1,0 +1,164 @@
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The capability handshake's compatibility claim, proved over a REAL SignalR connection rather than
+/// asserted in a comment (#2457, #2459).
+///
+/// The handshake rests entirely on one property of SignalR: that a client invoking a hub method
+/// GENERICALLY - <c>InvokeAsync&lt;GatewayCapabilities?&gt;("Hello", ...)</c> - against a Gateway whose
+/// Hello returns NOTHING gets null back, and does not fail. Every part of the design leans on it. Null
+/// is how a Director recognises a Gateway older than itself, and it is why no version negotiation, no
+/// second round trip, and no new hub method were needed.
+///
+/// If that property does not hold, this feature is not merely useless - it is catastrophic, and in the
+/// worst possible place. Hello is the FIRST message on the tunnel, and the Director sends it on every
+/// connect and every reconnect. A generic invoke that threw against an older Gateway would fail the
+/// reseed, take the roster push down with it, and do so on exactly the deployment - new Director, old
+/// Gateway - that this whole change exists to make survivable. It would turn a Gateway that refuses
+/// session keys into a Gateway a Director cannot talk to at all.
+///
+/// That is far too much weight for an assertion about someone else's framework, so it is tested here,
+/// in the suite that stands up a genuine hub and dials it with a genuine client. Both directions:
+/// new client against old server, and old client against new server.
+///
+/// The hubs below are deliberately hand-written stand-ins rather than the real DirectorHub. The point
+/// is the SHAPE of the method - returns nothing versus returns a value - and a stand-in states that
+/// shape in one line, with no identity binding, tenant resolution or registry to satisfy first.
+/// </summary>
+public sealed class HelloCapabilityCompatibilityTests : IAsyncLifetime
+{
+    /// <summary>A Gateway from before this work: Hello returns NOTHING.</summary>
+    private sealed class OldShapeHub : Hub
+    {
+        public void Hello(DirectorStreamHello hello) { _ = hello; }
+    }
+
+    /// <summary>A Gateway with this work: Hello returns its capabilities.</summary>
+    private sealed class NewShapeHub : Hub
+    {
+        public GatewayCapabilities Hello(DirectorStreamHello hello)
+        {
+            _ = hello;
+            return new GatewayCapabilities
+            {
+                Version = "1.9.11",
+                Commit = "abc1234",
+                HubMethods = new List<string> { "Hello", "RegisterSessionKey" },
+            };
+        }
+    }
+
+    private WebApplication _old = null!;
+    private WebApplication _new = null!;
+
+    public async Task InitializeAsync()
+    {
+        _old = await StartAsync<OldShapeHub>();
+        _new = await StartAsync<NewShapeHub>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _old.StopAsync();
+        await _old.DisposeAsync();
+        await _new.StopAsync();
+        await _new.DisposeAsync();
+    }
+
+    private static async Task<WebApplication> StartAsync<THub>() where THub : Hub
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Logging.ClearProviders();
+        builder.Services.AddSignalR();
+        var app = builder.Build();
+        app.MapHub<THub>("/director-stream");
+        await app.StartAsync();
+        return app;
+    }
+
+    private static string UrlOf(WebApplication app)
+    {
+        var address = app.Urls.First();
+        return $"{address}/director-stream";
+    }
+
+    private static async Task<HubConnection> ConnectAsync(WebApplication app)
+    {
+        var conn = new HubConnectionBuilder().WithUrl(UrlOf(app)).Build();
+        await conn.StartAsync();
+        return conn;
+    }
+
+    private static DirectorStreamHello AnyHello() => new()
+    {
+        DirectorId = "director-under-test",
+        Version = "1.9.11",
+        MachineName = "test-machine",
+        User = "test-user",
+        Pid = 1234,
+        StartedAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task NewDirector_AgainstAnOldGateway_GetsNullRatherThanAFailure()
+    {
+        // THE claim the whole handshake rests on. If this ever starts throwing, the Director cannot
+        // complete Hello against any Gateway older than itself, and the tunnel is dead on the exact
+        // deployment this change exists to survive.
+        await using var conn = await ConnectAsync(_old);
+
+        var capabilities = await conn.InvokeAsync<GatewayCapabilities?>("Hello", AnyHello());
+
+        Assert.Null(capabilities);
+        Assert.Equal(HubConnectionState.Connected, conn.State);
+    }
+
+    [Fact]
+    public async Task NewDirector_AgainstANewGateway_ReadsTheCapabilities()
+    {
+        await using var conn = await ConnectAsync(_new);
+
+        var capabilities = await conn.InvokeAsync<GatewayCapabilities?>("Hello", AnyHello());
+
+        Assert.NotNull(capabilities);
+        Assert.Equal("1.9.11", capabilities!.Version);
+        Assert.Equal("abc1234", capabilities.Commit);
+        Assert.Contains("RegisterSessionKey", capabilities.HubMethods);
+    }
+
+    [Fact]
+    public async Task OldDirector_AgainstANewGateway_IsUnaffectedByTheReturnValue()
+    {
+        // The other direction, and it is not hypothetical: every Director already in the field invokes
+        // Hello non-generically. Giving the hub a return type must not disturb them, or deploying the
+        // Gateway would break the fleet it is meant to repair.
+        await using var conn = await ConnectAsync(_new);
+
+        await conn.InvokeAsync("Hello", AnyHello());
+
+        Assert.Equal(HubConnectionState.Connected, conn.State);
+    }
+
+    [Fact]
+    public async Task OldDirector_AgainstAnOldGateway_StillWorks()
+    {
+        // The control. Without it, a failure in the three tests above could be read as "this harness
+        // cannot invoke Hello at all" rather than as the compatibility break it would actually be.
+        await using var conn = await ConnectAsync(_old);
+
+        await conn.InvokeAsync("Hello", AnyHello());
+
+        Assert.Equal(HubConnectionState.Connected, conn.State);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/GatewayCapabilityHandshakeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/GatewayCapabilityHandshakeTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.ControlApi;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.UnitTests;
+
+/// <summary>
+/// The capability handshake on Hello (#2457, #2459).
+///
+/// On 2026-08-05 the hosted Gateway was older than every Director talking to it - built before the
+/// RegisterSessionKey hub method existed. Each Director went on minting a Gateway session key for
+/// every session it launched and sending a registration that could never be accepted, so every
+/// agent's command line answered 401 across the whole fleet. Nothing said "this Gateway is too old
+/// for me", because nothing had ever asked. The Director discovered it one failed call at a time,
+/// from a transport error carrying no version and no list.
+///
+/// These tests pin the two halves of the answer: that the Gateway reports what it can actually do,
+/// and that the Director says something a person can act on when it cannot.
+/// </summary>
+public class GatewayCapabilityHandshakeTests
+{
+    // ----- the Gateway's half -----
+
+    [Fact]
+    public void TheHubReportsTheMethodsItReallyHas()
+    {
+        // Reflected from the hub, so it cannot drift from the truth. Hello and RegisterSessionKey are
+        // asserted by name because they are the two the outage turned on.
+        var capabilities = InvokeHelloCapabilities();
+
+        Assert.Contains("Hello", capabilities.HubMethods);
+        Assert.Contains("RegisterSessionKey", capabilities.HubMethods);
+        Assert.Contains("RevokeSessionKey", capabilities.HubMethods);
+    }
+
+    [Fact]
+    public void TheReportedMethodsAreExactlyTheHubsOwnPublicSurface()
+    {
+        // The list must be neither short (a method a Director needs, reported missing when it is
+        // there) nor long (a method reported present that nothing can call). Compared against
+        // reflection over the type itself rather than a written list, because a written list here
+        // would just be the same drift risk moved into the test.
+        var expected = typeof(DirectorHub)
+            .GetMethods(System.Reflection.BindingFlags.Public
+                        | System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName)
+            .Where(m => m.GetBaseDefinition().DeclaringType == typeof(DirectorHub))
+            .Select(m => m.Name)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(expected, InvokeHelloCapabilities().HubMethods);
+    }
+
+    [Fact]
+    public void TheHubDoesNotReportInheritedPlumbingAsACallableMethod()
+    {
+        // Hub's own members are not things a Director invokes; listing them would pad the answer with
+        // names that mean nothing to the caller.
+        var methods = InvokeHelloCapabilities().HubMethods;
+
+        Assert.DoesNotContain("Dispose", methods);
+        Assert.DoesNotContain("ToString", methods);
+        Assert.DoesNotContain("OnConnectedAsync", methods);
+    }
+
+    /// <summary>
+    /// The capabilities the hub would return, read from the same static the hub returns. Building a
+    /// DirectorHub needs a connection context this test has no business faking - the value under test
+    /// is process-wide and computed once, so it is read directly.
+    /// </summary>
+    private static GatewayCapabilities InvokeHelloCapabilities()
+    {
+        var field = typeof(DirectorHub).GetField("Capabilities",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(field);
+        var value = field!.GetValue(null) as GatewayCapabilities;
+        Assert.NotNull(value);
+        return value!;
+    }
+
+    // ----- the Director's half -----
+
+    [Fact]
+    public void ANullAnswerIsReadAsAGatewayOlderThanThisDirector()
+    {
+        // THE case this exists for. SignalR returns null when a hub method returns nothing, so a
+        // Gateway built before this work answers null - and that alone dates it.
+        var report = GatewayStreamClient.DescribeGatewayCapabilities(null);
+
+        Assert.Contains("OLDER than this Director", report, StringComparison.Ordinal);
+        Assert.Contains("deploying the Gateway", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AMissingRegisterSessionKeyIsNamed_AndSaysWhatItCostsTheFleet()
+    {
+        // The exact 2026-08-05 Gateway: everything else present, session keys absent.
+        var report = GatewayStreamClient.DescribeGatewayCapabilities(new GatewayCapabilities
+        {
+            Version = "1.9.6",
+            Commit = "dae83a3",
+            HubMethods = new List<string> { "Hello", "PushSnapshot", "PushDelta", "PushRepoSnapshot" },
+        });
+
+        Assert.Contains("RegisterSessionKey", report, StringComparison.Ordinal);
+        // The version is what makes the two halves comparable in one line.
+        Assert.Contains("1.9.6", report, StringComparison.Ordinal);
+        Assert.Contains("dae83a3", report, StringComparison.Ordinal);
+        // And the consequence, in the words the person reading it will have already heard from an agent.
+        Assert.Contains("401", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AGatewayWithEverythingNeededSaysSo_WithoutNamingAMissingMethod()
+    {
+        var report = GatewayStreamClient.DescribeGatewayCapabilities(new GatewayCapabilities
+        {
+            Version = "1.9.10",
+            Commit = "860f76e",
+            HubMethods = new List<string>
+            {
+                "Hello", "RegisterSessionKey", "RevokeSessionKey",
+                "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+            },
+        });
+
+        Assert.DoesNotContain("MISSING", report, StringComparison.Ordinal);
+        Assert.Contains("1.9.10", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ARealGatewaySatisfiesEveryMethodThisDirectorNeeds()
+    {
+        // The two lists are written in different files for different reasons, and nothing but this
+        // test stops them parting company: a Director that "needs" a method this Gateway never had
+        // would report a healthy, current Gateway as out of date on every reseed.
+        var report = GatewayStreamClient.DescribeGatewayCapabilities(InvokeHelloCapabilities());
+
+        Assert.DoesNotContain("MISSING", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnUnstampedBuildReportsTheVersionWithoutAnEmptyCommitBracket()
+    {
+        // A local development run has no COCKPIT_COMMIT. The line must still read as a sentence.
+        var report = GatewayStreamClient.DescribeGatewayCapabilities(new GatewayCapabilities
+        {
+            Version = "1.9.10",
+            Commit = "",
+            HubMethods = new List<string>
+            {
+                "Hello", "RegisterSessionKey", "RevokeSessionKey",
+                "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+            },
+        });
+
+        Assert.DoesNotContain("()", report, StringComparison.Ordinal);
+        Assert.Contains("Gateway v1.9.10", report, StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/SessionHistoryEndpointTranscriptTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionHistoryEndpointTranscriptTests.cs
@@ -32,7 +32,7 @@ public class SessionHistoryEndpointTranscriptTests
     {
         var missingPath = Path.Combine(Path.GetTempPath(), "cc-history-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
         var session = MakeClaudeSession(claudeSessionId: "stale-id");
-        session.UpdateClaudeSessionPointer("current-id", missingPath, "clear");
+        session.UpdateClaudeSessionPointer("cccccccc-3333-4333-8333-cccccccccccc", missingPath, "clear");
 
         var dto = SessionHistoryEndpoint.BuildHistory(session, session.Id.ToString());
 
@@ -52,7 +52,7 @@ public class SessionHistoryEndpointTranscriptTests
         try
         {
             var session = MakeClaudeSession(claudeSessionId: "some-id");
-            session.UpdateClaudeSessionPointer("some-id", path, "startup");
+            session.UpdateClaudeSessionPointer("dddddddd-4444-4444-8444-dddddddddddd", path, "startup");
 
             var dto = SessionHistoryEndpoint.BuildHistory(session, session.Id.ToString());
 

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -143,14 +143,25 @@ public sealed class DirectorHub : Hub
         }
     }
 
-    /// <summary>Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.</summary>
-    public void Hello(DirectorStreamHello hello)
+    /// <summary>
+    /// Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.
+    ///
+    /// RETURNS this Gateway's capabilities, so a Director learns at the moment of connection what the
+    /// Gateway it just reached can do - see <see cref="GatewayCapabilities"/> for why a null answer
+    /// (an older Gateway, whose Hello returns nothing) is the useful case rather than a problem.
+    /// Returning a value changes nothing for an older Director: it invokes Hello non-generically and
+    /// discards the result.
+    ///
+    /// The rejection paths return null. The connection is being aborted, so nothing is waiting for an
+    /// answer on it; a capabilities object there would describe a Gateway the caller is not bound to.
+    /// </summary>
+    public GatewayCapabilities? Hello(DirectorStreamHello hello)
     {
         if (hello is null || string.IsNullOrWhiteSpace(hello.DirectorId))
         {
             FileLog.Write($"[DirectorHub] Hello REJECTED (missing directorId): conn={Short(Context.ConnectionId)}");
             Context.Abort();
-            return;
+            return null;
         }
 
         var directorId = hello.DirectorId.Trim();
@@ -159,7 +170,7 @@ public sealed class DirectorHub : Hub
         {
             FileLog.Write($"[DirectorHub] Hello REJECTED (conn already bound to {alreadyBound}, cannot re-claim {directorId}): conn={Short(Context.ConnectionId)}");
             Context.Abort();
-            return;
+            return null;
         }
 
         // Hosted Multi-Tenancy increment 1: resolve the tenant this connection belongs to ONCE, here at bind
@@ -172,7 +183,7 @@ public sealed class DirectorHub : Hub
         {
             FileLog.Write($"[DirectorHub] Hello REJECTED (hosted: the authenticated device key resolves to no tenant): conn={Short(Context.ConnectionId)}");
             Context.Abort();
-            return;
+            return null;
         }
         Context.Items[DirectorIdItemKey] = directorId;
         Context.Items[TenantIdItemKey] = tenant;
@@ -196,6 +207,49 @@ public sealed class DirectorHub : Hub
         _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant,
             hello.DisplayName);
         FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version}, machine={hello.MachineName})");
+        return Capabilities;
+    }
+
+    /// <summary>
+    /// This Gateway's capabilities, computed ONCE from the hub itself.
+    ///
+    /// The method list is REFLECTED, never hand-maintained. A hand-written list is a second statement
+    /// of the same fact, and the two drift the moment someone adds a hub method and does not think to
+    /// update it - at which point the Director is told a method is missing that is right there, or
+    /// worse, told one exists that does not. Reflection cannot be wrong about what this class exposes.
+    /// </summary>
+    private static readonly GatewayCapabilities Capabilities = BuildCapabilities();
+
+    private static GatewayCapabilities BuildCapabilities()
+    {
+        // Public instance methods declared on the hub ARE the callable surface; anything inherited
+        // from Hub itself (Dispose, ToString, and friends) is not something a Director invokes.
+        //
+        // The OVERRIDES have to go too, and they are the non-obvious part: OnConnectedAsync and
+        // OnDisconnectedAsync are declared right here, so DeclaredOnly keeps them - but they are
+        // lifecycle callbacks the server calls on itself, and a Director can no more invoke them than
+        // it can invoke Dispose. Detected by asking whether the method's base definition still points
+        // at this type: an override's does not. That covers any future override without naming it.
+        var methods = typeof(DirectorHub)
+            .GetMethods(System.Reflection.BindingFlags.Public
+                        | System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName)
+            .Where(m => m.GetBaseDefinition().DeclaringType == typeof(DirectorHub))
+            .Select(m => m.Name)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        return new GatewayCapabilities
+        {
+            Version = Core.Utilities.AppVersion.Semver,
+            // The same source /healthz reads, so the commit a Director is told over the tunnel and the
+            // commit a deploy verifies over HTTP are the same string by construction rather than by
+            // coincidence.
+            Commit = Environment.GetEnvironmentVariable("COCKPIT_COMMIT") ?? "",
+            HubMethods = methods,
+        };
     }
 
     /// <summary>

--- a/tools/cc_shared/gateway.py
+++ b/tools/cc_shared/gateway.py
@@ -102,11 +102,12 @@ def session_id() -> Optional[str]:
 # tells the two apart. It is deliberately not a guess about which cause applies - the tool cannot
 # tell from here, and inventing a verdict is how the wrong one gets chased next time.
 _REFUSED_KEY_CAUSES = (
-    "A session key is refused for two very different reasons, and this answer cannot tell them "
-    "apart.\n"
+    "A 401 here has more than one cause and this answer cannot tell them apart.\n"
     "  1. The Gateway is OLDER than the Director that minted the key. It then has no session key "
     "registry at all, and refuses EVERY session on EVERY machine - the key is fine.\n"
     "  2. This session's key really is unknown or expired.\n"
+    "  3. Something IN FRONT of the Gateway refused the request before it ever arrived - a proxy or "
+    "an edge rule. Then no session key was ever examined and neither of the above applies.\n"
     "Check the Director log for \"session key re-registration incomplete (older Gateway?)\" - if it "
     "is there, the Gateway needs deploying and nothing is wrong with this session. Compare the "
     "Gateway's /healthz commit with the Director's version before suspecting the credential."

--- a/tools/cc_shared/gateway.py
+++ b/tools/cc_shared/gateway.py
@@ -88,6 +88,31 @@ def session_id() -> Optional[str]:
     return sid or None
 
 
+# What a 401 gets added to it, ALWAYS, on top of whatever sentence the server wrote.
+#
+# The Gateway's own words for a refused session key are "missing or invalid token", and read alone
+# they ASSERT the credential is the fault. On 2026-08-05 that assertion was wrong for every session
+# on every machine at once: the keys were minted correctly and were not expired, and the hosted
+# Gateway was simply OLDER than the Directors talking to it - built before `RegisterSessionKey`
+# existed, so it had no registry to register a key against and refused all of them (issues #2457,
+# #2459). Two sessions spent the morning hunting a token that was never wrong, and #2457 was filed
+# against the credential, because this is the only sentence they were given.
+#
+# So the addendum names the cause the server CANNOT know about, and points at the one line that
+# tells the two apart. It is deliberately not a guess about which cause applies - the tool cannot
+# tell from here, and inventing a verdict is how the wrong one gets chased next time.
+_REFUSED_KEY_CAUSES = (
+    "A session key is refused for two very different reasons, and this answer cannot tell them "
+    "apart.\n"
+    "  1. The Gateway is OLDER than the Director that minted the key. It then has no session key "
+    "registry at all, and refuses EVERY session on EVERY machine - the key is fine.\n"
+    "  2. This session's key really is unknown or expired.\n"
+    "Check the Director log for \"session key re-registration incomplete (older Gateway?)\" - if it "
+    "is there, the Gateway needs deploying and nothing is wrong with this session. Compare the "
+    "Gateway's /healthz commit with the Director's version before suspecting the credential."
+)
+
+
 def _error_message(body: str, code: int, fault_is_director: bool = False) -> str:
     """What the user reads when a Gateway call fails.
 
@@ -104,24 +129,34 @@ def _error_message(body: str, code: int, fault_is_director: bool = False) -> str
     `fault_is_director` names the machine, not the Gateway, when the Gateway stamped the answer as a
     Director-side failure. Same status code, different truth - and an agent told "the Gateway is
     down" when one machine went quiet will go and debug the wrong thing.
+
+    A 401 additionally carries `_REFUSED_KEY_CAUSES`. See that constant for why the server's own
+    sentence is not enough on its own.
     """
     who = "the machine that owns it (the Gateway answered)" if fault_is_director else "the Gateway"
     status = f"HTTP {code} from {who}"
+    sentence = None
     try:
         obj = json.loads(body)
     except (ValueError, TypeError):
-        return status
-    if not isinstance(obj, dict):
-        return status
-    for key in ("error", "Error", "detail", "Detail"):
-        value = obj.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    for key in ("title", "Title"):
-        value = obj.get(key)
-        if isinstance(value, str) and value.strip():
-            return f"{status}: {value.strip()}"
-    return status
+        obj = None
+    if isinstance(obj, dict):
+        for key in ("error", "Error", "detail", "Detail"):
+            value = obj.get(key)
+            if isinstance(value, str) and value.strip():
+                sentence = value.strip()
+                break
+        else:
+            for key in ("title", "Title"):
+                value = obj.get(key)
+                if isinstance(value, str) and value.strip():
+                    sentence = f"{status}: {value.strip()}"
+                    break
+    if sentence is None:
+        sentence = status
+    if code == 401:
+        return f"{sentence}\n\n{_REFUSED_KEY_CAUSES}"
+    return sentence
 
 
 def _origin(url: str) -> tuple:

--- a/tools/cc_shared/tests/test_gateway.py
+++ b/tools/cc_shared/tests/test_gateway.py
@@ -198,6 +198,51 @@ def test_error_message_blames_the_machine_when_the_gateway_says_the_machine_fail
     assert "the Gateway answered" in message
 
 
+# A refused session key (issues #2457, #2459). The Gateway's own sentence asserts the credential is
+# the fault; on 2026-08-05 that was wrong for every session in the fleet at once, because the hosted
+# Gateway predated the session key registry entirely.
+
+def test_a_401_keeps_the_servers_sentence_and_admits_an_out_of_date_gateway():
+    body = json.dumps({"error": "missing or invalid token"})
+    message = gateway._error_message(body, 401)
+
+    # The server's own words survive - this must ADD to the answer, never replace it.
+    assert message.startswith("missing or invalid token")
+    # ...and the cause the server cannot know about is named, with the line that tells them apart.
+    assert "OLDER than the Director" in message
+    assert "session key re-registration incomplete (older Gateway?)" in message
+
+
+def test_a_401_does_not_assert_which_of_the_two_causes_it_is():
+    """The tool cannot tell from here, and a confident wrong verdict is what cost the morning.
+
+    Both causes must be offered as possibilities. A message that concluded "your key expired" would
+    reproduce the original defect with different words.
+    """
+    message = gateway._error_message(json.dumps({"error": "missing or invalid token"}), 401)
+    assert "unknown or expired" in message   # cause 2 is still on the table
+    assert "the key is fine" in message      # cause 1 is too
+
+
+def test_a_401_with_no_body_still_carries_the_causes():
+    # An edge proxy can refuse before the Gateway is reached, so there may be no sentence at all.
+    message = gateway._error_message("", 401)
+    assert message.startswith("HTTP 401 from the Gateway")
+    assert "OLDER than the Director" in message
+
+
+@pytest.mark.parametrize("code", [400, 403, 404, 500, 502])
+def test_only_a_401_carries_the_refused_key_causes(code):
+    """Scoped to the one status it explains.
+
+    403 is the near miss that makes this worth a test: a session key presented to a route outside
+    its scope is refused with 403, and it is NOT this problem. Pasting the session-key story onto
+    every failure would bury the sentence that does apply.
+    """
+    message = gateway._error_message(json.dumps({"error": "nope"}), code)
+    assert "OLDER than the Director" not in message
+
+
 def _http_error(code: int, body: str, headers=None) -> urllib.error.HTTPError:
     return urllib.error.HTTPError(
         url="http://gw.example/sessions", code=code, msg="Internal Server Error",


### PR DESCRIPTION
The hosted Gateway outage on 2026-08-05 (#2459, and thefrederiksen/devthrottle_internal#1774 reporting the same thing from a session) is already fixed - the Gateway was deployed and the fleet healed. This is the other half: the fleet had no way to TELL anyone, and that is what turned a deploy into a morning.

Five changes and a run-book line, each a place the system knew and said nothing useful - plus a sixth found while proving them, which turned out to be destroying sessions outright (#2456).

## The Home page showed no row at all

The worst of them. When the Gateway refuses a session key, `MintFleetToolProbeCredentialAsync` throws - deliberately, so a live refusal can never be mistaken for the benign no-Gateway state. But it threw a plain `InvalidOperationException`, indistinguishable from a bug in the probe, so the caller could only record NO VERDICT - and `HomeStatus.BuildSessions` renders no row at all for no verdict.

So the one screen built to surface exactly this failure was blank for five hours while every session in the fleet was locked out.

- A dedicated `GatewayRefusedSessionKeyException`, so the refusal is distinguishable from any other failure. Anything else still means no verdict, which is still right.
- A `FleetToolVerdict.GatewayRefusedKey`, and a red Sessions row that names the Gateway and says EVERY session - one refused session looks like bad luck, all of them do not.
- It routes to Settings, NOT to Tools. Offering to repair an install that has nothing wrong with it is the wrong-destination mistake #1045 already fixed once.
- `EveryVerdictInTheEnumHasBeenDecided_NoneFallsThroughToSilence` is exhaustive over the enum: a verdict added later fails until someone decides what it renders, and the two that legitimately show no row are named with their reason. Silence must be a choice, never a default.

## The command line asserted the token was bad

`tools/cc_shared/gateway.py` printed the Gateway's own words for a 401 - "missing or invalid token" - which asserts the credential is at fault. On the day, the credential was fine and the Gateway was simply older than the Director. That sentence is why thefrederiksen/devthrottle_internal#1774 was filed against the token.

A 401 now keeps the server's sentence and adds the cause the server cannot know about, plus the Director log line that tells the two apart. It deliberately does NOT conclude which one applies: the tool cannot tell from here, and a confident wrong verdict is what cost the time. Scoped to 401 only - a session key presented outside its scope is refused with 403, which is a different thing.

## A capability handshake on Hello

The Director had no way to ask what the Gateway could do, and found out one hub method at a time from a runtime error carrying no version and no list.

`Hello` now returns the Gateway's version, commit and its hub-method list. The list is REFLECTED off the hub, never hand-maintained, so it cannot drift from the truth. A Gateway too old to answer returns nothing, and SignalR gives the client null - which is itself the diagnosis, at no cost to the older Gateway and with no negotiation.

It only LOGS, on change. Nothing here refuses to mint a key or short-circuits a call: the recovery paths already retry, and a second mechanism deciding the same question would give two answers to it.

**The compatibility claim is proved over a real connection, not asserted.** The whole design rests on a generic invoke against a void hub method returning null rather than throwing - and if that were wrong the consequence would be far worse than the bug being fixed, because Hello is the FIRST message on the tunnel and a throw would kill it against exactly the old Gateway this exists to survive. `HelloCapabilityCompatibilityTests` stands up two real hubs, old shape and new, dials them with real clients, and covers all four combinations including a control.

## The discarded registration result

`ControlApiHost.cs` fired the registration into an unobserved task. Narrower than the issue implied, and worth saying so: `RegisterSessionKeyAsync` already logged its own failure, so this was never silent at the transport level. What was missing is a line in the LAUNCH path naming which session was just handed a credential the Gateway will refuse - and the call site was silently depending on the callee catching everything, which is a property that can stop being true without anyone noticing.

## The test suite was destroying the voice of the session that ran it (#2456)

Found while investigating why one session had never spoken once in its life. The cause was its own test run.

`HookScriptRoundTripTests` feeds the hook `{"session_id":"x"}`, and `RunHook` only ever ADDED to `ProcessStartInfo.Environment`, which starts as a copy of the caller's. A case passing null for the pointer path was therefore not testing "the variable is not set" - it inherited whatever the caller had. Inside a session both variables ARE set, so the hook did its job against the REAL session: the drop landed in that session's own pointer file, and `UpdateClaudeSessionPointer` accepted the literal `"x"` over a verified transcript GUID because its only check was that the value is not blank. It was persisted.

From there the session could never resolve its transcript, so narration read no reply, recorded "nothing to narrate" and returned before generating anything. `VoiceAudioReady` never became true, so the rail sat on "Preparing voice" **forever** - never red, never played, no error, no retry, no reason recorded anywhere.

**Three sessions took the damage, one of them while running the v1.9.11 release gate.** So the documented release gate both could never go green from inside a session AND destroyed the seat performing the release.

thefrederiksen/devthrottle_internal#1773 is filed as "the release gate reports a false red". That is the least important effect, and the issue has been updated.

Two fixes, deliberately separate:

- `RunHook` now REMOVES both variables before setting either. A test whose premise is "no variables are set" must establish that; inheriting the answer is how it came to be false in exactly the environment that mattered most.
- The pointer drop is refused at the WATCHER when its id is not a GUID - see the review section below for why guarding the obvious place was not enough.

Proved under the conditions that caused it: with the pointer variable set, as the release gate runs, all 8 hook tests pass and the live session's pointer is intact.

## The deploy pipeline cried rollback on a healthy deploy

Found while proving this fix, and unrelated to the outage.

Run 31005677755 - the deploy that fixed all this - recorded its outcome as `superseded`: "production served dae83a3, not the deployed 860f76e". That verdict was wrong. At the cutover the front door alternated between the old and new instance for about 2.9 seconds; the detector arms after 3 consecutive samples of the new commit and then treats a single later sample of anything else as a swap-back, so it armed at the tail of the flap and fired on one straggler from inside that same flap. Production served the new commit solidly for the rest of the record and is serving it now. The 2026-08-03 run reported the same shape for the same reason.

This is the expensive direction of wrong: a pipeline that cries rollback on healthy deploys is one whose rollback verdict stops being read, and then a real rollback goes by unnoticed.

The other commit must now also be SUSTAINED - 10 consecutive samples, about 1.5 seconds at the observed rate. The measured flap never produced more than 2 in a row; a genuine swap-back serves the old commit for the remainder of the watch. Proved both directions against the real poll log from that run:

| case | old detector | new detector |
| --- | --- | --- |
| the real healthy deploy 31005677755 | `dae83a3` (false alarm) | clean |
| synthetic genuine swap-back | `dae83a3` | `dae83a3` |
| swap-back to an unstamped image | `none` | `none` |
| swap-back preceded by an outage | `dae83a3` | `dae83a3` |
| target commit never served | clean | clean |

## The run-book line

A release that adds or changes a Gateway hub method deploys the hosted Gateway BEFORE the tag is pushed, with the `git diff` command to check. The Director auto-updates and the hosted Gateway does not, so a release teaching the Director to call something the live Gateway has never heard of breaks the whole fleet the moment machines update. That single rule is what would have prevented this.


## What an independent review changed

Reviewed inline by Codex (a spawned Codex session dies on this machine, so the diff was fed to it in the foreground). It returned five findings; four were real and are fixed in the third commit. Recording them because one of them mattered a great deal.

**The pointer guard was on the wrong door, and every existing test still passed.** `Session.ClaudeSessionId` has an `internal set`, and the id reaches a session by TWO routes: the guarded pointer update, and `SessionManager.RelinkClaudeSession`, which the watcher calls one line later and which assigns the property directly. Guarding only the first left the second to re-apply exactly what had just been refused. That is not theoretical - it is what the 2026-08-05 log shows, `RelinkClaudeSession: Linked ... to Claude session x` immediately after the refused update. **This would have merged, closed the issue, and left the corruption path fully open.** The refusal now happens at the watcher, before either writer, and a refused drop is deleted so the two-second sweep does not retry a body that can never become valid.

**`Task.Run` was a real regression.** Wrapping the registration in `Task.Run` looks equivalent to the original discard and is not: it defers the whole call until the thread pool gets to it, so a session could present its key before registration had begun and be answered 401, and a short-lived session could be revoked before the queued work started and then have its dead credential re-registered behind it. The call is now started synchronously and only its result is observed.

**The red row asserted a cause it could not observe.** It said "the Gateway is out of date and needs deploying", drawn from a single `false` out of `RegisterSessionKeyAsync` - which returns the same value for a hub refusal, an unconnected tunnel and a transport failure. That is precisely the failure this whole change exists to end, committed in the row meant to fix it. It now says the key was not accepted and offers the old Gateway as the likely cause, with a test pinning that it does not assert.

**The supersession detector reset on any non-200**, so a rollback that was also unhealthy - old commit interleaved with 503s - could run the entire watch unreported, which is the worst case rather than an edge one. Only a 200 back on the target resets now.

The fifth finding is recorded rather than fixed: `Guid.TryParse` validates SHAPE, not identity, so a well-formed GUID naming a transcript that does not exist is still accepted. That limit is now stated in the code rather than left for a reader to find.

## Testing

`.\scripts\test-local.ps1 -Parked` - the parked suites are included because the gate flagged this change as touching code they cover.

| suite | result |
| --- | --- |
| CcDirector.Gateway.Tests (parked) | 2213 passed, 0 failed, 47 skipped |
| CcDirector.Core.Tests (parked) | 4218 passed, **1 failed** - see below |
| CcDirector.Gateway.UnitTests | 2966 passed, 8 skipped |
| CcDirector.Core.UnitTests | 147 passed |
| CcDirector.Avalonia.Tests | 364 passed |
| CcDirector.Engine.Tests | 63 passed |
| CcDirector.HostedAgent.Tests | 88 passed |
| CcDirector.Launcher.Tests | 113 passed |
| CcDirector.Terminal.Avalonia.Tests | 24 passed |
| cc-director-setup.Tests | 25 passed |
| cc-director-setup-engine.Tests | 456 passed |
| tools/cc_shared (pytest) | 46 passed |

**The Gateway suite was run TWICE, and the second run is the one that counts.** The first green build predated `HelloCapabilityCompatibilityTests.cs`, so it executed none of it - checked in the TRX by name rather than inferred from the total. A green suite that never ran the test you care about says nothing about that test. The full suite was re-run with the file present: 2256 results became 2260, skips unchanged at 47, no failures, and all four are listed by `--list-tests` in the built assembly.

### The two failures, both environmental, both the same cause

Neither is related to this change, and both come from the gate inheriting a live session's environment.

- **Core.Tests, 1 failure:** `HookScriptRoundTripTests.With_no_variables_set_the_hook_is_inert` - this is issue thefrederiksen/devthrottle_internal#1773, filed before this branch existed. The test's premise is that neither hook variable is set; run from inside a session they ARE set, so the hook correctly emits that session's preamble. Checked against the filed issue, not pattern-matched: same test, same mechanism, same assertion shape.
- **Gateway.UnitTests, 8 skipped:** the PostgreSQL-backed tests opt in through `CC_GATEWAY_TEST_PG_CONNECTION`, which thefrederiksen/devthrottle_internal#1773 lists among the inherited variables. Docker Desktop has not been healthy on this machine since a restart, so with the variable set they FAIL on a refused socket and with it cleared they SKIP. Stated plainly: those eight covered nothing for this change.
