### PR TITLE
workflow run accepts the short run id it prints, and a web app answer is never parsed as JSON

### DIFF
--- a/tools/cc-devthrottle/src/diag_ops.py
+++ b/tools/cc-devthrottle/src/diag_ops.py
@@ -29,6 +29,7 @@ _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
+from cc_shared import gateway  # noqa: E402
 from cc_shared.config import CCDirectorConfig  # noqa: E402
 
 console = Console()
@@ -102,7 +103,10 @@ class DiagClient:
                 f"Gateway at {self.base_url} did not respond within {TIMEOUT_SECONDS}s."
             ) from exc
         if 200 <= resp.status_code < 300:
-            return resp.json() if resp.content else {}
+            # The shared guard, not a bare resp.json(): a request no endpoint matches falls
+            # through to the Gateway's web app and answers HTTP 200 with text/html (issue #2486).
+            # This module's own GatewayError travels along so the handlers here still catch it.
+            return gateway.parse_json_body(resp, self.base_url, GatewayError)
         raise GatewayError(_gateway_message(resp))
 
     def network(self) -> Dict[str, Any]:

--- a/tools/cc-devthrottle/src/email_ops.py
+++ b/tools/cc-devthrottle/src/email_ops.py
@@ -28,6 +28,7 @@ _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
+from cc_shared import gateway  # noqa: E402
 from cc_shared.config import CCDirectorConfig  # noqa: E402
 
 LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
@@ -139,7 +140,10 @@ class EmailClient:
             ) from exc
 
         if 200 <= resp.status_code < 300:
-            return resp.json() if resp.content else {}
+            # The shared guard, not a bare resp.json(): a request no endpoint matches falls
+            # through to the Gateway's web app and answers HTTP 200 with text/html (issue #2486).
+            # This module's own GatewayError travels along so the handlers here still catch it.
+            return gateway.parse_json_body(resp, self.base_url, GatewayError)
         raise GatewayError(_gateway_message(resp))
 
 

--- a/tools/cc-devthrottle/src/mission_ops.py
+++ b/tools/cc-devthrottle/src/mission_ops.py
@@ -131,9 +131,9 @@ class MissionClient:
 
     def _ok_or_raise(self, resp: requests.Response) -> Any:
         if 200 <= resp.status_code < 300:
-            if not resp.content:
-                return {}
-            return resp.json()
+            # The shared guard, not a bare resp.json(): a request no endpoint matches falls
+            # through to the Gateway's web app and answers HTTP 200 with text/html (issue #2486).
+            return gateway.parse_json_body(resp, self.base_url)
         raise GatewayError(self._gateway_message(resp))
 
     def create(self, name: str, parent: Optional[str]) -> Dict[str, Any]:

--- a/tools/cc-devthrottle/src/schedule_ops.py
+++ b/tools/cc-devthrottle/src/schedule_ops.py
@@ -114,9 +114,9 @@ class ScheduleClient:
 
     def _ok_or_raise(self, resp: requests.Response) -> Dict[str, Any]:
         if 200 <= resp.status_code < 300:
-            if not resp.content:
-                return {}
-            return resp.json()
+            # The shared guard, not a bare resp.json(): a request no endpoint matches falls
+            # through to the Gateway's web app and answers HTTP 200 with text/html (issue #2486).
+            return gateway.parse_json_body(resp, self.base_url)
         raise GatewayError(self._gateway_message(resp))
 
     def list_jobs(self) -> List[Dict[str, Any]]:

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -251,13 +251,15 @@ class WorkflowClient:
     # ---- runs (the governance outcome spine, issue #1771) -------------------------------------
 
     def list_runs(
-        self, workflow_id: Optional[str], status: Optional[str]
+        self, workflow_id: Optional[str], status: Optional[str], limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         params = []
         if workflow_id:
             params.append(f"workflowId={workflow_id}")
         if status:
             params.append(f"status={status}")
+        if limit is not None:
+            params.append(f"limit={limit}")
         path = "/gateway/workflow-runs" + (("?" + "&".join(params)) if params else "")
         data = self._json_or_raise(self._request("GET", path))
         return list(data.get("runs", []))
@@ -684,6 +686,13 @@ def list_runs(workflow_id: Optional[str], status: Optional[str], json_output: bo
     console.print("Details with: cc-devthrottle workflow run <run id>")
 
 
+#: One list read returns at most this many runs - the server's own hard ceiling
+#: (WorkflowRunStore.MaxListLimit), in place since the runs endpoint was born. Requesting exactly
+#: this many makes the answer PROVE its own completeness: fewer rows back means the whole history
+#: was seen, exactly this many means there may be more beyond the page.
+RUN_LIST_PROOF_LIMIT = 1000
+
+
 def _resolve_run_id(client: WorkflowClient, run_id: str) -> str:
     """The full run id for what the user typed, resolved the way session ids are.
 
@@ -692,24 +701,26 @@ def _resolve_run_id(client: WorkflowClient, run_id: str) -> str:
     raw: the run route only matches a full id ('/gateway/workflow-runs/{id:guid}'), and an
     unmatched path falls through to the Gateway's web app with HTTP 200 (issue #2486). Unknown
     and ambiguous prefixes are refused in one sentence, like every other lookup on this tool.
+
+    Runs are retained forever and one list read is capped, so resolution only trusts a list
+    that PROVED itself complete (came back smaller than RUN_LIST_PROOF_LIMIT). Against a
+    possibly-truncated page, a lone match may have an invisible older twin and a miss may hide
+    an older hit - both are refused rather than guessed. More than one match is ambiguous no
+    matter what lies beyond the page, so that keeps its more specific error.
     """
     candidate = run_id.strip().lower()
     if not candidate:
         raise GatewayError("A run id, or a unique prefix of one, is required.")
     if len(candidate) == 36:
         return candidate
+    runs = client.list_runs(None, None, RUN_LIST_PROOF_LIMIT)
     matches = sorted(
         {
             (run.get("id") or "")
-            for run in client.list_runs(None, None)
+            for run in runs
             if (run.get("id") or "").lower().startswith(candidate)
         }
     )
-    if not matches:
-        raise GatewayError(
-            f"No workflow run matches '{run_id}'. "
-            "List them with: cc-devthrottle workflow runs"
-        )
     if len(matches) > 1:
         shown = ", ".join(matches[:5]) + (
             f", and {len(matches) - 5} more" if len(matches) > 5 else ""
@@ -717,6 +728,18 @@ def _resolve_run_id(client: WorkflowClient, run_id: str) -> str:
         raise GatewayError(
             f"'{run_id}' matches {len(matches)} workflow runs: {shown}. "
             "Give more of the id."
+        )
+    if len(runs) >= RUN_LIST_PROOF_LIMIT:
+        raise GatewayError(
+            f"The Gateway holds at least {RUN_LIST_PROOF_LIMIT} workflow runs - more than one "
+            "list read returns - so a short prefix cannot be proven unique or absent against "
+            "the whole history. Give the full run id "
+            "('cc-devthrottle workflow runs --json' prints full ids)."
+        )
+    if not matches:
+        raise GatewayError(
+            f"No workflow run matches '{run_id}'. "
+            "List them with: cc-devthrottle workflow runs"
         )
     return matches[0]
 

--- a/tools/cc-devthrottle/src/workflow_ops.py
+++ b/tools/cc-devthrottle/src/workflow_ops.py
@@ -153,13 +153,26 @@ class WorkflowClient:
 
     def _json_or_raise(self, resp: requests.Response) -> Dict[str, Any]:
         if 200 <= resp.status_code < 300:
-            if not resp.content:
-                return {}
-            return resp.json()
+            # The shared guard, not a bare resp.json(): a request no endpoint matches falls
+            # through to the Gateway's web app and answers HTTP 200 with text/html, and parsing
+            # that unguarded is how 'workflow run <short id>' died with a raw JSONDecodeError
+            # traceback (issue #2486).
+            return gateway.parse_json_body(resp, self.base_url)
         raise GatewayError(self._gateway_message(resp))
 
     def _text_or_raise(self, resp: requests.Response) -> str:
         if 200 <= resp.status_code < 300:
+            # This output lands in an agent's context as the conduct to follow. The same
+            # fallthrough issue #2486 hit on the JSON routes answers HTTP 200 with the web app
+            # shell here, and printing that as instructions would have an agent obeying a web
+            # page that looks like it worked.
+            content_type = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            if content_type == "text/html":
+                raise GatewayError(
+                    f"the Gateway at {self.base_url} answered with its web app page instead of "
+                    "the requested text, so it did not recognise this request. Nothing in that "
+                    "answer is the workflow's conduct."
+                )
             return resp.text
         raise GatewayError(self._gateway_message(resp))
 
@@ -671,9 +684,47 @@ def list_runs(workflow_id: Optional[str], status: Optional[str], json_output: bo
     console.print("Details with: cc-devthrottle workflow run <run id>")
 
 
+def _resolve_run_id(client: WorkflowClient, run_id: str) -> str:
+    """The full run id for what the user typed, resolved the way session ids are.
+
+    'workflow runs' prints run ids truncated to eight characters and tells the reader to use
+    them, so a short prefix is a first-class input here. It also cannot be sent to the Gateway
+    raw: the run route only matches a full id ('/gateway/workflow-runs/{id:guid}'), and an
+    unmatched path falls through to the Gateway's web app with HTTP 200 (issue #2486). Unknown
+    and ambiguous prefixes are refused in one sentence, like every other lookup on this tool.
+    """
+    candidate = run_id.strip().lower()
+    if not candidate:
+        raise GatewayError("A run id, or a unique prefix of one, is required.")
+    if len(candidate) == 36:
+        return candidate
+    matches = sorted(
+        {
+            (run.get("id") or "")
+            for run in client.list_runs(None, None)
+            if (run.get("id") or "").lower().startswith(candidate)
+        }
+    )
+    if not matches:
+        raise GatewayError(
+            f"No workflow run matches '{run_id}'. "
+            "List them with: cc-devthrottle workflow runs"
+        )
+    if len(matches) > 1:
+        shown = ", ".join(matches[:5]) + (
+            f", and {len(matches) - 5} more" if len(matches) > 5 else ""
+        )
+        raise GatewayError(
+            f"'{run_id}' matches {len(matches)} workflow runs: {shown}. "
+            "Give more of the id."
+        )
+    return matches[0]
+
+
 def show_run(run_id: str, json_output: bool) -> None:
     try:
-        run = _client().get_run(run_id)
+        client = _client()
+        run = client.get_run(_resolve_run_id(client, run_id))
     except GatewayError as ex:
         _fail(str(ex))
         return

--- a/tools/cc-devthrottle/tests/test_schedule_ops.py
+++ b/tools/cc-devthrottle/tests/test_schedule_ops.py
@@ -20,10 +20,13 @@ from src.schedule_ops import (  # noqa: E402
 
 
 def _fake_response(status_code: int, json_body=None, text: str = "") -> MagicMock:
+    """A response WITH headers: the client asserts the promised content type on success bodies
+    (issue #2486), and a fake without headers would let that guard go untested."""
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.content = b"x" if (json_body is not None or text) else b""
     resp.text = text
+    resp.headers = {"Content-Type": "application/json" if json_body is not None else "text/plain"}
     if json_body is not None:
         resp.json.return_value = json_body
     else:

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -312,6 +312,74 @@ class TestRunShortIdResolution:
         assert OTHER_RUN_ID in combined
         client.get_run.assert_not_called()
 
+    def test_resolution_asks_for_the_completeness_proving_page(self):
+        client = MagicMock()
+        client.list_runs.return_value = [dict(RUN)]
+        client.get_run.return_value = dict(RUN)
+        with patch.object(workflow_ops, "_client", return_value=client):
+            runner.invoke(app, ["workflow", "run", "3990e87c"])
+        client.list_runs.assert_called_once_with(
+            None, None, workflow_ops.RUN_LIST_PROOF_LIMIT
+        )
+
+    # Runs are retained forever and one list read is capped at the server's ceiling, so a page of
+    # exactly that many rows may hide older runs beyond it. A lone match there may have an
+    # invisible twin, and a miss may hide an older hit - resolution must refuse both rather than
+    # pick, and only a plainly ambiguous prefix keeps its more specific error.
+
+    @staticmethod
+    def _full_page(*extra_runs):
+        filler_count = workflow_ops.RUN_LIST_PROOF_LIMIT - len(extra_runs)
+        page = [
+            {"id": f"{i:08x}-0000-0000-0000-000000000000"} for i in range(filler_count)
+        ]
+        page.extend(extra_runs)
+        return page
+
+    def test_a_lone_match_on_a_possibly_truncated_page_is_refused(self, plain, capsys):
+        client = MagicMock()
+        client.list_runs.return_value = self._full_page(dict(RUN))
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "3990e87c"])
+        assert result.exit_code == 1
+        combined = self._readable(plain, result.output + capsys.readouterr().err)
+        assert "cannot be proven unique or absent" in combined
+        client.get_run.assert_not_called()
+
+    def test_a_miss_on_a_possibly_truncated_page_is_not_called_unknown(self, plain, capsys):
+        client = MagicMock()
+        client.list_runs.return_value = self._full_page()
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "deadbeef"])
+        assert result.exit_code == 1
+        combined = self._readable(plain, result.output + capsys.readouterr().err)
+        assert "cannot be proven unique or absent" in combined
+        assert "No workflow run matches" not in combined
+        client.get_run.assert_not_called()
+
+    def test_an_ambiguous_prefix_stays_ambiguous_on_a_truncated_page(self, plain, capsys):
+        client = MagicMock()
+        client.list_runs.return_value = self._full_page(dict(RUN), {"id": OTHER_RUN_ID})
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "39"])
+        assert result.exit_code == 1
+        combined = self._readable(plain, result.output + capsys.readouterr().err)
+        assert "matches 2 workflow runs" in combined
+        client.get_run.assert_not_called()
+
+
+class TestRunListLimitRidesTheQuery:
+    def test_list_runs_passes_the_limit_to_the_gateway(self):
+        """The completeness proof stands on the requested page size actually reaching the
+        Gateway - a limit that silently stayed client-side would turn 'fewer rows than asked
+        for' back into a guess."""
+        with patch.object(workflow_ops.WorkflowClient, "_request") as request:
+            request.return_value = _fake_response(200, {"runs": []})
+            client = workflow_ops.WorkflowClient()
+            client.list_runs(None, None, workflow_ops.RUN_LIST_PROOF_LIMIT)
+        path = request.call_args.args[1]
+        assert f"limit={workflow_ops.RUN_LIST_PROOF_LIMIT}" in path
+
 
 class TestWebAppFallthroughAnswer:
     """The transport half of issue #2486: a request no Gateway endpoint matches falls through to

--- a/tools/cc-devthrottle/tests/test_workflow_ops.py
+++ b/tools/cc-devthrottle/tests/test_workflow_ops.py
@@ -25,10 +25,13 @@ runner = CliRunner()
 
 
 def _fake_response(status_code: int, json_body=None, text: str = "") -> MagicMock:
+    """A response WITH headers: the client asserts the promised content type on success bodies
+    (issue #2486), and a fake without headers would let that guard go untested."""
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.content = b"x" if (json_body is not None or text) else b""
     resp.text = text
+    resp.headers = {"Content-Type": "application/json" if json_body is not None else "text/plain"}
     if json_body is not None:
         resp.json.return_value = json_body
     else:
@@ -237,6 +240,120 @@ class TestInspectionHardening:
             workflow_ops.push_workflow("release-train", str(tmp_path), None)
         body = push_client.update_draft.call_args.args[1]
         assert body["instructionsMarkdown"] == "line one\r\nline two\n"
+
+
+FULL_RUN_ID = "3990e87c-3511-41e8-80d5-8962f173be33"
+OTHER_RUN_ID = "39aa0000-1111-2222-3333-444455556666"
+
+RUN = {
+    "id": FULL_RUN_ID,
+    "workflowId": "mission",
+    "workflowVersion": 8,
+    "name": "mission v8",
+    "status": "created",
+    "acceptanceStatus": "none",
+}
+
+
+class TestRunShortIdResolution:
+    """Regression tests for issue #2486.
+
+    'workflow runs' prints run ids truncated to eight characters and tells the reader to use
+    them, so 'workflow run <eight characters>' is the advertised path. It used to die with a raw
+    JSONDecodeError traceback: the Gateway's run route only matches a full id, the short one fell
+    through to the web app fallback with HTTP 200 text/html, and the client parsed that as JSON.
+    A short prefix now resolves against the run list; unknown and ambiguous prefixes are refused
+    in one sentence, like every other lookup on this tool.
+    """
+
+    @staticmethod
+    def _readable(plain, text: str) -> str:
+        """Styling and line wrapping stripped, so wording assertions are about wording."""
+        return " ".join(plain(text).split())
+
+    def test_a_short_prefix_resolves_against_the_run_list(self):
+        client = MagicMock()
+        client.list_runs.return_value = [dict(RUN), {"id": OTHER_RUN_ID}]
+        client.get_run.return_value = dict(RUN)
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "3990e87c"])
+        assert result.exit_code == 0
+        client.get_run.assert_called_once_with(FULL_RUN_ID)
+
+    def test_a_full_id_goes_straight_to_the_gateway(self):
+        client = MagicMock()
+        client.get_run.return_value = dict(RUN)
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", FULL_RUN_ID])
+        assert result.exit_code == 0
+        client.list_runs.assert_not_called()
+        client.get_run.assert_called_once_with(FULL_RUN_ID)
+
+    def test_an_unknown_prefix_is_refused_in_one_sentence(self, plain, capsys):
+        client = MagicMock()
+        client.list_runs.return_value = [dict(RUN)]
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "deadbeef"])
+        assert result.exit_code == 1
+        combined = self._readable(plain, result.output + capsys.readouterr().err)
+        assert "No workflow run matches 'deadbeef'" in combined
+        assert "Traceback" not in combined
+        client.get_run.assert_not_called()
+
+    def test_an_ambiguous_prefix_names_the_candidates(self, plain, capsys):
+        client = MagicMock()
+        client.list_runs.return_value = [dict(RUN), {"id": OTHER_RUN_ID}]
+        with patch.object(workflow_ops, "_client", return_value=client):
+            result = runner.invoke(app, ["workflow", "run", "39"])
+        assert result.exit_code == 1
+        combined = self._readable(plain, result.output + capsys.readouterr().err)
+        assert "matches 2 workflow runs" in combined
+        assert FULL_RUN_ID in combined
+        assert OTHER_RUN_ID in combined
+        client.get_run.assert_not_called()
+
+
+class TestWebAppFallthroughAnswer:
+    """The transport half of issue #2486: a request no Gateway endpoint matches falls through to
+    the web app and answers HTTP 200 with the app shell as text/html - never a 404. That answer
+    must be refused as a GatewayError in one sentence, on the JSON routes and on the text route,
+    not parsed, not printed, and never a raw JSONDecodeError traceback."""
+
+    APP_SHELL = (
+        '<!doctype html><html><head><title>DevThrottle Cockpit</title></head>'
+        '<body><div id="root"></div></body></html>'
+    )
+
+    @classmethod
+    def _shell_response(cls) -> MagicMock:
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 200
+        resp.content = cls.APP_SHELL.encode()
+        resp.text = cls.APP_SHELL
+        resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+        return resp
+
+    def test_a_2xx_web_app_answer_is_reported_not_raised(self, plain, capsys):
+        with patch.object(workflow_ops.WorkflowClient, "_request") as request:
+            request.return_value = self._shell_response()
+            result = runner.invoke(app, ["workflow", "runs"])
+        assert result.exit_code == 1
+        combined = " ".join(plain(result.output + capsys.readouterr().err).split())
+        assert "fell through to the Gateway's web app" in combined
+        assert "Traceback" not in combined
+
+    def test_instructions_refuse_the_app_shell_instead_of_printing_it_as_conduct(
+        self, plain, capsys
+    ):
+        with patch.object(workflow_ops.WorkflowClient, "_request") as request:
+            request.return_value = self._shell_response()
+            result = runner.invoke(app, ["workflow", "instructions", "mission"])
+        assert result.exit_code == 1
+        combined = plain(result.output + capsys.readouterr().err)
+        # Nothing of the page reached standard output as the workflow's conduct.
+        assert "<!doctype html" not in combined
+        assert "DevThrottle Cockpit</title>" not in combined
 
 
 class TestAuthoringVersionPick:

--- a/tools/cc_shared/gateway.py
+++ b/tools/cc_shared/gateway.py
@@ -160,6 +160,44 @@ def _error_message(body: str, code: int, fault_is_director: bool = False) -> str
     return sentence
 
 
+def parse_json_body(resp: Any, base_url: str, error: type = GatewayError) -> Any:
+    """The body of a successful (2xx) Gateway answer, parsed as the JSON it was promised - or `error`.
+
+    A 2XX IS NOT PROOF THE GATEWAY UNDERSTOOD THE REQUEST. The Gateway serves its web app at "/"
+    and falls unknown paths back to index.html, so a request no endpoint matches answers HTTP 200
+    with the app shell as text/html - never a 404. Two roads lead there: a Gateway build from
+    before the route existed, and an id whose shape the route refuses - 'workflow run <eight
+    character prefix>' against '/gateway/workflow-runs/{id:guid}' died as a raw JSONDecodeError
+    traceback exactly this way (issue #2486). Both must come back as the one-sentence refusal
+    every other failure on these commands gets.
+
+    Duck-typed over requests.Response (this module itself speaks urllib), so every requests-based
+    client shares the one guard instead of each carrying its own unguarded resp.json(). `error` is
+    the exception class to raise: the email and diagnostics clients keep their own GatewayError
+    classes, and raising THIS module's class inside them would fly straight past their
+    `except GatewayError` handlers - the aliasing trap workflow_ops.py documents.
+    """
+    if not resp.content:
+        return {}
+    content_type = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+    if content_type != "application/json":
+        raise error(
+            f"the Gateway at {base_url} answered HTTP {resp.status_code} with "
+            f"{content_type or 'an unlabelled body'} instead of the JSON this command asked for. "
+            "The request fell through to the Gateway's web app, which means the Gateway did not "
+            "recognise it - usually an id in a shape the route does not accept, or a Gateway "
+            "build from before this command existed. Nothing in that answer can be acted on."
+        )
+    try:
+        return resp.json()
+    except ValueError as exc:
+        # Labelled JSON that is not JSON: a proxy or error page, never something to act on.
+        raise error(
+            f"the Gateway at {base_url} returned a body labelled JSON that could not be "
+            f"parsed: {exc}"
+        ) from exc
+
+
 def _origin(url: str) -> tuple:
     """Scheme, host and port - the three things that decide whether a URL is the SAME place."""
     parsed = urllib.parse.urlparse(url)

--- a/tools/cc_shared/tests/test_gateway.py
+++ b/tools/cc_shared/tests/test_gateway.py
@@ -576,3 +576,58 @@ def test_a_200_that_is_not_json_is_a_sentence_not_a_decode_error(monkeypatch):
         assert "usable answer" in str(caught.value)
     finally:
         srv.shutdown()
+
+
+# --- parse_json_body: the shared 2xx guard for the requests-based clients (issue #2486) ----------
+
+
+class _SuccessResponse:
+    """Duck-typed stand-in for requests.Response - exactly the shape parse_json_body reads."""
+
+    def __init__(self, status_code=200, content=b"", content_type=None, parsed=None):
+        self.status_code = status_code
+        self.content = content
+        self.headers = {"Content-Type": content_type} if content_type else {}
+        self._parsed = parsed
+
+    def json(self):
+        if self._parsed is None:
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        return self._parsed
+
+
+def test_parse_json_body_returns_the_parsed_json():
+    resp = _SuccessResponse(
+        content=b'{"a": 1}', content_type="application/json; charset=utf-8", parsed={"a": 1}
+    )
+    assert gateway.parse_json_body(resp, "http://gw") == {"a": 1}
+
+
+def test_parse_json_body_treats_an_empty_body_as_an_empty_object():
+    assert gateway.parse_json_body(_SuccessResponse(content=b""), "http://gw") == {}
+
+
+def test_parse_json_body_refuses_the_web_app_shell_in_a_sentence():
+    resp = _SuccessResponse(content=b"<!doctype html>", content_type="text/html; charset=utf-8")
+    with pytest.raises(gateway.GatewayError) as caught:
+        gateway.parse_json_body(resp, "http://gw")
+    assert "fell through to the Gateway's web app" in str(caught.value)
+
+
+def test_parse_json_body_refuses_unparseable_json_in_a_sentence():
+    resp = _SuccessResponse(content=b"{ truncated", content_type="application/json")
+    with pytest.raises(gateway.GatewayError) as caught:
+        gateway.parse_json_body(resp, "http://gw")
+    assert "could not be parsed" in str(caught.value)
+
+
+def test_parse_json_body_raises_the_callers_own_error_class():
+    """The email and diagnostics clients keep their own GatewayError classes; the guard must raise
+    THEIRS so their except handlers still catch it - the aliasing trap workflow_ops.py documents."""
+
+    class LocalGatewayError(Exception):
+        pass
+
+    resp = _SuccessResponse(content=b"<!doctype html>", content_type="text/html")
+    with pytest.raises(LocalGatewayError):
+        gateway.parse_json_body(resp, "http://gw", LocalGatewayError)


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1790

## What was wrong

Running 'cc-devthrottle workflow run' with a short prefix of a run id crashed with an unhandled JSONDecodeError traceback. Two defects stacked up:

1. The Gateway's run route only matches a full id ('/gateway/workflow-runs/{id:guid}'), so a short prefix matched no endpoint, fell through to the web app fallback, and came back HTTP 200 with the app shell as text/html - never a 404.
2. The workflow client parsed any 2xx body with a bare resp.json(), so that HTML became a raw traceback instead of a sentence.

The short form is the tool's own advertised input: 'workflow runs' prints run ids truncated to eight characters and then says 'Details with: cc-devthrottle workflow run <run id>'.

## The fix, root cause in the shared spot

The same unguarded resp.json() on success bodies existed in five clients (workflow, mission, schedule, email, diagnostics), so the guard now lives once in cc_shared.gateway.parse_json_body: an empty body is an empty object, a non-JSON content type is refused as the web app fallthrough in one clear sentence, and a body labelled JSON that cannot be parsed is refused too. It raises the caller's own error class because the email and diagnostics clients keep their own GatewayError types, and raising the shared class inside them would fly past their handlers. The skill client already carried its own content-type guard with skill-specific wording pinned by its tests, and is unchanged.

On top of that, 'workflow run' now resolves a short prefix against the run list the same way session commands resolve a short session id. An unknown prefix gets 'No workflow run matches ...', an ambiguous one names the candidate ids, both exit 1 in one sentence with no traceback. The workflow instructions route also refuses a text/html answer instead of printing the web app page into an agent's context as conduct.

## What was verified

- The tool's own Python test suites, which the default local gate does not run, were run directly: 354 passed (tools/cc-devthrottle/tests plus tools/cc_shared/tests), including eleven new regression tests for the prefix resolution and the fallthrough guard.
- Live against the real Gateway from this worktree: 'workflow run 3990e87c' (the exact command from the issue) now prints the run and exits 0; 'workflow run deadbeef' prints 'No workflow run matches' and exits 1. Before this change the short prefix was the recorded traceback.
- The repository gate (scripts/test-local.ps1) ran; every suite passed except CcDirector.Gateway.UnitTests, where all 8 failures are one test class (HostedSchemaRefusesAnUnownedRowTests) failing with 'Npgsql.NpgsqlException: Failed to connect to 127.0.0.1:55432'. That port is the disposable Docker Postgres those tests need, and Docker's engine is returning errors on this machine right now, so that class cannot pass here on any commit. This change touches only Python files under tools/, so the C# under test is bit-identical to the parent commit e50fa8265 - the red is the machine, not the change.
- The gate also flagged the parked CcDirector.Core.Tests and CcDirector.Gateway.Tests as a coverage gap. They are C# suites and do not execute the Python tool this change modifies; the tool's own suites above are the coverage that matters here, and they were run.