### PR TITLE
Fix the CANVAS_PIVOTS comment: the title search does apply to the Fleet list

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -92,7 +92,8 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
 ];
 
 // The pivots that lay the fleet out on the node canvas (root -> lanes). "list" is a flat grid and
-// "mission" is its own board; neither uses the canvas or the title search.
+// "mission" is its own board, so neither uses the canvas. The title search applies to the canvas
+// pivots and to "list"; only the Missions board hides it.
 const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "director", "repo", "worktree", "agent", "model"]);
 
 // The grouping is sticky per browser: the map opens on whatever the user last chose (rather than a


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1789

The CANVAS_PIVOTS comment in apps/cockpit/src/fleet/FleetMapView.tsx said the Fleet list and Missions pivots use neither the canvas nor the title search. That contradicted the code directly below it, and the wording had already been copied verbatim into a documentation page and caught in review.

What was verified against origin/main before changing anything:
- The flatSessions memo applies the title search query to the Fleet list pivot.
- Only the Missions pivot hides the search box, with a comment at that site saying exactly that.

The comment now reads: the flat list and the Missions board do not use the canvas; the title search applies to the canvas pivots and to the Fleet list; only the Missions board hides it. Comment-only change - no behavior, no rendered output, no test surface.

Local gate: .\scripts\test-local.ps1 ran with 8 failures, all in one suite (Gateway.UnitTests) and all one cause - the HostedSchemaRefusesAnUnownedRow tests could not connect to a Postgres database at 127.0.0.1:55432 (connection refused; nothing is listening on this machine). That is machine state, not code, and this change is a comment in a TypeScript file that no dotnet test project compiles, so the red is inherited from the environment, not introduced by this change. The same run also reported the Gateway suite over the 120-second budget, which is the known timing noise on this machine. Every other suite passed: 1286 tests green across the remaining eight projects.

The gate also flagged a coverage gap naming the parked Core.Tests and Gateway.Tests suites. They were not run: this change is a comment in a TypeScript file, and no dotnet suite - parked or not - compiles it.