### PR TITLE
Reword the root folders caption to what ships: discovery is the local scan

### DIFF
--- a/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
+++ b/src/CcDirector.Avalonia/Controls/RepositoriesView.axaml
@@ -101,7 +101,7 @@
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel Grid.Column="0" Spacing="3" VerticalAlignment="Center">
                             <TextBlock Text="Root folders" Foreground="#CCCCCC" FontSize="14" FontWeight="SemiBold" />
-                            <TextBlock Text="The directories scanned for repositories. GitHub uses the gh login; Azure DevOps uses az."
+                            <TextBlock Text="The directories scanned locally for repositories. Each root records a provider (GitHub, Azure DevOps, Local Only), shown as a label on the root."
                                        Foreground="#888888" FontSize="11" TextWrapping="Wrap" MaxWidth="560" />
                         </StackPanel>
                         <Button Grid.Column="1" x:Name="AddRootButton" Content="+ Add root folder"


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1784

The caption under the Root folders heading in src/CcDirector.Avalonia/Controls/RepositoriesView.axaml (line 104) read: "The directories scanned for repositories. GitHub uses the gh login; Azure DevOps uses az." That implies a root folder's provider drives repository discovery. It does not.

What was verified against origin/main before changing anything:
- RemoteRepoProvider.ScanLocalRepos has three production callers: RepositoryMonitor.cs line 742, RepositoryStatusService.cs line 48, and CodeFolderScout.cs line 150.
- ListGitHubReposAsync and ListAzureDevOpsReposAsync have zero callers.
- Each root row in the Repositories view shows the root's ProviderDisplayName (GitHub, Azure DevOps, or Local Only) as a label, from RootDirectoryConfig.

The caption now reads: "The directories scanned locally for repositories. Each root records a provider (GitHub, Azure DevOps, Local Only), shown as a label on the root." That is exactly what ships. This change deliberately does NOT wire the provider listers up - the issue leaves that as a backlog decision, and this pull request takes the reword path only. No test asserts the old caption text.

Local gate: .\scripts\test-local.ps1 ran with 8 failures, all in Gateway.UnitTests and all one cause - the HostedSchemaRefusesAnUnownedRow tests could not connect to a Postgres database at 127.0.0.1:55432 (connection refused; nothing is listening on this machine). The identical 8 tests failed with the identical error on a second worktree cut from the same origin/main commit carrying an unrelated comment-only change (pull request thefrederiksen/devthrottle#2488), so the red belongs to the parent commit's environment, not to this change. Every other suite passed, including all 364 Avalonia render tests, which cover this view.

The gate also flagged a coverage gap naming the parked Core.Tests and Gateway.Tests suites. They were not run: this change is one user-facing string in a XAML file, and neither parked suite renders this view.
