### PR TITLE
release: v2.0.0 - the Gateway says when it will not accept your sessions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.9.11</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.


### PR DESCRIPTION
Bumps `Directory.Build.props` from 1.9.11 to 2.0.0. That is the only file the version lives in.

Merges after thefrederiksen/devthrottle#2472 (the notes) and thefrederiksen/devthrottle#2471 (the content), and before the tag.

## The two steps between this merge and the tag

**1. Deploy the hosted Gateway first.** thefrederiksen/devthrottle#2471 changes the `Hello` hub method. A Director that auto-updates to 2.0 and calls something the live Gateway has never heard of is the 5 August lockout repeating - and this release is the one that adds exactly that rule to the release run-book. Compatibility is proven in both directions over real connections, so an old Gateway will not break, but the rule stands on the cost of being wrong rather than on the odds.

The deploy is only possible at all because thefrederiksen/devthrottle#2470 got the mainline green again: the deploy workflow refuses any commit whose checks have FAILED.

**2. Run the release gate on merged main, at the exact commit being tagged**, with the session variables cleared:

```powershell
$env:CC_SESSION_POINTER_FILE = $null
$env:CC_SESSION_PREAMBLE_FILE = $null
.\scripts\test-local.ps1 -Parked -Configuration Release
```

Clearing those two is not optional and is not tidiness. Without it the gate cannot go green from inside a session at all, and running it destroys the narration of the seat performing the release - which is this release's own thefrederiksen/devthrottle_internal#1773 finding, applied to its own cut. It has already happened to a seat running the v1.9.11 gate.

A run against a pull request head does not count: the squash merge produces a different commit, and the release workflow runs zero tests, so this local run is the only thing standing between a defect and a tag that cannot be un-pushed.

## After the tag

The workflow creates the release as a DRAFT and publishes it only once the manifest is provably attached - so nothing here is created or published by hand. Verification is the published artifacts (mirror manifest and the release page body), not the workflow exit code.