### PR TITLE
A malformed dictionary no longer fails a transcription - the dictionary read fails open to raw text

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
@@ -249,6 +249,46 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
             () => Service().TranscribeSegmentRawAsync(new byte[] { 1, 2, 3 }, "audio.webm", "audio/webm", CancellationToken.None));
     }
 
+    [Fact]
+    public async Task TranscribeAsync_DictionaryProviderThrows_StillReturnsRawText()
+    {
+        // Issue #2483: a malformed or unreadable dictionary file made the provider read throw AFTER
+        // the transcription had already succeeded, failing the whole request. The documented contract
+        // is fail-open - the dictionary corrector degrades to the raw transcript on any fault, and a
+        // fault reading the dictionary is exactly such a fault.
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_abc");
+
+        var service = new GatewayTranscriptionService(
+            new KeyVault(_vaultPath),
+            dictionaryProvider: () => throw new InvalidDataException("dictionary file is malformed"),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.OK, "{\"text\":\"the raw words\"}")),
+            audioArchive: ScratchArchive());
+
+        var result = await service.TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.wav", "audio/wav", applyCorrection: true, CancellationToken.None);
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal("the raw words", result.Text);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_DictionaryProviderThrows_FailsOpenToRawText()
+    {
+        // The Notes assemble-then-clean path goes through CleanupAsync directly; a throwing
+        // dictionary provider must yield the raw text there too, never an exception.
+        var service = new GatewayTranscriptionService(
+            new KeyVault(_vaultPath),
+            dictionaryProvider: () => throw new InvalidDataException("dictionary file is malformed"),
+            audioArchive: ScratchArchive());
+
+        var outcome = await service.CleanupAsync("the raw words", CancellationToken.None);
+
+        Assert.Equal("the raw words", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Contains("dictionary unavailable", outcome.Reason);
+    }
+
     [Theory]
     [InlineData("audio/webm;codecs=opus", "webm")]
     [InlineData("audio/wav", "wav")]

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -321,7 +321,21 @@ public sealed class GatewayTranscriptionService
         // Cleanup is deterministic and in-process now - no key or provider endpoint is needed, so it
         // runs even offline. CleanAsync short-circuits an empty dictionary to a verbatim passthrough;
         // the early check just avoids constructing the orchestrator for nothing.
-        var dictionary = _dictionaryProvider();
+        //
+        // The dictionary read shares the corrector's fail-open contract (issue #2483): a malformed or
+        // unreadable dictionary file must never fail a transcription that already produced text, so a
+        // provider fault degrades to the raw transcript exactly like a fault inside CleanAsync does.
+        DictationDictionary dictionary;
+        try
+        {
+            dictionary = _dictionaryProvider();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayTranscriptionService] dictionary read FAILED (fail-open, returning raw text): {ex.Message}");
+            return new CleanupOutcome(raw, Applied: false, Reason: "dictionary unavailable: " + ex.Message);
+        }
+
         if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
             return new CleanupOutcome(raw, Applied: false, Reason: "empty dictionary");
 


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1787

## The defect, verified against origin/main

`GatewayTranscriptionService.CleanupCoreAsync` read the dictation dictionary by calling
`_dictionaryProvider()` **before** entering `CleanupOrchestrator.CleanAsync`, and the
orchestrator's fail-open guard only covers its own body. The default provider is
`DictionaryLoader.LoadFromDisk`, which reads the file and parses the YAML with no guard of its
own, so a malformed or unreadable dictionary throws right there.

That throw happens **after** the transcription has already succeeded and produced text, and
`TranscribeAsync` calls the cleanup outside its own try/catch, so the exception escaped and
failed the whole request. The documented and intended behavior is the opposite: the dictionary
corrector fails open, and the caller gets the raw transcript.

Citation confirmed by reading `origin/main` directly (`git show origin/main:...`), not the
working tree. The work was done in a fresh worktree cut from `origin/main` at `e50fa8265`.

## The fix

The dictionary read is now inside a guard that gives it the same contract the corrector already
had: on any fault it logs and returns the raw transcript with the reason
`dictionary unavailable: <message>`. Twelve lines in the one method that had the gap - no change
to the orchestrator, no new option, no second code path.

## What was verified

**The regression tests bite.** Two tests were added, covering both callers of the cleanup core:
the full `TranscribeAsync` request path (with a stubbed transcription provider returning text)
and the phone Notes `CleanupAsync` path. Each injects a dictionary provider that throws.

- With the fix reverted and the tests kept: `Failed: 2, Passed: 0`.
- With the fix applied: both pass, and the transcript comes back as the raw text.

**Independently reproduced by the review seat**, in its own fresh worktree rather than on my word:
applied head `3c28dfa` gave `Passed: 2`; reverting only the production guard while keeping the
tests gave `Failed: 2`, with the `InvalidDataException` escaping through both `CleanupAsync` and
`TranscribeAsync` exactly as described. The reviewer restored the file and confirmed its worktree
clean afterwards.

**The red in the gate is not reachable from this change, and that is provable without any test
run.** Lead with this, because it is the only part of the evidence that no amount of flakiness can
touch. The modified method `CleanupCoreAsync` has exactly two callers, both in the same file:
`TranscribeAsync` (line 191, behind `if (applyCorrection)`) and `CleanupAsync` (line 294). Across
the entire `Gateway.Tests` project only two files call either entry point -
`GatewayTranscriptionServiceTests` and `GatewayTranscriptionServiceTranscriptStoreTests` - and
neither appears anywhere among the failures below. **No failing test executes the changed lines.**
Everything after this section is corroboration, not the argument.

**The local gate.** Ran `.\scripts\test-local.ps1 -Parked` from the worktree - the parked run,
because the change lands in Gateway code and `Gateway.Tests` does not run by default. Eleven
projects, all built clean.

Nine of eleven suites passed, including `Core.Tests` (4265 passed) and
`Gateway.UnitTests` apart from one environmental class. Both new tests passed inside that full
run.

Two suites were red, and neither red belongs to this change:

- `Gateway.UnitTests`: 8 failed, all in `HostedSchemaRefusesAnUnownedRowTests`, every one
  `Failed to connect to 127.0.0.1:55432` - the throwaway test PostgreSQL that
  `CC_GATEWAY_TEST_PG_CONNECTION` points at is not running on this machine. Environmental, and
  known to be red here.
- `Gateway.Tests`: 338 failed out of 2268. The failures group into buckets that have nothing to
  do with the dictionary: 105 unauthorized responses, 58 hosted-mode tenant-boundary
  construction errors, 41 more PostgreSQL connection refusals, and assertion failures spread
  across `Account`, `SessionsAggregation`, `SnoozeEndToEnd`, `LauncherRegistryEndpoint` and
  others.

Rather than assume that red was pre-existing, ten of the failing classes were re-run on their
own against this branch: `DurableDictationDedupe`, `VoiceQualityEndpoint`,
`TranscriptionKeyAutoProvisioner`, `VoiceTestEndpoint` (53 tests) and `SessionsAggregation`,
`SnoozeEndToEnd`, `LauncherRegistryEndpoint`, `SpokenLanguageEndpoint`, `GatewayInterrupted`,
`DirectorShutdownGate` (106 tests). **All 159 passed.** The same tests that failed inside the
full run pass when the run is not polluted, on this exact commit - so those failures are run
interference and the absent test database, not this change.

### Correction: the cause, established by the reviewer and independently confirmed here

An earlier version of this description blamed the ambient shell `CC_DIRECTOR_ROOT`. **That was
wrong, and the code disproves it.** `TestStorageRootRedirect.Redirect()`
(`src/CcDirector.Gateway.Tests/TestStorageRootRedirect.cs:43-53`) is a `[ModuleInitializer]` that
overwrites `CC_DIRECTOR_ROOT` unconditionally, and its own comment says respecting an existing
value would be a hole. Whatever the shell sets is replaced before any test runs, so the ambient
value cannot be causal. The review seat caught this; the corrected chain below is theirs, and each
link was then confirmed here against the code and the result file.

1. `CC_GATEWAY_TEST_PG_STATS_CONNECTION` and `CC_GATEWAY_TEST_PG_CONNECTION` are both set on this
   machine, pointing at the throwaway proof database on `127.0.0.1:55432`. The rig is **not
   running** - the local container runtime is itself failing. So the gate that decides whether the
   PostgreSQL-dependent classes run checks for a connection *string*, and passes, while the server
   behind it is dead.
2. `HostedStatsServeTests` therefore runs rather than skipping. Its **constructor**
   (`HostedStatsServeTests.cs:94-108`) sets `CC_DIRECTOR_ROOT` to its own
   `ccd-stats-serve-<guid>` temporary root and sets `CC_GATEWAY_HOSTED=1`.
3. `InitializeAsync` then calls `ResetSchema()` as its first act, which opens an Npgsql connection
   and throws against the dead port. Because `InitializeAsync` throws, xUnit never calls
   `DisposeAsync`, so **neither variable is restored**. The whole test process is left pointing at
   a foreign storage root and believing it is in hosted mode.
4. Everything downstream follows. `TestStorageRootRedirectTests.CcStorage`
   `Root_ResolvesUnderTheTemporaryRoot_NotTheOwnersRealStorage` fails with
   `Expected: ...\cc-gateway-tests-ee3216...` against `Actual: ...\ccd-stats-serve-68ea5bc...` -
   direct proof of the leak. The leaked hosted flag produces the 58 "hosted mode, but the tenant
   boundary was constructed without the ambient tenant context" errors, and the moved root
   invalidates the device and lease stores, producing the 105 unauthorized responses and the
   assertions that read as "values differ" rather than as authentication errors.

One environmental trigger, a missing test database, cascades into 338 failures through a test-rig
lifecycle gap. It is not this change, and it is not reachable from this change.

That test-rig gap is filed separately as thefrederiksen/devthrottle_internal#1793, so it stops being rediscovered as "the change under
review" by the next person on a machine without the rig. It is deliberately **not** fixed here -
this pull request stays a single-purpose fix.

**The reachability argument, which settles it independently of any run.** The modified method
`CleanupCoreAsync` has exactly two callers, both in the same file: `TranscribeAsync` (line 191,
behind `if (applyCorrection)`) and `CleanupAsync` (line 294). Across the entire `Gateway.Tests`
project only two files call either entry point - `GatewayTranscriptionServiceTests` and
`GatewayTranscriptionServiceTranscriptStoreTests` - and neither appears among the 338 failures.
No failing test can reach the changed lines.

A full parent baseline of `Gateway.Tests` was not run; that suite took one hour ten minutes here
and holds a machine-wide lock the rest of the fleet queues behind. Given the causal chain above
and the reachability argument, it would not change the conclusion. Stated so the gap is on the
record rather than implied.
