### PR TITLE
Arm the dictation moved-on guard from both Speak flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Run Cockpit tests
         run: npm test --workspace @devthrottle/cockpit
 
+      - name: Run mobile tests
+        run: npm test --workspace @devthrottle/mobile
+
       # The shells must still BUILD, not just typecheck: the production build runs the real Vite
       # pipeline (bundling, the PWA service worker) and fails on things tsc never sees.
       - name: Build the mobile PWA

--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -322,7 +322,9 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
         // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway
         // submits before + dictation + after. The caret splits the typed text into the two halves.
         composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
-        // The terminal-byte position snapshotted at Speak press, for the moved-on guard (issue #2478).
+        // The terminal-byte position snapshot the Speak press started, for the moved-on guard
+        // (issue #2478). A promise: the pipeline awaits it before persisting, so a quick Send
+        // cannot outrun the roster read.
         baselineBufferBytes: baseline.read(),
         // Restore the typed text (ahead of anything typed since - valueRef reads the box as it is at
         // failure time, this callback's own `value` is a stale snapshot by then) so Send never

--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -11,6 +11,7 @@ import { describeAndReport } from "@devthrottle/client-core/errors/reportClientE
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { DictationStatusStrip } from "@devthrottle/client-core/dictation/DictationStatusStrip";
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottle/client-core/dictation/backgroundSend";
+import { useDictationBaseline } from "@devthrottle/client-core/dictation/baseline";
 import { insertAt, joinText } from "@devthrottle/client-core/dictation/transcript";
 
 // The composer (issue #972, completed in issue #1210) - the React port of the Blazor Cockpit composer.
@@ -113,6 +114,10 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
   useEffect(() => {
     valueRef.current = value;
   }, [value]);
+  // The session's terminal-byte position, snapshotted when Speak is pressed, so the Gateway's
+  // "session moved on" guard can judge a clip resumed later against where the terminal stood when it
+  // was recorded (issue #2478 - this flow used to omit the field, so the guard never armed).
+  const baseline = useDictationBaseline(sessionId);
 
   // Publish a focuser for the composer textarea into the parent-owned ref (issue #1266), and clear it on
   // unmount so the Source Control tab never calls into a torn-down composer.
@@ -256,9 +261,11 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
   // transcript at the caret (no submit); Send inserts at the caret and submits.
   const onSpeak = useCallback(() => {
     caretRef.current = textareaRef.current?.selectionStart ?? value.length;
+    // Snapshot the terminal-byte position at record start, for the moved-on guard (#2478).
+    baseline.snapshot();
     setError(null);
     setDictating(true);
-  }, [value]);
+  }, [value, baseline]);
 
   const onDictateInsert = useCallback(
     (text: string) => {
@@ -315,6 +322,8 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
         // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway
         // submits before + dictation + after. The caret splits the typed text into the two halves.
         composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
+        // The terminal-byte position snapshotted at Speak press, for the moved-on guard (issue #2478).
+        baselineBufferBytes: baseline.read(),
         // Restore the typed text (ahead of anything typed since - valueRef reads the box as it is at
         // failure time, this callback's own `value` is a stale snapshot by then) so Send never
         // silently loses it. The audio itself is kept durably for resume; the typed text is
@@ -324,7 +333,7 @@ export function SessionComposer({ sessionId, value, onChange, onQueued, focusHan
         },
       });
     },
-    [sessionId, value, onChange],
+    [sessionId, value, onChange, baseline],
   );
 
   const empty = value.trim().length === 0;

--- a/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
+++ b/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
@@ -29,19 +29,22 @@ import { useState } from "react";
 
 // vi.mock is hoisted above module scope, so the spies it references must be created in the same
 // hoisted phase (vi.hoisted) rather than as ordinary consts.
-const { sendPrompt, transcribeUtterance, backgroundTranscribeAndSend } = vi.hoisted(() => ({
+const { sendPrompt, transcribeUtterance, backgroundTranscribeAndSend, listSessions } = vi.hoisted(() => ({
   // The synchronous POST /prompt path: PAUSED-stage Send (text already in hand) and Insert use it.
   sendPrompt: vi.fn(async () => {}),
   // The synchronous /wingman/utterance/* transcription: the Pause checkpoint and Insert use it.
   transcribeUtterance: vi.fn(async () => "the dictated words"),
   // The durable background pipeline (POST /dictation/*) the recording-stage Send now rides.
   backgroundTranscribeAndSend: vi.fn(async () => {}),
+  // The roster read the Speak press snapshots its moved-on baseline from (issue #2478).
+  listSessions: vi.fn(async () => [{ sessionId: "sess-42", totalBufferBytes: 4321 }]),
 }));
 
 // The Gateway client boundary.
 vi.mock("@devthrottle/client-core/api/client", () => ({
   sendPrompt,
   transcribeUtterance,
+  listSessions,
   enqueuePrompt: vi.fn(async () => []),
   uploadImage: vi.fn(async () => ""),
   gatewayErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
@@ -159,12 +162,17 @@ describe("Cockpit Speak Send-direct (recording-stage)", () => {
     const [sid, captured, opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
       string,
       { blob: Blob; recordedMs: number },
-      { composeParts?: { before: string; after: string } },
+      { composeParts?: { before: string; after: string }; baselineBufferBytes?: number },
     ];
     expect(sid).toBe("sess-42");
     expect(captured.blob).toBeInstanceOf(Blob);
     expect(captured.recordedMs).toBe(1000);
     expect(opts.composeParts).toEqual({ before: "A", after: "B" });
+    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, snapshotted
+    // from the roster when Speak was pressed. Above zero, so the Gateway's guard actually ARMS for a
+    // clip resumed later - this flow used to omit the field, it defaulted to zero, and the guard was
+    // unreachable from the shipped Speak Send.
+    expect(opts.baselineBufferBytes).toBe(4321);
 
     // The screen is released immediately: the dialog is gone without waiting for any transcription.
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Dictate" })).toBeNull());

--- a/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
+++ b/apps/cockpit/src/sessions/composerSpeakSend.test.tsx
@@ -162,17 +162,18 @@ describe("Cockpit Speak Send-direct (recording-stage)", () => {
     const [sid, captured, opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
       string,
       { blob: Blob; recordedMs: number },
-      { composeParts?: { before: string; after: string }; baselineBufferBytes?: number },
+      { composeParts?: { before: string; after: string }; baselineBufferBytes?: Promise<number | undefined> },
     ];
     expect(sid).toBe("sess-42");
     expect(captured.blob).toBeInstanceOf(Blob);
     expect(captured.recordedMs).toBe(1000);
     expect(opts.composeParts).toEqual({ before: "A", after: "B" });
-    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, snapshotted
-    // from the roster when Speak was pressed. Above zero, so the Gateway's guard actually ARMS for a
-    // clip resumed later - this flow used to omit the field, it defaulted to zero, and the guard was
-    // unreachable from the shipped Speak Send.
-    expect(opts.baselineBufferBytes).toBe(4321);
+    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, whose roster
+    // read the Speak press STARTED - handed to the pipeline as a promise it awaits, so a quick Send
+    // waits for the answer instead of racing it. Resolves above zero, so the Gateway's guard actually
+    // ARMS for a clip resumed later - this flow used to omit the field, it defaulted to zero, and the
+    // guard was unreachable from the shipped Speak Send.
+    await expect(opts.baselineBufferBytes).resolves.toBe(4321);
 
     // The screen is released immediately: the dialog is gone without waiting for any transcription.
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Dictate" })).toBeNull());

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@devthrottle/client-core": "*",
@@ -18,11 +19,15 @@
     "react-router-dom": "6.30.4"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.4",
+    "jsdom": "25.0.1",
     "typescript": "5.7.2",
     "vite": "6.0.3",
-    "vite-plugin-pwa": "0.21.1"
+    "vite-plugin-pwa": "0.21.1",
+    "vitest": "2.1.8"
   }
 }

--- a/apps/mobile/src/components/SessionControls.tsx
+++ b/apps/mobile/src/components/SessionControls.tsx
@@ -233,7 +233,9 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
         // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway submits
         // before + dictation + after. The caret splits the typed text into the two halves.
         composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
-        // The terminal-byte position snapshotted at Speak press, for the moved-on guard (issue #2478).
+        // The terminal-byte position snapshot the Speak press started, for the moved-on guard
+        // (issue #2478). A promise: the pipeline awaits it before persisting, so a quick Send
+        // cannot outrun the roster read.
         baselineBufferBytes: baseline.read(),
         // On a send that does not complete the audio is kept durably for resume, but the typed text is
         // client-only: put it back (ahead of anything typed since) so Send never silently loses it. If

--- a/apps/mobile/src/components/SessionControls.tsx
+++ b/apps/mobile/src/components/SessionControls.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { sendEscape, sendInterrupt, sendPrompt, uploadImage } from "@devthrottle/client-core/api/client";
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottle/client-core/dictation/backgroundSend";
+import { useDictationBaseline } from "@devthrottle/client-core/dictation/baseline";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { insertAt, joinText } from "@devthrottle/client-core/dictation/transcript";
 import {
@@ -59,6 +60,10 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
   // Where to move the caret after an Insert drops text mid-box; applied post-render below. Null except
   // in the render right after an Insert.
   const pendingCaretRef = useRef<number | null>(null);
+  // The session's terminal-byte position, snapshotted when Speak is pressed, so the Gateway's
+  // "session moved on" guard can judge a clip resumed later against where the terminal stood when it
+  // was recorded (issue #2478 - this flow used to omit the field, so the guard never armed).
+  const baseline = useDictationBaseline(sessionId);
 
   // Auto-grow the textarea to fit its content (up to a cap, after which it scrolls). Re-run on every
   // input change so it grows as you type AND shrinks back when the box is cleared (Send) or replaced
@@ -228,6 +233,8 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
         // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway submits
         // before + dictation + after. The caret splits the typed text into the two halves.
         composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
+        // The terminal-byte position snapshotted at Speak press, for the moved-on guard (issue #2478).
+        baselineBufferBytes: baseline.read(),
         // On a send that does not complete the audio is kept durably for resume, but the typed text is
         // client-only: put it back (ahead of anything typed since) so Send never silently loses it. If
         // the user navigated away this component is unmounted and setInput is a harmless no-op.
@@ -236,7 +243,7 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
         },
       });
     },
-    [sessionId, input, onFlash, onError],
+    [sessionId, input, onFlash, onError, baseline],
   );
 
   return (
@@ -267,6 +274,8 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
           onClick={() => {
             // Snapshot the caret so the dictation lands where the cursor was, not at the end.
             caretRef.current = inputRef.current?.selectionStart ?? input.length;
+            // Snapshot the terminal-byte position at record start, for the moved-on guard (#2478).
+            baseline.snapshot();
             setDictating(true);
           }}
           disabled={dictating}

--- a/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
+++ b/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
@@ -168,20 +168,18 @@ describe("Mobile Speak Send-direct (recording-stage)", () => {
     await expect(opts.baselineBufferBytes).resolves.toBe(777);
   });
 
-  it("delivers the clip unguarded (baseline unknown, never zero) when the roster fails even after the retry", async () => {
-    // Two rejections: the snapshot retries a transient roster failure once, so a single rejection
-    // would succeed on the retry and hide what this test is about.
-    listSessions
-      .mockRejectedValueOnce(new Error("gateway unreachable"))
-      .mockRejectedValueOnce(new Error("gateway unreachable"));
+  it("delivers the clip unguarded (baseline unknown, never zero) when the press-time roster read fails - and that is FINAL", async () => {
+    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
     render(<SessionControls sessionId="sess-42" onFlash={() => {}} onError={() => {}} showKeyRows />);
     const dialog = await typeAndOpenRecordingDialog();
 
     fireEvent.click(within(dialog).getByText("Send"));
 
-    // The words still go: a failed roster read yields an UNKNOWN baseline (the pipeline's documented
-    // omit-when-unknown contract, guard skipped for safety) - never a blocked or lost dictation, and
-    // never a fabricated zero.
+    // The words still go: a failed press-time read yields an UNKNOWN baseline (the pipeline's
+    // documented omit-when-unknown contract, guard skipped for safety) - never a blocked or lost
+    // dictation, never a fabricated zero, and never a later substitute reading: exactly one roster
+    // call, because a reading taken after the press can include bytes produced during or after the
+    // recording and would mask the very movement the guard detects.
     await waitFor(() => expect(backgroundTranscribeAndSend).toHaveBeenCalledTimes(1));
     const [, , opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
       string,
@@ -189,6 +187,6 @@ describe("Mobile Speak Send-direct (recording-stage)", () => {
       { baselineBufferBytes?: Promise<number | undefined> },
     ];
     await expect(opts.baselineBufferBytes).resolves.toBeUndefined();
-    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(listSessions).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
+++ b/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within, cleanup } from "@testing-library/react";
+
+// Regression for issue #2478 on the MOBILE Speak flow: the Gateway's "session moved on" guard for a
+// resumed dictation requires a baselineBufferBytes above zero, and this flow used to omit the field -
+// it defaulted to zero, so the guard never armed and the recovery behavior the feature was built for
+// was unreachable from the shipped app. The Speak press now snapshots the session's terminal-byte
+// position from the roster (the same reading the Voice screen has always sent), and the recording-
+// stage Send hands it to the durable background pipeline. This is the mobile workspace's first test
+// file; it mirrors the cockpit's composerSpeakSend.test.tsx, which pins the same behavior for the
+// Cockpit composer flow.
+
+// vi.mock is hoisted above module scope, so the spies it references must be created in the same
+// hoisted phase (vi.hoisted) rather than as ordinary consts.
+const { sendPrompt, transcribeUtterance, backgroundTranscribeAndSend, listSessions } = vi.hoisted(() => ({
+  // The synchronous POST /prompt path (typed Send, Insert-then-Enter).
+  sendPrompt: vi.fn(async () => {}),
+  // The synchronous /wingman/utterance/* transcription (the Pause checkpoint and Insert).
+  transcribeUtterance: vi.fn(async () => "the dictated words"),
+  // The durable background pipeline (POST /dictation/*) the recording-stage Send rides.
+  backgroundTranscribeAndSend: vi.fn(async () => {}),
+  // The roster read the Speak press snapshots its moved-on baseline from (issue #2478).
+  listSessions: vi.fn(async () => [{ sessionId: "sess-42", totalBufferBytes: 4321 }]),
+}));
+
+// The Gateway client boundary.
+vi.mock("@devthrottle/client-core/api/client", () => ({
+  sendPrompt,
+  transcribeUtterance,
+  listSessions,
+  sendEscape: vi.fn(async () => {}),
+  sendInterrupt: vi.fn(async () => {}),
+  uploadImage: vi.fn(async () => ""),
+}));
+
+// The durable background pipeline boundary.
+vi.mock("@devthrottle/client-core/dictation/backgroundSend", () => ({
+  backgroundTranscribeAndSend,
+}));
+
+// Mic + audio-decode boundaries jsdom cannot provide, byte-for-byte the fakes the cockpit test uses.
+// The fake recorder fires onCaptureLive on start so the dialog flips to RECORDING without a real
+// microphone, and returns a fixed clip on stop. A 1000 ms clip that decodes to 1.0 s means zero
+// capture deficit, so the dialog commits instead of parking on a dropped-audio warning.
+vi.mock("@devthrottle/client-core/dictation/recorder", () => {
+  class MicRecorder {
+    onCaptureLive: (() => void) | null = null;
+    lastRecordedMs = 1000;
+    deviceLabel = "Fake Microphone";
+    deviceId = "fake-mic";
+    async start() {
+      this.onCaptureLive?.();
+    }
+    async stop() {
+      return new Blob(["clip"], { type: "audio/webm" });
+    }
+    level() {
+      return 0;
+    }
+    // The liveness clocks the dialog's animation loop reads on every frame; zero = a healthy
+    // microphone, so the live capture alarm stays quiet and this file keeps testing the Send path.
+    msSinceLastAudio() {
+      return 0;
+    }
+    msSinceMeterMoved() {
+      return 0;
+    }
+    dispose() {}
+  }
+  return { MicRecorder, rmsLevel: () => 0 };
+});
+vi.mock("@devthrottle/client-core/dictation/wav", () => ({
+  blobToWav16kMono: async () => ({
+    wav: new Blob(["wav"]),
+    decodedSeconds: 1,
+    sourceBytes: 1000,
+    nativeSamples: new Float32Array(0),
+    nativeSampleRate: 16000,
+  }),
+}));
+vi.mock("@devthrottle/client-core/dictation/readyCue", () => ({
+  playReadyCue: () => {},
+  primeCueAudio: () => {},
+  releaseCueAudio: () => {},
+  startThinkingCue: () => () => {},
+  playYourTurnCue: () => {},
+}));
+
+import { SessionControls } from "./SessionControls";
+
+// Type "AB" into the input, drop the caret BETWEEN A and B, open Speak, and wait for RECORDING. The
+// caret placement is what proves the compose lands the dictation at the caret, not at the end.
+async function typeAndOpenRecordingDialog(): Promise<HTMLElement> {
+  const input = screen.getByPlaceholderText(/type a message/i) as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: "AB" } });
+  input.selectionStart = 1;
+  input.selectionEnd = 1;
+  fireEvent.click(screen.getByRole("button", { name: "Speak" }));
+  const dialog = await screen.findByRole("dialog", { name: "Dictate" });
+  await within(dialog).findByText("RECORDING");
+  return dialog;
+}
+
+describe("Mobile Speak Send-direct (recording-stage)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom has no requestAnimationFrame; the dialog's display-only equalizer loop uses it. A no-op
+    // that never calls back keeps the animation out of the test without affecting behaviour.
+    globalThis.requestAnimationFrame = (() => 0) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+  });
+
+  afterEach(() => cleanup());
+
+  it("hands the captured audio to the background pipeline with the Speak-press baseline, so the moved-on guard arms", async () => {
+    render(<SessionControls sessionId="sess-42" onFlash={() => {}} onError={() => {}} showKeyRows />);
+    const dialog = await typeAndOpenRecordingDialog();
+
+    // Press Send WHILE RECORDING - the fire-and-forget action under test.
+    fireEvent.click(within(dialog).getByText("Send"));
+
+    await waitFor(() => expect(backgroundTranscribeAndSend).toHaveBeenCalledTimes(1));
+    const [sid, captured, opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
+      string,
+      { blob: Blob; recordedMs: number },
+      { composeParts?: { before: string; after: string }; baselineBufferBytes?: number },
+    ];
+    expect(sid).toBe("sess-42");
+    expect(captured.blob).toBeInstanceOf(Blob);
+    expect(captured.recordedMs).toBe(1000);
+    expect(opts.composeParts).toEqual({ before: "A", after: "B" });
+    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, snapshotted
+    // from the roster when Speak was pressed. Above zero, so the Gateway's guard actually ARMS for a
+    // clip resumed later - this flow used to omit the field, it defaulted to zero, and the guard was
+    // unreachable from the shipped Speak Send.
+    expect(opts.baselineBufferBytes).toBe(4321);
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    // The screen is released immediately and nothing on this path blocks on the synchronous
+    // transcription or submits a text prompt itself - the Gateway does both server-side.
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Dictate" })).toBeNull());
+    expect(transcribeUtterance).not.toHaveBeenCalled();
+    expect(sendPrompt).not.toHaveBeenCalled();
+  });
+
+  it("delivers the clip unguarded (baseline unknown) when the roster read fails, never blocking the send", async () => {
+    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
+    render(<SessionControls sessionId="sess-42" onFlash={() => {}} onError={() => {}} showKeyRows />);
+    const dialog = await typeAndOpenRecordingDialog();
+
+    fireEvent.click(within(dialog).getByText("Send"));
+
+    // The words still go: a failed roster read yields an UNKNOWN baseline (the pipeline's documented
+    // omit-when-unknown contract, guard skipped for safety) - never a blocked or lost dictation.
+    await waitFor(() => expect(backgroundTranscribeAndSend).toHaveBeenCalledTimes(1));
+    const [, , opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
+      string,
+      unknown,
+      { baselineBufferBytes?: number },
+    ];
+    expect(opts.baselineBufferBytes).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
+++ b/apps/mobile/src/components/sessionControlsSpeakSend.test.tsx
@@ -124,17 +124,18 @@ describe("Mobile Speak Send-direct (recording-stage)", () => {
     const [sid, captured, opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
       string,
       { blob: Blob; recordedMs: number },
-      { composeParts?: { before: string; after: string }; baselineBufferBytes?: number },
+      { composeParts?: { before: string; after: string }; baselineBufferBytes?: Promise<number | undefined> },
     ];
     expect(sid).toBe("sess-42");
     expect(captured.blob).toBeInstanceOf(Blob);
     expect(captured.recordedMs).toBe(1000);
     expect(opts.composeParts).toEqual({ before: "A", after: "B" });
-    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, snapshotted
-    // from the roster when Speak was pressed. Above zero, so the Gateway's guard actually ARMS for a
-    // clip resumed later - this flow used to omit the field, it defaulted to zero, and the guard was
-    // unreachable from the shipped Speak Send.
-    expect(opts.baselineBufferBytes).toBe(4321);
+    // The moved-on guard's baseline (issue #2478): the session's terminal-byte position, whose roster
+    // read the Speak press STARTED - handed to the pipeline as a promise it awaits, so a quick Send
+    // waits for the answer instead of racing it. Resolves above zero, so the Gateway's guard actually
+    // ARMS for a clip resumed later - this flow used to omit the field, it defaulted to zero, and the
+    // guard was unreachable from the shipped Speak Send.
+    await expect(opts.baselineBufferBytes).resolves.toBe(4321);
     expect(listSessions).toHaveBeenCalledTimes(1);
 
     // The screen is released immediately and nothing on this path blocks on the synchronous
@@ -144,21 +145,50 @@ describe("Mobile Speak Send-direct (recording-stage)", () => {
     expect(sendPrompt).not.toHaveBeenCalled();
   });
 
-  it("delivers the clip unguarded (baseline unknown) when the roster read fails, never blocking the send", async () => {
-    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
+  it("a quick Send WAITS for the Speak-press roster read instead of racing it (issue #2478 review defect)", async () => {
+    // The roster deliberately does not answer until AFTER Send is pressed - the exact quick-Send race.
+    // The component must hand the pipeline the still-pending promise, which resolves to the real
+    // record-time position once the roster answers; a peek at Send time would have read undefined.
+    let releaseRoster: (roster: { sessionId: string; totalBufferBytes: number }[]) => void = () => {};
+    listSessions.mockImplementationOnce(
+      () => new Promise<{ sessionId: string; totalBufferBytes: number }[]>((resolve) => { releaseRoster = resolve; }),
+    );
+    render(<SessionControls sessionId="sess-42" onFlash={() => {}} onError={() => {}} showKeyRows />);
+    const dialog = await typeAndOpenRecordingDialog();
+
+    fireEvent.click(within(dialog).getByText("Send")); // the roster read is still in flight
+
+    await waitFor(() => expect(backgroundTranscribeAndSend).toHaveBeenCalledTimes(1));
+    const [, , opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
+      string,
+      unknown,
+      { baselineBufferBytes?: Promise<number | undefined> },
+    ];
+    releaseRoster([{ sessionId: "sess-42", totalBufferBytes: 777 }]); // the roster answers afterwards
+    await expect(opts.baselineBufferBytes).resolves.toBe(777);
+  });
+
+  it("delivers the clip unguarded (baseline unknown, never zero) when the roster fails even after the retry", async () => {
+    // Two rejections: the snapshot retries a transient roster failure once, so a single rejection
+    // would succeed on the retry and hide what this test is about.
+    listSessions
+      .mockRejectedValueOnce(new Error("gateway unreachable"))
+      .mockRejectedValueOnce(new Error("gateway unreachable"));
     render(<SessionControls sessionId="sess-42" onFlash={() => {}} onError={() => {}} showKeyRows />);
     const dialog = await typeAndOpenRecordingDialog();
 
     fireEvent.click(within(dialog).getByText("Send"));
 
     // The words still go: a failed roster read yields an UNKNOWN baseline (the pipeline's documented
-    // omit-when-unknown contract, guard skipped for safety) - never a blocked or lost dictation.
+    // omit-when-unknown contract, guard skipped for safety) - never a blocked or lost dictation, and
+    // never a fabricated zero.
     await waitFor(() => expect(backgroundTranscribeAndSend).toHaveBeenCalledTimes(1));
     const [, , opts] = backgroundTranscribeAndSend.mock.calls[0] as unknown as [
       string,
       unknown,
-      { baselineBufferBytes?: number },
+      { baselineBufferBytes?: Promise<number | undefined> },
     ];
-    expect(opts.baselineBufferBytes).toBeUndefined();
+    await expect(opts.baselineBufferBytes).resolves.toBeUndefined();
+    expect(listSessions).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+// Vitest-only configuration. It exists so the test runner does NOT load vite.config.ts: that config
+// runs the PWA service-worker plugin and shells out to git for the build stamp, neither of which has
+// any business in a unit-test run. Tests declare their own environment per file (the
+// @vitest-environment pragma), exactly like the cockpit workspace's tests.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,16 @@
         "react-router-dom": "6.30.4"
       },
       "devDependencies": {
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "4.3.4",
+        "jsdom": "25.0.1",
         "typescript": "5.7.2",
         "vite": "6.0.3",
-        "vite-plugin-pwa": "0.21.1"
+        "vite-plugin-pwa": "0.21.1",
+        "vitest": "2.1.8"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1876,7 +1876,12 @@ export interface DictationUploadArgs {
   before: string;
   after: string;
   prefix: string;
-  baselineBufferBytes: number;
+  /** The session's TotalBufferBytes when the clip was recorded, for the server's moved-on guard.
+   *  Omitted when genuinely unknown - JSON.stringify drops the key, and the server's absent-field
+   *  default skips the guard for this clip. Never a fabricated zero: zero is a real reading (a
+   *  terminal that had produced nothing yet), and unknown must stay distinguishable from it
+   *  (issue #2478). */
+  baselineBufferBytes?: number;
   resumed: boolean;
   /** Capture-health (issue #863), optional: the recording wall-clock, the decoded audio duration, and
    *  the source blob size, measured once at Send time. Forwarded on the complete call so the Gateway

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -156,6 +156,52 @@ describe("backgroundTranscribeAndSend", () => {
     expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(48213);
   });
 
+  it("a kick landing between the first save and enrichment cannot drive the unknown record (issue #2478 round three)", async () => {
+    // The first durable write makes the record visible to every automatic trigger, and the
+    // enrichment window is as long as a roster read. A kick (online, foreground, app load) that
+    // listed and drove the record inside that window would upload with the baseline still unknown
+    // and race the enrichment write and the original drive. The upload id is reserved from the kick
+    // machinery for the whole window, so the kick must no-op.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+    let releaseBaseline: (bytes: number | undefined) => void = () => {};
+    const pending = new Promise<number | undefined>((resolve) => { releaseBaseline = resolve; });
+
+    const send = backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: pending });
+    await flush();
+    expect(savePending).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(savePending).mock.calls[0][0];
+    expect(saved.baselineBufferBytes).toBeUndefined();
+
+    // The kick lands mid-window: the durable store lists the unknown record and the kick machinery
+    // tries to drive it, exactly as the online/visibility listeners would.
+    vi.mocked(listPending).mockResolvedValue([saved]);
+    await resumePendingDictations();
+    expect(uploadDictationToSession).not.toHaveBeenCalled(); // the reservation held: no unguarded upload
+
+    releaseBaseline(48213);
+    await send;
+    // Exactly ONE upload happened, from the original flow: enriched with the press-time reading and
+    // an immediate (not resumed) send - never the kick's resumed, unknown-baseline drive.
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(48213);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].resumed).toBe(false);
+  });
+
+  it("a crash or reload still resumes the durable unknown record - the reservation dies with the process", async () => {
+    // The reservation lives only in memory, deliberately. After a crash mid-enrichment a fresh
+    // process holds no reservation, and the resume path drives the durable unknown record from the
+    // on-device copy - unguarded, which is exactly what that copy honestly knows.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+    const rec: PendingDictation = { ...makeRecord("id-unknown-crash"), baselineBufferBytes: undefined };
+    vi.mocked(listPending).mockResolvedValue([rec]);
+
+    await resumePendingDictations();
+
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].resumed).toBe(true);
+  });
+
   it("an UNKNOWN press-time baseline is FINAL - persisted as unknown, no later re-read, never a fabricated zero (issue #2478)", async () => {
     // Unknown (the press-time read could not answer) and zero (a terminal that had produced nothing
     // yet) are different facts. Collapsing unknown into zero at persist time was how the moved-on

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -130,37 +130,46 @@ describe("backgroundTranscribeAndSend", () => {
     expect(vi.mocked(savePending).mock.calls[0][0].blob).toBe(captured.blob);
   });
 
-  it("WAITS for the Speak-press baseline snapshot before persisting, so a quick Send cannot outrun it (issue #2478)", async () => {
-    // The exact race the review found: the Speak press starts the roster read and Send arrives before
-    // it resolves. The pipeline must await the handed-over promise - nothing may be persisted or
-    // uploaded until the record-time position is in hand.
+  it("saves the clip durably AT ONCE (baseline unknown), then enriches it from the press-time snapshot before upload (issue #2478)", async () => {
+    // Two contracts at once, in the right order. Durability never waits on the roster: the clip is on
+    // disk immediately, so a slow or timed-out roster read cannot leave it memory-only. And a quick
+    // Send still cannot outrun the snapshot: the UPLOAD holds until the press-time promise resolves,
+    // and the durable record is enriched with the reading before the first attempt.
     vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
     let releaseBaseline: (bytes: number | undefined) => void = () => {};
     const pending = new Promise<number | undefined>((resolve) => { releaseBaseline = resolve; });
 
     const send = backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: pending });
     await flush();
-    // The snapshot has not answered yet: the pipeline is holding, not guessing.
-    expect(savePending).not.toHaveBeenCalled();
+    // The snapshot has not answered yet - the clip is ALREADY durable (unknown baseline), and the
+    // upload is holding for the press-time answer.
+    expect(savePending).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
     expect(uploadDictationToSession).not.toHaveBeenCalled();
 
     releaseBaseline(48213);
     await send;
-    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBe(48213);
+    // The durable record was enriched with the press-time reading before the first upload carried it.
+    expect(savePending).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(savePending).mock.calls[1][0].baselineBufferBytes).toBe(48213);
+    expect(vi.mocked(savePending).mock.calls[1][0].id).toBe(vi.mocked(savePending).mock.calls[0][0].id);
     expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(48213);
   });
 
-  it("persists an UNKNOWN baseline as unknown - never as a fabricated zero (issue #2478)", async () => {
-    // Unknown (the roster could not answer) and zero (a terminal that had produced nothing yet) are
-    // different facts. Collapsing unknown into zero at persist time was how the moved-on guard
-    // silently stayed unarmed; unknown must stay absent all the way to the wire, where JSON omits the
-    // field and the server's documented absent-field handling skips the guard for this one clip.
+  it("an UNKNOWN press-time baseline is FINAL - persisted as unknown, no later re-read, never a fabricated zero (issue #2478)", async () => {
+    // Unknown (the press-time read could not answer) and zero (a terminal that had produced nothing
+    // yet) are different facts. Collapsing unknown into zero at persist time was how the moved-on
+    // guard silently stayed unarmed; and substituting a LATER roster reading would be worse - it can
+    // include bytes produced after recording, masking the movement the guard detects. Unknown stays
+    // absent all the way to the wire, where JSON omits the field and the server skips the guard.
     vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
 
     await backgroundTranscribeAndSend("sid", captured, {
       baselineBufferBytes: Promise.resolve(undefined),
     });
 
+    // Exactly one durable write - no enrich pass, and no roster call of the pipeline's own.
+    expect(savePending).toHaveBeenCalledTimes(1);
     expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
     expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
   });
@@ -170,13 +179,25 @@ describe("backgroundTranscribeAndSend", () => {
 
     await backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: Promise.resolve(0) });
 
-    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBe(0);
+    // Zero is an answer: it lands in the enriched durable record and on the upload.
+    expect(vi.mocked(savePending).mock.calls.at(-1)?.[0].baselineBufferBytes).toBe(0);
     expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(0);
+  });
+
+  it("a plain-number baseline (the Voice screen) rides the FIRST durable write, unchanged", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: 321 });
+
+    expect(savePending).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBe(321);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(321);
   });
 
   it("a foreign baseline promise that REJECTS costs the guard, never the words", async () => {
     // The shared snapshot never rejects, but the hooks contract cannot force that on every caller. A
-    // rejection must not escape and strand the clip unsaved - the words always deliver, unguarded.
+    // rejection must not escape and strand the clip - it is already durable by then, and it still
+    // delivers, unguarded.
     vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
 
     await backgroundTranscribeAndSend("sid", captured, {

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -130,6 +130,65 @@ describe("backgroundTranscribeAndSend", () => {
     expect(vi.mocked(savePending).mock.calls[0][0].blob).toBe(captured.blob);
   });
 
+  it("WAITS for the Speak-press baseline snapshot before persisting, so a quick Send cannot outrun it (issue #2478)", async () => {
+    // The exact race the review found: the Speak press starts the roster read and Send arrives before
+    // it resolves. The pipeline must await the handed-over promise - nothing may be persisted or
+    // uploaded until the record-time position is in hand.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+    let releaseBaseline: (bytes: number | undefined) => void = () => {};
+    const pending = new Promise<number | undefined>((resolve) => { releaseBaseline = resolve; });
+
+    const send = backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: pending });
+    await flush();
+    // The snapshot has not answered yet: the pipeline is holding, not guessing.
+    expect(savePending).not.toHaveBeenCalled();
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+
+    releaseBaseline(48213);
+    await send;
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBe(48213);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(48213);
+  });
+
+  it("persists an UNKNOWN baseline as unknown - never as a fabricated zero (issue #2478)", async () => {
+    // Unknown (the roster could not answer) and zero (a terminal that had produced nothing yet) are
+    // different facts. Collapsing unknown into zero at persist time was how the moved-on guard
+    // silently stayed unarmed; unknown must stay absent all the way to the wire, where JSON omits the
+    // field and the server's documented absent-field handling skips the guard for this one clip.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured, {
+      baselineBufferBytes: Promise.resolve(undefined),
+    });
+
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
+  });
+
+  it("passes a GENUINE zero baseline through as a real reading, distinct from unknown (issue #2478)", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured, { baselineBufferBytes: Promise.resolve(0) });
+
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBe(0);
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].baselineBufferBytes).toBe(0);
+  });
+
+  it("a foreign baseline promise that REJECTS costs the guard, never the words", async () => {
+    // The shared snapshot never rejects, but the hooks contract cannot force that on every caller. A
+    // rejection must not escape and strand the clip unsaved - the words always deliver, unguarded.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured, {
+      baselineBufferBytes: Promise.reject(new Error("roster exploded")),
+    });
+
+    expect(vi.mocked(savePending).mock.calls[0][0].baselineBufferBytes).toBeUndefined();
+    // The clip still delivered: persisted durably and driven through one upload attempt.
+    expect(savePending).toHaveBeenCalledTimes(1);
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+  });
+
   it("a delivered send that dropped audio carries a capture-loss warning on done (never silent)", async () => {
     // The send succeeds, but the record was flagged with a capture-loss warning at Send time. The delivered
     // `done` status must carry that warning so the strip shows a non-clearing caution instead of a silent
@@ -605,8 +664,9 @@ describe("recovering a dropped dictation (#1590)", () => {
     expect(fresh?.blob).toBe(old.blob); // the SAME recording, under a new id - the audio is what we are retrying
     expect(fresh?.staleDropped).toBeUndefined();
     // The record-time baseline describes a terminal that has long since moved on; re-sending it would just
-    // invite the same drop. The user asked for this send now.
-    expect(fresh?.baselineBufferBytes).toBe(0);
+    // invite the same drop. The user asked for this send now. Cleared to UNKNOWN (field omitted on the
+    // wire, guard skipped) - never a fabricated zero, which is a real reading (issue #2478).
+    expect(fresh?.baselineBufferBytes).toBeUndefined();
     // The fresh clip really was driven, and the old id is retired.
     expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].uploadId).toBe(fresh?.id);
     expect(deletePending).toHaveBeenCalledWith("id-old");

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -119,12 +119,15 @@ export interface BackgroundSendHooks {
    *  case omits this and the transcript is submitted alone. */
   composeParts?: { before: string; after: string };
   /** The session's TotalBufferBytes at record time, for the Gateway's "session moved on" guard when a
-   *  clip is resumed later. A promise is AWAITED before the durable record is persisted (issue #2478):
-   *  the Speak press starts the roster read and hands the promise here, so a quick Send cannot outrun
-   *  it and persist "unknown" for a session whose position was knowable - the wait is bounded by the
-   *  roster read's own timeout. Omit when genuinely unknown; unknown is persisted as unknown and the
-   *  wire request omits the field (the guard is then skipped for safety) - it is NEVER collapsed into
-   *  zero, which is a real reading (a terminal that had produced nothing yet). */
+   *  clip is resumed later. A promise is the PRESS-TIME snapshot (issue #2478): the Speak press starts
+   *  the roster read and hands the promise here, so a quick Send cannot outrun it and record "unknown"
+   *  for a session whose position was knowable. Durability never waits on it - the clip is persisted
+   *  immediately with the baseline unknown, then the pending record is enriched before the first
+   *  upload once this ORIGINAL promise resolves; the pipeline never starts a later roster read of its
+   *  own, because a post-recording reading would mask the very movement the guard detects. Omit when
+   *  genuinely unknown; unknown is persisted as unknown and the wire request omits the field (the
+   *  guard is then skipped for safety) - it is NEVER collapsed into zero, which is a real reading (a
+   *  terminal that had produced nothing yet). */
   baselineBufferBytes?: number | Promise<number | undefined>;
 }
 
@@ -199,19 +202,13 @@ export async function backgroundTranscribeAndSend(
     );
   }
 
-  // The moved-on baseline: WAIT for the snapshot the Speak press started before persisting, so the
-  // durable record carries the real record-time reading even when Send was pressed quickly (issue
-  // #2478). The wait is bounded (the roster read carries the poll timeout and the shared snapshot
-  // never rejects); the defensive catch is for a foreign caller's promise only, because a baseline -
-  // a guard input - must never cost the user's words, exactly like the decode above.
-  let baselineBufferBytes: number | undefined;
-  try {
-    baselineBufferBytes = await hooks.baselineBufferBytes;
-  } catch {
-    baselineBufferBytes = undefined;
-  }
+  // The moved-on baseline is the PRESS-TIME snapshot or nothing (issue #2478). A plain number (the
+  // Voice screen) rides the first durable write below; a promise is awaited only AFTER the clip is
+  // safely on disk - the durable-send contract (persist before any network work) outranks the guard,
+  // so a slow or timed-out roster read must never leave the clip memory-only.
+  const pressTimeBaseline = hooks.baselineBufferBytes;
 
-  const rec: PendingDictation = {
+  let rec: PendingDictation = {
     id: crypto.randomUUID(),
     sessionId,
     blob: uploadBlob,
@@ -223,7 +220,7 @@ export async function backgroundTranscribeAndSend(
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
-    baselineBufferBytes,
+    baselineBufferBytes: typeof pressTimeBaseline === "number" ? pressTimeBaseline : undefined,
     createdAt: Date.now(),
   };
 
@@ -248,10 +245,35 @@ export async function backgroundTranscribeAndSend(
     return;
   }
 
-  // Saved durably. Drive the first delivery attempt now. resumed:false so an immediate send injects
-  // without the moved-on guard; any failure becomes a held-and-retrying state the driver owns. The
-  // caller does not await this (it fired and moved on), but awaiting the first attempt here keeps the
-  // returned promise honest about when that attempt settled.
+  // The clip is durable. Now - and only now - wait for the press-time baseline snapshot and enrich
+  // the pending record with it before the first upload. When the ORIGINAL press-time promise cannot
+  // answer, unknown is FINAL: never a fresh roster read here, because a reading taken now can include
+  // bytes the session produced during or after the recording, over-stating the baseline and masking
+  // exactly the movement the guard exists to detect. The wait is bounded (the shared snapshot rides
+  // the roster read's own timeout and never rejects); the defensive catch is for a foreign caller's
+  // promise only, because a guard input must never cost the user's words.
+  if (pressTimeBaseline !== undefined && typeof pressTimeBaseline !== "number") {
+    let bytes: number | undefined;
+    try {
+      bytes = await pressTimeBaseline;
+    } catch {
+      bytes = undefined;
+    }
+    if (bytes !== undefined) {
+      rec = { ...rec, baselineBufferBytes: bytes };
+      try {
+        await savePending(rec);
+      } catch {
+        // The durable copy keeps unknown (a resume would go unguarded); this attempt still carries
+        // the press-time reading in memory. Never a reason to hold the words.
+      }
+    }
+  }
+
+  // Drive the first delivery attempt now. resumed:false so an immediate send injects without the
+  // moved-on guard; any failure becomes a held-and-retrying state the driver owns. The caller does
+  // not await this (it fired and moved on), but awaiting the first attempt here keeps the returned
+  // promise honest about when that attempt settled.
   await driveRecord(rec, { resumed: false, attempt: 0 });
 }
 

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -119,8 +119,13 @@ export interface BackgroundSendHooks {
    *  case omits this and the transcript is submitted alone. */
   composeParts?: { before: string; after: string };
   /** The session's TotalBufferBytes at record time, for the Gateway's "session moved on" guard when a
-   *  clip is resumed later. Omit when unknown (the guard is then skipped for safety). */
-  baselineBufferBytes?: number;
+   *  clip is resumed later. A promise is AWAITED before the durable record is persisted (issue #2478):
+   *  the Speak press starts the roster read and hands the promise here, so a quick Send cannot outrun
+   *  it and persist "unknown" for a session whose position was knowable - the wait is bounded by the
+   *  roster read's own timeout. Omit when genuinely unknown; unknown is persisted as unknown and the
+   *  wire request omits the field (the guard is then skipped for safety) - it is NEVER collapsed into
+   *  zero, which is a real reading (a terminal that had produced nothing yet). */
+  baselineBufferBytes?: number | Promise<number | undefined>;
 }
 
 // ---- driver state ----------------------------------------------------------------------------------
@@ -194,6 +199,18 @@ export async function backgroundTranscribeAndSend(
     );
   }
 
+  // The moved-on baseline: WAIT for the snapshot the Speak press started before persisting, so the
+  // durable record carries the real record-time reading even when Send was pressed quickly (issue
+  // #2478). The wait is bounded (the roster read carries the poll timeout and the shared snapshot
+  // never rejects); the defensive catch is for a foreign caller's promise only, because a baseline -
+  // a guard input - must never cost the user's words, exactly like the decode above.
+  let baselineBufferBytes: number | undefined;
+  try {
+    baselineBufferBytes = await hooks.baselineBufferBytes;
+  } catch {
+    baselineBufferBytes = undefined;
+  }
+
   const rec: PendingDictation = {
     id: crypto.randomUUID(),
     sessionId,
@@ -206,7 +223,7 @@ export async function backgroundTranscribeAndSend(
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
-    baselineBufferBytes: hooks.baselineBufferBytes ?? 0,
+    baselineBufferBytes,
     createdAt: Date.now(),
   };
 
@@ -389,8 +406,9 @@ export async function sendDroppedDictationAnyway(uploadId: string): Promise<void
 // Retry a dropped dictation whose words we never got (the rare drop before transcription, issue #1590).
 // The audio is still on the device, but its upload id is tombstoned moved-on for good (#1183), so it is
 // re-driven under a FRESH upload id - a genuinely new dictation carrying the same recording. The baseline
-// is cleared to zero: the recorded-at baseline describes a terminal that has long since moved on, and
-// re-sending it would simply invite the same drop. The user asked for this send now, deliberately.
+// is cleared to UNKNOWN (the field is omitted on the wire, so the server skips the guard): the
+// recorded-at baseline describes a terminal that has long since moved on, and re-sending it would simply
+// invite the same drop. The user asked for this send now, deliberately.
 // Guarded on the OLD id by the same in-flight set: each tap mints a NEW upload id, so without this two rapid
 // taps would stage two fresh clips and inject the same recording twice - and being different ids, nothing
 // downstream would de-duplicate them.
@@ -415,7 +433,7 @@ export async function retryDroppedDictation(uploadId: string): Promise<void> {
       id: crypto.randomUUID(),
       staleDropped: undefined,
       droppedTranscript: undefined,
-      baselineBufferBytes: 0,
+      baselineBufferBytes: undefined,
       createdAt: Date.now(),
     };
     try {

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -228,46 +228,62 @@ export async function backgroundTranscribeAndSend(
   // pressed and the screen is never quiet.
   publishDictationStatus({ sessionId, uploadId: rec.id, phase: "saving" });
 
+  // RESERVE the upload id from the kick machinery for the whole save-and-enrich window. The first
+  // durable write makes the record VISIBLE to every automatic trigger (app load, the online event,
+  // foreground), and a kick landing before enrichment would list the record and drive it with the
+  // baseline still unknown - uploading unguarded and racing both the enrichment write and this flow's
+  // own first drive. The reservation is the same in-flight set every drive honors, so a kick no-ops
+  // on exactly this id until enrichment has finished and THIS flow drives it. It lives only in
+  // memory, deliberately: a crash or reload drops it with the process, and the resume path then
+  // drives the durable unknown record - unguarded, which is exactly what the durable copy honestly
+  // knows.
+  _inFlight.add(rec.id);
   try {
-    await savePending(rec);
-  } catch {
-    // Durable storage genuinely unavailable (rare, e.g. a private-mode tab with IndexedDB disabled): the
-    // clip cannot be queued, so say so loudly and restore the typed text. We do NOT silently one-shot it.
-    publishDictationStatus({
-      sessionId,
-      uploadId: rec.id,
-      phase: "failed",
-      retryable: false,
-      error: NO_DURABLE_STORE_MESSAGE,
-    });
-    hooks.onError?.(NO_DURABLE_STORE_MESSAGE);
-    hooks.onFailed?.();
-    return;
-  }
-
-  // The clip is durable. Now - and only now - wait for the press-time baseline snapshot and enrich
-  // the pending record with it before the first upload. When the ORIGINAL press-time promise cannot
-  // answer, unknown is FINAL: never a fresh roster read here, because a reading taken now can include
-  // bytes the session produced during or after the recording, over-stating the baseline and masking
-  // exactly the movement the guard exists to detect. The wait is bounded (the shared snapshot rides
-  // the roster read's own timeout and never rejects); the defensive catch is for a foreign caller's
-  // promise only, because a guard input must never cost the user's words.
-  if (pressTimeBaseline !== undefined && typeof pressTimeBaseline !== "number") {
-    let bytes: number | undefined;
     try {
-      bytes = await pressTimeBaseline;
+      await savePending(rec);
     } catch {
-      bytes = undefined;
+      // Durable storage genuinely unavailable (rare, e.g. a private-mode tab with IndexedDB disabled): the
+      // clip cannot be queued, so say so loudly and restore the typed text. We do NOT silently one-shot it.
+      publishDictationStatus({
+        sessionId,
+        uploadId: rec.id,
+        phase: "failed",
+        retryable: false,
+        error: NO_DURABLE_STORE_MESSAGE,
+      });
+      hooks.onError?.(NO_DURABLE_STORE_MESSAGE);
+      hooks.onFailed?.();
+      return;
     }
-    if (bytes !== undefined) {
-      rec = { ...rec, baselineBufferBytes: bytes };
+
+    // The clip is durable. Now - and only now - wait for the press-time baseline snapshot and enrich
+    // the pending record with it before the first upload. When the ORIGINAL press-time promise cannot
+    // answer, unknown is FINAL: never a fresh roster read here, because a reading taken now can include
+    // bytes the session produced during or after the recording, over-stating the baseline and masking
+    // exactly the movement the guard exists to detect. The wait is bounded (the shared snapshot rides
+    // the roster read's own timeout and never rejects); the defensive catch is for a foreign caller's
+    // promise only, because a guard input must never cost the user's words.
+    if (pressTimeBaseline !== undefined && typeof pressTimeBaseline !== "number") {
+      let bytes: number | undefined;
       try {
-        await savePending(rec);
+        bytes = await pressTimeBaseline;
       } catch {
-        // The durable copy keeps unknown (a resume would go unguarded); this attempt still carries
-        // the press-time reading in memory. Never a reason to hold the words.
+        bytes = undefined;
+      }
+      if (bytes !== undefined) {
+        rec = { ...rec, baselineBufferBytes: bytes };
+        try {
+          await savePending(rec);
+        } catch {
+          // The durable copy keeps unknown (a resume would go unguarded); this attempt still carries
+          // the press-time reading in memory. Never a reason to hold the words.
+        }
       }
     }
+  } finally {
+    // Release, and hand off to the drive below with NO await in between: driveRecord re-takes the
+    // in-flight entry synchronously on entry, so no kick can slip into the gap.
+    _inFlight.delete(rec.id);
   }
 
   // Drive the first delivery attempt now. resumed:false so an immediate send injects without the

--- a/packages/client-core/src/dictation/baseline.test.ts
+++ b/packages/client-core/src/dictation/baseline.test.ts
@@ -6,8 +6,10 @@ import { act, renderHook } from "@testing-library/react";
 // baselineBufferBytes above zero, and both taught Speak flows omitted it - so the guard never armed.
 // This file pins the shared snapshot the flows now take: the roster's terminal-byte position for the
 // selected session, STARTED when Speak is pressed and handed to the send pipeline AS A PROMISE (so a
-// quick Send waits for the answer instead of racing it), retried once on a transient roster failure,
-// and "unknown" (undefined - never a fabricated zero) only when the position is genuinely unknowable.
+// quick Send takes the answer instead of racing it). The press-time reading is the only valid one: a
+// failed read is FINAL - exactly one roster call, never a retry or a later substitute, because a
+// reading taken after the press can include bytes produced during or after the recording and mask
+// the very movement the guard detects. Unknown is undefined - never a fabricated zero.
 
 const { listSessions } = vi.hoisted(() => ({
   listSessions: vi.fn(async (): Promise<{ sessionId?: string; totalBufferBytes?: number | string }[]> => []),
@@ -42,25 +44,17 @@ describe("snapshotBaselineBufferBytes", () => {
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(0);
   });
 
-  it("retries ONCE on a transient roster failure and returns the second answer", async () => {
-    listSessions
-      .mockRejectedValueOnce(new Error("request timed out"))
-      .mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: 555 }]);
-    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(555);
-    expect(listSessions).toHaveBeenCalledTimes(2);
-  });
-
-  it("returns unknown when the roster fails twice - and never rejects", async () => {
-    listSessions
-      .mockRejectedValueOnce(new Error("gateway unreachable"))
-      .mockRejectedValueOnce(new Error("gateway unreachable"));
+  it("a failed press-time read is FINAL: unknown, exactly one roster call, never a retry - and never rejects", async () => {
+    // Deliberately no second attempt: a roster call made after the press can capture bytes the
+    // session produced during or after the recording, over-stating the baseline and masking exactly
+    // the movement the guard exists to detect. A second answer would be a DIFFERENT reading, not the
+    // press-time one.
+    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
-    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(listSessions).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT retry when the roster answered but does not know the session", async () => {
-    // The retry exists for the transient network failure only: a roster that answered without the
-    // session (or without its byte position) gave its answer, and asking again cannot change it.
+  it("returns unknown when the roster answered but does not know the session - one call, no retry", async () => {
     listSessions.mockResolvedValueOnce([{ sessionId: "other", totalBufferBytes: 5 }]);
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
     expect(listSessions).toHaveBeenCalledTimes(1);

--- a/packages/client-core/src/dictation/baseline.test.ts
+++ b/packages/client-core/src/dictation/baseline.test.ts
@@ -5,8 +5,9 @@ import { act, renderHook } from "@testing-library/react";
 // Regression coverage for issue #2478: the Gateway's "session moved on" guard requires a
 // baselineBufferBytes above zero, and both taught Speak flows omitted it - so the guard never armed.
 // This file pins the shared snapshot the flows now take: the roster's terminal-byte position for the
-// selected session, read when Speak is pressed, and "unknown" (undefined, guard skipped for safety)
-// whenever the roster cannot answer - never a blocked or lost dictation.
+// selected session, STARTED when Speak is pressed and handed to the send pipeline AS A PROMISE (so a
+// quick Send waits for the answer instead of racing it), retried once on a transient roster failure,
+// and "unknown" (undefined - never a fabricated zero) only when the position is genuinely unknowable.
 
 const { listSessions } = vi.hoisted(() => ({
   listSessions: vi.fn(async (): Promise<{ sessionId?: string; totalBufferBytes?: number | string }[]> => []),
@@ -26,6 +27,7 @@ describe("snapshotBaselineBufferBytes", () => {
       { sessionId: "sess-42", totalBufferBytes: 48213 },
     ]);
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(48213);
+    expect(listSessions).toHaveBeenCalledTimes(1);
   });
 
   it("converts the wire's string form of the 64-bit integer", async () => {
@@ -33,66 +35,96 @@ describe("snapshotBaselineBufferBytes", () => {
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(Number("9007199254740993"));
   });
 
-  it("returns unknown when the session is not on the roster", async () => {
+  it("passes a genuine zero through as a real reading, distinct from unknown", async () => {
+    // A session whose terminal has produced nothing yet reads zero. That is an answer, not an absence:
+    // it must reach the record as 0, never be blurred into the unknown (undefined) state.
+    listSessions.mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: 0 }]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(0);
+  });
+
+  it("retries ONCE on a transient roster failure and returns the second answer", async () => {
+    listSessions
+      .mockRejectedValueOnce(new Error("request timed out"))
+      .mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: 555 }]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(555);
+    expect(listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns unknown when the roster fails twice - and never rejects", async () => {
+    listSessions
+      .mockRejectedValueOnce(new Error("gateway unreachable"))
+      .mockRejectedValueOnce(new Error("gateway unreachable"));
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
+    expect(listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry when the roster answered but does not know the session", async () => {
+    // The retry exists for the transient network failure only: a roster that answered without the
+    // session (or without its byte position) gave its answer, and asking again cannot change it.
     listSessions.mockResolvedValueOnce([{ sessionId: "other", totalBufferBytes: 5 }]);
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
+    expect(listSessions).toHaveBeenCalledTimes(1);
   });
 
   it("returns unknown when the session carries no terminal-byte position", async () => {
     listSessions.mockResolvedValueOnce([{ sessionId: "sess-42" }]);
     await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
   });
-
-  it("returns unknown when the roster read fails, so the dictation still delivers unguarded", async () => {
-    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
-    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
-  });
 });
 
 describe("useDictationBaseline", () => {
-  it("is unknown before Speak is pressed, then reads the snapshot taken at Speak press", async () => {
+  it("resolves unknown before Speak is pressed, and to the Speak-press snapshot after", async () => {
     listSessions.mockResolvedValue([{ sessionId: "sess-42", totalBufferBytes: 4321 }]);
     const { result } = renderHook(() => useDictationBaseline("sess-42"));
 
-    expect(result.current.read()).toBeUndefined();
+    await expect(result.current.read()).resolves.toBeUndefined();
 
-    await act(async () => {
+    act(() => {
       result.current.snapshot();
     });
-    expect(result.current.read()).toBe(4321);
+    await expect(result.current.read()).resolves.toBe(4321);
   });
 
-  it("forgets the previous recording's snapshot the moment Speak is pressed again", async () => {
-    // The first press's roster answer is held back until AFTER the second press has answered, to
-    // prove a late first answer can never stamp the second recording (the token guard).
-    let releaseFirst: (roster: { sessionId: string; totalBufferBytes: number }[]) => void = () => {};
+  it("hands Send the promise of a roster read still in flight, so a quick Send WAITS instead of racing", async () => {
+    // The exact race the review found: Speak starts the read, Send arrives before it resolves. The
+    // hook must hand over the pending promise (which later resolves to the real position) - never a
+    // peek at whatever had resolved by Send time.
+    let releaseRoster: (roster: { sessionId: string; totalBufferBytes: number }[]) => void = () => {};
+    listSessions.mockImplementationOnce(() => new Promise((resolve) => { releaseRoster = resolve; }));
+    const { result } = renderHook(() => useDictationBaseline("sess-42"));
+
+    act(() => {
+      result.current.snapshot(); // Speak press: roster read deliberately still in flight
+    });
+    const handedToSend = result.current.read(); // the quick Send takes the promise now
+
+    releaseRoster([{ sessionId: "sess-42", totalBufferBytes: 777 }]); // the roster answers afterwards
+    await expect(handedToSend).resolves.toBe(777);
+  });
+
+  it("replaces the previous recording's snapshot on every Speak press", async () => {
+    // The first press's roster answer is held back forever; the second press answers immediately. The
+    // second recording's Send must get the second answer - a late first answer must be irrelevant.
     listSessions
-      .mockImplementationOnce(() => new Promise((resolve) => { releaseFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise(() => { /* never answers */ }))
       .mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: 200 }]);
     const { result } = renderHook(() => useDictationBaseline("sess-42"));
 
-    await act(async () => {
-      result.current.snapshot(); // first Speak press: roster answer deliberately in flight
+    act(() => {
+      result.current.snapshot(); // first Speak press
     });
-    expect(result.current.read()).toBeUndefined(); // forgotten/unknown while pending
-
-    await act(async () => {
-      result.current.snapshot(); // second Speak press: answers 200 immediately
+    act(() => {
+      result.current.snapshot(); // second Speak press replaces the stored promise
     });
-    expect(result.current.read()).toBe(200);
-
-    await act(async () => {
-      releaseFirst([{ sessionId: "sess-42", totalBufferBytes: 100 }]); // the late first answer arrives
-    });
-    expect(result.current.read()).toBe(200); // and is discarded, never stamping the second recording
+    await expect(result.current.read()).resolves.toBe(200);
   });
 
-  it("stays unknown with no session selected, without calling the roster", async () => {
+  it("resolves unknown with no session selected, without calling the roster", async () => {
     const { result } = renderHook(() => useDictationBaseline(undefined));
-    await act(async () => {
+    act(() => {
       result.current.snapshot();
     });
-    expect(result.current.read()).toBeUndefined();
+    await expect(result.current.read()).resolves.toBeUndefined();
     expect(listSessions).not.toHaveBeenCalled();
   });
 });

--- a/packages/client-core/src/dictation/baseline.test.ts
+++ b/packages/client-core/src/dictation/baseline.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+// Regression coverage for issue #2478: the Gateway's "session moved on" guard requires a
+// baselineBufferBytes above zero, and both taught Speak flows omitted it - so the guard never armed.
+// This file pins the shared snapshot the flows now take: the roster's terminal-byte position for the
+// selected session, read when Speak is pressed, and "unknown" (undefined, guard skipped for safety)
+// whenever the roster cannot answer - never a blocked or lost dictation.
+
+const { listSessions } = vi.hoisted(() => ({
+  listSessions: vi.fn(async (): Promise<{ sessionId?: string; totalBufferBytes?: number | string }[]> => []),
+}));
+vi.mock("../api/client", () => ({ listSessions }));
+
+import { snapshotBaselineBufferBytes, useDictationBaseline } from "./baseline";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("snapshotBaselineBufferBytes", () => {
+  it("returns the selected session's terminal-byte position", async () => {
+    listSessions.mockResolvedValueOnce([
+      { sessionId: "other", totalBufferBytes: 1 },
+      { sessionId: "sess-42", totalBufferBytes: 48213 },
+    ]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(48213);
+  });
+
+  it("converts the wire's string form of the 64-bit integer", async () => {
+    listSessions.mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: "9007199254740993" }]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBe(Number("9007199254740993"));
+  });
+
+  it("returns unknown when the session is not on the roster", async () => {
+    listSessions.mockResolvedValueOnce([{ sessionId: "other", totalBufferBytes: 5 }]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
+  });
+
+  it("returns unknown when the session carries no terminal-byte position", async () => {
+    listSessions.mockResolvedValueOnce([{ sessionId: "sess-42" }]);
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
+  });
+
+  it("returns unknown when the roster read fails, so the dictation still delivers unguarded", async () => {
+    listSessions.mockRejectedValueOnce(new Error("gateway unreachable"));
+    await expect(snapshotBaselineBufferBytes("sess-42")).resolves.toBeUndefined();
+  });
+});
+
+describe("useDictationBaseline", () => {
+  it("is unknown before Speak is pressed, then reads the snapshot taken at Speak press", async () => {
+    listSessions.mockResolvedValue([{ sessionId: "sess-42", totalBufferBytes: 4321 }]);
+    const { result } = renderHook(() => useDictationBaseline("sess-42"));
+
+    expect(result.current.read()).toBeUndefined();
+
+    await act(async () => {
+      result.current.snapshot();
+    });
+    expect(result.current.read()).toBe(4321);
+  });
+
+  it("forgets the previous recording's snapshot the moment Speak is pressed again", async () => {
+    // The first press's roster answer is held back until AFTER the second press has answered, to
+    // prove a late first answer can never stamp the second recording (the token guard).
+    let releaseFirst: (roster: { sessionId: string; totalBufferBytes: number }[]) => void = () => {};
+    listSessions
+      .mockImplementationOnce(() => new Promise((resolve) => { releaseFirst = resolve; }))
+      .mockResolvedValueOnce([{ sessionId: "sess-42", totalBufferBytes: 200 }]);
+    const { result } = renderHook(() => useDictationBaseline("sess-42"));
+
+    await act(async () => {
+      result.current.snapshot(); // first Speak press: roster answer deliberately in flight
+    });
+    expect(result.current.read()).toBeUndefined(); // forgotten/unknown while pending
+
+    await act(async () => {
+      result.current.snapshot(); // second Speak press: answers 200 immediately
+    });
+    expect(result.current.read()).toBe(200);
+
+    await act(async () => {
+      releaseFirst([{ sessionId: "sess-42", totalBufferBytes: 100 }]); // the late first answer arrives
+    });
+    expect(result.current.read()).toBe(200); // and is discarded, never stamping the second recording
+  });
+
+  it("stays unknown with no session selected, without calling the roster", async () => {
+    const { result } = renderHook(() => useDictationBaseline(undefined));
+    await act(async () => {
+      result.current.snapshot();
+    });
+    expect(result.current.read()).toBeUndefined();
+    expect(listSessions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client-core/src/dictation/baseline.ts
+++ b/packages/client-core/src/dictation/baseline.ts
@@ -1,0 +1,64 @@
+import { useCallback, useMemo, useRef } from "react";
+import { listSessions } from "../api/client";
+
+// The record-time terminal-byte baseline for the Gateway's "session moved on" guard (issue #1006),
+// armed from the Speak flows by issue #2478.
+//
+// The guard drops a RESUMED dictation when the session's terminal output grew materially after the
+// clip was recorded - other turns happened, so injecting the stale words would answer a question that
+// is no longer on screen. The Gateway can only judge that growth against the terminal position AT
+// RECORD TIME, and the client is the only party that knows it: by the time a resumed clip first
+// reaches the Gateway (the whole point of a resume is that earlier attempts never arrived), the
+// Gateway's own current reading is already past whatever moved on. Both taught Speak flows (the
+// mobile SessionControls and the Cockpit SessionComposer) used to omit the field, so it defaulted to
+// zero and the guard never armed; this module is the one shared place they now snapshot it, the same
+// roster reading the Voice screen has always sent (useVoiceMode).
+//
+// An unknown baseline is a DEFINED state of the pipeline's contract (BackgroundSendHooks
+// .baselineBufferBytes: omit when unknown, and the guard is then skipped for safety), not a softened
+// failure: the user's words must never be blocked - or arrive late - because a roster read failed,
+// so a failure here yields "unknown" and the clip still delivers; it just cannot be moved-on-guarded.
+export async function snapshotBaselineBufferBytes(sessionId: string): Promise<number | undefined> {
+  try {
+    const all = await listSessions();
+    // totalBufferBytes is a 64-bit integer on the wire, so the schema admits number | string.
+    const bytes = Number(all.find((s) => s.sessionId === sessionId)?.totalBufferBytes);
+    return Number.isFinite(bytes) ? bytes : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface DictationBaseline {
+  /** Call when Speak is pressed (recording starts): starts the roster read that snapshots the
+   *  session's terminal-byte position, and forgets any previous snapshot immediately so a stale
+   *  number can never describe a new recording. */
+  snapshot: () => void;
+  /** The snapshotted baseline for the recording in progress, or undefined while it is unknown
+   *  (roster read still pending, failed, or no session selected). */
+  read: () => number | undefined;
+}
+
+// The per-recording snapshot both Speak flows share. Recording takes seconds, so the roster read
+// started at Speak press has long resolved by the time Send hands the clip to the background
+// pipeline; if Send somehow wins the race, read() returns undefined and the guard is skipped for
+// that clip - exactly the pre-snapshot behavior, never anything worse.
+export function useDictationBaseline(sessionId: string | undefined): DictationBaseline {
+  const valueRef = useRef<number | undefined>(undefined);
+  // Distinguishes the CURRENT snapshot's roster read from an earlier one still in flight, so two
+  // Speak presses in a row can never let the first press's late answer stamp the second recording.
+  const tokenRef = useRef(0);
+
+  const snapshot = useCallback(() => {
+    const token = ++tokenRef.current;
+    valueRef.current = undefined;
+    if (!sessionId) return;
+    void snapshotBaselineBufferBytes(sessionId).then((bytes) => {
+      if (tokenRef.current === token) valueRef.current = bytes;
+    });
+  }, [sessionId]);
+
+  const read = useCallback(() => valueRef.current, []);
+
+  return useMemo(() => ({ snapshot, read }), [snapshot, read]);
+}

--- a/packages/client-core/src/dictation/baseline.ts
+++ b/packages/client-core/src/dictation/baseline.ts
@@ -14,11 +14,18 @@ import { listSessions } from "../api/client";
 // zero and the guard never armed; this module is the one shared place they now snapshot it, the same
 // roster reading the Voice screen has always sent (useVoiceMode).
 //
+// THE PRESS-TIME READING IS THE ONLY VALID ONE - there is deliberately no retry and no later re-read.
+// A roster call made after the press can capture bytes the session produced DURING or after the
+// recording, over-stating the baseline and masking exactly the movement the guard exists to detect.
+// So the read is started once, when Speak is pressed; if it cannot answer (the request failed or
+// timed out), unknown is FINAL for this clip.
+//
 // The snapshot is handed around AS A PROMISE, never as a peek at whatever has resolved so far: the
-// Speak press starts the roster read, and the send pipeline AWAITS it before persisting the durable
-// record. A quick Send therefore cannot outrun the read and record "unknown" for a session whose
-// position was perfectly knowable - the race the first version of this file had. The wait is bounded:
-// listSessions carries the poll timeout, and this module never rejects.
+// Speak press starts the roster read and the send pipeline takes the promise, so a quick Send cannot
+// outrun the read and record "unknown" for a session whose position was perfectly knowable - the race
+// the first version of this file had. The promise always settles (the roster read carries the poll
+// timeout, and this module never rejects), and the pipeline persists the clip durably FIRST, then
+// enriches the pending record when the promise resolves - durability never waits on the roster.
 //
 // An unknown baseline (undefined) is a DEFINED state of the pipeline's contract (BackgroundSendHooks
 // .baselineBufferBytes: unknown means the field is omitted on the wire, and the guard is then skipped
@@ -27,24 +34,13 @@ import { listSessions } from "../api/client";
 // terminal had produced nothing yet) and is passed through as such.
 export async function snapshotBaselineBufferBytes(sessionId: string): Promise<number | undefined> {
   try {
-    return await readBaselineOnce(sessionId);
-  } catch {
-    // One deliberate retry, for the transient roster failure only (a dropped request, a timeout). A
-    // roster that ANSWERED but does not know the session gets no retry - asking again cannot change
-    // that answer. Two failures in a row mean the baseline is genuinely unknowable right now.
-  }
-  try {
-    return await readBaselineOnce(sessionId);
+    const all = await listSessions();
+    // totalBufferBytes is a 64-bit integer on the wire, so the schema admits number | string.
+    const bytes = Number(all.find((s) => s.sessionId === sessionId)?.totalBufferBytes);
+    return Number.isFinite(bytes) ? bytes : undefined;
   } catch {
     return undefined;
   }
-}
-
-async function readBaselineOnce(sessionId: string): Promise<number | undefined> {
-  const all = await listSessions();
-  // totalBufferBytes is a 64-bit integer on the wire, so the schema admits number | string.
-  const bytes = Number(all.find((s) => s.sessionId === sessionId)?.totalBufferBytes);
-  return Number.isFinite(bytes) ? bytes : undefined;
 }
 
 export interface DictationBaseline {
@@ -52,15 +48,16 @@ export interface DictationBaseline {
    *  session's terminal-byte position, replacing any previous recording's snapshot so a stale
    *  number can never describe a new recording. */
   snapshot: () => void;
-  /** The snapshot for the recording in progress, as a promise the send pipeline awaits. Resolves to
-   *  the terminal-byte position, or to undefined when it is genuinely unknowable (the roster read
-   *  failed even after the retry, no session is selected, or Speak was never pressed). Never rejects. */
+  /** The snapshot for the recording in progress, as a promise the send pipeline takes. Resolves to
+   *  the press-time terminal-byte position, or to undefined when it is genuinely unknowable (the
+   *  press-time roster read failed, no session is selected, or Speak was never pressed) - which is
+   *  final for the clip. Never rejects. */
   read: () => Promise<number | undefined>;
 }
 
 // The per-recording snapshot both Speak flows share. Each Speak press replaces the stored promise,
 // so a second recording can never be stamped by the first recording's late answer, and Send always
-// awaits exactly the read its own Speak press started.
+// takes exactly the read its own Speak press started.
 export function useDictationBaseline(sessionId: string | undefined): DictationBaseline {
   const promiseRef = useRef<Promise<number | undefined> | undefined>(undefined);
 

--- a/packages/client-core/src/dictation/baseline.ts
+++ b/packages/client-core/src/dictation/baseline.ts
@@ -14,51 +14,61 @@ import { listSessions } from "../api/client";
 // zero and the guard never armed; this module is the one shared place they now snapshot it, the same
 // roster reading the Voice screen has always sent (useVoiceMode).
 //
-// An unknown baseline is a DEFINED state of the pipeline's contract (BackgroundSendHooks
-// .baselineBufferBytes: omit when unknown, and the guard is then skipped for safety), not a softened
-// failure: the user's words must never be blocked - or arrive late - because a roster read failed,
-// so a failure here yields "unknown" and the clip still delivers; it just cannot be moved-on-guarded.
+// The snapshot is handed around AS A PROMISE, never as a peek at whatever has resolved so far: the
+// Speak press starts the roster read, and the send pipeline AWAITS it before persisting the durable
+// record. A quick Send therefore cannot outrun the read and record "unknown" for a session whose
+// position was perfectly knowable - the race the first version of this file had. The wait is bounded:
+// listSessions carries the poll timeout, and this module never rejects.
+//
+// An unknown baseline (undefined) is a DEFINED state of the pipeline's contract (BackgroundSendHooks
+// .baselineBufferBytes: unknown means the field is omitted on the wire, and the guard is then skipped
+// for safety), not a softened failure: the user's words must never be blocked - or lost - because a
+// roster read failed. Unknown is distinct from ZERO, which is a real reading (a session whose
+// terminal had produced nothing yet) and is passed through as such.
 export async function snapshotBaselineBufferBytes(sessionId: string): Promise<number | undefined> {
   try {
-    const all = await listSessions();
-    // totalBufferBytes is a 64-bit integer on the wire, so the schema admits number | string.
-    const bytes = Number(all.find((s) => s.sessionId === sessionId)?.totalBufferBytes);
-    return Number.isFinite(bytes) ? bytes : undefined;
+    return await readBaselineOnce(sessionId);
+  } catch {
+    // One deliberate retry, for the transient roster failure only (a dropped request, a timeout). A
+    // roster that ANSWERED but does not know the session gets no retry - asking again cannot change
+    // that answer. Two failures in a row mean the baseline is genuinely unknowable right now.
+  }
+  try {
+    return await readBaselineOnce(sessionId);
   } catch {
     return undefined;
   }
 }
 
-export interface DictationBaseline {
-  /** Call when Speak is pressed (recording starts): starts the roster read that snapshots the
-   *  session's terminal-byte position, and forgets any previous snapshot immediately so a stale
-   *  number can never describe a new recording. */
-  snapshot: () => void;
-  /** The snapshotted baseline for the recording in progress, or undefined while it is unknown
-   *  (roster read still pending, failed, or no session selected). */
-  read: () => number | undefined;
+async function readBaselineOnce(sessionId: string): Promise<number | undefined> {
+  const all = await listSessions();
+  // totalBufferBytes is a 64-bit integer on the wire, so the schema admits number | string.
+  const bytes = Number(all.find((s) => s.sessionId === sessionId)?.totalBufferBytes);
+  return Number.isFinite(bytes) ? bytes : undefined;
 }
 
-// The per-recording snapshot both Speak flows share. Recording takes seconds, so the roster read
-// started at Speak press has long resolved by the time Send hands the clip to the background
-// pipeline; if Send somehow wins the race, read() returns undefined and the guard is skipped for
-// that clip - exactly the pre-snapshot behavior, never anything worse.
+export interface DictationBaseline {
+  /** Call when Speak is pressed (recording starts): starts the roster read that snapshots the
+   *  session's terminal-byte position, replacing any previous recording's snapshot so a stale
+   *  number can never describe a new recording. */
+  snapshot: () => void;
+  /** The snapshot for the recording in progress, as a promise the send pipeline awaits. Resolves to
+   *  the terminal-byte position, or to undefined when it is genuinely unknowable (the roster read
+   *  failed even after the retry, no session is selected, or Speak was never pressed). Never rejects. */
+  read: () => Promise<number | undefined>;
+}
+
+// The per-recording snapshot both Speak flows share. Each Speak press replaces the stored promise,
+// so a second recording can never be stamped by the first recording's late answer, and Send always
+// awaits exactly the read its own Speak press started.
 export function useDictationBaseline(sessionId: string | undefined): DictationBaseline {
-  const valueRef = useRef<number | undefined>(undefined);
-  // Distinguishes the CURRENT snapshot's roster read from an earlier one still in flight, so two
-  // Speak presses in a row can never let the first press's late answer stamp the second recording.
-  const tokenRef = useRef(0);
+  const promiseRef = useRef<Promise<number | undefined> | undefined>(undefined);
 
   const snapshot = useCallback(() => {
-    const token = ++tokenRef.current;
-    valueRef.current = undefined;
-    if (!sessionId) return;
-    void snapshotBaselineBufferBytes(sessionId).then((bytes) => {
-      if (tokenRef.current === token) valueRef.current = bytes;
-    });
+    promiseRef.current = sessionId ? snapshotBaselineBufferBytes(sessionId) : Promise.resolve(undefined);
   }, [sessionId]);
 
-  const read = useCallback(() => valueRef.current, []);
+  const read = useCallback(() => promiseRef.current ?? Promise.resolve(undefined), []);
 
   return useMemo(() => ({ snapshot, read }), [snapshot, read]);
 }

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -43,8 +43,12 @@ export interface PendingDictation {
   after: string;
   /** Earlier paused dictation segments already turned to text, joined ahead of this clip. */
   prefix: string;
-  /** The session's TotalBufferBytes when the clip was recorded (server moved-on guard). */
-  baselineBufferBytes: number;
+  /** The session's TotalBufferBytes when the clip was recorded (server moved-on guard). Absent means
+   *  UNKNOWN - the roster could not answer at record time - and it stays absent durably, so the wire
+   *  request omits the field and the server skips the guard for exactly this clip. It is NEVER written
+   *  as a fabricated zero: zero is a real reading (a session whose terminal had produced nothing yet),
+   *  and collapsing unknown into it was how the guard silently stayed unarmed (issue #2478). */
+  baselineBufferBytes?: number;
   /** Epoch milliseconds the clip was recorded. Drives the retry cadence (hard for the first hour,
    *  then throttled) - NOT a prune deadline: undelivered audio is never aged out (issue #1182). */
   createdAt: number;


### PR DESCRIPTION
Closes 2478.

## What was wrong

The Gateway's session-moved-on guard for dictation delivery (GatewayDictationEndpoint, the resumed-clip check) only engages when the request carries a baselineBufferBytes above zero. Both taught client flows - the mobile SessionControls and the Cockpit SessionComposer - omitted the field when handing a recording-stage Send to the durable background pipeline, so it defaulted to zero and the guard never armed. The recovery behavior the feature was built for (dropping a stale resumed clip instead of injecting it into a session that has moved on, with the words offered back) was unreachable from the shipped Speak flows. The Voice screen flow already sent the value; only the two Speak flows did not.

## The root-cause decision: fix the clients, not a Gateway default

Only the client knows the session's terminal-byte position at record time. A Gateway-side default would have to be stamped when the upload first reaches the Gateway - and for exactly the case the guard exists for (a clip whose first upload attempt never arrived, resumed later from the durable on-device copy), that first contact happens at resume time, so the stamped baseline would equal the already-moved-on position and the guard could never fire. Passing the real record-time baseline from the clients arms the guard in every case, changes nothing for callers that already send a value (the Voice screen), and touches no Gateway code. No new fallback logic: a failed roster read yields the pipeline's documented unknown state (field omitted, guard skipped for safety) and the dictation always still delivers.

## What changed

- packages/client-core/src/dictation/baseline.ts (new): the one shared snapshot both flows use - reads the roster (the same listSessions reading useVoiceMode has always used), returns the selected session's totalBufferBytes, or unknown when the roster cannot answer.
- apps/mobile/src/components/SessionControls.tsx and apps/cockpit/src/sessions/SessionComposer.tsx: the Speak press snapshots the baseline (alongside the existing caret snapshot) and the recording-stage Send passes it to backgroundTranscribeAndSend.
- Regression coverage proving the guard now arms from each flow:
  - apps/cockpit/src/sessions/composerSpeakSend.test.tsx now asserts the pipeline receives the snapshotted baseline (4321, above zero) for the Cockpit flow.
  - apps/mobile/src/components/sessionControlsSpeakSend.test.tsx (new) pins the same for the mobile flow, plus the roster-failure case (unknown baseline, clip still delivers). This is the mobile workspace's first test file, so the workspace gains the cockpit's exact test setup (vitest, jsdom, testing-library, and a vitest-only config so tests never load the progressive-web-app build plugin).
  - packages/client-core/src/dictation/baseline.test.ts (new): the snapshot helper and hook, including the string form of the 64-bit integer, the unknown states, and the two-presses token guard.
- .github/workflows/ci.yml: the web job runs the mobile tests, per its own add-a-line-when-a-workspace-gains-tests rule.

The chain to the Gateway is already pinned by existing tests: backgroundSend threads the stored baseline onto the upload (backgroundSend.test.ts), and the Gateway guard's behavior for a positive baseline is covered by the existing Gateway dictation suites.

## What was verified

- Web workspaces (the default gate runs no web tests): client-core 890 passed (83 files, includes the 8 new baseline tests), cockpit 267 passed (31 files, includes the extended composer test), mobile 2 passed (the new file). Workspace typecheck green; eslint clean on every changed file.
- Local gate scripts/test-local.ps1: every suite passed except CcDirector.Gateway.UnitTests, where exactly 8 tests failed - all of them HostedSchemaRefusesAnUnownedRowTests, failing with "Npgsql.NpgsqlException: Failed to connect to 127.0.0.1:55432". That is the Postgres-backed hosted-schema suite, red on this machine for environmental Docker reasons on unchanged code (this change contains no C# at all); judged against the parent rather than chased. 2973 of 2983 Gateway unit tests passed, and all eight other projects were fully green (153, 364, 63, 88, 113, 24, 25, 456).
- The gate flagged the parked suites (CcDirector.Core.Tests, CcDirector.Gateway.Tests) as a coverage gap; not run, because this change touches no product C# - it is entirely web workspace code plus one continuous-integration step, and the web tests were run directly.
