### PR TITLE
docs: the v2.0.0 release notes

### DIFF
--- a/docs/public/release-notes/v2.0.0.md
+++ b/docs/public/release-notes/v2.0.0.md
@@ -1,0 +1,72 @@
+# DevThrottle v2.0.0
+
+## When the Gateway will not accept your sessions, the app now tells you
+
+On 5 August every session on every machine was locked out at once. The cloud
+Gateway was older than the app talking to it, so it refused each session's
+credential, and every command an agent ran answered "missing or invalid token".
+The outage itself lasted hours. What made it hours rather than minutes is that
+nothing said so: the Home page showed no problem, and the error the command line
+printed blamed the credential, which was fine all along.
+
+That is what this release fixes.
+
+- **The Home page now shows a red Sessions row** when the Gateway will not accept
+  this Director's session keys, and says that it affects every session rather
+  than one. Previously that state produced no row at all, so the one screen built
+  to surface it was blank while the whole fleet was locked out.
+- **The command line no longer blames your credential.** A refused session key
+  now explains that the Gateway may simply be older than the app - and says which
+  line in the log tells the two apart - instead of asserting that your token is
+  wrong. It deliberately does not guess which cause applies, because it cannot
+  tell from where it stands.
+- **The app asks the Gateway what it can do** the moment it connects, and says
+  plainly in its log when the Gateway is missing something it needs. Before, it
+  discovered this one failed call at a time, from an error carrying no version
+  and no detail.
+
+## Sessions no longer go permanently silent
+
+A session could stop speaking forever, with nothing reporting a fault. Its rail
+sat on "Preparing voice" indefinitely, it was never played, and no error was
+raised anywhere.
+
+The cause was a corrupted internal pointer: something could overwrite a session's
+record of its own transcript with a value that was not a transcript at all, after
+which the session could never be narrated again. Running DevThrottle's own test
+suite from inside a live session did exactly that, which is how it was found.
+
+Both halves are fixed - the value is now refused before it can be stored, and the
+test can no longer reach a real session. A session that has already been damaged
+this way is repaired by restarting it.
+
+## Also in this release
+
+- The app's own release checks pass again. A test suite change had left the
+  mainline failing, which blocked deploying the cloud Gateway entirely.
+
+## Upgrading
+
+Nothing to do beyond the usual update. There is no migration and no new setting.
+
+**If you run your own Gateway, update it as well as the app.** This release
+changes what the app asks the Gateway for. An older Gateway will still work -
+that is tested in both directions and the app now says clearly when it happens -
+but the fleet features are only fully available once both sides are current.
+
+## Known and not fixed here
+
+- The cloud Gateway stopped writing its own log on 6 August and served traffic
+  without one. Filed, not fixed; it does not affect the app.
+- The Director still opens a local listener during interactive sign-in. The
+  statement is that the Director runs without a listening socket, not that it
+  never opens one. Unchanged from v1.9.11.
+- The first-run wizard has not yet been verified on a genuinely clean Windows
+  machine. Unchanged from v1.9.9.
+- The v1.9.9 launcher work has not been run on macOS or Linux.
+- Two places still fall back to a local answer when the Gateway fails - session
+  numbering and the dictation dictionary. Both are filed.
+- The Director's large-object heap still grows on a long-running instance.
+- A vault catalog scan over a synced folder can run away. Diagnosed, not fixed.
+- Four repository views still show a failed git read as an empty result rather
+  than saying the read failed.


### PR DESCRIPTION
The canonical release notes for v2.0.0, at `docs/public/release-notes/v2.0.0.md`.

**This lands before the tag on purpose.** The release workflow publishes this file verbatim and FAILS if it is missing, and a pushed tag cannot be un-pushed - so a tag cut without this burns a whole build for nothing.

## What it claims, and why

Written against the code, not against the version number.

- **The headline is the 5 August lockout** and specifically the half of it that was never fixed. The Gateway refused every session's credential on every machine for hours, and nothing said so: the Home page showed no problem at all, and the command line asserted the credential was bad when it was fine throughout. That is what thefrederiksen/devthrottle#2471 fixes and it is what a user would actually notice.
- **Sessions going permanently silent** is described in the terms a user experiences - a session that stops speaking and never resumes - rather than as the internal pointer corruption it is. The user-facing remedy (restart the session) is given; the by-hand repair is not, because that is not something a user can do.
- **The mainline test fix** is one line under "also", because it is not user-visible.

## Two things stated rather than omitted

**Self-hosted Gateway operators are told to update both sides.** This release changes what the app asks the Gateway for. It is backward compatible and proven so in both directions over real connections - but running an old Gateway is a thing someone should know they are doing, and "still works, update it anyway" is the honest phrasing.

**The cloud Gateway serving without a log** (#2469) is listed under "Known and not fixed here". It does not affect the app, but it is ours and it is real.

## What is deliberately absent

No milestone narrative for the major version. Nothing in the shipped code supports "the culmination of the 1.9 line" or similar, and inventing one for a permanent public record is exactly what the accuracy gate exists to prevent. The notes stand on what changed since v1.9.11.

Follows the shape of `v1.9.11.md`, including carrying its "Known and not fixed here" list forward.